### PR TITLE
feat(SmartAI): improve add quest action

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1548013361501724652.sql
+++ b/data/sql/updates/pending_db_world/rev_1548013361501724652.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1548013361501724652');
+
+UPDATE `smart_scripts` SET `action_param2`=1 WHERE `action_type`=7;
+UPDATE `smart_scripts` SET `action_param2`=0 WHERE `source_type`=0 AND `entryorguid`=11216 AND `id`=3;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -393,7 +393,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                                 menu.SendQuestGiverQuestDetails(q, me->GetGUID(), true);
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
                                 sLog->outDebug(
-                                        "LOG_FILTER_DATABASE_AI",
+                                        LOG_FILTER_DATABASE_AI,
                                         "SmartScript::ProcessAction:: SMART_ACTION_OFFER_QUEST: Player guidLow %u - offering quest %u",
                                         (*itr)->GetGUIDLow(),
                                         e.action.questOffer.questID);
@@ -405,7 +405,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                         (*itr)->ToPlayer()->AddQuestAndCheckCompletion(q, nullptr);
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
                         sLog->outDebug(
-                                "LOG_FILTER_DATABASE_AI",
+                                LOG_FILTER_DATABASE_AI,
                                 "SmartScript::ProcessAction:: SMART_ACTION_OFFER_QUEST: Player guidLow %u - quest %u added",
                                      (*itr)->GetGUIDLow(),
                                      e.action.questOffer.questID);

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -395,7 +395,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                                 sLog->outDebug(
                                         "LOG_FILTER_DATABASE_AI",
                                         "SmartScript::ProcessAction:: SMART_ACTION_OFFER_QUEST: Player guidLow %u - offering quest %u",
-                                        pTarget->GetGUID().GetCounter(),
+                                        (*itr)->GetGUIDLow(),
                                         e.action.questOffer.questID);
 #endif
                             }
@@ -407,7 +407,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                         sLog->outDebug(
                                 "LOG_FILTER_DATABASE_AI",
                                 "SmartScript::ProcessAction:: SMART_ACTION_OFFER_QUEST: Player guidLow %u - quest %u added",
-                                     pTarget->GetGUID().GetCounter(),
+                                     (*itr)->GetGUIDLow(),
                                      e.action.questOffer.questID);
 #endif
                     }

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -372,7 +372,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         delete targets;
         break;
     }
-    case SMART_ACTION_ADD_QUEST:
+    case SMART_ACTION_OFFER_QUEST:
     {
         ObjectList* targets = GetTargets(e, unit);
         if (!targets)
@@ -380,15 +380,37 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
         for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
         {
-            if (IsPlayer(*itr))
+            if (Player* pTarget = (*itr)->ToPlayer())
             {
-                if (Quest const* q = sObjectMgr->GetQuestTemplate(e.action.quest.quest))
+                if (Quest const* q = sObjectMgr->GetQuestTemplate(e.action.questOffer.questID))
                 {
-                    (*itr)->ToPlayer()->AddQuestAndCheckCompletion(q, NULL);
+                    if (me && e.action.questOffer.directAdd == 0)
+                    {
+                        if (pTarget->CanTakeQuest(q, true))
+                            if (WorldSession* session = pTarget->GetSession())
+                            {
+                                PlayerMenu menu(session);
+                                menu.SendQuestGiverQuestDetails(q, me->GetGUID(), true);
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
-                    sLog->outDebug(LOG_FILTER_DATABASE_AI, "SmartScript::ProcessAction:: SMART_ACTION_ADD_QUEST: Player guidLow %u add quest %u",
-                        (*itr)->GetGUIDLow(), e.action.quest.quest);
+                                sLog->outDebug(
+                                        "LOG_FILTER_DATABASE_AI",
+                                        "SmartScript::ProcessAction:: SMART_ACTION_OFFER_QUEST: Player guidLow %u - offering quest %u",
+                                        pTarget->GetGUID().GetCounter(),
+                                        e.action.questOffer.questID);
 #endif
+                            }
+                    }
+                    else
+                    {
+                        (*itr)->ToPlayer()->AddQuestAndCheckCompletion(q, nullptr);
+#if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
+                        sLog->outDebug(
+                                "LOG_FILTER_DATABASE_AI",
+                                "SmartScript::ProcessAction:: SMART_ACTION_OFFER_QUEST: Player guidLow %u - quest %u added",
+                                     pTarget->GetGUID().GetCounter(),
+                                     e.action.questOffer.questID);
+#endif
+                    }
                 }
             }
         }

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -749,7 +749,7 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
                 return false;
             break;
         case SMART_ACTION_FAIL_QUEST:
-        case SMART_ACTION_ADD_QUEST:
+        case SMART_ACTION_OFFER_QUEST:
             if (!e.action.quest.quest || !IsQuestValid(e, e.action.quest.quest))
                 return false;
             break;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -436,7 +436,7 @@ enum SMART_ACTION
     SMART_ACTION_SOUND                              = 4,      // SoundId, onlySelf
     SMART_ACTION_PLAY_EMOTE                         = 5,      // EmoteId
     SMART_ACTION_FAIL_QUEST                         = 6,      // QuestID
-    SMART_ACTION_ADD_QUEST                          = 7,      // QuestID
+    SMART_ACTION_OFFER_QUEST                        = 7,      // QuestID, directAdd
     SMART_ACTION_SET_REACT_STATE                    = 8,      // state
     SMART_ACTION_ACTIVATE_GOBJECT                   = 9,      //
     SMART_ACTION_RANDOM_EMOTE                       = 10,     // EmoteId1, EmoteId2, EmoteId3...
@@ -618,6 +618,12 @@ struct SmartAction
         {
             uint32 quest;
         } quest;
+
+        struct
+        {
+            uint32 questID;
+            uint32 directAdd;
+        } questOffer;
 
         struct
         {


### PR DESCRIPTION
##### CHANGES PROPOSED:

-  Rename ` SMART_ACTION_ADD_QUEST` to `SMART_ACTION_OFFER_QUEST`
-  This action can now open a dialog to offer the quest instead of adding it straight to the quest log
- With `action_param2` = `1` it will be like the old behaviour, with `0` it's the new behaviour
- All existing scripts will keep the same behaviour, except for creature `11216`

Feature by **@Treeston** imported from TC

###### ISSUES ADDRESSED:

- Updates https://github.com/azerothcore/azerothcore-wotlk/issues/1326

##### TESTS PERFORMED:

Builds


##### HOW TO TEST THE CHANGES:

- Test that the current scripts that use this action are not broken and use the same behaviour (with the exception of creature `11216` that will have the new behaviour). So check some existing scripts that add quests.
- Test the script of creature `11216` and make sure it asks for quest with a quest dialog

##### Target branch(es):

Master
