### PR TITLE
chore(DB): set main DB version

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1547897046380364588.sql
+++ b/data/sql/updates/pending_db_world/rev_1547897046380364588.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1547897046380364588');
+
+UPDATE `acore_world`.`version` SET `db_version`='ACDB 335.2 (dev)', `cache_id`=2


### PR DESCRIPTION
This is more an idea that I would like to share and discuss.

---------------

The idea is the following:

- We are currently using the third column's name of the `version_db_world` table to uniquely identify the `world` DB version (and same for `auth` and `characters` DBs). This system has proven to work well and it's **not** changing.

- We can use the (currently unused) `db_version` and `cache_id` to keep track of every time that we squash our DB updates (i.e. merge all updates into the base table files).

- The idea is to flag with "`(dev)`" when there are pending sql updates. This means that next time we want to do the sql update squash, we will: 
  1. remove  "`(dev)`"
  2. squash and fix the `db_version` to just `ACDB 335.2`
  3. add a new sql update that flags the "beginning" of the development of the next db version, setting  `db_version` to `ACDB 335.3 (dev)` and `cache_id` to simply `3`

Opinions? Suggestions?