### PR TITLE
fix(Core/Spell): Healing Discount

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8354,6 +8354,13 @@ bool Unit::HandleProcTriggerSpell(Unit* victim, uint32 damage, AuraEffect* trigg
             {
                 switch (auraSpellInfo->Id)
                 {
+                    // Healing Discount: Each healing spell you cast has a 2% chance to make your next heal cast within 15 sec cost 450 less mana.
+                    case 37705:
+                    {
+                        trigger_spell_id = 37706;
+                        target = this;
+                        break;
+                    }
                     // Soul Preserver
                     case 60510:
                     {


### PR DESCRIPTION
http://wotlk.cavernoftime.com/spell=37705
Each healing spell you cast has a 2% chance to make your next heal cast within 15 sec cost 450 less mana.

http://wotlk.cavernoftime.com/spell=37706

Your next healing spell costs 450 less mana.

The paladin no gain mana on my server ! problem solved and tested with raid

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  Benefit the healing paladins, so they do not lose much mana


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes 


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

- I test on my mac and compile with docker



##### HOW TO TEST THE CHANGES:
- Go to Raid with Paladin Holy and cast holy spell and see it  no benefit


##### KNOWN ISSUES AND TODO LIST:

