### PR TITLE
fix(DB/SAI): fix creature text for "Battle for the Undercity"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1555073136028342544.sql
+++ b/data/sql/updates/pending_db_world/rev_1555073136028342544.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1555073136028342544');
+
+UPDATE `smart_scripts` SET `action_param1` = 0 WHERE `entryorguid` = 32277 AND `source_type` = 0 AND `id` = 0;


### PR DESCRIPTION
##### CHANGES PROPOSED:
When finishing the Horde side of the event a distant voice yells "YOU HAVE FAILED ME, VARIMATHRAS!", but without sound sample. This is fixed with this PR.

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested in-game

##### HOW TO TEST THE CHANGES:
- preparation:
 ```
.quest remove 13266
.quest remove 13267
.quest add 13266
.go 1955.33 242.527 41.5081 0
```
- play through the event until the end, when Varimathras is defeated the appropriate sound sample for the voice should be played

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master