### PR TITLE
Core/Spells: Fix Corpse Explosion picking ghoul as a target without selection.

### DIFF
--- a/src/scripts/Spells/spell_dk.cpp
+++ b/src/scripts/Spells/spell_dk.cpp
@@ -1313,13 +1313,13 @@ class spell_dk_blood_gorged : public SpellScriptLoader
 class CorpseExplosionCheck
 {
 public:
-    explicit CorpseExplosionCheck(uint64 casterGUID) : _casterGUID(casterGUID) { }
+    explicit CorpseExplosionCheck(uint64 casterGUID, bool allowGhoul) : _casterGUID(casterGUID), _allowGhoul(allowGhoul) { }
 
     bool operator()(WorldObject* obj) const
     {
         if (Unit* target = obj->ToUnit())
         {
-            if ((target->isDead() || (target->GetEntry() == NPC_DK_GHOUL && target->GetOwnerGUID() == _casterGUID))
+            if ((target->isDead() || (_allowGhoul && (target->GetEntry() == NPC_DK_GHOUL && target->GetOwnerGUID() == _casterGUID))
                 && !(target->GetCreatureTypeMask() & CREATURE_TYPEMASK_MECHANICAL_OR_ELEMENTAL)
                 && target->GetDisplayId() == target->GetNativeDisplayId())
                 return false;
@@ -1360,7 +1360,7 @@ class spell_dk_corpse_explosion : public SpellScriptLoader
 
             void CheckTarget(WorldObject*& target)
             {
-                if (CorpseExplosionCheck(GetCaster()->GetGUID())(target))
+                if (CorpseExplosionCheck(GetCaster()->GetGUID(), true)(target))
                     target = NULL;
 
                 _target = target;
@@ -1371,7 +1371,7 @@ class spell_dk_corpse_explosion : public SpellScriptLoader
                 WorldObject* target = _target;
                 if (!target)
                 {
-                    targets.remove_if(CorpseExplosionCheck(GetCaster()->GetGUID()));
+                    targets.remove_if(CorpseExplosionCheck(GetCaster()->GetGUID(), false));
                     if (targets.empty())
                     {
                         FinishCast(SPELL_FAILED_CANT_DO_THAT_RIGHT_NOW);


### PR DESCRIPTION
Changes proposed: Fix Corpse Explosion picking ghoul as a target without selection

Target branch(es): 1.x

Tests performed: (Does it build, tested in-game, etc)
Tested in-game , works as intended.

Known issues and TODO list: No issue.