### PR TITLE
[Script/SAI] Fixed Shattered Hand Blood Guard Event

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1503630648814585000.sql
+++ b/data/sql/updates/pending_db_world/rev_1503630648814585000.sql
@@ -1,0 +1,21 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1503630648814585000');
+
+-- fix arrows and spawn script, must be started after talk
+UPDATE `smart_scripts` SET  `id` = '6' WHERE `entryorguid` = '1746100' AND `source_type` = '9' AND `id` = '4' AND `link` = '0';
+UPDATE `smart_scripts` SET  `id` = '4' WHERE `entryorguid` = '1746100' AND `source_type` = '9' AND `id` = '3' AND `link` = '0'; 
+UPDATE `smart_scripts` SET  `id` = '5',`source_type` = '9',`entryorguid` = '1746100' WHERE `entryorguid` = '17461' AND `source_type` = '0' AND `id` = '2' AND `link` = '0'; 
+UPDATE `smart_scripts` SET  `id` = '3',`source_type` = '9',`entryorguid` = '1746100' WHERE `entryorguid` = '17461' AND `source_type` = '0' AND `id` = '1' AND `link` = '0'; 
+
+
+-- fix infinite spawn bug
+UPDATE `smart_scripts` SET `event_param3` = '0' , `event_param4` = '0' WHERE `entryorguid` = '1746100' AND `source_type` = '9' AND `id` = '5' AND `link` = '0';
+
+-- fix timings
+UPDATE `smart_scripts` SET `event_param1` = '4000' , `event_param2` = '4000' WHERE `entryorguid` = '1746100' AND `source_type` = '9' AND `id` = '2' AND `link` = '0'; 
+UPDATE `smart_scripts` SET `event_param1` = '0' , `event_param2` = '0' WHERE `entryorguid` = '1746100' AND `source_type` = '9' AND `id` = '3' AND `link` = '0';
+
+-- added voice to blood guard 
+UPDATE `creature_text` SET `sound` = '10156' WHERE `entry` = '17461' AND `groupid` = '0' AND `id` = '0'; 
+UPDATE `creature_text` SET `sound` = '10157' WHERE `entry` = '17461' AND `groupid` = '1' AND `id` = '0'; 
+UPDATE `creature_text` SET `sound` = '10158' WHERE `entry` = '17461' AND `groupid` = '2' AND `id` = '0'; 
+UPDATE `creature_text` SET `sound` = '10159' WHERE `entry` = '17461' AND `groupid` = '3' AND `id` = '0'; 


### PR DESCRIPTION
**Changes proposed:**

Fixed Shattered Hand Blood Guard Event

expecially:
- [x] fixed arrows and spawns events
- [x] avoid infinite spawns
- [x] added voice audio

How it worked before:
https://www.youtube.com/watch?v=hXWud6JoJwo

How it works now:
https://www.youtube.com/watch?v=mhquiJv1I_M

**Target branch(es):** master

**Issues addressed:** Closes https://github.com/azerothcore/azerothcore-wotlk/issues/529

**Tests performed:** tested on local, it works as in video

**Known issues and TODO list:**

In Retail server, the areatriggers seems to start in ~150 yards ...instead in our case it's about ~70 yards, but it's not an huge issue. 
I think we need to create a table where fix this kind of special areatrigger instead of read directly from dbc (or use an npc trigger instead)