### PR TITLE
Fixed permission in docker-database

### DIFF
--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -8,8 +8,8 @@ ADD data /azerothcore/data
 ADD deps /azerothcore/deps
 ADD acore.json /azerothcore/acore.json
 
-RUN /azerothcore/apps/db_assembler/db_assembler.sh 1
-
+RUN chmod 755 azerothcore/apps/db_assembler/db_assembler.sh; \
+    /azerothcore/apps/db_assembler/db_assembler.sh 1
 
 FROM mysql:5.7
 


### PR DESCRIPTION
Fixed permission in docker-database, added command chmod 755 before run the file db_assembler.sh in the Dockerfile for the database.