### PR TITLE
feat(CI): Travis check modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ git:
 stages:
   - prepare_cache
   - run
+  - run_modules
 
 jobs:
   include:
@@ -53,6 +54,18 @@ jobs:
         - source ./apps/ci/ci-compile.sh
         - source ./apps/ci/ci-worldserver-dry-run.sh
 
+    - stage: run_modules
+      env: TRAVIS_BUILD_ID="1"
+      before_install:
+        - source ./apps/ci/ci-before_install.sh
+      install:
+        - source ./apps/ci/ci-install.sh ON
+        - source -/apps/ci/ci-install-modules.sh
+        - source ./apps/ci/ci-import-db.sh
+      script:
+        - source ./apps/ci/ci-compile.sh
+        - source ./apps/ci/ci-worldserver-dry-run.sh
+
     - stage: prepare_cache
       env: TRAVIS_BUILD_ID="2"
       before_install:
@@ -68,5 +81,15 @@ jobs:
         - source ./apps/ci/ci-before_install.sh
       install:
         - source ./apps/ci/ci-install.sh ON
+      script:
+        - source ./apps/ci/ci-compile.sh
+
+    - stage: run_modules
+      env: TRAVIS_BUILD_ID="2"
+      before_install:
+        - source ./apps/ci/ci-before_install.sh
+      install:
+        - source ./apps/ci/ci-install.sh ON
+        - source -/apps/ci/ci-install-modules.sh
       script:
         - source ./apps/ci/ci-compile.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ git:
 stages:
   - prepare_cache
   - run
-  - run_modules
 
 jobs:
   include:
@@ -40,21 +39,11 @@ jobs:
           - source ./apps/ci/ci-before_install.sh
       install:
         - source ./apps/ci/ci-install.sh OFF
+        - source ./apps/ci/ci-install-modules.sh
       script:
         - source ./apps/ci/ci-compile.sh
 
     - stage: run
-      env: TRAVIS_BUILD_ID="1"
-      before_install:
-        - source ./apps/ci/ci-before_install.sh
-      install:
-        - source ./apps/ci/ci-install.sh ON
-        - source ./apps/ci/ci-import-db.sh
-      script:
-        - source ./apps/ci/ci-compile.sh
-        - source ./apps/ci/ci-worldserver-dry-run.sh
-
-    - stage: run_modules
       env: TRAVIS_BUILD_ID="1"
       before_install:
         - source ./apps/ci/ci-before_install.sh
@@ -72,19 +61,11 @@ jobs:
           - source ./apps/ci/ci-before_install.sh
       install:
         - source ./apps/ci/ci-install.sh OFF
+        - source ./apps/ci/ci-install-modules.sh
       script:
         - source ./apps/ci/ci-compile.sh
 
     - stage: run
-      env: TRAVIS_BUILD_ID="2"
-      before_install:
-        - source ./apps/ci/ci-before_install.sh
-      install:
-        - source ./apps/ci/ci-install.sh ON
-      script:
-        - source ./apps/ci/ci-compile.sh
-
-    - stage: run_modules
       env: TRAVIS_BUILD_ID="2"
       before_install:
         - source ./apps/ci/ci-before_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
         - source ./apps/ci/ci-before_install.sh
       install:
         - source ./apps/ci/ci-install.sh ON
-        - source -/apps/ci/ci-install-modules.sh
+        - source ./apps/ci/ci-install-modules.sh
         - source ./apps/ci/ci-import-db.sh
       script:
         - source ./apps/ci/ci-compile.sh
@@ -90,6 +90,6 @@ jobs:
         - source ./apps/ci/ci-before_install.sh
       install:
         - source ./apps/ci/ci-install.sh ON
-        - source -/apps/ci/ci-install-modules.sh
+        - source ./apps/ci/ci-install-modules.sh
       script:
         - source ./apps/ci/ci-compile.sh

--- a/apps/ci/ci-error-check.sh
+++ b/apps/ci/ci-error-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DB_ERRORS_FILE="/home/travis/build/azerothcore/azerothcore-wotlk/env/dist/bin/DBErrors.log";
+DB_ERRORS_FILE="$TRAVIS_BUILD_DIR/env/dist/bin/DBErrors.log";
 #DB_ERRORS_FILE="./env/dist/bin/DBErrors.log";
 
 if [[ ! -f ${DB_ERRORS_FILE} ]]; then

--- a/apps/ci/ci-import-db.sh
+++ b/apps/ci/ci-import-db.sh
@@ -6,4 +6,10 @@ if [ "$TRAVIS_BUILD_ID" = "1" ]
 then
   echo "import DB"
   bash ./acore.sh "db-assembler" "import-all"
+  
+  if [ -s modules/mod-premium/sql/example_item_9017.sql ]
+  then
+    # if the premium module is available insert the example item or else the worldserver dry run will fail
+    mysql -u root world_$DB_RND_NAME <modules/mod-premium/sql/example_item_9017.sql
+  fi
 fi

--- a/apps/ci/ci-install-modules.sh
+++ b/apps/ci/ci-install-modules.sh
@@ -3,10 +3,10 @@
 set -e
 
 echo "install modules"
-git clone --depth=1 --branch=master https://github.com/azerothcore/mod-eluna-lua-engine.git modules/mod-eluna-lua-engine
-git clone --depth=1 --branch=master https://github.com/ElunaLuaEngine/Eluna.git modules/mod-eluna-lua-engine/LuaEngine
+#git clone --depth=1 --branch=master https://github.com/azerothcore/mod-eluna-lua-engine.git modules/mod-eluna-lua-engine
+#git clone --depth=1 --branch=master https://github.com/ElunaLuaEngine/Eluna.git modules/mod-eluna-lua-engine/LuaEngine
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-vas-autobalance.git modules/mod-vas-autobalance
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-transmog.git modules/mod-transmog
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-npc-beastmaster.git modules/mod-npc-beastmaster
-git clone --depth=1 --branch=master https://github.com/azerothcore/mod-duel-reset.git modules/mod-duel-reset
-git clone --depth=1 --branch=master https://github.com/azerothcore/mod-premium modules/mod-premium
+#git clone --depth=1 --branch=master https://github.com/azerothcore/mod-duel-reset.git modules/mod-duel-reset
+#git clone --depth=1 --branch=master https://github.com/azerothcore/mod-premium modules/mod-premium

--- a/apps/ci/ci-install-modules.sh
+++ b/apps/ci/ci-install-modules.sh
@@ -8,4 +8,4 @@ git clone --depth=1 --branch=master https://github.com/azerothcore/mod-vas-autob
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-transmog.git modules/mod-transmog
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-npc-beastmaster.git modules/mod-npc-beastmaster
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-duel-reset.git modules/mod-duel-reset
-#git clone --depth=1 --branch=master https://github.com/azerothcore/mod-premium modules/mod-premium
+git clone --depth=1 --branch=master https://github.com/azerothcore/mod-premium modules/mod-premium

--- a/apps/ci/ci-install-modules.sh
+++ b/apps/ci/ci-install-modules.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "install modules"
-#git clone --depth=1 --branch=master --recursive https://github.com/azerothcore/mod-eluna-lua-engine.git modules/mod-eluna-lua-engine
+git clone --depth=1 --branch=master --recursive https://github.com/azerothcore/mod-eluna-lua-engine.git modules/mod-eluna-lua-engine
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-vas-autobalance.git modules/mod-vas-autobalance
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-transmog.git modules/mod-transmog
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-npc-beastmaster.git modules/mod-npc-beastmaster

--- a/apps/ci/ci-install-modules.sh
+++ b/apps/ci/ci-install-modules.sh
@@ -3,10 +3,9 @@
 set -e
 
 echo "install modules"
-#git clone --depth=1 --branch=master https://github.com/azerothcore/mod-eluna-lua-engine.git modules/mod-eluna-lua-engine
-#git clone --depth=1 --branch=master https://github.com/ElunaLuaEngine/Eluna.git modules/mod-eluna-lua-engine/LuaEngine
+#git clone --depth=1 --branch=master --recursive https://github.com/azerothcore/mod-eluna-lua-engine.git modules/mod-eluna-lua-engine
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-vas-autobalance.git modules/mod-vas-autobalance
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-transmog.git modules/mod-transmog
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-npc-beastmaster.git modules/mod-npc-beastmaster
-#git clone --depth=1 --branch=master https://github.com/azerothcore/mod-duel-reset.git modules/mod-duel-reset
+git clone --depth=1 --branch=master https://github.com/azerothcore/mod-duel-reset.git modules/mod-duel-reset
 #git clone --depth=1 --branch=master https://github.com/azerothcore/mod-premium modules/mod-premium

--- a/apps/ci/ci-install-modules.sh
+++ b/apps/ci/ci-install-modules.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+echo "install modules"
+git clone --depth=1 --branch=master https://github.com/azerothcore/mod-eluna-lua-engine.git modules/mod-eluna-lua-engine
+git clone --depth=1 --branch=master https://github.com/ElunaLuaEngine/Eluna.git modules/mod-eluna-lua-engine/LuaEngine
+git clone --depth=1 --branch=master https://github.com/azerothcore/mod-vas-autobalance.git modules/mod-vas-autobalance
+git clone --depth=1 --branch=master https://github.com/azerothcore/mod-transmog.git modules/mod-transmog
+git clone --depth=1 --branch=master https://github.com/azerothcore/mod-npc-beastmaster.git modules/mod-npc-beastmaster
+git clone --depth=1 --branch=master https://github.com/azerothcore/mod-duel-reset.git modules/mod-duel-reset
+git clone --depth=1 --branch=master https://github.com/azerothcore/mod-premium modules/mod-premium

--- a/apps/ci/ci-worldserver-dry-run.sh
+++ b/apps/ci/ci-worldserver-dry-run.sh
@@ -7,6 +7,10 @@ then
   echo "start worldserver dry-run"
   git clone --depth=1 --branch=master --single-branch https://github.com/ac-data/ac-data.git "$TRAVIS_BUILD_DIR/env/dist/data"
   sed -e "s/;;acore_auth/;$DB_RND_NAME;auth_$DB_RND_NAME/" -e "s/;;acore_world/;$DB_RND_NAME;world_$DB_RND_NAME/" -e "s/;;acore_characters/;$DB_RND_NAME;characters_$DB_RND_NAME/" ./data/travis/worldserver.conf >./env/dist/etc/worldserver.conf
+  cat >>./env/dist/etc/worldserver.conf <<WORLD_CONF
+DataDir = "$TRAVIS_BUILD_DIR/env/dist/data"
+LogsDir = "$TRAVIS_BUILD_DIR/env/dist/bin"
+WORLD_CONF
   ./env/dist/bin/worldserver --dry-run
   ./apps/ci/ci-error-check.sh
 fi

--- a/apps/ci/ci-worldserver-dry-run.sh
+++ b/apps/ci/ci-worldserver-dry-run.sh
@@ -5,7 +5,7 @@ set -e
 if [ "$TRAVIS_BUILD_ID" = "1" ]
 then
   echo "start worldserver dry-run"
-  git clone --depth=1 --branch=master --single-branch https://github.com/ac-data/ac-data.git /home/travis/build/azerothcore/azerothcore-wotlk/env/dist/data
+  git clone --depth=1 --branch=master --single-branch https://github.com/ac-data/ac-data.git "$TRAVIS_BUILD_DIR/env/dist/data"
   sed -e "s/;;acore_auth/;$DB_RND_NAME;auth_$DB_RND_NAME/" -e "s/;;acore_world/;$DB_RND_NAME;world_$DB_RND_NAME/" -e "s/;;acore_characters/;$DB_RND_NAME;characters_$DB_RND_NAME/" ./data/travis/worldserver.conf >./env/dist/etc/worldserver.conf
   ./env/dist/bin/worldserver --dry-run
   ./apps/ci/ci-error-check.sh

--- a/data/travis/worldserver.conf
+++ b/data/travis/worldserver.conf
@@ -8,5 +8,3 @@ WorldDatabaseInfo     = "127.0.0.1;3306;root;;acore_world"
 CharacterDatabaseInfo = "127.0.0.1;3306;root;;acore_characters"
 
 EnableLogDB = 1
-DataDir = "/home/travis/build/azerothcore/azerothcore-wotlk/env/dist/data"
-LogsDir = "/home/travis/build/azerothcore/azerothcore-wotlk/env/dist/bin"


### PR DESCRIPTION
##### CHANGES PROPOSED:
- Extend Travis compilation check by including some of the most popular modules.
- Change the absolute paths of the CI scripts to use environment variable "TRAVIS_BUILD_DIR". This way it is also possible to run Travis on forks.

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
see Travis runs

##### HOW TO TEST THE CHANGES:
see Travis runs

##### KNOWN ISSUES AND TODO LIST:
All modules included here have to make sure that they don't throw any Travis errors. In order to check this they have to activate Travis and include (or update) this file in their repository:
https://github.com/azerothcore/skeleton-module/blob/master/.travis.yml
I already did this for beastmaster, transmog and VAS autobalance.

TODO list:
- [x] [mod-duel-reset](https://github.com/azerothcore/mod-duel-reset)
- [x] [mod-eluna-lua-engine](https://github.com/azerothcore/mod-eluna-lua-engine)
- [x] [mod-npc-beastmaster](https://github.com/azerothcore/mod-npc-beastmaster)
- [x] [mod-premium](https://github.com/azerothcore/mod-premium)
- [x] [mod-transmog](https://github.com/azerothcore/mod-transmog)
- [x] [mod-vas-autobalance](https://github.com/azerothcore/mod-vas-autobalance)

I will remove the comments in "apps/ci/ci-install-modules.sh" after each of the modules passes the Travis check.

##### Target branch(es):
Master
