### PR TITLE
Core/Tools: Fix compilation of tools under windows

### DIFF
--- a/modules/worldengine/nucleus/src/cmake/compiler/msvc/settings.cmake
+++ b/modules/worldengine/nucleus/src/cmake/compiler/msvc/settings.cmake
@@ -42,6 +42,10 @@ message(STATUS "MSVC: Disabled NON-SECURE warnings")
 add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
 message(STATUS "MSVC: Disabled POSIX warnings")
 
+#Ignore warnings about INTMAX_MAX
+add_definitions(-D__STDC_LIMIT_MACROS)
+message(STATUS "MSVC: Disabled INTMAX_MAX warnings")
+
 # disable warnings in Visual Studio 8 and above if not wanted
 if(NOT WITH_WARNINGS)
   if(MSVC AND NOT CMAKE_GENERATOR MATCHES "Visual Studio 7")


### PR DESCRIPTION
**Changes proposed:**

-  This fixes the compilation of tools under windows

**Target branch(es):** 1.x/2.x etc.

**Issues addressed:** Closes #212 

**Tests performed:** Compile just fine with VS15

**Known issues and TODO list:**

- [ ] Althought the compilation works, it seems to throw an error when data are extracted "ERROR: Map file './data/maps/0004331.map' is from an incompatible clientversion. Please recreate using the mapextractor." same for vmaps and I assume it will be the same for mmaps
- [ ] We need to update extractors to current TC, it should also fixes others issue about vmaps/los


