### PR TITLE
Core/Spells: Effect leap back fix

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -5010,7 +5010,7 @@ void Spell::EffectLeapBack(SpellEffIndex effIndex)
     float speedxy = m_spellInfo->Effects[effIndex].MiscValue / 10.0f;
     float speedz = damage / 10.0f;
     //1891: Disengage
-    m_caster->JumpTo(speedxy, speedz, m_spellInfo->SpellFamilyName != SPELLFAMILY_HUNTER);
+    unitTarget->JumpTo(speedxy, speedz, m_spellInfo->SpellFamilyName != SPELLFAMILY_HUNTER);
 
     // xinef: changes fall time
     if (m_caster->GetTypeId() == TYPEID_PLAYER)


### PR DESCRIPTION
**Changes proposed:**
-  Change SPELL_EFFECT_LEAP_BACK so that the victim of the spell effect leaps, and not the caster

**Target branch(es):** 1.x

**Issues addressed:** Found no issues related to fix

**Tests performed:** Builds, tested with spells that seemed to be related to the issue and they properly worked after the suggested code change

**Known issues and TODO list:** No known issues or todo's

TC commit [https://github.com/TrinityCore/TrinityCore/commit/73a72fb7d3d7e504f3eecc801f7e3a95893e5741]

By @Krudor
- Fixed unintentional typo?

Seemed to fix the issues related to the effect for the spells I tried.
Sometimes the caster triggers leapback onto targets, and with the old
code, it instead made the caster leap back instead of its targets
