### PR TITLE
fix(DB): Sturdy Vine Despawn (quest "Some Make Lemonade, Some Make Liquor")

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1556709959826673022.sql
+++ b/data/sql/updates/pending_db_world/rev_1556709959826673022.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1556709959826673022');
+
+UPDATE `gameobject_template` SET `Data3` = 8000 WHERE `entry` = 190622;


### PR DESCRIPTION
##### CHANGES PROPOSED:
This concerns the quest "Some Make Lemonade, Some Make Liquor" (12634):
As it is now you can use the same "Sturdy Vine" many times in succession. After applying this PR the vines will correctly despawn (they respawn after ca. 5 minutes).

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.quest remove 12634
.quest add 12634
.go 5611.36 5207.23 -133.34 571
```
- proceed with the quest by clicking on the vines in the area

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master