### PR TITLE
fix(Core/Eluna): fix compiler warning concerning Eluna

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -964,11 +964,11 @@ void MovementInfo::OutDebug()
         sLog->outString("splineElevation: %f", splineElevation);
 }
 
-WorldObject::WorldObject(bool isWorldObject) : WorldLocation(), LastUsedScriptID(0),
+WorldObject::WorldObject(bool isWorldObject) : WorldLocation(),
 #ifdef ELUNA
 elunaEvents(NULL),
 #endif
-m_name(""), m_isActive(false), m_isWorldObject(isWorldObject), m_zoneScript(NULL),
+LastUsedScriptID(0), m_name(""), m_isActive(false), m_isWorldObject(isWorldObject), m_zoneScript(NULL),
 m_transport(NULL), m_currMap(NULL), m_InstanceId(0),
 m_phaseMask(PHASEMASK_NORMAL), m_notifyflags(0), m_executed_notifies(0)
 {


### PR DESCRIPTION
##### CHANGES PROPOSED:
Fix the following compiler warning by reordering the parameters:
```
src/server/game/Entities/Object/Object.cpp:967:65: fatal error: field 'LastUsedScriptID' will be initialized after field 'elunaEvents' [-Wreorder]
WorldObject::WorldObject(bool isWorldObject) : WorldLocation(), LastUsedScriptID(0),
```
This is necessary as preparation for including Eluna into the Travis run (see https://github.com/azerothcore/mod-eluna-lua-engine/pull/11 and #1663)

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested build on Ubuntu 16.04 incl. Eluna with warnings enabled, clang 7

##### HOW TO TEST THE CHANGES:
other than the build no testing is necessary

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master