### PR TITLE
CI: Import pending sql from Travis only master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - git config user.email "travis@build.bot" && git config user.name "Travis CI"
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then cd bin/; fi
   # import pending sql
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash acore-db-pendings; fi
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then bash acore-db-pendings; fi
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then cd ..; fi
   # push changes to git if any
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then git fetch --unshallow; fi


### PR DESCRIPTION
##### CHANGES PROPOSED:

-  Add a branch constraint to the travis config to only execute pending sql imports when the activation comes from _master_ branch


###### ISSUES ADDRESSED:

Currently, we have a problem with working branches from collaborators in the main repo, explained by the following:

1. Collab creates a working branch, i.e. **john-hotfix-ulduar**
2. Collab pushes some scripts to **pending_db_world**
3. Travis imports that pending sql script
4. Collab creates a pull request
5. Time passes while the PR is tested. Meanwhile, other PRs got approved
6. PR is approved and merged into master branch.

In step 6, the **pr column name** will be older than the **current column name** in master branch, breaking the update chain.