### PR TITLE
fix(quest): fix some quest chains + align NextQuestID with TC

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1548367133880932410.sql
+++ b/data/sql/updates/pending_db_world/rev_1548367133880932410.sql
@@ -1,0 +1,13 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1548367133880932410');
+
+-- original fix by Killyana
+UPDATE `quest_template_addon` SET `NextQuestID`=0 WHERE `id` IN (415, 618, 8554);
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`= 19 AND `SourceEntry`= 619;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`SourceId`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionTarget`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`NegativeCondition`,`ErrorType`,`ErrorTextId`,`ScriptName`,`Comment`) VALUES
+(19, 0, 619, 0, 0, 9, 0, 618, 0, 0, 0, 0, 0, '', "Enticing Negolash"),
+(19, 0, 619, 0, 1, 9, 0, 8554, 0, 0, 0, 0, 0, '', "Enticing Negolash");
+UPDATE `quest_template_addon` SET `PrevQuestID`=12294, `NextQuestID`=12225, `ExclusiveGroup`=-12222 WHERE `id` IN (12222);
+UPDATE `quest_template_addon` SET `PrevQuestID`=12294, `NextQuestID`=12225, `ExclusiveGroup`=-12222 WHERE `id` IN (12223);
+
+-- original fix by ariel-
+ALTER TABLE `quest_template_addon` CHANGE `NextQuestID` `NextQuestID` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT 0;

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -4528,16 +4528,13 @@ void ObjectMgr::LoadQuests()
 
         if (qinfo->NextQuestId)
         {
-            QuestMap::iterator qNextItr = _questTemplates.find(abs(qinfo->GetNextQuestId()));
+            QuestMap::iterator qNextItr = _questTemplates.find(qinfo->GetNextQuestId());
             if (qNextItr == _questTemplates.end())
             {
-                sLog->outErrorDb("Quest %d has NextQuestId %i, but no such quest", qinfo->GetQuestId(), qinfo->GetNextQuestId());
+                sLog->outErrorDb("Quest %d has NextQuestId %u, but no such quest", qinfo->GetQuestId(), qinfo->GetNextQuestId());
             }
             else
-            {
-                int32 signedQuestId = qinfo->NextQuestId < 0 ? -int32(qinfo->GetQuestId()) : int32(qinfo->GetQuestId());
-                qNextItr->second->prevQuests.push_back(signedQuestId);
-            }
+                qNextItr->second->prevQuests.push_back(static_cast<int32>(qinfo->GetQuestId()));
         }
 
         if (qinfo->ExclusiveGroup)

--- a/src/server/game/Quests/QuestDef.cpp
+++ b/src/server/game/Quests/QuestDef.cpp
@@ -154,7 +154,7 @@ void Quest::LoadQuestTemplateAddon(Field* fields)
     RequiredClasses = fields[2].GetUInt32();
     SourceSpellid = fields[3].GetUInt32();
     PrevQuestId = fields[4].GetInt32();
-    NextQuestId = fields[5].GetInt32();
+    NextQuestId = fields[5].GetUInt32();
     ExclusiveGroup = fields[6].GetInt32();
     RewardMailTemplateId = fields[7].GetUInt32();
     RewardMailDelay = fields[8].GetUInt32();

--- a/src/server/game/Quests/QuestDef.h
+++ b/src/server/game/Quests/QuestDef.h
@@ -230,7 +230,7 @@ class Quest
         uint32 GetSuggestedPlayers() const { return SuggestedPlayers; }
         uint32 GetTimeAllowed() const { return TimeAllowed; }
         int32  GetPrevQuestId() const { return PrevQuestId; }
-        int32  GetNextQuestId() const { return NextQuestId; }
+        uint32 GetNextQuestId() const { return NextQuestId; }
         int32  GetExclusiveGroup() const { return ExclusiveGroup; }
         uint32 GetNextQuestInChain() const { return RewardNextQuest; }
         uint32 GetCharTitleId() const { return RewardTitleId; }
@@ -371,7 +371,7 @@ class Quest
         uint32 RequiredClasses        = 0;
         uint32 SourceSpellid          = 0;
         int32  PrevQuestId            = 0;
-        int32  NextQuestId            = 0;
+        uint32 NextQuestId            = 0;
         int32  ExclusiveGroup         = 0;
         uint32 RewardMailTemplateId   = 0;
         uint32 RewardMailDelay        = 0;


### PR DESCRIPTION
Imported & adapted 2 fixes from TC, original authors:

- Killyana
- ariel-

##### CHANGES PROPOSED:

-  Fix some quest chains (`12222` and `12223`)
-  Align `NextQuestID` to TC (made unsigned)


###### ISSUES ADDRESSED:

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1328


##### TESTS PERFORMED:

Build, runs.


##### HOW TO TEST THE CHANGES:

- Check that the quest chains involving `12222` and `12223` still works
- Test other quest chains and make sure everything still works

##### Target branch(es):

Master
