### PR TITLE
fix(CI): fix paths for dry-run check

### DIFF
--- a/apps/ci/ci-error-check.sh
+++ b/apps/ci/ci-error-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DB_ERRORS_FILE="$TRAVIS_BUILD_DIR/env/dist/bin/DBErrors.log";
+DB_ERRORS_FILE="/home/travis/build/azerothcore/azerothcore-wotlk/env/dist/bin/DBErrors.log";
 #DB_ERRORS_FILE="./env/dist/bin/DBErrors.log";
 
 if [[ ! -f ${DB_ERRORS_FILE} ]]; then

--- a/apps/ci/ci-worldserver-dry-run.sh
+++ b/apps/ci/ci-worldserver-dry-run.sh
@@ -5,7 +5,7 @@ set -e
 if [ "$TRAVIS_BUILD_ID" = "1" ]
 then
   echo "start worldserver dry-run"
-  git clone --depth=1 --branch=master --single-branch https://github.com/ac-data/ac-data.git "$TRAVIS_BUILD_DIR/env/dist/data"
+  git clone --depth=1 --branch=master --single-branch https://github.com/ac-data/ac-data.git /home/travis/build/azerothcore/azerothcore-wotlk/env/dist/data
   sed -e "s/;;acore_auth/;$DB_RND_NAME;auth_$DB_RND_NAME/" -e "s/;;acore_world/;$DB_RND_NAME;world_$DB_RND_NAME/" -e "s/;;acore_characters/;$DB_RND_NAME;characters_$DB_RND_NAME/" ./data/travis/worldserver.conf >./env/dist/etc/worldserver.conf
   cat >>./env/dist/etc/worldserver.conf <<WORLD_CONF
 DataDir = "$TRAVIS_BUILD_DIR/env/dist/data"

--- a/apps/ci/ci-worldserver-dry-run.sh
+++ b/apps/ci/ci-worldserver-dry-run.sh
@@ -7,10 +7,6 @@ then
   echo "start worldserver dry-run"
   git clone --depth=1 --branch=master --single-branch https://github.com/ac-data/ac-data.git /home/travis/build/azerothcore/azerothcore-wotlk/env/dist/data
   sed -e "s/;;acore_auth/;$DB_RND_NAME;auth_$DB_RND_NAME/" -e "s/;;acore_world/;$DB_RND_NAME;world_$DB_RND_NAME/" -e "s/;;acore_characters/;$DB_RND_NAME;characters_$DB_RND_NAME/" ./data/travis/worldserver.conf >./env/dist/etc/worldserver.conf
-  cat >>./env/dist/etc/worldserver.conf <<WORLD_CONF
-DataDir = "$TRAVIS_BUILD_DIR/env/dist/data"
-LogsDir = "$TRAVIS_BUILD_DIR/env/dist/bin"
-WORLD_CONF
   ./env/dist/bin/worldserver --dry-run
   ./apps/ci/ci-error-check.sh
 fi

--- a/data/travis/worldserver.conf
+++ b/data/travis/worldserver.conf
@@ -8,3 +8,5 @@ WorldDatabaseInfo     = "127.0.0.1;3306;root;;acore_world"
 CharacterDatabaseInfo = "127.0.0.1;3306;root;;acore_characters"
 
 EnableLogDB = 1
+DataDir = "/home/travis/build/azerothcore/azerothcore-wotlk/env/dist/data"
+LogsDir = "/home/travis/build/azerothcore/azerothcore-wotlk/env/dist/bin"


### PR DESCRIPTION
##### CHANGES PROPOSED:
Revert the part of PR #1663 where the environment variable "TRAVIS_BUILD_DIR" is used for the dry-run. This breaks the Travis check for modules as the variable has another value there. Sorry, I did not think about this when creating #1663.

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
see Travis check

##### HOW TO TEST THE CHANGES:
see Travis check

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
