### PR TITLE
Change Fear spell of Bleeding Hollow Tormentor

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1525369633022692869.sql
+++ b/data/sql/updates/pending_db_world/rev_1525369633022692869.sql
@@ -1,0 +1,3 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1525369633022692869');
+
+UPDATE `smart_scripts` SET `action_param1` = 12542 WHERE `entryorguid` = 19424 AND `id` = 0;


### PR DESCRIPTION
**Changes proposed:**
Change spell from 33924 to 12542. They are both equal, but the former caused the NPC to always cast the spell on itself.

**Target branch(es):** master

**Issues addressed:** Closes  #838 

**Tests performed:** tested build incl. DB update, tested in-game

**Known issues and TODO list:** none

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


