### PR TITLE
feat(SmartAI): Implement action type 115 "SMART_ACTION_RANDOM_SOUND"

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -264,6 +264,50 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         }
         break;
     }
+    case SMART_ACTION_RANDOM_SOUND:
+    {
+        ObjectList* targets = GetTargets(e, unit);
+        if (!targets)
+            break;
+
+        uint32 sounds[4];
+        sounds[0] = e.action.randomSound.sound1;
+        sounds[1] = e.action.randomSound.sound2;
+        sounds[2] = e.action.randomSound.sound3;
+        sounds[3] = e.action.randomSound.sound4;
+        uint32 temp[4];
+        uint32 count = 0;
+        for (uint8 i = 0; i < 4; i++)
+        {
+            if (sounds[i])
+            {
+                temp[count] = sounds[i];
+                ++count;
+            }
+        }
+
+        if (count == 0)
+        {
+            delete targets;
+            break;
+        }
+
+        for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
+        {
+            if (IsUnit(*itr))
+            {
+                uint32 sound = temp[urand(0, count - 1)];
+                (*itr)->SendPlaySound(sound, e.action.randomSound.onlySelf > 0);
+#if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
+                sLog->outDebug(LOG_FILTER_DATABASE_AI, "SmartScript::ProcessAction:: SMART_ACTION_RANDOM_SOUND: target: %s (GuidLow: %u), sound: %u, onlyself: %u",
+                    (*itr)->GetName().c_str(), (*itr)->GetGUIDLow(), sound, e.action.randomSound.onlySelf);
+#endif
+            }
+        }
+
+        delete targets;
+        break;
+    }
     case SMART_ACTION_SET_FACTION:
     {
         ObjectList* targets = GetTargets(e, unit);

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -369,7 +369,6 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
             sLog->outErrorDb("SmartAIMgr: EntryOrGuid %d using event(%u) has an action type that is not supported on 3.3.5a (%u), skipped.",
                              e.entryOrGuid, e.event_id, e.GetActionType());
             return false;
-        case SMART_ACTION_RANDOM_SOUND:
         case SMART_ACTION_SET_CORPSE_DELAY:
         case SMART_ACTION_DISABLE_EVADE:
         case SMART_ACTION_GO_SET_GO_STATE:
@@ -768,6 +767,19 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
             break;
         case SMART_ACTION_SOUND:
             if (!IsSoundValid(e, e.action.sound.sound))
+                return false;
+            break;
+        case SMART_ACTION_RANDOM_SOUND:
+            if (e.action.randomSound.sound1 && !IsSoundValid(e, e.action.randomSound.sound1))
+                return false;
+
+            if (e.action.randomSound.sound2 && !IsSoundValid(e, e.action.randomSound.sound2))
+                return false;
+
+            if (e.action.randomSound.sound3 && !IsSoundValid(e, e.action.randomSound.sound3))
+                return false;
+
+            if (e.action.randomSound.sound4 && !IsSoundValid(e, e.action.randomSound.sound4))
                 return false;
             break;
         case SMART_ACTION_SET_EMOTE_STATE:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -544,7 +544,7 @@ enum SMART_ACTION
     SMART_ACTION_GAME_EVENT_START                   = 112,    // GameEventId
     SMART_ACTION_START_CLOSEST_WAYPOINT             = 113,    // wp1, wp2, wp3, wp4, wp5, wp6, wp7
     SMART_ACTION_RISE_UP                            = 114,    // distance
-    SMART_ACTION_RANDOM_SOUND                       = 115,    // TODO: NOT SUPPORTED YET
+    SMART_ACTION_RANDOM_SOUND                       = 115,    // SoundId1, SoundId2, SoundId3, SoundId4, onlySelf
     SMART_ACTION_SET_CORPSE_DELAY                   = 116,    // TODO: NOT SUPPORTED YET
     SMART_ACTION_DISABLE_EVADE                      = 117,    // TODO: NOT SUPPORTED YET
     SMART_ACTION_GO_SET_GO_STATE                    = 118,    // TODO: NOT SUPPORTED YET
@@ -619,6 +619,15 @@ struct SmartAction
             uint32 sound;
             uint32 onlySelf;
         } sound;
+
+        struct
+        {
+            uint32 sound1;
+            uint32 sound2;
+            uint32 sound3;
+            uint32 sound4;
+            uint32 onlySelf;
+        } randomSound;
 
         struct
         {


### PR DESCRIPTION
##### CHANGES PROPOSED:
Implement action type 115 "SMART_ACTION_RANDOM_SOUND". This will allow smart scripts like the one contained in PR #1348 to play random sound samples.

###### ISSUES ADDRESSED:
None

##### TESTS PERFORMED:
Tested build and in-game (Ubuntu 16.04)

##### HOW TO TEST THE CHANGES:
This can be tested via quest 5441 (see #1348)
- ```.quest add 5441```
- ```.go creature 3345```
- use Foreman's Blackjack on the peon
- he will now randomly say "okey dokey" or "I can do that"

##### KNOWN ISSUES AND TODO LIST:
None

##### Target branch(es):
Master