### PR TITLE
DB/Quest: Fixes for opened Quest issues

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1549809565412286900.sql
+++ b/data/sql/updates/pending_db_world/rev_1549809565412286900.sql
@@ -1,0 +1,34 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1549809565412286900');
+
+-- Ironband's excavation and gathering idols quest fix
+UPDATE `quest_template_addon` SET `PrevQuestID`='436' WHERE `ID`=297;
+
+-- Find bingles and bingles missing supplies quest fix
+UPDATE `quest_template_addon` SET `PrevQuestID`='2039' WHERE `ID`=2038;
+
+-- Data rescue quest fix
+DELETE FROM conditions WHERE SourceTypeOrReferenceId=15 AND SourceGroup=1050;
+INSERT INTO conditions VALUES (15, 1052, 0, 0, 0, 2, 0, 9281, 1, 0, 0, 0, 0, '', 'Display option if player has red card');
+INSERT INTO conditions VALUES (15, 1052, 1, 0, 0, 2, 0, 9281, 1, 0, 0, 0, 0, '', 'Display option if player has red card');
+INSERT INTO conditions VALUES (15, 1052, 1, 0, 0, 2, 0, 9327, 1, 0, 0, 0, 0, '', 'Display option if player has delta card');
+INSERT INTO conditions VALUES (15, 1052, 1, 0, 0, 25, 0, 3959, 0, 0, 1, 0, 0, '', 'Display option if player has no Discombobulator Ray spell');
+
+-- Fixed the SmartAI scripts for Cursed and Tainted Ooze - The corpse must disappear on Spell Hit
+UPDATE `creature_template` SET `AIName`='SmartAI' WHERE  `entry`=7086;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=7086 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+(7086, 0, 0, 0, 8, 0, 100, 1, 15698, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Cursed Ooze - On Spell Hit (Filling Empty Jar) - Despawn');
+
+-- Tainted Ooze SAI
+UPDATE `creature_template` SET `AIName`='SmartAI' WHERE  `entry`=7092;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=7092 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+(7092, 0, 0, 0, 8, 0, 100, 1, 15699, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Tainted Ooze - On Spell Hit (Filling Empty Jar) - Despawn'),
+(7092, 0, 1, 0, 9, 0, 100, 0, 0, 5, 180000, 180000,11,3335,0,0,0,0,0,2,0,0,0,0,0,0,0,"Tainted Ooze - Within 0-5 Range - Cast 'Dark Sludge'");
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=17 AND `SourceEntry` IN (15698,15699);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`SourceId`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionTarget`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`NegativeCondition`,`ErrorType`,`ErrorTextId`,`ScriptName`,`Comment`) VALUES 
+(17, 0, 15698, 0, 0, 31, 1, 3, 7086, 0, 0, 0, 0, '', "'Filling Empty Jar' must target Cursed Ooze"),
+(17, 0, 15698, 0, 0, 36, 1, 0,    0, 0, 1, 0, 0, '', "'Filling Empty Jar' - Target must be dead"),
+(17, 0, 15699, 0, 0, 31, 1, 3, 7092, 0, 0, 0, 0, '', "'Filling Empty Jar' must target Tainted Ooze"),
+(17, 0, 15699, 0, 0, 36, 1, 0,    0, 0, 1, 0, 0, '', "'Filling Empty Jar' - Target must be dead");

--- a/data/sql/updates/pending_db_world/rev_1549809565412286900.sql
+++ b/data/sql/updates/pending_db_world/rev_1549809565412286900.sql
@@ -6,13 +6,6 @@ UPDATE `quest_template_addon` SET `PrevQuestID`='436' WHERE `ID`=297;
 -- Find bingles and bingles missing supplies quest fix
 UPDATE `quest_template_addon` SET `PrevQuestID`='2039' WHERE `ID`=2038;
 
--- Data rescue quest fix
-DELETE FROM conditions WHERE SourceTypeOrReferenceId=15 AND SourceGroup=1050;
-INSERT INTO conditions VALUES (15, 1052, 0, 0, 0, 2, 0, 9281, 1, 0, 0, 0, 0, '', 'Display option if player has red card');
-INSERT INTO conditions VALUES (15, 1052, 1, 0, 0, 2, 0, 9281, 1, 0, 0, 0, 0, '', 'Display option if player has red card');
-INSERT INTO conditions VALUES (15, 1052, 1, 0, 0, 2, 0, 9327, 1, 0, 0, 0, 0, '', 'Display option if player has delta card');
-INSERT INTO conditions VALUES (15, 1052, 1, 0, 0, 25, 0, 3959, 0, 0, 1, 0, 0, '', 'Display option if player has no Discombobulator Ray spell');
-
 -- Fixed the SmartAI scripts for Cursed and Tainted Ooze - The corpse must disappear on Spell Hit
 UPDATE `creature_template` SET `AIName`='SmartAI' WHERE  `entry`=7086;
 DELETE FROM `smart_scripts` WHERE `entryorguid`=7086 AND `source_type`=0;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: https://github.com/azerothcore/azerothcore-wotlk/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
Fixes for Opened Quest issues

##### CHANGES PROPOSED:

- Ironband's excavation and gathering idols quest fix. The quest 297 can't be used without finishing quest 436.
- Find bingles and bingles missing supplies quest fix. The quest 2038 can't be used without finishing quest 2039.
- Data rescue quest fix. Added Missing options for the  Matrix Punchograph 3005-D to finish quest.
- Fixed the SmartAI scripts for Cursed and Tainted Ooze - The corpse will disappear now on Spell Hit.


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1434 
Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1428
Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1425


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
The Sql is imported without any errors. Tested in game, the Quest and listed quest issues are fixed, and can be done without any problems.


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

> 1.  .add quest 4512
>  .go creature 39443 and use both items on corpse - The corpse must dissaper while using item
>  .go creature 39427 and use both items on corpse - The corpse must dissaper while using item

> 2.   .go creature 8197  &  .quest add 2039 (1st quest Find Bingles)
> .go creature 26 ( 2nd quest Bingles' Missing Supplies can't be used without completing quest ( Find Bingles- 2039) )

> 3. .go creature 8200
> .go creature 8746
>  ( The quest 267 Gathering Idols can't be used if you didn't finish the quest Ironband's Excavation 436 )


##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
