### PR TITLE
Core/Misc: Fix instant logout config

### DIFF
--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -410,7 +410,7 @@ void WorldSession::HandleLogoutRequestOpcode(WorldPacket & /*recv_data*/)
     if (uint64 lguid = GetPlayer()->GetLootGUID())
         DoLootRelease(lguid);
 
-    bool instantLogout = (GetSecurity() > SEC_PLAYER || GetPlayer()->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) && !GetPlayer()->IsInCombat()) || GetPlayer()->IsInFlight();
+    bool instantLogout = (GetSecurity() >= sWorld->getIntConfig(CONFIG_INSTANT_LOGOUT) || GetPlayer()->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) && !GetPlayer()->IsInCombat()) || GetPlayer()->IsInFlight();
 
     /// TODO: Possibly add RBAC permission to log out in combat
     bool canLogoutInCombat = GetPlayer()->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING);


### PR DESCRIPTION
**Changes proposed:**
-    Make use of CONFIG_INSTANT_LOGOUT instead of comparing player's security level against SEC_PLAYER

**Target branch(es):** 1.x

**Issues addressed:** Closes #65 

**Tests performed:** (Does it build, tested in-game, etc)
Tested in-game , works as intended.

**Known issues and TODO list:**
No issue.



