### PR TITLE
auto-attack for warbear matriarch

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1495461970084153283.sql
+++ b/data/sql/updates/pending_db_world/rev_1495461970084153283.sql
@@ -1,5 +1,5 @@
 INSERT INTO version_db_world (`sql_rev`) VALUES ('1495461970084153283');
 
 -- set Warbear Matriarch (NPC 29918) AI to PetAI
-UPDATE creature_template SET AIName= 'PetAI', mindmg=1360, maxdmg=1840, dmg_multiplier=1 WHERE entry= 29918;
+UPDATE `creature_template` SET `AIName`= 'PetAI', `mindmg`=1360, `maxdmg`=1840, `dmg_multiplier`=1 WHERE `entry`= 29918;
 

--- a/data/sql/updates/pending_db_world/rev_1495461970084153283.sql
+++ b/data/sql/updates/pending_db_world/rev_1495461970084153283.sql
@@ -1,0 +1,5 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1495461970084153283');
+
+-- set Warbear Matriarch (NPC 29918) AI to PetAI
+UPDATE creature_template SET AIName= 'PetAI', mindmg=1360, maxdmg=1840, dmg_multiplier=1 WHERE entry= 29918;
+


### PR DESCRIPTION
**Changes proposed:**
Borrowed from TC issue#13905

The Warbear Matriarch vehicle for The Warm-Up (12996) and Into the Pit (12997) is not doing any auto-attacks, neither does an auto-attack button appear on the action bar.

This update fixes the first issue, and adjust the auto attack damage to be the same as the maul ability, as that's what it seems to be from this video: https://youtu.be/CJ28xVAeh6M?t=41s

**Target branch(es):** master

**Tests performed:** Tested it in-game

**Known issues and TODO list:**
Fix the action bar to include auto-attack, currently you have to right click the target to start auto-attacking.
