### PR TITLE
Docker: Naming errors for some sql files

### DIFF
--- a/docker/database/generate-databases.sh
+++ b/docker/database/generate-databases.sh
@@ -21,13 +21,13 @@ mysql -u root -p$MYSQL_ROOT_PASSWORD acore_world < /sql/world_base.sql
 
 
 echo "Importing auth updates..."
-mysql -u root -p$MYSQL_ROOT_PASSWORD acore_auth < /sql/auth_update.sql
+mysql -u root -p$MYSQL_ROOT_PASSWORD acore_auth < /sql/auth_updates.sql
 
 echo "Importing characters updates..."
-mysql -u root -p$MYSQL_ROOT_PASSWORD acore_characters < /sql/characters_update.sql
+mysql -u root -p$MYSQL_ROOT_PASSWORD acore_characters < /sql/characters_updates.sql
 
 echo "Importing world updates..."
-mysql -u root -p$MYSQL_ROOT_PASSWORD acore_world < /sql/world_update.sql
+mysql -u root -p$MYSQL_ROOT_PASSWORD acore_world < /sql/world_updates.sql
 
 
 echo "Importing auth custom (if any)..."


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: https://github.com/azerothcore/azerothcore-wotlk/wiki/Contribute#how-to-create-a-pull-request
-->


Docker: Naming errors for some sql files


##### CHANGES PROPOSED:

Fixes naming errors in `generate-databases.sh`  


###### ISSUES ADDRESSED:

When running `docker-compose up`, the `ac-database` exited, since it didn't find the following sql files:
- /sql/auth_update.sql
- /sql/characters_update.sql
- /sql/world_update.sql

By running `docker-compose run ac-database /bin/bash` i checked the files with `ls /sql` and could find the files, but they were named in plurally. So when I changed in the `generate-databases.sh` the names, the databases could be generated, and at last the authserver and worldserver could connect to the database.


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

Tests only done on Mac. But I guess, since the fix was made in docker, it should have the same effects on all platforms

##### HOW TO TEST THE CHANGES:

1. `git clone https://github.com/Raschaad/azerothcore-wotlk.git`
2. Copy the data (client files) to `docker/worldserver/data` (as in the [Installation with Docker](https://github.com/azerothcore/azerothcore-wotlk/wiki/install-with-Docker) stated)
3. Generate your server configuration files: `./bin/acore-docker-generate-etc`
4. Compile AzerothCore: `./bin/acore-docker-build`
5. Run the containers: `docker-compose up`

With these changes, the server should be up after a few minutes. Before these changes, this didn't work for me.

##### Target branch(es):

Master
