### PR TITLE
refactor(DB-world): minor changes

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1547906915621116396.sql
+++ b/data/sql/updates/pending_db_world/rev_1547906915621116396.sql
@@ -1,0 +1,52 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1547906915621116396');
+
+
+-- ALTER TABLE CHANGE COLUMN
+
+ALTER TABLE `creature_equip_template`
+	CHANGE COLUMN `VerifiedBuild` `VerifiedBuild` smallint(5) DEFAULT '0';
+
+ALTER TABLE `item_set_names`
+  CHANGE COLUMN `VerifiedBuild` `VerifiedBuild` smallint(5) DEFAULT '0';
+
+ALTER TABLE `item_template`
+  CHANGE COLUMN `VerifiedBuild` `VerifiedBuild` smallint(5) DEFAULT '0';
+
+ALTER TABLE `quest_template`
+  CHANGE COLUMN `VerifiedBuild` `VerifiedBuild` smallint(5) DEFAULT '0';
+
+ALTER TABLE `quest_template_addon`
+  CHANGE COLUMN `NextQuestID` `NextQuestID` mediumint(8) unsigned NOT NULL DEFAULT '0';
+
+ALTER TABLE `spell_bonus_data`
+  CHANGE COLUMN `entry` `entry` mediumint(8) unsigned NOT NULL DEFAULT '0';
+
+ALTER TABLE `version`
+  CHANGE COLUMN `core_version` `core_version` varchar(255) NOT NULL DEFAULT '' COMMENT 'Core revision dumped at startup.';
+
+ALTER TABLE `waypoint_data`
+  CHANGE COLUMN `wpguid` `wpguid` int(11) unsigned NOT NULL DEFAULT '0';
+
+
+-- ALTER TABLE ADD COLUMN
+
+ALTER TABLE `creature_questitem`
+	ADD COLUMN `VerifiedBuild` smallint(5) NOT NULL DEFAULT '0';
+
+ALTER TABLE `gameobject_questitem`
+	ADD COLUMN `VerifiedBuild` smallint(5) NOT NULL DEFAULT '0';
+
+ALTER TABLE `lfg_dungeon_template`
+	ADD COLUMN `VerifiedBuild` smallint(5) DEFAULT '0';
+
+ALTER TABLE `npc_vendor`
+	ADD COLUMN `VerifiedBuild` smallint(5) DEFAULT '0';
+
+ALTER TABLE `quest_poi`
+	ADD COLUMN `VerifiedBuild` smallint(5) DEFAULT '0';
+
+ALTER TABLE `spell_target_position`
+	ADD COLUMN `VerifiedBuild` smallint(5) DEFAULT '0';
+
+ALTER TABLE `quest_poi_points`
+	ADD COLUMN `VerifiedBuild` smallint(5) DEFAULT '0';

--- a/data/sql/updates/pending_db_world/rev_1547906915621116396.sql
+++ b/data/sql/updates/pending_db_world/rev_1547906915621116396.sql
@@ -15,9 +15,6 @@ ALTER TABLE `item_template`
 ALTER TABLE `quest_template`
   CHANGE COLUMN `VerifiedBuild` `VerifiedBuild` smallint(5) DEFAULT '0';
 
-ALTER TABLE `quest_template_addon`
-  CHANGE COLUMN `NextQuestID` `NextQuestID` mediumint(8) unsigned NOT NULL DEFAULT '0';
-
 ALTER TABLE `spell_bonus_data`
   CHANGE COLUMN `entry` `entry` mediumint(8) unsigned NOT NULL DEFAULT '0';
 


### PR DESCRIPTION
##### CHANGES PROPOSED:

- Remove minor differences to sync with TC

###### ISSUES ADDRESSED:
Closes  https://github.com/azerothcore/azerothcore-wotlk/issues/1178


##### TESTS PERFORMED:

Compile, runs


##### HOW TO TEST THE CHANGES:

The only affected fields that are actually used by the core are:
```
- `quest_template_addon`.`NextQuestID`
- `spell_bonus_data`.`entry`
- `waypoint_data`.`wpguid`
```

the test should just make sure that the data stored in those fields is not altered after this PR.

##### Target branch(es):

Master
