### PR TITLE
Fix warning under GCC Unix

### DIFF
--- a/src/game/Battlefield/Battlefield.cpp
+++ b/src/game/Battlefield/Battlefield.cpp
@@ -838,7 +838,7 @@ GameObject* Battlefield::SpawnGameObject(uint32 entry, float x, float y, float z
 // ******************* CapturePoint **********************
 // *******************************************************
 
-BfCapturePoint::BfCapturePoint(Battlefield* battlefield) : m_Bf(battlefield), m_capturePoint(NULL)
+BfCapturePoint::BfCapturePoint(Battlefield* battlefield) : m_Bf(battlefield), m_capturePoint(0)
 {
     m_team = TEAM_NEUTRAL;
     m_value = 0;


### PR DESCRIPTION
**Changes proposed:**

-  Fix warning for compiler GCC under UNIX.

**Target branch(es):** master

**Issues addressed:** None

https://media.discordapp.net/attachments/348114153849749516/356393487735980032/image.png?width=1200&height=66

**Tests performed:** Tested, working

