### PR TITLE
refactor(SmartAI): move AC-only SMART_ACTIONs to avoid conflicts with TC

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1547990516486417003.sql
+++ b/data/sql/updates/pending_db_world/rev_1547990516486417003.sql
@@ -1,0 +1,47 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1547990516486417003');
+
+
+-- SMART_ACTION_MOVE_TO_POS_TARGET
+UPDATE `smart_scripts` SET `action_type` = 201 WHERE `action_type` = 130;
+
+-- SMART_ACTION_SET_GO_STATE
+UPDATE `smart_scripts` SET `action_type` = 202 WHERE `action_type` = 131;
+
+-- SMART_ACTION_EXIT_VEHICLE
+UPDATE `smart_scripts` SET `action_type` = 203 WHERE `action_type` = 132;
+
+-- SMART_ACTION_SET_UNIT_MOVEMENT_FLAGS
+UPDATE `smart_scripts` SET `action_type` = 204 WHERE `action_type` = 133;
+
+-- SMART_ACTION_SET_COMBAT_DISTANCE
+UPDATE `smart_scripts` SET `action_type` = 205 WHERE `action_type` = 134;
+
+-- SMART_ACTION_SET_CASTER_COMBAT_DIST
+UPDATE `smart_scripts` SET `action_type` = 206 WHERE `action_type` = 135;
+
+-- SMART_ACTION_SET_HOVER
+UPDATE `smart_scripts` SET `action_type` = 207 WHERE `action_type` = 141;
+
+-- SMART_ACTION_ADD_IMMUNITY
+UPDATE `smart_scripts` SET `action_type` = 208 WHERE `action_type` = 142;
+
+-- SMART_ACTION_REMOVE_IMMUNITY
+UPDATE `smart_scripts` SET `action_type` = 209 WHERE `action_type` = 143;
+
+-- SMART_ACTION_FALL
+UPDATE `smart_scripts` SET `action_type` = 210 WHERE `action_type` = 144;
+
+-- SMART_ACTION_SET_EVENT_FLAG_RESET
+UPDATE `smart_scripts` SET `action_type` = 211 WHERE `action_type` = 145;
+
+-- SMART_ACTION_STOP_MOTION
+UPDATE `smart_scripts` SET `action_type` = 212 WHERE `action_type` = 147;
+
+-- SMART_ACTION_NO_ENVIRONMENT_UPDATE
+UPDATE `smart_scripts` SET `action_type` = 213 WHERE `action_type` = 148;
+
+-- SMART_ACTION_ZONE_UNDER_ATTACK
+UPDATE `smart_scripts` SET `action_type` = 214 WHERE `action_type` = 149;
+
+-- SMART_ACTION_LOAD_GRID
+UPDATE `smart_scripts` SET `action_type` = 215 WHERE `action_type` = 150;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -353,7 +353,9 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         sLog->outErrorDb("SmartAIMgr: EntryOrGuid %d, event type %u can not be used for Script type %u", e.entryOrGuid, e.GetEventType(), e.GetScriptType());
         return false;
     }
-    if (e.action.type <= 0 || e.action.type >= SMART_ACTION_END)
+    if (e.action.type <= 0
+        || (e.action.type >= SMART_ACTION_TC_END && e.action.type <= SMART_ACTION_AC_START)
+        || e.action.type >= SMART_ACTION_AC_END)
     {
         sLog->outErrorDb("SmartAIMgr: EntryOrGuid %d using event(%u) has invalid action type (%u), skipped.", e.entryOrGuid, e.event_id, e.GetActionType());
         return false;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -558,25 +558,35 @@ enum SMART_ACTION
     SMART_ACTION_REMOVE_ALL_GAMEOBJECTS             = 126,
     // RESERVED                                     = 127,
     // RESERVED                                     = 128,
-    // RESERVED                                     = 129,
-    // 113!
-    SMART_ACTION_MOVE_TO_POS_TARGET                 = 130,    // pointId
-    SMART_ACTION_SET_GO_STATE                       = 131,    // state
-    SMART_ACTION_EXIT_VEHICLE                       = 132,    // none
-    SMART_ACTION_SET_UNIT_MOVEMENT_FLAGS            = 133,    // flags
-    SMART_ACTION_SET_COMBAT_DISTANCE                = 134,    // combatDistance
-    SMART_ACTION_SET_CASTER_COMBAT_DIST             = 135,    // followDistance, resetToMax
-    SMART_ACTION_SET_HOVER                          = 141,    // 0/1
-    SMART_ACTION_ADD_IMMUNITY                       = 142,    // type, id, value
-    SMART_ACTION_REMOVE_IMMUNITY                    = 143,    // type, id, value
-    SMART_ACTION_FALL                               = 144,    // 
-    SMART_ACTION_SET_EVENT_FLAG_RESET               = 145,    // 0/1
-    SMART_ACTION_STOP_MOTION                        = 147,    // stopMoving, movementExpired
-    SMART_ACTION_NO_ENVIRONMENT_UPDATE              = 148,
-    SMART_ACTION_ZONE_UNDER_ATTACK                  = 149,
-    SMART_ACTION_LOAD_GRID                          = 150,
+    // RESERVED                                     = 130,
+    // RESERVED                                     = 131,
+    // RESERVED                                     = 132,
+    // RESERVED                                     = 133,
+    // RESERVED                                     = 134,
 
-    SMART_ACTION_END                                = 151,    // ZOMG!, zmienic w sql
+    SMART_ACTION_TC_END                             = 135,    // placeholder
+
+    // AC-only SmartActions:
+
+    SMART_ACTION_AC_START                           = 200,    // placeholder
+
+    SMART_ACTION_MOVE_TO_POS_TARGET                 = 201,    // pointId
+    SMART_ACTION_SET_GO_STATE                       = 202,    // state
+    SMART_ACTION_EXIT_VEHICLE                       = 203,    // none
+    SMART_ACTION_SET_UNIT_MOVEMENT_FLAGS            = 204,    // flags
+    SMART_ACTION_SET_COMBAT_DISTANCE                = 205,    // combatDistance
+    SMART_ACTION_SET_CASTER_COMBAT_DIST             = 206,    // followDistance, resetToMax
+    SMART_ACTION_SET_HOVER                          = 207,    // 0/1
+    SMART_ACTION_ADD_IMMUNITY                       = 208,    // type, id, value
+    SMART_ACTION_REMOVE_IMMUNITY                    = 209,    // type, id, value
+    SMART_ACTION_FALL                               = 210,    //
+    SMART_ACTION_SET_EVENT_FLAG_RESET               = 211,    // 0/1
+    SMART_ACTION_STOP_MOTION                        = 212,    // stopMoving, movementExpired
+    SMART_ACTION_NO_ENVIRONMENT_UPDATE              = 213,
+    SMART_ACTION_ZONE_UNDER_ATTACK                  = 214,
+    SMART_ACTION_LOAD_GRID                          = 215,
+
+    SMART_ACTION_AC_END                             = 216,    // placeholder
 };
 
 struct SmartAction


### PR DESCRIPTION
##### CHANGES PROPOSED:

Moved some AC-only SmartAI actions. This will avoid conflicts with TC 3.3.5.

We will use enums **> 200** for all the actions that are in AC but not in TC.

- Move `SMART_ACTION_MOVE_TO_POS_TARGET` to `201`  (previous value `130`)
- Move `SMART_ACTION_SET_GO_STATE` to `202`  (previous value `131`)
- Move `SMART_ACTION_EXIT_VEHICLE` to `203`  (previous value `132`)
- Move `SMART_ACTION_SET_UNIT_MOVEMENT_FLAGS` to `204`  (previous value `133`)
- Move `SMART_ACTION_SET_COMBAT_DISTANCE` to `205`  (previous value `134`)
- Move `SMART_ACTION_SET_CASTER_COMBAT_DIST` to `206`  (previous value `135`)
- Move `SMART_ACTION_SET_HOVER` to `207`  (previous value `141`)
- Move `SMART_ACTION_ADD_IMMUNITY` to `208`  (previous value `142`)
- Move `SMART_ACTION_REMOVE_IMMUNITY` to `209`  (previous value `143`)
- Move `SMART_ACTION_FALL` to `210`  (previous value `144`)
- Move `SMART_ACTION_SET_EVENT_FLAG_RESET` to `211`  (previous value `145`)
- Move `SMART_ACTION_STOP_MOTION` to `212`  (previous value `147`)
- Move `SMART_ACTION_NO_ENVIRONMENT_UPDATE` to `213`  (previous value `148`)
- Move `SMART_ACTION_ZONE_UNDER_ATTACK` to `214`  (previous value `149`)
- Move `SMART_ACTION_LOAD_GRID` to `215`  (previous value `150`)

###### ISSUES ADDRESSED:

Updates https://github.com/azerothcore/azerothcore-wotlk/issues/1326 

##### TESTS PERFORMED:

Builds, runs.

##### HOW TO TEST THE CHANGES:

- Test some existing SmartAI scripts (ideally checking all those moved actions)

##### Target branch(es):

Master
