### PR TITLE
CORE/conf: Note about MaxCoreStuckTime danger

### DIFF
--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -349,7 +349,8 @@ LogDB.Opt.ClearTime = 1209600
 #    MaxCoreStuckTime
 #        Description: Time (in seconds) before the server is forced to crash if it is frozen.
 #        Default:     0   - (Disabled)
-#                     10+ - (Enabled, Recommended 10+)
+#                     10+ - (Enabled, Recommended 30+)
+# Note: If enabled and the setting is too low, it can cause unexpected crash.
 
 MaxCoreStuckTime = 0
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: https://github.com/azerothcore/azerothcore-wotlk/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  Warning note to avoid stupid crashes.


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

https://github.com/azerothcore/azerothcore-wotlk/issues/1042

Crashes also happen when using the anticheat module with a low MaxCoreStuckTime

Note: maybe there is an issue with .reload all which makes the server considered "stuck". That's why I make this PR, if someone thinks there is a more serious issue, please comment below :)