### PR TITLE
fix(DB/SAI): Darkspear Spear Thrower

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1556147118750847662.sql
+++ b/data/sql/updates/pending_db_world/rev_1556147118750847662.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1556147118750847662');
+
+UPDATE `smart_scripts` SET `action_param1` = 38556, `comment` = REPLACE(`comment`,'Shoot','Throw') WHERE `entryorguid` = 27560 AND `action_param1` = 6660;


### PR DESCRIPTION
##### CHANGES PROPOSED:
Use spell "Throw" (38556) instead of "Shoot" (6660) for Darkspear Spear Thrower, allowing them to launch ranged attacks.

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested in-game

##### HOW TO TEST THE CHANGES:
- ```.go 4826.99 1269.52 190.221 571```
- watch them fight the undead

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
