### PR TITLE
fix(Core/Dungeon) BRD - The seven minibosses re-order

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
@@ -159,7 +159,7 @@ public:
 
         void EnterCombat(Unit* /*who*/) override
         {
-            _events.ScheduleEvent(EVENT_SPELL_SHADOWVOLLEY, 10000);
+            _events.ScheduleEvent(EVENT_SPELL_SHADOWBOLTVOLLEY, 10000);
             _events.ScheduleEvent(EVENT_SPELL_IMMOLATE, 18000);
             _events.ScheduleEvent(EVENT_SPELL_CURSEOFWEAKNESS, 5000);
             _events.ScheduleEvent(EVENT_SPELL_DEMONARMOR, 16000);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
@@ -106,10 +106,8 @@ public:
                 break;
             case GOSSIP_ACTION_INFO_DEF+2:
                 CloseGossipMenuFor(player);
-                //start event here
-                creature->setFaction(FACTION_HOSTILE);
-                creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
-                creature->AI()->AttackStart(player);
+
+                // Start encounter
                 InstanceScript* instance = creature->GetInstanceScript();
                 if (instance)
                     instance->SetData64(DATA_EVENSTARTER, player->GetGUID());

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
@@ -81,7 +81,7 @@ enum DoomrelSpells
     SPELL_DEMONARMOR                                       = 13787,
     SPELL_SUMMON_VOIDWALKERS                               = 15092
 };
-enum DoomrelSpells
+enum DoomrelEvents
 {
     EVENT_SPELL_SHADOWBOLTVOLLEY    = 1,
     EVENT_SPELL_IMMOLATE            = 2,

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
@@ -106,7 +106,7 @@ public:
                 break;
             case GOSSIP_ACTION_INFO_DEF+2:
                 CloseGossipMenuFor(player);
-                me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
+                creature->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                 // Start encounter
                 InstanceScript* instance = creature->GetInstanceScript();
                 if (instance)

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
@@ -81,6 +81,14 @@ enum DoomrelSpells
     SPELL_DEMONARMOR                                       = 13787,
     SPELL_SUMMON_VOIDWALKERS                               = 15092
 };
+enum DoomrelSpells
+{
+    EVENT_SPELL_SHADOWBOLTVOLLEY    = 1,
+    EVENT_SPELL_IMMOLATE            = 2,
+    EVENT_SPELL_CURSEOFWEAKNESS     = 3,
+    EVENT_SPELL_DEMONARMOR          = 4,
+    EVENT_SPELL_SUMMON_VOIDWALKERS  = 5,
+};
 
 class boss_doomrel : public CreatureScript
 {
@@ -131,18 +139,11 @@ public:
         }
 
         InstanceScript* instance;
-        uint32 ShadowVolley_Timer;
-        uint32 Immolate_Timer;
-        uint32 CurseOfWeakness_Timer;
-        uint32 DemonArmor_Timer;
+        EventMap _events;
         bool Voidwalkers;
 
         void Reset() override
         {
-            ShadowVolley_Timer = 10000;
-            Immolate_Timer = 18000;
-            CurseOfWeakness_Timer = 5000;
-            DemonArmor_Timer = 16000;
             Voidwalkers = false;
 
             me->setFaction(FACTION_FRIEND);
@@ -158,6 +159,10 @@ public:
 
         void EnterCombat(Unit* /*who*/) override
         {
+            _events.ScheduleEvent(EVENT_SPELL_SHADOWVOLLEY, 10000);
+            _events.ScheduleEvent(EVENT_SPELL_IMMOLATE, 18000);
+            _events.ScheduleEvent(EVENT_SPELL_CURSEOFWEAKNESS, 5000);
+            _events.ScheduleEvent(EVENT_SPELL_DEMONARMOR, 16000);
         }
 
         void EnterEvadeMode() override
@@ -182,41 +187,38 @@ public:
             if (!UpdateVictim())
                 return;
 
-            //ShadowVolley_Timer
-            if (ShadowVolley_Timer <= diff)
+            switch(_events.ExecuteEvent())
             {
-                DoCastVictim(SPELL_SHADOWBOLTVOLLEY);
-                ShadowVolley_Timer = 12000;
-            } else ShadowVolley_Timer -= diff;
-
-            //Immolate_Timer
-            if (Immolate_Timer <= diff)
-            {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))
-                    DoCast(target, SPELL_IMMOLATE);
-
-                Immolate_Timer = 25000;
-            } else Immolate_Timer -= diff;
-
-            //CurseOfWeakness_Timer
-            if (CurseOfWeakness_Timer <= diff)
-            {
-                DoCastVictim(SPELL_CURSEOFWEAKNESS);
-                CurseOfWeakness_Timer = 45000;
-            } else CurseOfWeakness_Timer -= diff;
-
-            //DemonArmor_Timer
-            if (DemonArmor_Timer <= diff)
-            {
-                DoCast(me, SPELL_DEMONARMOR);
-                DemonArmor_Timer = 300000;
-            } else DemonArmor_Timer -= diff;
-
-            //Summon Voidwalkers
-            if (!Voidwalkers && HealthBelowPct(51))
-            {
-                DoCastVictim(SPELL_SUMMON_VOIDWALKERS, true);
-                Voidwalkers = true;
+                case EVENT_SPELL_SHADOWVOLLEY:
+                    DoCastVictim(SPELL_SHADOWBOLTVOLLEY);
+                    _events.ScheduleEvent(EVENT_SPELL_SHADOWVOLLEY, 12000);
+                    break;
+                case EVENT_SPELL_IMMOLATE:
+                    if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))
+                    {
+                       DoCast(target, SPELL_IMMOLATE);
+                       _events.ScheduleEvent(EVENT_SPELL_IMMOLATE, 25000);
+                    }
+                    // Didn't get a target, try again in 1s
+                    _events.ScheduleEvent(EVENT_SPELL_IMMOLATE, 1000);
+                    break;
+                case EVENT_SPELL_CURSEOFWEAKNESS:
+                    DoCastVictim(SPELL_CURSEOFWEAKNESS);
+                    _events.ScheduleEvent(EVENT_SPELL_CURSEOFWEAKNESS, 45000);
+                    break;
+                case EVENT_SPELL_DEMONARMOR:
+                    DoCast(me, SPELL_DEMONARMOR);
+                    _events.ScheduleEvent(EVENT_SPELL_DEMONARMOR, 300000);
+                    break;
+                case EVENT_SPELL_SUMMONVOIDWALKERS:
+                    if (!Voidwalkers && HealthBelowPct(51))
+                    {
+                        DoCastVictim(SPELL_SUMMON_VOIDWALKERS, true);
+                        Voidwalkers = true;
+                    }
+                    // Not ready yet, try again in 1s
+                    _events.ScheduleEvent(EVENT_SPELL_SUMMON_VOIDWALKERS, 1000);
+                    break;
             }
 
             DoMeleeAttackIfReady();

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
@@ -189,9 +189,9 @@ public:
 
             switch(_events.ExecuteEvent())
             {
-                case EVENT_SPELL_SHADOWVOLLEY:
+                case EVENT_SPELL_SHADOWBOLTVOLLEY:
                     DoCastVictim(SPELL_SHADOWBOLTVOLLEY);
-                    _events.ScheduleEvent(EVENT_SPELL_SHADOWVOLLEY, 12000);
+                    _events.ScheduleEvent(EVENT_SPELL_SHADOWBOLTVOLLEY, 12000);
                     break;
                 case EVENT_SPELL_IMMOLATE:
                     if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
@@ -163,6 +163,7 @@ public:
             _events.ScheduleEvent(EVENT_SPELL_IMMOLATE, 18000);
             _events.ScheduleEvent(EVENT_SPELL_CURSEOFWEAKNESS, 5000);
             _events.ScheduleEvent(EVENT_SPELL_DEMONARMOR, 16000);
+            _events.ScheduleEvent(EVENT_SPELL_SUMMON_VOIDWALKERS, 1000);
         }
 
         void EnterEvadeMode() override
@@ -210,7 +211,7 @@ public:
                     DoCast(me, SPELL_DEMONARMOR);
                     _events.ScheduleEvent(EVENT_SPELL_DEMONARMOR, 300000);
                     break;
-                case EVENT_SPELL_SUMMONVOIDWALKERS:
+                case EVENT_SPELL_SUMMON_VOIDWALKERS:
                     if (!Voidwalkers && HealthBelowPct(51))
                     {
                         DoCastVictim(SPELL_SUMMON_VOIDWALKERS, true);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
@@ -188,6 +188,8 @@ public:
             if (!UpdateVictim())
                 return;
 
+            _events.Update(diff);
+            
             switch(_events.ExecuteEvent())
             {
                 case EVENT_SPELL_SHADOWBOLTVOLLEY:

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
@@ -106,7 +106,7 @@ public:
                 break;
             case GOSSIP_ACTION_INFO_DEF+2:
                 CloseGossipMenuFor(player);
-
+                me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                 // Start encounter
                 InstanceScript* instance = creature->GetInstanceScript();
                 if (instance)
@@ -143,6 +143,8 @@ public:
         void Reset() override
         {
             Voidwalkers = false;
+            // Reset his gossip menu
+            me->SetFlag(UNIT_FIELD_FLAGS, UNIT_NPC_FLAG_GOSSIP);
 
             me->setFaction(FACTION_FRIEND);
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/instance_blackrock_depths.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/instance_blackrock_depths.cpp
@@ -155,13 +155,13 @@ public:
             case NPC_EMPEROR: EmperorGUID = creature->GetGUID(); break;
             case NPC_PHALANX: PhalanxGUID = creature->GetGUID(); break;
             case NPC_MOIRA: MoiraGUID = creature->GetGUID(); break;
-            case NPC_DOOMREL: TombBossGUIDs[0] = creature->GetGUID(); break;
-            case NPC_DOPEREL: TombBossGUIDs[1] = creature->GetGUID(); break;
-            case NPC_HATEREL: TombBossGUIDs[2] = creature->GetGUID(); break;
-            case NPC_VILEREL: TombBossGUIDs[3] = creature->GetGUID(); break;
-            case NPC_SEETHREL: TombBossGUIDs[4] = creature->GetGUID(); break;
-            case NPC_GLOOMREL: TombBossGUIDs[5] = creature->GetGUID(); break;
-            case NPC_ANGERREL: TombBossGUIDs[6] = creature->GetGUID(); break;
+            case NPC_ANGERREL:  TombBossGUIDs[0] = creature->GetGUID(); break;
+            case NPC_SEETHREL:  TombBossGUIDs[1] = creature->GetGUID(); break;
+            case NPC_DOPEREL:   TombBossGUIDs[2] = creature->GetGUID(); break;
+            case NPC_GLOOMREL:  TombBossGUIDs[3] = creature->GetGUID(); break;
+            case NPC_VILEREL:   TombBossGUIDs[4] = creature->GetGUID(); break;
+            case NPC_HATEREL:   TombBossGUIDs[5] = creature->GetGUID(); break;
+            case NPC_DOOMREL:   TombBossGUIDs[6] = creature->GetGUID(); break;
             case NPC_MAGMUS:
                 MagmusGUID = creature->GetGUID();
                 if (!creature->IsAlive())

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/instance_blackrock_depths.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/instance_blackrock_depths.cpp
@@ -441,8 +441,8 @@ public:
                 if (TombTimer <= diff)
                 {
                     TombTimer = TIMER_TOMBOFTHESEVEN;
-                    ++TombEventCounter;
                     TombOfSevenEvent();
+                    ++TombEventCounter;
                     // Check Killed bosses
                     for (uint8 i = 0; i < 7; ++i)
                     {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->
## The bosses are not coming in the right order

##### CHANGES PROPOSED:

- Swapped timers to EventMap
- 1st attacker is Anger'rel
- 2nd attacker is Seeth'rel
- 3rd Attacker is Dope'rel
- 4th Attacker is Gloom'rel
- 5th attacker is Vile'rel
- 6th attacker is Hate'rel
- 7th attacker is Doom'rel

###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes #1772 


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

No testes performed.

##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

Events start Boss Doomrel ID 9039

Either one of the two choices:
1. Look on the database for the GUID on creature with entry 9039 and then do
.go c \<guid\>
2. Do the entire dungeon

##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
