### PR TITLE
Fix Forlorn Spirit (part of the "Legend of Stalvan" quest chain)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1525370516654001760.sql
+++ b/data/sql/updates/pending_db_world/rev_1525370516654001760.sql
@@ -1,0 +1,19 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1525370516654001760');
+
+UPDATE `smart_scripts` SET `link` = 3, `target_type` = 21, `target_param1` = 30, `action_param2` = 5000 WHERE `entryorguid` = 2044 AND `id` = 0;
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 2044 AND `id` IN (3,4);
+INSERT INTO `smart_scripts`
+(`entryorguid`,`source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`,`event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(2044, 0, 3, 4,
+52, 0, 100, 0, 0, 2044, 0, 0,
+2, 16, 0, 0, 0, 0, 0,
+1, 0, 0, 0, 0, 0, 0, 0, 'Forlorn Spirit - On Text Over - Set Faction 16'),
+(2044, 0, 4, 0,
+61, 0, 100, 0, 0, 0, 0, 0,
+49, 0, 0, 0, 0, 0, 0,
+21, 30, 0, 0, 0, 0, 0, 0, 'Forlorn Spirit - On Text Over - Start Attacking');


### PR DESCRIPTION
**Changes proposed:**
The "Forlorn Spirit" (NPC 2044) is part of the "Legend of Stalvan" quest chain:
https://wowgaming.altervista.org/aowow/?quest=66

It spawns at different places when finding traces of Stalvan. The following fixes have been applied:

- Target closest player (<30 yards) in order to fill the name and race variables with correct values
- Change from neutral to hostile after 5 seconds and attack the closest player (<30 yards)

**Target branch(es):** master

**Tests performed:** tested build incl. DB update, tested in-game

**Known issues and TODO list:** none

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


