### PR TITLE
Fix overlapping mailbox in undercity (Trade Quarter, south)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1525439768213092888.sql
+++ b/data/sql/updates/pending_db_world/rev_1525439768213092888.sql
@@ -1,0 +1,3 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1525439768213092888');
+
+DELETE FROM `gameobject` WHERE `id` = 195629;


### PR DESCRIPTION
**Changes proposed:**
There are two overlapping mailboxes in Undercity, south Trade Quarter. Delete one of them.

**Target branch(es):** master

**Tests performed:** tested build incl. DB update, tested in-game

**Known issues and TODO list:** none

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


