### PR TITLE
fix(Core): implement "SCRIPT_COMMAND_MOVEMENT" (35) to fix Defias Thug waypoint errors

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1555246241741494428.sql
+++ b/data/sql/updates/pending_db_world/rev_1555246241741494428.sql
@@ -1,4 +1,0 @@
-INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1555246241741494428');
-
-DELETE FROM `waypoint_scripts` WHERE `id` IN (8014900,8025100);
-UPDATE `waypoint_data` SET `action` = 0 WHERE `action` IN (8014900,8025100);

--- a/data/sql/updates/pending_db_world/rev_1555246241741494428.sql
+++ b/data/sql/updates/pending_db_world/rev_1555246241741494428.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1555246241741494428');
+
+DELETE FROM `waypoint_scripts` WHERE `id` IN (8014900,8025100);
+UPDATE `waypoint_data` SET `action` = 0 WHERE `action` IN (8014900,8025100);

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -110,7 +110,8 @@ enum ScriptCommands
     SCRIPT_COMMAND_EQUIP                 = 31,               // soucre = Creature, datalong = equipment id
     SCRIPT_COMMAND_MODEL                 = 32,               // source = Creature, datalong = model id
     SCRIPT_COMMAND_CLOSE_GOSSIP          = 33,               // source = Player
-    SCRIPT_COMMAND_PLAYMOVIE             = 34                // source = Player, datalong = movie id
+    SCRIPT_COMMAND_PLAYMOVIE             = 34,               // source = Player, datalong = movie id
+    SCRIPT_COMMAND_MOVEMENT              = 35                // soucre = Creature, datalong = MovementType, datalong2 = MovementDistance (spawndist f.ex.), dataint = pathid
 };
 
 // Benchmarked: Faster than std::unordered_map (insert/find)
@@ -359,6 +360,13 @@ struct ScriptInfo
         {
             uint32 MovieID;         // datalong
         } PlayMovie;
+
+        struct                       // SCRIPT_COMMAND_MOVEMENT (35)
+        {
+            uint32 MovementType;     // datalong
+            uint32 MovementDistance; // datalong2
+            int32  Path;             // dataint
+        } Movement;
     };
 
     std::string GetDebugInfo() const;

--- a/src/server/game/Scripting/MapScripts.cpp
+++ b/src/server/game/Scripting/MapScripts.cpp
@@ -916,6 +916,28 @@ void Map::ScriptsProcess()
                     player->SendMovieStart(step.script->PlayMovie.MovieID);
                 break;
 
+            case SCRIPT_COMMAND_MOVEMENT:
+                // Source must be Creature.
+                if (Creature* cSource = _GetScriptCreature(source, true, step.script))
+                {
+                    if (!cSource->IsAlive())
+                        return;
+
+                    cSource->GetMotionMaster()->MovementExpired();
+                    cSource->GetMotionMaster()->MoveIdle();
+
+                    switch (step.script->Movement.MovementType)
+                    {
+                        case RANDOM_MOTION_TYPE:
+                            cSource->GetMotionMaster()->MoveRandom((float)step.script->Movement.MovementDistance);
+                            break;
+                        case WAYPOINT_MOTION_TYPE:
+                            cSource->GetMotionMaster()->MovePath(step.script->Movement.Path, false);
+                            break;
+                    }
+                }
+                break;
+
             default:
                 sLog->outError("Unknown script command %s.", step.script->GetDebugInfo().c_str());
                 break;


### PR DESCRIPTION
##### CHANGES PROPOSED:
The following errors are caused by a non existing waypoint script command:
```
ERROR: Unknown script command Unknown command: 35 ('waypoint_scripts' script id: 8025100).
ERROR: Unknown script command Unknown command: 35 ('waypoint_scripts' script id: 8014900).
```
Implement "SCRIPT_COMMAND_MOVEMENT" (35) based on this TC commit:
https://github.com/TrinityCore/TrinityCore/commit/85357c75c4a202e2b7b72e14fe0d4083f74c87bb
Thanks @Meltie2013

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested in-game

##### HOW TO TEST THE CHANGES:
- ```.go creature 80149```
- stay in the area for a while
- the errors mentioned above should not occur after this PR is applied

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master