### PR TITLE
Fix voice samples for Headless Horseman during quest "Let the Fires Come!"

### DIFF
--- a/src/server/scripts/Events/hallows_end.cpp
+++ b/src/server/scripts/Events/hallows_end.cpp
@@ -662,9 +662,15 @@ class npc_hallows_end_soh : public CreatureScript
                             return;
                         }
                         if (counter == 5)
+                        {
                             me->MonsterYell("The sky is dark. The fire burns. You strive in vain as Fate's wheel turns.", LANG_UNIVERSAL, 0);
+                            me->PlayDirectSound(12570);
+                        }
                         else if (counter == 10)
+                        {
                             me->MonsterYell("The town still burns. A cleansing fire! Time is short, I'll soon retire!", LANG_UNIVERSAL, 0);
+                            me->PlayDirectSound(12571);
+                        }
 
                         if (Unit* trigger = getTrigger())
                             me->CastSpell(trigger, SPELL_START_FIRE, true);


### PR DESCRIPTION
##### CHANGES PROPOSED:
Add voice samples for the following texts:
- "The sky is dark. The fire burns. You strive in vain as Fate's wheel turns."
- "The town still burns. A cleansing fire! Time is short, I'll soon retire!"

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
Tested build on Ubuntu 16.04; tested in-game

##### HOW TO TEST THE CHANGES:
Start daily quest "Let the Fires Come!", do not put out the fires.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
