### PR TITLE
Change waypoint data of Deathguard Terrence in Brill

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1525369154910150908.sql
+++ b/data/sql/updates/pending_db_world/rev_1525369154910150908.sql
@@ -1,0 +1,3 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1525369154910150908');
+
+UPDATE `waypoint_data` SET `action` = 484 WHERE `id` = 297790 AND `point` = 13;


### PR DESCRIPTION
**Changes proposed:**
Change the action when he reaches the lantern: Use oneshot "laughing" instead of emote state

**Target branch(es):** master

**Issues addressed:** Closes #837 

**Tests performed:** tested build incl. DB update, tested in-game

**Known issues and TODO list:** none

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


