### PR TITLE
log unused config options

### DIFF
--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -6,6 +6,7 @@
 
 #include "Config.h"
 #include "Errors.h"
+#include "Log.h"
 
 // Defined here as it must not be exposed to end-users.
 bool ConfigMgr::GetValueHelper(const char* name, ACE_TString &result)
@@ -83,33 +84,63 @@ bool ConfigMgr::LoadData(char const* file)
     return false;
 }
 
-std::string ConfigMgr::GetStringDefault(const char* name, const std::string &def)
+std::string ConfigMgr::GetStringDefault(const char* name, const std::string &def, bool logUnused /*= true*/)
 {
     ACE_TString val;
+
+    if (GetValueHelper(name, val))
+        return val.c_str();
+    else
+    {
+        if (logUnused)
+            sLog->outError("-> Not found option '%s'. The default value is used (%s)", name, def.c_str());
+        return def;
+    }
+
     return GetValueHelper(name, val) ? val.c_str() : def;
 }
 
-bool ConfigMgr::GetBoolDefault(const char* name, bool def)
+bool ConfigMgr::GetBoolDefault(const char* name, bool def, bool logUnused /*= true*/)
 {
     ACE_TString val;
 
     if (!GetValueHelper(name, val))
+    {
+        if (logUnused)
+            def ? sLog->outError("-> Not found option '%s'. The default value is used (Yes)", name) : sLog->outError(">> Not found option '%s'. The default value is used (No)", name);
         return def;
+    }
 
     return (val == "true" || val == "TRUE" || val == "yes" || val == "YES" ||
         val == "1");
 }
 
-int ConfigMgr::GetIntDefault(const char* name, int def)
+int ConfigMgr::GetIntDefault(const char* name, int def, bool logUnused /*= true*/)
 {
     ACE_TString val;
-    return GetValueHelper(name, val) ? atoi(val.c_str()) : def;
+
+    if (GetValueHelper(name, val))
+        return atoi(val.c_str());
+    else
+    {
+        if (logUnused)
+            sLog->outError("-> Not found option '%s'. The default value is used (%i)", name, def);
+        return def;
+    }
 }
 
-float ConfigMgr::GetFloatDefault(const char* name, float def)
+float ConfigMgr::GetFloatDefault(const char* name, float def, bool logUnused /*= true*/)
 {
     ACE_TString val;
-    return GetValueHelper(name, val) ? (float)atof(val.c_str()) : def;
+
+    if (GetValueHelper(name, val))
+        return (float)atof(val.c_str());
+    else
+    {
+        if (logUnused)
+            sLog->outError("-> Not found option '%s'. The default value is used (%f)", name, def);
+        return def;
+    }
 }
 
 std::list<std::string> ConfigMgr::GetKeysByString(std::string const& name)

--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -96,8 +96,6 @@ std::string ConfigMgr::GetStringDefault(const char* name, const std::string &def
             sLog->outError("-> Not found option '%s'. The default value is used (%s)", name, def.c_str());
         return def;
     }
-
-    return GetValueHelper(name, val) ? val.c_str() : def;
 }
 
 bool ConfigMgr::GetBoolDefault(const char* name, bool def, bool logUnused /*= true*/)
@@ -107,7 +105,7 @@ bool ConfigMgr::GetBoolDefault(const char* name, bool def, bool logUnused /*= tr
     if (!GetValueHelper(name, val))
     {
         if (logUnused)
-            def ? sLog->outError("-> Not found option '%s'. The default value is used (Yes)", name) : sLog->outError(">> Not found option '%s'. The default value is used (No)", name);
+            def ? sLog->outError("-> Not found option '%s'. The default value is used (Yes)", name) : sLog->outError("-> Not found option '%s'. The default value is used (No)", name);
         return def;
     }
 

--- a/src/common/Configuration/Config.h
+++ b/src/common/Configuration/Config.h
@@ -39,10 +39,10 @@ public:
 
     bool Reload();
 
-    std::string GetStringDefault(const char* name, const std::string& def);
-    bool GetBoolDefault(const char* name, bool def);
-    int GetIntDefault(const char* name, int def);
-    float GetFloatDefault(const char* name, float def);
+    std::string GetStringDefault(const char* name, const std::string& def, bool logUnused = true);
+    bool GetBoolDefault(const char* name, bool def, bool logUnused = true);
+    int GetIntDefault(const char* name, int def, bool logUnused = true);
+    float GetFloatDefault(const char* name, float def, bool logUnused = true);
 
     std::list<std::string> GetKeysByString(std::string const& name);
 

--- a/src/common/Logging/Log.cpp
+++ b/src/common/Logging/Log.cpp
@@ -88,16 +88,16 @@ void Log::SetLogFileLevel(char *Level)
 void Log::Initialize()
 {
     /// Check whether we'll log GM commands/RA events/character outputs/chat stuffs
-    m_dbChar = sConfigMgr->GetBoolDefault("LogDB.Char", false);
-    m_dbRA = sConfigMgr->GetBoolDefault("LogDB.RA", false);
-    m_dbGM = sConfigMgr->GetBoolDefault("LogDB.GM", false);
-    m_dbChat = sConfigMgr->GetBoolDefault("LogDB.Chat", false);
+    m_dbChar = sConfigMgr->GetBoolDefault("LogDB.Char", false, false);
+    m_dbRA = sConfigMgr->GetBoolDefault("LogDB.RA", false, false);
+    m_dbGM = sConfigMgr->GetBoolDefault("LogDB.GM", false, false);
+    m_dbChat = sConfigMgr->GetBoolDefault("LogDB.Chat", false, false);
 
     /// Realm must be 0 by default
     SetRealmID(0);
 
     /// Common log files data
-    m_logsDir = sConfigMgr->GetStringDefault("LogsDir", "");
+    m_logsDir = sConfigMgr->GetStringDefault("LogsDir", "", false);
     if (!m_logsDir.empty())
         if ((m_logsDir.at(m_logsDir.length() - 1) != '/') && (m_logsDir.at(m_logsDir.length() - 1) != '\\'))
             m_logsDir.push_back('/');
@@ -106,18 +106,18 @@ void Log::Initialize()
 
     /// Open specific log files
     logfile = openLogFile("LogFile", "LogTimestamp", "w");
-    InitColors(sConfigMgr->GetStringDefault("LogColors", ""));
+    InitColors(sConfigMgr->GetStringDefault("LogColors", "", false));
 
-    m_gmlog_per_account = sConfigMgr->GetBoolDefault("GmLogPerAccount", false);
+    m_gmlog_per_account = sConfigMgr->GetBoolDefault("GmLogPerAccount", false, false);
     if (!m_gmlog_per_account)
         gmLogfile = openLogFile("GMLogFile", "GmLogTimestamp", "a");
     else
     {
         // GM log settings for per account case
-        m_gmlog_filename_format = sConfigMgr->GetStringDefault("GMLogFile", "");
+        m_gmlog_filename_format = sConfigMgr->GetStringDefault("GMLogFile", "", false);
         if (!m_gmlog_filename_format.empty())
         {
-            bool m_gmlog_timestamp = sConfigMgr->GetBoolDefault("GmLogTimestamp", false);
+            bool m_gmlog_timestamp = sConfigMgr->GetBoolDefault("GmLogTimestamp", false, false);
 
             size_t dot_pos = m_gmlog_filename_format.find_last_of('.');
             if (dot_pos!=m_gmlog_filename_format.npos)
@@ -148,19 +148,19 @@ void Log::Initialize()
     miscLogFile = fopen((m_logsDir+"Misc.log").c_str(), "a");
 
     // Main log file settings
-    m_logLevel     = sConfigMgr->GetIntDefault("LogLevel", LOGL_NORMAL);
-    m_logFileLevel = sConfigMgr->GetIntDefault("LogFileLevel", LOGL_NORMAL);
-    m_dbLogLevel   = sConfigMgr->GetIntDefault("DBLogLevel", LOGL_NORMAL);
-    m_sqlDriverQueryLogging  = sConfigMgr->GetBoolDefault("SQLDriverQueryLogging", false);
+    m_logLevel     = sConfigMgr->GetIntDefault("LogLevel", LOGL_NORMAL, false);
+    m_logFileLevel = sConfigMgr->GetIntDefault("LogFileLevel", LOGL_NORMAL, false);
+    m_dbLogLevel   = sConfigMgr->GetIntDefault("DBLogLevel", LOGL_NORMAL, false);
+    m_sqlDriverQueryLogging  = sConfigMgr->GetBoolDefault("SQLDriverQueryLogging", false, false);
 
-    m_DebugLogMask = DebugLogFilters(sConfigMgr->GetIntDefault("DebugLogMask", LOG_FILTER_NONE));
+    m_DebugLogMask = DebugLogFilters(sConfigMgr->GetIntDefault("DebugLogMask", LOG_FILTER_NONE, false));
 
     // Char log settings
-    m_charLog_Dump = sConfigMgr->GetBoolDefault("CharLogDump", false);
-    m_charLog_Dump_Separate = sConfigMgr->GetBoolDefault("CharLogDump.Separate", false);
+    m_charLog_Dump = sConfigMgr->GetBoolDefault("CharLogDump", false, false);
+    m_charLog_Dump_Separate = sConfigMgr->GetBoolDefault("CharLogDump.Separate", false, false);
     if (m_charLog_Dump_Separate)
     {
-        m_dumpsDir = sConfigMgr->GetStringDefault("CharLogDump.SeparateDir", "");
+        m_dumpsDir = sConfigMgr->GetStringDefault("CharLogDump.SeparateDir", "", false);
         if (!m_dumpsDir.empty())
             if ((m_dumpsDir.at(m_dumpsDir.length() - 1) != '/') && (m_dumpsDir.at(m_dumpsDir.length() - 1) != '\\'))
                 m_dumpsDir.push_back('/');
@@ -178,11 +178,11 @@ void Log::ReloadConfig()
 
 FILE* Log::openLogFile(char const* configFileName, char const* configTimeStampFlag, char const* mode)
 {
-    std::string logfn=sConfigMgr->GetStringDefault(configFileName, "");
+    std::string logfn=sConfigMgr->GetStringDefault(configFileName, "", false);
     if (logfn.empty())
         return NULL;
 
-    if (configTimeStampFlag && sConfigMgr->GetBoolDefault(configTimeStampFlag, false))
+    if (configTimeStampFlag && sConfigMgr->GetBoolDefault(configTimeStampFlag, false, false))
     {
         size_t dot_pos = logfn.find_last_of(".");
         if (dot_pos!=logfn.npos)


### PR DESCRIPTION
##### CHANGES PROPOSED:
This is basically PR #908 by @Winfidonarleyan with an alternative fix to the deadlock problem of the auth server. Instead of pulling the initialization of the log files out of the Log constructor (which led to #991) the extended logging functionality is deactivated for the logging options. This should not be a problem as this was mainly implemented to track unused options in modules.

Here's the list of option names which won't be tracked if unused:
LogDB.Char
LogDB.RA
LogDB.GM
LogDB.Chat
LogsDir
LogFile
LogFileLevel
LogTimestamp
LogColors
LogLevel
GmLogPerAccount
GMLogFile
GmLogTimestamp
DBLogLevel
DBErrorLogFile
SQLDriverLogFile
SQLDriverQueryLogging
SQLDeveloperLogFile
CharLogFile
CharLogTimestamp
CharLogDump
CharLogDump.Separate
CharLogDump.SeparateDir
RaLogFile
ChatLogFile
ChatLogTimestamp
DebugLogMask

##### TESTS PERFORMED:
tested build and in-game

##### HOW TO TEST THE CHANGES:
see PR #908 

##### Target branch(es):
Master

