### PR TITLE
Minor SQL fixes

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1486291697316845600.sql
+++ b/data/sql/updates/pending_db_world/rev_1486291697316845600.sql
@@ -1,0 +1,150 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1486291697316845600');
+-- [NPC][WotlK] Stormforged Saboteur, missing paths
+-- Pathing for  Entry: 31693 'TDB FORMAT' 
+SET @NPC := 88115;
+SET @PATH := @NPC * 10;
+UPDATE `creature` SET `spawndist`=0,`MovementType`=2,`position_x`=7693.506,`position_y`=-2324.018,`position_z`=1038.417 WHERE `guid`=@NPC;
+DELETE FROM `creature_addon` WHERE `guid`=@NPC;
+INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,1,0, '');
+DELETE FROM `waypoint_data` WHERE `id`=@PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`move_type`,`action`,`action_chance`,`wpguid`) VALUES
+(@PATH,1,7693.506,-2324.018,1038.417,0,0,0,0,100,0),
+(@PATH,2,7681.481,-2302.699,1024.499,0,0,0,0,100,0),
+(@PATH,3,7692.982,-2323.4,1038.048,0,0,0,0,100,0),
+(@PATH,4,7698.107,-2330.618,1043.213,0,0,0,0,100,0),
+(@PATH,5,7733.517,-2353.724,1068.687,0,0,0,0,100,0),
+(@PATH,6,7717.036,-2345.113,1058.945,0,0,0,0,100,0),
+(@PATH,7,7706.17,-2339.842,1050.38,0,0,0,0,100,0),
+(@PATH,8,7694.688,-2325.7,1039.569,0,0,0,0,100,0);
+-- 0x203CD047601EF340000C1D000008E709 .go 7693.506 -2324.018 1038.417
+
+-- Pathing for  Entry: 31693 'TDB FORMAT' 
+SET @NPC := 88121;
+SET @PATH := @NPC * 10;
+UPDATE `creature` SET `spawndist`=0,`MovementType`=2,`position_x`=7717.821,`position_y`=-2373.15,`position_z`=1076.397 WHERE `guid`=@NPC;
+DELETE FROM `creature_addon` WHERE `guid`=@NPC;
+INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,1,0, '');
+DELETE FROM `waypoint_data` WHERE `id`=@PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`move_type`,`action`,`action_chance`,`wpguid`) VALUES
+(@PATH,1,7717.821,-2373.15,1076.397,0,0,0,0,100,0),
+(@PATH,2,7716.69,-2373.623,1076.546,0,0,0,0,100,0),
+(@PATH,3,7713.94,-2375.873,1077.046,0,0,0,0,100,0),
+(@PATH,4,7712.434,-2377.115,1077.223,0,0,0,0,100,0),
+(@PATH,5,7708.74,-2383.643,1077.744,0,0,0,0,100,0),
+(@PATH,6,7707.24,-2390.143,1078.244,0,0,0,0,100,0),
+(@PATH,7,7708.308,-2384.875,1077.819,0,0,0,0,100,0),
+(@PATH,8,7709.108,-2383.253,1077.683,0,0,0,0,100,0),
+(@PATH,9,7712.659,-2376.858,1077.257,0,0,0,0,100,0),
+(@PATH,10,7715.409,-2374.608,1076.757,0,0,0,0,100,0),
+(@PATH,11,7716.896,-2373.736,1076.646,0,0,0,0,100,0),
+(@PATH,12,7721.577,-2372.192,1075.534,0,0,0,0,100,0),
+(@PATH,13,7723.327,-2371.942,1075.284,0,0,0,0,100,0),
+(@PATH,14,7721.291,-2372.098,1075.588,0,0,0,0,100,0);
+-- 0x203CD047601EF340000C1D000009FFF3 .go 7717.821 -2373.15 1076.397
+
+
+
+-- Pathing for  Entry: 31693 'TDB FORMAT' 
+SET @NPC := 88116;
+SET @PATH := @NPC * 10;
+UPDATE `creature` SET `spawndist`=0,`MovementType`=2,`position_x`=7716.721,`position_y`=-2417.521,`position_z`=1078.866 WHERE `guid`=@NPC;
+DELETE FROM `creature_addon` WHERE `guid`=@NPC;
+INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,1,0, '');
+DELETE FROM `waypoint_data` WHERE `id`=@PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`move_type`,`action`,`action_chance`,`wpguid`) VALUES
+(@PATH,1,7716.721,-2417.521,1078.866,0,0,0,0,100,0),
+(@PATH,2,7721.32,-2423.333,1078.504,0,0,0,0,100,0),
+(@PATH,3,7726.283,-2426.826,1078.622,0,0,0,0,100,0),
+(@PATH,4,7734.296,-2428.488,1079.077,0,0,0,0,100,0),
+(@PATH,5,7741.796,-2428.331,1079.079,0,0,0,0,100,0),
+(@PATH,6,7734.083,-2428.462,1078.925,0,0,0,0,100,0),
+(@PATH,7,7726.114,-2426.458,1078.75,0,0,0,0,100,0),
+(@PATH,8,7721.104,-2423.094,1078.602,0,0,0,0,100,0);
+-- 0x203CD047601EF340000C1D00000A6AE6 .go 7716.721 -2417.521 1078.866
+
+
+-- Pathing for  Entry: 31693 'TDB FORMAT' 
+SET @NPC := 88122;
+SET @PATH := @NPC * 10;
+UPDATE `creature` SET `spawndist`=0,`MovementType`=2,`position_x`=7708.882,`position_y`=-2383.844,`position_z`=1077.573 WHERE `guid`=@NPC;
+DELETE FROM `creature_addon` WHERE `guid`=@NPC;
+INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,1,0, '');
+DELETE FROM `waypoint_data` WHERE `id`=@PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`move_type`,`action`,`action_chance`,`wpguid`) VALUES
+(@PATH,1,7708.882,-2383.844,1077.573,0,0,0,0,100,0),
+(@PATH,2,7712.606,-2376.904,1077.29,0,0,0,0,100,0),
+(@PATH,3,7715.585,-2374.437,1076.769,0,0,0,0,100,0),
+(@PATH,4,7717.085,-2373.687,1076.519,0,0,0,0,100,0),
+(@PATH,5,7721.5,-2372.127,1075.651,0,0,0,0,100,0),
+(@PATH,6,7723.25,-2371.877,1075.401,0,0,0,0,100,0),
+(@PATH,7,7722.302,-2371.998,1075.731,0,0,0,0,100,0),
+(@PATH,8,7716.878,-2373.573,1076.597,0,0,0,0,100,0),
+(@PATH,9,7713.878,-2375.823,1077.097,0,0,0,0,100,0),
+(@PATH,10,7712.221,-2377.236,1077.321,0,0,0,0,100,0);
+-- 0x203CD047601EF340000C1D00008B704D .go 7708.882 -2383.844 1077.573
+
+
+-- Pathing for  Entry: 31693 'TDB FORMAT' 
+SET @NPC := 88112;
+SET @PATH := @NPC * 10;
+UPDATE `creature` SET `spawndist`=0,`MovementType`=2,`position_x`=7810.335,`position_y`=-2396.439,`position_z`=1093.944 WHERE `guid`=@NPC;
+DELETE FROM `creature_addon` WHERE `guid`=@NPC;
+INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,1,0, '');
+DELETE FROM `waypoint_data` WHERE `id`=@PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`move_type`,`action`,`action_chance`,`wpguid`) VALUES
+(@PATH,1,7810.335,-2396.439,1093.944,0,0,0,0,100,0),
+(@PATH,2,7811.585,-2396.189,1094.694,0,0,0,0,100,0),
+(@PATH,3,7817.335,-2396.189,1097.694,0,0,0,0,100,0),
+(@PATH,4,7833.19,-2401.916,1106.79,0,0,0,0,100,0),
+(@PATH,5,7830.69,-2400.916,1105.54,0,0,0,0,100,0),
+(@PATH,6,7828.484,-2400.28,1103.903,0,0,0,0,100,0),
+(@PATH,7,7825.484,-2399.28,1102.153,0,0,0,0,100,0),
+(@PATH,8,7822.984,-2398.28,1100.653,0,0,0,0,100,0),
+(@PATH,9,7820.234,-2397.28,1099.653,0,0,0,0,100,0),
+(@PATH,10,7818.22,-2396.551,1098.187,0,0,0,0,100,0),
+(@PATH,11,7811.454,-2396.305,1094.445,0,0,0,0,100,0),
+(@PATH,12,7809.454,-2396.555,1093.445,0,0,0,0,100,0),
+(@PATH,13,7806.704,-2396.805,1092.195,0,0,0,0,100,0),
+(@PATH,14,7804.516,-2397.255,1090.906,0,0,0,0,100,0),
+(@PATH,15,7802.516,-2397.755,1089.906,0,0,0,0,100,0),
+(@PATH,16,7799.766,-2398.255,1088.656,0,0,0,0,100,0),
+(@PATH,17,7802.344,-2397.896,1089.801,0,0,0,0,100,0),
+(@PATH,18,7804.471,-2397.053,1090.839,0,0,0,0,100,0),
+(@PATH,19,7808.221,-2396.803,1092.839,0,0,0,0,100,0);
+-- 0x203CD047601EF340000C1D000288E709 .go 7810.335 -2396.439 1093.944
+
+-- Pathing for  Entry: 31693 'TDB FORMAT' 
+SET @NPC :=  88111;
+SET @PATH := @NPC * 10;
+UPDATE `creature` SET `spawndist`=0,`MovementType`=2,`position_x`=7594.389,`position_y`=-2281.263,`position_z`=940.06 WHERE `guid`=@NPC;
+DELETE FROM `creature_addon` WHERE `guid`=@NPC;
+INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,1,0, '');
+DELETE FROM `waypoint_data` WHERE `id`=@PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`move_type`,`action`,`action_chance`,`wpguid`) VALUES
+(@PATH,1,7594.389,-2281.263,940.06,0,0,0,0,100,0),
+(@PATH,2,7590.639,-2284.263,935.81,0,0,0,0,100,0),
+(@PATH,3,7583.639,-2287.263,929.31,0,0,0,0,100,0),
+(@PATH,4,7587.911,-2285.628,933.4109,0,0,0,0,100,0),
+(@PATH,5,7594.338,-2281.126,940.1424,0,0,0,0,100,0),
+(@PATH,6,7596.588,-2278.876,942.6424,0,0,0,0,100,0),
+(@PATH,7,7602.338,-2272.376,949.6424,0,0,0,0,100,0),
+(@PATH,8,7606.058,-2268.674,953.5016,0,0,0,0,100,0),
+(@PATH,9,7607.808,-2266.674,955.2516,0,0,0,0,100,0),
+(@PATH,10,7612.058,-2262.424,961.2516,0,0,0,0,100,0),
+(@PATH,11,7612.923,-2261.475,962.8279,0,0,0,0,100,0),
+(@PATH,12,7617.423,-2259.975,966.5779,0,0,0,0,100,0),
+(@PATH,13,7622.441,-2258.586,971.277,0,0,0,0,100,0),
+(@PATH,14,7623.191,-2258.336,972.277,0,0,0,0,100,0),
+(@PATH,15,7628.944,-2257.969,976.8357,0,0,0,0,100,0),
+(@PATH,16,7639.093,-2262.12,985.2325,0,0,0,0,100,0),
+(@PATH,17,7645.936,-2263.47,991.0493,0,0,0,0,100,0),
+(@PATH,18,7653.126,-2270.09,997.1328,0,0,0,0,100,0),
+(@PATH,19,7649.956,-2266.439,994.4049,0,0,0,0,100,0),
+(@PATH,20,7645.541,-2263.432,990.6445,0,0,0,0,100,0),
+(@PATH,21,7636.538,-2260.767,982.4916,0,0,0,0,100,0),
+(@PATH,22,7633.74,-2259.331,980.5753,0,0,0,0,100,0),
+(@PATH,23,7628.049,-2257.727,975.717,0,0,0,0,100,0),
+(@PATH,24,7614.933,-2261.062,964.6306,0,0,0,0,100,0),
+(@PATH,25,7608.933,-2265.812,956.8806,0,0,0,0,100,0),
+(@PATH,26,7596.662,-2278.802,942.7743,0,0,0,0,100,0);
+-- 0x203CD047601EF340000C1D000408E709 .go 7594.389 -2281.263 940.06

--- a/data/sql/updates/pending_db_world/rev_1486291780487602700.sql
+++ b/data/sql/updates/pending_db_world/rev_1486291780487602700.sql
@@ -1,0 +1,24 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1486291780487602700');
+-- Pathing for  Entry: 32478 'TDB FORMAT' 
+SET @NPC := 88139;
+SET @PATH := @NPC * 10;
+
+UPDATE `creature` SET `spawndist`=0,`MovementType`=2,`position_x`=8877.512,`position_y`=-1358.266,`position_z`=1033.88 WHERE `guid`=@NPC;
+
+DELETE FROM `creature_addon` WHERE `guid`=@NPC;
+INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,1,0, '');
+
+DELETE FROM `waypoint_data` WHERE `id`=@PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`move_type`,`action`,`action_chance`,`wpguid`) VALUES
+(@PATH,1,8877.512,-1358.266,1033.88,0,0,0,0,100,0),
+(@PATH,2,8877.512,-1359.266,1033.88,0,0,0,0,100,0),
+(@PATH,3,8876.762,-1360.266,1033.63,0,0,0,0,100,0),
+(@PATH,4,8876.447,-1360.297,1033.653,0,0,0,0,100,0),
+(@PATH,5,8875.947,-1362.047,1033.653,0,0,0,0,100,0),
+(@PATH,6,8873.364,-1366.144,1033.657,1.099557,120000,0,0,100,0),
+(@PATH,7,8873.255,-1358.092,1033.895,0,0,0,0,100,0),
+(@PATH,8,8873.492,-1357.932,1034.002,0,0,0,0,100,0),
+(@PATH,9,8873.856,-1353.284,1034.383,0,0,0,0,100,0),
+(@PATH,10,8878.05,-1356.542,1033.729,0,0,0,0,100,0),
+(@PATH,11,8878.05,-1356.542,1033.729,0.541052,120000,0,0,100,0);
+-- 0x203CD047601FB780000C1D000008E709 .go 8877.512 -1358.266 1033.88

--- a/data/sql/updates/pending_db_world/rev_1486297438962248900.sql
+++ b/data/sql/updates/pending_db_world/rev_1486297438962248900.sql
@@ -1,0 +1,2 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1486297438962248900');
+UPDATE `creature_addon` SET `bytes1`=0, `auras`=45787 WHERE  `guid`=97150;

--- a/data/sql/updates/pending_db_world/rev_1486298304560758300.sql
+++ b/data/sql/updates/pending_db_world/rev_1486298304560758300.sql
@@ -1,0 +1,5 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1486298304560758300');
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` IN (48778, 73313);
+INSERT INTO `spell_linked_spell` (`spell_trigger` ,`spell_effect`, `type`, `comment`)  VALUES
+(48778, 50772, 0, 'Acherus Deathcharger - Summon Unholy Mount Visual'),
+(73313, 50772, 0, 'Crimson Deathcharger - Summon Unholy Mount Visual');

--- a/data/sql/updates/pending_db_world/rev_1486299378460181900.sql
+++ b/data/sql/updates/pending_db_world/rev_1486299378460181900.sql
@@ -1,0 +1,2 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1486299378460181900');
+UPDATE `creature_addon` SET `auras`=55701 WHERE `guid`=100071;

--- a/data/sql/updates/pending_db_world/rev_1486299918082046500.sql
+++ b/data/sql/updates/pending_db_world/rev_1486299918082046500.sql
@@ -1,0 +1,4 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1486299918082046500');
+-- DB/Creature: Add flag guard Deathguard Elite
+-- creature is a guard (Will ignore feign death and vanish)
+UPDATE `creature_template` SET `flags_extra`=32768 WHERE `entry`=7980;

--- a/data/sql/updates/pending_db_world/rev_1486300771173840500.sql
+++ b/data/sql/updates/pending_db_world/rev_1486300771173840500.sql
@@ -1,0 +1,43 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1486300771173840500');
+-- [NPC][WotlK] Library Guardian and Databank, missing spell, wrong movement 
+UPDATE `creature_template` SET `InhabitType`=4 WHERE  `entry`=29746;
+UPDATE `creature` SET `spawndist`=18 WHERE  `id`=29724 AND `spawndist` >0;
+UPDATE `creature` SET `spawndist`=0, `MovementType`=0 WHERE  `id`=29746;
+
+-- Library Guardian SAI
+SET @ENTRY := 29724;
+UPDATE `creature_template` SET `AIName`="SmartAI" WHERE `entry`=@ENTRY;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=@ENTRY AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(@ENTRY,0,0,0,1,0,100,0,2000,45000,60000,60000,80,@ENTRY*100+00,0,0,0,0,0,1,0,0,0,0,0,0,0,"Library Guardian - Out of Combat - Run Script"),
+(@ENTRY,0,1,0,4,0,100,0,0,0,0,0,103,0,0,0,0,0,0,1,0,0,0,0,0,0,0,"Library Guardian - On Aggro - Set Rooted Off");
+
+-- Actionlist SAI
+SET @ENTRY := 2972400;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=@ENTRY AND `source_type`=9;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(@ENTRY,9,0,0,0,0,100,0,0,0,0,0,48,1,0,0,0,0,0,1,0,0,0,0,0,0,0,"Library Guardian - On Script - Set Active On"),
+(@ENTRY,9,1,0,0,0,100,0,0,0,0,0,66,1,0,0,0,0,0,19,29746,25,0,0,0,0,0,"Library Guardian - On Script - Set Orientation Closest Creature 'Databank'"),
+(@ENTRY,9,2,0,0,0,100,0,100,100,0,0,103,1,0,0,0,0,0,1,0,0,0,0,0,0,0,"Library Guardian - On Script - Set Rooted On"),
+(@ENTRY,9,3,0,0,0,100,0,0,0,0,0,1,0,6000,0,0,0,0,1,0,0,0,0,0,0,0,"Library Guardian - On Script - Say Line 0"),
+(@ENTRY,9,4,0,0,0,100,0,1300,1300,0,0,11,55134,0,0,0,0,0,19,29746,25,0,0,0,0,0,"Library Guardian - On Script - Cast 'Data Stream'"),
+(@ENTRY,9,5,0,0,0,100,0,12000,12000,0,0,103,0,0,0,0,0,0,1,0,0,0,0,0,0,0,"Library Guardian - On Script - Set Rooted Off"),
+(@ENTRY,9,6,0,0,0,100,0,0,0,0,0,48,0,0,0,0,0,0,1,0,0,0,0,0,0,0,"Library Guardian - On Script - Set Active Off");
+
+-- Conditions for spellcast and sai execution
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=22 AND `SourceGroup`=1 AND `SourceEntry`=29724;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`SourceId`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionTarget`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`NegativeCondition`,`ErrorType`,`ErrorTextId`,`ScriptName`,`Comment`) VALUES
+(22,1,29724,0,0,29,1,29746,25,0,0,0,0,"","Library Guardian - Run SAI near Creature 'Databank'");
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND  `SourceGroup`=1 AND `SourceEntry`=55134;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
+(13, 1, 55134, 0, 0, 31, 0, 3, 29746, 0, 0, 0, 0, '', 'Data Strea only targets Creature Databank');
+
+DELETE FROM `creature_text` WHERE `entry`=29724;
+INSERT INTO `creature_text` (`entry`, `groupid`, `id`, `text`, `type`, `language`, `probability`, `emote`, `duration`, `sound`, `BroadcastTextId`, `comment`) VALUES
+(29724, 0, 0, 'Defragmenting swap file ...', 12, 0, 100, 1, 0, 0, 30375, 'Library Guardian'),
+(29724, 0, 1, 'Running a level three diagnostic ...', 12, 0, 100, 1, 0, 0, 30374, 'Library Guardian'),
+(29724, 0, 2, 'Attempting to restore lost data ...', 12, 0, 100, 1, 0, 0, 30377, 'Library Guardian'),
+(29724, 0, 3, 'Implementing new security protocols ...', 12, 0, 100, 1, 0, 0, 30378, 'Library Guardian'),
+(29724, 0, 4, 'Verifying encryption key ...', 12, 0, 100, 1, 0, 0, 30376, 'Library Guardian'),
+(29724, 0, 5, 'Assessing database integrity ...', 12, 0, 100, 1, 0, 0, 30373, 'Library Guardian');


### PR DESCRIPTION
### CORE
- [x] _**Acherus Deathcharger** and **Crimson Deathcharger** now have their appropriate visuals upon summoning._

### Vanilla
- [x]  **[NPC][CLASSIC] Deathguard Elite** 
_**Deathguard Elite** will now ignore the spells **STEALTH** and **FEIGN DEATH**._

### Wrath of the Lich King
- [x]  **[NPC][WOTLK] Stormforged Saboteur** 
_The **Stormforged Saboteur** will now walk with its equitable waypoints._

- [x]  **[NPC][WOTLK] Libary Guardian** 
_The **Library Guardian** will now use the correct spell on **Databank** and use the correct waypoints._

- [x]  **[NPC][WOTLK] Slosh <Food & Drink>**
_The **Slosh <Food & Drink>** will now walk with his equitable movement and waypoints._

- [x]  **[NPC][WOTLK] Hamat**
_**Hamat** will appear as laying down instead of standing up._

- [x]  **[NPC][WOTLK] Snorts**
_**Snorts** now got the appropriate aura for snoozing away._