### PR TITLE
feat(CI): add commit hashes to the automatic SQL import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   # push changes to git if any
   - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then git fetch --unshallow; fi
   - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then git checkout $TRAVIS_BRANCH; fi
-  - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [[ -n "$GITHUB_API_KEY" ]]; then git add -A . && git diff --cached --quiet || git commit -am "Import pending SQL update file (commit$COMMIT_HASH)" && git push https://$GITHUB_API_KEY@github.com/$TRAVIS_REPO_SLUG.git $TRAVIS_BRANCH; fi
+  - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [[ -n "$GITHUB_API_KEY" ]]; then git add -A . && git diff --cached --quiet || git commit -am "Import pending SQL update file..." -m "Referenced commit(s):$COMMIT_HASH" && git push https://$GITHUB_API_KEY@github.com/$TRAVIS_REPO_SLUG.git $TRAVIS_BRANCH; fi
   # sync staging with master
   - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ] && [[ -n "$GITHUB_API_KEY" ]]; then git fetch origin staging:staging && git checkout staging && git merge --no-edit master && git push https://$GITHUB_API_KEY@github.com/$TRAVIS_REPO_SLUG.git staging; git checkout master; fi
   - source ./apps/ci/ci-before_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ before_install:
   - git config user.email "azerothcorebot@gmail.com" && git config user.name "AzerothCoreBot"
   - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then cd bin/; fi
   # import pending sql
-  - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then bash acore-db-pendings; fi
+  - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then source acore-db-pendings; fi
   - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then cd ..; fi
   # push changes to git if any
   - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then git fetch --unshallow; fi
   - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then git checkout $TRAVIS_BRANCH; fi
-  - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [[ -n "$GITHUB_API_KEY" ]]; then git add -A . && git diff --cached --quiet || git commit -am "Import pending SQL update file" && git push https://$GITHUB_API_KEY@github.com/$TRAVIS_REPO_SLUG.git $TRAVIS_BRANCH; fi
+  - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [[ -n "$GITHUB_API_KEY" ]]; then git add -A . && git diff --cached --quiet || git commit -am "Import pending SQL update file (commit$COMMIT_HASH)" && git push https://$GITHUB_API_KEY@github.com/$TRAVIS_REPO_SLUG.git $TRAVIS_BRANCH; fi
   # sync staging with master
   - if [ "$TRAVIS_BUILD_ID" = "1" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ] && [[ -n "$GITHUB_API_KEY" ]]; then git fetch origin staging:staging && git checkout staging && git merge --no-edit master && git push https://$GITHUB_API_KEY@github.com/$TRAVIS_REPO_SLUG.git staging; git checkout master; fi
   - source ./apps/ci/ci-before_install.sh

--- a/apps/db_pendings/import.sh
+++ b/apps/db_pendings/import.sh
@@ -6,6 +6,8 @@ source "$CURRENT_PATH/../bash_shared/includes.sh"
 
 UPDATES_PATH="$AC_PATH_ROOT/data/sql/updates/"
 
+COMMIT_HASH=
+
 function import() {
     db=$1
     folder="db_"$db
@@ -30,8 +32,6 @@ function import() {
     if [ "$oldDate" = "$dateToday" ]; then
         ((counter=$oldCnt+1))
     fi;
-
-    COMMIT_HASH=
 
     for entry in "$pendingPath"/*.sql
     do

--- a/apps/db_pendings/import.sh
+++ b/apps/db_pendings/import.sh
@@ -31,6 +31,8 @@ function import() {
         ((counter=$oldCnt+1))
     fi;
 
+    COMMIT_HASH=
+
     for entry in "$pendingPath"/*.sql
     do
         if [[ -e $entry ]]; then
@@ -97,6 +99,7 @@ function import() {
                 echo "DROP PROCEDURE IF EXISTS \`updateDb\`;" >> "$newFile";
             fi;
 
+            COMMIT_HASH="$COMMIT_HASH $(git log --diff-filter=A "$entry" | grep "^commit " | sed -e 's/commit //')"
             rm $entry;
 
             oldDate=$dateToday

--- a/apps/db_pendings/import.sh
+++ b/apps/db_pendings/import.sh
@@ -99,7 +99,13 @@ function import() {
                 echo "DROP PROCEDURE IF EXISTS \`updateDb\`;" >> "$newFile";
             fi;
 
-            COMMIT_HASH="$COMMIT_HASH $(git log --diff-filter=A "$entry" | grep "^commit " | sort -u | sed -e 's/commit //')"
+            currentHash="$(git log --diff-filter=A "$entry" | grep "^commit " | sed -e 's/commit //')"
+
+            if [[ "$COMMIT_HASH" != *"$currentHash"* ]]
+            then
+              COMMIT_HASH="$COMMIT_HASH $currentHash"
+            fi
+
             rm $entry;
 
             oldDate=$dateToday

--- a/apps/db_pendings/import.sh
+++ b/apps/db_pendings/import.sh
@@ -99,7 +99,7 @@ function import() {
                 echo "DROP PROCEDURE IF EXISTS \`updateDb\`;" >> "$newFile";
             fi;
 
-            COMMIT_HASH="$COMMIT_HASH $(git log --diff-filter=A "$entry" | grep "^commit " | sed -e 's/commit //')"
+            COMMIT_HASH="$COMMIT_HASH $(git log --diff-filter=A "$entry" | grep "^commit " | sort -u | sed -e 's/commit //')"
             rm $entry;
 
             oldDate=$dateToday


### PR DESCRIPTION
##### CHANGES PROPOSED:
Add commit hashes to the automatic SQL import.

###### ISSUES ADDRESSED:
Closes #1449 

##### TESTS PERFORMED:
Tested on Ubuntu 16.04
(sadly, I don't know how to test the Travis run itself)

##### HOW TO TEST THE CHANGES:
- clone azerothcore-wotlk
- reset to commit 38830f29c18159327707ff9d40cc97306b588c6a (this commit contains 3 pending SQL files)
 ```git reset --hard 38830f29c18159327707ff9d40cc97306b588c6a```
- manually apply the PR changes to ```apps/db_pendings/import.sh```
- execute ```source bin/acore-db-pendings```
- execute ```echo "$COMMIT_HASH"```; result (please also take note of the leading blank!):
 ```  275dbec76d023da6824e44c725813f10802287f8 6a53a73c1b235b111194e44b0dff5e6e6fda8927 38830f29c18159327707ff9d40cc97306b588c6a```

The Travis configuration is changed to also call ```source acore-db-pendings```, so the variable should be set for the commit comment when importing the SQL files.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master