### PR TITLE
Change determination of pet type

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -671,20 +671,18 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
 
     //Determine pet type
     PetType petType = MAX_PET_TYPE;
+
     if (IsPet() && m_owner->GetTypeId() == TYPEID_PLAYER)
     {
-        if (m_owner->getClass() == CLASS_WARLOCK ||
-            m_owner->getClass() == CLASS_SHAMAN ||          // Fire Elemental
-            m_owner->getClass() == CLASS_DEATH_KNIGHT ||    // Risen Ghoul
-            m_owner->getClass() == CLASS_MAGE)              // Water Elemental with glyph
-            petType = SUMMON_PET;
-        else if (m_owner->getClass() == CLASS_HUNTER)
+        if (cinfo->IsTameable(true))
         {
             petType = HUNTER_PET;
             m_unitTypeMask |= UNIT_MASK_HUNTER_PET;
         }
         else
-            sLog->outError("Unknown type pet %u is summoned by player class %u", GetEntry(), m_owner->getClass());
+        {
+            petType = SUMMON_PET;
+        }
     }
 
     uint32 creature_ID = (petType == HUNTER_PET) ? 1 : cinfo->Entry;


### PR DESCRIPTION
Allow modules like NPC Beastmaster to handle hunter pets for all classes without regression to Azerothcore.

**Changes proposed:**
Change determination of pet type: Instead of evaluating the player class only check if the pet is tameable. Neither demons, elementals nor undead are tameable, so this would be an improvement for the NPC Beastmaster module without regression to Azerothcore.

**Target branch(es):** master

**Tests performed:** tested build, tested in-game

**Known issues and TODO list:** none

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


