### PR TITLE
[Raid] Naxxramas - Patchwerk

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
@@ -37,15 +37,6 @@ enum Misc
     ACHIEV_TIMED_START_EVENT        = 10286,
 };
 
-// These are the Creature entries
-int const CreatureEntriesToPullOnAggro [] = { 16017, 16018, 16020, 16021, 16022 };
-
-// Due to current Pathfinding system being in unstable, I have to filter
-// which GUID I will pull to avoid creatures clipping through textures
-uint64 const CreatureGUIDS[] = { 97736, 97718, 97747, 128068, 128069, 128078, 128079,
-                                128080, 128082, 128083, 128085, 128086, 128089, 128090,
-                                128091, 128093, 128094, 128095, 128096, 128100, 128101, 128102 };
-
 class boss_patchwerk : public CreatureScript
 {
 public:
@@ -90,29 +81,10 @@ public:
             Talk(SAY_DEATH);
         }
 
-        // If any of the adds on his chamber are alive, pull them
-        void PullChamberAdds()
-        {
-            for (uint64 GUID : CreatureGUIDS)
-            {
-                for (int entry : CreatureEntriesToPullOnAggro)
-                {
-                    std::list<Creature*> a;
-                    me->GetCreaturesWithEntryInRange(a, 500.0f, entry);
-                    for (std::list<Creature*>::const_iterator itr = a.begin(); itr != a.end(); ++itr)
-                    {
-                        if ((*itr)->GetGUID() & GUID)
-                            (*itr)->ToCreature()->AI()->AttackStart(me->GetVictim());
-                    }
-                }
-            }
-        }
-
         void EnterCombat(Unit * who)
         {
             BossAI::EnterCombat(who);
             Talk(SAY_AGGRO);
-            PullChamberAdds();
             me->SetInCombatWithZone();
             events.ScheduleEvent(EVENT_SPELL_HATEFUL_STRIKE, 1200);
             events.ScheduleEvent(EVENT_SPELL_BERSERK, 360000);

--- a/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
@@ -42,7 +42,7 @@ int const CreatureEntriesToPullOnAggro [] = { 16017, 16018, 16020, 16021, 16022 
 
 // Due to current Pathfinding system being in unstable, I have to filter
 // which GUID I will pull to avoid creatures clipping through textures
-int const CreatureGUIDS[] = { 97736, 97718, 97747, 128068, 128069, 128078, 128079,
+uint64 const CreatureGUIDS[] = { 97736, 97718, 97747, 128068, 128069, 128078, 128079,
                                 128080, 128082, 128083, 128085, 128086, 128089, 128090,
                                 128091, 128093, 128094, 128095, 128096, 128100, 128101, 128102 };
 
@@ -93,17 +93,16 @@ public:
         // If any of the adds on his chamber are alive, pull them
         void PullChamberAdds()
         {
-            for (int entry : CreatureEntriesToPullOnAggro)
+            for (uint64 GUID : CreatureGUIDS)
             {
-                std::list<Creature*> creatures;
-                me->GetCreaturesWithEntryInRange(creatures, 1000.0f, entry);
-                for (std::list<Creature*>::const_iterator itr = creatures.begin(); itr != creatures.end(); ++itr)
+                for (int entry : CreatureEntriesToPullOnAggro)
                 {
-                    Unit* unit = ObjectAccessor::GetUnit((*me), (*itr)->GetGUID());
-                    for (int GUID : CreatureGUIDS)
+                    std::list<Creature*> a;
+                    me->GetCreaturesWithEntryInRange(a, 500.0f, entry);
+                    for (std::list<Creature*>::const_iterator itr = a.begin(); itr != a.end(); ++itr)
                     {
-                        if (unit->GetGUID() == GUID) // Once the Pathfinding gets fixed, remove this check
-                            unit->GetAI()->AttackStart(me->GetVictim());
+                        if ((*itr)->GetGUID() & GUID)
+                            (*itr)->ToCreature()->AI()->AttackStart(me->GetVictim());
                     }
                 }
             }

--- a/src/server/scripts/Northrend/Naxxramas/naxxramas.h
+++ b/src/server/scripts/Northrend/Naxxramas/naxxramas.h
@@ -107,7 +107,16 @@ enum NXNPCs
     // Frogger
     NPC_LIVING_POISON               = 16027,
     NPC_NAXXRAMAS_TRIGGER           = 16082,
-    NPC_MR_BIGGLESWORTH             = 16998
+    NPC_MR_BIGGLESWORTH             = 16998,
+
+    // Patchwerk
+    NPC_PATCHWERK                   = 16028,
+    NPC_PATCHWORK_GOLEM             = 16017,
+    NPC_BILE_RETCHER                = 16018,
+    NPC_MAD_SCIENTIST               = 16020,
+    NPC_LIVING_MONSTROSITY          = 16021,
+    NPC_SURGICAL_ASSIST             = 16022,
+    NPC_SLUDGE_BELCHER              = 16029,
 };
 
 enum NXMisc


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
# If you haven't killed the adds, Patchwerk will pull them.

##### CHANGES PROPOSED:

@FALL1N1 Fixed it on his [PR](https://github.com/azerothcore/azerothcore-wotlk/pull/935) 👍 
I just gave it a small tweak considering the comments.
When you enter in combat with Patchwerk his whole chamber will enter in combat if you haven't killed them.

###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes #935 


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

- Compiles, tests and works

##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

- Go to Naxxramas and engage combat with Kelthuzad's avatar of war

##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

Pathing needs to be re-written

##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
