### PR TITLE
fix(Bash/Exporter): correct path + add prompt to prevent user to use it by mistake

### DIFF
--- a/apps/db_exporter/db_export.sh
+++ b/apps/db_exporter/db_export.sh
@@ -8,6 +8,13 @@ if [ -f "./config.sh"  ]; then
     source "./config.sh" # should overwrite previous
 fi
 
+echo "This is a dev-only procedure to export the DB into the SQL base files. All base files will be overwritten."
+read -p "Are you sure you want to continue (y/N)? " choice
+case "$choice" in
+  y|Y ) echo "Exporting the DB into the SQL base files...";;
+  * ) return;;
+esac
+
 echo "===== STARTING PROCESS ====="
 
 
@@ -34,7 +41,7 @@ function export() {
     base_name=${!var_base_name}
 
 
-    bash $AC_PATH_MODULES"/drassil/mysql-tools/mysql-tools" dump "" $base_name "" "$base_conf"
+    bash $AC_PATH_DEPS"/drassil/mysql-tools/mysql-tools" dump "" $base_name "" "$base_conf"
 }
 
 for db in ${DATABASES[@]}

--- a/bin/acore-db-export
+++ b/bin/acore-db-export
@@ -2,4 +2,4 @@
 
 CUR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-source "$CUR_PATH/../apps/db_exporter/db_exporter.sh"
+source "$CUR_PATH/../apps/db_exporter/db_export.sh"


### PR DESCRIPTION
This tool is for developers-only and it's not supposed to be used by users. Test is not required for this PR.

- Fixed bad path
- Prompt the user before actually executing, since this scripts overrides the DB base files.