### PR TITLE
DB - Areatrigger - Removes warnings when booting the server

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1522263653566045620.sql
+++ b/data/sql/updates/pending_db_world/rev_1522263653566045620.sql
@@ -1,3 +1,3 @@
-INSERT INTO version_db_auth(sql_rev) VALUES ('1522263653566045620');
+INSERT INTO version_db_world(sql_rev) VALUES ('1522263653566045620');
 
 DELETE FROM `areatrigger` WHERE map IN (24,28);

--- a/data/sql/updates/pending_db_world/rev_1522263653566045620.sql
+++ b/data/sql/updates/pending_db_world/rev_1522263653566045620.sql
@@ -1,0 +1,3 @@
+INSERT INTO version_db_auth(sql_rev) VALUES ('1522263653566045620');
+
+DELETE FROM `areatrigger` WHERE map IN (24,28);


### PR DESCRIPTION
There are 3 triggers that are from the areatrigger.dbc which are useless since the linked maps don't exist.
It's probably a mistake from blizz.

**Changes proposed:**

-  Fixes:
Loading Area Trigger definitions
Area trigger (ID:60) map (ID: 24) does not exist in `Map.dbc`.
Area trigger (ID:81) map (ID: 28) does not exist in `Map.dbc`.
Area trigger (ID:83) map (ID: 28) does not exist in `Map.dbc`.

**Target branch(es):** 1.x/2.x etc.

**Issues addressed:** Part of https://github.com/azerothcore/azerothcore-wotlk/issues/679

**Tests performed:** yes, removed



**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


