### PR TITLE
Fix VS2017 build

### DIFF
--- a/src/game/Movement/Spline/MovementTypedefs.h
+++ b/src/game/Movement/Spline/MovementTypedefs.h
@@ -35,12 +35,6 @@ namespace Movement
     float computeFallTime(float path_length, bool isSafeFall);
     float computeFallElevation(float t_passed, bool isSafeFall, float start_velocity = 0.0f);
 
-#ifndef static_assert
-    #define CONCAT(x, y) CONCAT1 (x, y)
-    #define CONCAT1(x, y) x##y
-    #define static_assert(expr, msg) typedef char CONCAT(static_assert_failed_at_line_, __LINE__) [(expr) ? 1 : -1]
-#endif
-
     template<class T, T limit>
     class counter
     {


### PR DESCRIPTION
**Changes proposed:**

- Remove code that conflicts with the keyword static_assert http://en.cppreference.com/w/cpp/language/static_assert
- Should fix VS2017 compilation, not sure on the effects on other compilers
- If build fails on other compilers or similar, then we can probably try to just remove all usages of static_assert since its only used in one place: https://github.com/azerothcore/azerothcore-wotlk/blob/736b92d9a70a30db1bff67cd2df2c596b4ce99c9/src/game/Movement/Spline/Spline.h#L41-L48

**Target branch(es):** 1.x/2.x etc.

**Issues addressed:** Closes #

**Tests performed:** (Does it build, tested in-game, etc)

- Compiled successfully on VS 2017

**Known issues and TODO list:**

- [ ] Test on other popular and supported compilers and platforms

# How to help with testing:
```
git clone -b Rochet2-patch-1 https://github.com/azerothcore/azerothcore-wotlk.git VS2017
```
then compile that source and post back here what compiler you used and if the build succeeded or not.
If it did not succeed post the errors.

You should preferably try compile with any other compiler than what is already tested. VS 2017 is already tested.

