### PR TITLE
Core/Spells: fix deterrence melee hits

### DIFF
--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -741,7 +741,7 @@ void Player::UpdateParryPercentage()
         value = std::max(diminishing + nondiminishing, 0.0f);
     }
 
-    SetStatFloatValue(PLAYER_PARRY_PERCENTAGE, value);
+    SetStatFloatValue(PLAYER_PARRY_PERCENTAGE, m_realParry);
 }
 
 void Player::UpdateDodgePercentage()

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -2316,9 +2316,9 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* victim, WeaponAttackTy
             if (victim->IsNonMeleeSpellCast(false, false, true) || victim->HasUnitState(UNIT_STATE_CONTROLLED))
                 tmp = 0;
 
-            if (tmp > 0                                         // check if unit _can_ parry
+            if ((tmp > 0                                         // check if unit _can_ parry
                 && (tmp -= skillBonus) > 0
-                && roll < (sum += tmp))
+                && roll < (sum += tmp)) || (victim->HasAura(19263))) // deterrence
             {
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
                 sLog->outStaticDebug ("RollMeleeOutcomeAgainst: PARRY <%d, %d)", sum-tmp, sum);


### PR DESCRIPTION
##### CHANGES PROPOSED:

-  Deterrence will make you parry melee auto attacks, if possible.


Closes 
https://github.com/azerothcore/azerothcore-wotlk/issues/1522

##### TESTS PERFORMED:
None



##### HOW TO TEST THE CHANGES:
- Cast deterrence when npcs auto attack you



##### KNOWN ISSUES AND TODO LIST:
 
- Check if we also have issues with melee spells or any spell


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
