### PR TITLE
Fix world server crash when using the Atal'ai Statue with ID 148833 in Sunken Temple

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1527544749488242746.sql
+++ b/data/sql/updates/pending_db_world/rev_1527544749488242746.sql
@@ -1,0 +1,3 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1527544749488242746');
+
+UPDATE `smart_scripts` SET `target_type` = 7 WHERE `entryorguid` IN (148830,148831,148832,148833,148834,148835) AND `id` = 3 AND `action_type` = 11;


### PR DESCRIPTION
**Changes proposed:**
The column "target_type" in table "smart_scripts" should use "SMART_TARGET_ACTION_INVOKER" (ID 7) instead of "SMART_TARGET_SELF" (ID 1) for the spell cast of the Atal'ai Statues. Especially the statue with ID 148833 crashes the world server when used, as the spell "Atal'ai Poison" (ID 18949) does not seem to work with "SMART_TARGET_SELF".

**Target branch(es):** master

**Issues addressed:**

**Tests performed:**
Tested in-game:
- .gm on
- .go xyz -495.318 55.7233 -148.741 109
- .gm off
- Use Atal'ai Statue -> crash after a few seconds
- Apply SQL update statement
- Use Atal'ai Statue -> no crash

**Known issues and TODO list:** none

<!--
/!\
/!\
**NOTE** You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit).
/!\
/!\
-->


