### PR TITLE
fix: core reporting wrong mail_loot_template startup DB errors

### DIFF
--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -1801,8 +1801,8 @@ void LoadLootTemplates_Mail()
     uint32 count = LootTemplates_Mail.LoadAndCollectLootIds(lootIdSet);
 
     // remove real entries and check existence loot
-    for (uint32 i = 1; i < sAreaTableStore.GetNumRows(); ++i)
-        if (sAreaTableStore.LookupEntry(i))
+    for (uint32 i = 1; i < sMailTemplateStore.GetNumRows(); ++i)
+        if (sMailTemplateStore.LookupEntry(i))
             if (lootIdSet.find(i) != lootIdSet.end())
                 lootIdSet.erase(i);
 


### PR DESCRIPTION
##### CHANGES PROPOSED:

- Fixed bug that made the core complaining about "unused mail_loot_template" while they were actually used (thanks @wetbrownsauce for verifying those)

###### ISSUES ADDRESSED:

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1155


##### TESTS PERFORMED:

- Builds, run -> no more errors


##### HOW TO TEST THE CHANGES:

- There should no longer be any `mail_loot_template` errors at startup (check `DBErrors.log`)
- Test a couple of `mail_loot_template` and make sure they still works

##### Target branch(es):

Master
