### PR TITLE
Solve if run executable in another machine, config of modules doesn't…

### DIFF
--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -80,7 +80,7 @@
 #include "LuaEngine.h"
 #endif
 
-#include <experimental/filesystem>
+#include <experimental/filesystem> 
 
 ACE_Atomic_Op<ACE_Thread_Mutex, bool> World::m_stopEvent = false;
 uint8 World::m_ExitCode = SHUTDOWN_EXIT_CODE;

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -431,7 +431,7 @@ void World::LoadModuleConfigSettings()
     {
         for (auto& p : fs::recursive_directory_iterator(fs::current_path()))
         {
-            if (p.path().extension() == std::string(".dist"))
+            if (p.path().extension() == std::string(".conf"))
             {
                 std::string cfg_file = p.path().filename().u8string();
                 std::string cfg_def_file = cfg_file + ".dist";

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -80,6 +80,8 @@
 #include "LuaEngine.h"
 #endif
 
+#include <experimental/filesystem>
+
 ACE_Atomic_Op<ACE_Thread_Mutex, bool> World::m_stopEvent = false;
 uint8 World::m_ExitCode = SHUTDOWN_EXIT_CODE;
 uint32 World::m_worldLoopCounter = 0;
@@ -416,7 +418,6 @@ bool World::RemoveQueuedPlayer(WorldSession* sess)
     return found;
 }
 
-#include <filesystem>
 void World::LoadModuleConfigSettings()
 {
     //GetConfigFileList() can return an empty list if module makers didn't call AC_ADD_CONFIG_FILE("${CMAKE_CURRENT_LIST_DIR}/conf/my_custom.conf.dist") in their


### PR DESCRIPTION
… get loaded because _CONF_DIR doesn't exists

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: https://github.com/azerothcore/azerothcore-wotlk/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  add another loading method, load from the current executable's working directory


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->



##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->



##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ] Need testing on linux
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
