### PR TITLE
feat(MMAPS/mapbuilder):  mmaps_generator now working with MapID >= 1000

### DIFF
--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -90,14 +90,14 @@ namespace MMAP
     void MapBuilder::discoverTiles()
     {
         std::vector<std::string> files;
-        uint32 mapID, tileX, tileY, tileID, count = 0;
+        uint32 mapID, tileX, tileY, tileID, count, fsize = 0;
         char filter[12];
 
         printf("Discovering maps... ");
         getDirContents(files, "maps");
         for (uint32 i = 0; i < files.size(); ++i)
         {
-            mapID = uint32(atoi(files[i].substr(0,3).c_str()));
+            mapID = uint32(atoi(files[i].substr(0, files[i].size() - 8).c_str()));
             if (std::find(m_tiles.begin(), m_tiles.end(), mapID) == m_tiles.end())
             {
                 m_tiles.emplace_back(MapTiles(mapID, new std::set<uint32>));
@@ -109,7 +109,7 @@ namespace MMAP
         getDirContents(files, "vmaps", "*.vmtree");
         for (uint32 i = 0; i < files.size(); ++i)
         {
-            mapID = uint32(atoi(files[i].substr(0,3).c_str()));
+            mapID = uint32(atoi(files[i].substr(0, files[i].size() - 7).c_str()));
             if (std::find(m_tiles.begin(), m_tiles.end(), mapID) == m_tiles.end())
             {
                 m_tiles.emplace_back(MapTiles(mapID, new std::set<uint32>));
@@ -130,8 +130,10 @@ namespace MMAP
             getDirContents(files, "vmaps", filter);
             for (uint32 i = 0; i < files.size(); ++i)
             {
-                tileX = uint32(atoi(files[i].substr(7,2).c_str()));
-                tileY = uint32(atoi(files[i].substr(4,2).c_str()));
+                fsize = files[i].size();
+
+                tileY = uint32(atoi(files[i].substr(fsize - 12, 2).c_str()));
+                tileX = uint32(atoi(files[i].substr(fsize - 9, 2).c_str()));
                 tileID = StaticMapTree::packTileID(tileY, tileX);
 
                 tiles->insert(tileID);
@@ -143,8 +145,10 @@ namespace MMAP
             getDirContents(files, "maps", filter);
             for (uint32 i = 0; i < files.size(); ++i)
             {
-                tileY = uint32(atoi(files[i].substr(3,2).c_str()));
-                tileX = uint32(atoi(files[i].substr(5,2).c_str()));
+                fsize = files[i].size();
+
+                tileY = uint32(atoi(files[i].substr(fsize - 8,2).c_str()));
+                tileX = uint32(atoi(files[i].substr(fsize - 6,2).c_str()));
                 tileID = StaticMapTree::packTileID(tileX, tileY);
 
                 if (tiles->insert(tileID).second)

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -90,7 +90,7 @@ namespace MMAP
     void MapBuilder::discoverTiles()
     {
         std::vector<std::string> files;
-        uint32 mapID, tileX, tileY, tileID, count, fsize = 0;
+        uint32 mapID, tileX, tileY, tileID, count = 0, fsize = 0;
         char filter[12];
 
         printf("Discovering maps... ");


### PR DESCRIPTION
Get the mmaps_generator working with MapID >= 1000.

mmaps_generator doesn't work with maps that have MapID >= 1000, theses changes will fix it.


##### CHANGES PROPOSED:
-  See pull request


###### ISSUES ADDRESSED:
The issue was that the mmaps_generator doesn't generate the mmaps properly when MapID is above 999. (length of MapID > 3)
Noticed that I've 3 custom maps : 996, 1514 and 1600.
Everything is fine with 996 (generating 996.mmap and 996YYXX.mmtile)
For map 1514 and 1600, it generate : 151.mmap, 151YYXX.mmtile and 160.mmap and 160YYXX.mmtile

The "problem" is that the tool is overriding files, so imagine if you've a custom map with ID 5710, it'll create 571.mmap and 571YYXX.mmtile instead of 5710.mmap and 5710YYXX.mmtile. In consequence, it'll override Northrend (MapID 571) mmaps.


##### TESTS PERFORMED:
Build without errors.
Mmaps working fine in-game : creature follows the player when aggroed and doesn't walk though walls/trees...
Theses changes don't affect non-custom maps
Tested on Windows 10.


##### HOW TO TEST THE CHANGES:
- [ ] Make a custom map with ID > 999, like 1246.
Extract maps, vmaps and mmaps for this new map.
See that the name of created files for MapID 1246 are 1246.mmap and 1246YYXX.mmtile
- [ ] Test with hashes of the old and new generated mmap folders to make sure the files did not change in any way. This way we know it did not break or change anything existing.


##### Target branch(es):
Master
