### PR TITLE
[Naxxramas] Gluth - Eating zombies in meele range

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/boss_gluth.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gluth.cpp
@@ -186,7 +186,7 @@ public:
                     }
                 case EVENT_CAN_EAT_ZOMBIE:
                     events.RepeatEvent(1000);
-                    if (me->GetVictim()->GetEntry() == NPC_ZOMBIE_CHOW && me->IsWithinMeleeRange(me->GetVictim()))
+                    if (me->FindNearestCreature(NPC_ZOMBIE_CHOW, 4.0f, true))
                     {
                         me->CastCustomSpell(SPELL_CHOW_SEARCHER, SPELLVALUE_RADIUS_MOD, 20000, me, true);
                         me->MonsterTextEmote("%s devour all nearby zombies!", 0, false);


### PR DESCRIPTION
Gluth was moving torwards any zombie that spawned ignoring all range. Like this he will only eat the ones that get in Meele range.

**Changes proposed:**

-  Changed the distance at which he ate the zombies to meele

**Target branch(es):** 1.x/2.x/ Master

**Issues addressed:** Closes #736 

**Tests performed:** (Does it build, tested in-game, etc)

Builds and tested in-game by me

**Known issues and TODO list:**

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


