### PR TITLE
Fix Malmortis text (quest "Disclosure", ID 12710)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1528731505867561398.sql
+++ b/data/sql/updates/pending_db_world/rev_1528731505867561398.sql
@@ -1,0 +1,21 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1528731505867561398');
+
+DELETE FROM `creature_text` WHERE `entry` = 28948;
+INSERT INTO `creature_text` (`entry`,`groupid`,`id`,`text`,`type`,`language`,`probability`,`emote`,`duration`,`sound`,`BroadcastTextID`,`TextRange`,`comment`)
+VALUES
+(28948,0,0,'Ahh... there you are. The master told us you''d be arriving soon.',12,0,100,1,0,0,29127,0,'Malmortis text'),
+(28948,1,0,'Please, follow me, $N. There is much for you to see...',12,0,100,1,0,0,29128,0,'Malmortis text'),
+(28948,2,0,'You should feel honored. You are the first of the master''s prospects to be shown our operation.',12,0,100,1,0,0,29171,0,'Malmortis text'),
+(28948,2,1,'Ever since his arrival from Drak''Tharon, the master has spoken of the time you would be joining him here.',12,0,100,1,0,0,29172,0,'Malmortis text'),
+(28948,3,0,'The things I show you now must never be spoken of outside Voltarus. The world shall come to know our secret soon enough!',12,0,100,1,0,0,29173,0,'Malmortis text'),
+(28948,4,0,'Here lie our stores of blight crystal, without which our project would be impossible.',12,0,100,1,0,0,29174,0,'Malmortis text'),
+(28948,5,0,'I understand that you are to thank for the bulk of our supply.',12,0,100,1,0,0,29175,0,'Malmortis text'),
+(28948,6,0,'These trolls are among those you exposed on the battlefield. Masterfully done, indeed....',12,0,100,1,0,0,29176,0,'Malmortis text'),
+(28948,7,0,'We feel it best to position them here, where they might come in terms with their impending fate.',12,0,100,1,0,0,29433,0,'Malmortis text'),
+(28948,8,0,'This is their destiny....',12,0,100,1,0,0,29434,0,'Malmortis text'),
+(28948,9,0,'The blight slowly seeps into their bodies, gradually preparing them for their conversion.',12,0,100,1,0,0,29435,0,'Malmortis text'),
+(28948,10,0,'This special preparation grants them unique powers far greater than they would otherwise know.',12,0,100,1,0,0,29436,0,'Malmortis text'),
+(28948,11,0,'Soon, the master will grant them the dark gift, making them fit to server the Lich King for eternity!',12,0,100,1,0,0,29437,0,'Malmortis text'),
+(28948,12,0,'Stay for as long as you like, $N. Glory in the fruits of your labor!',12,0,100,1,0,0,29438,0,'Malmortis text'),
+(28948,13,0,'Your service has been invaluable in fulfilling the master''s plan. May you forever grow in power....',12,0,100,1,0,0,29439,0,'Malmortis text'),
+(28948,14,0,'Farewell.',12,0,100,1,0,0,29440,0,'Malmortis text');


### PR DESCRIPTION
**Changes proposed:**
Update creature text for Malmortis (NPC 28948).

**Target branch(es):**
master

**Issues addressed:**
Closes #920 

**Tests performed:**
tested in-game

**How to test the changes:**
Use the coffin which is around these coordinates:
`.go xyz 6251.59 -1969.51 484.782 571`

