### PR TITLE
C'Thun Dark Glare spell timer

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -296,7 +296,7 @@ public:
                         {
                             //Face our target
                             DarkGlareAngle = me->GetAngle(target);
-                            DarkGlareTickTimer = 1000;
+                            DarkGlareTickTimer = 4000;
                             DarkGlareTick = 0;
                             ClockWise = RAND(true, false);
                         }


### PR DESCRIPTION
C'Thun Dark Glare spell should be casted about 4 seconds after C'Thun turns red, but is currently casting after just 1 second.

https://youtu.be/vZcR-OcrJGg?t=70