### PR TITLE
Core/Commands: Added cheat command

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1549320792563626100.sql
+++ b/data/sql/updates/pending_db_world/rev_1549320792563626100.sql
@@ -1,0 +1,16 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1549320792563626100');
+
+DELETE FROM `command` WHERE `name`='explorecheat';
+DELETE FROM `command` WHERE `name`='taxicheat';
+DELETE FROM `command` WHERE `name`='waterwalk';
+
+DELETE FROM `command` WHERE `name`='cheat' OR `name` LIKE 'cheat%';
+INSERT INTO `command` (`name`, `security`, `help`) VALUES 
+('cheat',           2, 'Syntax: .cheat $subcommand\r\nType .cheat to see the list of possible subcommands or .help cheat $subcommand to see info on subcommands'),
+('cheat god',       2, 'Syntax: .cheat god [on/off]\r\nEnables or disables your character''s ability to take damage.'),
+('cheat casttime',  2, 'Syntax: .cheat casttime [on/off]\r\nEnables or disables your character''s spell cast times.'),
+('cheat cooldown',  2, 'Syntax: .cheat cooldown [on/off]\r\nEnables or disables your character''s spell cooldowns.'),
+('cheat power',     2, 'Syntax: .cheat power [on/off]\r\nEnables or disables your character''s spell cost (e.g mana).'),
+('cheat waterwalk', 2, 'Syntax: .cheat waterwalk on/off\r\nSet on/off waterwalk state for selected player or self if no player selected.'),
+('cheat explore',   2, 'Syntax: .cheat explore #flag\r\nReveal or hide all maps for the selected player. If no player is selected, hide or reveal maps to you.\r\nUse a #flag of value 1 to reveal, use a #flag value of 0 to hide all maps.'),
+('cheat taxi',      2, 'Syntax: .cheat taxi on/off\r\nTemporary grant access or remove to all taxi routes for the selected character.\r\n If no character is selected, hide or reveal all routes to you. Visited taxi nodes sill accessible after removing access.');

--- a/data/sql/updates/pending_db_world/rev_1549320792563626100.sql
+++ b/data/sql/updates/pending_db_world/rev_1549320792563626100.sql
@@ -1,6 +1,5 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1549320792563626100');
 
-DELETE FROM `command` WHERE `name`='explorecheat';
 DELETE FROM `command` WHERE `name`='taxicheat';
 DELETE FROM `command` WHERE `name`='waterwalk';
 
@@ -12,5 +11,4 @@ INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('cheat cooldown',  2, 'Syntax: .cheat cooldown [on/off]\r\nDisable spells\' cooldowns.'),
 ('cheat power',     2, 'Syntax: .cheat power [on/off]\r\nRemove spells\' cost (mana, energy, rage...).'),
 ('cheat waterwalk', 2, 'Syntax: .cheat waterwalk on/off\r\nAllow to walk on water (self or selected character).'),
-('cheat explore',   2, 'Syntax: .cheat explore #flag\r\nReveal or hide all maps for the selected player. If no player is selected, hide or reveal maps to you.\r\nUse a #flag value of 1 to reveal, use a #flag value of 0 to hide all maps.'),
 ('cheat taxi',      2, 'Syntax: .cheat taxi on/off\r\nTemporary grant access to all taxi routes for the selected character.\r\n If no character is selected, hide or reveal all routes to you. Visited taxi nodes are still accessible after removing access.');

--- a/data/sql/updates/pending_db_world/rev_1549320792563626100.sql
+++ b/data/sql/updates/pending_db_world/rev_1549320792563626100.sql
@@ -7,10 +7,10 @@ DELETE FROM `command` WHERE `name`='waterwalk';
 DELETE FROM `command` WHERE `name`='cheat' OR `name` LIKE 'cheat%';
 INSERT INTO `command` (`name`, `security`, `help`) VALUES 
 ('cheat',           2, 'Syntax: .cheat $subcommand\r\nType .cheat to see the list of possible subcommands or .help cheat $subcommand to see info on subcommands'),
-('cheat god',       2, 'Syntax: .cheat god [on/off]\r\nEnables or disables your character''s ability to take damage.'),
-('cheat casttime',  2, 'Syntax: .cheat casttime [on/off]\r\nEnables or disables your character''s spell cast times.'),
-('cheat cooldown',  2, 'Syntax: .cheat cooldown [on/off]\r\nEnables or disables your character''s spell cooldowns.'),
-('cheat power',     2, 'Syntax: .cheat power [on/off]\r\nEnables or disables your character''s spell cost (e.g mana).'),
-('cheat waterwalk', 2, 'Syntax: .cheat waterwalk on/off\r\nSet on/off waterwalk state for selected player or self if no player selected.'),
-('cheat explore',   2, 'Syntax: .cheat explore #flag\r\nReveal or hide all maps for the selected player. If no player is selected, hide or reveal maps to you.\r\nUse a #flag of value 1 to reveal, use a #flag value of 0 to hide all maps.'),
-('cheat taxi',      2, 'Syntax: .cheat taxi on/off\r\nTemporary grant access or remove to all taxi routes for the selected character.\r\n If no character is selected, hide or reveal all routes to you. Visited taxi nodes sill accessible after removing access.');
+('cheat god',       2, 'Syntax: .cheat god [on/off]\r\nTurn the user invulnerable.'),
+('cheat casttime',  2, 'Syntax: .cheat casttime [on/off]\r\nRemove spells\' casting time.'),
+('cheat cooldown',  2, 'Syntax: .cheat cooldown [on/off]\r\nDisable spells\' cooldowns.'),
+('cheat power',     2, 'Syntax: .cheat power [on/off]\r\nRemove spells\' cost (mana, energy, rage...).'),
+('cheat waterwalk', 2, 'Syntax: .cheat waterwalk on/off\r\nAllow to walk on water (self or selected character).'),
+('cheat explore',   2, 'Syntax: .cheat explore #flag\r\nReveal or hide all maps for the selected player. If no player is selected, hide or reveal maps to you.\r\nUse a #flag value of 1 to reveal, use a #flag value of 0 to hide all maps.'),
+('cheat taxi',      2, 'Syntax: .cheat taxi on/off\r\nTemporary grant access to all taxi routes for the selected character.\r\n If no character is selected, hide or reveal all routes to you. Visited taxi nodes are still accessible after removing access.');

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -912,6 +912,8 @@ Player::Player(WorldSession* session): Unit(true), m_mover(this)
 
     SetPendingBind(0, 0);
 
+    _activeCheats = CHEAT_NONE;
+
     m_achievementMgr = new AchievementMgr(this);
     m_reputationMgr = new ReputationMgr(this);
 

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (C) 2016+     AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-GPL2
  * Copyright (C) 2008-2016 TrinityCore <http://www.trinitycore.org/>
  * Copyright (C) 2005-2009 MaNGOS <http://getmangos.com/>
@@ -899,6 +899,16 @@ enum AdditionalSaving
     ADDITIONAL_SAVING_QUEST_STATUS              = 0x02,
 };
 
+enum PlayerCommandStates
+{
+    CHEAT_NONE = 0x00,
+    CHEAT_GOD = 0x01,
+    CHEAT_CASTTIME = 0x02,
+    CHEAT_COOLDOWN = 0x04,
+    CHEAT_POWER = 0x08,
+    CHEAT_WATERWALK = 0x10
+};
+
 class PlayerTaxi
 {
     public:
@@ -1176,6 +1186,11 @@ class Player : public Unit, public GridObject<Player>
         void GiveLevel(uint8 level);
 
         void InitStatsForLevel(bool reapplyMods = false);
+
+        // .cheat command related
+        bool GetCommandStatus(uint32 command) const { return _activeCheats & command; }
+        void SetCommandStatusOn(uint32 command) { _activeCheats |= command; }
+        void SetCommandStatusOff(uint32 command) { _activeCheats &= ~command; }
 
         // Played Time Stuff
         time_t m_logintime;
@@ -2937,6 +2952,8 @@ class Player : public Unit, public GridObject<Player>
         InstanceTimeMap _instanceResetTimes;
         uint32 _pendingBindId;
         uint32 _pendingBindTimer;
+
+        uint32 _activeCheats;
 
         // duel health and mana reset attributes
         uint32 healthBeforeDuel;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -696,6 +696,10 @@ uint32 Unit::DealDamage(Unit* attacker, Unit* victim, uint32 damage, CleanDamage
         // Signal to pets that their owner was attacked
         Pet* pet = victim->ToPlayer()->GetPet();
 
+        if (victim->GetTypeId() == TYPEID_PLAYER)
+            if (victim->ToPlayer()->GetCommandStatus(CHEAT_GOD))
+                return 0;
+
         if (pet && pet->IsAlive())
             pet->AI()->OwnerAttackedBy(attacker);
     }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4961,10 +4961,8 @@ void Spell::TakePower()
 
     //Don't take power if the spell is cast while .cheat power is enabled.
     if (m_caster->GetTypeId() == TYPEID_PLAYER)
-    {
         if (m_caster->ToPlayer()->GetCommandStatus(CHEAT_POWER))
             return;
-    }
 
     Powers powerType = Powers(m_spellInfo->PowerType);
     bool hit = true;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3414,6 +3414,10 @@ void Spell::prepare(SpellCastTargets const* targets, AuraEffect const* triggered
     // calculate cast time (calculated after first CheckCast check to prevent charge counting for first CheckCast fail)
     m_casttime = (_triggeredCastFlags & TRIGGERED_CAST_DIRECTLY) ? 0 : m_spellInfo->CalcCastTime(m_caster, this);
 
+    if (m_caster->GetTypeId() == TYPEID_PLAYER)
+        if (m_caster->ToPlayer()->GetCommandStatus(CHEAT_CASTTIME))
+            m_casttime = 0;
+
     // don't allow channeled spells / spells with cast time to be casted while moving
     // (even if they are interrupted on moving, spells with almost immediate effect get to have their effect processed before movement interrupter kicks in)
     if ((m_spellInfo->IsChanneled() || m_casttime) && m_caster->GetTypeId() == TYPEID_PLAYER && m_caster->isMoving() && m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT && !IsTriggered())
@@ -3831,6 +3835,10 @@ void Spell::_cast(bool skipCheck)
         if (m_caster->GetTypeId() == TYPEID_PLAYER || (m_caster->IsPet() && m_caster->IsControlledByPlayer()))
             if (GetDelayMoment() > 0 && !m_caster->IsFriendlyTo(target) && !m_spellInfo->HasAura(SPELL_AURA_BIND_SIGHT) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)))
                 m_caster->CombatStartOnCast(target, !m_spellInfo->HasAttribute(SPELL_ATTR3_NO_INITIAL_AGGRO), GetDelayMoment() + 500); // xinef: increase this time so we dont leave and enter combat in a moment
+
+    if (m_caster->GetTypeId() == TYPEID_PLAYER)
+        if (m_caster->ToPlayer()->GetCommandStatus(CHEAT_COOLDOWN))
+            m_caster->ToPlayer()->RemoveSpellCooldown(m_spellInfo->Id, true);
 
     SetExecutedCurrently(false);
 }
@@ -4950,6 +4958,13 @@ void Spell::TakePower()
 {
     if (m_CastItem || m_triggeredByAuraSpell)
         return;
+
+    //Don't take power if the spell is cast while .cheat power is enabled.
+    if (m_caster->GetTypeId() == TYPEID_PLAYER)
+    {
+        if (m_caster->ToPlayer()->GetCommandStatus(CHEAT_POWER))
+            return;
+    }
 
     Powers powerType = Powers(m_spellInfo->PowerType);
     bool hit = true;
@@ -8299,6 +8314,10 @@ void Spell::TriggerGlobalCooldown()
         else
             return;
     }
+
+    if (m_caster->GetTypeId() == TYPEID_PLAYER)
+        if (m_caster->ToPlayer()->GetCommandStatus(CHEAT_COOLDOWN))
+            return;
 
     // Global cooldown can't leave range 1..1.5 secs
     // There are some spells (mostly not casted directly by player) that have < 1 sec and > 1.5 sec global cooldowns

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -276,6 +276,10 @@ void Spell::EffectInstaKill(SpellEffIndex /*effIndex*/)
     if (!unitTarget || !unitTarget->IsAlive() || unitTarget->HasAura(27827)) // Spirit of redemption doesn't make you death, but can cause infinite loops
         return;
 
+    if (unitTarget->GetTypeId() == TYPEID_PLAYER)
+        if (unitTarget->ToPlayer()->GetCommandStatus(CHEAT_GOD))
+            return;
+
     if (m_caster == unitTarget)                              // prevent interrupt message
         finish();
 

--- a/src/server/scripts/Commands/CMakeLists.txt
+++ b/src/server/scripts/Commands/CMakeLists.txt
@@ -16,6 +16,7 @@ set(scripts_STAT_SRCS
   Commands/cs_bf.cpp
   Commands/cs_cast.cpp
   Commands/cs_character.cpp
+  Commands/cs_cheat.cpp
   Commands/cs_debug.cpp
   Commands/cs_disable.cpp
   Commands/cs_event.cpp

--- a/src/server/scripts/Commands/cs_cheat.cpp
+++ b/src/server/scripts/Commands/cs_cheat.cpp
@@ -1,27 +1,8 @@
 /*
- * Copyright (C) 2008-2012 TrinityCore <http://www.trinitycore.org/>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program. If not, see <http://www.gnu.org/licenses/>.
+ * Copyright (C) 2016+     AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-GPL2
+ * Copyright (C) 2008-2016 TrinityCore <http://www.trinitycore.org/>
+ * Copyright (C) 2005-2009 MaNGOS <http://getmangos.com/>
  */
-
- /* ScriptData
- Name: cheat_commandscript
- %Complete: 100
- Comment: All cheat related commands
- Category: commandscripts
- EndScriptData */
-
 
 #include "Chat.h"
 #include "Language.h"

--- a/src/server/scripts/Commands/cs_cheat.cpp
+++ b/src/server/scripts/Commands/cs_cheat.cpp
@@ -1,7 +1,5 @@
 /*
- * Copyright (C) 2016+     AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-GPL2
- * Copyright (C) 2008-2016 TrinityCore <http://www.trinitycore.org/>
- * Copyright (C) 2005-2009 MaNGOS <http://getmangos.com/>
+ * Copyright (C) 2016+     AzerothCore <www.azerothcore.org>
  */
 
 #include "Chat.h"

--- a/src/server/scripts/Commands/cs_cheat.cpp
+++ b/src/server/scripts/Commands/cs_cheat.cpp
@@ -26,7 +26,6 @@ public:
             { "waterwalk",      SEC_GAMEMASTER,     false, &HandleWaterwalkCheatCommand,       "" },
             { "status",         SEC_GAMEMASTER,     false, &HandleCheatStatusCommand,          "" },
             { "taxi",           SEC_GAMEMASTER,     false, &HandleTaxiCheatCommand,            "" },
-            { "explore",        SEC_GAMEMASTER,     false, &HandleExploreCheatCommand,         "" },
 
         };
 
@@ -224,45 +223,6 @@ public:
         handler->SetSentErrorMessage(true);
 
         return false;
-    }
-
-    static bool HandleExploreCheatCommand(ChatHandler* handler, char const* args)
-    {
-        if (!*args)
-            return false;
-
-        int32 flag = int32(atoi((char*)args));
-
-        Player* playerTarget = handler->getSelectedPlayer();
-        if (!playerTarget)
-        {
-            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        if (flag != 0)
-        {
-            handler->PSendSysMessage(LANG_YOU_SET_EXPLORE_ALL, handler->GetNameLink(playerTarget).c_str());
-            if (handler->needReportToTarget(playerTarget))
-                ChatHandler(playerTarget->GetSession()).PSendSysMessage(LANG_YOURS_EXPLORE_SET_ALL, handler->GetNameLink().c_str());
-        }
-        else
-        {
-            handler->PSendSysMessage(LANG_YOU_SET_EXPLORE_NOTHING, handler->GetNameLink(playerTarget).c_str());
-            if (handler->needReportToTarget(playerTarget))
-                ChatHandler(playerTarget->GetSession()).PSendSysMessage(LANG_YOURS_EXPLORE_SET_NOTHING, handler->GetNameLink().c_str());
-        }
-
-        for (uint8 i = 0; i < PLAYER_EXPLORED_ZONES_SIZE; ++i)
-        {
-            if (flag != 0)
-                handler->GetSession()->GetPlayer()->SetFlag(PLAYER_EXPLORED_ZONES_1 + i, 0xFFFFFFFF);
-            else
-                handler->GetSession()->GetPlayer()->SetFlag(PLAYER_EXPLORED_ZONES_1 + i, 0);
-        }
-
-        return true;
     }
 };
 

--- a/src/server/scripts/Commands/cs_cheat.cpp
+++ b/src/server/scripts/Commands/cs_cheat.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (C) 2008-2012 TrinityCore <http://www.trinitycore.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ /* ScriptData
+ Name: cheat_commandscript
+ %Complete: 100
+ Comment: All cheat related commands
+ Category: commandscripts
+ EndScriptData */
+
+
+#include "Chat.h"
+#include "Language.h"
+#include "Player.h"
+#include "ScriptMgr.h"
+
+class cheat_commandscript : public CommandScript
+{
+public:
+    cheat_commandscript() : CommandScript("cheat_commandscript") { }
+
+    std::vector<ChatCommand> GetCommands() const override
+    {
+
+        static std::vector<ChatCommand> cheatCommandTable =
+        {
+            { "god",            SEC_GAMEMASTER,     false, &HandleGodModeCheatCommand,         "" },
+            { "casttime",       SEC_GAMEMASTER,     false, &HandleCasttimeCheatCommand,        "" },
+            { "cooldown",       SEC_GAMEMASTER,     false, &HandleCoolDownCheatCommand,        "" },
+            { "power",          SEC_GAMEMASTER,     false, &HandlePowerCheatCommand,           "" },
+            { "waterwalk",      SEC_GAMEMASTER,     false, &HandleWaterwalkCheatCommand,       "" },
+            { "status",         SEC_GAMEMASTER,     false, &HandleCheatStatusCommand,          "" },
+            { "taxi",           SEC_GAMEMASTER,     false, &HandleTaxiCheatCommand,            "" },
+            { "explore",        SEC_GAMEMASTER,     false, &HandleExploreCheatCommand,         "" },
+
+        };
+
+        static std::vector<ChatCommand> commandTable =
+        {
+            { "cheat",          SEC_GAMEMASTER,     false, nullptr,                  "", cheatCommandTable },
+
+        };
+        return commandTable;
+    }
+
+    static bool HandleGodModeCheatCommand(ChatHandler* handler, char const* args)
+    {
+        std::string argstr = (char*)args;
+
+        if (!*args)
+            argstr = (handler->GetSession()->GetPlayer()->GetCommandStatus(CHEAT_GOD)) ? "off" : "on";
+
+        if (argstr == "off")
+        {
+            handler->GetSession()->GetPlayer()->SetCommandStatusOff(CHEAT_GOD);
+            handler->SendSysMessage("Godmode is OFF. You can take damage.");
+            return true;
+        }
+        else if (argstr == "on")
+        {
+            handler->GetSession()->GetPlayer()->SetCommandStatusOn(CHEAT_GOD);
+            handler->SendSysMessage("Godmode is ON. You won't take damage.");
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool HandleCasttimeCheatCommand(ChatHandler* handler, char const* args)
+    {
+        std::string argstr = (char*)args;
+
+        if (!*args)
+            argstr = (handler->GetSession()->GetPlayer()->GetCommandStatus(CHEAT_CASTTIME)) ? "off" : "on";
+
+        if (argstr == "off")
+        {
+            handler->GetSession()->GetPlayer()->SetCommandStatusOff(CHEAT_CASTTIME);
+            handler->SendSysMessage("CastTime Cheat is OFF. Your spells will have a casttime.");
+            return true;
+        }
+        else if (argstr == "on")
+        {
+            handler->GetSession()->GetPlayer()->SetCommandStatusOn(CHEAT_CASTTIME);
+            handler->SendSysMessage("CastTime Cheat is ON. Your spells won't have a casttime.");
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool HandleCoolDownCheatCommand(ChatHandler* handler, char const* args)
+    {
+        std::string argstr = (char*)args;
+
+        if (!*args)
+            argstr = (handler->GetSession()->GetPlayer()->GetCommandStatus(CHEAT_COOLDOWN)) ? "off" : "on";
+
+        if (argstr == "off")
+        {
+            handler->GetSession()->GetPlayer()->SetCommandStatusOff(CHEAT_COOLDOWN);
+            handler->SendSysMessage("Cooldown Cheat is OFF. You are on the global cooldown.");
+            return true;
+        }
+        else if (argstr == "on")
+        {
+            handler->GetSession()->GetPlayer()->SetCommandStatusOn(CHEAT_COOLDOWN);
+            handler->SendSysMessage("Cooldown Cheat is ON. You are not on the global cooldown.");
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool HandlePowerCheatCommand(ChatHandler* handler, char const* args)
+    {
+        std::string argstr = (char*)args;
+
+        if (!*args)
+            argstr = (handler->GetSession()->GetPlayer()->GetCommandStatus(CHEAT_POWER)) ? "off" : "on";
+
+        if (argstr == "off")
+        {
+            handler->GetSession()->GetPlayer()->SetCommandStatusOff(CHEAT_POWER);
+            handler->SendSysMessage("Power Cheat is OFF. You need mana/rage/energy to use spells.");
+            return true;
+        }
+        else if (argstr == "on")
+        {
+            handler->GetSession()->GetPlayer()->SetCommandStatusOn(CHEAT_POWER);
+            handler->SendSysMessage("Power Cheat is ON. You don't need mana/rage/energy to use spells.");
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool HandleWaterwalkCheatCommand(ChatHandler* handler, char const* args)
+    {
+        if (!*args)
+            return false;
+
+        Player* player = handler->getSelectedPlayer();
+        if (!player)
+        {
+            handler->PSendSysMessage(LANG_NO_CHAR_SELECTED);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        // check online security
+        if (handler->HasLowerSecurity(player, 0))
+            return false;
+
+        if (strncmp(args, "on", 3) == 0)
+        {
+            player->SetMovement(MOVE_WATER_WALK);               // ON
+            handler->GetSession()->GetPlayer()->SetCommandStatusOn(CHEAT_WATERWALK);
+        }
+        else if (strncmp(args, "off", 4) == 0)
+        {
+            player->SetMovement(MOVE_LAND_WALK);                // OFF
+            handler->GetSession()->GetPlayer()->SetCommandStatusOff(CHEAT_WATERWALK);
+        }
+        else
+        {
+            handler->SendSysMessage(LANG_USE_BOL);
+            return false;
+        }
+
+        handler->PSendSysMessage(LANG_YOU_SET_WATERWALK, args, handler->GetNameLink(player).c_str());
+        if (handler->needReportToTarget(player))
+            ChatHandler(player->GetSession()).PSendSysMessage(LANG_YOUR_WATERWALK_SET, args, handler->GetNameLink().c_str());
+        return true;
+    }
+
+    static bool HandleCheatStatusCommand(ChatHandler* handler, char const* /*args*/)
+    {
+        Player* player = handler->GetSession()->GetPlayer();
+
+        char const* enabled = "ON";
+        char const* disabled = "OFF";
+
+        handler->SendSysMessage(LANG_COMMAND_CHEAT_STATUS);
+        handler->PSendSysMessage(LANG_COMMAND_CHEAT_GOD, player->GetCommandStatus(CHEAT_GOD) ? enabled : disabled);
+        handler->PSendSysMessage(LANG_COMMAND_CHEAT_CD, player->GetCommandStatus(CHEAT_COOLDOWN) ? enabled : disabled);
+        handler->PSendSysMessage(LANG_COMMAND_CHEAT_CT, player->GetCommandStatus(CHEAT_CASTTIME) ? enabled : disabled);
+        handler->PSendSysMessage(LANG_COMMAND_CHEAT_POWER, player->GetCommandStatus(CHEAT_POWER) ? enabled : disabled);
+        handler->PSendSysMessage(LANG_COMMAND_CHEAT_WW, player->GetCommandStatus(CHEAT_WATERWALK) ? enabled : disabled);
+        handler->PSendSysMessage(LANG_COMMAND_CHEAT_TAXINODES, player->isTaxiCheater() ? enabled : disabled);
+
+        return true;
+    }
+
+    
+    static bool HandleTaxiCheatCommand(ChatHandler* handler, char const* args)
+    {
+        std::string argStr = (char*)args;
+
+        Player* chr = handler->getSelectedPlayer();
+
+        if (!chr)
+            chr = handler->GetSession()->GetPlayer();
+        else if (handler->HasLowerSecurity(chr, 0)) // check online security
+            return false;
+
+        if (!*args)
+            argStr = (chr->isTaxiCheater()) ? "off" : "on";
+
+        if (argStr == "off")
+        {
+            chr->SetTaxiCheater(false);
+            handler->PSendSysMessage(LANG_YOU_REMOVE_TAXIS, handler->GetNameLink(chr).c_str());
+            if (handler->needReportToTarget(chr))
+                ChatHandler(chr->GetSession()).PSendSysMessage(LANG_YOURS_TAXIS_REMOVED, handler->GetNameLink().c_str());
+
+            return true;
+        }
+        else if (argStr == "on")
+        {
+            chr->SetTaxiCheater(true);
+            handler->PSendSysMessage(LANG_YOU_GIVE_TAXIS, handler->GetNameLink(chr).c_str());
+            if (handler->needReportToTarget(chr))
+                ChatHandler(chr->GetSession()).PSendSysMessage(LANG_YOURS_TAXIS_ADDED, handler->GetNameLink().c_str());
+            return true;
+        }
+
+        handler->SendSysMessage(LANG_USE_BOL);
+        handler->SetSentErrorMessage(true);
+
+        return false;
+    }
+
+    static bool HandleExploreCheatCommand(ChatHandler* handler, char const* args)
+    {
+        if (!*args)
+            return false;
+
+        int32 flag = int32(atoi((char*)args));
+
+        Player* playerTarget = handler->getSelectedPlayer();
+        if (!playerTarget)
+        {
+            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        if (flag != 0)
+        {
+            handler->PSendSysMessage(LANG_YOU_SET_EXPLORE_ALL, handler->GetNameLink(playerTarget).c_str());
+            if (handler->needReportToTarget(playerTarget))
+                ChatHandler(playerTarget->GetSession()).PSendSysMessage(LANG_YOURS_EXPLORE_SET_ALL, handler->GetNameLink().c_str());
+        }
+        else
+        {
+            handler->PSendSysMessage(LANG_YOU_SET_EXPLORE_NOTHING, handler->GetNameLink(playerTarget).c_str());
+            if (handler->needReportToTarget(playerTarget))
+                ChatHandler(playerTarget->GetSession()).PSendSysMessage(LANG_YOURS_EXPLORE_SET_NOTHING, handler->GetNameLink().c_str());
+        }
+
+        for (uint8 i = 0; i < PLAYER_EXPLORED_ZONES_SIZE; ++i)
+        {
+            if (flag != 0)
+                handler->GetSession()->GetPlayer()->SetFlag(PLAYER_EXPLORED_ZONES_1 + i, 0xFFFFFFFF);
+            else
+                handler->GetSession()->GetPlayer()->SetFlag(PLAYER_EXPLORED_ZONES_1 + i, 0);
+        }
+
+        return true;
+    }
+};
+
+void AddSC_cheat_commandscript()
+{
+    new cheat_commandscript();
+}

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -82,6 +82,7 @@ public:
             { "unstuck",            SEC_GAMEMASTER,         true,  &HandleUnstuckCommand,               "" },
             { "linkgrave",          SEC_ADMINISTRATOR,      false, &HandleLinkGraveCommand,             "" },
             { "neargrave",          SEC_GAMEMASTER,         false, &HandleNearGraveCommand,             "" },
+            { "explorecheat",       SEC_ADMINISTRATOR,      false, &HandleExploreCheatCommand,          "" },
             { "showarea",           SEC_GAMEMASTER,         false, &HandleShowAreaCommand,              "" },
             { "hidearea",           SEC_ADMINISTRATOR,      false, &HandleHideAreaCommand,              "" },
             { "additem",            SEC_GAMEMASTER,         false, &HandleAddItemCommand,               "" },
@@ -1310,6 +1311,45 @@ public:
             //    handler->PSendSysMessage(LANG_COMMAND_ZONENOGRAVEYARDS, zone_id);
             //else
                 handler->PSendSysMessage(LANG_COMMAND_ZONENOGRAFACTION, zone_id, team_name.c_str());
+        }
+
+        return true;
+    }
+
+    static bool HandleExploreCheatCommand(ChatHandler* handler, char const* args)
+    {
+        if (!*args)
+            return false;
+
+        int32 flag = int32(atoi((char*)args));
+
+        Player* playerTarget = handler->getSelectedPlayer();
+        if (!playerTarget)
+        {
+            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        if (flag != 0)
+        {
+            handler->PSendSysMessage(LANG_YOU_SET_EXPLORE_ALL, handler->GetNameLink(playerTarget).c_str());
+            if (handler->needReportToTarget(playerTarget))
+                ChatHandler(playerTarget->GetSession()).PSendSysMessage(LANG_YOURS_EXPLORE_SET_ALL, handler->GetNameLink().c_str());
+        }
+        else
+        {
+            handler->PSendSysMessage(LANG_YOU_SET_EXPLORE_NOTHING, handler->GetNameLink(playerTarget).c_str());
+            if (handler->needReportToTarget(playerTarget))
+                ChatHandler(playerTarget->GetSession()).PSendSysMessage(LANG_YOURS_EXPLORE_SET_NOTHING, handler->GetNameLink().c_str());
+        }
+
+        for (uint8 i = 0; i < PLAYER_EXPLORED_ZONES_SIZE; ++i)
+        {
+            if (flag != 0)
+                handler->GetSession()->GetPlayer()->SetFlag(PLAYER_EXPLORED_ZONES_1 + i, 0xFFFFFFFF);
+            else
+                handler->GetSession()->GetPlayer()->SetFlag(PLAYER_EXPLORED_ZONES_1 + i, 0);
         }
 
         return true;

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -80,10 +80,8 @@ public:
             { "saveall",            SEC_GAMEMASTER,         true,  &HandleSaveAllCommand,               "" },
             { "kick",               SEC_GAMEMASTER,         true,  &HandleKickPlayerCommand,            "" },
             { "unstuck",            SEC_GAMEMASTER,         true,  &HandleUnstuckCommand,               "" },
-            { "taxicheat",          SEC_GAMEMASTER,         false, &HandleTaxiCheatCommand,             "" },
             { "linkgrave",          SEC_ADMINISTRATOR,      false, &HandleLinkGraveCommand,             "" },
             { "neargrave",          SEC_GAMEMASTER,         false, &HandleNearGraveCommand,             "" },
-            { "explorecheat",       SEC_ADMINISTRATOR,      false, &HandleExploreCheatCommand,          "" },
             { "showarea",           SEC_GAMEMASTER,         false, &HandleShowAreaCommand,              "" },
             { "hidearea",           SEC_ADMINISTRATOR,      false, &HandleHideAreaCommand,              "" },
             { "additem",            SEC_GAMEMASTER,         false, &HandleAddItemCommand,               "" },
@@ -105,7 +103,6 @@ public:
             { "combatstop",         SEC_GAMEMASTER,         true,  &HandleCombatStopCommand,            "" },
             { "flusharenapoints",   SEC_ADMINISTRATOR,      false, &HandleFlushArenaPointsCommand,      "" },
             { "repairitems",        SEC_GAMEMASTER,         true,  &HandleRepairitemsCommand,           "" },
-            { "waterwalk",          SEC_GAMEMASTER,         false, &HandleWaterwalkCommand,             "" },
             { "freeze",             SEC_GAMEMASTER,         false, &HandleFreezeCommand,                "" },
             { "unfreeze",           SEC_GAMEMASTER,         false, &HandleUnFreezeCommand,              "" },
             { "group",              SEC_GAMEMASTER,         false, nullptr,                             "", groupCommandTable },
@@ -1201,49 +1198,6 @@ public:
         return false;
 
     }
-    // Enable on\off all taxi paths
-    static bool HandleTaxiCheatCommand(ChatHandler* handler, char const* args)
-    {
-        if (!*args)
-        {
-            handler->SendSysMessage(LANG_USE_BOL);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        std::string argStr = (char*)args;
-
-        Player* chr = handler->getSelectedPlayer();
-
-        if (!chr)
-            chr = handler->GetSession()->GetPlayer();
-        else if (handler->HasLowerSecurity(chr, 0)) // check online security
-            return false;
-
-        if (argStr == "on")
-        {
-            chr->SetTaxiCheater(true);
-            handler->PSendSysMessage(LANG_YOU_GIVE_TAXIS, handler->GetNameLink(chr).c_str());
-            if (handler->needReportToTarget(chr))
-                ChatHandler(chr->GetSession()).PSendSysMessage(LANG_YOURS_TAXIS_ADDED, handler->GetNameLink().c_str());
-            return true;
-        }
-
-        if (argStr == "off")
-        {
-            chr->SetTaxiCheater(false);
-            handler->PSendSysMessage(LANG_YOU_REMOVE_TAXIS, handler->GetNameLink(chr).c_str());
-            if (handler->needReportToTarget(chr))
-                ChatHandler(chr->GetSession()).PSendSysMessage(LANG_YOURS_TAXIS_REMOVED, handler->GetNameLink().c_str());
-
-            return true;
-        }
-
-        handler->SendSysMessage(LANG_USE_BOL);
-        handler->SetSentErrorMessage(true);
-
-        return false;
-    }
 
     static bool HandleLinkGraveCommand(ChatHandler* handler, char const* args)
     {
@@ -1356,45 +1310,6 @@ public:
             //    handler->PSendSysMessage(LANG_COMMAND_ZONENOGRAVEYARDS, zone_id);
             //else
                 handler->PSendSysMessage(LANG_COMMAND_ZONENOGRAFACTION, zone_id, team_name.c_str());
-        }
-
-        return true;
-    }
-
-    static bool HandleExploreCheatCommand(ChatHandler* handler, char const* args)
-    {
-        if (!*args)
-            return false;
-
-        int32 flag = int32(atoi((char*)args));
-
-        Player* playerTarget = handler->getSelectedPlayer();
-        if (!playerTarget)
-        {
-            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        if (flag != 0)
-        {
-            handler->PSendSysMessage(LANG_YOU_SET_EXPLORE_ALL, handler->GetNameLink(playerTarget).c_str());
-            if (handler->needReportToTarget(playerTarget))
-                ChatHandler(playerTarget->GetSession()).PSendSysMessage(LANG_YOURS_EXPLORE_SET_ALL, handler->GetNameLink().c_str());
-        }
-        else
-        {
-            handler->PSendSysMessage(LANG_YOU_SET_EXPLORE_NOTHING, handler->GetNameLink(playerTarget).c_str());
-            if (handler->needReportToTarget(playerTarget))
-                ChatHandler(playerTarget->GetSession()).PSendSysMessage(LANG_YOURS_EXPLORE_SET_NOTHING, handler->GetNameLink().c_str());
-        }
-
-        for (uint8 i = 0; i < PLAYER_EXPLORED_ZONES_SIZE; ++i)
-        {
-            if (flag != 0)
-                handler->GetSession()->GetPlayer()->SetFlag(PLAYER_EXPLORED_ZONES_1+i, 0xFFFFFFFF);
-            else
-                handler->GetSession()->GetPlayer()->SetFlag(PLAYER_EXPLORED_ZONES_1+i, 0);
         }
 
         return true;
@@ -2605,39 +2520,6 @@ public:
         if (handler->needReportToTarget(target))
             ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOUR_ITEMS_REPAIRED, handler->GetNameLink().c_str());
 
-        return true;
-    }
-
-    static bool HandleWaterwalkCommand(ChatHandler* handler, char const* args)
-    {
-        if (!*args)
-            return false;
-
-        Player* player = handler->getSelectedPlayer();
-        if (!player)
-        {
-            handler->PSendSysMessage(LANG_NO_CHAR_SELECTED);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        // check online security
-        if (handler->HasLowerSecurity(player, 0))
-            return false;
-
-        if (strncmp(args, "on", 3) == 0)
-            player->SetMovement(MOVE_WATER_WALK);               // ON
-        else if (strncmp(args, "off", 4) == 0)
-            player->SetMovement(MOVE_LAND_WALK);                // OFF
-        else
-        {
-            handler->SendSysMessage(LANG_USE_BOL);
-            return false;
-        }
-
-        handler->PSendSysMessage(LANG_YOU_SET_WATERWALK, args, handler->GetNameLink(player).c_str());
-        if (handler->needReportToTarget(player))
-            ChatHandler(player->GetSession()).PSendSysMessage(LANG_YOUR_WATERWALK_SET, args, handler->GetNameLink().c_str());
         return true;
     }
 

--- a/src/server/scripts/ScriptLoader.cpp
+++ b/src/server/scripts/ScriptLoader.cpp
@@ -31,6 +31,7 @@ void AddSC_ban_commandscript();
 void AddSC_bf_commandscript();
 void AddSC_cast_commandscript();
 void AddSC_character_commandscript();
+void AddSC_cheat_commandscript();
 void AddSC_debug_commandscript();
 void AddSC_disable_commandscript();
 void AddSC_event_commandscript();
@@ -607,6 +608,7 @@ void AddCommandScripts()
     AddSC_bf_commandscript();
     AddSC_cast_commandscript();
     AddSC_character_commandscript();
+    AddSC_cheat_commandscript();
     AddSC_debug_commandscript();
     AddSC_disable_commandscript();
     AddSC_event_commandscript();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: https://github.com/azerothcore/azerothcore-wotlk/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  Add the cheat command, it's very useful for testing purposes. 


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

#533


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Compiled and test all of them, they work.


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

Just enter to the game and use the `cheat` commands:

```
('cheat',           2, 'Syntax: .cheat $subcommand\r\nType .cheat to see the list of possible subcommands or .help cheat $subcommand to see info on subcommands'),
('cheat god',       2, 'Syntax: .cheat god [on/off]\r\nTurn the user invulnerable.'),
('cheat casttime',  2, 'Syntax: .cheat casttime [on/off]\r\nRemove spells\' casting time.'),
('cheat cooldown',  2, 'Syntax: .cheat cooldown [on/off]\r\nDisable spells\' cooldowns.'),
('cheat power',     2, 'Syntax: .cheat power [on/off]\r\nRemove spells\' cost (mana, energy, rage...).'),
('cheat waterwalk', 2, 'Syntax: .cheat waterwalk on/off\r\nAllow to walk on water (self or selected character).'),
('cheat explore',   2, 'Syntax: .cheat explore #flag\r\nReveal or hide all maps for the selected player. If no player is selected, hide or reveal maps to you.\r\nUse a #flag value of 1 to reveal, use a #flag value of 0 to hide all maps.'),
('cheat taxi',      2, 'Syntax: .cheat taxi on/off\r\nTemporary grant access to all taxi routes for the selected character.\r\n If no character is selected, hide or reveal all routes to you. Visited taxi nodes are still accessible after removing access.');
```

##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
