### PR TITLE
DB/Core: Fix hover height and some flying animations of vanity pets

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1546694249586814731.sql
+++ b/data/sql/updates/pending_db_world/rev_1546694249586814731.sql
@@ -1,0 +1,109 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1546694249586814731');
+
+-- Moths:
+DELETE FROM `creature_template_addon` WHERE `entry` IN (21008,21009,21010,21018);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(21008,0,0,33554432,0,0,''),
+(21009,0,0,33554432,0,0,''),
+(21010,0,0,33554432,0,0,''),
+(21018,0,0,33554432,0,0,'');
+UPDATE `creature_template` SET `ScriptName` = 'npc_pet_gen_moth' WHERE `entry` IN (21008,21009,21010,21018);
+
+-- Gryphon Hatchling / Wind Rider Cub:
+DELETE FROM `creature_template_addon` WHERE `entry` IN (36908,36909);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(36908,0,0,50331648,0,0,''),
+(36909,0,0,50331648,0,0,'');
+
+-- Dragonhawk Hatchlings:
+DELETE FROM `creature_template_addon` WHERE `entry` IN (21055,21056,21063,21064);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(21055,0,0,33554432,0,0,''),
+(21056,0,0,33554432,0,0,''),
+(21063,0,0,33554432,0,0,''),
+(21064,0,0,33554432,0,0,'');
+
+-- Dragon Whelplings (including Frosty and Netherwhelp):
+DELETE FROM `creature_template_addon` WHERE `entry` IN (7543,7544,7545,7547,36607,28883,18381);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(7543,0,0,33554432,0,0,''),
+(7544,0,0,33554432,0,0,''),
+(7545,0,0,33554432,0,0,''),
+(7547,0,0,33554432,0,0,''),
+(36607,0,0,33554432,0,0,''),
+(28883,0,0,33554432,0,0,''),
+(18381,0,0,33554432,0,0,'');
+
+-- Parrots:
+DELETE FROM `creature_template_addon` WHERE `entry` IN (7390,7387,7391,22445,7389);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(7390,0,0,33554432,0,0,''),
+(7387,0,0,33554432,0,0,''),
+(7391,0,0,33554432,0,0,''),
+(22445,0,0,33554432,0,0,''),
+(7389,0,0,33554432,0,0,'');
+
+-- Tickbird Hatchlings:
+DELETE FROM `creature_template_addon` WHERE `entry` IN (32589,32590);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(32589,0,0,33554432,0,0,''),
+(32590,0,0,33554432,0,0,'');
+
+-- Owls:
+DELETE FROM `creature_template_addon` WHERE `entry` IN (7553,7555);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(7553,0,0,33554432,0,0,''),
+(7555,0,0,33554432,0,0,'');
+
+-- Batlings:
+DELETE FROM `creature_template_addon` WHERE `entry` IN (28513,33197);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(28513,0,0,33554432,0,0,''),
+(33197,0,0,33554432,0,0,'');
+
+-- Sprite Darter Hatchling:
+DELETE FROM `creature_template_addon` WHERE `entry` IN (9662);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(9662,0,0,33554432,0,0,'');
+
+-- Willy:
+UPDATE `creature_template_addon` SET `bytes1` = 33554432 WHERE `entry` = 23231;
+
+-- Firefly:
+DELETE FROM `creature_template_addon` WHERE `entry` IN (21076);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(21076,0,0,33554432,0,0,'');
+
+-- Mana Wyrmling:
+DELETE FROM `creature_template_addon` WHERE `entry` IN (20408);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(20408,0,0,33554432,0,0,'');
+
+-- Nether Ray Fry:
+DELETE FROM `creature_template_addon` WHERE `entry` IN (28470);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(28470,0,0,33554432,0,0,'');
+
+-- Phoenix Hatchling:
+DELETE FROM `creature_template_addon` WHERE `entry` IN (26119);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(26119,0,0,33554432,0,0,'');
+
+-- Tiny Sporebat:
+DELETE FROM `creature_template_addon` WHERE `entry` IN (25062);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)
+VALUES
+(25062,0,0,33554432,0,0,'');

--- a/data/sql/updates/pending_db_world/rev_1546694249586814731.sql
+++ b/data/sql/updates/pending_db_world/rev_1546694249586814731.sql
@@ -17,6 +17,9 @@ VALUES
 (36908,0,0,50331648,0,0,''),
 (36909,0,0,50331648,0,0,'');
 
+-- The smart script for the Wind Rider Cub can also be used for the Gryphon Hatchling:
+UPDATE `creature_template` SET `ScriptName` = 'npc_pet_gen_wind_rider_cub' WHERE `entry` = 36908;
+
 -- Dragonhawk Hatchlings:
 DELETE FROM `creature_template_addon` WHERE `entry` IN (21055,21056,21063,21064);
 INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`)

--- a/src/server/scripts/Pet/pet_generic.cpp
+++ b/src/server/scripts/Pet/pet_generic.cpp
@@ -704,7 +704,6 @@ public:
     {
         npc_pet_gen_wind_rider_cubAI(Creature *c) : NullCreatureAI(c)
         {
-            allowMove = true;
             isFlying = true;
             checkTimer = 0;
             checkTimer2 = 2000;
@@ -712,15 +711,8 @@ public:
         }
 
         bool isFlying;
-        bool allowMove;
         uint32 checkTimer;
         uint32 checkTimer2;
-
-        void MovementInform(uint32 type, uint32 id)
-        {
-            if (type == POINT_MOTION_TYPE && id == 1)
-                allowMove = true;
-        }
 
         void UpdateAI(uint32 diff)
         {
@@ -730,7 +722,7 @@ public:
                 checkTimer2 = 0;
                 if (Unit* owner = me->GetOwner())
                 {
-                    if (owner->HasAuraType(SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED))
+                    if (owner->HasAuraType(SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED) || owner->HasAuraType(SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED))
                     {
                         isFlying = true;
                         me->SetCanFly(true);
@@ -743,24 +735,6 @@ public:
                         me->SetDisableGravity(false);
                         me->GetMotionMaster()->MoveFall();
                     }
-                }
-            }
-
-            checkTimer += diff;
-            if (allowMove || checkTimer > 2000)
-            {
-                allowMove = false;
-                checkTimer = 0;
-                if (Unit* owner = me->GetOwner())
-                {
-                    if (me->GetMotionMaster()->GetMotionSlotType(MOTION_SLOT_ACTIVE) == POINT_MOTION_TYPE ||
-                        me->GetDistance(owner) < 1.0f)
-                        return;
-                    float x, y, z;
-                    owner->GetNearPoint2D(x, y, 0.5f, owner->GetOrientation()+PET_FOLLOW_ANGLE);
-                    z = owner->GetPositionZ() + (isFlying ? 2.5f : 0.0f);
-
-                    me->GetMotionMaster()->MovePoint(1, x, y, z);
                 }
             }
         }
@@ -956,6 +930,27 @@ public:
     }
 };
 
+class npc_pet_gen_moth : public CreatureScript
+{
+public:
+    npc_pet_gen_moth() : CreatureScript("npc_pet_gen_moth") { }
+
+    struct npc_pet_gen_mothAI : public NullCreatureAI
+    {
+        npc_pet_gen_mothAI(Creature *c) : NullCreatureAI(c)
+        {
+            me->AddUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
+            me->SetCanFly(true);
+            me->SetDisableGravity(true);
+        }
+    };
+
+    CreatureAI* GetAI(Creature* pCreature) const
+    {
+        return new npc_pet_gen_mothAI (pCreature);
+    }
+};
+
 void AddSC_generic_pet_scripts()
 {
     new npc_pet_gen_mojo();
@@ -970,4 +965,5 @@ void AddSC_generic_pet_scripts()
     new npc_pet_gen_plump_turkey();
     new npc_pet_gen_toxic_wasteling();
     new npc_pet_gen_fetch_ball();
+    new npc_pet_gen_moth();
 }


### PR DESCRIPTION
##### CHANGES PROPOSED:
Fix the hover height for some of the flying vanity pets (they fly nearly on the ground). Also fix the animation while following the player for the moths, the "Gryphon Hatchling" and the "Wind Rider Cub".

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
Tested build, tested in-game

##### HOW TO TEST THE CHANGES:
Summon the following vanity pets, especially the moths, the "Gryphon Hatchling" and the "Wind Rider Cub":
Azure Whelpling
Blue Dragonhawk Hatchling
Blue Moth
Cockatiel
Crimson Whelpling
Dark Whelpling
Emerald Whelpling
Firefly
Frosty
Golden Dragonhawk Hatchling
Great Horned Owl
Green Wing Macaw
Gryphon Hatchling
Hawk Owl
Hyacinth Macaw
Mana Wyrmling
Miniwing
Nether Ray Fry
Netherwhelp
Onyxian Whelpling
Phoenix Hatchling
Red Dragonhawk Hatchling
Red Moth
Senegal
Silver Dragonhawk Hatchling
Sprite Darter Hatchling
Tickbird Hatchling
Tiny Sporebat
Tirisfal Batling
Vampiric Batling
White Moth
White Tickbird Hatchling
Willy
Wind Rider Cub
Yellow Moth

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
