### PR TITLE
Spell/Death Knight: Death Coil.

### DIFF
--- a/data/sql/updates/world/2016_08_24_01.sql
+++ b/data/sql/updates/world/2016_08_24_01.sql
@@ -1,0 +1,3 @@
+ALTER TABLE world_db_version CHANGE COLUMN 2016_08_24_00 2016_08_24_01 bit;
+
+DELETE FROM `spell_bonus_data` WHERE `entry` IN (47632,47633);

--- a/src/scripts/Spells/spell_dk.cpp
+++ b/src/scripts/Spells/spell_dk.cpp
@@ -1446,19 +1446,23 @@ class spell_dk_death_coil : public SpellScriptLoader
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
-                int32 damage = GetEffectValue();
                 Unit* caster = GetCaster();
                 if (Unit* target = GetHitUnit())
                 {
                     if (caster->IsFriendlyTo(target))
                     {
-                        int32 bp = int32(damage * 1.5f);
-                        caster->CastCustomSpell(target, SPELL_DK_DEATH_COIL_HEAL, &bp, NULL, NULL, true);
+                        int32 heal = int32(665 + caster->GetTotalAttackPowerValue(BASE_ATTACK) * 0.15);
+                        if (AuraEffect const* impurityEff = caster->GetDummyAuraEffect(SPELLFAMILY_DEATHKNIGHT, 1986, 0))
+                            heal += impurityEff->GetAmount();
+                        caster->CastCustomSpell(target, SPELL_DK_DEATH_COIL_HEAL, &heal, NULL, NULL, true);
                     }
                     else
                     {
+                        int32 damage = int32(443 + caster->GetTotalAttackPowerValue(BASE_ATTACK) * 0.15);
                         if (AuraEffect const* auraEffect = caster->GetAuraEffect(SPELL_DK_ITEM_SIGIL_VENGEFUL_HEART, EFFECT_1))
                             damage += auraEffect->GetBaseAmount();
+                        if (AuraEffect const* impurityEff = caster->GetDummyAuraEffect(SPELLFAMILY_DEATHKNIGHT, 1986, 0))
+                            heal += impurityEff->GetAmount();
                         caster->CastCustomSpell(target, SPELL_DK_DEATH_COIL_DAMAGE, &damage, NULL, NULL, true);
                     }
                 }

--- a/src/scripts/Spells/spell_dk.cpp
+++ b/src/scripts/Spells/spell_dk.cpp
@@ -1462,7 +1462,7 @@ class spell_dk_death_coil : public SpellScriptLoader
                         if (AuraEffect const* auraEffect = caster->GetAuraEffect(SPELL_DK_ITEM_SIGIL_VENGEFUL_HEART, EFFECT_1))
                             damage += auraEffect->GetBaseAmount();
                         if (AuraEffect const* impurityEff = caster->GetDummyAuraEffect(SPELLFAMILY_DEATHKNIGHT, 1986, 0))
-                            heal += impurityEff->GetAmount();
+                            damage += impurityEff->GetAmount();
                         caster->CastCustomSpell(target, SPELL_DK_DEATH_COIL_DAMAGE, &damage, NULL, NULL, true);
                     }
                 }


### PR DESCRIPTION
Changes proposed: Fix formula damage/heal.

(443 + (AP* 0.15 * impurity)) = damage.
(665+ (AP* 0.15 * impurity)) = heal.

Target branch(es): 1.x

Tests performed: (Does it build, tested in-game, etc)
Tested in-game , works as intended.

Known issues and TODO list: No issue.

P.S. Need help, I decided talent impurity problem , but a problem of the work of the talent calculation of damage is too small. If talent should add 4 % is, in reality there is not even 2%.