### PR TITLE
Prince Malchezaar: Add cooldown to Amplify Damage in phase 3

### DIFF
--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
@@ -421,6 +421,7 @@ public:
 
                     if (target)
                         DoCast(target, SPELL_AMPLIFY_DAMAGE);
+                        AmplifyDamageTimer = urand(20000, 30000);
                 }
                 else
                     AmplifyDamageTimer -= diff;


### PR DESCRIPTION
Added a cooldown to amplify damage in phase 3, else it's cast every frame. Used random between 20 and 30 seconds as that's what's set at the start of phase 3.

**Changes proposed:**

-  Add a cooldown to Prince Malchezaar's Amplify Damage (currently there is none)
-  


**Target branch(es):**

1.x/2.x etc.


**Issues addressed:**

<!-- Just paste the link to the issue you close -->
Closes #


**Tests performed:**
Did you test in-game? Yes
What did you test? Fought and defeated the Prince normally
Did you do all these tests on Linux, Mac or Windows? Windows

<!-- Does it build without errors?
etc)-->


**How to test the changes:**
Go to the prince in Karazhan and fight him, in phase 3 he currently spams Amplify Damage every frame after the first cast. I've added in a cooldown of 20-30 seconds (same as the inital cooldown is set to when he enters phase 3).

Which commands to use? Which NPC to teleport to? Teleport to Prince Malchezaar (template 15690) and engage, get him to 30% to enter phase 3.
<!--
Describe how to test the issue before and after the pull request.
Do we need to have debug flags on Cmake?
Do we need to look at the console? etc...
Try to make the work easy for testers, please -->


**Known issues and TODO list:**

<!-- This is a list with checkboxes -->
- [ ] 
- [ ] 



<!--
/!\
/!\
**NOTE** You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit).
/!\
/!\
-->


