### PR TITLE
Minor SQL fixes

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1486213838562161500.sql
+++ b/data/sql/updates/pending_db_world/rev_1486213838562161500.sql
@@ -1,0 +1,13 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1486213838562161500');
+-- BRITTLE REVENANT LOOT TABLE AND DROP RATE fixed.
+DELETE FROM `creature_loot_template` WHERE (entry = 30160) AND (item IN (42246));
+INSERT INTO `creature_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `lootmode`, `groupid`, `mincountOrRef`, `maxcount`) VALUES
+(30160, 42246, 68, 1, 0, 1, 1);
+
+DELETE FROM `creature_loot_template` WHERE (entry = 30160) AND (item IN (42780));
+INSERT INTO `creature_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `lootmode`, `groupid`, `mincountOrRef`, `maxcount`) VALUES
+(30160, 42780, 34, 1, 0, 1, 1);
+
+DELETE FROM `creature_loot_template` WHERE (entry = 30160) AND (item IN (37701));
+INSERT INTO `creature_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `lootmode`, `groupid`, `mincountOrRef`, `maxcount`) VALUES
+(30160, 37701, 26, 1, 0, 1, 2);

--- a/data/sql/updates/pending_db_world/rev_1486214058938766300.sql
+++ b/data/sql/updates/pending_db_world/rev_1486214058938766300.sql
@@ -1,0 +1,4 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1486214058938766300');
+-- CIVILIAN RECRUIT CHANGED MODIELID FROM 3422 TO 24821/24818 --
+UPDATE `creature` SET `modelid` = 24821 WHERE `guid` IN (117788);
+UPDATE `creature` SET `modelid` = 24818 WHERE `guid` IN (117789);


### PR DESCRIPTION
### Wrath of the Lich King
- [x]  **[NPC][WOTLK] Civilian Recruit** - Closes #346 
_**Civilian Recruit(s)** will now appear as their correct model._

- [x]  **[NPC][WOTLK] Brittle Revenant**
_Brittle Revenant will now drop the quest item **[Essence of Ice]** with the correct drop rates._
_Added item(s) **[Crystallized Earth]** and **[Relic of Ulduar]** to loot table._