### PR TITLE
Gruul: Add a minimum cooldown for Cave In

### DIFF
--- a/src/server/scripts/Outland/GruulsLair/boss_gruul.cpp
+++ b/src/server/scripts/Outland/GruulsLair/boss_gruul.cpp
@@ -103,7 +103,8 @@ class boss_gruul : public CreatureScript
                     case EVENT_CAVE_IN:
                         if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                             me->CastSpell(target, SPELL_CAVE_IN, false);
-                        _caveInTimer -= 1500;
+                        if (m_uiCaveIn_StaticTimer >= 4000)
+                            _caveInTimer -= 1500;
                         events.ScheduleEvent(EVENT_CAVE_IN, _caveInTimer);
                         break;
                     case EVENT_REVERBERATION:

--- a/src/server/scripts/Outland/GruulsLair/boss_gruul.cpp
+++ b/src/server/scripts/Outland/GruulsLair/boss_gruul.cpp
@@ -103,7 +103,7 @@ class boss_gruul : public CreatureScript
                     case EVENT_CAVE_IN:
                         if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                             me->CastSpell(target, SPELL_CAVE_IN, false);
-                        if (m_uiCaveIn_StaticTimer >= 4000)
+                        if (_caveInTimer >= 4000)
                             _caveInTimer -= 1500;
                         events.ScheduleEvent(EVENT_CAVE_IN, _caveInTimer);
                         break;


### PR DESCRIPTION
Currently if the Gruul fight goes on for long enough he will cast a new cave in every frame. Added a minimum of 2.5 seconds (taken from Trinity).

**Changes proposed:**

-  Add a cooldown to Gruul's cave in ability, else he spams it at the end of the fight.
-  


**Target branch(es):**

1.x/2.x etc. 


**Issues addressed:**

<!-- Just paste the link to the issue you close -->
Closes #


**Tests performed:**
Did you test in-game? Yes
What did you test? Fought Gruul, encounter worked correctly
Did you do all these tests on Linux, Mac or Windows? Windows

<!-- Does it build without errors?
etc)--> 


**How to test the changes:**
Try to kill Gruul before and after the changes. You'll need to kill him slowly to see a difference.
Current has Cave in starting at 29 seconds and removing 1.5 per cast. So it takes 21 casts for the Cave in Timer to become negative (around 300 seconds / 5 minutes) so he casts every frame at around 10 growths.

After the changes he will have a minimum time between casts of 2.5 seconds.

<!--
Describe how to test the issue before and after the pull request.
Which commands to use? Which NPC to teleport to? Tele to gruul's lair, .die maulgaur and engage Gruul and wait for 5 minutes.
Do we need to have debug flags on Cmake?
Do we need to look at the console? etc...
Try to make the work easy for testers, please -->


**Known issues and TODO list:**

<!-- This is a list with checkboxes -->
- [ ] 
- [ ] 



<!--
/!\
/!\
**NOTE** You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit).
/!\
/!\
-->


