### PR TITLE
feat(SmartAI): display error on unsupported targets + align TC enums

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1548282125491483924.sql
+++ b/data/sql/updates/pending_db_world/rev_1548282125491483924.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1548282125491483924');
+
+-- SMART_TARGET_FARTHEST
+UPDATE `smart_scripts` SET `target_type` = 28 WHERE `target_type` = 40;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -357,7 +357,7 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         || (e.action.type >= SMART_ACTION_TC_END && e.action.type <= SMART_ACTION_AC_START)
         || e.action.type >= SMART_ACTION_AC_END)
     {
-        sLog->outErrorDb("SmartAIMgr: EntryOrGuid %d using event(%u) has invalid action type (%u), skipped.", e.entryOrGuid, e.event_id, e.GetActionType());
+        sLog->outErrorDb("SmartAIMgr: EntryOrGuid %d using event(%u) has an invalid action type (%u), skipped.", e.entryOrGuid, e.event_id, e.GetActionType());
         return false;
     }
     switch (e.action.type)
@@ -384,6 +384,17 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
             return false;
         default:
             break;
+    }
+    if (e.target.type < 0 || e.target.type >= SMART_TARGET_END)
+    {
+        sLog->outErrorDb("SmartAIMgr: EntryOrGuid %d using event(%u) has an invalid target type (%u), skipped.",
+                e.entryOrGuid, e.event_id, e.GetActionType());
+        return false;
+    }
+    if (e.target.type == SMART_TARGET_LOOT_RECIPIENTS || e.target.type == SMART_TARGET_VEHICLE_PASSENGER) {
+        sLog->outErrorDb("SmartAIMgr: EntryOrGuid %d using event(%u) has a target type that is not yet supported on AzerothCore (%u), skipped.",
+                e.entryOrGuid, e.event_id, e.GetTargetType());
+        return false;
     }
     if (e.event.event_phase_mask > SMART_EVENT_PHASE_ALL)
     {

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -388,7 +388,7 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
     if (e.target.type < 0 || e.target.type >= SMART_TARGET_END)
     {
         sLog->outErrorDb("SmartAIMgr: EntryOrGuid %d using event(%u) has an invalid target type (%u), skipped.",
-                e.entryOrGuid, e.event_id, e.GetActionType());
+                e.entryOrGuid, e.event_id, e.GetTargetType());
         return false;
     }
     if (e.target.type == SMART_TARGET_LOOT_RECIPIENTS || e.target.type == SMART_TARGET_VEHICLE_PASSENGER) {

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -1201,22 +1201,11 @@ enum SMARTAI_TARGETS
     SMART_TARGET_THREAT_LIST                    = 24,   // All units on creature's threat list, maxdist, playerOnly
     SMART_TARGET_CLOSEST_ENEMY                  = 25,   // maxDist, playerOnly
     SMART_TARGET_CLOSEST_FRIENDLY               = 26,   // maxDist, playerOnly
-    // RESERVED                                 = 27,
-    // RESERVED                                 = 28,
-    // RESERVED                                 = 29,
-    // RESERVED                                 = 30,
-    // RESERVED                                 = 31,
-    // RESERVED                                 = 32,
-    // RESERVED                                 = 33,
-    // RESERVED                                 = 34,
-    // RESERVED                                 = 35,
-    // RESERVED                                 = 36,
-    // RESERVED                                 = 37,
-    // RESERVED                                 = 38,
-    // RESERVED                                 = 39,
-    SMART_TARGET_FARTHEST                       = 40,
+    SMART_TARGET_LOOT_RECIPIENTS                = 27,   // TODO: NOT SUPPORTED YET
+    SMART_TARGET_FARTHEST                       = 28,   // maxDist, playerOnly, isInLos
+    SMART_TARGET_VEHICLE_PASSENGER              = 29,   // TODO: NOT SUPPORTED YET
 
-    SMART_TARGET_END                            = 41
+    SMART_TARGET_END                            = 30
 };
 
 struct SmartTarget


### PR DESCRIPTION
##### CHANGES PROPOSED:

- Move `SMART_TARGET_FARTHEST` to `28`  (previous value `40`) to avoid conflicts with TC
- Display error when an invalid `target_type` is used, which is lower than `0` or bigger the the max taget we have (currently the max is `29`)
> "SmartAIMgr: EntryOrGuid %d using event(%u) has an invalid target type (%u), skipped."
- Display error when an unsupported `target_type` is used (currently `27` or `29`)
> "SmartAIMgr: EntryOrGuid %d using event(%u) has a target type that is not yet supported on AzerothCore (%u), skipped."

###### ISSUES ADDRESSED:

Updates https://github.com/azerothcore/azerothcore-wotlk/issues/1326 

##### TESTS PERFORMED:

Builds, runs.

##### HOW TO TEST THE CHANGES:

- Try to put an invalid `target_type` in table `smart_scripts` and see if the error is properly displayed ( lower than ` 0` and bigger than `29` )
- Try to put an unsupported `target_type` in table `smart_scripts` and see if the error is properly displayed ( `27` or `29` )
- Make sure that the scripts that used `target_type` = `40` (now changed to `28`) are still working (in a clean AC the only script would be `15547`)

##### Target branch(es):

Master
