### PR TITLE
Fix(DB/SAI): Small fix for the Rift Spawns (Mage only quests 1920 / 1960)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1548717283055325995.sql
+++ b/data/sql/updates/pending_db_world/rev_1548717283055325995.sql
@@ -1,0 +1,19 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1548717283055325995');
+
+SET
+@RIFT_SPAWN := 6492,
+@CANTATION  := 9095;
+
+DELETE FROM `disables` WHERE `sourceType` = 0 AND `entry` = @CANTATION;
+INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, `comment`)
+VALUES 
+(0, @CANTATION, 64, '', '', 'Ignore LoS for Cantation of Manifestation');
+
+UPDATE `smart_scripts` SET `link` = 12 WHERE `entryorguid` = @RIFT_SPAWN AND `id` = 4;
+UPDATE `smart_scripts` SET `action_param1` = 1 WHERE `entryorguid` = @RIFT_SPAWN AND `id` = 8;
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = @RIFT_SPAWN AND `id` in (12,13);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(@RIFT_SPAWN, 0, 12, 13, 61, 0, 100, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, "Rift Spawn - Linked - Say line 0"),
+(@RIFT_SPAWN, 0, 13, 0, 61, 0, 100, 1, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, "Rift Spawn - Linked - Attack ActionInvoker");


### PR DESCRIPTION
##### CHANGES PROPOSED:
The Mage only quests "Investigate the Blue Recluse" (1920) and "Investigate the Alchemist Shop" (1960) are already working, but triggered by the PR #1360 created by @poszer I took the chance to look a little deeper into those quests. As pointed out by @poszer and seen in this old [video](https://www.youtube.com/watch?v=M9XbZWgzHpM), the Rift Spawns are indeed attacking the player once the "Cantation of Manifestation" is used.

This PR contains the following changes:
- The Rift Spawns will immediately attack after using "Cantation of Manifestation" and now correctly say "Rift Spawn is angered and attacks!"
- The Rift Spawns will now correctly say "Rift Spawn escapes into the void!" if it takes too long to catch them after being stunned.
- The LoS restriction of "Cantation of Manifestation" is removed (I took this over from PR #1360).

###### ISSUES ADDRESSED:
None

##### TESTS PERFORMED:
Tested in-game on Ubuntu 16.04, commit 9af2a461f65316ce4c21c9668dd62515b8e4f370

##### HOW TO TEST THE CHANGES:
Horde:
- ```.quest remove 1960```
- ```.quest add 1960```
- ```.additem 7308```
- ```.additem 7247```
- ```.go 1412.23 349.395 -66 0```
- use "Cantation of Manifestation"

Alliance:
- ```.quest remove 1920```
- ```.quest add 1920```
- ```.additem 7308```
- ```.additem 7247```
- ```.go -9104.66 832.794 97.6296 0```
- use "Cantation of Manifestation"

##### KNOWN ISSUES AND TODO LIST:
None

##### Target branch(es):
Master