### PR TITLE
minor quest fixes

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1494230753178074480.sql
+++ b/data/sql/updates/pending_db_world/rev_1494230753178074480.sql
@@ -1,0 +1,25 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1494230753178074480');
+
+-- The boar hunter requires 12 kills, not 8
+UPDATE `quest_template` SET `RequiredNpcOrGoCount1` = 12 where `ID` = 183;
+
+-- Quest Westbrook Garrison Needs Help! has The Jasperlode Mine as prequest
+UPDATE `quest_template_addon` SET `PrevQuestID` = 76 WHERE `ID` = 239;
+
+-- The Everstill Bridge has The Lost Tools as prequest
+UPDATE `quest_template_addon` SET `PrevQuestID` = 125 WHERE `ID` = 89;
+
+-- Kurzen's Mystery follows Bad Medicine, not Colonel Kurzen
+UPDATE `quest_template_addon` SET `PrevQuestId` = 204 WHERE `ID` = 207;
+
+-- Spirits of the Stonemaul Hold follows The Essence of Enmity
+UPDATE `quest_template_addon` SET `PrevQuestId` = 11161 WHERE `ID` = 11159;
+
+-- Bungle in the jungle follows March of the Silithid (alliance: 4493, horde:4494), which follow Rise of the Silithid (alliance: 162, horde: 32)
+UPDATE `quest_template_addon` SET `PrevQuestID` = 162, `NextQuestID` = 4496, `ExclusiveGroup` = 4493 WHERE `ID` = 4493;
+UPDATE `quest_template_addon` SET `PrevQuestID` =  32, `NextQuestID` = 4496, `ExclusiveGroup` = 4493 WHERE `ID` = 4494;
+
+-- Salve via hunting first time quest for alliance was not rewarding money or xp
+UPDATE `quest_template` SET RewardXPDifficulty = 4, RewardBonusMoney = 3600 WHERE ID = 4103;
+-- Salve via hunting repeatable quest for horde WAS!
+UPDATE `quest_template` SET RewardXPDifficulty = 0, RewardBonusMoney =    0 WHERE ID = 5887;


### PR DESCRIPTION
A couple of minor fixes, mostly prequest related.

**The boar hunter**: needs 12 kills not 8.
http://www.wowhead.com/quest=183/the-boar-hunter
http://wow.gamepedia.com/Quest:The_Boar_Hunter

**Westbrook garrison needs help!** has The jasperlode mine as prequest.
http://www.wowhead.com/quest=239/westbrook-garrison-needs-help#comments:id=161626

**The Everstill Bridge** has The Lost Tools as prequest.
http://www.wowhead.com/quest=89/the-everstill-bridge#comments:id=246622

**Kurzen's Mystery** has Bad Medicine as prequest, not Colonel Kurzen.
http://www.wowhead.com/quest=207/kurzens-mystery#comments:id=98747
wow.gamepedia.com/Stranglethorn_Vale_quests (search for Rebel Camp)

**Spirits of the Stonemaul Hold** has Essence of Enmity as prequest.
http://wow.gamepedia.com/Quest:Spirits_of_Stonemaul_Hold

**Bungle in the Jungle** follows March of the Silithid (alliance: 4493, horde:4494), which follow Rise of the Silithid (alliance: 162, horde: 32).
http://wow.gamepedia.com/Quest:Bungle_in_the_Jungle

**Salve Via Hunting** alliance first time quest was not rewarding xp or money, however horde version repeatable was.

**Target branch(es):** master

**Issues addressed:** Closes #

**Tests performed:** tested myself.