### PR TITLE
Core/Extractors : Fix MMAP version

### DIFF
--- a/modules/acore/extractors/mmaps_generator/MapBuilder.cpp
+++ b/modules/acore/extractors/mmaps_generator/MapBuilder.cpp
@@ -24,7 +24,7 @@ namespace DisableMgr
 }
 
 #define MMAP_MAGIC 0x4d4d4150   // 'MMAP'
-#define MMAP_VERSION 5
+#define MMAP_VERSION 3
 
 struct MmapTileHeader
 {


### PR DESCRIPTION
**Changes proposed:**

-  Fix MMAP:loadMap: X.mmtile was built with generator v5, expected v3

**Target branch(es):** 1.x/2.x etc.

**Issues addressed:** Any issue that has problem with mmaps

**Tests performed:** Not tested

**Known issues and TODO list:**

- [ ] 
- [ ] 



