### PR TITLE
fix(DB): Pit of Saron intro creature texts

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1550874957572075786.sql
+++ b/data/sql/updates/pending_db_world/rev_1550874957572075786.sql
@@ -1,0 +1,13 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1550874957572075786');
+
+UPDATE `creature_text`
+SET `BroadcastTextID` = 37093, `Sound` = 16747, `Text` = 'Intruders have entered the master''s domain. Signal the alarms!', `comment` = 'tyrannus SAY_TYRANNUS_INTRO_1'
+WHERE `CreatureID` = 36794 AND `groupid` = 1;
+
+UPDATE `creature_text`
+SET `BroadcastTextID` = 37392, `Sound` = 17045, `Text` = 'Soldiers of the Horde, attack!', `comment` = 'sylvanas SAY_SYLVANAS_INTRO_1'
+WHERE `CreatureID` = 36990 AND `groupid` = 3;
+
+UPDATE `creature_text`
+SET `BroadcastTextID` = 37087, `Sound` = 16626, `Text` = 'Heroes of the Alliance, attack!', `comment` = 'jaina SAY_JAINA_INTRO_1'
+WHERE `CreatureID` = 36993 AND `groupid` = 2;


### PR DESCRIPTION
##### CHANGES PROPOSED:
Fix wrong creature texts during the Pit of Saron intro for Horde and Alliance. This was already fixed some time ago via PR #1033 but somehow it seems to got reverted through commit b34bc28e5b02514fca3519beac420c58faa89cad.

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested in-game

##### HOW TO TEST THE CHANGES:
- enter Pit of Saron with a Horde character
- wrong intro text Tyrannus: "Worthless gnat! Death is all that awaits you!"
- wrong intro text Sylvanas: "Take cover behind me! Quickly!"
- enter Pit of Saron with a Alliance character
- wrong intro text Jaina: "What a cruel end. Come, heroes. We must see if the gnome\'s story is true. If we can separate Arthas from Frostmourne, we might have a chance at stopping him."
- apply SQL script
- correct intro text Tyrannus: "Intruders have entered the master's domain. Signal the alarms!"
- correct intro text Sylvanas: "Soldiers of the Horde, attack!"
- correct intro text Jaina: "Heroes of the Alliance, attack!"

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master