### PR TITLE
Show default options, missing in config files

### DIFF
--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -6,6 +6,7 @@
 
 #include "Config.h"
 #include "Errors.h"
+#include "Log.h"
 
 // Defined here as it must not be exposed to end-users.
 bool ConfigMgr::GetValueHelper(const char* name, ACE_TString &result)
@@ -86,6 +87,15 @@ bool ConfigMgr::LoadData(char const* file)
 std::string ConfigMgr::GetStringDefault(const char* name, const std::string &def)
 {
     ACE_TString val;
+
+    if (GetValueHelper(name, val))
+        return val.c_str();
+    else
+    {
+        sLog->outError("-> Not found option '%s'. The default value is used (%s)", name, def.c_str());
+        return def;
+    }
+
     return GetValueHelper(name, val) ? val.c_str() : def;
 }
 
@@ -94,7 +104,10 @@ bool ConfigMgr::GetBoolDefault(const char* name, bool def)
     ACE_TString val;
 
     if (!GetValueHelper(name, val))
+    {
+        def ? sLog->outError("-> Not found option '%s'. The default value is used (Yes)", name) : sLog->outError(">> Not found option '%s'. The default value is used (No)", name);
         return def;
+    }
 
     return (val == "true" || val == "TRUE" || val == "yes" || val == "YES" ||
         val == "1");
@@ -103,13 +116,27 @@ bool ConfigMgr::GetBoolDefault(const char* name, bool def)
 int ConfigMgr::GetIntDefault(const char* name, int def)
 {
     ACE_TString val;
-    return GetValueHelper(name, val) ? atoi(val.c_str()) : def;
+
+    if (GetValueHelper(name, val))
+        return atoi(val.c_str());
+    else
+    {
+        sLog->outError("-> Not found option '%s'. The default value is used (%i)", name, def);
+        return def;
+    }
 }
 
 float ConfigMgr::GetFloatDefault(const char* name, float def)
 {
     ACE_TString val;
-    return GetValueHelper(name, val) ? (float)atof(val.c_str()) : def;
+
+    if (GetValueHelper(name, val))
+        return (float)atof(val.c_str());
+    else
+    {
+        sLog->outError("-> Not found option '%s'. The default value is used (%f)", name, def);
+        return def;
+    }
 }
 
 std::list<std::string> ConfigMgr::GetKeysByString(std::string const& name)


### PR DESCRIPTION
#### Made a mistake, created new pull request. Old (https://github.com/azerothcore/azerothcore-wotlk/pull/906)

**Changes proposed:**

* Update code in Log.cpp (To avoid errors when opening authserver.exe)
* If the required settings are not found when the configuration file is opened, a notification is displayed and the value that was set by default

**Target branch(es):** master.


**Issues addressed:** No issue

**Tests performed:** Tested build, tested in-game (Windows 10 / VS 2017)

**How to test the changes:**
* Comment out the option not related to category Log (.conf and .conf.dist)
**Example** MaxPingTime

![image](https://user-images.githubusercontent.com/18329778/40887866-3f22d2e2-6779-11e8-802d-05646155c874.png)

**Known issues and TODO list:**

- Notifications are working, if everything is in order with the options category Log

#### This script is very useful for those who use modules with config files. It will show you whether you have connected the config file correctly or not. I had a couple of cases, this script helped me to understand.

#### Also with it I found not used options https://github.com/azerothcore/azerothcore-wotlk/issues/874
