### PR TITLE
Bash scripts conf - Set backup to false by default

### DIFF
--- a/conf/config.sh.dist
+++ b/conf/config.sh.dist
@@ -74,11 +74,11 @@ DATABASES=(
 OUTPUT_FOLDER="$AC_PATH_ROOT/env/dist/sql/"
 
 #
-# Enable following flag 
-# if you want backup your db
-# before import sql with db_assembler
-#
-BACKUP_ENABLE=true
+# Set to true if you want to backup your db
+# before importing the SQL with the db_assembler
+# Do not forget to stop the database before doing so
+
+BACKUP_ENABLE=false
 
 BACKUP_FOLDER="$AC_PATH_ROOT/env/dist/sql/backup/"
 


### PR DESCRIPTION

**Changes proposed:**

-  Set backup option to false by default
-  Fixed typos
-  Added a small warning in the comment


Why?
Because some people might not have a look at the conf (or in depth) and don't have a use for this backup. It shouldn't happen without user's consent in my opinion.


