### PR TITLE
Bash: Fix incorrect apply sql files at import

### DIFF
--- a/apps/db_assembler/includes/functions.sh
+++ b/apps/db_assembler/includes/functions.sh
@@ -299,7 +299,7 @@ function dbasm_db_import() {
 
     export MYSQL_PWD=$MYSQL_PASS
     
-	"$DB_MYSQL_EXEC" -h "$MYSQL_HOST" -u "$MYSQL_USER" "$dbname" < "${OUTPUT_FOLDER}${database}_${type}.sql"
+	"$DB_MYSQL_EXEC" -h "$MYSQL_HOST" -u "$MYSQL_USER" --default-character-set=utf8 "$dbname" < "${OUTPUT_FOLDER}${database}_${type}.sql"
 	if [[ $? -ne 0 ]]; then
 		err=$("$DB_MYSQL_EXEC" -h "$MYSQL_HOST" -u "$MYSQL_USER" "$dbname" 2>&1 )
 		if [[ "$err" == *"Access denied"* ]]; then


### PR DESCRIPTION
##### CHANGES PROPOSED:
-  Added option `--default-character-set=utf8`
-  Fix incorrect apply not English text

##### ISSUES ADDRESSED:
Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1250

##### TESTS PERFORMED: 
- `import-all: Assemble & Import all` in Windows

##### HOW TO TEST THE CHANGES:
**Need full clean DB!**
1. Apply PR
2. Use `db_assembler`
3. Choose `5 - import-all: Assemble & Import all`
4. Check DB table e.g. `locales_broadcast_text`
5. First data should be as follows
![image](https://user-images.githubusercontent.com/18329778/50926126-d5674980-1486-11e9-9606-bbe4c16ca3e8.png)


##### KNOWN ISSUES AND TODO LIST:
- [x] in Windows
- [ ] in Linux

##### Target branch(es): Master
