### PR TITLE
GroupHandler.cpp - Clean useless group invites

### DIFF
--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -171,15 +171,17 @@ void WorldSession::HandleGroupInviteOpcode(WorldPacket& recvData)
         }
         if (!group->AddInvite(player))
         {
+            group->RemoveAllInvites();
             delete group;
             return;
         }
     }
     else
     {
-        // already existed group: if can't add then just leave
+        // Group already existing, if can't add any more player (full group?), then just leave
         if (!group->AddInvite(player))
         {
+            group->RemoveAllInvites();
             return;
         }
     }

--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -169,6 +169,7 @@ void WorldSession::HandleGroupInviteOpcode(WorldPacket& recvData)
             delete group;
             return;
         }
+        // If group has been disbanded, delete group and pending invites and return
         if (!group->AddInvite(player))
         {
             group->RemoveAllInvites();
@@ -178,7 +179,7 @@ void WorldSession::HandleGroupInviteOpcode(WorldPacket& recvData)
     }
     else
     {
-        // Group already existing, if can't add any more player (full group?), then just leave
+        // Group already existing, if can't add any more player (full group?), then remove invites and return
         if (!group->AddInvite(player))
         {
             group->RemoveAllInvites();


### PR DESCRIPTION


**Changes proposed:**

-  Remove pending group invites when we can't invite someone to a group (if group has just been disbanded)
-  Remove pending group invites when we can't invite someone to a group (full group)
- Improve comments


**Target branch(es):**

1.x/2.x etc.


**Tests performed:**

I tested nothing and not even sure about the second change


**How to test the changes:**

This is speculation on how to test:

- Compile
- Invite a player in your group
- With a formed group, invite a new player but disband the group before the player accepts the invite. It should disappear automatically from the player's screen
- With a full group of 5, invite someone. He should not see any invite prompt. You can also try this WITHOUT this pull request and see if he still gets the invite prompt (because I didn't test either)




<!--
/!\
/!\
**NOTE** You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit).
/!\
/!\
-->


