### PR TITLE
fix(DB): zeppelin master - remove gossip option "Where is the zeppelin now?"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1552778052775198017.sql
+++ b/data/sql/updates/pending_db_world/rev_1552778052775198017.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1552778052775198017');
+
+DELETE FROM `gossip_menu_option` WHERE `MenuID` IN (1969,1971);


### PR DESCRIPTION
##### CHANGES PROPOSED:
Fix another PR which got partly reverted through b34bc28e5b02514fca3519beac420c58faa89cad: #907 

Remove gossip menu options 1969 and 1971 ("Where is the zeppelin now?"), as this functionality is not implemented and the option only existed for Frezza and Zapetta.

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested in-game

##### HOW TO TEST THE CHANGES:
- ```.go creature id 9564``` (Frezza) and ```.go creature id 9566``` (Zapetta)
- speak with the zeppelin masters

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
