### PR TITLE
Core/World: do not consider error when no players in the DB

### DIFF
--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -3210,8 +3210,7 @@ void World::LoadGlobalPlayerDataStore()
     QueryResult result = CharacterDatabase.Query("SELECT guid, account, name, gender, race, class, level FROM characters WHERE deleteDate IS NULL");
     if (!result)
     {
-        sLog->outString();
-        sLog->outErrorDb(">>  Loaded 0 Players data!");
+        sLog->outString(">> Loaded 0 Players data.");
         return;
     }
 


### PR DESCRIPTION
Updates: https://github.com/azerothcore/azerothcore-wotlk/issues/679

Having 0 players in the Database is the default state of a fresh installation of AzerothCore, therefore it should **not** be considered as a DB error.
