### PR TITLE
[QUEST][WOTLK] Basic Chemistry

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1487514602617381300.sql
+++ b/data/sql/updates/pending_db_world/rev_1487514602617381300.sql
@@ -1,0 +1,3 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1487514602617381300');
+-- Table `item_template`
+UPDATE `item_template` SET `spellcooldown_1` = 30000 WHERE `entry` IN (44010);


### PR DESCRIPTION
**TESTED**
------------
Fixes item cooldown from 1 min 30 seconds to 30 seconds, to remedy the
uncompletable quest [Basic Chemistry]. Please remove your items cache in
your World of Warcraft directory to reset the item cooldown.

Closes: #332 

@talamortis - here we go :+1: 


