### PR TITLE
fix: remove data for unsupported criteria type

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1549149082825412953.sql
+++ b/data/sql/updates/pending_db_world/rev_1549149082825412953.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1549149082825412953');
+
+DELETE FROM `achievement_criteria_data` WHERE `criteria_id` IN (4989, 4988, 5620, 5632, 5619, 4987);


### PR DESCRIPTION
This change was already tested by @wetbrownsauce in another PR (which was closed because containing other unwanted changes), the result was:

> As for the achievement_criteria changes, most of the affected achievements are actually statistics for number of 5 player, 10 player, and 25 player instances entered. These don't appear to work before or after the PR, so the changes in their db table make no difference aside from removing start up warnings/errors.

##### CHANGES PROPOSED:

-  Fix DB startup errors about unsupported achievement criteria types


###### ISSUES ADDRESSED:

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1156


##### TESTS PERFORMED:

- Run and those DB errors are gone


##### HOW TO TEST THE CHANGES:

- Just make sure we're not breaking anything that is currently working, apparently this was already tested by @wetbrownsauce 


##### Target branch(es):

Master
