### PR TITLE
fix(DB): Fezzix "jumping" through the air

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1553556583989604427.sql
+++ b/data/sql/updates/pending_db_world/rev_1553556583989604427.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1553556583989604427');
+
+UPDATE `creature_template` SET `InhabitType` = 7 WHERE `entry` = 25849;


### PR DESCRIPTION
##### CHANGES PROPOSED:
Change "InhabitType" to 7 for Fezzix Geartwist to prevent him from "jumping" through the air while testing his flying machine when finishing quest "Patching Up" (11894).

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested in-game

##### HOW TO TEST THE CHANGES:
- ```.go creature id 25849```
- ```.quest remove 11894```
- ```.quest add 11894```
- ```.additem 35289 5```
- finish quest

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master