### PR TITLE
DB/Script: Fix Captain Dranarus sound range

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1531706256840900300.sql
+++ b/data/sql/updates/pending_db_world/rev_1531706256840900300.sql
@@ -1,0 +1,2 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1531706256840900300');
+UPDATE `waypoint_scripts` SET `datalong2`='2' WHERE `guid`=15;


### PR DESCRIPTION
Fix by:
https://github.com/offl

DB/Script: Fix Captain Dranarus sound range

##### CHANGES PROPOSED:

-  Change datalong2 for guid:15 to 2 in waypoint_scripts

###### ISSUES ADDRESSED:
Closes https://github.com/azerothcore/azerothcore-wotlk/issues/621

##### TESTS PERFORMED:
Tested before fix
Tested after fix
All tests were done on Windows 10 Pro Edition 64bit

##### HOW TO TEST THE CHANGES:
Do .tele Shattrath (Walk around for a bit)
You will hear an annoying elf talking crap on you
Apply provided SQL
Tele again, but this time he will only talk crap on you if you are close to him.

(Note: Npc is Captain Dranarus and he is right in front of where you get teleported.)

##### Target branch(es):

Master