### PR TITLE
DB: Fix crash in waypoint_scripts

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1548170266680613800.sql
+++ b/data/sql/updates/pending_db_world/rev_1548170266680613800.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1548170266680613800');
+
+UPDATE `waypoint_scripts` SET `dataint` = 13572 WHERE `guid` = 346;


### PR DESCRIPTION
##### CHANGES PROPOSED:
- Fix crash in https://github.com/azerothcore/azerothcore-wotlk/issues/1336

##### ISSUES ADDRESSED:
Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1336

##### TESTS PERFORMED:
- [x] Tested in game

##### HOW TO TEST THE CHANGES:
1. Make a new Draenei (any class)
2. Teleport to azure watch .tele azurewatch
3. Talk to NPCs

##### KNOWN ISSUES AND TODO LIST:

##### Target branch(es): Master

### NOTE: In TC `ASSERT(data->GetOpcode() != MSG_NULL_ACTION);` delete. Maybe we should delete it too?
- In AC [GridNotifiersImpl.h](https://github.com/azerothcore/azerothcore-wotlk/blob/6c233c4d8c49cd8f014f2df497d7c8a646b2bf74/src/server/game/Grids/Notifiers/GridNotifiersImpl.h#L524)
```cpp
template<class Builder>
void Trinity::LocalizedPacketDo<Builder>::operator()(Player* p)
{
    LocaleConstant loc_idx = p->GetSession()->GetSessionDbLocaleIndex();
    uint32 cache_idx = loc_idx+1;
    WorldPacket* data;

    // create if not cached yet
    if (i_data_cache.size() < cache_idx + 1 || !i_data_cache[cache_idx])
    {
        if (i_data_cache.size() < cache_idx + 1)
            i_data_cache.resize(cache_idx + 1);

        data = new WorldPacket();

        i_builder(*data, loc_idx);

        ASSERT(data->GetOpcode() != MSG_NULL_ACTION);

        i_data_cache[cache_idx] = data;
    }
    else
        data = i_data_cache[cache_idx];

    p->SendDirectMessage(data);
}
```
- In TC [GridNotifiersImpl.h](https://github.com/TrinityCore/TrinityCore/blob/af46f3fd4c7512b1c0337e05fd3ec9f8cc24d30f/src/server/game/Grids/Notifiers/GridNotifiersImpl.h#L513)
```cpp
template<class Builder>
void Trinity::LocalizedPacketDo<Builder>::operator()(Player* p)
{
    LocaleConstant loc_idx = p->GetSession()->GetSessionDbLocaleIndex();
    uint32 cache_idx = loc_idx+1;
    WorldPacket* data;

    // create if not cached yet
    if (i_data_cache.size() < cache_idx + 1 || !i_data_cache[cache_idx])
    {
        if (i_data_cache.size() < cache_idx + 1)
            i_data_cache.resize(cache_idx + 1);

        data = new WorldPacket();

        i_builder(*data, loc_idx);

        i_data_cache[cache_idx] = data;
    }
    else
        data = i_data_cache[cache_idx];

    p->SendDirectMessage(data);
}
```
- Diff
```diff
- ASSERT(data->GetOpcode() != MSG_NULL_ACTION);
```