### PR TITLE
DB/SAI: fix tortured skeletons in Shadow Labyrinth

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1542839405121938872.sql
+++ b/data/sql/updates/pending_db_world/rev_1542839405121938872.sql
@@ -6,4 +6,4 @@ DELETE FROM `smart_scripts` WHERE `entryorguid`=@ENTRY AND `source_type`=0;
 INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
 (@ENTRY,0,0,0,4,0,100,0,0,0,0,0,91,7,0,0,0,0,0,1,0,0,0,0,0,0,0,"Tortured Skeleton - On Aggro - Remove Flag Standstate Dead");
 
-UPDATE `creature` SET `spawndist`=0 WHERE `guid` IN (67091,67096,67097,67098,67099,67133);
+UPDATE `creature` SET `spawndist`=0,`MovementType`=0 WHERE `guid` IN (67091,67096,67097,67098,67099,67133);

--- a/data/sql/updates/pending_db_world/rev_1542839405121938872.sql
+++ b/data/sql/updates/pending_db_world/rev_1542839405121938872.sql
@@ -1,0 +1,9 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1542839405121938872');
+
+SET @ENTRY := 18797;
+UPDATE `creature_template` SET `AIName`="SmartAI" WHERE `entry`=@ENTRY;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=@ENTRY AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(@ENTRY,0,0,0,4,0,100,0,0,0,0,0,91,7,0,0,0,0,0,1,0,0,0,0,0,0,0,"Tortured Skeleton - On Aggro - Remove Flag Standstate Dead");
+
+UPDATE `creature` SET `spawndist`=0 WHERE `guid` IN (67091,67096,67097,67098,67099,67133);


### PR DESCRIPTION
##### CHANGES PROPOSED:
Some of the tortured skeletons in Shadow Labyrinth are moving around while lying on the ground. They are also not standing up when attacking. The following TC commit fixes part of this (skeletons standing up):
https://github.com/TrinityCore/TrinityCore/issues/14367

I added another statement to prevent the movement of the lying skeletons.

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested build and in-game

##### HOW TO TEST THE CHANGES:
- check the skeletons:
 .go creature 67091
 .go creature 67096
 .go creature 67133
- attack the skeletons

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master