### PR TITLE
Core/ICC: Lord marrowgar, bone storm target selection

### DIFF
--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -200,7 +200,7 @@ class UnitAI
 
             ThreatContainer::StorageType const& threatlist = me->getThreatManager().getThreatList();
             if (position >= threatlist.size())
-                return NULL;
+                return nullptr;
 
             std::list<Unit*> targetList;
             for (ThreatContainer::StorageType::const_iterator itr = threatlist.begin(); itr != threatlist.end(); ++itr)
@@ -208,7 +208,7 @@ class UnitAI
                     targetList.push_back((*itr)->getTarget());
 
             if (position >= targetList.size())
-                return NULL;
+                return nullptr;
 
             if (targetType == SELECT_TARGET_NEAREST || targetType == SELECT_TARGET_FARTHEST || targetType == SELECT_TARGET_FARTHEST_RANDOM)
                 targetList.sort(Trinity::ObjectDistanceOrderPred(me));
@@ -245,7 +245,7 @@ class UnitAI
                     break;
             }
 
-            return NULL;
+            return nullptr;
         }
 
         void SelectTargetList(std::list<Unit*>& targetList, uint32 num, SelectAggroTarget targetType, float dist = 0.0f, bool playerOnly = false, int32 aura = 0);

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -196,7 +196,9 @@ class UnitAI
         template <class PREDICATE> Unit* SelectTarget(SelectAggroTarget targetType, uint32 position, PREDICATE const& predicate)
         {
             ThreatContainer::StorageType const& threatlist = me->getThreatManager().getThreatList();
-            if (position >= threatlist.size())
+            if (targetType != SELECT_TARGET_FARTHEST_RANDOM && position >= threatlist.size())
+                return NULL;
+            else if (targetType == SELECT_TARGET_FARTHEST_RANDOM && position > threatlist.size())
                 return NULL;
 
             std::list<Unit*> targetList;
@@ -204,10 +206,12 @@ class UnitAI
                 if (predicate((*itr)->getTarget()))
                     targetList.push_back((*itr)->getTarget());
 
-            if (position >= targetList.size())
+            if (targetType != SELECT_TARGET_FARTHEST_RANDOM && position >= threatlist.size())
+                return NULL;
+            else if (targetType == SELECT_TARGET_FARTHEST_RANDOM && position > threatlist.size())
                 return NULL;
 
-            if (targetType == SELECT_TARGET_NEAREST || targetType == SELECT_TARGET_FARTHEST)
+            if (targetType == SELECT_TARGET_NEAREST || targetType == SELECT_TARGET_FARTHEST || targetType == SELECT_TARGET_FARTHEST_RANDOM)
                 targetList.sort(Trinity::ObjectDistanceOrderPred(me));
 
             switch (targetType)
@@ -235,7 +239,7 @@ class UnitAI
                 case SELECT_TARGET_FARTHEST_RANDOM:
                 {
                     std::list<Unit*>::reverse_iterator ritr = targetList.rbegin();
-                    std::advance(ritr, urand(0, std::max(position - 1, targetList.size() - 1));
+                    std::advance(ritr, urand(0, std::max(0, position - 1)));
                     return *ritr;
                 }
                 default:

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -195,7 +195,7 @@ class UnitAI
         // predicate shall extend std::unary_function<Unit*, bool>
         template <class PREDICATE> Unit* SelectTarget(SelectAggroTarget targetType, uint32 position, PREDICATE const& predicate)
         {
-            if (targetType == SELECT_TARGET_FARTHEST_RANDOM)
+            if (targetType == SELECT_TARGET_FARTHEST_RANDOM && position != 0)
                 --position;
 
             ThreatContainer::StorageType const& threatlist = me->getThreatManager().getThreatList();

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -239,7 +239,7 @@ class UnitAI
                 case SELECT_TARGET_FARTHEST_RANDOM:
                 {
                     std::list<Unit*>::reverse_iterator ritr = targetList.rbegin();
-                    std::advance(ritr, urand(0, std::max(0, position - 1)));
+                    std::advance(ritr, position == 0 ? position : urand(0, position - 1));
                     return *ritr;
                 }
                 default:

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -196,9 +196,7 @@ class UnitAI
         template <class PREDICATE> Unit* SelectTarget(SelectAggroTarget targetType, uint32 position, PREDICATE const& predicate)
         {
             ThreatContainer::StorageType const& threatlist = me->getThreatManager().getThreatList();
-            if (targetType != SELECT_TARGET_FARTHEST_RANDOM && position >= threatlist.size())
-                return NULL;
-            else if (targetType == SELECT_TARGET_FARTHEST_RANDOM && position > threatlist.size())
+            if (position >= threatlist.size())
                 return NULL;
 
             std::list<Unit*> targetList;
@@ -206,9 +204,7 @@ class UnitAI
                 if (predicate((*itr)->getTarget()))
                     targetList.push_back((*itr)->getTarget());
 
-            if (targetType != SELECT_TARGET_FARTHEST_RANDOM && position >= threatlist.size())
-                return NULL;
-            else if (targetType == SELECT_TARGET_FARTHEST_RANDOM && position > threatlist.size())
+            if (position >= threatlist.size())
                 return NULL;
 
             if (targetType == SELECT_TARGET_NEAREST || targetType == SELECT_TARGET_FARTHEST || targetType == SELECT_TARGET_FARTHEST_RANDOM)

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -25,6 +25,7 @@ enum SelectAggroTarget
     SELECT_TARGET_BOTTOMAGGRO,                              //Selects targets from bottom aggro to top
     SELECT_TARGET_NEAREST,
     SELECT_TARGET_FARTHEST,
+    SELECT_TARGET_FARTHEST_RANDOM,
 };
 
 // default predicate function to select target based on distance, player and/or aura criteria
@@ -230,6 +231,12 @@ class UnitAI
                     std::list<Unit*>::iterator itr = targetList.begin();
                     std::advance(itr, urand(position, targetList.size() - 1));
                     return *itr;
+                }
+                case SELECT_TARGET_FARTHEST_RANDOM:
+                {
+                    std::list<Unit*>::reverse_iterator ritr = targetList.rbegin();
+                    std::advance(ritr, urand(0, std::max(position - 1, targetList.size() - 1));
+                    return *ritr;
                 }
                 default:
                     break;

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -204,7 +204,7 @@ class UnitAI
                 if (predicate((*itr)->getTarget()))
                     targetList.push_back((*itr)->getTarget());
 
-            if (position >= threatlist.size())
+            if (position >= targetList.size())
                 return NULL;
 
             if (targetType == SELECT_TARGET_NEAREST || targetType == SELECT_TARGET_FARTHEST || targetType == SELECT_TARGET_FARTHEST_RANDOM)

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -195,6 +195,9 @@ class UnitAI
         // predicate shall extend std::unary_function<Unit*, bool>
         template <class PREDICATE> Unit* SelectTarget(SelectAggroTarget targetType, uint32 position, PREDICATE const& predicate)
         {
+            if (targetType == SELECT_TARGET_FARTHEST_RANDOM)
+                --position;
+
             ThreatContainer::StorageType const& threatlist = me->getThreatManager().getThreatList();
             if (position >= threatlist.size())
                 return NULL;
@@ -235,7 +238,7 @@ class UnitAI
                 case SELECT_TARGET_FARTHEST_RANDOM:
                 {
                     std::list<Unit*>::reverse_iterator ritr = targetList.rbegin();
-                    std::advance(ritr, position == 0 ? position : urand(0, position - 1));
+                    std::advance(ritr, position == 0 ? position : urand(0, position));
                     return *ritr;
                 }
                 default:

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
@@ -208,10 +208,10 @@ class boss_lord_marrowgar : public CreatureScript
                                 break;
                             }
                             events.RepeatEvent(5000);
-                            Unit* unit = SelectTarget(SELECT_TARGET_RANDOM, 0, BoneStormMoveTargetSelector(me));
+                            Unit* unit = SelectTarget(SELECT_TARGET_FARTHEST_RANDOM, RAID_MODE<uint32>(2, 4, 2, 4), BoneStormMoveTargetSelector(me));
                             if (!unit)
                             {
-                                if ((unit = SelectTarget(SELECT_TARGET_TOPAGGRO, 0, 175.0f, true)))
+                                if ((unit = SelectTarget(SELECT_TARGET_FARTHEST_RANDOM, RAID_MODE<uint32>(4, 8, 4, 8), 175.0f, true)))
                                     if (unit->GetPositionX() > -337.0f)
                                     {
                                         EnterEvadeMode();

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
@@ -211,7 +211,7 @@ class boss_lord_marrowgar : public CreatureScript
                             Unit* unit = SelectTarget(SELECT_TARGET_FARTHEST_RANDOM, RAID_MODE<uint32>(2, 4, 2, 4), BoneStormMoveTargetSelector(me));
                             if (!unit)
                             {
-                                if ((unit = SelectTarget(SELECT_TARGET_FARTHEST_RANDOM, RAID_MODE<uint32>(4, 8, 4, 8), 175.0f, true)))
+                                if ((unit = SelectTarget(SELECT_TARGET_FARTHEST_RANDOM, RAID_MODE<uint32>(1, 2, 1, 2), 175.0f, true)))
                                     if (unit->GetPositionX() > -337.0f)
                                     {
                                         EnterEvadeMode();


### PR DESCRIPTION
###### CHANGES PROPOSED:
-  Lord marrowgar will select top 2 or 4, depending on raid mode, farthest raid members during bone storm.


###### ISSUES ADDRESSED:
#786


##### TESTS PERFORMED:
None



##### HOW TO TEST THE CHANGES:
Fight this boss with more than 2 or 3 players

##### TODO
I am not sure about the numbers, had several retail videos as reference.

##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
