### PR TITLE
fix(DB/Quest): Healthy Dragon Scale

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1557180801797784400.sql
+++ b/data/sql/updates/pending_db_world/rev_1557180801797784400.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1557180801797784400');
+
+-- Healthy Dragon Scale https://www.wowdb.com/items/13920-healthy-dragon-scale
+DELETE FROM `conditions` WHERE  `SourceGroup`=10678 AND `SourceEntry` IN (13920,5582) AND `ConditionValue1`=5529;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
+(1, 10678, 13920, 0, 0, 8, 0, 5529, 0, 0, 0, 0, 0, '', 'Healthy Dragon Scale drop if Quest 5529 rewarded');
+
+UPDATE `creature_loot_template` SET `Chance`='100' WHERE `Entry`=10678 AND `Item`=13920;

--- a/data/sql/updates/pending_db_world/rev_1557180801797784400.sql
+++ b/data/sql/updates/pending_db_world/rev_1557180801797784400.sql
@@ -5,4 +5,4 @@ DELETE FROM `conditions` WHERE  `SourceGroup`=10678 AND `SourceEntry` IN (13920,
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
 (1, 10678, 13920, 0, 0, 8, 0, 5529, 0, 0, 0, 0, 0, '', 'Healthy Dragon Scale drop if Quest 5529 rewarded');
 
-UPDATE `creature_loot_template` SET `Chance`='100' WHERE `Entry`=10678 AND `Item`=13920;
+UPDATE `creature_loot_template` SET `Chance`='6' WHERE `Entry`=10678 AND `Item`=13920;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
Healthy Dragon Scale should drop just after Quest ID: 5529 is completed

##### CHANGES PROPOSED:

-  Added conditions. Item will be drop, just if the quest 5529 is completed.
-  Loot updated to 6 drop chance.


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1805


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Yes, tested in game. The item is dropped just when the player have finished quest ID 5529


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
Read here : https://github.com/azerothcore/azerothcore-wotlk/issues/1805



##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
