### PR TITLE
Core/Achiev: Warning if GM mode enabled

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -497,7 +497,7 @@ void AchievementMgr::ResetAchievementCriteria(AchievementCriteriaCondition condi
     if (m_player->IsGameMaster())
     {
         sLog->outString("Not available in GM mode.");
-        ChatHandler(m_player->getSession()).PsendSysMessage("Not available in GM mode");        
+        ChatHandler(m_player->GetSession()).PSendSysMessage("Not available in GM mode");        
         return;
     }
 
@@ -760,7 +760,7 @@ void AchievementMgr::UpdateAchievementCriteria(AchievementCriteriaTypes type, ui
     if (m_player->IsGameMaster())
     {
         sLog->outString("Not available in GM mode.");
-        ChatHandler(m_player->getSession()).PsendSysMessage("Not available in GM mode");        
+        ChatHandler(m_player->GetSession()).PSendSysMessage("Not available in GM mode");        
         return;
     }
 
@@ -2157,7 +2157,7 @@ void AchievementMgr::CompletedAchievement(AchievementEntry const* achievement)
     if (m_player->IsGameMaster())
     {
         sLog->outString("Not available in GM mode.");
-        ChatHandler(m_player->getSession()).PsendSysMessage("Not available in GM mode");        
+        ChatHandler(m_player->GetSession()).PSendSysMessage("Not available in GM mode");        
         return;
     }
 

--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -493,7 +493,17 @@ void AchievementMgr::Reset()
 
 void AchievementMgr::ResetAchievementCriteria(AchievementCriteriaCondition condition, uint32 value, bool evenIfCriteriaComplete)
 {
-    AchievementCriteriaEntryList const* achievementCriteriaList = sAchievementMgr->GetAchievementCriteriaByCondition(condition, value);
+    // disable for gamemasters with GM-mode enabled
+    if (m_player->IsGameMaster())
+    {
+        sLog->outString("Not available in GM mode.");
+        ChatHandler(m_player->getSession()).PsendSysMessage("Not available in GM mode");        
+        return;
+    }
+
+    sLog->outDebug(LOG_FILTER_ACHIEVEMENTSYS, "AchievementMgr::ResetAchievementCriteria(%u, %u, %u)", condition, value, evenIfCriteriaComplete);
+
+     AchievementCriteriaEntryList const* achievementCriteriaList = sAchievementMgr->GetAchievementCriteriaByCondition(condition, value);
     if (!achievementCriteriaList)
         return;
 
@@ -745,13 +755,24 @@ static const uint32 achievIdForDungeon[][4] =
  */
 void AchievementMgr::UpdateAchievementCriteria(AchievementCriteriaTypes type, uint32 miscValue1 /*= 0*/, uint32 miscValue2 /*= 0*/, Unit* unit /*= NULL*/)
 {
-#if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
-    sLog->outDebug(LOG_FILTER_ACHIEVEMENTSYS, "AchievementMgr::UpdateAchievementCriteria(%u, %u, %u)", type, miscValue1, miscValue2);
-#endif
 
     // disable for gamemasters with GM-mode enabled
     if (m_player->IsGameMaster())
+    {
+        sLog->outString("Not available in GM mode.");
+        ChatHandler(m_player->getSession()).PsendSysMessage("Not available in GM mode");        
         return;
+    }
+
+#if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
+    if (type >= ACHIEVEMENT_CRITERIA_TYPE_TOTAL)
+    {
+        sLog->outDebug(LOG_FILTER_ACHIEVEMENTSYS, "UpdateAchievementCriteria: Wrong criteria type %u", type);
+        return;
+    }
+    
+    sLog->outDebug(LOG_FILTER_ACHIEVEMENTSYS, "AchievementMgr::UpdateAchievementCriteria(%u, %u, %u)", type, miscValue1, miscValue2);
+#endif
 
     AchievementCriteriaEntryList const* achievementCriteriaList = NULL;
 
@@ -2132,16 +2153,20 @@ void AchievementMgr::RemoveTimedAchievement(AchievementCriteriaTimedTypes type, 
 
 void AchievementMgr::CompletedAchievement(AchievementEntry const* achievement)
 {
-#if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
-    sLog->outDetail("AchievementMgr::CompletedAchievement(%u)", achievement->ID);
-#endif
 
-    // disable for gamemasters with GM-mode enabled
     if (m_player->IsGameMaster())
+    {
+        sLog->outString("Not available in GM mode.");
+        ChatHandler(m_player->getSession()).PsendSysMessage("Not available in GM mode");        
         return;
+    }
 
     if (achievement->flags & ACHIEVEMENT_FLAG_COUNTER || HasAchieved(achievement->ID))
         return;
+
+#if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
+    sLog->outDetail("AchievementMgr::CompletedAchievement(%u)", achievement->ID);
+#endif
 
     SendAchievementEarned(achievement);
     CompletedAchievementData& ca = m_completedAchievements[achievement->ID];

--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -2153,7 +2153,7 @@ void AchievementMgr::RemoveTimedAchievement(AchievementCriteriaTimedTypes type, 
 
 void AchievementMgr::CompletedAchievement(AchievementEntry const* achievement)
 {
-
+    // disable for gamemasters with GM-mode enabled
     if (m_player->IsGameMaster())
     {
         sLog->outString("Not available in GM mode.");


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: https://github.com/azerothcore/azerothcore-wotlk/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

1. Added a warning ingame and in console when you're a GM testing achievements (else it was confusing).
2. Added another GM mode check in ResetAchievement from TrinityCore.
3. Added an extra type check in UpdateAchievementCriteria, ported from TrinityCore.



##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

None yet.

##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

- Compile
- Enter the game in GM mode on
- Type `.achiev add 504` and see if it warns you ingame and in console.
- I'm not sure how to test change 3) though :P


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
