### PR TITLE
Cmake: Enable include file ScriptPCH.h in lib game-interface

### DIFF
--- a/src/server/scripts/CMakeLists.txt
+++ b/src/server/scripts/CMakeLists.txt
@@ -81,9 +81,7 @@ add_library(scripts-interface INTERFACE)
 
 CollectIncludeDirectories(
   ${CMAKE_CURRENT_SOURCE_DIR}
-  PUBLIC_INCLUDES
-  # Exclude
-  ${CMAKE_CURRENT_SOURCE_DIR}/PrecompiledHeaders)
+  PUBLIC_INCLUDES)
 
 target_include_directories(scripts-interface
   INTERFACE


### PR DESCRIPTION
##### CHANGES PROPOSED:
-  Enable include file ScriptPCH.h in lib game-interface

##### ISSUES ADDRESSED: 
Close https://github.com/azerothcore/mod-learn-spells/issues/5

##### TESTS PERFORMED:
- [x] Build in VS 16 2019

##### HOW TO TEST THE CHANGES:
- Apply PR
- Rebuild modules which used this file

##### KNOWN ISSUES AND TODO LIST:
- [x] Build in Travis

##### Target branch(es): Master