### PR TITLE
Cmake/MYSQL: Correct support MariaDB for windows

### DIFF
--- a/conf/config.cmake.dist
+++ b/conf/config.cmake.dist
@@ -5,7 +5,6 @@ option(USE_SCRIPTPCH       "Use precompiled headers when compiling scripts"     
 option(USE_COREPCH         "Use precompiled headers when compiling servers"              1)
 option(WITH_WARNINGS       "Show all warnings during compile"                            0)
 option(WITH_COREDEBUG      "Include additional debug-code in core"                       0)
-option(MARIADB             "Compatibility with 10.2+ versions of MariaDB library"        0)
 option(WITH_PERFTOOLS      "Enable compilation with gperftools libraries included"       0)
 option(WITH_MESHEXTRACTOR  "Build meshextractor (alpha)"                                 0)
 option(WITHOUT_GIT         "Disable the GIT testing routines"                            0)

--- a/src/cmake/macros/FindMySQL.cmake
+++ b/src/cmake/macros/FindMySQL.cmake
@@ -12,6 +12,77 @@
 
 set( MYSQL_FOUND 0 )
 
+if(WIN32)
+  # read environment variables and change \ to /
+  SET(PROGRAM_FILES_32 $ENV{ProgramFiles})
+  if (${PROGRAM_FILES_32})
+    STRING(REPLACE "\\\\" "/" PROGRAM_FILES_32 ${PROGRAM_FILES_32})
+  endif(${PROGRAM_FILES_32})
+
+  SET(PROGRAM_FILES_64 $ENV{ProgramW6432})
+  if (${PROGRAM_FILES_64})
+     STRING(REPLACE "\\\\" "/" PROGRAM_FILES_64 ${PROGRAM_FILES_64})
+  endif(${PROGRAM_FILES_64})
+endif(WIN32)
+
+# Find MariaDB for Windows
+if (WIN32)
+  # Set know versions MariaDB
+  set(_MARIADB_KNOWN_VERSIONS "MariaDB 10.4" "MariaDB 10.3" "MariaDB 10.2" "MariaDB 10.1")
+
+  # Set default oprions
+  set(MARIADB_FOUND_LIB 0)
+  set(MARIADB_FOUND_INCLUDE 0)
+  set(MARIADB_FOUND_EXECUTABLE 0)
+  set(MARIADB_FOUND 0)
+
+  macro(FindLibMariaDB MariaDBVersion)
+  # Find include
+  find_path(MYSQL_INCLUDE_DIR
+    NAMES
+      mysql.h
+    PATHS
+      ${MYSQL_ADD_INCLUDE_PATH}
+      "${PROGRAM_FILES_64}/${MariaDBVersion}/include/mysql"
+      "${PROGRAM_FILES_32}/${MariaDBVersion}/include/mysql"
+    DOC
+      "Specify the directory containing mysql.h."
+  )
+
+  if(MYSQL_INCLUDE_DIR)
+    set(MARIADB_FOUND_INCLUDE 1)
+  endif()
+
+  find_library(MYSQL_LIBRARY
+    NAMES
+      libmariadb
+    PATHS
+      ${MYSQL_ADD_LIBRARIES_PATH}
+      "${PROGRAM_FILES_64}/${MariaDBVersion}/lib"
+      "${PROGRAM_FILES_64}/${MariaDBVersion}/lib/opt"
+      "${PROGRAM_FILES_32}/${MariaDBVersion}/lib"
+      "${PROGRAM_FILES_32}/${MariaDBVersion}/lib/opt"
+      "$ENV{ProgramFiles}/${MariaDBVersion}/lib/opt"
+      "$ENV{SystemDrive}/${MariaDBVersion}/lib/opt"
+    DOC
+      "Specify the location of the mysql library here."
+  )
+
+  if(MYSQL_LIBRARY)
+    set(MARIADB_FOUND_LIB 1)
+  endif()
+  if (MYSQL_LIBRARY AND MYSQL_INCLUDE_DIR)
+    set(MARIADB_FOUND 1)
+  endif()
+  endmacro(FindLibMariaDB)
+
+  foreach(version ${_MARIADB_KNOWN_VERSIONS})
+    if (NOT MARIADB_FOUND)
+      FindLibMariaDB(${version})
+    endif()
+  endforeach()
+endif()
+
 if( UNIX )
   set(MYSQL_CONFIG_PREFER_PATH "$ENV{MYSQL_HOME}/bin" CACHE FILEPATH
     "preferred path to MySQL (mysql_config)"

--- a/src/cmake/showoptions.cmake
+++ b/src/cmake/showoptions.cmake
@@ -65,13 +65,6 @@ else()
   message("* Use coreside debug              : No  (default)")
 endif()
 
-if( MARIADB )
-  message("* Enable MariaDB 10.2+ support    : Yes")
-  add_definitions(-DMARIADB)
-else()
-  message("* Enable MariaDB 10.2+ support    : No (default)")
-endif()
-
 if ( UNIX )
   if( WITH_PERFTOOLS )
     message("* Use unix gperftools             : Yes")

--- a/src/common/Database/MySQLConnection.cpp
+++ b/src/common/Database/MySQLConnection.cpp
@@ -517,7 +517,7 @@ bool MySQLConnection::_HandleMySQLErrno(uint32 errNo)
         case CR_SERVER_GONE_ERROR:
         case CR_SERVER_LOST:
         case CR_SERVER_LOST_EXTENDED:
-#if !defined MARIADB
+#if !(MARIADB_VERSION_ID >= 100200)
         case CR_INVALID_CONN_HANDLE:
 #endif
         {


### PR DESCRIPTION
##### CHANGES PROPOSED:
* Delete CMake option MARIADB
* Delete definitions (-DMARIADB)
* Added support MariaDB 10.1 / 10.2 / 10.3 / 10.4 for windows
* Replaced condition for error `CR_INVALID_CONN_HANDLE`

##### ISSUES ADDRESSED: 

##### TESTS PERFORMED:
- [x] Build in VS 16 2019

##### HOW TO TEST THE CHANGES:
- Apply PR
- Rebuild core
- - **If you use WIN** replace `libmysql.dll` to `libmariadb.dll`
- Launch `worldserver` or `authserver`

##### KNOWN ISSUES AND TODO LIST:
- [x] Build in Travis

##### Target branch(es): Master