### PR TITLE
Talk method for translations

### DIFF
--- a/src/server/scripts/EasternKingdoms/zone_silverpine_forest.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_silverpine_forest.cpp
@@ -262,9 +262,15 @@ public:
             switch (Phase)
             {
                 case 0:
-					if (WaitTimer == WAIT_SECS)
-						me->AI()->Talk(NPCSAY_INIT);
-
+					if (WaitTimer == WAIT_SECS) {
+						if (PlayerGUID)
+						{
+							if (Player* player = ObjectAccessor::GetPlayer(*me, PlayerGUID))
+							{
+								me->AI()->Talk(NPCSAY_INIT, player);
+							}
+						}
+					}
                     if (WaitTimer <= diff)
                     {
                         WaitTimer -= diff;

--- a/src/server/scripts/EasternKingdoms/zone_silverpine_forest.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_silverpine_forest.cpp
@@ -129,9 +129,9 @@ public:
 
 enum PyrewoodAmbush
 {
-	QUEST_PYREWOOD_AMBUSH = 452,
-	NPCSAY_INIT = 0,
-	NPCSAY_END = 1
+    QUEST_PYREWOOD_AMBUSH = 452,
+    NPCSAY_INIT = 0,
+    NPCSAY_END = 1
 };
 
 static float PyrewoodSpawnPoints[3][4] =
@@ -262,15 +262,15 @@ public:
             switch (Phase)
             {
                 case 0:
-					if (WaitTimer == WAIT_SECS) {
-						if (PlayerGUID)
-						{
-							if (Player* player = ObjectAccessor::GetPlayer(*me, PlayerGUID))
-							{
-								me->AI()->Talk(NPCSAY_INIT, player);
-							}
-						}
-					}
+                    if (WaitTimer == WAIT_SECS) {
+                        if (PlayerGUID)
+                        {
+                            if (Player* player = ObjectAccessor::GetPlayer(*me, PlayerGUID))
+                            {
+                                me->AI()->Talk(NPCSAY_INIT, player);
+                            }
+                        }
+                    }
                     if (WaitTimer <= diff)
                     {
                         WaitTimer -= diff;
@@ -299,7 +299,7 @@ public:
                     {
                         if (Player* player = ObjectAccessor::GetPlayer(*me, PlayerGUID))
                         {
-							me->AI()->Talk(NPCSAY_END, player);
+                            me->AI()->Talk(NPCSAY_END, player);
                             player->GroupEventHappens(QUEST_PYREWOOD_AMBUSH, me);
                         }
                     }

--- a/src/server/scripts/EasternKingdoms/zone_silverpine_forest.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_silverpine_forest.cpp
@@ -127,10 +127,12 @@ public:
 ## pyrewood_ambush
 #######*/
 
-#define QUEST_PYREWOOD_AMBUSH 452
-
-#define NPCSAY_INIT "Get ready, they'll be arriving any minute..." //not blizzlike
-#define NPCSAY_END "Thanks for your help!" //not blizzlike
+enum PyrewoodAmbush
+{
+	QUEST_PYREWOOD_AMBUSH = 452,
+	NPCSAY_INIT = 0,
+	NPCSAY_END = 1
+};
 
 static float PyrewoodSpawnPoints[3][4] =
 {
@@ -260,8 +262,8 @@ public:
             switch (Phase)
             {
                 case 0:
-                    if (WaitTimer == WAIT_SECS)
-                        me->MonsterSay(NPCSAY_INIT, LANG_UNIVERSAL, NULL); //no blizzlike
+					if (WaitTimer == WAIT_SECS)
+						me->AI()->Talk(NPCSAY_INIT);
 
                     if (WaitTimer <= diff)
                     {
@@ -291,7 +293,7 @@ public:
                     {
                         if (Player* player = ObjectAccessor::GetPlayer(*me, PlayerGUID))
                         {
-                            me->MonsterSay(NPCSAY_END, LANG_UNIVERSAL, NULL); //not blizzlike
+							me->AI()->Talk(NPCSAY_END, player);
                             player->GroupEventHappens(QUEST_PYREWOOD_AMBUSH, me);
                         }
                     }


### PR DESCRIPTION
PROPOSED CHANGES:

The string can now be translated in the database

ISSUES ADDRESSED:

The creature currently says the script dialogs instead of searching the database, which does not allow to translate it in case of having dialogs in local_creature_text

TESTS PERFORMED:

Windows; tested in-game

HOW TO TEST THE CHANGES:

.go creature 18352

KNOWN PROBLEMS AND LIST OF THINGS TO DO:

  

Destination branch(s):

Master
