### PR TITLE
fix faction of Midsummer Celebrant (NPC ID 16781)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1530048726574700306.sql
+++ b/data/sql/updates/pending_db_world/rev_1530048726574700306.sql
@@ -1,0 +1,3 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1530048726574700306');
+
+UPDATE `creature_template` SET `faction` = 35 where `entry` = 16781;


### PR DESCRIPTION
**Changes proposed:**
Fix faction of Midsummer Celebrant (NPC ID 16781):
old: 84 (Alliance Generic)
new: 35 (Friendly)

**Target branch(es):**
master

**Issues addressed:**
Closes #949 

**Tests performed:**
tested in-game

**How to test the changes:**
- .go creature 94615 (NPC is hostile)
- apply SQL script
- .go creature 94615 (NPC is not hostile anymore)

**Known issues and TODO list:**
none

