### PR TITLE
fix(CORE/Spells): Shadowmourne spell effect

### DIFF
--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -2517,11 +2517,17 @@ class spell_item_shadowmourne : public SpellScriptLoader
                     }
                 }
             }
+			
+			void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+			{
+				GetTarget()->RemoveAurasDueToSpell(SPELL_SHADOWMOURNE_SOUL_FRAGMENT);
+			}
 
             void Register()
             {
                 DoCheckProc += AuraCheckProcFn(spell_item_shadowmourne_AuraScript::CheckProc);
                 OnEffectProc += AuraEffectProcFn(spell_item_shadowmourne_AuraScript::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
+				AfterEffectRemove += AuraEffectRemoveFn(spell_item_shadowmourne_AuraScript::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
             }
         };
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
Shadowmourne soul fragment spell effect 

##### CHANGES PROPOSED:

-  Remove if the player unequip item while the effect/buff is active
-  


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 --> The issue is next, atm i'll say about Shadowmourne Axe. When you equip it, and fight someone and your spell effect/buff from weapon is activated  (In this case Soul Fragment) if you swap it with new weapon, the spell effect stay on player, doesn't get removed, which is wrong. Spell effect/buff should disappear in a moment when the player change item.

Closes 


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Yes, on Win. Builded without errors, tested in game, everything looks okay now. 
The effect is removed when the item is unequiped/removed


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
1. Create War / Pala or DK 
2. Equip Shadowmourne
3. Attack player or dummy until the spell effect/buff get activated ( Soul Fragment ) 
4. Get some stacks ( 10 is max ) 
5. Leave combat and unequip Shadowmorune ( The spell effect/buff should be removed if the weapon isn't equiped )

Issue Image below: 
![remove aura](https://user-images.githubusercontent.com/41213210/56420902-4006fd00-62a0-11e9-8670-ab03710d3b54.png)

P.S. Posible same problem is with :

- [Val'anyr, Hammer of Ancient Kings](https://wotlk.evowow.com/?item=46017)

- [Tiny Abomination in a Jar](https://wotlk.evowow.com/?item=50706)

- [Talisman of Resurgence](https://wotlk.evowow.com/?item=48724)

- [Deathbringer's Will](https://wotlk.evowow.com/?item=50363)




##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
