### PR TITLE
fix(Core): increase visibility distance of large game objects

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -358,8 +358,6 @@ bool GameObject::Create(uint32 guidlow, uint32 name_id, Map* map, uint32 phaseMa
     return true;
 }
 
-
-
 void GameObject::Update(uint32 diff)
 {
 #ifdef ELUNA

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -351,8 +351,14 @@ bool GameObject::Create(uint32 guidlow, uint32 name_id, Map* map, uint32 phaseMa
     LastUsedScriptID = GetGOInfo()->ScriptId;
     AIM_Initialize();
 
+    // Check if GameObject is Large
+    if (goinfo->IsLargeGameObject())
+        SetVisibilityDistanceOverride(true);
+
     return true;
 }
+
+
 
 void GameObject::Update(uint32 diff)
 {

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -524,6 +524,22 @@ struct GameObjectTemplate
         }
     }
 
+    bool IsLargeGameObject() const
+    {
+        switch (type)
+        {
+            case GAMEOBJECT_TYPE_BUTTON:            return button.large != 0;
+            case GAMEOBJECT_TYPE_QUESTGIVER:        return questgiver.large != 0;
+            case GAMEOBJECT_TYPE_GENERIC:           return _generic.large != 0;
+            case GAMEOBJECT_TYPE_TRAP:              return trap.large != 0;
+            case GAMEOBJECT_TYPE_SPELL_FOCUS:       return spellFocus.large != 0;
+            case GAMEOBJECT_TYPE_GOOBER:            return goober.large != 0;
+            case GAMEOBJECT_TYPE_SPELLCASTER:       return spellcaster.large != 0;
+            case GAMEOBJECT_TYPE_CAPTURE_POINT:     return capturePoint.large != 0;
+            default: return false;
+        }
+    }
+
     bool IsGameObjectForQuests() const
     {
         return IsForQuests;

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -968,7 +968,7 @@ WorldObject::WorldObject(bool isWorldObject) : WorldLocation(),
 #ifdef ELUNA
 elunaEvents(NULL),
 #endif
-LastUsedScriptID(0), m_name(""), m_isActive(false), m_isWorldObject(isWorldObject), m_zoneScript(NULL),
+LastUsedScriptID(0), m_name(""), m_isActive(false), m_isVisibilityDistanceOverride(false), m_isWorldObject(isWorldObject), m_zoneScript(NULL),
 m_transport(NULL), m_currMap(NULL), m_InstanceId(0),
 m_phaseMask(PHASEMASK_NORMAL), m_notifyflags(0), m_executed_notifies(0)
 {
@@ -1037,6 +1037,14 @@ void WorldObject::setActive(bool on)
         else if (GetTypeId() == TYPEID_GAMEOBJECT)
             map->RemoveFromActive((GameObject*)this);
     }
+}
+
+void WorldObject::SetVisibilityDistanceOverride(bool isVisibilityDistanceOverride)
+{
+    if (GetTypeId() == TYPEID_PLAYER)
+        return;
+
+    m_isVisibilityDistanceOverride = isVisibilityDistanceOverride;
 }
 
 void WorldObject::CleanupsBeforeDelete(bool /*finalCleanup*/)
@@ -1515,7 +1523,14 @@ float WorldObject::GetVisibilityRange() const
     if (isActiveObject() && !ToPlayer())
         return MAX_VISIBILITY_DISTANCE;
     else if (GetTypeId() == TYPEID_GAMEOBJECT)
-        return IsInWintergrasp() ? VISIBILITY_DIST_WINTERGRASP+VISIBILITY_INC_FOR_GOBJECTS : GetMap()->GetVisibilityRange()+VISIBILITY_INC_FOR_GOBJECTS;
+    {
+        if (IsInWintergrasp())
+            return VISIBILITY_DIST_WINTERGRASP+VISIBILITY_INC_FOR_GOBJECTS;
+        else if (IsVisibilityOverridden())
+            return MAX_VISIBILITY_DISTANCE;
+        else
+            return GetMap()->GetVisibilityRange()+VISIBILITY_INC_FOR_GOBJECTS;
+    }
     else
         return IsInWintergrasp() ? VISIBILITY_DIST_WINTERGRASP : GetMap()->GetVisibilityRange();
 }
@@ -1531,7 +1546,14 @@ float WorldObject::GetSightRange(const WorldObject* target) const
                 if (target->isActiveObject() && !target->ToPlayer())
                     return MAX_VISIBILITY_DISTANCE;
                 else if (target->GetTypeId() == TYPEID_GAMEOBJECT)
-                    return IsInWintergrasp() && target->IsInWintergrasp() ? VISIBILITY_DIST_WINTERGRASP+VISIBILITY_INC_FOR_GOBJECTS : GetMap()->GetVisibilityRange()+VISIBILITY_INC_FOR_GOBJECTS;
+                {
+                    if (IsInWintergrasp() && target->IsInWintergrasp())
+                        return VISIBILITY_DIST_WINTERGRASP+VISIBILITY_INC_FOR_GOBJECTS;
+                    else if (target->IsVisibilityOverridden())
+                        return MAX_VISIBILITY_DISTANCE;
+                    else
+                        return GetMap()->GetVisibilityRange()+VISIBILITY_INC_FOR_GOBJECTS;
+                }
 
                 return IsInWintergrasp() && target->IsInWintergrasp() ? VISIBILITY_DIST_WINTERGRASP : GetMap()->GetVisibilityRange();
             }

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -974,6 +974,8 @@ class WorldObject : public Object, public WorldLocation
 
         bool isActiveObject() const { return m_isActive; }
         void setActive(bool isActiveObject);
+        bool IsVisibilityOverridden() const { return m_isVisibilityDistanceOverride; }
+        void SetVisibilityDistanceOverride(bool isVisibilityDistanceOverride);
         void SetWorldObject(bool apply);
         bool IsPermanentWorldObject() const { return m_isWorldObject; }
         bool IsWorldObject() const;
@@ -1018,6 +1020,7 @@ class WorldObject : public Object, public WorldLocation
     protected:
         std::string m_name;
         bool m_isActive;
+        bool m_isVisibilityDistanceOverride;
         const bool m_isWorldObject;
         ZoneScript* m_zoneScript;
 


### PR DESCRIPTION
##### CHANGES PROPOSED:
Based on this TC commit: https://github.com/TrinityCore/TrinityCore/commit/d1c3ee957962897a8b323e8ca40302fc5ff8c932

I only took over code parts concerning the visibility distance of large game objects as the visibility calculation of AC seems to be quite different from TC.
- large game objects will be handled like active objects:
 visibility distance is set to MAX_VISIBILITY_DISTANCE (250.0f)
- the logic concerning Wintergrasp visibility calculation is not touched
- I tried to keep the code changes to a minimum

It looks much better to see large game objects from far away in my opinion, e.g. the demon portals in Hellfire Peninsula:
before:
![WoWScrnShot_043019_103403](https://user-images.githubusercontent.com/38475780/56970362-45e5c380-6b67-11e9-9502-8688485ecf37.jpg)
after:
![WoWScrnShot_043019_103700](https://user-images.githubusercontent.com/38475780/56970390-539b4900-6b67-11e9-98af-cdef5484f108.jpg)

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested build (Ubuntu 16.04, Clang 7) and in-game

##### HOW TO TEST THE CHANGES:
- GAMEOBJECT_TYPE_BUTTON (1):
 ```.go object 27370``` (Night Elf Moon Crystal)
- GAMEOBJECT_TYPE_QUESTGIVER (2):
 ```.go object 59875``` (Elder Atkanok)
- GAMEOBJECT_TYPE_GENERIC (5):
 ```.go object 24222``` (Gateway Murketh)
- GAMEOBJECT_TYPE_TRAP (6):
 ```.go object 57161``` (Kvaldir Inferno)
- GAMEOBJECT_TYPE_SPELL_FOCUS (8):
 ```.go object 62204``` (Ymirheim Peak Skulls)
- GAMEOBJECT_TYPE_GOOBER (10):
 ```.go object 25256``` (Portal Grimh)
- GAMEOBJECT_TYPE_SPELLCASTER (22):
 ```.gobject add temp 192819``` (Defender's Portal)
- GAMEOBJECT_TYPE_CAPTURE_POINT (29):
 ```.gobject add temp 184380``` (Visual Banner (Horde))

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
