### PR TITLE
minor quest fixes 2

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
+++ b/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
@@ -138,4 +138,6 @@ DELETE FROM `gameobject_loot_template` WHERE `entry` IN ( 2954, 2959) and `item`
 -- Blue Pearls do not drop from Small Barnacle Clam or Thick Shell Clam items.
 DELETE FROM      `spell_loot_template` WHERE `entry` IN (58168,58172) and `item` = 4611;
 
+-- Black Dragonflight Molt is a guaranteed drop from Hoard of the Black Dragonflight
+UPDATE item_loot_template SET ChanceOrQuestChance = 100 WHERE entry = 10569 AND item = 10575;
 

--- a/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
+++ b/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
@@ -38,7 +38,11 @@ UPDATE creature_loot_template SET ChanceOrQuestChance = -40 WHERE entry IN 4397 
 UPDATE quest_template_addon SET PrevQuestID = 0 WHERE ID = 5082;
 
 -- Raising the drop rate of Thick Yeti Fur
-UPDATE creature_loot_template SET ChanceOrQuestChance = -50 WHERE entry IN (7457, 7458, 7459, 7460) AND item = 12366;
+UPDATE creature_loot_template SET ChanceOrQuestChance = -71 WHERE entry = 7457 AND item = 12366;
+UPDATE creature_loot_template SET ChanceOrQuestChance = -41 WHERE entry = 7458 AND item = 12366;
+UPDATE creature_loot_template SET ChanceOrQuestChance = -43 WHERE entry = 7459 AND item = 12366;
+UPDATE creature_loot_template SET ChanceOrQuestChance = -45 WHERE entry = 7460 AND item = 12366;
+
 
 -- Flesh Eating Worm adjustment
 UPDATE creature_template SET mindmg = 8, maxdmg = 12, scale=0.4 WHERE entry = 2462;

--- a/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
+++ b/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
@@ -1,0 +1,146 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1495464409315344160');
+
+-- The Troll Cave requires 14 kills, not 10.
+UPDATE `quest_template` SET `RequiredNpcOrGoCount1` = 14 where `ID` = 182;
+
+-- Make The Grizzled Den more tolerable.
+DELETE FROM `creature` WHERE `guid` IN (3137,3255,3261,3262,3548,3551,3554,3558,3583,3239,3243,3246,3257,3258,3552,3565,3566,3567,3570,3573,3574,3578);
+
+-- The Perfect Stout does not require Rejold's New Brew, it's the otherway around.
+UPDATE `quest_template_addon` SET `NextQuestId` = 0, `PrevQuestID` = 315 WHERE `ID` = 415;
+
+-- http://www.wowhead.com/quest=416/rat-catching
+-- http://www.wowhead.com/item=3110/tunnel-rat-ear
+-- All Tunnel Rats should be able to drop ears, not just 1 out of 6 types.
+INSERT INTO creature_loot_template VALUES
+(1172, 3110,-38,1,0,1,1),
+(1174, 3110,-80,1,0,1,1),
+(1175, 3110,-80,1,0,1,1),
+(1176, 3110,-38,1,0,1,1),
+(1177, 3110,-80,1,0,1,1)
+
+-- Red Silk Bandanas needs The Defias Brotherhood (6), not Red Leather Bandanas.
+UPDATE quest_template_addon SET PrevQuestID = 155 WHERE ID = 214;
+
+-- Letter to Stormpike follows Encrypted Letter
+UPDATE quest_template_addon SET PrevQuestID = 511 WHERE ID = 514;
+
+-- http://www.wowhead.com/item=2633/jungle-remedy#comments:id=163587
+-- Kurzen Jungle Fighter also drops Jungle Remedy
+INSERT INTO creature_loot_template VALUES (937,2633,-33,1,0,1,1);
+
+-- Inspecting the ruins requires either They Call Him Smilling Jim or James Hyal
+UPDATE quest_template_addon SET NextQuestID = 11123 WHERE ID = 1282;
+UPDATE quest_template_addon SET NextQuestID = 11123 WHERE ID = 1302;
+UPDATE quest_template_addon SET PrevQuestID =     0 WHERE ID = 11123;
+
+-- Raising the drop rate on Forked Mudrock Tongues
+UPDATE creature_loot_template SET ChanceOrQuestChance = -40 WHERE entry IN (4396, 4397, 4398, 4399, 4400) AND item = 5883;
+
+-- Trouble in Winterspring! is a breadcrumb quest, not prequest.
+UPDATE quest_template_addon SET PrevQuestID = 0 WHERE ID = 5082;
+
+-- Raising the drop rate of Thick Yeti Fur
+UPDATE creature_loot_template SET ChanceOrQuestChance = -50 WHERE entry IN (7457, 7458, 7459, 7460) AND item = 12366;
+
+-- http://wow.gamepedia.com/File:Flesh_Eating_Worm.jpg
+-- Flesh Eating Worm adjustment
+UPDATE creature_template SET mindmg = 8, maxdmg = 12, scale=0.4 WHERE entry = 2462;
+
+-- Fool's stout follows Report Back to Fizzlebub
+UPDATE quest_template_addon SET PrevQuestID = 1122 WHERE ID = 1127;
+
+-- Fixing Half-Buried Bottle loot table
+-- SELECT name, gameobject_loot_template.*
+-- FROM item_template
+-- JOIN gameobject_loot_template ON item_template.entry = gameobject_loot_template.item
+-- WHERE gameobject_loot_template.entry = 2032;
+DELETE FROM `gameobject_loot_template` WHERE `entry` = 2032;
+INSERT INTO `gameobject_loot_template` VALUES
+(2032,1477,2.5,1,0,1,1),
+(2032,1711,4.2,1,0,1,1),
+(2032,2289,2.7,1,0,1,1),
+(2032,2290,4.4,1,0,1,1),
+(2032,3608,0.02,1,0,1,1),
+(2032,4098,25,1,1,1,1),
+(2032,4100,25,1,1,1,1),
+(2032,4101,25,1,1,1,1),
+(2032,4102,25,1,1,1,1),
+(2032,4298,0.02,1,0,1,1),
+(2032,4299,0.02,1,0,1,1),
+(2032,4350,0.02,1,0,1,1),
+(2032,4351,0.02,1,0,1,1),
+(2032,4352,0.02,1,0,1,1),
+(2032,4412,0.02,1,0,1,1),
+(2032,4414,0.02,1,0,1,1),
+(2032,4416,0.02,1,0,1,1),
+(2032,4417,0.02,1,0,1,1),
+(2032,5543,0.02,1,0,1,1),
+(2032,5774,0.02,1,0,1,1),
+(2032,6045,0.02,1,0,1,1),
+(2032,6454,0.02,1,0,1,1),
+(2032,7085,0.02,1,0,1,1),
+(2032,7090,0.02,1,0,1,1),
+(2032,7360,0.02,1,0,1,1),
+(2032,7363,0.02,1,0,1,1),
+(2032,7364,0.02,1,0,1,1),
+(2032,7449,0.02,1,0,1,1),
+(2032,7450,0.02,1,0,1,1),
+(2032,7975,0.1,1,0,1,1),
+(2032,7992,0.0508056,1,0,1,1),
+(2032,8029,0.0508056,1,0,1,1),
+(2032,8385,0.0508056,1,0,1,1),
+(2032,8386,0.0580636,1,0,1,1),
+(2032,8387,0.0725795,1,0,1,1),
+(2032,9293,0.0435477,1,0,1,1),
+(2032,10300,0.1,1,0,1,1),
+(2032,10301,0.1,1,0,1,1),
+(2032,10302,0.0653215,1,0,1,1),
+(2032,10312,0.0290318,1,0,1,1),
+(2032,10424,0.02,1,0,1,1),
+(2032,10601,0.02,1,0,1,1),
+(2032,10603,0.0362897,1,0,1,1),
+(2032,10604,0.0653215,1,0,1,1),
+(2032,10606,0.1,1,0,1,1),
+(2032,11098,0.02,1,0,1,1),
+(2032,11164,0.02,1,0,1,1),
+(2032,11165,0.02,1,0,1,1),
+(2032,11167,0.02,1,0,1,1),
+(2032,11202,0.0290318,1,0,1,1),
+(2032,11204,0.1,1,0,1,1);
+
+-- Atal'ai Artifacts (and 1 mithril deposit) are underground
+UPDATE gameobject SET position_z=-15.29  WHERE guid=30371;
+UPDATE gameobject SET position_z= 14.5   WHERE guid=30374;
+UPDATE gameobject SET position_z= 31.63  WHERE guid=30380;
+UPDATE gameobject SET position_z=-16.75  WHERE guid=30381;
+UPDATE gameobject SET position_z= 19.57  WHERE guid=30383;
+UPDATE gameobject SET position_z= 10.58  WHERE guid=30541;
+UPDATE gameobject SET position_z=-19     WHERE guid=30542;
+UPDATE gameobject SET position_z=-16.9   WHERE guid=30543;
+UPDATE gameobject SET position_z= 20.2   WHERE guid=30546;
+UPDATE gameobject SET position_z=-2.2    WHERE guid=30547;
+UPDATE gameobject SET position_z= 10.5   WHERE guid=30550;
+UPDATE gameobject SET position_z=-11.9   WHERE guid=30551;
+UPDATE gameobject SET position_z= 10.91  WHERE guid=30554;
+UPDATE gameobject SET position_z=-3.56   WHERE guid=30556;
+UPDATE gameobject SET position_z= 18.70  WHERE guid=30558;
+UPDATE gameobject SET position_z= 19.1   WHERE guid=30559;
+UPDATE gameobject SET position_z= 18.66  WHERE guid=30561;
+UPDATE gameobject SET position_z=-19     WHERE guid=30643;
+UPDATE gameobject SET position_z=-6      WHERE guid=30646;
+UPDATE gameobject SET position_z=-10.4   WHERE guid=30375;
+UPDATE gameobject SET position_z=-8.5    WHERE guid=30378;
+UPDATE gameobject SET position_z= 19     WHERE guid=31029;
+
+--Atal'ai Artifact twin spawn
+DELETE FROM gameobject WHERE guid=30593;
+DELETE FROM gameobject WHERE guid=30594;
+DELETE FROM gameobject WHERE guid=30587;
+
+-- Blue Pearls do not drop from giant clams outside of the Vile Reef in STV.
+DELETE FROM gameobject_loot_template WHERE entry IN (2954,2959) and item = 4611;
+-- Blue Pearls do not drop from Small Barnacle Clam or Thick Shell Clam items.
+DELETE FROM      spell_loot_template WHERE entry IN (58168,58172) and item = 4611;
+
+

--- a/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
+++ b/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
@@ -9,8 +9,6 @@ DELETE FROM `creature` WHERE `guid` IN (3137,3255,3261,3262,3548,3551,3554,3558,
 -- The Perfect Stout does not require Rejold's New Brew, it's the otherway around.
 UPDATE `quest_template_addon` SET `NextQuestId` = 0, `PrevQuestID` = 315 WHERE `ID` = 415;
 
--- http://www.wowhead.com/quest=416/rat-catching
--- http://www.wowhead.com/item=3110/tunnel-rat-ear
 -- All Tunnel Rats should be able to drop ears, not just 1 out of 6 types.
 INSERT INTO creature_loot_template VALUES
 (1172, 3110,-38,1,0,1,1),
@@ -25,7 +23,6 @@ UPDATE quest_template_addon SET PrevQuestID = 155 WHERE ID = 214;
 -- Letter to Stormpike follows Encrypted Letter
 UPDATE quest_template_addon SET PrevQuestID = 511 WHERE ID = 514;
 
--- http://www.wowhead.com/item=2633/jungle-remedy#comments:id=163587
 -- Kurzen Jungle Fighter also drops Jungle Remedy
 INSERT INTO creature_loot_template VALUES (937,2633,-33,1,0,1,1);
 
@@ -43,18 +40,13 @@ UPDATE quest_template_addon SET PrevQuestID = 0 WHERE ID = 5082;
 -- Raising the drop rate of Thick Yeti Fur
 UPDATE creature_loot_template SET ChanceOrQuestChance = -50 WHERE entry IN (7457, 7458, 7459, 7460) AND item = 12366;
 
--- http://wow.gamepedia.com/File:Flesh_Eating_Worm.jpg
 -- Flesh Eating Worm adjustment
 UPDATE creature_template SET mindmg = 8, maxdmg = 12, scale=0.4 WHERE entry = 2462;
 
 -- Fool's stout follows Report Back to Fizzlebub
 UPDATE quest_template_addon SET PrevQuestID = 1122 WHERE ID = 1127;
 
--- Fixing Half-Buried Bottle loot table
--- SELECT name, gameobject_loot_template.*
--- FROM item_template
--- JOIN gameobject_loot_template ON item_template.entry = gameobject_loot_template.item
--- WHERE gameobject_loot_template.entry = 2032;
+-- Fixing Half-Buried Bottle loot table, it's not a raptor.
 DELETE FROM `gameobject_loot_template` WHERE `entry` = 2032;
 INSERT INTO `gameobject_loot_template` VALUES
 (2032,1477,2.5,1,0,1,1),

--- a/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
+++ b/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
@@ -32,7 +32,7 @@ UPDATE quest_template_addon SET NextQuestID = 11123 WHERE ID = 1302;
 UPDATE quest_template_addon SET PrevQuestID =     0 WHERE ID = 11123;
 
 -- Raising the drop rate on Forked Mudrock Tongues
-UPDATE creature_loot_template SET ChanceOrQuestChance = -40 WHERE entry IN (4396, 4397, 4398, 4399, 4400) AND item = 5883;
+UPDATE creature_loot_template SET ChanceOrQuestChance = -40 WHERE entry IN 4397 AND item = 5883;
 
 -- Trouble in Winterspring! is a breadcrumb quest, not prequest.
 UPDATE quest_template_addon SET PrevQuestID = 0 WHERE ID = 5082;

--- a/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
+++ b/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
@@ -7,10 +7,10 @@ UPDATE `quest_template` SET `RequiredNpcOrGoCount1` = 14 where `ID` = 182;
 DELETE FROM `creature` WHERE `guid` IN (3137,3255,3261,3262,3548,3551,3554,3558,3583,3239,3243,3246,3257,3258,3552,3565,3566,3567,3570,3573,3574,3578);
 
 -- The Perfect Stout does not require Rejold's New Brew, it's the otherway around.
-UPDATE `quest_template_addon` SET `NextQuestId` = 0, `PrevQuestID` = 315 WHERE `ID` = 415;
+UPDATE `quest_template_addon` SET `NextQuestID` = 0, `PrevQuestID` = 315 WHERE `ID` = 415;
 
 -- All Tunnel Rats should be able to drop ears, not just 1 out of 6 types.
-INSERT INTO creature_loot_template VALUES
+INSERT INTO `creature_loot_template` VALUES
 (1172, 3110,-38,1,0,1,1),
 (1174, 3110,-80,1,0,1,1),
 (1175, 3110,-80,1,0,1,1),
@@ -18,37 +18,36 @@ INSERT INTO creature_loot_template VALUES
 (1177, 3110,-80,1,0,1,1)
 
 -- Red Silk Bandanas needs The Defias Brotherhood (6), not Red Leather Bandanas.
-UPDATE quest_template_addon SET PrevQuestID = 155 WHERE ID = 214;
+UPDATE `quest_template_addon` SET `PrevQuestID` = 155 WHERE `ID` = 214;
 
 -- Letter to Stormpike follows Encrypted Letter
-UPDATE quest_template_addon SET PrevQuestID = 511 WHERE ID = 514;
+UPDATE `quest_template_addon` SET `PrevQuestID` = 511 WHERE `ID` = 514;
 
 -- Kurzen Jungle Fighter also drops Jungle Remedy
-INSERT INTO creature_loot_template VALUES (937,2633,-33,1,0,1,1);
+INSERT INTO `creature_loot_template` VALUES (937,2633,-33,1,0,1,1);
 
 -- Inspecting the ruins requires either They Call Him Smilling Jim or James Hyal
-UPDATE quest_template_addon SET NextQuestID = 11123 WHERE ID = 1282;
-UPDATE quest_template_addon SET NextQuestID = 11123 WHERE ID = 1302;
-UPDATE quest_template_addon SET PrevQuestID =     0 WHERE ID = 11123;
+UPDATE `quest_template_addon` SET `NextQuestID` = 11123 WHERE `ID` = 1282;
+UPDATE `quest_template_addon` SET `NextQuestID` = 11123 WHERE `ID` = 1302;
+UPDATE `quest_template_addon` SET `PrevQuestID` =     0 WHERE `ID` = 11123;
 
 -- Raising the drop rate on Forked Mudrock Tongues
-UPDATE creature_loot_template SET ChanceOrQuestChance = -40 WHERE entry IN 4397 AND item = 5883;
+UPDATE `creature_loot_template` SET `ChanceOrQuestChance` = -40 WHERE `entry` IN 4397 AND `item` = 5883;
 
 -- Trouble in Winterspring! is a breadcrumb quest, not prequest.
-UPDATE quest_template_addon SET PrevQuestID = 0 WHERE ID = 5082;
+UPDATE `quest_template_addon` SET `PrevQuestID` = 0 WHERE `ID` = 5082;
 
 -- Raising the drop rate of Thick Yeti Fur
-UPDATE creature_loot_template SET ChanceOrQuestChance = -71 WHERE entry = 7457 AND item = 12366;
-UPDATE creature_loot_template SET ChanceOrQuestChance = -41 WHERE entry = 7458 AND item = 12366;
-UPDATE creature_loot_template SET ChanceOrQuestChance = -43 WHERE entry = 7459 AND item = 12366;
-UPDATE creature_loot_template SET ChanceOrQuestChance = -45 WHERE entry = 7460 AND item = 12366;
-
+UPDATE `creature_loot_template` SET `ChanceOrQuestChance` = -71 WHERE `entry` = 7457 AND `item` = 12366;
+UPDATE `creature_loot_template` SET `ChanceOrQuestChance` = -41 WHERE `entry` = 7458 AND `item` = 12366;
+UPDATE `creature_loot_template` SET `ChanceOrQuestChance` = -43 WHERE `entry` = 7459 AND `item` = 12366;
+UPDATE `creature_loot_template` SET `ChanceOrQuestChance` = -45 WHERE `entry` = 7460 AND `item` = 12366;
 
 -- Flesh Eating Worm adjustment
-UPDATE creature_template SET mindmg = 8, maxdmg = 12, scale=0.4 WHERE entry = 2462;
+UPDATE `creature_template` SET `mindmg` = 8, `maxdmg` = 12, `scale`=0.4 WHERE `entry` = 2462;
 
 -- Fool's stout follows Report Back to Fizzlebub
-UPDATE quest_template_addon SET PrevQuestID = 1122 WHERE ID = 1127;
+UPDATE `quest_template_addon` SET `PrevQuestID` = 1122 WHERE `ID` = 1127;
 
 -- Fixing Half-Buried Bottle loot table, it's not a raptor.
 DELETE FROM `gameobject_loot_template` WHERE `entry` = 2032;
@@ -106,37 +105,37 @@ INSERT INTO `gameobject_loot_template` VALUES
 (2032,11204,0.1,1,0,1,1);
 
 -- Atal'ai Artifacts (and 1 mithril deposit) are underground
-UPDATE gameobject SET position_z=-15.29  WHERE guid=30371;
-UPDATE gameobject SET position_z= 14.5   WHERE guid=30374;
-UPDATE gameobject SET position_z= 31.63  WHERE guid=30380;
-UPDATE gameobject SET position_z=-16.75  WHERE guid=30381;
-UPDATE gameobject SET position_z= 19.57  WHERE guid=30383;
-UPDATE gameobject SET position_z= 10.58  WHERE guid=30541;
-UPDATE gameobject SET position_z=-19     WHERE guid=30542;
-UPDATE gameobject SET position_z=-16.9   WHERE guid=30543;
-UPDATE gameobject SET position_z= 20.2   WHERE guid=30546;
-UPDATE gameobject SET position_z=-2.2    WHERE guid=30547;
-UPDATE gameobject SET position_z= 10.5   WHERE guid=30550;
-UPDATE gameobject SET position_z=-11.9   WHERE guid=30551;
-UPDATE gameobject SET position_z= 10.91  WHERE guid=30554;
-UPDATE gameobject SET position_z=-3.56   WHERE guid=30556;
-UPDATE gameobject SET position_z= 18.70  WHERE guid=30558;
-UPDATE gameobject SET position_z= 19.1   WHERE guid=30559;
-UPDATE gameobject SET position_z= 18.66  WHERE guid=30561;
-UPDATE gameobject SET position_z=-19     WHERE guid=30643;
-UPDATE gameobject SET position_z=-6      WHERE guid=30646;
-UPDATE gameobject SET position_z=-10.4   WHERE guid=30375;
-UPDATE gameobject SET position_z=-8.5    WHERE guid=30378;
-UPDATE gameobject SET position_z= 19     WHERE guid=31029;
+UPDATE `gameobject` SET `position_z`=-15.29  WHERE `guid`=30371;
+UPDATE `gameobject` SET `position_z`= 14.5   WHERE `guid`=30374;
+UPDATE `gameobject` SET `position_z`= 31.63  WHERE `guid`=30380;
+UPDATE `gameobject` SET `position_z`=-16.75  WHERE `guid`=30381;
+UPDATE `gameobject` SET `position_z`= 19.57  WHERE `guid`=30383;
+UPDATE `gameobject` SET `position_z`= 10.58  WHERE `guid`=30541;
+UPDATE `gameobject` SET `position_z`=-19     WHERE `guid`=30542;
+UPDATE `gameobject` SET `position_z`=-16.9   WHERE `guid`=30543;
+UPDATE `gameobject` SET `position_z`= 20.2   WHERE `guid`=30546;
+UPDATE `gameobject` SET `position_z`=-2.2    WHERE `guid`=30547;
+UPDATE `gameobject` SET `position_z`= 10.5   WHERE `guid`=30550;
+UPDATE `gameobject` SET `position_z`=-11.9   WHERE `guid`=30551;
+UPDATE `gameobject` SET `position_z`= 10.91  WHERE `guid`=30554;
+UPDATE `gameobject` SET `position_z`=-3.56   WHERE `guid`=30556;
+UPDATE `gameobject` SET `position_z`= 18.70  WHERE `guid`=30558;
+UPDATE `gameobject` SET `position_z`= 19.1   WHERE `guid`=30559;
+UPDATE `gameobject` SET `position_z`= 18.66  WHERE `guid`=30561;
+UPDATE `gameobject` SET `position_z`=-19     WHERE `guid`=30643;
+UPDATE `gameobject` SET `position_z`=-6      WHERE `guid`=30646;
+UPDATE `gameobject` SET `position_z`=-10.4   WHERE `guid`=30375;
+UPDATE `gameobject` SET `position_z`=-8.5    WHERE `guid`=30378;
+UPDATE `gameobject` SET `position_z`= 19     WHERE `guid`=31029;
 
 --Atal'ai Artifact twin spawn
-DELETE FROM gameobject WHERE guid=30593;
-DELETE FROM gameobject WHERE guid=30594;
-DELETE FROM gameobject WHERE guid=30587;
+DELETE FROM `gameobject` WHERE `guid`=30593;
+DELETE FROM `gameobject` WHERE `guid`=30594;
+DELETE FROM `gameobject` WHERE `guid`=30587;
 
 -- Blue Pearls do not drop from giant clams outside of the Vile Reef in STV.
-DELETE FROM gameobject_loot_template WHERE entry IN (2954,2959) and item = 4611;
+DELETE FROM `gameobject_loot_template` WHERE `entry` IN ( 2954, 2959) and `item` = 4611;
 -- Blue Pearls do not drop from Small Barnacle Clam or Thick Shell Clam items.
-DELETE FROM      spell_loot_template WHERE entry IN (58168,58172) and item = 4611;
+DELETE FROM      `spell_loot_template` WHERE `entry` IN (58168,58172) and `item` = 4611;
 
 

--- a/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
+++ b/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
@@ -44,7 +44,10 @@ UPDATE `creature_loot_template` SET `ChanceOrQuestChance` = -43 WHERE `entry` = 
 UPDATE `creature_loot_template` SET `ChanceOrQuestChance` = -45 WHERE `entry` = 7460 AND `item` = 12366;
 
 -- Flesh Eating Worm adjustment
-UPDATE `creature_template` SET `mindmg` = 8, `maxdmg` = 12, `scale`=0.4 WHERE `entry` = 2462;
+UPDATE `creature_template` SET `mindmg` = 16, `maxdmg` = 25, `scale`=0.4 WHERE `entry` = 2462;
+
+-- Rotting Worm adjustment
+UPDATE `creature_template` SET `mindmg` = 41, `maxdmg` = 66, `scale`=0.4 WHERE `entry` = 10925;
 
 -- Fool's stout follows Report Back to Fizzlebub
 UPDATE `quest_template_addon` SET `PrevQuestID` = 1122 WHERE `ID` = 1127;
@@ -139,5 +142,6 @@ DELETE FROM `gameobject_loot_template` WHERE `entry` IN ( 2954, 2959) and `item`
 DELETE FROM      `spell_loot_template` WHERE `entry` IN (58168,58172) and `item` = 4611;
 
 -- Black Dragonflight Molt is a guaranteed drop from Hoard of the Black Dragonflight
-UPDATE item_loot_template SET ChanceOrQuestChance = 100 WHERE entry = 10569 AND item = 10575;
+UPDATE `item_loot_template` SET `ChanceOrQuestChance` = 100 WHERE `entry` = 10569 AND `item` = 10575;
+
 

--- a/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
+++ b/data/sql/updates/pending_db_world/rev_1495464409315344160.sql
@@ -10,12 +10,13 @@ DELETE FROM `creature` WHERE `guid` IN (3137,3255,3261,3262,3548,3551,3554,3558,
 UPDATE `quest_template_addon` SET `NextQuestID` = 0, `PrevQuestID` = 315 WHERE `ID` = 415;
 
 -- All Tunnel Rats should be able to drop ears, not just 1 out of 6 types.
+DELETE FROM `creature_loot_template` WHERE `entry` in (1172,1174,1175,1176,1177) and `item` = 3110;
 INSERT INTO `creature_loot_template` VALUES
 (1172, 3110,-38,1,0,1,1),
 (1174, 3110,-80,1,0,1,1),
 (1175, 3110,-80,1,0,1,1),
 (1176, 3110,-38,1,0,1,1),
-(1177, 3110,-80,1,0,1,1)
+(1177, 3110,-80,1,0,1,1);
 
 -- Red Silk Bandanas needs The Defias Brotherhood (6), not Red Leather Bandanas.
 UPDATE `quest_template_addon` SET `PrevQuestID` = 155 WHERE `ID` = 214;
@@ -24,6 +25,7 @@ UPDATE `quest_template_addon` SET `PrevQuestID` = 155 WHERE `ID` = 214;
 UPDATE `quest_template_addon` SET `PrevQuestID` = 511 WHERE `ID` = 514;
 
 -- Kurzen Jungle Fighter also drops Jungle Remedy
+DELETE FROM `creature_loot_template` WHERE `entry` = 937 AND `item` = 2633;
 INSERT INTO `creature_loot_template` VALUES (937,2633,-33,1,0,1,1);
 
 -- Inspecting the ruins requires either They Call Him Smilling Jim or James Hyal
@@ -32,7 +34,7 @@ UPDATE `quest_template_addon` SET `NextQuestID` = 11123 WHERE `ID` = 1302;
 UPDATE `quest_template_addon` SET `PrevQuestID` =     0 WHERE `ID` = 11123;
 
 -- Raising the drop rate on Forked Mudrock Tongues
-UPDATE `creature_loot_template` SET `ChanceOrQuestChance` = -40 WHERE `entry` IN 4397 AND `item` = 5883;
+UPDATE `creature_loot_template` SET `ChanceOrQuestChance` = -40 WHERE `entry` = 4397 AND `item` = 5883;
 
 -- Trouble in Winterspring! is a breadcrumb quest, not prequest.
 UPDATE `quest_template_addon` SET `PrevQuestID` = 0 WHERE `ID` = 5082;
@@ -131,7 +133,7 @@ UPDATE `gameobject` SET `position_z`=-10.4   WHERE `guid`=30375;
 UPDATE `gameobject` SET `position_z`=-8.5    WHERE `guid`=30378;
 UPDATE `gameobject` SET `position_z`= 19     WHERE `guid`=31029;
 
---Atal'ai Artifact twin spawn
+-- Atal'ai Artifact twin spawn
 DELETE FROM `gameobject` WHERE `guid`=30593;
 DELETE FROM `gameobject` WHERE `guid`=30594;
 DELETE FROM `gameobject` WHERE `guid`=30587;


### PR DESCRIPTION
**The Troll Cave**: needs 14 kills, not 10.
http://wow.gamepedia.com/Quest:The_Troll_Cave

**The Grizzled Den**
The wendigos at this den, especially at the entrance, are very dense. It looks as if they're double spawned a lot. It's very hard on lvl 6-8 players, as you're forced to grab 2 at a time.

The id list is gathered from this query.
```
SELECT guid FROM sunwell_world.creature
WHERE id in (1134,1135) AND guid NOT IN
( SELECT A.guid
  FROM sunwell_world.creature AS A
  JOIN trinity_world.creature AS B
  ON A.guid = B.guid
  WHERE A.id in (1134,1135) AND B.id IN (1134,1135)
);
```
Turns out TC is a subset of AC, with this fix both are the same. This result is much more tolerable.

**The Perfect Stout**: Rejold's New Brew has The Perfect Stout as prequest, not the otherway around.
http://www.wowhead.com/quest=415/rejolds-new-brew#comments:id=190337

**Tunnel Rat**:
Currently only 1 type drop ears, when all 6 should.
Some mobs have 4/5 drop rate.
http://www.wowhead.com/quest=416/rat-catching#comments:id=74106:reply=305815
Drop rate inside the cave is way higher.
http://www.wowhead.com/item=3110/tunnel-rat-ear#comments:id=353270

**Red Silk Bandanas**: Follows the second to last Defias Brotherhood quest, not Red Leather Bandanas.
http://wow.gamepedia.com/Quest:Red_Silk_Bandanas

**Letter to Stormpike**: Has Encrypted Letter as prequest.
http://wow.gamepedia.com/Quest:Letter_to_Stormpike

**Kurzen Jungle Fighter**: These should also drop Jungle Remedy.
http://www.wowhead.com/item=2633/jungle-remedy#comments:id=163587

**Inspecting the Ruins**: Has either They Call Him Smiling Jim or James Hyal as prequest, currently only the former.

**Forked Mudrock Tongue droprate**:
http://www.wowhead.com/quest=1204/mudrock-soup-and-bugs
http://www.wowhead.com/item=5883/forked-mudrock-tongue#dropped-by
Currently 25%, making it 40%.
From the comments some complain it's terrible, some say it's 100% and great.
I'm getting the suspicion it depends on the type of Mudrock. In the database there's 5 different Mudrocks, but as of patch 2.3, 4 turtle types were removed in favour of 1.
http://www.wowhead.com/npc=4396/mudrock-tortoise#comments
http://www.wowhead.com/npc=4398/mudrock-burrower#comments
http://www.wowhead.com/npc=4399/mudrock-borer#comments
http://www.wowhead.com/npc=4400/mudrock-snapjaw#comments

**Trouble in Winterspring!**: This is a breadcrumb quest, not a prequest.
http://www.wowhead.com/quest=6603/trouble-in-winterspring#comments:id=931604

**Thick Yeti Fur droprate**:
Increasing drop rates from 33% across the board.
http://www.wowhead.com/quest=3783/deprecated-are-we-there-yeti#comments:id=1043214
It varies between the types, and seems it was buffed at the end of wotlk.
http://www.wowhead.com/npc=7457/
http://www.wowhead.com/npc=7458/
http://www.wowhead.com/npc=7459/
http://www.wowhead.com/npc=7460/

**Flesh Eating Worm  and Rotting Worm**:
These are the worms that spawn when a Rotted One in Duskwood and Rotting Cadaver in Western Plaguelands respectively dies.
http://wow.gamepedia.com/File:Flesh_Eating_Worm.jpg
I reduced the size based on the image from 2008, sorta got it right.
I reduced their damage to be 50% of the associated ghoul based on http://www.wowhead.com/npc=10925/rotting-worm#comments:id=245916.

**Fool's Stout**: Has Report Back to Fizzlebub as prequest.
http://wow.gamepedia.com/Quest:Report_Back_to_Fizzlebub

**Half-Buried Bottle loottable**:
This one was dropping Raptor Eggs at 71%, I'm taking the wild guess that that's wrong and just replacing it with the trinity core table.
```
SELECT name, gameobject_loot_template.*
FROM item_template
JOIN gameobject_loot_template ON item_template.entry = gameobject_loot_template.item
WHERE gameobject_loot_template.entry = 2032;
```
Run that for a quick laugh.

**Atal'Ai Artifacts**
I could hardly find any of these, turns out most of them were underground, so I moved them up a little.
Found 21 artifacts and 1 mithril deposit underground and 3 double spawned artifacts that are deleted.
Run around as a dwarf with the racial tracking to see what I mean.

**Blue Pearls**: These only drop from the Giant Clam objects in the vile reef.
Not Giant Clam objects in other zones nor clam items from murlocs.

**Black  Dragonflight Molt**: This item is a guaranteed drop from the Hoard of the Black Dragonflight. Currently 88.8%

**Target branch(es)**: master

**Tests performed**: tested myself.