### PR TITLE
Core/Build: Never overwrite the msvc cxx flags in the cache

### DIFF
--- a/modules/worldengine/nucleus/src/cmake/compiler/msvc/settings.cmake
+++ b/modules/worldengine/nucleus/src/cmake/compiler/msvc/settings.cmake
@@ -59,7 +59,7 @@ endif()
 # Fixes a compiler-problem when using PCH - the /Ym flag is adjusted by the compiler in MSVC2012, hence we need to set an upper limit with /Zm to avoid discrepancies)
 # (And yes, this is a verified , unresolved bug with MSVC... *sigh*)
 string(REGEX REPLACE "/Zm[0-9]+ *" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zm500" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zm500")
 
 # Enable and treat as errors the following warnings to easily detect virtual function signature failures:
 # 'function' : member function does not override any base class virtual member function


### PR DESCRIPTION
* Setting all compiler flags in the cache led to circular bloating of
  msvc cxx parameters (was visible in console) which caused MSVC to
  rebuild the whole solution even on a small CMake change.
  It's not neccessary anyway to set the cxx parameters to the cache
  to take effect.
* Cleaning the CMake cache is recommended!

Basically when you run cmake then you always need to rebuild the whole solution.
This fix will fix it so that only changed files need to be rebuilt.
This is a cherry pick from TC.

**Target branch(es):** 1.x/2.x etc.
all

**Tests performed:** (Does it build, tested in-game, etc)
Does build and rebuild after using cmake (configure generate) does not compile anything again if nothing has changed.

**Known issues and TODO list:**

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


