### PR TITLE
chore(BG): change default MinPlayersPerTeam for new servers

### DIFF
--- a/data/sql/base/db_world/battleground_template.sql
+++ b/data/sql/base/db_world/battleground_template.sql
@@ -30,18 +30,18 @@ LOCK TABLES `battleground_template` WRITE;
 /*!40000 ALTER TABLE `battleground_template` DISABLE KEYS */;
 INSERT INTO `battleground_template` VALUES 
 (1,20,40,51,80,611,3.16312,610,0.715504,100,1,'','Alterac Valley'),
-(2,5,10,10,80,769,3.14159,770,0.151581,75,1,'','Warsong Gulch'),
-(3,8,15,20,80,890,3.91571,889,0.813671,75,1,'','Arathi Basin'),
+(2,2,10,10,80,769,3.14159,770,0.151581,75,1,'','Warsong Gulch'),
+(3,5,15,20,80,890,3.91571,889,0.813671,75,1,'','Arathi Basin'),
 (4,0,5,10,80,929,0,936,3.14159,0,1,'','Nagrand Arena'),
 (5,0,5,10,80,939,0,940,3.14159,0,1,'','Blades\'s Edge Arena'),
 (6,0,5,10,80,0,0,0,0,0,1,'','All Arena'),
-(7,8,15,61,80,1103,3.03123,1104,0.055761,75,1,'','Eye of The Storm'),
+(7,5,15,61,80,1103,3.03123,1104,0.055761,75,1,'','Eye of The Storm'),
 (8,0,5,10,80,1258,0,1259,3.14159,0,1,'','Ruins of Lordaeron'),
-(9,7,15,71,80,1367,0,1368,0,0,1,'','Strand of the Ancients'),
+(9,5,15,71,80,1367,0,1368,0,0,1,'','Strand of the Ancients'),
 (10,0,5,10,80,1362,0,1363,3.14159,0,1,'','Dalaran Sewers'),
 (11,0,5,10,80,1364,0,1365,0,0,1,'','The Ring of Valor'),
 (30,20,40,71,80,1485,0,1486,3.16124,200,1,'','Isle of Conquest'),
-(32,10,10,80,80,0,0,0,0,0,1,'','Random battleground');
+(32,5,10,80,80,0,0,0,0,0,1,'','Random battleground');
 /*!40000 ALTER TABLE `battleground_template` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;


### PR DESCRIPTION
##### CHANGES PROPOSED:

Changed default `MinPlayersPerTeam` to more realistic values for private servers.

According to my experience as a player in small/medium servers, there is no real reason not to lower those values.

Notes:
-  For 99% of the cases, server administrator do want to lower those limits so let's just save an extra step
-  This affects only new AC setups, not existing servers
- Those values can be always changed according to the user's preference

##### TESTS PERFORMED:

The query runs

##### HOW TO TEST THE CHANGES:

Trivial change, no tests needed.

##### Target branch(es):

Master
