### PR TITLE
delete duplicate Midsummer Celebrants in Tanaris; Fire Breathing for all Fire/Flame Eaters

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1530226452517673074.sql
+++ b/data/sql/updates/pending_db_world/rev_1530226452517673074.sql
@@ -1,0 +1,18 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1530226452517673074');
+
+-- Delete duplicate Midsummer Celebrants in Tanaris
+DELETE FROM `creature` WHERE `guid` IN (86895,94715,94717,94716,94733,94513,94724,94586,94726,94696);
+
+-- Festival Fire Breathing (Spell 45385) for Fire Eaters and Flame Eaters:
+-- Master Fire Eater (NPC 25975)
+-- Flame Eater (NPC 25994)
+-- Master Flame Eater (NPC 26113)
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (25975,25994,26113);
+INSERT INTO `smart_scripts`
+(`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`)
+VALUES
+(25975,0,0,0,60,0,100,0,5000,10000,15000,20000,11,45385,0,0,0,0,0,1,0,0,0,0,0,0,0,'spell cast'),
+(25994,0,0,0,60,0,100,0,5000,10000,15000,20000,11,45385,0,0,0,0,0,1,0,0,0,0,0,0,0,'spell cast'),
+(26113,0,0,0,60,0,100,0,5000,10000,15000,20000,11,45385,0,0,0,0,0,1,0,0,0,0,0,0,0,'spell cast');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (25975,25994,26113);


### PR DESCRIPTION
**Changes proposed:**
-  delete duplicate Midsummer Celebrants in Tanaris
-  Fire Breathing for all Fire/Flame Eaters (currently only for Fire Eaters)

**Target branch(es):**
master

**Tests performed:**
tested in-game

**How to test the changes:**
- Go to Tanaris/Gadgetzan and check the duplicate NPCs in both Midsummer Festival camps, e.g.:
 `.go creature 94715`
 or
 `.go creature 94726`
- Check the Master Fire Eaters, Master Flame Eaters and Flame Eaters: They are not breathing fire, e.g.:
 `.go creature 90510` (Master Fire Eater)
 `.go creature 83243` (Master Flame Eater)
 `.go creature 94475` (Flame Eater)
- After applying the SQL script the duplicate NPCs in Tanaris have vanished and all Fire/Flame Eaters are breathing fire.