### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ language: cpp
 compiler:
   - clang
 
+addons:
+  apt:
+    update: true
+
 git:
   depth: 1
 


### PR DESCRIPTION
Fixes travis compile: https://travis-ci.org/azerothcore/azerothcore-wotlk/builds/377302311
Travis changed recently:
```
Running apt-get update by default has been disabled.
You can opt into running apt-get update by setting this in your .travis.yml file:
  addons:
    apt:
      update: true
```
without the setting the following errors occur:
```
=====     INSTALLER SCRIPT     =====
Platform: linux-gnu
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'cmake3' instead of 'cmake'
Note, selecting 'cmake3-data' instead of 'cmake-data'
Package clang is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  clang-3.5 clang-3.5:i386
E: Package 'clang' has no installation candidate
E: Unable to locate package libgoogle-perftools-dev
E: Unable to locate package libmysql++-dev
E: Couldn't find any package by regex 'libmysql++-dev'
E: Unable to locate package libace-dev
The command "bash ./install.sh 2" failed and exited with 100 during .
Your build has been stopped.
```
So this PR adds that setting.