### PR TITLE
 DB/QUEST: fix OfferRewardText for The New Horde

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1542756898843297200.sql
+++ b/data/sql/updates/pending_db_world/rev_1542756898843297200.sql
@@ -1,2 +1,2 @@
 INSERT INTO version_db_world (`sql_rev`) VALUES ('1542756898843297200');
-UPDATE `quest_template` SET `OfferRewardText`='Another one of Eitrigg\'s recruits, hm?$B$BA sorry state of affairs we find ourselves in if this is the best the Horde can produce.  No matter.  By the time we think you\'re ready to leave the Valley, you\'ll be a proud warrior of the Horde.' WHERE  `ID`=787;
+UPDATE `quest_template` SET `OfferRewardText`='Another one of Eitrigg\'s recruits, hm?$B$BA sorry state of affairs we find ourselves in if this is the best the Horde can produce. No matter. By the time we think you\'re ready to leave the Valley, you\'ll be a proud warrior of the Horde.' WHERE  `ID`=787;

--- a/data/sql/updates/pending_db_world/rev_1542756898843297200.sql
+++ b/data/sql/updates/pending_db_world/rev_1542756898843297200.sql
@@ -1,0 +1,2 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1542756898843297200');
+UPDATE `quest_template` SET `OfferRewardText`='Another one of Eitrigg\'s recruits, hm?$B$BA sorry state of affairs we find ourselves in if this is the best the Horde can produce.  No matter.  By the time we think you\'re ready to leave the Valley, you\'ll be a proud warrior of the Horde.' WHERE  `ID`=787;


### PR DESCRIPTION
##### TITLE
Wrong Offer Reward Text

##### CHANGES PROPOSED:
The current reward text says: "Thanks for the done work!" 
It should says 

> Another one of Eitrigg's recruits, hm? A sorry state of affairs we find ourselves in if this is the best the Horde can produce. No matter. By the time we think you're ready to leave the Valley, you'll be a proud warrior of the Horde. 


###### ISSUES ADDRESSED:
1.  Simply create Horde character
2.  .quest add 787 ( The New Horde )
3.  .go creature 3443 ( Gornek )
4.  Finish Quest ( To see the current OfferRewardText ) 
5. > It will say : Thanks for the done work <--- **Which is Wrong** 

##### TESTS PERFORMED:
Builded without errors.  --> Tested in game, work as like Blizzlike.
[Quest Take](http://prntscr.com/lkwmxb)
[Quest Finished](http://prntscr.com/lkwlnw)



##### HOW TO TEST THE CHANGES:
1.  Now create another Horde character
2.  .quest add 787 ( The New Horde )
3.  .go creature 3443 ( Gornek )
4.  Finish Quest ( To see the New OfferRewardText ) 
5. > It will say :  > > Another one of Eitrigg's recruits, hm? A sorry state of affairs we find ourselves in if this is the best the Horde can produce. No matter. By the time we think you're ready to leave the Valley, you'll be a proud warrior of the Horde.  <--- **Which is Correct** 


##### Target branch(es):

Master
