### PR TITLE
Heart-Shaped Box

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1518477962308987200.sql
+++ b/data/sql/updates/pending_db_world/rev_1518477962308987200.sql
@@ -1,0 +1,7 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1518477962308987200');
+
+--Evilpriest #0003
+--Added EoF from Heart-Shaped Box
+
+INSERT INTO `item_loot_template` (`entry`,`item`,`ChanceOrQuestChance`,`lootmode`,`groupid`,`mincountOrRef`,`maxcount`) VALUES
+('54537','49426','100','1','0','2','2')

--- a/data/sql/updates/pending_db_world/rev_1518477962308987200.sql
+++ b/data/sql/updates/pending_db_world/rev_1518477962308987200.sql
@@ -1,7 +1,4 @@
-INSERT INTO version_db_world (`sql_rev`) VALUES ('1518477962308987200');
-
-#--Evilpriest #0003
-#--Added EoF from Heart-Shaped Box
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1518477962308987200');
 
 DELETE FROM `item_loot_template` WHERE (`entry` = 54537 AND `item` = 49426);
 INSERT INTO `item_loot_template` (`entry`,`item`,`ChanceOrQuestChance`,`lootmode`,`groupid`,`mincountOrRef`,`maxcount`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1518477962308987200.sql
+++ b/data/sql/updates/pending_db_world/rev_1518477962308987200.sql
@@ -1,5 +1,5 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1518477962308987200');
 
-DELETE FROM `item_loot_template` WHERE (`entry` = 54537 AND `item` = 49426);
-INSERT INTO `item_loot_template` (`entry`,`item`,`ChanceOrQuestChance`,`lootmode`,`groupid`,`mincountOrRef`,`maxcount`) VALUES
-('54537','49426','100','1','0','2','2');
+DELETE FROM `item_loot_template` WHERE `Entry` = 54537 AND `Item` = 49426;
+INSERT INTO `item_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
+(54537, 49426, 0, 100, 0, 1, 0, 2, 2, '');

--- a/data/sql/updates/pending_db_world/rev_1518477962308987200.sql
+++ b/data/sql/updates/pending_db_world/rev_1518477962308987200.sql
@@ -1,7 +1,7 @@
 INSERT INTO version_db_world (`sql_rev`) VALUES ('1518477962308987200');
 
---Evilpriest #0003
---Added EoF from Heart-Shaped Box
+#--Evilpriest #0003
+#--Added EoF from Heart-Shaped Box
 
 INSERT INTO `item_loot_template` (`entry`,`item`,`ChanceOrQuestChance`,`lootmode`,`groupid`,`mincountOrRef`,`maxcount`) VALUES
 ('54537','49426','100','1','0','2','2')

--- a/data/sql/updates/pending_db_world/rev_1518477962308987200.sql
+++ b/data/sql/updates/pending_db_world/rev_1518477962308987200.sql
@@ -3,5 +3,6 @@ INSERT INTO version_db_world (`sql_rev`) VALUES ('1518477962308987200');
 #--Evilpriest #0003
 #--Added EoF from Heart-Shaped Box
 
+DELETE FROM `item_loot_template` WHERE (`entry` = 54537 AND `item` = 49426);
 INSERT INTO `item_loot_template` (`entry`,`item`,`ChanceOrQuestChance`,`lootmode`,`groupid`,`mincountOrRef`,`maxcount`) VALUES
-('54537','49426','100','1','0','2','2')
+('54537','49426','100','1','0','2','2');


### PR DESCRIPTION
Doing the first Event Dungeon Finder of the day currently won't award any Emblem of Frost and will aswell count as the first RDF of the day, thus making impossible to get the first two EoFs of the day (with RDFs).

**Changes proposed:**
Adding 2x Emblem of Frost inside the Heart-Shaped Box.

**Target branch(es):** master

**Tests performed:** Tested in game.