### PR TITLE
Core/Spells: Fix Hellscream's Warsong & Strength of Wrynn buffs.

### DIFF
--- a/data/sql/updates/2016_08_14_01.sql
+++ b/data/sql/updates/2016_08_14_01.sql
@@ -1,0 +1,8 @@
+ALTER TABLE world_db_version CHANGE COLUMN 2016_08_14_00 2016_08_14_01 bit;
+
+-- Hellscream's Warsong
+UPDATE `spell_area` SET `spell`='73822'
+WHERE `spell`='73818' AND `area`='4812' AND `quest_start`='0' AND `aura_spell`='0' AND `racemask`='690' AND `gender`='2';
+-- Strength of Wrynn
+UPDATE `spell_area` SET `spell`='73828'
+WHERE `spell`='73824' AND `area`='4812' AND `quest_start`='0' AND `aura_spell`='0' AND `racemask`='1101' AND `gender`='2';


### PR DESCRIPTION
Changes proposed: Fix Hellscream's Warsong & Strength of Wrynn buffs

- Currently, ICC uses 10% buff, but we have a version 3.3.5a and it is 30%.

Target branch(es): 1.x

Tests performed: (Does it build, tested in-game, etc)
Tested in-game , works as intended.

Known issues and TODO list: No issue.