### PR TITLE
DB: Fix Sen'jin Fetish model

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1546271889931245071.sql
+++ b/data/sql/updates/pending_db_world/rev_1546271889931245071.sql
@@ -1,0 +1,3 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1546271889931245071');
+
+UPDATE `creature_template` SET `modelid2` = 0 WHERE `entry` = 33810;


### PR DESCRIPTION
##### CHANGES PROPOSED:
The vanity pet "Sen'jin Fetish" has an invisible model assigned for modelid2. Through this PR this model is removed.

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
Tested in-game

##### HOW TO TEST THE CHANGES:
- ```.additem 45606```
- Use the item and summon the vanity pet; there's a 50% chance that you won't see a model
- Apply the SQL script
- ```.reload creature_template 33810```
- Resummon the pet

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
