### PR TITLE
Added Apprentice Riding (33388) spell to Death Knight playercreateinf…

### DIFF
--- a/data/sql/updates/pending_db_characters/rev_1520901993138566700.sql
+++ b/data/sql/updates/pending_db_characters/rev_1520901993138566700.sql
@@ -1,2 +1,0 @@
-DELETE FROM `playercreateinfo_spell` where `Note`='Apprentice Riding';
-INSERT INTO `playercreateinfo_spell` (`racemask`, `classmask`, `Spell`, `Note`) VALUES (0, 32, 33388, 'Apprentice Riding');

--- a/data/sql/updates/pending_db_characters/rev_1520901993138566700.sql
+++ b/data/sql/updates/pending_db_characters/rev_1520901993138566700.sql
@@ -1,2 +1,2 @@
-DELETE FROM `characters`.`playercreateinfo_spell` where `Note`='Apprentice Riding';
-INSERT INTO `characters`.`playercreateinfo_spell` (`racemask`, `classmask`, `Spell`, `Note`) VALUES (0, 32, 33388, 'Apprentice Riding');
+DELETE FROM `playercreateinfo_spell` where `Note`='Apprentice Riding';
+INSERT INTO `playercreateinfo_spell` (`racemask`, `classmask`, `Spell`, `Note`) VALUES (0, 32, 33388, 'Apprentice Riding');

--- a/data/sql/updates/pending_db_characters/rev_1520901993138566700.sql
+++ b/data/sql/updates/pending_db_characters/rev_1520901993138566700.sql
@@ -1,0 +1,2 @@
+DELETE FROM `characters`.`playercreateinfo_spell` where `Note`='Apprentice Riding';
+INSERT INTO `characters`.`playercreateinfo_spell` (`racemask`, `classmask`, `Spell`, `Note`) VALUES (0, 32, 33388, 'Apprentice Riding');

--- a/data/sql/updates/pending_db_world/rev_1520902066724046200.sql
+++ b/data/sql/updates/pending_db_world/rev_1520902066724046200.sql
@@ -1,4 +1,3 @@
 INSERT INTO version_db_world (`sql_rev`) VALUES ('1520902066724046200');
-
-DELETE FROM `playercreateinfo_spell` where `Note`='Apprentice Riding';
+DELETE FROM `playercreateinfo_spell` WHERE `Spell`=33388 AND `racemask`=0 AND `classmask`=32;
 INSERT INTO `playercreateinfo_spell` (`racemask`, `classmask`, `Spell`, `Note`) VALUES (0, 32, 33388, 'Apprentice Riding');

--- a/data/sql/updates/pending_db_world/rev_1520902066724046200.sql
+++ b/data/sql/updates/pending_db_world/rev_1520902066724046200.sql
@@ -1,0 +1,2 @@
+DELETE FROM `world`.`playercreateinfo_spell` where `Note`='Apprentice Riding';
+INSERT INTO `world`.`playercreateinfo_spell` (`racemask`, `classmask`, `Spell`, `Note`) VALUES (0, 32, 33388, 'Apprentice Riding');

--- a/data/sql/updates/pending_db_world/rev_1520902066724046200.sql
+++ b/data/sql/updates/pending_db_world/rev_1520902066724046200.sql
@@ -1,2 +1,4 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1520902066724046200');
+
 DELETE FROM `playercreateinfo_spell` where `Note`='Apprentice Riding';
 INSERT INTO `playercreateinfo_spell` (`racemask`, `classmask`, `Spell`, `Note`) VALUES (0, 32, 33388, 'Apprentice Riding');

--- a/data/sql/updates/pending_db_world/rev_1520902066724046200.sql
+++ b/data/sql/updates/pending_db_world/rev_1520902066724046200.sql
@@ -1,2 +1,2 @@
-DELETE FROM `world`.`playercreateinfo_spell` where `Note`='Apprentice Riding';
-INSERT INTO `world`.`playercreateinfo_spell` (`racemask`, `classmask`, `Spell`, `Note`) VALUES (0, 32, 33388, 'Apprentice Riding');
+DELETE FROM `playercreateinfo_spell` where `Note`='Apprentice Riding';
+INSERT INTO `playercreateinfo_spell` (`racemask`, `classmask`, `Spell`, `Note`) VALUES (0, 32, 33388, 'Apprentice Riding');


### PR DESCRIPTION
I couldn't find any documentation of Death Knights already having Expert Riding without buying the training in retail, so I only fixed the issue with Apprentice Riding.
^ Please correct me if I'm mistaken.

**Changes proposed:**
-  Added Apprentice Riding (33388) to 'playercreateinfo_spells' table in 'world' and 'characters' databases for Death Knights of all Races.

**Target branch(es):**  master

**Issues addressed:** Updates #639 

**Tests performed:** Tested in-game and working.