### PR TITLE
fix logger creating too much file descriptors

### DIFF
--- a/src/common/Logging/Log.h
+++ b/src/common/Logging/Log.h
@@ -10,6 +10,7 @@
 #include "Common.h"
 #include <ace/Task.h>
 #include <ace/Singleton.h>
+#include <ace/Thread_Mutex.h>
 
 class WorldPacket;
 
@@ -145,7 +146,8 @@ class Log
         void SetLogDB(bool enable) { m_enableLogDB = enable; }
         bool GetSQLDriverQueryLogging() const { return m_sqlDriverQueryLogging; }
     private:
-        FILE* openLogFile(char const* configFileName, char const* configTimeStampFlag, char const* mode);
+        void openLogFile(FILE** file, char const* configFileName, char const* configTimeStampFlag, char const* mode);
+        void openLogFile(FILE** file, char const* fileName, char const* mode);
         FILE* openGmlogPerAccount(uint32 account);
 
         FILE* raLogfile;
@@ -157,6 +159,8 @@ class Log
         FILE* sqlLogFile;
         FILE* sqlDevLogFile;
         FILE* miscLogFile;
+
+        std::string CharLogSeparate;
 
         // cache values for after initilization use (like gm log per account case)
         std::string m_logsDir;
@@ -191,6 +195,7 @@ class Log
         std::string m_dumpsDir;
 
         DebugLogFilters m_DebugLogMask;
+        ACE_Thread_Mutex m_mutex;
 };
 
 #define sLog ACE_Singleton<Log, ACE_Thread_Mutex>::instance()

--- a/src/common/Logging/Log.h
+++ b/src/common/Logging/Log.h
@@ -146,8 +146,7 @@ class Log
         void SetLogDB(bool enable) { m_enableLogDB = enable; }
         bool GetSQLDriverQueryLogging() const { return m_sqlDriverQueryLogging; }
     private:
-        void openLogFile(FILE** file, char const* configFileName, char const* configTimeStampFlag, char const* mode);
-        void openLogFile(FILE** file, char const* fileName, char const* mode);
+        FILE* openLogFile(char const* configFileName, char const* configTimeStampFlag, char const* mode);
         FILE* openGmlogPerAccount(uint32 account);
 
         FILE* raLogfile;


### PR DESCRIPTION
##### CHANGES PROPOSED:
This is PR #992 combined with the following modification:
- synchronize the check if a log file is initialized and the initialization itself using "ACE_Thread_Mutex"

##### ISSUES ADDRESSED:
Closes #991 

##### TESTS PERFORMED:
Built and tested in-game

##### HOW TO TEST THE CHANGES:
- before applying the changes check the number of opened log files (could be several hundreds):
 `ls -al /proc/$(pgrep worldserver)/fd | egrep ".*\.log$" | wc -l`
- after applying the changes, build and start the core and repeat the command above; the number of opened log files should now be <10

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
