### PR TITLE
Fix Lady Deathwhisper intro

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1517167424973293300.sql
+++ b/data/sql/updates/pending_db_world/rev_1517167424973293300.sql
@@ -1,0 +1,4 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1517167424973293300');
+
+DELETE FROM `areatrigger_scripts` WHERE `entry` = 5709;
+INSERT INTO `areatrigger_scripts` VALUES (5709, 'at_lady_deathwhisper_entrance');

--- a/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
@@ -157,6 +157,7 @@ class instance_icecrown_citadel : public InstanceMapScript
                 LoadDoorData(doorData);
                 TeamIdInInstance = TEAM_NEUTRAL;
                 HeroicAttempts = MaxHeroicAttempts;
+                LadyDeathwhisperGUID = 0;
                 LadyDeathwisperElevatorGUID = 0;
                 GunshipGUID = 0;
                 EnemyGunshipGUID = 0;
@@ -343,6 +344,9 @@ class instance_icecrown_citadel : public InstanceMapScript
                             instance->SummonCreature(NPC_UTHER_THE_LIGHTBRINGER_QUEST, UtherSpawnPos);
                             instance->SummonCreature(NPC_LADY_SYLVANAS_WINDRUNNER_QUEST, SylvanasSpawnPos);
                         }
+                        break;
+                    case NPC_LADY_DEATHWHISPER:
+                        LadyDeathwhisperGUID = creature->GetGUID();
                         break;
                     case NPC_DEATHBRINGER_SAURFANG:
                         DeathbringerSaurfangGUID = creature->GetGUID();
@@ -925,6 +929,8 @@ class instance_icecrown_citadel : public InstanceMapScript
             {
                 switch (type)
                 {
+                    case DATA_LADY_DEATHWHISPER:
+                        return LadyDeathwhisperGUID;
                     case DATA_ICECROWN_GUNSHIP_BATTLE:
                         return GunshipGUID;
                     case DATA_ENEMY_GUNSHIP:
@@ -1825,6 +1831,7 @@ class instance_icecrown_citadel : public InstanceMapScript
             uint64 ScourgeTransporterFirstGUID;
 
             EventMap Events;
+            uint64 LadyDeathwhisperGUID;
             uint64 LadyDeathwisperElevatorGUID;
             uint64 GunshipGUID;
             uint64 EnemyGunshipGUID;


### PR DESCRIPTION
When you are at Lord Marrowgar entrance and he starts his intro, Lady
starts her intro too. With this fix, that is fixed.

**Changes proposed:**

-  Use DoAction + AreaTriggerScript instead MoveInLOS for intro.

**Target branch(es):** master

**Issues addressed:** -

**Tests performed:** Build and tested in game.

**Known issues and TODO list:** -


