### PR TITLE
Remove Unneeded code

### DIFF
--- a/src/game/Entities/Player/Player.cpp
+++ b/src/game/Entities/Player/Player.cpp
@@ -23161,14 +23161,6 @@ void Player::ApplyEquipCooldown(Item* pItem)
         if (!spellData.SpellId)
             continue;
 
-        // xinef: apply hidden cooldown for procs
-        /*if (spellData.SpellTrigger == ITEM_SPELLTRIGGER_ON_EQUIP)
-        {
-            // xinef: uint32(-1) special marker for proc cooldowns
-            AddSpellCooldown(spellData.SpellId, uint32(-1), 30*IN_MILLISECONDS);
-            continue;
-        }*/
-
         // wrong triggering type (note: ITEM_SPELLTRIGGER_ON_NO_DELAY_USE not have cooldown)
         if (spellData.SpellTrigger != ITEM_SPELLTRIGGER_ON_USE)
             continue;

--- a/src/game/Entities/Player/Player.cpp
+++ b/src/game/Entities/Player/Player.cpp
@@ -23162,12 +23162,12 @@ void Player::ApplyEquipCooldown(Item* pItem)
             continue;
 
         // xinef: apply hidden cooldown for procs
-        if (spellData.SpellTrigger == ITEM_SPELLTRIGGER_ON_EQUIP)
+        /*if (spellData.SpellTrigger == ITEM_SPELLTRIGGER_ON_EQUIP)
         {
             // xinef: uint32(-1) special marker for proc cooldowns
             AddSpellCooldown(spellData.SpellId, uint32(-1), 30*IN_MILLISECONDS);
             continue;
-        }
+        }*/
 
         // wrong triggering type (note: ITEM_SPELLTRIGGER_ON_NO_DELAY_USE not have cooldown)
         if (spellData.SpellTrigger != ITEM_SPELLTRIGGER_ON_USE)

--- a/src/game/Entities/Player/Player.cpp
+++ b/src/game/Entities/Player/Player.cpp
@@ -23161,6 +23161,17 @@ void Player::ApplyEquipCooldown(Item* pItem)
         if (!spellData.SpellId)
             continue;
 
+	// xinef: apply hidden cooldown for procs
+	if (sWorld->getBoolConfig(CONFIG_ITEM_SPELLTRIGGER_ON_EQUIP)
+	{
+	   if (spellData.SpellTrigger == ITEM_SPELLTRIGGER_ON_EQUIP)
+	   {
+              // xinef: uint32(-1) special marker for proc cooldowns
+              AddSpellCooldown(spellData.SpellId, uint32(-1), 30*IN_MILLISECONDS);
+              continue;
+	   }    
+	}
+
         // wrong triggering type (note: ITEM_SPELLTRIGGER_ON_NO_DELAY_USE not have cooldown)
         if (spellData.SpellTrigger != ITEM_SPELLTRIGGER_ON_USE)
             continue;


### PR DESCRIPTION
**Changes proposed:**
Removing this will make sure that anything you equip that has a proc will work instantly. So you don't have to wait 30 seconds after equipping to proc.
-  
-  
Example: Equip Shadowmourne it won't proc untill 30 seconds have passed. Same thing for Solace of the fallen and other items that have procs.
-  

**Target branch(es):** 1.x/2.x etc.

**Issues addressed:** Closes #

**Tests performed:** (Does it build, tested in-game, etc)

**Known issues and TODO list:**

- [ ] 
- [ ] 

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


