### PR TITLE
fix(CI): prevent failing Travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
   - mysql
 
 git:
-  depth: 1
+  depth: 10
 
 stages:
   - prepare_cache


### PR DESCRIPTION
##### CHANGES PROPOSED:
Increase git depth to 10 in order to be able to see it's own commit even when other commits were already added before the checkout occurs.

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
see Travis runs

##### HOW TO TEST THE CHANGES:
see Travis runs

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master