### PR TITLE
Fix NPC 7856 (Southsea Freebooter)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1530734106945512205.sql
+++ b/data/sql/updates/pending_db_world/rev_1530734106945512205.sql
@@ -1,0 +1,4 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1530734106945512205');
+
+UPDATE `creature_template` SET `unit_flags` = 0 WHERE `entry` = 7856;
+UPDATE `smart_scripts` SET `event_type` = 9, `event_param1` = 2, `event_param2` = 30, `comment` = 'Southsea Freebooter - Within 2-30 Range - Shoot' WHERE `entryorguid` = 7856 AND `id` = 0;


### PR DESCRIPTION
**Changes proposed:**
Change smart script of the Southsea Freebooter to let him shoot from a distance.

**Target branch(es):**
master

**Tests performed:**
tested in-game

**How to test the changes:**
- `.go -8075.74 -5080.64 16.4176 1`
- aggro one of the Southsea Freebooters; they will just stand there, doing nothing
- apply the SQL script
- the Southsea Freebooters will now shoot from a distance