### PR TITLE
DB: Faceless Lurker drop

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1552859629415687000.sql
+++ b/data/sql/updates/pending_db_world/rev_1552859629415687000.sql
@@ -1,3 +1,4 @@
 INSERT INTO version_db_world (`sql_rev`) VALUES ('1552859629415687000');
 
+DELETE FROM `creature_loot_template` WHERE `Entry` = 31691 AND `Item` = 33470;
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (31691, 33470, 0, 100, 0, 1, 0, 1, 7, NULL);

--- a/data/sql/updates/pending_db_world/rev_1552859629415687000.sql
+++ b/data/sql/updates/pending_db_world/rev_1552859629415687000.sql
@@ -1,0 +1,3 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1552859629415687000');
+
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (31691, 33470, 0, 100, 0, 1, 0, 1, 7, NULL);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
The creature Faceless Lurker should drop Frostweave Cloth with drop chance 100

##### CHANGES PROPOSED:

-  Added missing row in DB
-  


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1539


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Tested, sql is imported without any issue. Tested in game, the listed creature now drop the item.


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
1. .go creature 203343
2. Kill him, Loot it. It should drop frostweave cloth 1-7 with drop chance 100%


##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
