### PR TITLE
bugfix Pit of Saron intro

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1537654210905936070.sql
+++ b/data/sql/updates/pending_db_world/rev_1537654210905936070.sql
@@ -2,3 +2,4 @@ INSERT INTO version_db_world (`sql_rev`) VALUES ('1537654210905936070');
 
 UPDATE `creature_text` SET `BroadcastTextID` = 37093 WHERE `entry` = 36794 AND `groupid` = 1;
 UPDATE `creature_text` SET `BroadcastTextID` = 37392 WHERE `entry` = 36990 AND `groupid` = 3;
+UPDATE `creature_text` SET `BroadcastTextID` = 37087 WHERE `entry` = 36993 AND `groupid` = 2;

--- a/data/sql/updates/pending_db_world/rev_1537654210905936070.sql
+++ b/data/sql/updates/pending_db_world/rev_1537654210905936070.sql
@@ -1,0 +1,4 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1537654210905936070');
+
+UPDATE `creature_text` SET `BroadcastTextID` = 37093 WHERE `entry` = 36794 AND `groupid` = 1;
+UPDATE `creature_text` SET `BroadcastTextID` = 37392 WHERE `entry` = 36990 AND `groupid` = 3;


### PR DESCRIPTION
##### CHANGES PROPOSED:
set correct broadcast IDs for creature texts during the Pit of Saron intro for Horde and Alliance

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested in-game

##### HOW TO TEST THE CHANGES:
- enter Pit of Saron with a Horde character
- wrong intro text Tyrannus: "Worthless gnat! Death is all that awaits you!"
- wrong intro text Sylvanas: "Take cover behind me! Quickly!"
- enter Pit of Saron with a Alliance character
- wrong intro text Jaina: "What a cruel end. Come, heroes. We must see if the gnome\'s story is true. If we can separate Arthas from Frostmourne, we might have a chance at stopping him."
- apply SQL script
- correct intro text Tyrannus: "Intruders have entered the master's domain. Signal the alarms!"
- correct intro text Sylvanas: "Soldiers of the Horde, attack!"
- correct intro text Jaina: "Heroes of the Alliance, attack!"

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master