### PR TITLE
Rupture remove when boss dies

### DIFF
--- a/src/scripts/Northrend/Gundrak/boss_gal_darah.cpp
+++ b/src/scripts/Northrend/Gundrak/boss_gal_darah.cpp
@@ -129,6 +129,7 @@ class boss_gal_darah : public CreatureScript
             {
                 Talk(SAY_DEATH);
                 BossAI::JustDied(killer);
+				killer->RemoveAurasDueToSpell(SPELL_PUNCTURE);
             }
 
             void KilledUnit(Unit*)


### PR DESCRIPTION
**Changes proposed:**

-  After the party kills the boss they have Rupture de-buff removed if this is still present on any of the players.

**Target branch:** Master

**Issues addressed:** Closes #514 

**Tests performed:** 
- Builds without errors
- Killed the boss after getting de-buffed and it works properly now.
