### PR TITLE
Core/Skills: Add FishingBaseSkillLevel dynamic change method

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -7798,15 +7798,13 @@ void ObjectMgr::LoadFishingBaseSkillLevel()
 
 void ObjectMgr::ChangeFishingBaseSkillLevel(uint32 entry, int32 skill)
 {
-
     AreaTableEntry const* fArea = sAreaTableStore.LookupEntry(entry);
-
     if (!fArea)
     {
         sLog->outErrorDb("AreaId %u defined in `skill_fishing_base_level` does not exist", entry);
         return;
     }
-
+    
     _fishingBaseForAreaStore[entry] = skill;
 
     sLog->outString(">> Fishing base skill level of area %u changed to %u", entry, skill);

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -7796,6 +7796,23 @@ void ObjectMgr::LoadFishingBaseSkillLevel()
     sLog->outString();
 }
 
+void ObjectMgr::ChangeFishingBaseSkillLevel(uint32 entry, int32 skill)
+{
+
+    AreaTableEntry const* fArea = sAreaTableStore.LookupEntry(entry);
+
+    if (!fArea)
+    {
+        sLog->outErrorDb("AreaId %u defined in `skill_fishing_base_level` does not exist", entry);
+        return;
+    }
+
+    _fishingBaseForAreaStore[entry] = skill;
+
+    sLog->outString(">> Fishing base skill level of area %u changed to %u", entry, skill);
+    sLog->outString();
+}
+
 bool ObjectMgr::CheckDeclinedNames(std::wstring w_ownname, DeclinedName const& names)
 {
     // get main part of the name

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -1013,6 +1013,7 @@ class ObjectMgr
         void LoadPetNumber();
         void LoadCorpses();
         void LoadFishingBaseSkillLevel();
+        void ChangeFishingBaseSkillLevel(uint32 entry, int32 skill);
 
         void LoadReputationRewardRate();
         void LoadReputationOnKill();


### PR DESCRIPTION
##### CHANGES PROPOSED:
-  Added new method `ObgectMgr::ChangeFishingBaseSkillLevel(uint32 entry, int32 skill)` to change the fishing base skill level for a particular zone.

##### TESTS PERFORMED:
- [x] Tested in build Win10 x64
- [x] Tested in game

##### Target branch(es): **Master**

##### KNOWN ISSUES AND TODO LIST:
- [x] Test build in Linux (Travis)