### PR TITLE
Core/Commands: Add missing message for .ticket complete

### DIFF
--- a/data/sql/updates/world/2016_08_13_01.sql
+++ b/data/sql/updates/world/2016_08_13_01.sql
@@ -1,0 +1,3 @@
+INSERT INTO `trinity_string` (`entry`, `content_default`) VALUES
+(1334, 'Your ticket has been closed.'),
+(1335, 'You received a ticket response.');

--- a/src/game/Miscellaneous/Language.h
+++ b/src/game/Miscellaneous/Language.h
@@ -1046,10 +1046,10 @@ enum TrinityStrings
     LANG_BG_AV_A_CAPTAIN_DEAD           = 1332,
     LANG_BG_AV_START_TWO_MINUTES        = 1333,
 
-	//Player Ticket Strings
-	LANG_TICKET_CLOSED                  = 1334,
-	LANG_TICKET_COMPLETED               = 1335,
-	// FREE IDS                           1336-1999
+    //Player Ticket Strings
+    LANG_TICKET_CLOSED                  = 1334,
+    LANG_TICKET_COMPLETED               = 1335,
+    // FREE IDS                           1336-1999
 
     // Ticket Strings 2000-2030
     LANG_COMMAND_TICKETNEW              = 2000,

--- a/src/game/Miscellaneous/Language.h
+++ b/src/game/Miscellaneous/Language.h
@@ -1045,7 +1045,11 @@ enum TrinityStrings
     LANG_BG_AV_H_CAPTAIN_DEAD           = 1331,
     LANG_BG_AV_A_CAPTAIN_DEAD           = 1332,
     LANG_BG_AV_START_TWO_MINUTES        = 1333,
-    // FREE IDS                           1334-1999
+
+	//Player Ticket Strings
+	LANG_TICKET_CLOSED                  = 1334,
+	LANG_TICKET_COMPLETED               = 1335,
+	// FREE IDS                           1336-1999
 
     // Ticket Strings 2000-2030
     LANG_COMMAND_TICKETNEW              = 2000,

--- a/src/scripts/Commands/cs_ticket.cpp
+++ b/src/scripts/Commands/cs_ticket.cpp
@@ -168,6 +168,7 @@ public:
             WorldPacket data(SMSG_GMTICKET_DELETETICKET, 4);
             data << uint32(GMTICKET_RESPONSE_TICKET_DELETED);
             submitter->GetSession()->SendPacket(&data);
+			ChatHandler(submitter->GetSession()).SendSysMessage(LANG_TICKET_CLOSED);
         }
         return true;
     }
@@ -233,25 +234,29 @@ public:
             return true;
         }
 
+		// Check if handler is not assignee in which case return
+		Player* player = handler->GetSession() ? handler->GetSession()->GetPlayer() : NULL;
+
+		if (player && ticket->IsAssignedNotTo(player->GetGUID()))
+		{
+			handler->PSendSysMessage(LANG_COMMAND_TICKETALREADYASSIGNED, ticket->GetId());
+			return true;
+		}
+
         char* response = strtok(NULL, "\n");
         if (response)
-        {
-            // Cannot add response to ticket, assigned to someone else
-            //! Console excluded
-            Player* player = handler->GetSession() ? handler->GetSession()->GetPlayer() : NULL;
-            if (player && ticket->IsAssignedNotTo(player->GetGUID()))
-            {
-                handler->PSendSysMessage(LANG_COMMAND_TICKETALREADYASSIGNED, ticket->GetId());
-                return true;
-            }
             ticket->AppendResponse(response);
-        }
 
-        if (Player* player = ticket->GetPlayer())
-            ticket->SendResponse(player->GetSession());
-
+		if (Player* player = ticket->GetPlayer())
+		{
+			ticket->SendResponse(player->GetSession());
+			ChatHandler(player->GetSession()).SendSysMessage(LANG_TICKET_COMPLETED);
+		}
         Player* gm = handler->GetSession() ? handler->GetSession()->GetPlayer() : NULL;
 
+		std::string msg = ticket->FormatMessageString(*handler, NULL, NULL, NULL, NULL);
+		msg += handler->PGetParseString(LANG_COMMAND_TICKETCOMPLETED, gm ? gm->GetName().c_str() : "Console");
+		handler->SendGlobalGMSysMessage(msg.c_str());
 
         SQLTransaction trans = SQLTransaction(NULL);
         ticket->SetCompleted();

--- a/src/scripts/Commands/cs_ticket.cpp
+++ b/src/scripts/Commands/cs_ticket.cpp
@@ -168,7 +168,7 @@ public:
             WorldPacket data(SMSG_GMTICKET_DELETETICKET, 4);
             data << uint32(GMTICKET_RESPONSE_TICKET_DELETED);
             submitter->GetSession()->SendPacket(&data);
-			ChatHandler(submitter->GetSession()).SendSysMessage(LANG_TICKET_CLOSED);
+            ChatHandler(submitter->GetSession()).SendSysMessage(LANG_TICKET_CLOSED);
         }
         return true;
     }
@@ -234,29 +234,29 @@ public:
             return true;
         }
 
-		// Check if handler is not assignee in which case return
-		Player* player = handler->GetSession() ? handler->GetSession()->GetPlayer() : NULL;
+        // Check if handler is not assignee in which case return
+        Player* player = handler->GetSession() ? handler->GetSession()->GetPlayer() : NULL;
 
-		if (player && ticket->IsAssignedNotTo(player->GetGUID()))
-		{
-			handler->PSendSysMessage(LANG_COMMAND_TICKETALREADYASSIGNED, ticket->GetId());
-			return true;
-		}
+        if (player && ticket->IsAssignedNotTo(player->GetGUID()))
+        {
+            handler->PSendSysMessage(LANG_COMMAND_TICKETALREADYASSIGNED, ticket->GetId());
+            return true;
+        }
 
         char* response = strtok(NULL, "\n");
         if (response)
             ticket->AppendResponse(response);
 
-		if (Player* player = ticket->GetPlayer())
-		{
-			ticket->SendResponse(player->GetSession());
-			ChatHandler(player->GetSession()).SendSysMessage(LANG_TICKET_COMPLETED);
-		}
+        if (Player* player = ticket->GetPlayer())
+        {
+            ticket->SendResponse(player->GetSession());
+            ChatHandler(player->GetSession()).SendSysMessage(LANG_TICKET_COMPLETED);
+        }
         Player* gm = handler->GetSession() ? handler->GetSession()->GetPlayer() : NULL;
 
-		std::string msg = ticket->FormatMessageString(*handler, NULL, NULL, NULL, NULL);
-		msg += handler->PGetParseString(LANG_COMMAND_TICKETCOMPLETED, gm ? gm->GetName().c_str() : "Console");
-		handler->SendGlobalGMSysMessage(msg.c_str());
+        std::string msg = ticket->FormatMessageString(*handler, NULL, NULL, NULL, NULL);
+        msg += handler->PGetParseString(LANG_COMMAND_TICKETCOMPLETED, gm ? gm->GetName().c_str() : "Console");
+        handler->SendGlobalGMSysMessage(msg.c_str());
 
         SQLTransaction trans = SQLTransaction(NULL);
         ticket->SetCompleted();


### PR DESCRIPTION
**Changes proposed:**
-  Do not allow the completion of the ticket if the handler is not the asignee
-  Let the player know when his/her ticket has been closed or completed.
-  Add missing .ticket complete global GM message.

**Target branch(es):** 1.x

**Issues addressed:** Closes #54 

**Tests performed:** (Does it build, tested in-game, etc)
The tests have been tested in-game.

**Known issues and TODO list:**
Nothing so far

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)



Do not allow the completion of a ticket with or without response if the handler isn't the asignee
Let players know when their ticket has been closed or they received a response.