### PR TITLE
Fix zeppelin master gossip text; remove gossip option "Where is the zeppelin now?"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1528129508252853447.sql
+++ b/data/sql/updates/pending_db_world/rev_1528129508252853447.sql
@@ -1,0 +1,5 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1528129508252853447');
+
+DELETE FROM `gossip_menu_option` WHERE `menu_id` IN (1969,1971);
+UPDATE `creature_template` SET `gossip_menu_id` = 2441 WHERE `entry` = 3149;
+UPDATE `creature_template` SET `gossip_menu_id` = 3842 WHERE `entry` = 12137;


### PR DESCRIPTION
**Changes proposed:**
-  set correct gossip menu ID for Squibby Overspeck (NPC 12137):
 old: 1969 (belongs to Frezza)
 new: 3842
-  set correct gossip menu ID for Nez'raz (NPC 3149):
 old: 1971 (belongs to Zapetta)
 new: 2441
- removed gossip menu options 1969 and 1971 ("Where is the zeppelin now?"), as this functionality is not implemented and the option only existed for Frezza and Zapetta

**Target branch(es):**
master

**Issues addressed:**

**Tests performed:**
tested in-game

**How to test the changes:**
 just speak to the affected zeppelin masters

**Known issues and TODO list:** none