### PR TITLE
Revert WMO changes

### DIFF
--- a/src/tools/vmap4_extractor/wmo.cpp
+++ b/src/tools/vmap4_extractor/wmo.cpp
@@ -338,11 +338,9 @@ int WMOGroup::ConvertToVMAPGroupWmo(FILE *output, WMORoot *rootWMO, bool precise
         for (int i=0; i<nTriangles; ++i)
         {
             // Skip no collision triangles
-            bool isRenderFace = (MOPY[2 * i] & WMO_MATERIAL_RENDER) && !(MOPY[2 * i] & WMO_MATERIAL_DETAIL);
-            bool isCollision = MOPY[2 * i] & WMO_MATERIAL_COLLISION || isRenderFace;
-            if (!isCollision)
+            if (MOPY[2*i]&WMO_MATERIAL_NO_COLLISION ||
+              !(MOPY[2*i]&(WMO_MATERIAL_HINT|WMO_MATERIAL_COLLIDE_HIT)) )
                 continue;
-
             // Use this triangle
             for (int j=0; j<3; ++j)
             {
@@ -474,33 +472,23 @@ WMOGroup::~WMOGroup()
 }
 
 WMOInstance::WMOInstance(MPQFile& f, char const* WmoInstName, uint32 mapID, uint32 tileX, uint32 tileY, FILE* pDirfile)
-    : currx(0), curry(0), wmo(NULL), doodadset(0), pos(), indx(0), id(0)
+    : currx(0), curry(0), wmo(NULL), doodadset(0), pos(), indx(0), id(0), d2(0), d3(0)
 {
     float ff[3];
     f.read(&id, 4);
-    f.read(ff, 12);
-    pos = Vec3D(ff[0], ff[1], ff[2]);
-    f.read(ff, 12);
-    rot = Vec3D(ff[0], ff[1], ff[2]);
-    f.read(ff, 12);
-    pos2 = Vec3D(ff[0], ff[1], ff[2]); // bounding box corners
-    f.read(ff, 12);
-    pos3 = Vec3D(ff[0], ff[1], ff[2]); // bounding box corners
+    f.read(ff,12);
+    pos = Vec3D(ff[0],ff[1],ff[2]);
+    f.read(ff,12);
+    rot = Vec3D(ff[0],ff[1],ff[2]);
+    f.read(ff,12);
+    pos2 = Vec3D(ff[0],ff[1],ff[2]);
+    f.read(ff,12);
+    pos3 = Vec3D(ff[0],ff[1],ff[2]);
+    f.read(&d2,4);
 
-    uint16 fflags;
-    f.read(&fflags, 2);
-
-    uint16 doodadSet;
-    f.read(&doodadSet, 2);
-
-    uint16 trash, adtId;
-    f.read(&adtId, 2);
-    f.read(&trash, 2);
-
-    // destructible wmo, do not dump. we can handle the vmap for these
-    // in dynamic tree (gameobject vmaps)
-    if ((fflags & 0x01) != 0)
-        return;
+    uint16 trash,adtId;
+    f.read(&adtId,2);
+    f.read(&trash,2);
 
     //-----------add_in _dir_file----------------
 

--- a/src/tools/vmap4_extractor/wmo.h
+++ b/src/tools/vmap4_extractor/wmo.h
@@ -15,17 +15,13 @@
 #include "loadlib/loadlib.h"
 
 // MOPY flags
-enum MopyFlags
-{
-    WMO_MATERIAL_UNK01          = 0x01,
-    WMO_MATERIAL_NOCAMCOLLIDE   = 0x02,
-    WMO_MATERIAL_DETAIL         = 0x04,
-    WMO_MATERIAL_COLLISION      = 0x08,
-    WMO_MATERIAL_HINT           = 0x10,
-    WMO_MATERIAL_RENDER         = 0x20,
-    WMO_MATERIAL_WALL_SURFACE   = 0x40, // Guessed
-    WMO_MATERIAL_COLLIDE_HIT    = 0x80
-};
+#define WMO_MATERIAL_NOCAMCOLLIDE    0x01
+#define WMO_MATERIAL_DETAIL          0x02
+#define WMO_MATERIAL_NO_COLLISION    0x04
+#define WMO_MATERIAL_HINT            0x08
+#define WMO_MATERIAL_RENDER          0x10
+#define WMO_MATERIAL_COLLIDE_HIT     0x20
+#define WMO_MATERIAL_WALL_SURFACE    0x40
 
 class WMOInstance;
 class WMOManager;
@@ -116,7 +112,7 @@ public:
     int doodadset;
     Vec3D pos;
     Vec3D pos2, pos3, rot;
-    uint32 indx, id;
+    uint32 indx, id, d2, d3;
 
     WMOInstance(MPQFile&f , char const* WmoInstName, uint32 mapID, uint32 tileX, uint32 tileY, FILE* pDirfile);
 


### PR DESCRIPTION
##### CHANGES PROPOSED:
Revert WMO changes applied via PR #926 due to issues with Wintergrasp

##### ISSUES ADDRESSED:
Closes #972 

##### TESTS PERFORMED:
tested in-game

##### HOW TO TEST THE CHANGES:
- after applying the changes compile the core including the tools
- extract vmaps and mmaps
- `.go creature id 30499`
 Verify that the NPC is not falling through the workshop.
- `.go xyz -3067.45 -4308.53 0.300854 1`
 Attack the Defias Rummager on the other side of the small hill and pull him on top of the hill. Verify that the NPC will not fall into the ground.

##### Target branch(es):
Master