### PR TITLE
fix(DB/Core): Emotes / reaction during quest "The Taste Test"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1556980489509436556.sql
+++ b/data/sql/updates/pending_db_world/rev_1556980489509436556.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1556980489509436556');
+
+UPDATE `creature_text` SET `Emote` = 92 WHERE `GroupID` = 1 AND `CreatureID` IN (27986,28047,28568);

--- a/src/server/scripts/Northrend/zone_sholazar_basin.cpp
+++ b/src/server/scripts/Northrend/zone_sholazar_basin.cpp
@@ -852,10 +852,15 @@ public:
 ## npc_jungle_punch_target
 #####*/
 
-#define SAY_OFFER     "Care to try Grimbooze Thunderbrew's new jungle punch?"
-
 enum JunglePunch
 {
+    SAY_OFFER                           = 28558,
+    ITEM_TANKARD                        = 2705,
+
+    NPC_HEMET                           = 27986,
+    NPC_HADRIUS                         = 28047,
+
+    SPELL_KNOCKDOWN                     = 42963,
     SPELL_OFFER                         = 51962,
     QUEST_TASTE_TEST                    = 12645,
 
@@ -977,8 +982,25 @@ public:
 
             if (sayTimer < diff)
             {
+                if (sayStep == 2)
+                {
+                    me->SetSheath(SHEATH_STATE_MELEE);
+                    SetEquipmentSlots(false, ITEM_TANKARD, EQUIP_UNEQUIP, EQUIP_UNEQUIP);
+                }
+                else if (sayStep == 3)
+                {
+                    if (me->GetEntry() == NPC_HEMET)
+                        me->SetSheath(SHEATH_STATE_RANGED);
+                    else if (me->GetEntry() == NPC_HADRIUS)
+                    {
+                        me->SetSheath(SHEATH_STATE_UNARMED);
+                        me->CastSpell(me,SPELL_KNOCKDOWN,false);
+                    }
+                    SetEquipmentSlots(true);
+                }
+
                 Talk(SAY_HEMET_HADRIUS_TAMARA_1 + sayStep - 1);
-                sayTimer = 3000;
+                sayTimer = 6000;
                 sayStep++;
 
                 if (sayStep > 3) // end
@@ -1014,7 +1036,7 @@ public:
                     continue;
 
                 player->KilledMonsterCredit(me->GetEntry(), 0);
-                player->Say(SAY_OFFER, LANG_UNIVERSAL);
+                player->MonsterSay(SAY_OFFER, LANG_UNIVERSAL, me);
                 sayStep = 1;
                 break;
             }


### PR DESCRIPTION
##### CHANGES PROPOSED:
Just a small adjustment to the core script handling the reaction of the NPCs during the quest "The Taste Test" (12645) in order to provide a better visual feedback for the player. Here's an old video showing the quest:
https://www.youtube.com/watch?v=uq_nvYpUyNA

Changes:
- use "MonsterSay" instead of "Say" for the player text and switch to broadcast text ID
- show drinking animation for the NPCs
- add knockdown effect for Hadrius (not visible in the video, but I remember this well from retail WotLK)
- increase the time interval between the NPC texts

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested build (Ubuntu 16.04, clang 7) and in-game

##### HOW TO TEST THE CHANGES:
- preparation
```
.quest remove 12645
.quest add 12645
.go 5567.68 5748.04 -75.4131 571
```
- just proceed with the quest

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master