### PR TITLE
fix(DB): Raised Mud Despawn (quest "An Embarassing Incident")

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1556953235734868559.sql
+++ b/data/sql/updates/pending_db_world/rev_1556953235734868559.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1556953235734868559');
+
+UPDATE `gameobject_template` SET `Data5` = 1 WHERE `entry` = 190779;


### PR DESCRIPTION
##### CHANGES PROPOSED:
Despawn game object "Raised Mud" after using it (see quest "An Embarassing Incident", ID 12699).

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.quest remove 12699
.quest add 12699
.go 5482.7  4757.96 -197.446 571
```
- dive into the lake and use the "Raised Mud" game objects there. They should despawn now and respawn after approximately 5 minutes.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master