### PR TITLE
fix error message and help text for new 'npc set faction' command

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1534115647861309430.sql
+++ b/data/sql/updates/pending_db_world/rev_1534115647861309430.sql
@@ -1,0 +1,12 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1534115647861309430');
+
+DELETE FROM `command` WHERE `name` IN
+('npc set factionid',
+'npc set faction temp',
+'npc set faction original',
+'npc set faction permanent');
+
+INSERT INTO `command` (`name`, `security`, `help`) VALUES
+('npc set faction temp', 3, 'Syntax: .npc set faction temp #factionid\r\n\r\nTemporarily set the faction of the selected creature to #factionid.'),
+('npc set faction original', 3, 'Syntax: .npc set faction original\r\n\r\nRevert the temporal faction of the selected creature.'),
+('npc set faction permanent', 3, 'Syntax: .npc set faction permanent #factionid\r\n\r\nPermanently set the faction of the selected creature to #factionid.');

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -133,9 +133,9 @@ public:
 
         static std::vector<ChatCommand> npcFactionCommandTable =
         {
-            { "Permanent",      SEC_ADMINISTRATOR,  false, &HandleNpcSetFactionIdCommand,      "" },
-            { "Temp",           SEC_ADMINISTRATOR,  false, &HandleNpcSetFactionTempIdCommand,  "" },
-            { "Original",       SEC_ADMINISTRATOR,  false, &HandleNpcSetOriginalFaction,       "" }
+            { "permanent",      SEC_ADMINISTRATOR,  false, &HandleNpcSetFactionIdCommand,      "" },
+            { "temp",           SEC_ADMINISTRATOR,  false, &HandleNpcSetFactionTempIdCommand,  "" },
+            { "original",       SEC_ADMINISTRATOR,  false, &HandleNpcSetOriginalFaction,       "" }
         };
 
         static std::vector<ChatCommand> npcSetCommandTable =


### PR DESCRIPTION
##### CHANGES PROPOSED:
Since commit 295f461fdde19256aee6f94f2ed8d83ce6fe26a4 the following error message appears if a command like `.help` is executed:
```
ERROR: Table `command` have non-existing subcommand 'factionid' in command 'npc set factionid', skip.
```
Also there's no help message for the new 'npc set faction' command and it's subcommands. Changes proposed:
-  convert the subcommands to lower case (it is confusing to read upper case subcommands in the help when everything else is lower case):
 temp
 original
 permanent
-  add help text to the 'command' table

##### TESTS PERFORMED:
tested build and in-game (Ubuntu 16.04)

##### HOW TO TEST THE CHANGES:
Execute help:
`.help npc set faction`
`.help npc set faction temp`
`.help npc set faction original`
`.help npc set faction permanent`

##### Target branch(es):
Master
