### PR TITLE
Restore chek in disables table for bg and random bg

### DIFF
--- a/src/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/game/Battlegrounds/BattlegroundMgr.cpp
@@ -587,9 +587,8 @@ void BattlegroundMgr::CreateInitialBattlegrounds()
 
         uint32 bgTypeId = fields[0].GetUInt32();
 
-        // pussywizard: currently not supported
-        //if (DisableMgr::IsDisabledFor(DISABLE_TYPE_BATTLEGROUND, bgTypeId, NULL))
-        //    continue;
+        if (DisableMgr::IsDisabledFor(DISABLE_TYPE_BATTLEGROUND, bgTypeId, NULL))
+            continue;
 
         // can be overwrite by values from DB
         BattlemasterListEntry const* bl = sBattlemasterListStore.LookupEntry(bgTypeId);


### PR DESCRIPTION
**Changes proposed:**

-  Restore chek for disables table for battelgraunds

**Target branch(es):** 1.x/2.x etc. master

**Issues addressed:** Closes #306 

**Tests performed:** (Does it build, tested in-game, etc)
no test can't test now
**Known issues and TODO list:**
- [ need test] 

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


