### PR TITLE
Blade flurry shouldn't target totems.

### DIFF
--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -125,7 +125,7 @@ class spell_rog_blade_flurry : public SpellScriptLoader
 
             bool CheckProc(ProcEventInfo& eventInfo)
             {
-                Unit* _procTarget = eventInfo.GetActor()->SelectNearbyTarget(eventInfo.GetProcTarget());
+                Unit* _procTarget = eventInfo.GetActor()->SelectNearbyNoTotemTarget(eventInfo.GetProcTarget());
                 if (_procTarget)
                     _procTargetGUID = _procTarget->GetGUID();
                 return _procTarget;


### PR DESCRIPTION
Tested in-game and it's working.