### PR TITLE
[Core/Script] Gunship battle, fix evade for battlemage & [Core/script] Quest, fix complete quest and remove morph on movementSpline complete

### DIFF
--- a/src/server/game/Handlers/TaxiHandler.cpp
+++ b/src/server/game/Handlers/TaxiHandler.cpp
@@ -213,6 +213,13 @@ void WorldSession::HandleMoveSplineDoneOpcode(WorldPacket& recvData)
     movementInfo.guid = guid;
     ReadMovementInfo(recvData, &movementInfo);
 
+    // Fix quest "As the crow flies" - Remove morph and complete quest
+    if(GetPlayer()->GetQuestStatus(9718) == QUEST_STATUS_INCOMPLETE)
+    {
+        GetPlayer()->CompleteQuest(9718);
+        GetPlayer()->RemoveAurasDueToSpell(38776);
+    }
+    
     recvData.read_skip<uint32>();                          // spline id
 }
 

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
@@ -1759,6 +1759,11 @@ class npc_gunship_mage : public CreatureScript
                     switch (Index)
                     {
                         case SLOT_FREEZE_MAGE:
+                            if (Player* player = me->SelectNearestPlayer(50.0f))
+                            {
+                                me->SetInCombatWithZone();
+                                me->AddThreat(player, 1.0f);
+                            }
                             me->CastSpell((Unit*)NULL, SPELL_BELOW_ZERO, false);
                             break;
                         case SLOT_MAGE_1:


### PR DESCRIPTION
1) When a player hit battlemage npc with a first spell of dot class, he enter in evade mode and not cast spell Below Zero.
2) When a player complete tour in bird morph, at movementSpline end, quest status change to complete and remove auraspell morph is done (quest AsTheCrowFlies).