### PR TITLE
Scripts - Fixed missing headers

### DIFF
--- a/src/server/scripts/Events/hallows_end.cpp
+++ b/src/server/scripts/Events/hallows_end.cpp
@@ -9,6 +9,7 @@
 #include "LFGMgr.h"
 #include "PassiveAI.h"
 #include "Group.h"
+#include "CellImpl.h"
 
 ///////////////////////////////////////
 ////// ITEMS FIXES, BASIC STUFF

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -19,6 +19,7 @@
 #include "MapManager.h"
 #include "CreatureTextMgr.h"
 #include "SpellAuraEffects.h"
+#include "CellImpl.h"
 
 // Ours
 class spell_q11065_wrangle_some_aether_rays : public SpellScriptLoader


### PR DESCRIPTION
Without these, the server would not compile when disabling precompiled headers (PCH)

**Changes proposed:**

-  Add missing headers to core scripts
-  
-  

**Target branch(es):** 1.x/2.x etc.


**Tests performed:**
It compiles fine when you disable PCH with Cmake (-DUSE_COREPCH=0)

**Known issues and TODO list:**

- [ ] Fix all modules if possible :'( (try to compile your modules with -DUSE_SCRIPTPCH=0 and they will all fail)


I should have pushed to master because there is not much to test atm lol