### PR TITLE
[DB & SAI] Rough Stone & Dragonmaw Bonewarder

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1553973207096786300.sql
+++ b/data/sql/updates/pending_db_world/rev_1553973207096786300.sql
@@ -1,13 +1,8 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1553973207096786300');
 
-DELETE FROM `gameobject_loot_template` WHERE `Entry`=18092 AND `Item`=2835;
-INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (18092, 2835, 0, 88, 0, 1, 0, 1, 6, NULL);
-
-DELETE FROM `gameobject_loot_template` WHERE `Entry`=1502 AND `Item`=2835;
-INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (1502, 2835, 0, 80, 0, 1, 0, 1, 11, NULL);
-
-DELETE FROM `gameobject_loot_template` WHERE `Entry`=1735 AND `Item`=2835;
-INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (1735, 2835, 0, 80, 0, 1, 0, 1, 6, NULL);
-
-DELETE FROM `gameobject_loot_template` WHERE `Entry`=2626 AND `Item`=2835;
-INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (2626, 2835, 0, 80, 0, 1, 0, 1, 6, NULL);
+DELETE FROM gameobject_loot_template WHERE Item=2835 AND Entry IN (18092, 1502, 1735, 2626);
+INSERT INTO gameobject_loot_template (Entry, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount, Comment) VALUES
+(18092, 2835, 0, 88, 0, 1, 0, 1, 6, NULL);
+(1502, 2835, 0, 80, 0, 1, 0, 1, 11, NULL);
+(1735, 2835, 0, 80, 0, 1, 0, 1, 6, NULL);
+(2626, 2835, 0, 80, 0, 1, 0, 1, 6, NULL);

--- a/data/sql/updates/pending_db_world/rev_1553973207096786300.sql
+++ b/data/sql/updates/pending_db_world/rev_1553973207096786300.sql
@@ -2,7 +2,7 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1553973207096786300');
 
 DELETE FROM gameobject_loot_template WHERE Item=2835 AND Entry IN (18092, 1502, 1735, 2626);
 INSERT INTO gameobject_loot_template (Entry, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount, Comment) VALUES
-(18092, 2835, 0, 88, 0, 1, 0, 1, 6, NULL);
-(1502, 2835, 0, 80, 0, 1, 0, 1, 11, NULL);
-(1735, 2835, 0, 80, 0, 1, 0, 1, 6, NULL);
+(18092, 2835, 0, 88, 0, 1, 0, 1, 6, NULL),
+(1502, 2835, 0, 80, 0, 1, 0, 1, 11, NULL),
+(1735, 2835, 0, 80, 0, 1, 0, 1, 6, NULL),
 (2626, 2835, 0, 80, 0, 1, 0, 1, 6, NULL);

--- a/data/sql/updates/pending_db_world/rev_1553973207096786300.sql
+++ b/data/sql/updates/pending_db_world/rev_1553973207096786300.sql
@@ -1,0 +1,13 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1553973207096786300');
+
+DELETE FROM `gameobject_loot_template` WHERE `Entry`=18092 AND `Item`=2835;
+INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (18092, 2835, 0, 88, 0, 1, 0, 1, 6, NULL);
+
+DELETE FROM `gameobject_loot_template` WHERE `Entry`=1502 AND `Item`=2835;
+INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (1502, 2835, 0, 80, 0, 1, 0, 1, 11, NULL);
+
+DELETE FROM `gameobject_loot_template` WHERE `Entry`=1735 AND `Item`=2835;
+INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (1735, 2835, 0, 80, 0, 1, 0, 1, 6, NULL);
+
+DELETE FROM `gameobject_loot_template` WHERE `Entry`=2626 AND `Item`=2835;
+INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (2626, 2835, 0, 80, 0, 1, 0, 1, 6, NULL);

--- a/data/sql/updates/pending_db_world/rev_1553974864385673300.sql
+++ b/data/sql/updates/pending_db_world/rev_1553974864385673300.sql
@@ -1,20 +1,13 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1553974864385673300');
 
 -- Table creature_template
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 1057;
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (1057, 6412);
 
 -- Table smart_scripts
-DELETE FROM `smart_scripts` WHERE (source_type = 0 AND entryorguid = 1057);
+DELETE FROM `smart_scripts` WHERE source_type = 0 AND entryorguid IN (1057, 6412);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(1057, 0, 0, 0, 11, 0, 100, 1, 0, 0, 0, 0, 11, 8853, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Dragonmaw Bonewarder - On Respawn - Cast \'8853\' (No Repeat)'),
-(1057, 0, 1, 0, 4, 0, 100, 1, 1000, 1000, 0, 0, 11, 13787, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Dragonmaw Bonewarder - On Aggro - Cast \'13787\' (No Repeat)'),
-(1057, 0, 2, 0, 0, 0, 100, 0, 3000, 4000, 120000, 120000, 11, 6205, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Dragonmaw Bonewarder - In Combat - Cast \'6205\''),
-(1057, 0, 3, 0, 0, 0, 100, 0, 5000, 6000, 15000, 15000, 11, 707, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Dragonmaw Bonewarder - In Combat - Cast \'707\'');
-
--- Table creature_template
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 6412;
-
--- Table smart_scripts
-DELETE FROM `smart_scripts` WHERE (source_type = 0 AND entryorguid = 6412);
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(1057, 0, 0, 0, 11, 0, 100, 1, 0, 0, 0, 0, 11, 8853, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Dragonmaw Bonewarder - On Respawn - Cast 8853 (No Repeat)'),
+(1057, 0, 1, 0, 4, 0, 100, 1, 1000, 1000, 0, 0, 11, 13787, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Dragonmaw Bonewarder - On Aggro - Cast 13787 (No Repeat)'),
+(1057, 0, 2, 0, 0, 0, 100, 0, 3000, 4000, 120000, 120000, 11, 6205, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Dragonmaw Bonewarder - In Combat - Cast 6205'),
+(1057, 0, 3, 0, 0, 0, 100, 0, 5000, 6000, 15000, 15000, 11, 707, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Dragonmaw Bonewarder - In Combat - Cast 707'),
 (6412, 0, 0, 0, 6, 0, 100, 0, 0, 0, 0, 0, 41, 5000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Skeleton - On Just Died - Despawn In 5000 ms');

--- a/data/sql/updates/pending_db_world/rev_1553974864385673300.sql
+++ b/data/sql/updates/pending_db_world/rev_1553974864385673300.sql
@@ -1,0 +1,20 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1553974864385673300');
+
+-- Table creature_template
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 1057;
+
+-- Table smart_scripts
+DELETE FROM `smart_scripts` WHERE (source_type = 0 AND entryorguid = 1057);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(1057, 0, 0, 0, 11, 0, 100, 1, 0, 0, 0, 0, 11, 8853, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Dragonmaw Bonewarder - On Respawn - Cast \'8853\' (No Repeat)'),
+(1057, 0, 1, 0, 4, 0, 100, 1, 1000, 1000, 0, 0, 11, 13787, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Dragonmaw Bonewarder - On Aggro - Cast \'13787\' (No Repeat)'),
+(1057, 0, 2, 0, 0, 0, 100, 0, 3000, 4000, 120000, 120000, 11, 6205, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Dragonmaw Bonewarder - In Combat - Cast \'6205\''),
+(1057, 0, 3, 0, 0, 0, 100, 0, 5000, 6000, 15000, 15000, 11, 707, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Dragonmaw Bonewarder - In Combat - Cast \'707\'');
+
+-- Table creature_template
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 6412;
+
+-- Table smart_scripts
+DELETE FROM `smart_scripts` WHERE (source_type = 0 AND entryorguid = 6412);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(6412, 0, 0, 0, 6, 0, 100, 0, 0, 0, 0, 0, 41, 5000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Skeleton - On Just Died - Despawn In 5000 ms');


### PR DESCRIPTION
Fix for Rough Stone from Copper Veins.

For some reason, there was only 10 or 20% drop chance -> Should be 80% except Ghostlands where's 88%.

To check it go to:

gameobject_template and take DATA IDs for loot
gameobject_loot_template and see drop chance

Also fix for Dragonmaw Bonewarder.

He's missing guardian and casting almost 2 same spells.
To test it .go cre 9626

Apply SQL fix, .reload smart_scripts
.npc add 1057

