### PR TITLE
Fix NPC 28611 (Scarlet Captain) in the DK area

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1526938640533602197.sql
+++ b/data/sql/updates/pending_db_world/rev_1526938640533602197.sql
@@ -1,6 +1,6 @@
 INSERT INTO version_db_world (`sql_rev`) VALUES ('1526938640533602197');
 
-UPDATE `smart_scripts` SET `event_param1` = 2, `event_param2` = 30, `comment` = 'Scarlet Captain - Within 5-30 Range - Shoot' WHERE `entryorguid` = 28611 AND `id` = 0;
+UPDATE `smart_scripts` SET `event_param1` = 2, `event_param2` = 30, `comment` = 'Scarlet Captain - Within 2-30 Range - Shoot' WHERE `entryorguid` = 28611 AND `id` = 0;
 
 DELETE FROM `smart_scripts` where `entryorguid` = 28611 and `id` = 4;
 INSERT INTO `smart_scripts`

--- a/data/sql/updates/pending_db_world/rev_1526938640533602197.sql
+++ b/data/sql/updates/pending_db_world/rev_1526938640533602197.sql
@@ -1,6 +1,6 @@
 INSERT INTO version_db_world (`sql_rev`) VALUES ('1526938640533602197');
 
-UPDATE `smart_scripts` SET `event_param1` = 5, `event_param2` = 30, `comment` = 'Scarlet Captain - Within 5-30 Range - Shoot' WHERE `entryorguid` = 28611 AND `id` = 0;
+UPDATE `smart_scripts` SET `event_param1` = 2, `event_param2` = 30, `comment` = 'Scarlet Captain - Within 5-30 Range - Shoot' WHERE `entryorguid` = 28611 AND `id` = 0;
 
 DELETE FROM `smart_scripts` where `entryorguid` = 28611 and `id` = 4;
 INSERT INTO `smart_scripts`

--- a/data/sql/updates/pending_db_world/rev_1526938640533602197.sql
+++ b/data/sql/updates/pending_db_world/rev_1526938640533602197.sql
@@ -1,0 +1,18 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1526938640533602197');
+
+UPDATE `smart_scripts` SET `event_param1` = 5, `event_param2` = 30, `comment` = 'Scarlet Captain - Within 5-30 Range - Shoot' WHERE `entryorguid` = 28611 AND `id` = 0;
+
+DELETE FROM `smart_scripts` where `entryorguid` = 28611 and `id` = 4;
+INSERT INTO `smart_scripts`
+(`entryorguid`,`source_type`, `id`, `link`,
+`event_type`, `event_phase_mask`,`event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`,
+`action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`,
+`target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(28611, 0, 4, 0,
+4, 0, 100, 0, 0, 0, 0, 0,
+1, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 'Scarlet Captain - On Aggro - Say Line 0');
+
+-- delete wrong text line "Light bless you, my child."
+DELETE FROM `creature_text` WHERE `entry` = 28611 AND `id` = 6;


### PR DESCRIPTION
He now shoots from a distance and says the correct text lines on aggro.

**Changes proposed:**
smart_scripts:
- Set min and max distance for shoot and corrected the comment for ID 0
- Added ID 4 to say the correct text lines on aggro

creature_text:
- Delete wrong text line "Light bless you, my child.", which is not contained in the quotes (see https://wowgaming.altervista.org/aowow/?npc=28611)

**Target branch(es):** master

**Issues addressed:** Closes #

**Tests performed:** tested in-game:
1. .npc add 28611 (NPC does not attack from a distance, just stands there)
2. apply SQL script
3. .reload smart_scripts
4. .reload creature_text
5. .npc add 28611 (NPC says correct text lines on aggro and shoots from a distance)

**Known issues and TODO list:** none

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


