### PR TITLE
Fix quest 13956 "Meeting a Great One" (Children's Week)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1525438412721008951.sql
+++ b/data/sql/updates/pending_db_world/rev_1525438412721008951.sql
@@ -1,0 +1,4 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1525438412721008951');
+
+UPDATE `creature_template` SET `scriptname` = 'npc_the_etymidian' WHERE `entry` = 28092;
+UPDATE `creature_template` SET `scriptname` = '' WHERE `entry` = 28033;


### PR DESCRIPTION
**Changes proposed:**
As Deku mentioned in Discord the quest 13956 "Meeting a Great One" is not working. The cause is the missing script name for NPC 28092 (The Etymidian). Somehow the script has been set for the wrong NPC 28033 (Weslex Quickwrench). The appropriate entries have been updated.

**Target branch(es):** master

**Tests performed:** tested build incl. DB update, tested in-game

**Known issues and TODO list:** none

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


