### PR TITLE
Fixed spell casting destination to require ENABLE_LOGS and ENABLE_EXTRA_LOGS to be enabled

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -977,46 +977,49 @@ void Spell::SelectImplicitChannelTargets(SpellEffIndex effIndex, SpellImplicitTa
         return;
     }
 
-    switch (targetType.GetTarget())
-    {
-        case TARGET_UNIT_CHANNEL_TARGET:
-        {
-            // Xinef: All channel selectors have needed data passed in m_targets structure
-            WorldObject* target = m_targets.GetObjectTargetChannel(m_caster);
-            if (target)
-            {
-                CallScriptObjectTargetSelectHandlers(target, effIndex, targetType);
-                // unit target may be no longer avalible - teleported out of map for example
-                if (target && target->ToUnit())
-                    AddUnitTarget(target->ToUnit(), 1 << effIndex);
-            }
-            else
+	switch (targetType.GetTarget())
+	{
+	case TARGET_UNIT_CHANNEL_TARGET:
+	{
+		// Xinef: All channel selectors have needed data passed in m_targets structure
+		WorldObject* target = m_targets.GetObjectTargetChannel(m_caster);
+		if (target)
+		{
+			CallScriptObjectTargetSelectHandlers(target, effIndex, targetType);
+			// unit target may be no longer avalible - teleported out of map for example
+			if (target && target->ToUnit())
+				AddUnitTarget(target->ToUnit(), 1 << effIndex);
+		}
+		else {
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
-                sLog->outDebug(LOG_FILTER_SPELLS_AURAS, "SPELL: cannot find channel spell target for spell ID %u, effect %u", m_spellInfo->Id, effIndex);
+			sLog->outDebug(LOG_FILTER_SPELLS_AURAS, "SPELL: cannot find channel spell target for spell ID %u, effect %u", m_spellInfo->Id, effIndex);
 #endif
-            break;
-        }
-        case TARGET_DEST_CHANNEL_TARGET:
-            if (m_targets.HasDstChannel())
-                m_targets.SetDst(*m_targets.GetDstChannel());
-            else if (WorldObject* target = m_targets.GetObjectTargetChannel(m_caster))
-            {
-                CallScriptObjectTargetSelectHandlers(target, effIndex, targetType);
-                if (target)
-                    m_targets.SetDst(*target);
-            }
-            else //if (!m_targets.HasDst())
+		}
+		break;
+	}
+	case TARGET_DEST_CHANNEL_TARGET:
+		if (m_targets.HasDstChannel())
+			m_targets.SetDst(*m_targets.GetDstChannel());
+		else if (WorldObject* target = m_targets.GetObjectTargetChannel(m_caster))
+		{
+			CallScriptObjectTargetSelectHandlers(target, effIndex, targetType);
+			if (target)
+				m_targets.SetDst(*target);
+		}
+		else //if (!m_targets.HasDst())
+		{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
-                sLog->outDebug(LOG_FILTER_SPELLS_AURAS, "SPELL: cannot find channel spell destination for spell ID %u, effect %u", m_spellInfo->Id, effIndex);
+			sLog->outDebug(LOG_FILTER_SPELLS_AURAS, "SPELL: cannot find channel spell destination for spell ID %u, effect %u", m_spellInfo->Id, effIndex);
 #endif
-            break;
-        case TARGET_DEST_CHANNEL_CASTER:
-            if (GetOriginalCaster())
-                m_targets.SetDst(*GetOriginalCaster());
-            break;
-        default:
-            ASSERT(false && "Spell::SelectImplicitChannelTargets: received not implemented target type");
-            break;
+		}
+        break;
+    case TARGET_DEST_CHANNEL_CASTER:
+        if (GetOriginalCaster())
+            m_targets.SetDst(*GetOriginalCaster());
+        break;
+    default:
+        ASSERT(false && "Spell::SelectImplicitChannelTargets: received not implemented target type");
+        break;
     }
 }
 

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -977,50 +977,50 @@ void Spell::SelectImplicitChannelTargets(SpellEffIndex effIndex, SpellImplicitTa
         return;
     }
 
-	switch (targetType.GetTarget())
-	{
-	case TARGET_UNIT_CHANNEL_TARGET:
-	{
-		// Xinef: All channel selectors have needed data passed in m_targets structure
-		WorldObject* target = m_targets.GetObjectTargetChannel(m_caster);
-		if (target)
-		{
-			CallScriptObjectTargetSelectHandlers(target, effIndex, targetType);
-			// unit target may be no longer avalible - teleported out of map for example
-			if (target && target->ToUnit())
-				AddUnitTarget(target->ToUnit(), 1 << effIndex);
-		}
-		else {
+    switch (targetType.GetTarget())
+    {
+    case TARGET_UNIT_CHANNEL_TARGET:
+    {
+        // Xinef: All channel selectors have needed data passed in m_targets structure
+        WorldObject* target = m_targets.GetObjectTargetChannel(m_caster);
+        if (target)
+        {
+            CallScriptObjectTargetSelectHandlers(target, effIndex, targetType);
+            // unit target may be no longer avalible - teleported out of map for example
+            if (target && target->ToUnit())
+                AddUnitTarget(target->ToUnit(), 1 << effIndex);
+        }
+        else {
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
-			sLog->outDebug(LOG_FILTER_SPELLS_AURAS, "SPELL: cannot find channel spell target for spell ID %u, effect %u", m_spellInfo->Id, effIndex);
+            sLog->outDebug(LOG_FILTER_SPELLS_AURAS, "SPELL: cannot find channel spell target for spell ID %u, effect %u", m_spellInfo->Id, effIndex);
 #endif
-		}
-		break;
-	}
-	case TARGET_DEST_CHANNEL_TARGET:
-		if (m_targets.HasDstChannel())
-			m_targets.SetDst(*m_targets.GetDstChannel());
-		else if (WorldObject* target = m_targets.GetObjectTargetChannel(m_caster))
-		{
-			CallScriptObjectTargetSelectHandlers(target, effIndex, targetType);
-			if (target)
-				m_targets.SetDst(*target);
-		}
-		else //if (!m_targets.HasDst())
-		{
+        }
+        break;
+    }
+    case TARGET_DEST_CHANNEL_TARGET:
+        if (m_targets.HasDstChannel())
+            m_targets.SetDst(*m_targets.GetDstChannel());
+        else if (WorldObject* target = m_targets.GetObjectTargetChannel(m_caster))
+        {
+            CallScriptObjectTargetSelectHandlers(target, effIndex, targetType);
+            if (target)
+                m_targets.SetDst(*target);
+        }
+        else //if (!m_targets.HasDst())
+        {
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
-			sLog->outDebug(LOG_FILTER_SPELLS_AURAS, "SPELL: cannot find channel spell destination for spell ID %u, effect %u", m_spellInfo->Id, effIndex);
+            sLog->outDebug(LOG_FILTER_SPELLS_AURAS, "SPELL: cannot find channel spell destination for spell ID %u, effect %u", m_spellInfo->Id, effIndex);
 #endif
-		}
-		break;
-	case TARGET_DEST_CHANNEL_CASTER:
-		if (GetOriginalCaster())
-			m_targets.SetDst(*GetOriginalCaster());
-		break;
-	default:
-		ASSERT(false && "Spell::SelectImplicitChannelTargets: received not implemented target type");
-		break;
-	}
+        }
+        break;
+    case TARGET_DEST_CHANNEL_CASTER:
+        if (GetOriginalCaster())
+            m_targets.SetDst(*GetOriginalCaster());
+        break;
+    default:
+        ASSERT(false && "Spell::SelectImplicitChannelTargets: received not implemented target type");
+        break;
+    }
 }
 
 void Spell::SelectImplicitNearbyTargets(SpellEffIndex effIndex, SpellImplicitTargetInfo const& targetType, uint32 effMask)

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -1012,15 +1012,15 @@ void Spell::SelectImplicitChannelTargets(SpellEffIndex effIndex, SpellImplicitTa
 			sLog->outDebug(LOG_FILTER_SPELLS_AURAS, "SPELL: cannot find channel spell destination for spell ID %u, effect %u", m_spellInfo->Id, effIndex);
 #endif
 		}
-        break;
-    case TARGET_DEST_CHANNEL_CASTER:
-        if (GetOriginalCaster())
-            m_targets.SetDst(*GetOriginalCaster());
-        break;
-    default:
-        ASSERT(false && "Spell::SelectImplicitChannelTargets: received not implemented target type");
-        break;
-    }
+		break;
+	case TARGET_DEST_CHANNEL_CASTER:
+		if (GetOriginalCaster())
+			m_targets.SetDst(*GetOriginalCaster());
+		break;
+	default:
+		ASSERT(false && "Spell::SelectImplicitChannelTargets: received not implemented target type");
+		break;
+	}
 }
 
 void Spell::SelectImplicitNearbyTargets(SpellEffIndex effIndex, SpellImplicitTargetInfo const& targetType, uint32 effMask)


### PR DESCRIPTION
**Changes proposed:**

-  Channeled spells cast by a player no longer require the ENABLE_LOGS and ENABLE_EXTRA_LOGS to be enabled for the spell to function correctly.

**Target branch(es):** master

**Issues addressed:** Closes #601 

**Tests performed:** (Does it build, tested in-game, etc) - Builds, tested Blizzard, Penance and Mindseer in game.

**Known issues and TODO list:**
-  None

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


