### PR TITLE
Bugfix quest "The Endless Hunger": Wrong source for second talk text.

### DIFF
--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -715,7 +715,7 @@ public:
                 me->CastSpell(me, SPELL_DK_INITIATE_VISUAL, true);
 
                 if (Player* starter = ObjectAccessor::GetPlayer(*me, playerGUID))
-                    sCreatureTextMgr->SendChat(me, SAY_EVENT_ATTACK, NULL, CHAT_MSG_ADDON, LANG_ADDON, TEXT_RANGE_NORMAL, 0, TEAM_NEUTRAL, false, starter);
+                    Talk(SAY_EVENT_ATTACK, starter);
 
                 phase = PHASE_TO_ATTACK;
             }


### PR DESCRIPTION
**Changes proposed:**
Currently the second talk text of the Unworthy Initiate has the player as source. This leads to a wrong text when the race variable "$r" is included ("Sate your hunger on cold steel, $r!").
Fix:
Both text lines should have the Unworthy Initiate as source (see also https://youtu.be/U6ZWyvp9b3Q?t=199). Replaced the function call "sCreatureTextMgr->SendChat" with "Talk".

**Target branch(es):** master

**Issues addressed:** Closes #

**Tests performed:** Tested build, tested in-game

**Known issues and TODO list:** none

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


