### PR TITLE
Core/Auth

### DIFF
--- a/src/authserver/Server/AuthSocket.cpp
+++ b/src/authserver/Server/AuthSocket.cpp
@@ -557,7 +557,7 @@ bool AuthSocket::_HandleLogonProof()
     A.SetBinary(lp.A, 32);
 
     // SRP safeguard: abort if A == 0
-    if ((A % N).IsZero())
+    if (A.isZero() || (A % N).isZero())
     {
         socket().shutdown();
         return true;

--- a/src/authserver/Server/AuthSocket.cpp
+++ b/src/authserver/Server/AuthSocket.cpp
@@ -557,7 +557,7 @@ bool AuthSocket::_HandleLogonProof()
     A.SetBinary(lp.A, 32);
 
     // SRP safeguard: abort if A == 0
-    if (A.isZero() || (A % N).isZero())
+    if ((A % N).isZero())
     {
         socket().shutdown();
         return true;

--- a/src/authserver/Server/AuthSocket.cpp
+++ b/src/authserver/Server/AuthSocket.cpp
@@ -557,7 +557,7 @@ bool AuthSocket::_HandleLogonProof()
     A.SetBinary(lp.A, 32);
 
     // SRP safeguard: abort if A == 0
-    if (A.isZero())
+    if ((A % N).IsZero())
     {
         socket().shutdown();
         return true;


### PR DESCRIPTION
Per SRP6a protocol, terminate connection of A % N == 0. This resolves another authentication bypass issue.

Ref:
https://github.com/TrinityCore/TrinityCore/commit/14abd1f5875d8c8e98ac9c76789d8b439008eba2