### PR TITLE
feat(CI): dynamically calculate thread count for build process

### DIFF
--- a/apps/ci/ci-install.sh
+++ b/apps/ci/ci-install.sh
@@ -19,7 +19,7 @@ echo "create config.sh"
 cat >>conf/config.sh <<CONFIG_SH
 CCOMPILERC=$CCOMPILERC
 CCOMPILERCXX=$CCOMPILERCXX
-MTHREADS=4
+MTHREADS=$(expr $(grep -c ^processor /proc/cpuinfo) + 2)
 CWARNINGS=ON
 CDEBUG=OFF
 CTYPE=Release


### PR DESCRIPTION
##### CHANGES PROPOSED:
Dynamically calculate the thread count for the build process by reading `/proc/cpuinfo` in order to be more independent from the environment.

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
has to be tested via Travis run

##### HOW TO TEST THE CHANGES:
see above

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master