### PR TITLE
Cmake: Add new hook AFTER_LOAD_CMAKE_MODULES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ include(CheckPlatform)
 include(GroupSources)
 include(AutoCollect)
 
+CU_RUN_HOOK("AFTER_LOAD_CMAKE_MODULES")
+
 # basic packagesearching and setup (further support will be needed, this is a preliminary release!)
 set(ACE_EXPECTED_VERSION 6.0.3)
 


### PR DESCRIPTION
##### CHANGES PROPOSED:
-  Add new hook AFTER_LOAD_CMAKE_MODULES
-  This hook is needed primarily for Eluna module


##### ISSUES ADDRESSED:

##### TESTS PERFORMED:
- [x] Build in VS 16 2019

##### HOW TO TEST THE CHANGES:
- I think that this PR does not need testing, this PR is necessary for the normal operation of the Eluna module
- See https://github.com/azerothcore/mod-eluna-lua-engine/pull/12

##### KNOWN ISSUES AND TODO LIST:
- [ ] Build in Travis 

##### Target branch(es): Master