### PR TITLE
fix(CI): break on errors in CI scripts

### DIFF
--- a/apps/ci/ci-before_install.sh
+++ b/apps/ci/ci-before_install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ "$TRAVIS_BUILD_ID" = "1" ]
 then
   export CCOMPILERC="clang-3.8"

--- a/apps/ci/ci-install.sh
+++ b/apps/ci/ci-install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo "install OS deps (apt-get)"
 bash ./acore.sh "install-deps"
 

--- a/apps/ci/ci-script.sh
+++ b/apps/ci/ci-script.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+set -e
+
 echo "compile core"
 export CCACHE_CPP2=true
 ccache -s
-timeout 2580 bash ./acore.sh "compiler" "all"
+timeout 2700 bash ./acore.sh "compiler" "all"
 ccache -s
 
 if [ "$TRAVIS_BUILD_ID" = "1" ]

--- a/apps/ci/ci-script.sh
+++ b/apps/ci/ci-script.sh
@@ -5,7 +5,7 @@ set -e
 echo "compile core"
 export CCACHE_CPP2=true
 ccache -s
-timeout 3 bash ./acore.sh "compiler" "all"
+timeout 2700 bash ./acore.sh "compiler" "all"
 ccache -s
 
 if [ "$TRAVIS_BUILD_ID" = "1" ]

--- a/apps/ci/ci-script.sh
+++ b/apps/ci/ci-script.sh
@@ -5,7 +5,7 @@ set -e
 echo "compile core"
 export CCACHE_CPP2=true
 ccache -s
-timeout 2700 bash ./acore.sh "compiler" "all"
+timeout 3 bash ./acore.sh "compiler" "all"
 ccache -s
 
 if [ "$TRAVIS_BUILD_ID" = "1" ]


### PR DESCRIPTION
##### CHANGES PROPOSED:
- currently the CI scripts don't break on errors, so Travis does not recognize problems in these scripts; fixed by adding `set -e`
- increase build timeout to 2700 seconds (45 minutes)

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
has to be tested by Travis run

##### HOW TO TEST THE CHANGES:
see above

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
