### PR TITLE
fix:Dungeon Queue - Not working(#856)

### DIFF
--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -495,10 +495,11 @@ void LFGMgr::JoinLfg(Player* player, uint8 roles, LfgDungeonSet& dungeons, const
         case LFG_STATE_PROPOSAL: // if joining again during proposal
             joinData.result = LFG_JOIN_INTERNAL_ERROR;
             break;
-        case LFG_STATE_FINISHED_DUNGEON:
+        /*case LFG_STATE_FINISHED_DUNGEON:
             if (grp && grp->isLFGGroup())
                 joinData.result = LFG_JOIN_PARTY_NOT_MEET_REQS;
             break;
+        */
         default:
             break;
     }

--- a/src/server/game/Handlers/LFGHandler.cpp
+++ b/src/server/game/Handlers/LFGHandler.cpp
@@ -41,13 +41,14 @@ void WorldSession::HandleLfgJoinOpcode(WorldPacket& recvData)
     }
 
     // pussywizard:
+    /*
     if (Group* g = GetPlayer()->GetGroup())
         if (g->isLFGGroup() ? g->GetMembersCount() == MAXGROUPSIZE : g->GetLeaderGUID() != GetPlayer()->GetGUID())
         {
             recvData.rfinish();
             return;
         }
-
+    */
     uint8 numDungeons;
     uint32 roles;
 

--- a/src/server/game/Handlers/LFGHandler.cpp
+++ b/src/server/game/Handlers/LFGHandler.cpp
@@ -41,14 +41,14 @@ void WorldSession::HandleLfgJoinOpcode(WorldPacket& recvData)
     }
 
     // pussywizard:
-    /*
+    
     if (Group* g = GetPlayer()->GetGroup())
-        if (g->isLFGGroup() ? g->GetMembersCount() == MAXGROUPSIZE : g->GetLeaderGUID() != GetPlayer()->GetGUID())
+        if (g->isLFGGroup() && g->GetLeaderGUID() != GetPlayer()->GetGUID())
         {
             recvData.rfinish();
             return;
         }
-    */
+    
     uint8 numDungeons;
     uint32 roles;
 

--- a/src/server/game/Handlers/LFGHandler.cpp
+++ b/src/server/game/Handlers/LFGHandler.cpp
@@ -41,14 +41,13 @@ void WorldSession::HandleLfgJoinOpcode(WorldPacket& recvData)
     }
 
     // pussywizard:
-    
     if (Group* g = GetPlayer()->GetGroup())
         if (g->isLFGGroup() && g->GetLeaderGUID() != GetPlayer()->GetGUID())
         {
             recvData.rfinish();
             return;
         }
-    
+
     uint8 numDungeons;
     uint32 roles;
 


### PR DESCRIPTION
**Changes proposed:**
Once LFG is finished, it is forbidden to queue again.
Now I've removed this restriction.

**Target branch(es):**  master

**Issues addressed:** Closes #856

**Tests performed:** i test in game.Normal work.


**Known issues and TODO list:**
I don't know why pussywizard wanted to disable it.
There may be other problems.
So need to test it.
- [x] Test various conditions to enter LFG.

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


