### PR TITLE
feat(SmartAI): import SMART_EVENT_FLAG_WHILE_CHARMED from TC

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1549656664508341873.sql
+++ b/data/sql/updates/pending_db_world/rev_1549656664508341873.sql
@@ -1,0 +1,34 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1549656664508341873');
+
+-- Set "execute event while charmed" flag on all events except:
+-- 1) movement actions
+-- 2) nontriggered cast actions
+-- 3) talk/emote/sound actions
+-- 4) ally summon actions
+UPDATE `smart_scripts` SET `event_flags`=(`event_flags`|0x200) WHERE `source_type`=0 AND
+  (`action_type` not in (1,4,5,10,11,12,17,25,27,38,39,40,49,62,69,84,85,86,89,92,97,103,107,114) OR
+   (`action_type` in (11,86) AND (`action_param2`&2)=2));
+
+
+-- QUEST FIXES:
+
+-- Seeds of Chaos (13172)
+UPDATE `smart_scripts` SET `event_flags`=(`event_flags`|0x200) WHERE `source_type`=0 AND `entryorguid`=31157;
+UPDATE `smart_scripts` SET `event_type`=29, `comment`='Skeletal Assault Gryphon - On Charmed - Start Waypoint'
+  WHERE `source_type`=0 AND `entryorguid`=31157 AND `id`=0;
+
+-- Generosity Abounds (13146)
+UPDATE `smart_scripts` SET `event_flags`=(`event_flags`|0x200) WHERE `source_type`=0 AND `entryorguid`=30894;
+
+-- Battling the Elements (12967)
+UPDATE `smart_scripts` SET `event_flags`=(`event_flags`|0x200) WHERE `source_type`=0 AND `entryorguid`=30124;
+
+-- Krolmir, Hammer of Storms (13010)
+UPDATE `smart_scripts` SET `event_flags`=(`event_flags`|0x200) WHERE `source_type`=0 AND `entryorguid`=30331;
+UPDATE `smart_scripts` SET `event_type`=29 WHERE `source_type`=0 AND `entryorguid`=30331 AND `id`=0;
+UPDATE `smart_scripts` SET `target_type`=23 WHERE `source_type`=0 AND `entryorguid`=30331 AND `id`=1;
+UPDATE `smart_scripts` SET `event_flags`=(`event_flags`|0x200) WHERE `source_type`=9 AND `entryorguid`=3033100;
+
+-- Spy Hunter (12994)
+UPDATE `smart_scripts` SET `event_flags`=(`event_flags`|0x200) WHERE `source_type`=0 AND `entryorguid`=30219;
+UPDATE `smart_scripts` SET `event_flags`=(`event_flags`|0x200) WHERE `source_type`=9 AND `entryorguid` IN (3021900,3021901,3021902);

--- a/data/sql/updates/pending_db_world/rev_1549656664508341873.sql
+++ b/data/sql/updates/pending_db_world/rev_1549656664508341873.sql
@@ -1,5 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1549656664508341873');
 
+-- From: https://github.com/TrinityCore/TrinityCore/commit/96f90381e3ed696861354ea4ddf4ac0c495031c5
+
 -- Set "execute event while charmed" flag on all events except:
 -- 1) movement actions
 -- 2) nontriggered cast actions
@@ -32,3 +34,40 @@ UPDATE `smart_scripts` SET `event_flags`=(`event_flags`|0x200) WHERE `source_typ
 -- Spy Hunter (12994)
 UPDATE `smart_scripts` SET `event_flags`=(`event_flags`|0x200) WHERE `source_type`=0 AND `entryorguid`=30219;
 UPDATE `smart_scripts` SET `event_flags`=(`event_flags`|0x200) WHERE `source_type`=9 AND `entryorguid` IN (3021900,3021901,3021902);
+
+
+-- From: 0f7efc86d066ed614fa7b192da81c48d586f8b85
+-- Fix Jewelcrafting stone statues for charm SAI changes
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (18372,18738) AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`event_type`,`event_chance`,`action_type`,`action_param1`,`target_type`,`comment`) VALUES
+(18372,0,1,100,11,32253,23,'Rough Stone Statue - OOC - Cast "Stone Healing"'),
+(18738,0,1,100,11,32792,23,'Primal Stone Statue - OOC - Cast "Stone Healing"');
+UPDATE `creature_template` SET `AIName`='SmartAI',`ScriptName`='' WHERE `entry` IN (18372,18738);
+UPDATE `smart_scripts` SET `event_flags`=(`event_flags`|0x200) WHERE `entryorguid` IN (18372,18734,18735,18736,18737,18738) AND `source_type`=0;
+
+-- Always for SMART_EVENT_JUST_SUMMONED (Creature can be summoned already charmed by player ie TempSummons)
+UPDATE `smart_scripts` SET `event_flags`=`event_flags`|0x200 WHERE `source_type` = 0 AND `event_type`=54;
+
+
+-- From: https://github.com/TrinityCore/TrinityCore/commit/3e596376a7fae9fd585fac12e5122fd8f1b7ce14
+
+-- Event linked actions (Many levels of linked calls, do 8 times)
+UPDATE `smart_scripts` `ss` LEFT JOIN `smart_scripts` `ssl` ON `ss`.`entryorguid` = `ssl`.`entryorguid` AND `ss`.`source_type` = `ssl`.`source_type` AND `ss`.`id` = `ssl`.`link` SET `ss`.`event_flags`=`ss`.`event_flags`|0x200 WHERE `ss`.`source_type`=0 AND
+    `ss`.`event_type` = 61 AND (`ssl`.`event_flags` & 0x200) != 0;
+UPDATE `smart_scripts` `ss` LEFT JOIN `smart_scripts` `ssl` ON `ss`.`entryorguid` = `ssl`.`entryorguid` AND `ss`.`source_type` = `ssl`.`source_type` AND `ss`.`id` = `ssl`.`link` SET `ss`.`event_flags`=`ss`.`event_flags`|0x200 WHERE `ss`.`source_type`=0 AND
+    `ss`.`event_type` = 61 AND (`ssl`.`event_flags` & 0x200) != 0;
+UPDATE `smart_scripts` `ss` LEFT JOIN `smart_scripts` `ssl` ON `ss`.`entryorguid` = `ssl`.`entryorguid` AND `ss`.`source_type` = `ssl`.`source_type` AND `ss`.`id` = `ssl`.`link` SET `ss`.`event_flags`=`ss`.`event_flags`|0x200 WHERE `ss`.`source_type`=0 AND
+    `ss`.`event_type` = 61 AND (`ssl`.`event_flags` & 0x200) != 0;
+UPDATE `smart_scripts` `ss` LEFT JOIN `smart_scripts` `ssl` ON `ss`.`entryorguid` = `ssl`.`entryorguid` AND `ss`.`source_type` = `ssl`.`source_type` AND `ss`.`id` = `ssl`.`link` SET `ss`.`event_flags`=`ss`.`event_flags`|0x200 WHERE `ss`.`source_type`=0 AND
+    `ss`.`event_type` = 61 AND (`ssl`.`event_flags` & 0x200) != 0;
+UPDATE `smart_scripts` `ss` LEFT JOIN `smart_scripts` `ssl` ON `ss`.`entryorguid` = `ssl`.`entryorguid` AND `ss`.`source_type` = `ssl`.`source_type` AND `ss`.`id` = `ssl`.`link` SET `ss`.`event_flags`=`ss`.`event_flags`|0x200 WHERE `ss`.`source_type`=0 AND
+    `ss`.`event_type` = 61 AND (`ssl`.`event_flags` & 0x200) != 0;
+UPDATE `smart_scripts` `ss` LEFT JOIN `smart_scripts` `ssl` ON `ss`.`entryorguid` = `ssl`.`entryorguid` AND `ss`.`source_type` = `ssl`.`source_type` AND `ss`.`id` = `ssl`.`link` SET `ss`.`event_flags`=`ss`.`event_flags`|0x200 WHERE `ss`.`source_type`=0 AND
+    `ss`.`event_type` = 61 AND (`ssl`.`event_flags` & 0x200) != 0;
+UPDATE `smart_scripts` `ss` LEFT JOIN `smart_scripts` `ssl` ON `ss`.`entryorguid` = `ssl`.`entryorguid` AND `ss`.`source_type` = `ssl`.`source_type` AND `ss`.`id` = `ssl`.`link` SET `ss`.`event_flags`=`ss`.`event_flags`|0x200 WHERE `ss`.`source_type`=0 AND
+    `ss`.`event_type` = 61 AND (`ssl`.`event_flags` & 0x200) != 0;
+UPDATE `smart_scripts` `ss` LEFT JOIN `smart_scripts` `ssl` ON `ss`.`entryorguid` = `ssl`.`entryorguid` AND `ss`.`source_type` = `ssl`.`source_type` AND `ss`.`id` = `ssl`.`link` SET `ss`.`event_flags`=`ss`.`event_flags`|0x200 WHERE `ss`.`source_type`=0 AND
+    `ss`.`event_type` = 61 AND (`ssl`.`event_flags` & 0x200) != 0;
+
+-- Vehicles
+UPDATE `smart_scripts` SET `event_flags`=`event_flags`|0x200 WHERE `source_type` = 0 AND `entryorguid` IN (SELECT `entry` FROM `creature_template` WHERE `AIName` = "SmartAI" AND `VehicleId` != 0);

--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
@@ -59,7 +59,7 @@ void npc_escortAI::AttackStart(Unit* who)
 }
 
 //see followerAI
-bool npc_escortAI::AssistPlayerInCombat(Unit* who)
+bool npc_escortAI::AssistPlayerInCombatAgainst(Unit* who)
 {
     if (!who || !who->GetVictim())
         return false;
@@ -92,7 +92,7 @@ void npc_escortAI::MoveInLineOfSight(Unit* who)
         return;
 
     if (!me->HasUnitState(UNIT_STATE_STUNNED) && who->isTargetableForAttack(true, me) && who->isInAccessiblePlaceFor(me))
-        if (HasEscortState(STATE_ESCORT_ESCORTING) && AssistPlayerInCombat(who))
+        if (HasEscortState(STATE_ESCORT_ESCORTING) && AssistPlayerInCombatAgainst(who))
             return;
 
     if (me->CanStartAttack(who))

--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.h
@@ -101,7 +101,7 @@ struct npc_escortAI : public ScriptedAI
         Player* GetPlayerForEscort() { return ObjectAccessor::GetPlayer(*me, m_uiPlayerGUID); }
 
     private:
-        bool AssistPlayerInCombat(Unit* who);
+        bool AssistPlayerInCombatAgainst(Unit* who);
         bool IsPlayerOrGroupInRange();
         void FillPointMovementListForCreature();
 

--- a/src/server/game/AI/ScriptedAI/ScriptedFollowerAI.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedFollowerAI.cpp
@@ -52,7 +52,7 @@ void FollowerAI::AttackStart(Unit* who)
 //This part provides assistance to a player that are attacked by who, even if out of normal aggro range
 //It will cause me to attack who that are attacking _any_ player (which has been confirmed may happen also on offi)
 //The flag (type_flag) is unconfirmed, but used here for further research and is a good candidate.
-bool FollowerAI::AssistPlayerInCombat(Unit* who)
+bool FollowerAI::AssistPlayerInCombatAgainst(Unit* who)
 {
     if (!who || !who->GetVictim())
         return false;
@@ -85,7 +85,7 @@ void FollowerAI::MoveInLineOfSight(Unit* who)
         return;
 
     if (!me->HasUnitState(UNIT_STATE_STUNNED) && who->isTargetableForAttack(true, me) && who->isInAccessiblePlaceFor(me))
-        if (HasFollowState(STATE_FOLLOW_INPROGRESS) && AssistPlayerInCombat(who))
+        if (HasFollowState(STATE_FOLLOW_INPROGRESS) && AssistPlayerInCombatAgainst(who))
             return;
 
     if (me->CanStartAttack(who))

--- a/src/server/game/AI/ScriptedAI/ScriptedFollowerAI.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedFollowerAI.h
@@ -56,7 +56,7 @@ class FollowerAI : public ScriptedAI
         void AddFollowState(uint32 uiFollowState) { m_uiFollowState |= uiFollowState; }
         void RemoveFollowState(uint32 uiFollowState) { m_uiFollowState &= ~uiFollowState; }
 
-        bool AssistPlayerInCombat(Unit* who);
+        bool AssistPlayerInCombatAgainst(Unit* who);
 
         uint64 m_uiLeaderGUID;
         uint32 m_uiUpdateFollowTimer;

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -60,6 +60,7 @@ SmartAI::SmartAI(Creature* c) : CreatureAI(c)
     mFollowArrivedTimer = 0;
     mInvincibilityHpLevel = 0;
 
+    mIsCharmed = false;
     mJustReset = false;
 
     // Xinef: Vehicle conditions
@@ -857,9 +858,6 @@ void SmartAI::SummonedCreatureDespawn(Creature* unit)
     GetScript()->ProcessEventsFor(SMART_EVENT_SUMMON_DESPAWNED, unit);
 }
 
-void SmartAI::UpdateAIWhileCharmed(const uint32 /*diff*/)
-{
-}
 
 void SmartAI::CorpseRemoved(uint32& respawnDelay)
 {

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -908,7 +908,7 @@ void SmartAI::InitializeAI()
     }
 }
 
-void SmartAI::OnCharmed(bool apply)
+void SmartAI::OnCharmed(bool /*apply*/)
 {
     bool const charmed = me->IsCharmed();
     if (charmed) // do this before we change charmed state, as charmed state might prevent these things from processing

--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -219,7 +219,7 @@ class SmartAI : public CreatureAI
         bool mForcedPaused;
         uint32 mInvincibilityHpLevel;
 
-        bool AssistPlayerInCombat(Unit* who);
+        bool AssistPlayerInCombatAgainst(Unit* who);
 
         uint32 mDespawnTime;
         uint32 mDespawnState;

--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -37,6 +37,9 @@ class SmartAI : public CreatureAI
         ~SmartAI(){};
         explicit SmartAI(Creature* c);
 
+        // Check whether we are currently permitted to make the creature take action
+        bool IsAIControlled() const;
+
         // Start moving to the desired MovePoint
         void StartPath(bool run = false, uint32 path = 0, bool repeat = false, Unit* invoker = NULL);
         bool LoadPath(uint32 entry);
@@ -120,9 +123,6 @@ class SmartAI : public CreatureAI
         // called when the corpse of this creature gets removed
         void CorpseRemoved(uint32& respawnDelay);
 
-        // Called at World update tick if creature is charmed
-        void UpdateAIWhileCharmed(const uint32 diff);
-
         // Called when a Player/Creature enters the creature (vehicle)
         void PassengerBoarded(Unit* who, int8 seatId, bool apply);
 
@@ -190,6 +190,7 @@ class SmartAI : public CreatureAI
         void SetForcedCombatMove(float dist);
 
     private:
+        bool mIsCharmed;
         uint32 mFollowCreditType;
         uint32 mFollowArrivedTimer;
         uint32 mFollowCredit;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -135,7 +135,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
     //calc random
     if (e.GetEventType() != SMART_EVENT_LINK && e.event.event_chance < 100 && e.event.event_chance)
     {
-        uint32 rnd = urand(0, 100);
+        uint32 rnd = urand(1, 100);
         if (e.event.event_chance <= rnd)
             return;
     }
@@ -3433,6 +3433,9 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
     if ((e.event.event_phase_mask && !IsInPhase(e.event.event_phase_mask)) || ((e.event.event_flags & SMART_EVENT_FLAG_NOT_REPEATABLE) && e.runOnce))
         return;
 
+    if (!(e.event.event_flags & SMART_EVENT_FLAG_WHILE_CHARMED) && IsCreature(me) && !IsCreatureInControlOfSelf(me))
+        return;
+
     switch (e.GetEventType())
     {
     case SMART_EVENT_LINK://special handling
@@ -3582,12 +3585,17 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
         ProcessTimedAction(e, e.event.aura.repeatMin, e.event.aura.repeatMax);
         break;
     }
+    case SMART_EVENT_CHARMED:
+    {
+        if (bvar == (e.event.charm.onRemove != 1))
+            ProcessAction(e, unit, var0, var1, bvar, spell, gob);
+        break;
+    }
     //no params
     case SMART_EVENT_AGGRO:
     case SMART_EVENT_DEATH:
     case SMART_EVENT_EVADE:
     case SMART_EVENT_REACHED_HOME:
-    case SMART_EVENT_CHARMED:
     case SMART_EVENT_CHARMED_TARGET:
     case SMART_EVENT_CORPSE_REMOVED:
     case SMART_EVENT_AI_INIT:

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3433,7 +3433,7 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
     if ((e.event.event_phase_mask && !IsInPhase(e.event.event_phase_mask)) || ((e.event.event_flags & SMART_EVENT_FLAG_NOT_REPEATABLE) && e.runOnce))
         return;
 
-    if (!(e.event.event_flags & SMART_EVENT_FLAG_WHILE_CHARMED) && IsCreature(me) && !IsCreatureInControlOfSelf(me))
+    if (!(e.event.event_flags & SMART_EVENT_FLAG_WHILE_CHARMED) && IsCharmedCreature(me))
         return;
 
     switch (e.GetEventType())

--- a/src/server/game/AI/SmartScripts/SmartScript.h
+++ b/src/server/game/AI/SmartScripts/SmartScript.h
@@ -67,12 +67,15 @@ class SmartScript
             return obj && obj->IsInWorld() && obj->GetTypeId() == TYPEID_UNIT;
         }
 
-        static bool IsCreatureInControlOfSelf(WorldObject* obj)
+        static bool IsCharmedCreature(WorldObject* obj)
         {
-            if (Creature* creatureObj = obj ? obj->ToCreature() : nullptr)
-                return !creatureObj->IsCharmed() && !creatureObj->IsControlledByPlayer();
-            else
+            if (!obj)
                 return false;
+
+            if (Creature* creatureObj = obj->ToCreature())
+                return creatureObj->IsCharmed();
+
+            return false;
         }
 
         static bool IsGameObject(WorldObject* obj)

--- a/src/server/game/AI/SmartScripts/SmartScript.h
+++ b/src/server/game/AI/SmartScripts/SmartScript.h
@@ -52,22 +52,30 @@ class SmartScript
             return obj;
         }
 
-        bool IsUnit(WorldObject* obj)
+        static bool IsUnit(WorldObject* obj)
         {
             return obj && obj->IsInWorld() && (obj->GetTypeId() == TYPEID_UNIT || obj->GetTypeId() == TYPEID_PLAYER);
         }
 
-        bool IsPlayer(WorldObject* obj)
+        static bool IsPlayer(WorldObject* obj)
         {
             return obj && obj->IsInWorld() && obj->GetTypeId() == TYPEID_PLAYER;
         }
 
-        bool IsCreature(WorldObject* obj)
+        static bool IsCreature(WorldObject* obj)
         {
             return obj && obj->IsInWorld() && obj->GetTypeId() == TYPEID_UNIT;
         }
 
-        bool IsGameObject(WorldObject* obj)
+        static bool IsCreatureInControlOfSelf(WorldObject* obj)
+        {
+            if (Creature* creatureObj = obj ? obj->ToCreature() : nullptr)
+                return !creatureObj->IsCharmed() && !creatureObj->IsControlledByPlayer();
+            else
+                return false;
+        }
+
+        static bool IsGameObject(WorldObject* obj)
         {
             return obj && obj->IsInWorld() && obj->GetTypeId() == TYPEID_GAMEOBJECT;
         }

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -117,7 +117,7 @@ enum SMART_EVENT
     SMART_EVENT_IC_LOS                   = 26,      // NoHostile, MaxRnage, CooldownMin, CooldownMax
     SMART_EVENT_PASSENGER_BOARDED        = 27,      // CooldownMin, CooldownMax
     SMART_EVENT_PASSENGER_REMOVED        = 28,      // CooldownMin, CooldownMax
-    SMART_EVENT_CHARMED                  = 29,      // NONE
+    SMART_EVENT_CHARMED                  = 29,      // onRemove (0 - on apply, 1 - on remove)
     SMART_EVENT_CHARMED_TARGET           = 30,      // NONE
     SMART_EVENT_SPELLHIT_TARGET          = 31,      // SpellID, School, CooldownMin, CooldownMax
     SMART_EVENT_DAMAGED                  = 32,      // MinDmg, MaxDmg, CooldownMin, CooldownMax
@@ -279,6 +279,11 @@ struct SmartEvent
             uint32 repeatMin;
             uint32 repeatMax;
         } aura;
+
+        struct
+        {
+            uint32 onRemove;
+        } charm;
 
         struct
         {
@@ -1500,9 +1505,10 @@ enum SmartEventFlags
     SMART_EVENT_FLAG_RESERVED_6            = 0x040,
     SMART_EVENT_FLAG_DEBUG_ONLY            = 0x080,                     //Event only occurs in debug build
     SMART_EVENT_FLAG_DONT_RESET            = 0x100,                     //Event will not reset in SmartScript::OnReset()
+    SMART_EVENT_FLAG_WHILE_CHARMED         = 0x200,                     //Event occurs even if AI owner is charmed
 
     SMART_EVENT_FLAG_DIFFICULTY_ALL        = (SMART_EVENT_FLAG_DIFFICULTY_0|SMART_EVENT_FLAG_DIFFICULTY_1|SMART_EVENT_FLAG_DIFFICULTY_2|SMART_EVENT_FLAG_DIFFICULTY_3),
-    SMART_EVENT_FLAGS_ALL                  = (SMART_EVENT_FLAG_NOT_REPEATABLE|SMART_EVENT_FLAG_DIFFICULTY_ALL|SMART_EVENT_FLAG_RESERVED_5|SMART_EVENT_FLAG_RESERVED_6|SMART_EVENT_FLAG_DEBUG_ONLY|SMART_EVENT_FLAG_DONT_RESET)
+    SMART_EVENT_FLAGS_ALL                  = (SMART_EVENT_FLAG_NOT_REPEATABLE|SMART_EVENT_FLAG_DIFFICULTY_ALL|SMART_EVENT_FLAG_RESERVED_5|SMART_EVENT_FLAG_RESERVED_6|SMART_EVENT_FLAG_DEBUG_ONLY|SMART_EVENT_FLAG_DONT_RESET|SMART_EVENT_FLAG_WHILE_CHARMED)
 };
 
 enum SmartCastFlags


### PR DESCRIPTION
**NOTE: this PR needs to be carefully tested since it affects many things**

---------

This PR implements `SMART_EVENT_FLAG_WHILE_CHARMED` by importing/adapting the following commits from TC (by Treeston and Ariel-):

* [TrinityCore/TrinityCore@96f9038](https://github.com/TrinityCore/TrinityCore/commit/96f90381e3ed696861354ea4ddf4ac0c495031c5)
* [TrinityCore/TrinityCore@a4623ef](https://github.com/TrinityCore/TrinityCore/commit/a4623efaa67be1cfea19e561be83f118a784b9d1)
* [TrinityCore/TrinityCore@3e59637](https://github.com/TrinityCore/TrinityCore/commit/3e596376a7fae9fd585fac12e5122fd8f1b7ce14)
* [TrinityCore/TrinityCore@0f7efc8](https://github.com/TrinityCore/TrinityCore/commit/0f7efc86d066ed614fa7b192da81c48d586f8b85)

- Closes: https://github.com/azerothcore/azerothcore-wotlk/issues/731
- Updates https://github.com/azerothcore/azerothcore-wotlk/issues/1372

## Original description:

Original PR here: https://github.com/TrinityCore/TrinityCore/pull/17738

Scripts/SmartScripts: Fix charmed behavior for SmartAI. 

- Core AI logic will no longer issue attack/movement commands while under player control.
- Add new `SMART_EVENT_FLAG_WHILE_CHARMED` (`0x200`). Any event without this flag won't run while charmed.
- Add `SMART_EVENT_FLAG_WHILE_CHARMED` to existing actions, except a select subset (movement, talking, and nontriggered casts, pretty much)

Note for quest fixes: **no claim to completeness**

## How to test

Basically this PR changes the default behaviour of all smart scripts except for the ones marked as   `SMART_EVENT_FLAG_WHILE_CHARMED` . So it needs to be properly checked.

To have an idea about what needs to be tested, I recommend to:

- Read the original PR discussions (as well as comments in the imported commits)
- Carefully check the SQL file introduced in this PR to better understand what's going on

