### PR TITLE
fix: spell_scripts DB startup errors

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1549150908212681677.sql
+++ b/data/sql/updates/pending_db_world/rev_1549150908212681677.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1549150908212681677');
+
+DELETE FROM spell_scripts WHERE id IN (28732, 54097);


### PR DESCRIPTION
##### CHANGES PROPOSED:

-  Removed a couple of `spell_scripts` that are causing DB startup errors


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes 


##### TESTS PERFORMED:

- Build, runs



##### HOW TO TEST THE CHANGES:

Those two `spell_scripts` where introduced in this commit: https://github.com/azerothcore/azerothcore-wotlk/commit/7a0a5613d0f94dcc2df62383df7bfadf1721e9ca
which was about "Fixing Encounter Boss Faerlina".

In particular, those 2 lines were marked as "Widow's Embrace".

The test should basically:

- make sure that Boss Faerlina still works as before 



##### Target branch(es):

Master
