### PR TITLE
Fix quest 12733 (Death's Challenge)

### DIFF
--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -217,6 +217,7 @@ public:
         uint64 _duelGUID;
         EventMap events;
         std::set<uint32> playerGUIDs;
+        uint32 timer = -1;
 
         uint32 GetData(uint32 data) const
         {
@@ -243,6 +244,9 @@ public:
                 playerGUIDs.insert(caster->GetGUIDLow());
                 _duelGUID = caster->GetGUID();
                 _duelInProgress = true;
+
+                timer = 600000; // clear playerGUIDs after 10 minutes if no one initiates a duel
+                me->GetMotionMaster()->MoveFollow(caster, 2.0f, 0.0f);
 
                 events.ScheduleEvent(EVENT_SPEAK, 3000);
                 events.ScheduleEvent(EVENT_SPEAK+1, 7000);
@@ -279,6 +283,16 @@ public:
 
         void UpdateAI(uint32 diff)
         {
+            if (timer != -1 && timer <= diff)
+            {
+                timer = -1;
+                playerGUIDs.clear();
+            }
+            else
+            {
+                timer -= diff;
+            }
+
             events.Update(diff);
             switch (events.ExecuteEvent())
             {

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -217,7 +217,7 @@ public:
         uint64 _duelGUID;
         EventMap events;
         std::set<uint32> playerGUIDs;
-        uint32 timer = -1;
+        uint32 timer = 0;
 
         uint32 GetData(uint32 data) const
         {
@@ -283,11 +283,11 @@ public:
 
         void UpdateAI(uint32 diff)
         {
-            if (timer != -1)
+            if (timer != 0)
             {
                 if (timer <= diff)
                 {
-                    timer = -1;
+                    timer = 0;
                     playerGUIDs.clear();
                 }
                 else

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -283,14 +283,17 @@ public:
 
         void UpdateAI(uint32 diff)
         {
-            if (timer != -1 && timer <= diff)
+            if (timer != -1)
             {
-                timer = -1;
-                playerGUIDs.clear();
-            }
-            else
-            {
-                timer -= diff;
+                if (timer <= diff)
+                {
+                    timer = -1;
+                    playerGUIDs.clear();
+                }
+                else
+                {
+                    timer -= diff;
+                }
             }
 
             events.Update(diff);


### PR DESCRIPTION
Prevent random movement of Death Knights; clean up internal player GUID list

**Changes proposed:**
- Follow the player at the beginning of the duel (prevent random movement)
- Clear the internal player GUID list if this NPC is not duelled for 10 minutes; this list is used to track the players which already duelled this NPC (you could theoretically flee from each duel and then have no Death Knights left to solve the quest; also the GUIDs did sum up over time)

**Target branch(es):** master

**Issues addressed:** none

**Tests performed:**
Tested build and in-game

**How to test the changes:**
As GM:
1. .quest remove 12733
2. .quest add 12733
3. .go creature 129520
4. Duel

**Known issues and TODO list:** none

<!--
/!\
/!\
**NOTE** You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit).
/!\
/!\
-->


