### PR TITLE
[Core/ Spell] Val'anyr Hammer of Ancient Kings Fix

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1548850930086940600.sql
+++ b/data/sql/updates/pending_db_world/rev_1548850930086940600.sql
@@ -1,3 +1,3 @@
 INSERT INTO version_db_world (`sql_rev`) VALUES ('1548850930086940600');
 
-INSERT INTO `spell_script_names` VALUES (64415, 'spell_item_valanyr_hammer_of_acient_kings');
+INSERT INTO `spell_script_names` VALUES (64415, 'spell_item_valanyr_hammer_of_ancient_kings');

--- a/data/sql/updates/pending_db_world/rev_1548850930086940600.sql
+++ b/data/sql/updates/pending_db_world/rev_1548850930086940600.sql
@@ -1,0 +1,3 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1548850930086940600');
+
+INSERT INTO `spell_script_names` VALUES (64415, 'spell_item_valanyr_hammer_of_acient_kings');

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -1502,18 +1502,35 @@ class spell_item_arcane_shroud : public SpellScriptLoader
 };
 
 // 64415 - Val'anyr Hammer of Ancient Kings - Equip Effect
-class spell_item_valanyr_hammer_of_acient_kings : public AuraScript
+class spell_item_valanyr_hammer_of_acient_kings : public SpellScriptLoader
 {
-    PrepareAuraScript(spell_item_valanyr_hammer_of_acient_kings);
+public:
+    spell_item_valanyr_hammer_of_acient_kings() : SpellScriptLoader("spell_item_valanyr_hammer_of_acient_kings") { }
 
-    bool CheckProc(ProcEventInfo& eventInfo)
+    class spell_item_valanyr_hammer_of_acient_kingsAuraScript : public AuraScript
     {
-        return eventInfo.GetHealInfo() && eventInfo.GetHealInfo()->GetHeal() > 0;
-    }
+        PrepareAuraScript(spell_item_valanyr_hammer_of_acient_kingsAuraScript);
 
-    void Register()
+        bool CheckProc(ProcEventInfo& eventInfo)
+        {
+
+            SpellInfo const* spellInfo = eventInfo.GetHealInfo()->GetSpellInfo();
+            if (!spellInfo || !spellInfo->HasEffect(SPELL_EFFECT_HEAL))
+                return false;
+
+            return eventInfo.GetHealInfo() && eventInfo.GetHealInfo()->GetHeal() > 0;
+
+        }
+
+        void Register()
+        {
+            DoCheckProc += AuraCheckProcFn(spell_item_valanyr_hammer_of_acient_kingsAuraScript::CheckProc);
+        }
+    };
+
+    AuraScript* GetAuraScript() const
     {
-        DoCheckProc += AuraCheckProcFn(spell_item_valanyr_hammer_of_acient_kings::CheckProc);
+        return new spell_item_valanyr_hammer_of_acient_kingsAuraScript();
     }
 };
 

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -1501,6 +1501,22 @@ class spell_item_arcane_shroud : public SpellScriptLoader
         }
 };
 
+// 64415 - Val'anyr Hammer of Ancient Kings - Equip Effect
+class spell_item_valanyr_hammer_of_acient_kings : public AuraScript
+{
+    PrepareAuraScript(spell_item_valanyr_hammer_of_acient_kings);
+
+    bool CheckProc(ProcEventInfo& eventInfo)
+    {
+        return eventInfo.GetHealInfo() && eventInfo.GetHealInfo()->GetHeal() > 0;
+    }
+
+    void Register()
+    {
+        DoCheckProc += AuraCheckProcFn(spell_item_valanyr_hammer_of_acient_kings::CheckProc);
+    }
+};
+
 // 64411 - Blessing of Ancient Kings (Val'anyr, Hammer of Ancient Kings)
 enum BlessingOfAncientKings
 {
@@ -3935,6 +3951,7 @@ void AddSC_item_spell_scripts()
     new spell_item_aegis_of_preservation();
     new spell_item_arcane_shroud();
     new spell_item_blessing_of_ancient_kings();
+    new spell_item_valanyr_hammer_of_acient_kings();
     new spell_item_defibrillate("spell_item_goblin_jumper_cables", 67, SPELL_GOBLIN_JUMPER_CABLES_FAIL);
     new spell_item_defibrillate("spell_item_goblin_jumper_cables_xl", 50, SPELL_GOBLIN_JUMPER_CABLES_XL_FAIL);
     new spell_item_defibrillate("spell_item_gnomish_army_knife", 33);

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -1502,14 +1502,14 @@ class spell_item_arcane_shroud : public SpellScriptLoader
 };
 
 // 64415 - Val'anyr Hammer of Ancient Kings - Equip Effect
-class spell_item_valanyr_hammer_of_acient_kings : public SpellScriptLoader
+class spell_item_valanyr_hammer_of_ancient_kings : public SpellScriptLoader
 {
 public:
-    spell_item_valanyr_hammer_of_acient_kings() : SpellScriptLoader("spell_item_valanyr_hammer_of_acient_kings") { }
+    spell_item_valanyr_hammer_of_ancient_kings() : SpellScriptLoader("spell_item_valanyr_hammer_of_ancient_kings") { }
 
-    class spell_item_valanyr_hammer_of_acient_kingsAuraScript : public AuraScript
+    class spell_item_valanyr_hammer_of_ancient_kingsAuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_item_valanyr_hammer_of_acient_kingsAuraScript);
+        PrepareAuraScript(spell_item_valanyr_hammer_of_ancient_kingsAuraScript);
 
         bool CheckProc(ProcEventInfo& eventInfo)
         {
@@ -1524,13 +1524,13 @@ public:
 
         void Register()
         {
-            DoCheckProc += AuraCheckProcFn(spell_item_valanyr_hammer_of_acient_kingsAuraScript::CheckProc);
+            DoCheckProc += AuraCheckProcFn(spell_item_valanyr_hammer_of_ancient_kingsAuraScript::CheckProc);
         }
     };
 
     AuraScript* GetAuraScript() const
     {
-        return new spell_item_valanyr_hammer_of_acient_kingsAuraScript();
+        return new spell_item_valanyr_hammer_of_ancient_kingsAuraScript();
     }
 };
 
@@ -3968,7 +3968,7 @@ void AddSC_item_spell_scripts()
     new spell_item_aegis_of_preservation();
     new spell_item_arcane_shroud();
     new spell_item_blessing_of_ancient_kings();
-    new spell_item_valanyr_hammer_of_acient_kings();
+    new spell_item_valanyr_hammer_of_ancient_kings();
     new spell_item_defibrillate("spell_item_goblin_jumper_cables", 67, SPELL_GOBLIN_JUMPER_CABLES_FAIL);
     new spell_item_defibrillate("spell_item_goblin_jumper_cables_xl", 50, SPELL_GOBLIN_JUMPER_CABLES_XL_FAIL);
     new spell_item_defibrillate("spell_item_gnomish_army_knife", 33);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: https://github.com/azerothcore/azerothcore-wotlk/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  Fixed Val'anyr Hammer of Ancient Kings
-  


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes #296 


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Tested ingame on a paladin, before applying fix was applying blessing of kings on self to check proc.

after applying fix doing the same.

##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

1. Before applying the PR, Create a paladin or priest log in on that character
2. Spam cast buff effects on yourself (such as blessing of kings or power word fortitude)
3. See shield was applied.
4. Apply the fix
5. Log back in and do the same.


##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
