### PR TITLE
Touch of Zanzil now prevents stealth.

### DIFF
--- a/src/game/Spells/SpellInfo.cpp
+++ b/src/game/Spells/SpellInfo.cpp
@@ -2013,6 +2013,10 @@ AuraStateType SpellInfo::LoadAuraState() const
     // Faerie Fire (druid versions)
     if (SpellFamilyName == SPELLFAMILY_DRUID && SpellFamilyFlags[0] & 0x400)
         return AURA_STATE_FAERIE_FIRE;
+    
+    // Touch of Zanzil (Rogue quest spell)
+	if (Id == 9991)
+		return AURA_STATE_FAERIE_FIRE;
 
     // Sting (hunter's pet ability)
     if (GetCategory() == 1133 || Id == 35325)

--- a/src/game/Spells/SpellInfo.cpp
+++ b/src/game/Spells/SpellInfo.cpp
@@ -2014,12 +2014,18 @@ AuraStateType SpellInfo::LoadAuraState() const
     if (SpellFamilyName == SPELLFAMILY_DRUID && SpellFamilyFlags[0] & 0x400)
         return AURA_STATE_FAERIE_FIRE;
     
-    // Touch of Zanzil (Rogue quest spell)
-	if (Id == 9991)
-		return AURA_STATE_FAERIE_FIRE;
+    // Any Spells that prevent spells can be added here.
+    uint32 StealthPreventionSpellList[] = { 9991, 35331, 9806, 35325 };
+	
+    // Goes through each of the spells and identifies them as Stealth Prevention Spell.
+    for (int i = 0; i < sizeof(StealthPreventionSpellList) / sizeof(uint32); i++) {
+        if (Id == StealthPreventionSpellList[i]) {
+            return AURA_STATE_FAERIE_FIRE;
+	}
+    }
 
     // Sting (hunter's pet ability)
-    if (GetCategory() == 1133 || Id == 35325)
+    if (GetCategory() == 1133)
         return AURA_STATE_FAERIE_FIRE;
 
     // Victorious


### PR DESCRIPTION
**Changes proposed:**

-  Spell ID: 9991 now prevents stealth.
-  Simple fast fix. 
-  Thanks to Rushor for pointing it out.

**Target branch(es):** 1.x/2.x etc.
Master
**Issues addressed:** Closes #
Not an AzerothCore specific issue, is a Trinitycore issue. https://github.com/TrinityCore/TrinityCore/issues/13053
**Tests performed:** (Does it build, tested in-game, etc)

**Known issues and TODO list:**
No known issues I found from this commit.
- [ ] 
- [ ] 

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


