### PR TITLE
Core/Conf: Remove StartAllReputation from player.cpp

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1097,49 +1097,6 @@ bool Player::Create(uint32 guidlow, CharacterCreateInfo* createInfo)
             SetFlag(PLAYER_EXPLORED_ZONES_1+i, 0xFFFFFFFF);
     }
 
-    //Reputations if "StartAllReputation" is enabled, -- TODO: Fix this in a better way
-    if (sWorld->getBoolConfig(CONFIG_START_ALL_REP))
-    {
-        GetReputationMgr().SetReputation(sFactionStore.LookupEntry(942), 42999);
-        GetReputationMgr().SetReputation(sFactionStore.LookupEntry(935), 42999);
-        GetReputationMgr().SetReputation(sFactionStore.LookupEntry(936), 42999);
-        GetReputationMgr().SetReputation(sFactionStore.LookupEntry(1011), 42999);
-        GetReputationMgr().SetReputation(sFactionStore.LookupEntry(970), 42999);
-        GetReputationMgr().SetReputation(sFactionStore.LookupEntry(967), 42999);
-        GetReputationMgr().SetReputation(sFactionStore.LookupEntry(989), 42999);
-        GetReputationMgr().SetReputation(sFactionStore.LookupEntry(932), 42999);
-        GetReputationMgr().SetReputation(sFactionStore.LookupEntry(934), 42999);
-        GetReputationMgr().SetReputation(sFactionStore.LookupEntry(1038), 42999);
-        GetReputationMgr().SetReputation(sFactionStore.LookupEntry(1077), 42999);
-
-        // Factions depending on team, like cities and some more stuff
-        switch (GetTeamId(true))
-        {
-        case TEAM_ALLIANCE:
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(72), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(47), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(69), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(930), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(730), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(978), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(54), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(946), 42999);
-            break;
-        case TEAM_HORDE:
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(76), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(68), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(81), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(911), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(729), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(941), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(530), 42999);
-            GetReputationMgr().SetReputation(sFactionStore.LookupEntry(947), 42999);
-            break;
-        default:
-            break;
-        }
-    }
-
     // Played time
     m_Last_tick = time(NULL);
     m_Played_time[PLAYED_TIME_TOTAL] = 0;

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -1117,28 +1117,28 @@ void WorldSession::HandlePlayerLoginFromDB(LoginQueryHolder* holder)
 
         switch (pCurrChar->getFaction())
         {
-        case ALLIANCE:
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(72), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(47), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(69), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(930), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(730), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(978), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(54), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(946), 42999, false);
-            break;
-        case HORDE:
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(76), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(68), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(81), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(911), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(729), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(941), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(530), 42999, false);
-            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(947), 42999, false);
-            break;
-        default:
-            break;
+            case ALLIANCE:
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(72), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(47), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(69), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(930), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(730), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(978), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(54), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(946), 42999, false);
+                break;
+            case HORDE:
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(76), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(68), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(81), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(911), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(729), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(941), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(530), 42999, false);
+                repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(947), 42999, false);
+                break;
+            default:
+                break;
         }
         repMgr.SendStates();
     }

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -1099,6 +1099,50 @@ void WorldSession::HandlePlayerLoginFromDB(LoginQueryHolder* holder)
         pCurrChar->CheckAllAchievementCriteria();
     }
 
+        // Reputations if "StartAllReputation" is enabled, -- TODO: Fix this in a better way
+    if (sWorld->getBoolConfig(CONFIG_START_ALL_REP))
+    {
+        ReputationMgr& repMgr = pCurrChar->GetReputationMgr();
+        repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(942), 42999, false);
+        repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(935), 42999, false);
+        repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(936), 42999, false);
+        repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(1011), 42999, false);
+        repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(970), 42999, false);
+        repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(967), 42999, false);
+        repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(989), 42999, false);
+        repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(932), 42999, false);
+        repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(934), 42999, false);
+        repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(1038), 42999, false);
+        repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(1077), 42999, false);
+
+        switch (pCurrChar->getFaction())
+        {
+        case ALLIANCE:
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(72), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(47), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(69), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(930), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(730), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(978), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(54), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(946), 42999, false);
+            break;
+        case HORDE:
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(76), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(68), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(81), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(911), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(729), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(941), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(530), 42999, false);
+            repMgr.SetOneFactionReputation(sFactionStore.LookupEntry(947), 42999, false);
+            break;
+        default:
+            break;
+        }
+        repMgr.SendStates();
+    }
+
     // show time before shutdown if shutdown planned.
     if (sWorld->IsShuttingDown())
         sWorld->ShutdownMsg(true, pCurrChar);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: https://github.com/azerothcore/azerothcore-wotlk/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  The player should start with most of the main city factions at Exalted status to allow the purchase of items, mounts, etc. when this setting is enabled


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/580


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

0 test performed by me, 1 test performed by Inifield


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

- Set ` PlayerStart.AllReputation = 1` in your worldserver.conf
- Create a new character and look at the reputation tab



##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ] Test the PR :)


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
