### PR TITLE
Scripts/Instances/Oculus: improvements

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1550579754213080400.sql
+++ b/data/sql/updates/pending_db_world/rev_1550579754213080400.sql
@@ -1,5 +1,5 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1550579754213080400');
-UPDATE `creature_template` SET `speed_walk` = 1, `speed_run` = 1 WHERE `entry` IN (27755, 27756, 27692);
+UPDATE `creature_template` SET `speed_walk` = 1.20000004768372, `speed_run` = 1 WHERE `entry` IN (27755, 27756, 27692);
 UPDATE `creature_template` SET `ScriptName` = 'npc_centrifuge_construct' WHERE `entry` = 27641;
 
 -- Spells of the dragons

--- a/data/sql/updates/pending_db_world/rev_1550579754213080400.sql
+++ b/data/sql/updates/pending_db_world/rev_1550579754213080400.sql
@@ -1,0 +1,13 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1550579754213080400');
+UPDATE `creature_template` SET `speed_walk` = 1, `speed_run` = 1 WHERE `entry` IN (27755, 27756, 27692);
+UPDATE `creature_template` SET `ScriptName` = 'npc_centrifuge_construct' WHERE `entry` = 27641;
+
+-- Spells of the dragons
+DELETE FROM `spell_script_names` WHERE spell_id IN (50241, 50325, 49460, 49464, 49346, 53797);
+INSERT INTO `spell_script_names` VALUES
+(50241, 'spell_oculus_evasive_charges'),
+(50325, 'spell_oculus_soar'),
+(49460, 'spell_oculus_rider_aura'),
+(49464, 'spell_oculus_rider_aura'),
+(49346, 'spell_oculus_rider_aura'),
+(53797, 'spell_oculus_drake_flag');

--- a/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
@@ -287,7 +287,7 @@ public:
                                     if (spell)
                                         me->CastSpell(summoner, spell, true);
                                     me->SetCanFly(true);
-                                    me->SetSpeed(MOVE_FLIGHT, me->GetSpeedRate(MOVE_RUN), true);
+                                    me->SetSpeedRate(MOVE_FLIGHT, 1.0f);
                                 }
                             }
                     }

--- a/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
@@ -329,9 +329,8 @@ public:
     {
         npc_centrifuge_constructAI(Creature *creature) : ScriptedAI(creature) {}
 
-
         void Reset() {}
-
+        
         void EnterCombat(Unit* who)
         {
             DoCast(IsHeroic() ? H_SPELL_EMPOWERING_BLOWS : SPELL_EMPOWERING_BLOWS);

--- a/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
@@ -331,12 +331,12 @@ public:
 
         void Reset() {}
         
-        void EnterCombat(Unit* who)
+        void EnterCombat(Unit* /*who*/)
         {
             DoCast(IsHeroic() ? H_SPELL_EMPOWERING_BLOWS : SPELL_EMPOWERING_BLOWS);
         }
 
-        void UpdateAI(const uint32 uiDiff)
+        void UpdateAI(uint32 diff)
         {
             if (!UpdateVictim())
                 return;

--- a/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
@@ -34,6 +34,7 @@ enum Drakes
     SPELL_SOAR_TRIGGER                      = 50325,
     SPELL_SOAR_BUFF                         = 50024,
     SPELL_SCALE_STATS                       = 66667,
+    
     // Ruby Drake
     SPELL_RUBY_EVASIVE_AURA                 = 50248,
     SPELL_RUBY_EVASIVE_MANEUVERS            = 50240,
@@ -315,19 +316,6 @@ public:
                                                 break;
                                         }
                                     }
-
-                                    uint32 spell = 0;
-                                    switch (me->GetEntry())
-                                    {
-                                        case 27692: spell = 49427; break;
-                                        case 27755: spell = 49459; break;
-                                        case 27756: spell = 49463; break;
-                                    }
-
-                                    //summoner->EnterVehicle(me);
-                                    if (spell)
-                                        me->CastSpell(summoner, spell, true);
-                                    me->SetSpeedRate(MOVE_FLIGHT, 1.0f);
                                 }
                             }
                     }
@@ -335,6 +323,7 @@ public:
                     {
                         me->DespawnOrUnsummon(2050);
                         me->SetOrientation(2.5f);
+                        me->SetSpeedRate(MOVE_FLIGHT, 1.0f);
                         Position pos = me->GetPosition();
                         Position offset = { 10.0f, 10.0f, 12.0f, 0.0f };
                         pos.RelocateOffset(offset);

--- a/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
@@ -34,7 +34,6 @@ enum Drakes
     SPELL_SOAR_TRIGGER                      = 50325,
     SPELL_SOAR_BUFF                         = 50024,
     SPELL_SCALE_STATS                       = 66667,
-    
     // Ruby Drake
     SPELL_RUBY_EVASIVE_AURA                 = 50248,
     SPELL_RUBY_EVASIVE_MANEUVERS            = 50240,
@@ -298,23 +297,19 @@ public:
                         if( me->GetVehicleKit() && me->IsSummon() )
                             if( !me->GetVehicleKit()->GetPassenger(0) )
                             {
-                                TempSummon* ts = (TempSummon*)me;
-                                if( Unit* summoner = ts->GetSummoner() )
+                                if( m_pInstance->GetData(DATA_UROM) == DONE )
                                 {
-                                    if( m_pInstance->GetData(DATA_UROM) == DONE )
+                                    switch( me->GetEntry() )
                                     {
-                                        switch( me->GetEntry() )
-                                        {
-                                            case 27692:
-                                                me->m_spells[5] = 50344;
-                                                break;
-                                            case 27755:
-                                                me->m_spells[5] = 49592;
-                                                break;
-                                            case 27756:
-                                                me->m_spells[5] = 50253;
-                                                break;
-                                        }
+                                        case 27692:
+                                            me->m_spells[5] = 50344;
+                                            break;
+                                        case 27755:
+                                            me->m_spells[5] = 49592;
+                                            break;
+                                        case 27756:
+                                            me->m_spells[5] = 50253;
+                                            break;
                                     }
                                 }
                             }

--- a/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
@@ -336,7 +336,7 @@ public:
             DoCast(IsHeroic() ? H_SPELL_EMPOWERING_BLOWS : SPELL_EMPOWERING_BLOWS);
         }
 
-        void UpdateAI(uint32 diff)
+        void UpdateAI(uint32 /*diff*/)
         {
             if (!UpdateVictim())
                 return;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!Scripts/Instances/Oculus: improvements>

##### Changes proposed:
A new feature was applied to the oculus dragons that were missing, the [drake-flag-visual](https://www.wowhead.com/spell=53797/drake-flag-visual) application after calling it

I fixed drakes flight error at the request of @comix1988 and @alexkulya using the trinitycore code

Link: https://www.youtube.com/watch?v=d6J2lH0fe28&t=327s&list=FL5HpOkw1d6zY_LtGCLSxeFg&index=11

###### Issues addressed:
after leaving any drake the parachute is not activated

###### TODO list:
-  added spell_oculus_evasive_charges
-  added spell_oculus_evasive_charges
-  added spell_oculus_soar
-  added spell_oculus_rider_aura
- added spell_oculus_drake_flag

###### Tests performed:
Tested by windows 7 operating system
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

##### [Target branch([develop](https://github.com/DesconCore/azerothcore-wotlk/tree/develop)); 3.3.5

<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
