### PR TITLE
fix(DB): a few improvements to the giant wandering outdoor creatures

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1552778845262248351.sql
+++ b/data/sql/updates/pending_db_world/rev_1552778845262248351.sql
@@ -1,0 +1,24 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1552778845262248351');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (18733,24812);
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 18733 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(18733,0,0,0,11,0,100,0,0,0,0,0,0,48,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Fel Reaver - On Respawn - Set Active On');
+
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 24812 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(24812,0,0,0,11,0,100,0,0,0,0,0,0,48,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Storm Giant - On Respawn - Set Active On');
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 18411 AND `source_type` = 0 AND `id` = 2;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(18411,0,2,0,11,0,100,0,0,0,0,0,0,48,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Durn the Hungerer - On Respawn - Set Active On');
+
+UPDATE `creature_addon` SET `auras` = '44385' WHERE `guid` = 118191;
+UPDATE `creature` SET `position_x` = 457.723, `position_y` = -4256.85, `position_z` = 235.1 WHERE `guid` = 118191;
+DELETE FROM `waypoint_scripts` WHERE `id` IN (1160,1161,1162,1163);
+UPDATE `waypoint_data` SET `delay` = 0, `action` = 0 WHERE `id` = 1181770;


### PR DESCRIPTION
##### CHANGES PROPOSED:
- set the following creatures active after spawning in order to resume their waypoints even if no player is near (this was originally the danger about them):
 Fel Reaver in Hellfire Peninsula (GUID 67001 & 203341)
 Durn the Hungerer in Nagrand (GUID 65801)
 Storm Giant in Howling Fjord (GUID 118177 & 118191)
- fix the aura 44385 (Storm Giant Warning Aura) for one of the Storm Giants (GUID 118177) which did cause the following error message in the logs:
 ```SCRIPT_COMMAND_CAST_SPELL ('waypoint_scripts' script id: 1161) no source unit found for spell 44385```
- remove the waypoint scripts for one of the Storm Giants (GUID 118177) which did cause him at a specific part of his path to just stand there spinning around
- update the spawning position for one of the Storm Giants (GUID 118191) in order to start the waypoint movement at once (otherwise he would float through various trees until reaching the first waypoint)

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested in-game

##### HOW TO TEST THE CHANGES:
just follow the creatures around; without being active they won't resume on their path if the player gets too far away
- ```.go creature 67001``` (Fel Reaver)
- ```.go creature 203341``` (Fel Reaver)
- ```.go creature 65801``` (Durn)
- ```.go creature 118177``` (Storm Giant)
- ```.go creature 118191``` (Storm Giant)

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
