### PR TITLE
MoveMent Spline Fix

### DIFF
--- a/src/game/Movement/Spline/MoveSpline.cpp
+++ b/src/game/Movement/Spline/MoveSpline.cpp
@@ -254,13 +254,13 @@ MoveSpline::UpdateResult MoveSpline::_updateState(int32& ms_time_diff)
             {
                 point_Idx = spline.first();
                 time_passed = time_passed % Duration();
-                result = Movement::MoveSpline::UpdateResult(Result_NextCycle | Result_JustArrived);
+                result = Result_NextCycle;
             }
             else
             {
                 _Finalize();
                 ms_time_diff = 0;
-                result = Movement::MoveSpline::UpdateResult(Result_Arrived | Result_JustArrived);
+                result = Result_Arrived;
             }
         }
     }


### PR DESCRIPTION
**Changes proposed:**

-  Altered MoveSpine Code to fix.
-  
-  

**Target branch(es):** Master

**Issues addressed:** Closes #
This does not close an issue, i have a movement spline crash the other week and it happend after about 24- 36 hours after the server was running, now my server has been up a week and i have not had a spline crash

**Tests performed:** (Does it build, tested in-game, etc)

Tested and works on Windows 10 x64
**Known issues and TODO list:**

- [ None] 
- [ ] 

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)



Updated Spine to no longer crash