### PR TITLE
Core/Movement: Prevent pet animation stuttering during movement

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13103,29 +13103,30 @@ void Unit::UpdateSpeed(UnitMoveType mtype, bool forced)
                     {
                         // special treatment for player pets in order to avoid stuttering
                         float ownerSpeed = pOwner->GetSpeedRate(mtype);
-                        float minDist = 1.0f;
+                        float distOwner = GetDistance(pOwner);
+                        float minDist = 2.5f;
 
                         if (ToCreature()->GetCreatureType() == CREATURE_TYPE_NON_COMBAT_PET)
                         {
-                            // vanity pets have to be treated different than normal pets
+                            // different minimum distance for vanity pets
                             minDist = 5.0f;
+
+                            if (mtype == MOVE_FLIGHT)
+                                mtype = MOVE_RUN; // vanity pets use run speed for flight
                         }
 
-                        if (GetDistance(pOwner) < minDist && m_petCatchUp)
+                        float maxDist = ownerSpeed >= 1.0f ? minDist * ownerSpeed * 1.5f : minDist * 1.5f;
+
+                        if (distOwner < minDist && m_petCatchUp)
                             m_petCatchUp = false;
 
-                        if (GetDistance(pOwner) > minDist * 2 && !m_petCatchUp)
+                        if (distOwner > maxDist && !m_petCatchUp)
                             m_petCatchUp = true;
 
                         if (m_petCatchUp)
-                        {
-                            if (GetDistance(pOwner) > minDist * 4)
-                                speed = ownerSpeed*2.0f;
-                            else
-                                speed = ownerSpeed*1.05f;
-                        }
+                            speed = ownerSpeed * 1.05f;
                         else
-                            speed = ownerSpeed*0.95f;
+                            speed = ownerSpeed * 0.95f;
                     }
                 }
                 else

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13103,33 +13103,29 @@ void Unit::UpdateSpeed(UnitMoveType mtype, bool forced)
                     {
                         // special treatment for player pets in order to avoid stuttering
                         float ownerSpeed = pOwner->GetSpeedRate(mtype);
+                        float minDist = 1.0f;
 
                         if (ToCreature()->GetCreatureType() == CREATURE_TYPE_NON_COMBAT_PET)
                         {
                             // vanity pets have to be treated different than normal pets
-                            if (GetDistance(pOwner) < 5.0f && m_petCatchUp)
-                                m_petCatchUp = false;
-
-                            if (GetDistance(pOwner) > 10.0f && !m_petCatchUp)
-                                m_petCatchUp = true;
-
-                            if (m_petCatchUp)
-                            {
-                                if (GetDistance(pOwner) > 20.0f)
-                                    speed = ownerSpeed*2.0f;
-                                else
-                                    speed = ownerSpeed*1.05f;
-                            }
-                            else
-                                speed = ownerSpeed*0.95f;
+                            minDist = 5.0f;
                         }
-                        else
+
+                        if (GetDistance(pOwner) < minDist && m_petCatchUp)
+                            m_petCatchUp = false;
+
+                        if (GetDistance(pOwner) > minDist * 2 && !m_petCatchUp)
+                            m_petCatchUp = true;
+
+                        if (m_petCatchUp)
                         {
-                            if (ToCreature()->IsWithinMeleeRange(pOwner))
-                                speed = ownerSpeed*0.95f;
+                            if (GetDistance(pOwner) > minDist * 4)
+                                speed = ownerSpeed*2.0f;
                             else
                                 speed = ownerSpeed*1.05f;
                         }
+                        else
+                            speed = ownerSpeed*0.95f;
                     }
                 }
                 else

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13126,7 +13126,7 @@ void Unit::UpdateSpeed(UnitMoveType mtype, bool forced)
                         else
                         {
                             if (ToCreature()->IsWithinMeleeRange(pOwner))
-                                speed = ownerSpeed;
+                                speed = ownerSpeed*0.95f;
                             else
                                 speed = ownerSpeed*1.05f;
                         }

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2561,6 +2561,7 @@ class Unit : public WorldObject
         bool m_duringRemoveFromWorld; // lock made to not add stuff after begining removing from world
 
         uint32 _oldFactionId;           ///< faction before charm
+        bool m_petCatchUp;
 };
 
 namespace Trinity

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -313,9 +313,10 @@ bool TargetedMovementGeneratorMedium<T,D>::DoUpdate(T* owner, uint32 time_diff)
     if (pOwner && pOwner->GetTypeId() == TYPEID_PLAYER)
     {
         // Update pet speed for players in order to avoid stuttering
-        owner->UpdateSpeed(MOVE_RUN, true);
-        owner->UpdateSpeed(MOVE_WALK, true);
-        owner->UpdateSpeed(MOVE_FLIGHT, true);
+        if (pOwner->IsFlying())
+            owner->UpdateSpeed(MOVE_FLIGHT, true);
+        else
+            owner->UpdateSpeed(MOVE_RUN, true);
     }
 
     return true;

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -298,6 +298,17 @@ bool TargetedMovementGeneratorMedium<T,D>::DoUpdate(T* owner, uint32 time_diff)
         if (i_recalculateTravel)
             _setTargetLocation(owner, false);
     }
+
+    Unit* pOwner = owner->GetCharmerOrOwner();
+
+    if (pOwner && pOwner->GetTypeId() == TYPEID_PLAYER)
+    {
+        // Update pet speed for players in order to avoid stuttering
+        owner->UpdateSpeed(MOVE_RUN, true);
+        owner->UpdateSpeed(MOVE_WALK, true);
+        owner->UpdateSpeed(MOVE_FLIGHT, true);
+    }
+
     return true;
 }
 

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -98,8 +98,16 @@ void TargetedMovementGeneratorMedium<T,D>::_setTargetLocation(T* owner, bool ini
         if ((!initial || (owner->movespline->Finalized() && this->GetMovementGeneratorType() == CHASE_MOTION_TYPE)) && i_target->IsWithinDistInMap(owner, dist) && i_target->IsWithinLOS(owner->GetPositionX(), owner->GetPositionY(), owner->GetPositionZ()))
             return;
 
-        // Xinef: Fix follow angle for hostile units
         float angle = i_angle;
+
+        if (i_target->GetTypeId() == TYPEID_PLAYER && owner->ToCreature()->GetCreatureType() == CREATURE_TYPE_NON_COMBAT_PET)
+        {
+            // fix distance and angle for vanity pets
+            dist = 0.3f;
+            angle = PET_FOLLOW_ANGLE + M_PI * 0.2f;
+        }
+
+        // Xinef: Fix follow angle for hostile units
         if (angle == 0.0f && owner->GetVictim() && owner->GetVictim()->GetGUID() == i_target->GetGUID())
             angle = MapManager::NormalizeOrientation(i_target->GetAngle(owner)-i_target->GetOrientation());
         // to at i_offset distance from target and i_angle from target facing

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -84,7 +84,7 @@ void TargetedMovementGeneratorMedium<T,D>::_setTargetLocation(T* owner, bool ini
         //  be (GetCombatReach() + i_offset) away.
         // Only applies when i_target is pet's owner otherwise pets and mobs end up
         //   doing a "dance" while fighting
-        if (i_target->GetTypeId() == TYPEID_PLAYER && (owner->IsPet() || owner->ToCreature()->GetCreatureType() == CREATURE_TYPE_NON_COMBAT_PET))
+        if (owner->IsPet() && i_target->GetTypeId() == TYPEID_PLAYER)
         {
             dist = i_target->GetCombatReach();
             size = i_target->GetCombatReach() - i_target->GetObjectSize();
@@ -105,6 +105,7 @@ void TargetedMovementGeneratorMedium<T,D>::_setTargetLocation(T* owner, bool ini
             // fix distance and angle for vanity pets
             dist = 0.3f;
             angle = PET_FOLLOW_ANGLE + M_PI * 0.2f;
+            size = i_target->GetCombatReach() - i_target->GetObjectSize();
         }
 
         // Xinef: Fix follow angle for hostile units

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -84,7 +84,7 @@ void TargetedMovementGeneratorMedium<T,D>::_setTargetLocation(T* owner, bool ini
         //  be (GetCombatReach() + i_offset) away.
         // Only applies when i_target is pet's owner otherwise pets and mobs end up
         //   doing a "dance" while fighting
-        if (owner->IsPet() && i_target->GetTypeId() == TYPEID_PLAYER)
+        if (i_target->GetTypeId() == TYPEID_PLAYER && (owner->IsPet() || owner->ToCreature()->GetCreatureType() == CREATURE_TYPE_NON_COMBAT_PET))
         {
             dist = i_target->GetCombatReach();
             size = i_target->GetCombatReach() - i_target->GetObjectSize();


### PR DESCRIPTION
##### CHANGES PROPOSED:
This is more of a base for discussion, although it works on my solo test-server.

It bugged me since starting with AC that the pets and vanity pets start to stutter while running beneath the character. The cause of this is a fixed speed calculation for the pet speed while not in combat, see line 13097 in Unit.cpp:

```
if (speed < pOwner->GetSpeedRate(mtype)+0.1f)
    speed = pOwner->GetSpeedRate(mtype)+0.1f; // pets derive speed from owner when not in combat
```

This leads to the pet constantly trying to outrun the player but has to wait if too far ahead. This wait is causing the animation to stutter.

As a possible fix I adjusted the "TargetedMovementGenerator" in order to update the speed of pets every tick and changed the speed calculation in Unit.cpp (only for pets and vanity pets). This works well for me, but I'm too inexperienced with AC to tell **if this could cause a greater performance issue.**

I also altered the distance and angle of vanity pets so that they are nearer and slightly behind the player.

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
Tested build on Ubuntu 16.04 and in-game

##### HOW TO TEST THE CHANGES:
Just summon pets or vanity pets and run or fly around.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master

