### PR TITLE
Karazhan rework

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1483918476110152000.sql
+++ b/data/sql/updates/pending_db_world/rev_1483918476110152000.sql
@@ -1,14 +1,12 @@
 INSERT INTO version_db_world (`sql_rev`) VALUES ('1483918476110152000');
 
+DELETE FROM `disables` WHERE `entry` = "532";
+DELETE FROM `creature` WHERE `guid` = "135921";
 DELETE FROM `creature` WHERE `ID` = "17644";
 
 UPDATE `creature_template` SET `ScriptName` = "prince_axes" WHERE `entry` = "17650";
 
 INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES (30843, 41624, 0, 'Prince Enfeelble');
-
-DELETE FROM `disables` WHERE `entry` = "532";
-
-DELETE FROM `creature` WHERE `guid` = "135921";
 
 INSERT INTO `creature` (`guid`, `id`, `map`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `spawndist`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`) VALUES
  (135921, 17645, 532, 1, 1, 11686, 0, -10935.6, -2043.06, 324.012, 2.17745, 604800, 0, 0, 42, 0, 0, 0, 0, 0);

--- a/data/sql/updates/pending_db_world/rev_1483918476110152000.sql
+++ b/data/sql/updates/pending_db_world/rev_1483918476110152000.sql
@@ -1,0 +1,14 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1483918476110152000');
+
+DELETE FROM `creature` WHERE `ID` = "17644";
+
+UPDATE `creature_template` SET `ScriptName` = "prince_axes" WHERE `entry` = "17650";
+
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES (30843, 41624, 0, 'Prince Enfeelble');
+
+DELETE FROM `disables` WHERE `entry` = "532";
+
+DELETE FROM `creature` WHERE `guid` = "135921";
+
+INSERT INTO `creature` (`guid`, `id`, `map`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `spawndist`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`) VALUES
+ (135921, 17645, 532, 1, 1, 11686, 0, -10935.6, -2043.06, 324.012, 2.17745, 604800, 0, 0, 42, 0, 0, 0, 0, 0);

--- a/src/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
@@ -269,7 +269,7 @@ public:
                 DoCast(SelectTarget(SELECT_TARGET_RANDOM, 1, 45, true), SPELL_VOIDZONE, true);
                 VoidZoneTimer = 15000;
             } else 
-				VoidZoneTimer -= diff;
+                VoidZoneTimer -= diff;
 
             // NetherInfusion Berserk
             if (!Berserk && NetherInfusionTimer <= diff)
@@ -278,7 +278,7 @@ public:
                 DoCast(me, SPELL_NETHERSPITE_ROAR);
                 Berserk = true;
             } else 
-				NetherInfusionTimer -= diff;
+                NetherInfusionTimer -= diff;
 
             if (PortalPhase) // PORTAL PHASE
             {
@@ -288,7 +288,7 @@ public:
                     UpdatePortals();
                     PortalTimer = 1000;
                 } else 
-					PortalTimer -= diff;
+                    PortalTimer -= diff;
 
                 // Empowerment & Nether Burn
                 if (EmpowermentTimer <= diff)
@@ -297,7 +297,7 @@ public:
                     me->AddAura(SPELL_NETHERBURN_AURA, me);
                     EmpowermentTimer = 90000;
                 } else 
-					EmpowermentTimer -= diff;
+                    EmpowermentTimer -= diff;
 
                 if (PhaseTimer <= diff)
                 {
@@ -307,7 +307,7 @@ public:
                         return;
                     }
                 } else 
-					PhaseTimer -= diff;
+                    PhaseTimer -= diff;
             }
             else // BANISH PHASE
             {
@@ -318,7 +318,7 @@ public:
                         DoCast(target, SPELL_NETHERBREATH);
                     NetherbreathTimer = urand(5000, 7000);
                 } else 
-					NetherbreathTimer -= diff;
+                    NetherbreathTimer -= diff;
 
                 if (PhaseTimer <= diff)
                 {
@@ -328,7 +328,7 @@ public:
                         return;
                     }
                 } else 
-					PhaseTimer -= diff;
+                    PhaseTimer -= diff;
             }
 
             DoMeleeAttackIfReady();

--- a/src/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
@@ -268,7 +268,8 @@ public:
             {
                 DoCast(SelectTarget(SELECT_TARGET_RANDOM, 1, 45, true), SPELL_VOIDZONE, true);
                 VoidZoneTimer = 15000;
-            } else VoidZoneTimer -= diff;
+            } else 
+				VoidZoneTimer -= diff;
 
             // NetherInfusion Berserk
             if (!Berserk && NetherInfusionTimer <= diff)
@@ -276,7 +277,8 @@ public:
                 me->AddAura(SPELL_NETHER_INFUSION, me);
                 DoCast(me, SPELL_NETHERSPITE_ROAR);
                 Berserk = true;
-            } else NetherInfusionTimer -= diff;
+            } else 
+				NetherInfusionTimer -= diff;
 
             if (PortalPhase) // PORTAL PHASE
             {
@@ -285,7 +287,8 @@ public:
                 {
                     UpdatePortals();
                     PortalTimer = 1000;
-                } else PortalTimer -= diff;
+                } else 
+					PortalTimer -= diff;
 
                 // Empowerment & Nether Burn
                 if (EmpowermentTimer <= diff)
@@ -293,7 +296,8 @@ public:
                     DoCast(me, SPELL_EMPOWERMENT);
                     me->AddAura(SPELL_NETHERBURN_AURA, me);
                     EmpowermentTimer = 90000;
-                } else EmpowermentTimer -= diff;
+                } else 
+					EmpowermentTimer -= diff;
 
                 if (PhaseTimer <= diff)
                 {
@@ -302,7 +306,8 @@ public:
                         SwitchToBanishPhase();
                         return;
                     }
-                } else PhaseTimer -= diff;
+                } else 
+					PhaseTimer -= diff;
             }
             else // BANISH PHASE
             {
@@ -312,7 +317,8 @@ public:
                     if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 40, true))
                         DoCast(target, SPELL_NETHERBREATH);
                     NetherbreathTimer = urand(5000, 7000);
-                } else NetherbreathTimer -= diff;
+                } else 
+					NetherbreathTimer -= diff;
 
                 if (PhaseTimer <= diff)
                 {
@@ -321,7 +327,8 @@ public:
                         SwitchToPortalPhase();
                         return;
                     }
-                } else PhaseTimer -= diff;
+                } else 
+					PhaseTimer -= diff;
             }
 
             DoMeleeAttackIfReady();

--- a/src/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
@@ -296,14 +296,14 @@ public:
                     DoCastVictim(SPELL_BELLOWING_ROAR);
                     BellowingRoarTimer = urand(30000, 40000);
                 } else 
-					BellowingRoarTimer -= diff;
+                    BellowingRoarTimer -= diff;
 
                 if (SmolderingBreathTimer <= diff)
                 {
                     DoCastVictim(SPELL_SMOLDERING_BREATH);
                     SmolderingBreathTimer = 20000;
                 } else 
-					SmolderingBreathTimer -= diff;
+                    SmolderingBreathTimer -= diff;
 
                 if (CharredEarthTimer <= diff)
                 {
@@ -311,7 +311,7 @@ public:
                         DoCast(target, SPELL_CHARRED_EARTH);
                     CharredEarthTimer = 20000;
                 } else 
-					CharredEarthTimer -= diff;
+                    CharredEarthTimer -= diff;
 
                 if (TailSweepTimer <= diff)
                 {
@@ -320,7 +320,7 @@ public:
                             DoCast(target, SPELL_TAIL_SWEEP);
                     TailSweepTimer = 15000;
                 } else 
-					TailSweepTimer -= diff;
+                    TailSweepTimer -= diff;
 
                 if (SearingCindersTimer <= diff)
                 {
@@ -328,7 +328,7 @@ public:
                         DoCast(target, SPELL_SEARING_CINDERS);
                     SearingCindersTimer = 10000;
                 } else 
-					SearingCindersTimer -= diff;
+                    SearingCindersTimer -= diff;
 
                 uint32 Prozent = uint32(me->GetHealthPct());
 
@@ -364,7 +364,7 @@ public:
                         RainBones = true;
                         SmokingBlastTimer = 20000;
                     } else 
-						RainofBonesTimer -= diff;
+                        RainofBonesTimer -= diff;
 
                     if (DistractingAshTimer <= diff)
                     {
@@ -372,7 +372,7 @@ public:
                             DoCast(target, SPELL_DISTRACTING_ASH);
                         DistractingAshTimer = 2000; //timer wrong
                     } else 
-						DistractingAshTimer -= diff;
+                        DistractingAshTimer -= diff;
                 }
 
                 if (RainBones)
@@ -382,7 +382,7 @@ public:
                         DoCastVictim(SPELL_SMOKING_BLAST);
                         SmokingBlastTimer = 1500; //timer wrong
                      } else 
-						 SmokingBlastTimer -= diff;
+                        SmokingBlastTimer -= diff;
                 }
 
                 if (FireballBarrageTimer <= diff)
@@ -391,7 +391,7 @@ public:
                         DoCast(target, SPELL_FIREBALL_BARRAGE);
                     FireballBarrageTimer = 20000;
                 } else 
-					FireballBarrageTimer -= diff;
+                    FireballBarrageTimer -= diff;
 
                 if (FlyTimer <= diff) //landing
                 {

--- a/src/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
@@ -295,20 +295,23 @@ public:
                 {
                     DoCastVictim(SPELL_BELLOWING_ROAR);
                     BellowingRoarTimer = urand(30000, 40000);
-                } else BellowingRoarTimer -= diff;
+                } else 
+					BellowingRoarTimer -= diff;
 
                 if (SmolderingBreathTimer <= diff)
                 {
                     DoCastVictim(SPELL_SMOLDERING_BREATH);
                     SmolderingBreathTimer = 20000;
-                } else SmolderingBreathTimer -= diff;
+                } else 
+					SmolderingBreathTimer -= diff;
 
                 if (CharredEarthTimer <= diff)
                 {
                     if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))
                         DoCast(target, SPELL_CHARRED_EARTH);
                     CharredEarthTimer = 20000;
-                } else CharredEarthTimer -= diff;
+                } else 
+					CharredEarthTimer -= diff;
 
                 if (TailSweepTimer <= diff)
                 {
@@ -316,14 +319,16 @@ public:
                         if (!me->HasInArc(M_PI, target))
                             DoCast(target, SPELL_TAIL_SWEEP);
                     TailSweepTimer = 15000;
-                } else TailSweepTimer -= diff;
+                } else 
+					TailSweepTimer -= diff;
 
                 if (SearingCindersTimer <= diff)
                 {
                     if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))
                         DoCast(target, SPELL_SEARING_CINDERS);
                     SearingCindersTimer = 10000;
-                } else SearingCindersTimer -= diff;
+                } else 
+					SearingCindersTimer -= diff;
 
                 uint32 Prozent = uint32(me->GetHealthPct());
 
@@ -358,14 +363,16 @@ public:
                         DoCastVictim(SPELL_RAIN_OF_BONES);
                         RainBones = true;
                         SmokingBlastTimer = 20000;
-                    } else RainofBonesTimer -= diff;
+                    } else 
+						RainofBonesTimer -= diff;
 
                     if (DistractingAshTimer <= diff)
                     {
                         if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))
                             DoCast(target, SPELL_DISTRACTING_ASH);
                         DistractingAshTimer = 2000; //timer wrong
-                    } else DistractingAshTimer -= diff;
+                    } else 
+						DistractingAshTimer -= diff;
                 }
 
                 if (RainBones)
@@ -374,7 +381,8 @@ public:
                      {
                         DoCastVictim(SPELL_SMOKING_BLAST);
                         SmokingBlastTimer = 1500; //timer wrong
-                     } else SmokingBlastTimer -= diff;
+                     } else 
+						 SmokingBlastTimer -= diff;
                 }
 
                 if (FireballBarrageTimer <= diff)
@@ -382,7 +390,8 @@ public:
                     if (Unit* target = SelectTarget(SELECT_TARGET_FARTHEST, 0))
                         DoCast(target, SPELL_FIREBALL_BARRAGE);
                     FireballBarrageTimer = 20000;
-                } else FireballBarrageTimer -= diff;
+                } else 
+					FireballBarrageTimer -= diff;
 
                 if (FlyTimer <= diff) //landing
                 {
@@ -392,7 +401,8 @@ public:
                     me->GetMotionMaster()->MovePoint(3, IntroWay[3][0], IntroWay[3][1], IntroWay[3][2]);
 
                     Flying = true;
-                } else FlyTimer -= diff;
+                } else 
+					FlyTimer -= diff;
             }
         }
     };

--- a/src/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
@@ -212,6 +212,7 @@ public:
         void Reset() override
         {
             Initialize();
+            
         }
 
         void KilledUnit(Unit* /*victim*/) override

--- a/src/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
@@ -2,27 +2,55 @@
 * Copyright (C) 2016+     AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license: http://github.com/azerothcore/azerothcore-wotlk/LICENSE-GPL2
 * Copyright (C) 2008-2016 TrinityCore <http://www.trinitycore.org/>
 * Copyright (C) 2005-2009 MaNGOS <http://getmangos.com/>
+* Rescripted By Lee (Talamortis)
 */
-
-/* ScriptData
-SDName: Boss_Prince_Malchezzar
-SD%Complete: 100
-SDComment:
-SDCategory: Karazhan
-EndScriptData */
 
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
 #include "karazhan.h"
 #include "SpellInfo.h"
 
-// 18 Coordinates for Infernal spawns
+
+enum PrinceSay
+{
+    SAY_AGGRO = 0,
+    SAY_AXE_TOSS1 = 1,
+    SAY_AXE_TOSS2 = 2,
+    SAY_SLAY = 6,
+    SAY_SUMMON = 7,
+    SAY_DEATH = 8,
+};
+
+enum Spells
+{
+    SPELL_ENFEEBLE = 30843,                       //Enfeeble during phase 1 and 2
+    SPELL_ENFEEBLE_EFFECT = 41624,
+    SPELL_SHADOWNOVA = 30852,                       //Shadownova used during all phases
+    SPELL_SW_PAIN = 30854,                       //Shadow word pain during phase 1 and 3 (different targeting rules though)
+    SPELL_THRASH_PASSIVE = 12787,                       //Extra attack chance during phase 2
+    SPELL_SUNDER_ARMOR = 30901,                       //Sunder armor during phase 2
+    SPELL_THRASH_AURA = 12787,                       //Passive proc chance for thrash
+    SPELL_EQUIP_AXES = 30857,                       //Visual for axe equiping
+    SPELL_AMPLIFY_DAMAGE = 39095,                       //Amplifiy during phase 3
+    SPELL_CLEAVE = 30131,                       //Same as Nightbane.
+    SPELL_HELLFIRE = 30859,                       //Infenals' hellfire aura
+};
+
+enum creatures
+{
+    NETHERSPITE_INFERNAL = 17646,
+    MALCHEZARS_AXE = 17650,
+    INFERNAL_MODEL_INVISIBLE = 11686,
+    SPELL_INFERNAL_RELAY =  33814,   // 30835,
+    EQUIP_ID_AXE = 33542
+};
+
 struct InfernalPoint
 {
     float x, y;
 };
 
-#define INFERNAL_Z  275.5f
+#define INFERNAL_Z 275.5f
 
 static InfernalPoint InfernalPoints[] =
 {
@@ -46,43 +74,6 @@ static InfernalPoint InfernalPoints[] =
     { -10935.7f, -1996.0f }
 };
 
-//Enfeeble is supposed to reduce hp to 1 and then heal player back to full when it ends
-//Along with reducing healing and regen while enfeebled to 0%
-//This spell effect will only reduce healing
-enum PrinceMalchezaar
-{
-    SAY_AGGRO = 0,
-    SAY_AXE_TOSS1 = 1,
-    SAY_AXE_TOSS2 = 2,
-    //  SAY_SPECIAL1                = 3, Not used, needs to be implemented, but I don't know where it should be used.
-    //  SAY_SPECIAL2                = 4, Not used, needs to be implemented, but I don't know where it should be used.
-    //  SAY_SPECIAL3                = 5, Not used, needs to be implemented, but I don't know where it should be used.
-    SAY_SLAY = 6,
-    SAY_SUMMON = 7,
-    SAY_DEATH = 8,
-
-    TOTAL_INFERNAL_POINTS = 18,
-
-    SPELL_ENFEEBLE = 30843,                       //Enfeeble during phase 1 and 2
-    SPELL_ENFEEBLE_EFFECT = 41624,
-
-    SPELL_SHADOWNOVA = 30852,                       //Shadownova used during all phases
-    SPELL_SW_PAIN = 30854,                       //Shadow word pain during phase 1 and 3 (different targeting rules though)
-    SPELL_THRASH_PASSIVE = 12787,                       //Extra attack chance during phase 2
-    SPELL_SUNDER_ARMOR = 30901,                       //Sunder armor during phase 2
-    SPELL_THRASH_AURA = 12787,                       //Passive proc chance for thrash
-    SPELL_EQUIP_AXES = 30857,                       //Visual for axe equiping
-    SPELL_AMPLIFY_DAMAGE = 39095,                       //Amplifiy during phase 3
-    SPELL_CLEAVE = 30131,                       //Same as Nightbane.
-    SPELL_HELLFIRE = 30859,                       //Infenals' hellfire aura
-    NETHERSPITE_INFERNAL = 17646,                       //The netherspite infernal creature
-    MALCHEZARS_AXE = 17650,                       //Malchezar's axes (creatures), summoned during phase 3
-
-    INFERNAL_MODEL_INVISIBLE = 11686,                       //Infernal Effects
-    SPELL_INFERNAL_RELAY = 30834,
-
-    EQUIP_ID_AXE = 33542                        //Axes info
-};
 
 //---------Infernal code first
 class netherspite_infernal : public CreatureScript
@@ -119,17 +110,18 @@ public:
                     DoCast(me, SPELL_HELLFIRE);
                     HellfireTimer = 0;
                 }
-                else HellfireTimer -= diff;
+                else 
+                    HellfireTimer -= diff;
             }
 
             if (CleanupTimer)
             {
                 if (CleanupTimer <= diff)
                 {
-                    Cleanup();
                     CleanupTimer = 0;
                 }
-                else CleanupTimer -= diff;
+                else 
+                    CleanupTimer -= diff;
             }
         }
 
@@ -156,17 +148,16 @@ public:
             if (!done_by || done_by->GetGUID() != malchezaar)
                 damage = 0;
         }
-
-        void Cleanup();
     };
 };
+
 
 class boss_malchezaar : public CreatureScript
 {
 public:
     boss_malchezaar() : CreatureScript("boss_malchezaar") { }
 
-    CreatureAI* GetAI(Creature* creature) const
+    CreatureAI* GetAI(Creature* creature) const override
     {
         return GetInstanceAI<boss_malchezaarAI>(creature);
     }
@@ -176,8 +167,8 @@ public:
         boss_malchezaarAI(Creature* creature) : ScriptedAI(creature)
         {
             instance = creature->GetInstanceScript();
-            memset(axes, 0, sizeof(axes));
         }
+
 
         InstanceScript* instance;
         uint32 EnfeebleTimer;
@@ -186,107 +177,69 @@ public:
         uint32 SWPainTimer;
         uint32 SunderArmorTimer;
         uint32 AmplifyDamageTimer;
-        uint32 Cleave_Timer;
         uint32 InfernalTimer;
-        uint32 AxesTargetSwitchTimer;
         uint32 InfernalCleanupTimer;
+        uint32 phase;
+        uint32 enfeeble_health[5];
+        uint64 enfeeble_targets[5];
 
         std::vector<uint64> infernals;
         std::vector<InfernalPoint*> positions;
 
-        uint64 axes[2];
-        uint64 enfeeble_targets[5];
-        uint32 enfeeble_health[5];
-
-        uint32 phase;
-
-        void Reset()
+        void Initialize()
         {
-            AxesCleanup();
-            ClearWeapons();
-            InfernalCleanup();
-            positions.clear();
-
-            for (uint8 i = 0; i < 5; ++i)
-            {
-                enfeeble_targets[i] = 0;
-                enfeeble_health[i] = 0;
-            }
-
-            for (uint8 i = 0; i < TOTAL_INFERNAL_POINTS; ++i)
-                positions.push_back(&InfernalPoints[i]);
-
             EnfeebleTimer = 30000;
             EnfeebleResetTimer = 38000;
             ShadowNovaTimer = 35500;
             SWPainTimer = 20000;
-            AmplifyDamageTimer = 5000;
-            Cleave_Timer = 8000;
-            InfernalTimer = 40000;
             InfernalCleanupTimer = 47000;
-            AxesTargetSwitchTimer = urand(7500, 20000);
+            AmplifyDamageTimer = 5000;
             SunderArmorTimer = urand(5000, 10000);
+            InfernalTimer = 40000;
             phase = 1;
-
+            clearweapons();
+            positions.clear();
             instance->HandleGameObject(instance->GetData64(DATA_GO_NETHER_DOOR), true);
+
         }
 
-        void KilledUnit(Unit* /*victim*/)
+        void clearweapons()
+        {
+            SetEquipmentSlots(false, EQUIP_UNEQUIP, EQUIP_UNEQUIP, EQUIP_NO_CHANGE);
+            me->SetCanDualWield(false);
+        }
+
+        void Reset() override
+        {
+            Initialize();
+        }
+
+        void KilledUnit(Unit* /*victim*/) override
         {
             Talk(SAY_SLAY);
         }
 
-        void JustDied(Unit* /*killer*/)
+        void JustDied(Unit* /*killer*/) override
         {
             Talk(SAY_DEATH);
-
-            AxesCleanup();
-            ClearWeapons();
-            InfernalCleanup();
-            positions.clear();
-
-            for (uint8 i = 0; i < TOTAL_INFERNAL_POINTS; ++i)
-                positions.push_back(&InfernalPoints[i]);
-
             instance->HandleGameObject(instance->GetData64(DATA_GO_NETHER_DOOR), true);
+            if (Creature*  Axe = me->FindNearestCreature(MALCHEZARS_AXE, 100.0f))
+            {
+                Axe->DespawnOrUnsummon();
+            }
+            
         }
 
-        void EnterCombat(Unit* /*who*/)
+        void EnterCombat(Unit* /*who*/) override
         {
             Talk(SAY_AGGRO);
-
-            instance->HandleGameObject(instance->GetData64(DATA_GO_NETHER_DOOR), false); // Open the door leading further in
+            DoZoneInCombat();
+            instance->HandleGameObject(instance->GetData64(DATA_GO_NETHER_DOOR), false);
         }
 
-        void InfernalCleanup()
+        void SummonAxes()
         {
-            //Infernal Cleanup
-            for (std::vector<uint64>::const_iterator itr = infernals.begin(); itr != infernals.end(); ++itr)
-                if (Unit* pInfernal = ObjectAccessor::GetUnit(*me, *itr))
-                    if (pInfernal->IsAlive())
-                    {
-                        pInfernal->SetVisible(false);
-                        pInfernal->setDeathState(JUST_DIED);
-                    }
-
-            infernals.clear();
-        }
-
-        void AxesCleanup()
-        {
-            for (uint8 i = 0; i < 2; ++i)
-            {
-                Unit* axe = ObjectAccessor::GetUnit(*me, axes[i]);
-                if (axe && axe->IsAlive())
-                    Unit::Kill(axe, axe);
-                axes[i] = 0;
-            }
-        }
-
-        void ClearWeapons()
-        {
-            SetEquipmentSlots(false, EQUIP_UNEQUIP, EQUIP_UNEQUIP, EQUIP_NO_CHANGE);
-            me->SetCanDualWield(false);
+            Creature* axe = me->SummonCreature(MALCHEZARS_AXE, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), 0, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 10000);
         }
 
         void EnfeebleHealthEffect()
@@ -320,7 +273,7 @@ public:
                     enfeeble_targets[i] = target->GetGUID();
                     enfeeble_health[i] = target->GetHealth();
 
-                    target->CastSpell(target, SPELL_ENFEEBLE, true, 0, 0, me->GetGUID());
+                    me->CastSpell(target, SPELL_ENFEEBLE, true, 0, 0, me->GetGUID());
                     target->SetHealth(1);
                 }
         }
@@ -337,38 +290,62 @@ public:
             }
         }
 
-        void SummonInfernal(const uint32 /*diff*/)
+        void SummonInfernal()
         {
-            InfernalPoint *point = NULL;
-            Position pos;
-            
-            if ((me->GetMapId() != 532) || positions.empty())
-                me->GetRandomNearPosition(pos, 60);
-            else
-            {
-                point = Trinity::Containers::SelectRandomContainerElement(positions);
-                pos.Relocate(point->x, point->y, INFERNAL_Z, frand(0.0f, float(M_PI * 2)));
-            }
+             InfernalPoint *point = 0;
+             Position pos;
 
-            Creature* infernal = me->SummonCreature(NETHERSPITE_INFERNAL, pos, TEMPSUMMON_TIMED_DESPAWN, 180000);
+             if ((me->GetMapId() == 532))
+             {
+                 me->GetRandomNearPosition(pos, 40.0);
+             }
+             else
+             {
+                 point = Trinity::Containers::SelectRandomContainerElement(positions);
+                 pos.Relocate(point->x, point->y, INFERNAL_Z, frand(0.0f, float(M_PI * 2)));
+                 
+             }
 
-            if (infernal)
-            {
-                
-                infernal->SetDisplayId(INFERNAL_MODEL_INVISIBLE);
-                infernal->setFaction(me->getFaction());
-                if (point)
-                    CAST_AI(netherspite_infernal::netherspite_infernalAI, infernal->AI())->point = point;
-                CAST_AI(netherspite_infernal::netherspite_infernalAI, infernal->AI())->malchezaar = me->GetGUID();
+             if (Creature*  RELAY = me->FindNearestCreature(NPC_RELAY, 100.0f))
+             {
+                 Creature* infernal = RELAY->SummonCreature(NETHERSPITE_INFERNAL, pos, TEMPSUMMON_TIMED_DESPAWN, 180000);
 
-                infernals.push_back(infernal->GetGUID());
-                DoCast(infernal, SPELL_INFERNAL_RELAY);
-            }
-
-            Talk(SAY_SUMMON);
+                 if (infernal)
+                 {
+                     infernal->SetDisplayId(INFERNAL_MODEL_INVISIBLE);
+                     infernal->setFaction(me->getFaction());
+                     infernals.push_back(infernal->GetGUID());
+                     infernal->SetControlled(true, UNIT_STATE_ROOT);
+                     RELAY->AI()->DoCast(infernal, SPELL_INFERNAL_RELAY);
+                 }
+             } 
+                Talk(SAY_SUMMON);
         }
 
-        void UpdateAI(uint32 diff)
+        void Phase2()
+        {
+            me->InterruptNonMeleeSpells(false);
+            phase = 2;
+            DoCast(me, SPELL_EQUIP_AXES);
+            Talk(SAY_AXE_TOSS1);
+            DoCast(me, SPELL_THRASH_AURA, true);
+            SetEquipmentSlots(false, EQUIP_ID_AXE, EQUIP_ID_AXE, EQUIP_NO_CHANGE);
+            me->SetCanDualWield(true);
+            me->SetAttackTime(OFF_ATTACK, (me->GetAttackTime(BASE_ATTACK) * 150) / 100);
+            SunderArmorTimer = urand(5000, 10000);
+        }
+
+        void Phase3()
+        {
+            me->RemoveAurasDueToSpell(SPELL_THRASH_AURA);
+            Talk(SAY_AXE_TOSS2);
+            phase = 3;
+            clearweapons();
+            SummonAxes();
+            AmplifyDamageTimer = urand(20000, 30000);
+        }
+
+        void UpdateAI(uint32 diff) override
         {
             if (!UpdateVictim())
                 return;
@@ -380,133 +357,12 @@ public:
             }
             else EnfeebleResetTimer -= diff;
 
-            if (me->HasUnitState(UNIT_STATE_STUNNED))      // While shifting to phase 2 malchezaar stuns himself
-                return;
-
-            if (me->GetUInt64Value(UNIT_FIELD_TARGET) != me->GetVictim()->GetGUID())
-                me->SetTarget(me->GetVictim()->GetGUID());
-
-            if (phase == 1)
-            {
-                if (HealthBelowPct(60))
-                {
-                    me->InterruptNonMeleeSpells(false);
-
-                    phase = 2;
-
-                    //animation
-                    DoCast(me, SPELL_EQUIP_AXES);
-
-                    //text
-                    Talk(SAY_AXE_TOSS1);
-
-                    //passive thrash aura
-                    DoCast(me, SPELL_THRASH_AURA, true);
-
-                    //models
-                    SetEquipmentSlots(false, EQUIP_ID_AXE, EQUIP_ID_AXE, EQUIP_NO_CHANGE);
-
-                    me->SetAttackTime(OFF_ATTACK, (me->GetAttackTime(BASE_ATTACK) * 150) / 100);
-                    me->SetCanDualWield(true);
-                }
-            }
-            else if (phase == 2)
-            {
-                if (HealthBelowPct(30))
-                {
-                    InfernalTimer = 15000;
-
-                    phase = 3;
-
-                    ClearWeapons();
-
-                    //remove thrash
-                    me->RemoveAurasDueToSpell(SPELL_THRASH_AURA);
-
-                    Talk(SAY_AXE_TOSS2);
-
-                    Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true);
-                    {
-                        Creature* axe = me->SummonCreature(MALCHEZARS_AXE, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), 0, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 1000);
-                        if (axe)
-                        {
-                            axe->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
-                            axe->setFaction(me->getFaction());
-                            axe->GetGUID();
-                            if (target)
-                            {
-                                axe->AI()->AttackStart(target);
-                                //axe->getThreatManager().tauntApply(target); //Taunt Apply and fade out does not work properly
-                                // So we'll use a hack to add a lot of threat to our target
-                                axe->AddThreat(target, 10000000.0f);
-                            }
-                        }
-                    }
-
-                    if (ShadowNovaTimer > 35000)
-                        ShadowNovaTimer = EnfeebleTimer + 5000;
-
-                    return;
-                }
-
-                if (SunderArmorTimer <= diff)
-                {
-                    DoCastVictim(SPELL_SUNDER_ARMOR);
-                    SunderArmorTimer = urand(10000, 18000);
-                }
-                else SunderArmorTimer -= diff;
-
-                if (Cleave_Timer <= diff)
-                {
-                    DoCastVictim(SPELL_CLEAVE);
-                    Cleave_Timer = urand(6000, 12000);
-                }
-                else Cleave_Timer -= diff;
-            }
-            else
-            {
-                if (AxesTargetSwitchTimer <= diff)
-                {
-                    AxesTargetSwitchTimer = urand(7500, 20000);
-
-                    if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))
-                    {
-                            if (Unit* axe = ObjectAccessor::GetUnit(*me, axes[0]))
-                            {
-                                if (axe->GetVictim())
-                                    DoModifyThreatPercent(axe->GetVictim(), -100);
-                                if (target)
-                                    axe->AddThreat(target, 1000000.0f);
-                                //axe->getThreatManager().tauntFadeOut(axe->GetVictim());
-                                //axe->getThreatManager().tauntApply(target);
-                            }
-                        }
-                }
-                else AxesTargetSwitchTimer -= diff;
-
-                if (AmplifyDamageTimer <= diff)
-                {
-                    if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))
-                        DoCast(target, SPELL_AMPLIFY_DAMAGE);
-                    AmplifyDamageTimer = urand(20000, 30000);
-                }
-                else AmplifyDamageTimer -= diff;
-            }
-
-            //Time for global and double timers
             if (InfernalTimer <= diff)
             {
-                SummonInfernal(diff);
+                SummonInfernal();
                 InfernalTimer = phase == 3 ? 14500 : 44500;    // 15 secs in phase 3, 45 otherwise
             }
             else InfernalTimer -= diff;
-
-            if (ShadowNovaTimer <= diff)
-            {
-                DoCastVictim(SPELL_SHADOWNOVA);
-                ShadowNovaTimer = phase == 3 ? 31000 : uint32(-1);
-            }
-            else ShadowNovaTimer -= diff;
 
             if (phase != 2)
             {
@@ -514,7 +370,7 @@ public:
                 {
                     Unit* target = NULL;
                     if (phase == 1)
-                        target = me->GetVictim();        // the tank
+                        target = me->GetVictim();                  // Target the Tank
                     else                                          // anyone but the tank
                         target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
 
@@ -523,7 +379,52 @@ public:
 
                     SWPainTimer = 20000;
                 }
-                else SWPainTimer -= diff;
+                else
+                    SWPainTimer -= diff;
+            }
+
+            if (ShadowNovaTimer <= diff)
+            {
+                DoCast(SPELL_SHADOWNOVA);
+                ShadowNovaTimer = 35500;
+            }
+            else
+                ShadowNovaTimer -= diff;
+
+            if (phase == 1)
+            {
+                if (HealthBelowPct(60))
+                {
+                    Phase2();
+            }
+
+            if (phase == 2)
+            {
+                if (SunderArmorTimer <= diff)
+                    DoCast(SPELL_SUNDER_ARMOR);
+                SunderArmorTimer = urand(5000, 10000);
+            }
+            else
+                SunderArmorTimer -= diff;
+
+                if (HealthBelowPct(30))
+                {
+                    Phase3();
+                }
+
+            }
+            if (phase == 3)
+            {
+                if (AmplifyDamageTimer <= diff)
+                {
+                    Unit* target = NULL;
+                    target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
+
+                    if (target)
+                        DoCast(target, SPELL_AMPLIFY_DAMAGE);
+                }
+                else
+                    AmplifyDamageTimer -= diff;
             }
 
             if (phase != 3)
@@ -538,56 +439,83 @@ public:
                 else EnfeebleTimer -= diff;
             }
 
-            if (phase == 2)
-                DoMeleeAttacksIfReady();
-            else
-                DoMeleeAttackIfReady();
+            DoMeleeAttackIfReady();
         }
 
-        void DoMeleeAttacksIfReady()
+    };
+};
+
+class prince_axes : public CreatureScript
+{
+public:
+    prince_axes() : CreatureScript("prince_axes") { }
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return GetInstanceAI<prince_axesAI>(creature);
+    }
+
+    struct prince_axesAI : public ScriptedAI
+    {
+
+        prince_axesAI(Creature* creature) : ScriptedAI(creature)
         {
-            if (me->IsWithinMeleeRange(me->GetVictim()) && !me->IsNonMeleeSpellCast(false))
+            Initialize();
+            instance = creature->GetInstanceScript();
+        }
+
+        uint32 AxesTargetSwitchTimer;
+        InstanceScript* instance;
+
+
+        void Initialize()
+        {
+            AxesTargetSwitchTimer = 7500;
+            me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
+            me->SetCanDualWield(true);
+        }
+
+        void Reset()
+        {
+        }
+
+        void EnterCombat(Unit* /*who*/) override
+        {
+            DoZoneInCombat();
+        }
+
+        void changetarget()
+        {
+            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))
             {
-                //Check for base attack
-                if (me->isAttackReady() && me->GetVictim())
-                {
-                    me->AttackerStateUpdate(me->GetVictim());
-                    me->resetAttackTimer();
-                }
-                //Check for offhand attack
-                if (me->isAttackReady(OFF_ATTACK) && me->GetVictim())
-                {
-                    me->AttackerStateUpdate(me->GetVictim(), OFF_ATTACK);
-                    me->resetAttackTimer(OFF_ATTACK);
-                }
+                if (me->GetVictim())
+                    DoModifyThreatPercent(me->GetVictim(), -100);
+                if (target)
+                    me->AddThreat(target, 1000000.0f);
             }
         }
 
-        void Cleanup(Creature* infernal, InfernalPoint *point)
+        void UpdateAI(uint32 diff) override
         {
-            for (std::vector<uint64>::iterator itr = infernals.begin(); itr != infernals.end(); ++itr)
-                if (*itr == infernal->GetGUID())
-                {
-                    infernals.erase(itr);
-                    break;
-                }
+            if (!UpdateVictim())
+                return;
 
-            positions.push_back(point);
+            if (AxesTargetSwitchTimer <= diff)
+            {
+                AxesTargetSwitchTimer = urand(7500, 20000);
+                changetarget();
+            }
+            else
+                AxesTargetSwitchTimer -= diff;
+
+            DoMeleeAttackIfReady();
         }
     };
 };
 
-void netherspite_infernal::netherspite_infernalAI::Cleanup()
-{
-    Creature* pMalchezaar = ObjectAccessor::GetCreature(*me, malchezaar);
-
-    if (pMalchezaar && pMalchezaar->IsAlive())
-        CAST_AI(boss_malchezaar::boss_malchezaarAI, pMalchezaar->AI())->Cleanup(me, point);
-    
-}
-
 void AddSC_boss_malchezaar()
 {
     new boss_malchezaar();
+    new prince_axes();
     new netherspite_infernal();
 }

--- a/src/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
@@ -23,17 +23,17 @@ enum PrinceSay
 
 enum Spells
 {
-    SPELL_ENFEEBLE = 30843,                       //Enfeeble during phase 1 and 2
+    SPELL_ENFEEBLE = 30843,                      //Enfeeble during phase 1 and 2
     SPELL_ENFEEBLE_EFFECT = 41624,
-    SPELL_SHADOWNOVA = 30852,                       //Shadownova used during all phases
+    SPELL_SHADOWNOVA = 30852,                    //Shadownova used during all phases
     SPELL_SW_PAIN = 30854,                       //Shadow word pain during phase 1 and 3 (different targeting rules though)
-    SPELL_THRASH_PASSIVE = 12787,                       //Extra attack chance during phase 2
-    SPELL_SUNDER_ARMOR = 30901,                       //Sunder armor during phase 2
-    SPELL_THRASH_AURA = 12787,                       //Passive proc chance for thrash
-    SPELL_EQUIP_AXES = 30857,                       //Visual for axe equiping
-    SPELL_AMPLIFY_DAMAGE = 39095,                       //Amplifiy during phase 3
-    SPELL_CLEAVE = 30131,                       //Same as Nightbane.
-    SPELL_HELLFIRE = 30859,                       //Infenals' hellfire aura
+    SPELL_THRASH_PASSIVE = 12787,                //Extra attack chance during phase 2
+    SPELL_SUNDER_ARMOR = 30901,                  //Sunder armor during phase 2
+    SPELL_THRASH_AURA = 12787,                   //Passive proc chance for thrash
+    SPELL_EQUIP_AXES = 30857,                    //Visual for axe equiping
+    SPELL_AMPLIFY_DAMAGE = 39095,                //Amplifiy during phase 3
+    SPELL_CLEAVE = 30131,                        //Same as Nightbane.
+    SPELL_HELLFIRE = 30859,                      //Infenals' hellfire aura
 };
 
 enum creatures
@@ -169,7 +169,6 @@ public:
             instance = creature->GetInstanceScript();
         }
 
-
         InstanceScript* instance;
         uint32 EnfeebleTimer;
         uint32 EnfeebleResetTimer;
@@ -304,7 +303,6 @@ public:
              {
                  point = Trinity::Containers::SelectRandomContainerElement(positions);
                  pos.Relocate(point->x, point->y, INFERNAL_Z, frand(0.0f, float(M_PI * 2)));
-                 
              }
 
              if (Creature*  RELAY = me->FindNearestCreature(NPC_RELAY, 100.0f))

--- a/src/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
@@ -403,8 +403,7 @@ public:
 
                 if (ElementalOne)
                 {
-                    Unit* target = NULL;
-                    target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
+                    Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
                     if (!target)
                         return;
 
@@ -419,8 +418,7 @@ public:
 
                 if (ElementalTwo)
                 {
-                    Unit* target = NULL;
-                    target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
+                    Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
                     if (!target)
                         return;
 
@@ -435,8 +433,7 @@ public:
 
                 if (ElementalThree)
                 {
-                    Unit* target = NULL;
-                    target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
+                    Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
                     if (!target)
                         return;
 
@@ -451,8 +448,7 @@ public:
 
                 if (ElementalFour)
                 {
-                    Unit* target = NULL;
-                    target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
+                    UnUnit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
                     if (!target)
                         return;
 

--- a/src/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
@@ -192,7 +192,8 @@ public:
                     instance->HandleGameObject(instance->GetData64(DATA_GO_LIBRARY_DOOR), false);
                     CloseDoorTimer = 0;
                 }
-                else CloseDoorTimer -= diff;
+                else 
+					CloseDoorTimer -= diff;
             }
 
             //Cooldowns for casts
@@ -200,21 +201,24 @@ public:
             {
                 if (ArcaneCooldown >= diff)
                     ArcaneCooldown -= diff;
-                else ArcaneCooldown = 0;
+                else 
+					ArcaneCooldown = 0;
             }
 
             if (FireCooldown)
             {
                 if (FireCooldown >= diff)
                     FireCooldown -= diff;
-                else FireCooldown = 0;
+                else 
+					FireCooldown = 0;
             }
 
             if (FrostCooldown)
             {
                 if (FrostCooldown >= diff)
                     FrostCooldown -= diff;
-                else FrostCooldown = 0;
+                else 
+					FrostCooldown = 0;
             }
 
             if (!Drinking && me->GetMaxPower(POWER_MANA) && (me->GetPower(POWER_MANA) * 100 / me->GetMaxPower(POWER_MANA)) < 20)
@@ -301,7 +305,8 @@ public:
                 }
                 NormalCastTimer = 1000;
             }
-            else NormalCastTimer -= diff;
+            else 
+				NormalCastTimer -= diff;
 
             if (SecondarySpellTimer <= diff)
             {
@@ -317,7 +322,8 @@ public:
                 }
                 SecondarySpellTimer = urand(5000, 20000);
             }
-            else SecondarySpellTimer -= diff;
+            else 
+				SecondarySpellTimer -= diff;
 
             if (SuperCastTimer <= diff)
             {
@@ -472,14 +478,16 @@ public:
 
                 BerserkTimer = 60000;
             }
-            else BerserkTimer -= diff;
+            else 
+				BerserkTimer -= diff;
 
             //Flame Wreath check
             if (FlameWreathTimer)
             {
                 if (FlameWreathTimer >= diff)
                     FlameWreathTimer -= diff;
-                else FlameWreathTimer = 0;
+                else 
+					FlameWreathTimer = 0;
 
                 if (FlameWreathCheckTime <= diff)
                 {
@@ -498,7 +506,8 @@ public:
                     }
                     FlameWreathCheckTime = 500;
                 }
-                else FlameWreathCheckTime -= diff;
+                else 
+					FlameWreathCheckTime -= diff;
             }
 
             if (ArcaneCooldown && FireCooldown && FrostCooldown)

--- a/src/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
@@ -403,13 +403,14 @@ public:
 
                 if (ElementalOne)
                 {
-                    Unit* pTarget = (SELECT_TARGET_RANDOM, 0);
-                    if (!pTarget)
+                    Unit* target = NULL;
+                    target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
+                    if (!target)
                         return;
 
-                    DoStartNoMovement(pTarget);
+                    DoStartNoMovement(target);
                     ElementalOne->SetInCombatWithZone();
-                    ElementalOne->CombatStart(pTarget);
+                    ElementalOne->CombatStart(target);
                     ElementalOne->setFaction(me->getFaction());
                     ElementalTwo->SetUnitMovementFlags(MOVEMENTFLAG_ROOT);
                     ElementalOne->ApplySpellImmune(0, IMMUNITY_SCHOOL, SPELL_SCHOOL_MASK_FROST, true);
@@ -418,13 +419,14 @@ public:
 
                 if (ElementalTwo)
                 {
-                    Unit* pTarget = (SELECT_TARGET_RANDOM, 0);
-                    if (!pTarget)
+                    Unit* target = NULL;
+                    target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
+                    if (!target)
                         return;
 
-                    DoStartNoMovement(pTarget);
+                    DoStartNoMovement(target);
                     ElementalTwo->SetInCombatWithZone();
-                    ElementalTwo->CombatStart(pTarget);
+                    ElementalTwo->CombatStart(target);
                     ElementalTwo->setFaction(me->getFaction());
                     ElementalTwo->SetUnitMovementFlags(MOVEMENTFLAG_ROOT);
                     ElementalTwo->ApplySpellImmune(0, IMMUNITY_SCHOOL, SPELL_SCHOOL_MASK_FROST, true);
@@ -433,13 +435,14 @@ public:
 
                 if (ElementalThree)
                 {
-                    Unit* pTarget = (SELECT_TARGET_RANDOM, 0);
-                    if (!pTarget)
+                    Unit* target = NULL;
+                    target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
+                    if (!target)
                         return;
 
-                    DoStartNoMovement(pTarget);
+                    DoStartNoMovement(target);
                     ElementalThree->SetInCombatWithZone();
-                    ElementalThree->CombatStart(pTarget);
+                    ElementalThree->CombatStart(target);
                     ElementalThree->setFaction(me->getFaction());
                     ElementalTwo->SetUnitMovementFlags(MOVEMENTFLAG_ROOT);
                     ElementalThree->ApplySpellImmune(0, IMMUNITY_SCHOOL, SPELL_SCHOOL_MASK_FROST, true);
@@ -448,13 +451,14 @@ public:
 
                 if (ElementalFour)
                 {
-                    Unit* pTarget = (SELECT_TARGET_RANDOM, 0);
-                    if (!pTarget)
+                    Unit* target = NULL;
+                    target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
+                    if (!target)
                         return;
 
-                    DoStartNoMovement(pTarget);
+                    DoStartNoMovement(target);
                     ElementalFour->SetInCombatWithZone();
-                    ElementalFour->CombatStart(pTarget);
+                    ElementalFour->CombatStart(target);
                     ElementalFour->setFaction(me->getFaction());
                     ElementalTwo->SetUnitMovementFlags(MOVEMENTFLAG_ROOT);
                     ElementalFour->ApplySpellImmune(0, IMMUNITY_SCHOOL, SPELL_SCHOOL_MASK_FROST, true);

--- a/src/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
@@ -448,7 +448,7 @@ public:
 
                 if (ElementalFour)
                 {
-                    UnUnit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
+                    Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
                     if (!target)
                         return;
 

--- a/src/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
@@ -193,7 +193,7 @@ public:
                     CloseDoorTimer = 0;
                 }
                 else 
-					CloseDoorTimer -= diff;
+                    CloseDoorTimer -= diff;
             }
 
             //Cooldowns for casts
@@ -202,7 +202,7 @@ public:
                 if (ArcaneCooldown >= diff)
                     ArcaneCooldown -= diff;
                 else 
-					ArcaneCooldown = 0;
+                    ArcaneCooldown = 0;
             }
 
             if (FireCooldown)
@@ -210,7 +210,7 @@ public:
                 if (FireCooldown >= diff)
                     FireCooldown -= diff;
                 else 
-					FireCooldown = 0;
+                    FireCooldown = 0;
             }
 
             if (FrostCooldown)
@@ -218,7 +218,7 @@ public:
                 if (FrostCooldown >= diff)
                     FrostCooldown -= diff;
                 else 
-					FrostCooldown = 0;
+                    FrostCooldown = 0;
             }
 
             if (!Drinking && me->GetMaxPower(POWER_MANA) && (me->GetPower(POWER_MANA) * 100 / me->GetMaxPower(POWER_MANA)) < 20)
@@ -306,7 +306,7 @@ public:
                 NormalCastTimer = 1000;
             }
             else 
-				NormalCastTimer -= diff;
+                NormalCastTimer -= diff;
 
             if (SecondarySpellTimer <= diff)
             {
@@ -323,7 +323,7 @@ public:
                 SecondarySpellTimer = urand(5000, 20000);
             }
             else 
-				SecondarySpellTimer -= diff;
+                SecondarySpellTimer -= diff;
 
             if (SuperCastTimer <= diff)
             {
@@ -384,7 +384,8 @@ public:
 
                 SuperCastTimer = urand(35000, 40000);
             }
-            else SuperCastTimer -= diff;
+            else 
+                SuperCastTimer -= diff;
 
             if (!ElementalsSpawned && HealthBelowPct(40))
             {
@@ -479,7 +480,7 @@ public:
                 BerserkTimer = 60000;
             }
             else 
-				BerserkTimer -= diff;
+                BerserkTimer -= diff;
 
             //Flame Wreath check
             if (FlameWreathTimer)
@@ -487,7 +488,7 @@ public:
                 if (FlameWreathTimer >= diff)
                     FlameWreathTimer -= diff;
                 else 
-					FlameWreathTimer = 0;
+                    FlameWreathTimer = 0;
 
                 if (FlameWreathCheckTime <= diff)
                 {
@@ -507,7 +508,7 @@ public:
                     FlameWreathCheckTime = 500;
                 }
                 else 
-					FlameWreathCheckTime -= diff;
+                    FlameWreathCheckTime -= diff;
             }
 
             if (ArcaneCooldown && FireCooldown && FrostCooldown)
@@ -585,7 +586,8 @@ public:
                 DoCastVictim(SPELL_WATERBOLT);
                 CastTimer = urand(2000, 5000);
             }
-            else CastTimer -= diff;
+            else
+                CastTimer -= diff;
         }
     };
 };

--- a/src/scripts/EasternKingdoms/Karazhan/boss_terestian_illhoof.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_terestian_illhoof.cpp
@@ -303,7 +303,7 @@ public:
                 }
             }
             else 
-				DoCast(me, SPELL_SUMMON_IMP, true);
+                DoCast(me, SPELL_SUMMON_IMP, true);
         }
 
         void EnterCombat(Unit* /*who*/)

--- a/src/scripts/EasternKingdoms/Karazhan/boss_terestian_illhoof.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_terestian_illhoof.cpp
@@ -109,7 +109,7 @@ public:
 
                 AmplifyTimer = urand(10000, 20000);
             } else 
-				AmplifyTimer -= diff;
+                AmplifyTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -224,7 +224,7 @@ public:
                 DoCastVictim(SPELL_FIREBOLT);
                 FireboltTimer = 2200;
             } else 
-				FireboltTimer -= diff;
+                FireboltTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -370,7 +370,7 @@ public:
                 me->RemoveAura(SPELL_BROKEN_PACT);
             }
             else 
-				SummonKilrekTimer -= diff;
+                SummonKilrekTimer -= diff;
          
             if (SacrificeTimer <= diff)
             {
@@ -390,14 +390,14 @@ public:
                     }
                 }
             } else 
-				SacrificeTimer -= diff;
+                SacrificeTimer -= diff;
 
             if (ShadowboltTimer <= diff)
             {
                 DoCast(SelectTarget(SELECT_TARGET_TOPAGGRO, 0), SPELL_SHADOW_BOLT);
                 ShadowboltTimer = 10000;
             } else 
-				ShadowboltTimer -= diff;
+                ShadowboltTimer -= diff;
 
             if (SummonTimer <= diff)
             {
@@ -414,7 +414,7 @@ public:
                     SummonTimer = 5000;
                 }
             } else 
-				SummonTimer -= diff;
+                SummonTimer -= diff;
 
             if (!Berserk)
             {
@@ -423,7 +423,7 @@ public:
                     DoCast(me, SPELL_BERSERK);
                     Berserk = true;
                 } else 
-					BerserkTimer -= diff;
+                    BerserkTimer -= diff;
             }
 
             DoMeleeAttackIfReady();

--- a/src/scripts/EasternKingdoms/Karazhan/boss_terestian_illhoof.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/boss_terestian_illhoof.cpp
@@ -108,7 +108,8 @@ public:
                 DoCastVictim(SPELL_AMPLIFY_FLAMES);
 
                 AmplifyTimer = urand(10000, 20000);
-            } else AmplifyTimer -= diff;
+            } else 
+				AmplifyTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -222,7 +223,8 @@ public:
             {
                 DoCastVictim(SPELL_FIREBOLT);
                 FireboltTimer = 2200;
-            } else FireboltTimer -= diff;
+            } else 
+				FireboltTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -300,7 +302,8 @@ public:
                     DoCast(me, SPELL_SUMMON_IMP, true);
                 }
             }
-            else DoCast(me, SPELL_SUMMON_IMP, true);
+            else 
+				DoCast(me, SPELL_SUMMON_IMP, true);
         }
 
         void EnterCombat(Unit* /*who*/)
@@ -366,7 +369,8 @@ public:
                 DoCast(me, SPELL_SUMMON_IMP, true);
                 me->RemoveAura(SPELL_BROKEN_PACT);
             }
-            else SummonKilrekTimer -= diff;
+            else 
+				SummonKilrekTimer -= diff;
          
             if (SacrificeTimer <= diff)
             {
@@ -385,13 +389,15 @@ public:
                         SacrificeTimer = 30000;
                     }
                 }
-            } else SacrificeTimer -= diff;
+            } else 
+				SacrificeTimer -= diff;
 
             if (ShadowboltTimer <= diff)
             {
                 DoCast(SelectTarget(SELECT_TARGET_TOPAGGRO, 0), SPELL_SHADOW_BOLT);
                 ShadowboltTimer = 10000;
-            } else ShadowboltTimer -= diff;
+            } else 
+				ShadowboltTimer -= diff;
 
             if (SummonTimer <= diff)
             {
@@ -407,7 +413,8 @@ public:
                         pPortal->CastSpell(me->GetVictim(), SPELL_SUMMON_FIENDISIMP, false);
                     SummonTimer = 5000;
                 }
-            } else SummonTimer -= diff;
+            } else 
+				SummonTimer -= diff;
 
             if (!Berserk)
             {
@@ -415,7 +422,8 @@ public:
                 {
                     DoCast(me, SPELL_BERSERK);
                     Berserk = true;
-                } else BerserkTimer -= diff;
+                } else 
+					BerserkTimer -= diff;
             }
 
             DoMeleeAttackIfReady();

--- a/src/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -203,19 +203,22 @@ public:
             {
                 DoCast(SelectTarget(SELECT_TARGET_RANDOM, 0), SPELL_WATERBOLT);
                 WaterBoltTimer = TitoDied ? 1500 : 5000;
-            } else WaterBoltTimer -= diff;
+            } else 
+				WaterBoltTimer -= diff;
 
             if (FearTimer <= diff)
             {
                 DoCastVictim(SPELL_SCREAM);
                 FearTimer = 30000;
-            } else FearTimer -= diff;
+            } else 
+				FearTimer -= diff;
 
             if (!SummonedTito)
             {
                 if (SummonTitoTimer <= diff)
                     SummonTito();
-                else SummonTitoTimer -= diff;
+                else 
+					SummonTitoTimer -= diff;
             }
 
             DoMeleeAttackIfReady();
@@ -273,7 +276,8 @@ public:
             {
                 DoCastVictim(SPELL_YIPPING);
                 YipTimer = 10000;
-            } else YipTimer -= diff;
+            } else 
+				YipTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -393,14 +397,16 @@ public:
             {
                 DoCastVictim(SPELL_BRAIN_BASH);
                 BrainBashTimer = 15000;
-            } else BrainBashTimer -= diff;
+            } else 
+				BrainBashTimer -= diff;
 
             if (BrainWipeTimer <= diff)
             {
                 if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))
                     DoCast(target, SPELL_BRAIN_WIPE);
                 BrainWipeTimer = 20000;
-            } else BrainWipeTimer -= diff;
+            } else 
+				BrainWipeTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -489,7 +495,8 @@ public:
                 {
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     AggroTimer = 0;
-                } else AggroTimer -= diff;
+                } else 
+					AggroTimer -= diff;
             }
 
             if (!UpdateVictim())
@@ -499,7 +506,8 @@ public:
             {
                 DoCastVictim(SPELL_CLEAVE);
                 CleaveTimer = 5000;
-            } else CleaveTimer -= diff;
+            } else 
+				CleaveTimer -= diff;
 
             if (RustCount < 8)
             {
@@ -509,7 +517,8 @@ public:
                     Talk(EMOTE_RUST);
                     DoCast(me, SPELL_RUST);
                     RustTimer = 6000;
-                } else RustTimer -= diff;
+                } else 
+					RustTimer -= diff;
             }
 
             DoMeleeAttackIfReady();
@@ -597,7 +606,8 @@ public:
                 {
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     AggroTimer = 0;
-                } else AggroTimer -= diff;
+                } else 
+					AggroTimer -= diff;
             }
 
             if (!UpdateVictim())
@@ -607,19 +617,22 @@ public:
             {
                 DoCastVictim(SPELL_MANGLE);
                 MangleTimer = urand(5000, 8000);
-            } else MangleTimer -= diff;
+            } else 
+				MangleTimer -= diff;
 
             if (ShredTimer <= diff)
             {
                 DoCastVictim(SPELL_SHRED);
                 ShredTimer = urand(10000, 15000);
-            } else ShredTimer -= diff;
+            } else 
+				ShredTimer -= diff;
 
             if (ScreamTimer <= diff)
             {
                 DoCastVictim(SPELL_FRIGHTENED_SCREAM);
                 ScreamTimer = urand(20000, 30000);
-            } else ScreamTimer -= diff;
+            } else 
+				ScreamTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -695,13 +708,15 @@ public:
                 if (Creature* Cyclone = DoSpawnCreature(CREATURE_CYCLONE, float(urand(0, 9)), float(urand(0, 9)), 0, 0, TEMPSUMMON_TIMED_DESPAWN, 15000))
                     Cyclone->CastSpell(Cyclone, SPELL_CYCLONE_VISUAL, true);
                 CycloneTimer = 22000;
-            } else CycloneTimer -= diff;
+            } else 
+				CycloneTimer -= diff;
 
             if (ChainLightningTimer <= diff)
             {
                 DoCastVictim(SPELL_CHAIN_LIGHTNING);
                 ChainLightningTimer = 8000;
-            } else ChainLightningTimer -= diff;
+            } else 
+				ChainLightningTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -746,8 +761,9 @@ public:
                 Position pos;
                 me->GetRandomNearPosition(pos, 10);
                 me->GetMotionMaster()->MovePoint(0, pos);
-                MoveTimer = urand(3.000, 5000);
-            } else MoveTimer -= diff;
+                MoveTimer = urand(3000, 5000);
+            } else 
+				MoveTimer -= diff;
         }
     };
 };
@@ -909,7 +925,8 @@ public:
 
                     ChaseTimer = 40000;
                 }
-            } else ChaseTimer -= diff;
+            } else 
+				ChaseTimer -= diff;
 
             if (IsChasing)
                 return;
@@ -918,13 +935,15 @@ public:
             {
                 DoCastVictim(SPELL_TERRIFYING_HOWL);
                 FearTimer = urand(25000, 35000);
-            } else FearTimer -= diff;
+            } else 
+				FearTimer -= diff;
 
             if (SwipeTimer <= diff)
             {
                 DoCastVictim(SPELL_WIDE_SWIPE);
                 SwipeTimer = urand(25000, 30000);
-            } else SwipeTimer -= diff;
+            } else 
+				SwipeTimer -= diff;
         }
     };
 };
@@ -1293,7 +1312,8 @@ public:
                         JulianneDead = false;
                         ResurrectTimer = 10000;
                     }
-                } else ResurrectTimer -= diff;
+                } else 
+					ResurrectTimer -= diff;
             }
 
             if (BackwardLungeTimer <= diff)
@@ -1304,26 +1324,30 @@ public:
                     DoCast(target, SPELL_BACKWARD_LUNGE);
                     BackwardLungeTimer = urand(15000, 30000);
                 }
-            } else BackwardLungeTimer -= diff;
+            } else 
+				BackwardLungeTimer -= diff;
 
             if (DaringTimer <= diff)
             {
                 DoCast(me, SPELL_DARING);
                 DaringTimer = urand(20000, 40000);
-            } else DaringTimer -= diff;
+            } else 
+				DaringTimer -= diff;
 
             if (DeadlySwatheTimer <= diff)
             {
                 if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))
                     DoCast(target, SPELL_DEADLY_SWATHE);
                 DeadlySwatheTimer = urand(15000, 25000);
-            } else DeadlySwatheTimer -= diff;
+            } else 
+				DeadlySwatheTimer -= diff;
 
             if (PoisonThrustTimer <= diff)
             {
                 DoCastVictim(SPELL_POISON_THRUST);
                 PoisonThrustTimer = urand(10000, 20000);
-            } else PoisonThrustTimer -= diff;
+            } else 
+				PoisonThrustTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -1338,7 +1362,8 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
         {
             Talk(SAY_JULIANNE_ENTER);
             EntryYellTimer = 0;
-        } else EntryYellTimer -= diff;
+        } else 
+			EntryYellTimer -= diff;
     }
 
     if (AggroYellTimer)
@@ -1349,7 +1374,8 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
             me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
             me->setFaction(16);
             AggroYellTimer = 0;
-        } else AggroYellTimer -= diff;
+        } else 
+			AggroYellTimer -= diff;
     }
 
     if (DrinkPoisonTimer)
@@ -1361,7 +1387,8 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
             Phase = PHASE_ROMULO;
             SummonRomuloTimer = 10000;
             DrinkPoisonTimer = 0;
-        } else DrinkPoisonTimer -= diff;
+        } else 
+			DrinkPoisonTimer -= diff;
     }
 
     if (Phase == PHASE_ROMULO && !SummonedRomulo)
@@ -1378,7 +1405,8 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
                 pRomulo->setFaction(16);
             }
             SummonedRomulo = true;
-        } else SummonRomuloTimer -= diff;
+        } else 
+			SummonRomuloTimer -= diff;
     }
 
     if (ResurrectSelfTimer)
@@ -1394,7 +1422,8 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
 
             ResurrectSelfTimer = 0;
             ResurrectTimer = 1000;
-        } else ResurrectSelfTimer -= diff;
+        } else 
+			ResurrectSelfTimer -= diff;
     }
 
     if (!UpdateVictim() || IsFakingDeath)
@@ -1413,7 +1442,8 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
                 RomuloDead = false;
                 ResurrectTimer = 10000;
             }
-        } else ResurrectTimer -= diff;
+        } else 
+			ResurrectTimer -= diff;
     }
 
     if (BlindingPassionTimer <= diff)
@@ -1421,19 +1451,22 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
         if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))
             DoCast(target, SPELL_BLINDING_PASSION);
         BlindingPassionTimer = urand(30000, 45000);
-    } else BlindingPassionTimer -= diff;
+    } else 
+		BlindingPassionTimer -= diff;
 
     if (DevotionTimer <= diff)
     {
         DoCast(me, SPELL_DEVOTION);
         DevotionTimer = urand(15000, 45000);
-    } else DevotionTimer -= diff;
+    } else 
+		DevotionTimer -= diff;
 
     if (PowerfulAttractionTimer <= diff)
     {
         DoCast(SelectTarget(SELECT_TARGET_RANDOM, 0), SPELL_POWERFUL_ATTRACTION);
         PowerfulAttractionTimer = urand(5000, 30000);
-    } else PowerfulAttractionTimer -= diff;
+    } else 
+		PowerfulAttractionTimer -= diff;
 
     if (EternalAffectionTimer <= diff)
     {
@@ -1445,7 +1478,8 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
         } else DoCast(me, SPELL_ETERNAL_AFFECTION);
 
         EternalAffectionTimer = urand(45000, 60000);
-    } else EternalAffectionTimer -= diff;
+    } else 
+		EternalAffectionTimer -= diff;
 
     DoMeleeAttackIfReady();
 }

--- a/src/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -193,7 +193,8 @@ public:
                 {
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     AggroTimer = 0;
-                } else AggroTimer -= diff;
+                } else 
+                    AggroTimer -= diff;
             }
 
             if (!UpdateVictim())
@@ -204,21 +205,21 @@ public:
                 DoCast(SelectTarget(SELECT_TARGET_RANDOM, 0), SPELL_WATERBOLT);
                 WaterBoltTimer = TitoDied ? 1500 : 5000;
             } else 
-				WaterBoltTimer -= diff;
+                WaterBoltTimer -= diff;
 
             if (FearTimer <= diff)
             {
                 DoCastVictim(SPELL_SCREAM);
                 FearTimer = 30000;
             } else 
-				FearTimer -= diff;
+                FearTimer -= diff;
 
             if (!SummonedTito)
             {
                 if (SummonTitoTimer <= diff)
                     SummonTito();
                 else 
-					SummonTitoTimer -= diff;
+                    SummonTitoTimer -= diff;
             }
 
             DoMeleeAttackIfReady();
@@ -277,7 +278,7 @@ public:
                 DoCastVictim(SPELL_YIPPING);
                 YipTimer = 10000;
             } else 
-				YipTimer -= diff;
+                YipTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -387,7 +388,8 @@ public:
                 {
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     AggroTimer = 0;
-                } else AggroTimer -= diff;
+                } else 
+                    AggroTimer -= diff;
             }
 
             if (!UpdateVictim())
@@ -398,7 +400,7 @@ public:
                 DoCastVictim(SPELL_BRAIN_BASH);
                 BrainBashTimer = 15000;
             } else 
-				BrainBashTimer -= diff;
+                BrainBashTimer -= diff;
 
             if (BrainWipeTimer <= diff)
             {
@@ -406,7 +408,7 @@ public:
                     DoCast(target, SPELL_BRAIN_WIPE);
                 BrainWipeTimer = 20000;
             } else 
-				BrainWipeTimer -= diff;
+                BrainWipeTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -496,7 +498,7 @@ public:
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     AggroTimer = 0;
                 } else 
-					AggroTimer -= diff;
+                    AggroTimer -= diff;
             }
 
             if (!UpdateVictim())
@@ -507,7 +509,7 @@ public:
                 DoCastVictim(SPELL_CLEAVE);
                 CleaveTimer = 5000;
             } else 
-				CleaveTimer -= diff;
+                CleaveTimer -= diff;
 
             if (RustCount < 8)
             {
@@ -518,7 +520,7 @@ public:
                     DoCast(me, SPELL_RUST);
                     RustTimer = 6000;
                 } else 
-					RustTimer -= diff;
+                    RustTimer -= diff;
             }
 
             DoMeleeAttackIfReady();
@@ -607,7 +609,7 @@ public:
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     AggroTimer = 0;
                 } else 
-					AggroTimer -= diff;
+                    AggroTimer -= diff;
             }
 
             if (!UpdateVictim())
@@ -618,21 +620,21 @@ public:
                 DoCastVictim(SPELL_MANGLE);
                 MangleTimer = urand(5000, 8000);
             } else 
-				MangleTimer -= diff;
+                MangleTimer -= diff;
 
             if (ShredTimer <= diff)
             {
                 DoCastVictim(SPELL_SHRED);
                 ShredTimer = urand(10000, 15000);
             } else 
-				ShredTimer -= diff;
+                ShredTimer -= diff;
 
             if (ScreamTimer <= diff)
             {
                 DoCastVictim(SPELL_FRIGHTENED_SCREAM);
                 ScreamTimer = urand(20000, 30000);
             } else 
-				ScreamTimer -= diff;
+                ScreamTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -709,14 +711,14 @@ public:
                     Cyclone->CastSpell(Cyclone, SPELL_CYCLONE_VISUAL, true);
                 CycloneTimer = 22000;
             } else 
-				CycloneTimer -= diff;
+                CycloneTimer -= diff;
 
             if (ChainLightningTimer <= diff)
             {
                 DoCastVictim(SPELL_CHAIN_LIGHTNING);
                 ChainLightningTimer = 8000;
             } else 
-				ChainLightningTimer -= diff;
+                ChainLightningTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -763,7 +765,7 @@ public:
                 me->GetMotionMaster()->MovePoint(0, pos);
                 MoveTimer = urand(3000, 5000);
             } else 
-				MoveTimer -= diff;
+                MoveTimer -= diff;
         }
     };
 };
@@ -926,7 +928,7 @@ public:
                     ChaseTimer = 40000;
                 }
             } else 
-				ChaseTimer -= diff;
+                ChaseTimer -= diff;
 
             if (IsChasing)
                 return;
@@ -936,14 +938,14 @@ public:
                 DoCastVictim(SPELL_TERRIFYING_HOWL);
                 FearTimer = urand(25000, 35000);
             } else 
-				FearTimer -= diff;
+                FearTimer -= diff;
 
             if (SwipeTimer <= diff)
             {
                 DoCastVictim(SPELL_WIDE_SWIPE);
                 SwipeTimer = urand(25000, 30000);
             } else 
-				SwipeTimer -= diff;
+                SwipeTimer -= diff;
         }
     };
 };
@@ -1313,7 +1315,7 @@ public:
                         ResurrectTimer = 10000;
                     }
                 } else 
-					ResurrectTimer -= diff;
+                    ResurrectTimer -= diff;
             }
 
             if (BackwardLungeTimer <= diff)
@@ -1325,14 +1327,14 @@ public:
                     BackwardLungeTimer = urand(15000, 30000);
                 }
             } else 
-				BackwardLungeTimer -= diff;
+                BackwardLungeTimer -= diff;
 
             if (DaringTimer <= diff)
             {
                 DoCast(me, SPELL_DARING);
                 DaringTimer = urand(20000, 40000);
             } else 
-				DaringTimer -= diff;
+                DaringTimer -= diff;
 
             if (DeadlySwatheTimer <= diff)
             {
@@ -1340,14 +1342,14 @@ public:
                     DoCast(target, SPELL_DEADLY_SWATHE);
                 DeadlySwatheTimer = urand(15000, 25000);
             } else 
-				DeadlySwatheTimer -= diff;
+                DeadlySwatheTimer -= diff;
 
             if (PoisonThrustTimer <= diff)
             {
                 DoCastVictim(SPELL_POISON_THRUST);
                 PoisonThrustTimer = urand(10000, 20000);
             } else 
-				PoisonThrustTimer -= diff;
+                PoisonThrustTimer -= diff;
 
             DoMeleeAttackIfReady();
         }
@@ -1363,7 +1365,7 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
             Talk(SAY_JULIANNE_ENTER);
             EntryYellTimer = 0;
         } else 
-			EntryYellTimer -= diff;
+            EntryYellTimer -= diff;
     }
 
     if (AggroYellTimer)
@@ -1375,7 +1377,7 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
             me->setFaction(16);
             AggroYellTimer = 0;
         } else 
-			AggroYellTimer -= diff;
+            AggroYellTimer -= diff;
     }
 
     if (DrinkPoisonTimer)
@@ -1388,7 +1390,7 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
             SummonRomuloTimer = 10000;
             DrinkPoisonTimer = 0;
         } else 
-			DrinkPoisonTimer -= diff;
+            DrinkPoisonTimer -= diff;
     }
 
     if (Phase == PHASE_ROMULO && !SummonedRomulo)
@@ -1406,7 +1408,7 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
             }
             SummonedRomulo = true;
         } else 
-			SummonRomuloTimer -= diff;
+            SummonRomuloTimer -= diff;
     }
 
     if (ResurrectSelfTimer)
@@ -1423,7 +1425,7 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
             ResurrectSelfTimer = 0;
             ResurrectTimer = 1000;
         } else 
-			ResurrectSelfTimer -= diff;
+            ResurrectSelfTimer -= diff;
     }
 
     if (!UpdateVictim() || IsFakingDeath)
@@ -1443,7 +1445,7 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
                 ResurrectTimer = 10000;
             }
         } else 
-			ResurrectTimer -= diff;
+            ResurrectTimer -= diff;
     }
 
     if (BlindingPassionTimer <= diff)
@@ -1452,21 +1454,21 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
             DoCast(target, SPELL_BLINDING_PASSION);
         BlindingPassionTimer = urand(30000, 45000);
     } else 
-		BlindingPassionTimer -= diff;
+        BlindingPassionTimer -= diff;
 
     if (DevotionTimer <= diff)
     {
         DoCast(me, SPELL_DEVOTION);
         DevotionTimer = urand(15000, 45000);
     } else 
-		DevotionTimer -= diff;
+        DevotionTimer -= diff;
 
     if (PowerfulAttractionTimer <= diff)
     {
         DoCast(SelectTarget(SELECT_TARGET_RANDOM, 0), SPELL_POWERFUL_ATTRACTION);
         PowerfulAttractionTimer = urand(5000, 30000);
     } else 
-		PowerfulAttractionTimer -= diff;
+        PowerfulAttractionTimer -= diff;
 
     if (EternalAffectionTimer <= diff)
     {
@@ -1479,7 +1481,7 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
 
         EternalAffectionTimer = urand(45000, 60000);
     } else 
-		EternalAffectionTimer -= diff;
+        EternalAffectionTimer -= diff;
 
     DoMeleeAttackIfReady();
 }

--- a/src/scripts/EasternKingdoms/Karazhan/instance_karazhan.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/instance_karazhan.cpp
@@ -47,6 +47,8 @@ public:
                 break;
             case NPC_NIGHTBANE:
                 m_uiNightBaneGUID = creature->GetGUID();
+            case NPC_RELAY:
+                m_uiRelayGUID = creature->GetGUID();
             }
         }
 
@@ -302,6 +304,7 @@ public:
         uint64 MastersTerraceDoor[2];
         uint64 ImageGUID;
         uint64 DustCoveredChest;
+        uint64 m_uiRelayGUID;
     };
 };
 

--- a/src/scripts/EasternKingdoms/Karazhan/karazhan.h
+++ b/src/scripts/EasternKingdoms/Karazhan/karazhan.h
@@ -87,7 +87,8 @@ enum KZMiscCreatures
     NPC_PHASE_HOUND = 16178,
     NPC_DREADBEAST = 16177,
     NPC_SHADOWBEAST = 16176,
-    NPC_KILREK = 17229
+    NPC_KILREK = 17229,
+    NPC_RELAY = 17645
 };
 
 enum KZGameObjectIds


### PR DESCRIPTION
Changes proposed:
**Opera Event**

- [ ] Fix loot tables for Opera event (RAJ)
- [x]     Opera events working correctly
- [x]     The crone cyclone will now move instead of stood in 1 place.
- [x]     The Crone chain lightning will now cast more often

**Nightbane**

- [ ]     Change Intro path of Nightbane
- [x]     Nightbane will now correctly work

**Shade of Aran**

- [x]     Shade of Aran will now summon water elementals in the correct place.

**Moroes**

- [x] Moroes will attack as he comes out of Vanish

**Illhoof**

- [x]     Illhoof will now spawn back his Imp after 45 seconds

**Prince Malcazhaar**

- [x]    Prince will now spawn only 1 axe instead of two.
- [x]    Prince axe will now attack with both weapons instead of just one.
- [x]    Prince Axe will now change target onto random, instead of focusing one player (fix on next push)
- [x]    Fix Enfeeble for Prince.
- [x]    Rescript Prince Malcazhaar
- [x]     Make Infernal Relay Cast infernal

Target branch(es): master

Issues addressed: Closes #173 #172 #174 #39

Tests performed: (Does it build, tested in-game, etc)
Tested in game all working correctly.

NOTE You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)