### PR TITLE
DB - Deadmines - Add missing waypathes to some patrols

### DIFF
--- a/data/sql/updates/db_world/2018_05_16_00.sql
+++ b/data/sql/updates/db_world/2018_05_16_00.sql
@@ -1,3 +1,19 @@
+-- DB update 2018_05_13_01 -> 2018_05_16_00
+DROP PROCEDURE IF EXISTS `updateDb`;
+DELIMITER //
+CREATE PROCEDURE updateDb ()
+proc:BEGIN DECLARE OK VARCHAR(100) DEFAULT 'FALSE';
+SELECT COUNT(*) INTO @COLEXISTS
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'version_db_world' AND COLUMN_NAME = '2018_05_13_01';
+IF @COLEXISTS = 0 THEN LEAVE proc; END IF;
+START TRANSACTION;
+ALTER TABLE version_db_world CHANGE COLUMN 2018_05_13_01 2018_05_16_00 bit;
+SELECT sql_rev INTO OK FROM version_db_world WHERE sql_rev = '1526486038703940708'; IF OK <> 'FALSE' THEN LEAVE proc; END IF;
+--
+-- START UPDATING QUERIES
+--
+
 INSERT INTO version_db_world (`sql_rev`) VALUES ('1526486038703940708');
 
 -- Add missing waypoints on patrolling mobs before the Ogre boss
@@ -13,3 +29,12 @@ INSERT INTO waypoint_data (id, point, position_x, position_y, position_z, orient
 (793730, 9, -172.693, -407.324, 56.4777, 0, 0, 0, 0, 100, 214533),
 (793730, 10, -169.554, -402.835, 57.1019, 0, 0, 0, 0, 100, 214534);
 
+
+--
+-- END UPDATING QUERIES
+--
+COMMIT;
+END //
+DELIMITER ;
+CALL updateDb();
+DROP PROCEDURE IF EXISTS `updateDb`;

--- a/data/sql/updates/pending_db_world/rev_1526486038703940708.sql
+++ b/data/sql/updates/pending_db_world/rev_1526486038703940708.sql
@@ -1,13 +1,15 @@
 INSERT INTO version_db_world (`sql_rev`) VALUES ('1526486038703940708');
 
--- Add missing waypoints on patrols before the Ogre boss
-INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 1, -158.903, -399.895, 56.3324, 0, 0, 0, 0, 100, 214525);
-INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 2, -151.984, -402.043, 56.9471, 0, 0, 0, 0, 100, 214526);
-INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 3, -144.297, -403.96, 57.6147, 0, 0, 0, 0, 100, 214527);
-INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 4, -154.368, -401.496, 56.7647, 0, 0, 0, 0, 100, 214528);
-INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 5, -161.632, -400.326, 56.6994, 0, 0, 0, 0, 100, 214529);
-INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 6, -167.493, -401.874, 57.0191, 0, 0, 0, 0, 100, 214530);
-INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 7, -170.658, -405.778, 57.1812, 0, 0, 0, 0, 100, 214531);
-INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 8, -179.541, -417.187, 55.0673, 0, 0, 0, 0, 100, 214532);
-INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 9, -172.693, -407.324, 56.4777, 0, 0, 0, 0, 100, 214533);
-INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 10, -169.554, -402.835, 57.1019, 0, 0, 0, 0, 100, 214534);
+-- Add missing waypoints on patrolling mobs before the Ogre boss
+INSERT INTO waypoint_data (id, point, position_x, position_y, position_z, orientation, delay, move_type, action, action_chance, wpguid) VALUES 
+(793730, 1, -158.903, -399.895, 56.3324, 0, 0, 0, 0, 100, 214525),
+(793730, 2, -151.984, -402.043, 56.9471, 0, 0, 0, 0, 100, 214526),
+(793730, 3, -144.297, -403.96, 57.6147, 0, 0, 0, 0, 100, 214527),
+(793730, 4, -154.368, -401.496, 56.7647, 0, 0, 0, 0, 100, 214528),
+(793730, 5, -161.632, -400.326, 56.6994, 0, 0, 0, 0, 100, 214529),
+(793730, 6, -167.493, -401.874, 57.0191, 0, 0, 0, 0, 100, 214530),
+(793730, 7, -170.658, -405.778, 57.1812, 0, 0, 0, 0, 100, 214531),
+(793730, 8, -179.541, -417.187, 55.0673, 0, 0, 0, 0, 100, 214532),
+(793730, 9, -172.693, -407.324, 56.4777, 0, 0, 0, 0, 100, 214533),
+(793730, 10, -169.554, -402.835, 57.1019, 0, 0, 0, 0, 100, 214534);
+

--- a/data/sql/updates/pending_db_world/rev_1526486038703940708.sql
+++ b/data/sql/updates/pending_db_world/rev_1526486038703940708.sql
@@ -1,0 +1,13 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1526486038703940708');
+
+-- Add missing waypoints on patrols before the Ogre boss
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 1, -158.903, -399.895, 56.3324, 0, 0, 0, 0, 100, 214525);
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 2, -151.984, -402.043, 56.9471, 0, 0, 0, 0, 100, 214526);
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 3, -144.297, -403.96, 57.6147, 0, 0, 0, 0, 100, 214527);
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 4, -154.368, -401.496, 56.7647, 0, 0, 0, 0, 100, 214528);
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 5, -161.632, -400.326, 56.6994, 0, 0, 0, 0, 100, 214529);
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 6, -167.493, -401.874, 57.0191, 0, 0, 0, 0, 100, 214530);
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 7, -170.658, -405.778, 57.1812, 0, 0, 0, 0, 100, 214531);
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 8, -179.541, -417.187, 55.0673, 0, 0, 0, 0, 100, 214532);
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 9, -172.693, -407.324, 56.4777, 0, 0, 0, 0, 100, 214533);
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES (793730, 10, -169.554, -402.835, 57.1019, 0, 0, 0, 0, 100, 214534);


### PR DESCRIPTION
Thanks to @Cillez from Renegade-WOW

**Changes proposed:**

-  Add missing waypathes for some patrols (But the query to activate the waypath is not included as of now.)

**Target branch(es):** 1.x/2.x etc.

**Issues addressed:**
https://github.com/azerothcore/azerothcore-wotlk/issues/820

But there might be more mobs to fix in the instance

**Tests performed:** (Does it build, tested in-game, etc)
None myself.
Need to init the waypath with `.wp load xxxx`


**Known issues and TODO list:**

- [x] Test ingame these creatures with ".go creature xxxx" where xxxx is the guid from
```2018-03-29 12:53:36 ERROR: WaypointMovementGenerator::LoadPath: creature Defias Overseer (Entry: 634 GUID: 2175191) doesn't have waypoint path id: 0
2018-03-29 12:53:36 ERROR: WaypointMovementGenerator::LoadPath: creature Defias Overseer (Entry: 634 GUID: 2175222) doesn't have waypoint path id: 0
2018-03-29 12:53:42 ERROR: WaypointMovementGenerator::LoadPath: creature Defias Taskmaster (Entry: 4417 GUID: 2175263) doesn't have waypoint path id: 0
2018-03-29 12:53:42 ERROR: WaypointMovementGenerator::LoadPath: creature Defias Overseer (Entry: 634 GUID: 2175357) doesn't have waypoint path id: 0
```
- [ ] In the original issues, there are 6 creature GUIDs missing waypath
- [ ] Find other bugged patrols
- [ ] Export the query after `.wp load xxxx` (so the patrol starts at server reboot automatically)

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


