### PR TITLE
exit compiler script if any statement returns non-zero exit code

### DIFF
--- a/apps/compiler/compiler.sh
+++ b/apps/compiler/compiler.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 CURRENT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "$CURRENT_PATH/includes/includes.sh"

--- a/apps/compiler/includes/functions.sh
+++ b/apps/compiler/includes/functions.sh
@@ -6,8 +6,8 @@ function comp_clean() {
 
   cd $BUILDPATH
 
-  make -f Makefile clean
-  make clean
+  make -f Makefile clean || true
+  make clean || true
   find -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} \+
 
   cd $CWD

--- a/apps/db_assembler/db_assembler.sh
+++ b/apps/db_assembler/db_assembler.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 CURRENT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "$CURRENT_PATH/includes/includes.sh"


### PR DESCRIPTION
Currently Travis won't complain if there are compiler errors. This is the case since the bash scripts have been rewritten (see commit 85388901cf6a69659569ad751767fd7108b25a3c) and the script
`apps/compiler/compiler.sh`
is called via bash from within script
`apps/installer/main.sh`

##### CHANGES PROPOSED:
- include `set -e` to the "compiler.sh"-script in order to exit the script on errors
- the same to the "db_assembler.sh"-script to also allow exit on errors (it is also called via bash from the main installer script)
- ignore exit code of 'make clean' as it won't find a Makefile if called as first action (which is the case for "compiler all"); see script
 `apps/compiler/includes/functions.sh`

##### TESTS PERFORMED:
Sadly, cannot test Travis

##### HOW TO TEST THE CHANGES:
Force a compiler error and check Travis

##### Target branch(es):
Master
