### PR TITLE
Core/Achiev: Fix unwanted GM warnings

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -495,15 +495,13 @@ void AchievementMgr::ResetAchievementCriteria(AchievementCriteriaCondition condi
 {
     // disable for gamemasters with GM-mode enabled
     if (m_player->IsGameMaster())
-    {
-        sLog->outString("Not available in GM mode.");
-        ChatHandler(m_player->GetSession()).PSendSysMessage("Not available in GM mode");        
+    {  
         return;
     }
 
     sLog->outDebug(LOG_FILTER_ACHIEVEMENTSYS, "AchievementMgr::ResetAchievementCriteria(%u, %u, %u)", condition, value, evenIfCriteriaComplete);
 
-     AchievementCriteriaEntryList const* achievementCriteriaList = sAchievementMgr->GetAchievementCriteriaByCondition(condition, value);
+    AchievementCriteriaEntryList const* achievementCriteriaList = sAchievementMgr->GetAchievementCriteriaByCondition(condition, value);
     if (!achievementCriteriaList)
         return;
 
@@ -758,9 +756,7 @@ void AchievementMgr::UpdateAchievementCriteria(AchievementCriteriaTypes type, ui
 
     // disable for gamemasters with GM-mode enabled
     if (m_player->IsGameMaster())
-    {
-        sLog->outString("Not available in GM mode.");
-        ChatHandler(m_player->GetSession()).PSendSysMessage("Not available in GM mode");        
+    {  
         return;
     }
 

--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -495,9 +495,7 @@ void AchievementMgr::ResetAchievementCriteria(AchievementCriteriaCondition condi
 {
     // disable for gamemasters with GM-mode enabled
     if (m_player->IsGameMaster())
-    {  
         return;
-    }
 
     sLog->outDebug(LOG_FILTER_ACHIEVEMENTSYS, "AchievementMgr::ResetAchievementCriteria(%u, %u, %u)", condition, value, evenIfCriteriaComplete);
 
@@ -756,9 +754,7 @@ void AchievementMgr::UpdateAchievementCriteria(AchievementCriteriaTypes type, ui
 
     // disable for gamemasters with GM-mode enabled
     if (m_player->IsGameMaster())
-    {  
         return;
-    }
 
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     if (type >= ACHIEVEMENT_CRITERIA_TYPE_TOTAL)


### PR DESCRIPTION
<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  It now only warns the player that he can't complete achievements.


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

I had added too many GM warnings (stupidly) in that PR https://github.com/azerothcore/azerothcore-wotlk/pull/1028

##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

No more useless warnings.

##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

- Enter the game in GM mode on
- Type `.achiev add 504` and see if it warns you ingame and in console.
- Do other stuff related to achievements and see if any bug?


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
