### PR TITLE
Fix building mmaps_geenrator on linux

### DIFF
--- a/modules/acore/extractors/mmaps_generator/CMakeLists.txt
+++ b/modules/acore/extractors/mmaps_generator/CMakeLists.txt
@@ -129,6 +129,7 @@ target_link_libraries(mmaps_generator
   ${OPENSSL_LIBRARIES}
   ${BZIP2_LIBRARIES}
   ${ZLIB_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT}
 )
 
 if( UNIX )


### PR DESCRIPTION
**Changes proposed:**

Compiling extraction tools on Fedora I got following error:
```
/bin/ld: CMakeFiles/mmaps_generator.dir/PathGenerator.cpp.o: undefined reference to symbol 'pthread_condattr_setpshared@@GLIBC_2.2.5'
/usr/lib64/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
modules/acore/extractors/mmaps_generator/CMakeFiles/mmaps_generator.dir/build.make:210: recipe for target 'modules/acore/extractors/mmaps_generator/mmaps_generator' failed
make[2]: *** [modules/acore/extractors/mmaps_generator/mmaps_generator] Error 1
CMakeFiles/Makefile2:1132: recipe for target 'modules/acore/extractors/mmaps_generator/CMakeFiles/mmaps_generator.dir/all' failed
make[1]: *** [modules/acore/extractors/mmaps_generator/CMakeFiles/mmaps_generator.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```
Commit in this PR allows compiling on Linux by adding pthread linking.

**Tests performed:** Build passes, extraction works, worldserver starts with extracted files, playing looks OK.
**Known issues and TODO list:**

- [ ]  Checking if it didn't break Windows build


