### PR TITLE
Addon message read fix

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -143,13 +143,14 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket & recvData)
 
                 if (sWorld->getBoolConfig(CONFIG_CHATLOG_ADDON))
                 {
-                    std::string msg = "";
-                    recvData >> msg;
+                    std::string to, msg;
+                    recvData >> to >> msg;
+                    Player* receiver = ObjectAccessor::FindPlayerByName(to, false); 
 
                     if (msg.empty())
                         return;
 
-                    sScriptMgr->OnPlayerChat(sender, uint32(CHAT_MSG_ADDON), lang, msg);
+                    sScriptMgr->OnPlayerChat(sender, type, lang, msg, receiver);
                 }
 
                 break;


### PR DESCRIPTION
The receiver player name is missing from the read and it was defined to be the "msg".

**Changes proposed:**
Fixing the received whisper addonmessage packet reading from the client.

**Target branch(es):** master

**Tests performed:** Tested in game.