### PR TITLE
Fix Midsummer Celebrants in Tirisfal Glades and add Festival Scorchling

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1530312696838521331.sql
+++ b/data/sql/updates/pending_db_world/rev_1530312696838521331.sql
@@ -1,0 +1,12 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1530312696838521331');
+
+UPDATE `creature` SET `modelid` = 16444, `orientation` = 1.2727 WHERE `guid` = 202761;
+UPDATE `creature` SET `modelid` = 16432, `orientation` = 4.35146 WHERE `guid` = 202762;
+UPDATE `creature` SET `modelid` = 16438 WHERE `guid` = 202759;
+UPDATE `creature` SET `modelid` = 16445 WHERE `guid` = 202760;
+
+DELETE FROM `creature` WHERE `guid` = 86895;
+INSERT INTO `creature`
+(`guid`,`id`,`map`,`spawnMask`,`phaseMask`,`modelid`,`equipment_id`,`position_x`,`position_y`,`position_z`,`orientation`,`spawntimesecs`,`spawndist`,`currentwaypoint`,`curhealth`,`curmana`,`MovementType`,`npcflag`,`unit_flags`,`dynamicflags`)
+VALUES
+(86895,26520,0,1,1,8409,0,2281.25,428.862,33.9647,3.54294,300,0,0,42,0,0,0,0,0);


### PR DESCRIPTION
**Changes proposed:**
-  Change Midsummer Celebrants in Tirisfal Glades from Alliance to Horde models
-  Add a Festival Scorchling in Tirisfal Glades for quest "Incense for the Festival Scorchlings" (11966)

**Target branch(es):**
master

**Tests performed:**
tested in-game

**How to test the changes:**
- `.go creature 202761`
- all Midsummer Celebrants have Alliance models
- apply SQL script
- all Midsummer Celebrants have now Horde models
- Festival Scorchling has been added (creature ID 86895 which was deleted in commit https://github.com/azerothcore/azerothcore-wotlk/commit/904ec49d4228f1b995239565dd0694886158022c and already has an entry in table "game_event_creature")