### PR TITLE
Core/Instance: Ruby Sanctum. Resistances ignored

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -5840,6 +5840,17 @@ void SpellMgr::LoadDbcDataCorrections()
         case 74637:
             spellInfo->speed = 0;
             break;
+        //Blazing Aura
+        case 75885:
+        case 75886:
+            spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
+            break;
+        //Meteor Strike
+        case 75952:
+        //Combustion Periodic
+        case 74629:
+            spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
+            break;
 
 
         // ///////////////////////////////////////////

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
@@ -1187,7 +1187,7 @@ class spell_halion_twilight_realm : public SpellScriptLoader
                 if (!target)
                     return;
 
-                target->RemoveAurasDueToSpell(SPELL_FIERY_COMBUSTION, 0, 0, AURA_REMOVE_BY_ENEMY_SPELL);                
+                target->RemoveAurasDueToSpell(SPELL_FIERY_COMBUSTION, 0, 0, AURA_REMOVE_BY_ENEMY_SPELL);
                 if (GetTarget()->GetTypeId() != TYPEID_PLAYER)
                     return;
                 GetTarget()->m_Events.AddEvent(new SendEncounterUnit(GetTarget()->ToPlayer()), GetTarget()->m_Events.CalculateTime(500));

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
@@ -46,6 +46,9 @@ enum Spells
     SPELL_METEOR_STRIKE_TARGETING       = 74638,
     SPELL_TAIL_LASH                     = 74531,
 
+    // Living Inferno
+    SPELL_BLAZING_AURA                  = 75885,
+
     // Combustion / Consumption
     SPELL_SCALE_AURA                    = 70507,
     SPELL_FIERY_COMBUSTION              = 74562,
@@ -1385,7 +1388,7 @@ class spell_halion_twilight_division : public SpellScriptLoader
                 halion->RemoveAurasDueToSpell(SPELL_TWILIGHT_PHASING);
                 if (GameObject* gobject = halion->FindNearestGameObject(GO_HALION_PORTAL_1, 100.0f))
                     gobject->Delete();
-                
+
                 instance->DoUpdateWorldState(WORLDSTATE_CORPOREALITY_TOGGLE, 1);
                 instance->DoUpdateWorldState(WORLDSTATE_CORPOREALITY_MATERIAL, 50);
                 instance->DoUpdateWorldState(WORLDSTATE_CORPOREALITY_TWILIGHT, 50);
@@ -1430,12 +1433,45 @@ class spell_halion_twilight_mending : public SpellScriptLoader
         }
 };
 
+class npc_living_inferno : public CreatureScript
+{
+public:
+    npc_living_inferno() : CreatureScript("npc_living_inferno") { }
+
+     struct npc_living_infernoAI : public ScriptedAI
+    {
+        npc_living_infernoAI(Creature* creature) : ScriptedAI(creature) { }
+
+         void IsSummonedBy(Unit* /*summoner*/)
+        {
+            me->SetInCombatWithZone();
+            me->CastSpell(me, SPELL_BLAZING_AURA, true);
+
+             if (InstanceScript* instance = me->GetInstanceScript())
+                if (Creature* controller = ObjectAccessor::GetCreature(*me, instance->GetData64(NPC_HALION_CONTROLLER)))
+                    controller->AI()->JustSummoned(me);
+        }
+
+         void JustDied(Unit* /*killer*/)
+        {
+            me->DespawnOrUnsummon(1);
+        }
+    };
+
+     CreatureAI* GetAI(Creature* creature) const
+    {
+        return GetInstanceAI<npc_living_infernoAI>(creature);
+    }
+};
+
+
 void AddSC_boss_halion()
 {
     new boss_halion();
     new boss_twilight_halion();
     new npc_halion_controller();
     new npc_orb_carrier();
+    new npc_living_inferno();
 
     new spell_halion_meteor_strike_targeting();
     new spell_halion_meteor_strike_marker();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: https://github.com/azerothcore/azerothcore-wotlk/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  Apply Resistances in Players VS damage spell Halion, Living Inferno
-  


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes 


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->



##### HOW TO TEST THE CHANGES:

- Start combat and wait for "Halion" and "Living Inferno" to appear, then see "Meteor Strike", "Combustion periodic" hit the "raid" or player.

-While "Living Inferno" causes damage with "Blazing Aura" to a player who takes it, and you will see that it does not resist



##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
