### PR TITLE
fix(Core): Reputation modifier now affects negative rep reward

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -982,7 +982,7 @@ Player::~Player()
 }
 
 void Player::CleanupsBeforeDelete(bool finalCleanup)
-{ 
+{
     TradeCancel(false);
     DuelComplete(DUEL_INTERRUPTED);
 
@@ -990,7 +990,7 @@ void Player::CleanupsBeforeDelete(bool finalCleanup)
 }
 
 bool Player::Create(uint32 guidlow, CharacterCreateInfo* createInfo)
-{ 
+{
     //FIXME: outfitId not used in player creating
     // TODO: need more checks against packet modifications
     // should check that skin, face, hair* are valid via DBC per race/class
@@ -1220,7 +1220,7 @@ bool Player::Create(uint32 guidlow, CharacterCreateInfo* createInfo)
 }
 
 bool Player::StoreNewItemInBestSlots(uint32 titem_id, uint32 titem_amount)
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_ITEMS, "STORAGE: Creating initial item, itemId = %u, count = %u", titem_id, titem_amount);
 #endif
@@ -1257,7 +1257,7 @@ bool Player::StoreNewItemInBestSlots(uint32 titem_id, uint32 titem_amount)
 }
 
 void Player::SendMirrorTimer(MirrorTimerType Type, uint32 MaxValue, uint32 CurrentValue, int32 Regen)
-{ 
+{
     if (int(MaxValue) == DISABLED_MIRROR_TIMER)
     {
         if (int(CurrentValue) != DISABLED_MIRROR_TIMER)
@@ -1275,7 +1275,7 @@ void Player::SendMirrorTimer(MirrorTimerType Type, uint32 MaxValue, uint32 Curre
 }
 
 void Player::StopMirrorTimer(MirrorTimerType Type)
-{ 
+{
     m_MirrorTimer[Type] = DISABLED_MIRROR_TIMER;
     WorldPacket data(SMSG_STOP_MIRROR_TIMER, 4);
     data << (uint32)Type;
@@ -1283,13 +1283,13 @@ void Player::StopMirrorTimer(MirrorTimerType Type)
 }
 
 bool Player::IsImmuneToEnvironmentalDamage()
-{ 
+{
     // check for GM and death state included in isAttackableByAOE
     return (!isTargetableForAttack(false, NULL));
 }
 
 uint32 Player::EnvironmentalDamage(EnviromentalDamage type, uint32 damage)
-{ 
+{
     if (IsImmuneToEnvironmentalDamage())
         return 0;
 
@@ -1335,7 +1335,7 @@ uint32 Player::EnvironmentalDamage(EnviromentalDamage type, uint32 damage)
 }
 
 int32 Player::getMaxTimer(MirrorTimerType timer)
-{ 
+{
     switch (timer)
     {
         case FATIGUE_TIMER:
@@ -1362,14 +1362,14 @@ int32 Player::getMaxTimer(MirrorTimerType timer)
 }
 
 void Player::UpdateMirrorTimers()
-{ 
+{
     // Desync flags for update on next HandleDrowning
     if (m_MirrorTimerFlags)
         m_MirrorTimerFlagsLast = ~m_MirrorTimerFlags;
 }
 
 void Player::HandleDrowning(uint32 time_diff)
-{ 
+{
     if (!m_MirrorTimerFlags)
         return;
 
@@ -1486,7 +1486,7 @@ void Player::HandleDrowning(uint32 time_diff)
 
 ///The player sobers by 1% every 9 seconds
 void Player::HandleSobering()
-{ 
+{
     m_drunkTimer = 0;
 
     uint8 currentDrunkValue = GetDrunkValue();
@@ -1506,7 +1506,7 @@ DrunkenState Player::GetDrunkenstateByValue(uint8 value)
 }
 
 void Player::SetDrunkValue(uint8 newDrunkValue, uint32 itemId /*= 0*/)
-{ 
+{
     bool isSobering = newDrunkValue < GetDrunkValue();
     uint32 oldDrunkenState = Player::GetDrunkenstateByValue(GetDrunkValue());
     if (newDrunkValue > 100)
@@ -1540,7 +1540,7 @@ void Player::SetDrunkValue(uint8 newDrunkValue, uint32 itemId /*= 0*/)
 }
 
 void Player::Update(uint32 p_time)
-{ 
+{
     if (!IsInWorld())
         return;
 
@@ -1901,7 +1901,7 @@ void Player::Update(uint32 p_time)
 }
 
 void Player::setDeathState(DeathState s, bool /*despawn = false*/)
-{ 
+{
     uint32 ressSpellId = 0;
 
     bool cur = IsAlive();
@@ -1975,11 +1975,11 @@ void Player::RemoveRestState()
 bool Player::BuildEnumData(PreparedQueryResult result, WorldPacket* data)
 {
     //             0               1                2                3                 4                  5                 6               7
-    //    "SELECT characters.guid, characters.name, characters.race, characters.class, characters.gender, characters.skin, characters.face, characters.hairStyle, 
+    //    "SELECT characters.guid, characters.name, characters.race, characters.class, characters.gender, characters.skin, characters.face, characters.hairStyle,
     //     8                     9                       10              11               12              13                     14                     15
     //    characters.hairColor, characters.facialStyle, character.level, characters.zone, characters.map, characters.position_x, characters.position_y, characters.position_z,
-    //    16                    17                      18                   19                   20                     21                   22               23                    
-    //    guild_member.guildid, characters.playerFlags, characters.at_login, character_pet.entry, character_pet.modelid, character_pet.level, characters.equipmentCache, character_banned.guid, 
+    //    16                    17                      18                   19                   20                     21                   22               23
+    //    guild_member.guildid, characters.playerFlags, characters.at_login, character_pet.entry, character_pet.modelid, character_pet.level, characters.equipmentCache, character_banned.guid,
     //    24                      25
     //    characters.extra_flags, character_declinedname.genitive
 
@@ -2013,7 +2013,7 @@ bool Player::BuildEnumData(PreparedQueryResult result, WorldPacket* data)
     uint8 hairStyle = fields[7].GetUInt8();
     uint8 hairColor = fields[8].GetUInt8();
     uint8 facialStyle = fields[9].GetUInt8();
-    
+
     *data << uint8(skin);
     *data << uint8(face);
     *data << uint8(hairStyle);
@@ -2126,7 +2126,7 @@ bool Player::BuildEnumData(PreparedQueryResult result, WorldPacket* data)
 }
 
 void Player::ToggleAFK()
-{ 
+{
     ToggleFlag(PLAYER_FLAGS, PLAYER_FLAGS_AFK);
 
     // afk player not allowed in battleground
@@ -2135,12 +2135,12 @@ void Player::ToggleAFK()
 }
 
 void Player::ToggleDND()
-{ 
+{
     ToggleFlag(PLAYER_FLAGS, PLAYER_FLAGS_DND);
 }
 
 uint8 Player::GetChatTag() const
-{ 
+{
     uint8 tag = CHAT_TAG_NONE;
 
     if (isGMChat())
@@ -2156,7 +2156,7 @@ uint8 Player::GetChatTag() const
 }
 
 void Player::SendTeleportAckPacket()
-{ 
+{
     WorldPacket data(MSG_MOVE_TELEPORT_ACK, 41);
     data.append(GetPackGUID());
     data << uint32(0);                                     // this value increments every time
@@ -2432,7 +2432,7 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
 }
 
 bool Player::TeleportToEntryPoint()
-{ 
+{
     ScheduleDelayedOperation(DELAYED_BG_MOUNT_RESTORE);
     ScheduleDelayedOperation(DELAYED_BG_TAXI_RESTORE);
     ScheduleDelayedOperation(DELAYED_BG_GROUP_RESTORE);
@@ -2443,7 +2443,7 @@ bool Player::TeleportToEntryPoint()
 }
 
 void Player::ProcessDelayedOperations()
-{ 
+{
     if (m_DelayedOperations == 0)
         return;
 
@@ -2508,7 +2508,7 @@ void Player::ProcessDelayedOperations()
         if (Vehicle* vehicle = GetVehicle())
         {
             SeatMap::iterator itr = vehicle->GetSeatIteratorForPassenger(this);
-            if (itr != vehicle->Seats.end())  
+            if (itr != vehicle->Seats.end())
                 if (Unit* base = vehicle->GetBase())
                 {
                     ExitVehicle();
@@ -2522,7 +2522,7 @@ void Player::ProcessDelayedOperations()
 }
 
 void Player::AddToWorld()
-{ 
+{
     ///- Do not add/remove the player from the object storage
     ///- It will crash when updating the ObjectAccessor
     ///- The player should only be added when logging in
@@ -2534,7 +2534,7 @@ void Player::AddToWorld()
 }
 
 void Player::RemoveFromWorld()
-{ 
+{
     // cleanup
     if (IsInWorld())
     {
@@ -2575,7 +2575,7 @@ void Player::RemoveFromWorld()
 }
 
 void Player::RegenerateAll()
-{ 
+{
     //if (m_regenTimer <= 500)
     //    return;
 
@@ -2625,7 +2625,7 @@ void Player::RegenerateAll()
     }
 
     m_regenTimer = 0;
-    
+
     // Handles the emotes for drinking and eating.
     // According to sniffs there is a background timer going on that repeats independed from the time window where the aura applies.
     // That's why we dont need to reset the timer on apply. In sniffs I have seen that the first call for the spell visual is totally random, then after
@@ -2659,7 +2659,7 @@ void Player::RegenerateAll()
 }
 
 void Player::Regenerate(Powers power)
-{ 
+{
     uint32 maxValue = GetMaxPower(power);
     if (!maxValue)
         return;
@@ -2777,7 +2777,7 @@ void Player::Regenerate(Powers power)
 }
 
 void Player::RegenerateHealth()
-{ 
+{
     uint32 curValue = GetHealth();
     uint32 maxValue = GetMaxHealth();
 
@@ -2824,7 +2824,7 @@ void Player::RegenerateHealth()
 }
 
 void Player::ResetAllPowers()
-{ 
+{
     SetHealth(GetMaxHealth());
     switch (getPowerType())
     {
@@ -2846,7 +2846,7 @@ void Player::ResetAllPowers()
 }
 
 bool Player::CanInteractWithQuestGiver(Object* questGiver)
-{ 
+{
     switch (questGiver->GetTypeId())
     {
         case TYPEID_UNIT:
@@ -2921,7 +2921,7 @@ Creature* Player::GetNPCIfCanInteractWith(uint64 guid, uint32 npcflagmask)
 }
 
 GameObject* Player::GetGameObjectIfCanInteractWith(uint64 guid, GameobjectTypes type) const
-{ 
+{
     if (GameObject* go = GetMap()->GetGameObject(guid))
     {
         if (go->GetGoType() == type)
@@ -2938,7 +2938,7 @@ GameObject* Player::GetGameObjectIfCanInteractWith(uint64 guid, GameobjectTypes 
 }
 
 bool Player::IsInWater(bool allowAbove) const
-{ 
+{
     if (m_isInWater || !allowAbove)
         return m_isInWater;
 
@@ -2956,7 +2956,7 @@ bool Player::IsInWater(bool allowAbove) const
 }
 
 bool Player::IsUnderWater() const
-{ 
+{
     return IsInWater() &&
         GetPositionZ() < (GetBaseMap()->GetWaterLevel(GetPositionX(), GetPositionY())-2);
 }
@@ -2968,7 +2968,7 @@ bool Player::IsFalling() const
 }
 
 void Player::SetInWater(bool apply)
-{ 
+{
     if (m_isInWater == apply)
         return;
 
@@ -3008,7 +3008,7 @@ bool Player::IsInAreaTriggerRadius(const AreaTrigger* trigger) const
 }
 
 void Player::SetGameMaster(bool on)
-{ 
+{
     if (on)
     {
         m_ExtraFlags |= PLAYER_EXTRA_GM_ON;
@@ -3094,7 +3094,7 @@ void Player::SetGMVisible(bool on)
 }
 
 bool Player::IsGroupVisibleFor(Player const* p) const
-{ 
+{
     switch (sWorld->getIntConfig(CONFIG_GROUP_VISIBILITY))
     {
         default: return IsInSameGroupWith(p);
@@ -3104,7 +3104,7 @@ bool Player::IsGroupVisibleFor(Player const* p) const
 }
 
 bool Player::IsInSameGroupWith(Player const* p) const
-{ 
+{
     return p == this || (GetGroup() != NULL &&
         GetGroup() == p->GetGroup() &&
         GetGroup()->SameSubGroup(this, p));
@@ -3113,7 +3113,7 @@ bool Player::IsInSameGroupWith(Player const* p) const
 ///- If the player is invited, remove him. If the group if then only 1 person, disband the group.
 /// \todo Shouldn't we also check if there is no other invitees before disbanding the group?
 void Player::UninviteFromGroup()
-{ 
+{
     Group* group = GetGroupInvite();
     if (!group)
         return;
@@ -3146,7 +3146,7 @@ void Player::RemoveFromGroup(Group* group, uint64 guid, RemoveMethod method /* =
 }
 
 void Player::SendLogXPGain(uint32 GivenXP, Unit* victim, uint32 BonusXP, bool recruitAFriend, float /*group_rate*/)
-{ 
+{
     WorldPacket data(SMSG_LOG_XPGAIN, 22); // guess size?
     data << uint64(victim ? victim->GetGUID() : 0);         // guid
     data << uint32(GivenXP + BonusXP);                      // given experience
@@ -3165,7 +3165,7 @@ void Player::SendLogXPGain(uint32 GivenXP, Unit* victim, uint32 BonusXP, bool re
 }
 
 void Player::GiveXP(uint32 xp, Unit* victim, float group_rate)
-{ 
+{
     if (xp < 1)
         return;
 
@@ -3227,7 +3227,7 @@ void Player::GiveXP(uint32 xp, Unit* victim, float group_rate)
 // Update player to next level
 // Current player experience not update (must be update by caller)
 void Player::GiveLevel(uint8 level)
-{ 
+{
     uint8 oldLevel = getLevel();
     if (level == oldLevel)
         return;
@@ -3326,7 +3326,7 @@ void Player::GiveLevel(uint8 level)
 }
 
 void Player::InitTalentForLevel()
-{ 
+{
     uint32 talentPointsForLevel = CalculateTalentsPoints();
 
     // xinef: more talent points that we have are used, reset
@@ -3341,7 +3341,7 @@ void Player::InitTalentForLevel()
 }
 
 void Player::InitStatsForLevel(bool reapplyMods)
-{ 
+{
     if (reapplyMods)                                        //reapply stats values only on .reset stats (level) command
         _RemoveAllStatBonuses();
 
@@ -3502,7 +3502,7 @@ void Player::InitStatsForLevel(bool reapplyMods)
 }
 
 void Player::SendInitialSpells()
-{ 
+{
     uint32 curTime = World::GetGameTimeMS();
     uint32 infTime = World::GetGameTimeMS()+infinityCooldownDelayCheck;
 
@@ -3592,7 +3592,7 @@ void Player::SendInitialSpells()
 }
 
 void Player::RemoveMail(uint32 id)
-{ 
+{
     for (PlayerMails::iterator itr = m_mail.begin(); itr != m_mail.end(); ++itr)
     {
         if ((*itr)->messageID == id)
@@ -3605,7 +3605,7 @@ void Player::RemoveMail(uint32 id)
 }
 
 void Player::SendMailResult(uint32 mailId, MailResponseType mailAction, MailResponseResult mailError, uint32 equipError, uint32 item_guid, uint32 item_count)
-{ 
+{
     WorldPacket data(SMSG_SEND_MAIL_RESULT, (4+4+4+(mailError == MAIL_ERR_EQUIP_ERROR?4:(mailAction == MAIL_ITEM_TAKEN?4+4:0))));
     data << (uint32) mailId;
     data << (uint32) mailAction;
@@ -3621,7 +3621,7 @@ void Player::SendMailResult(uint32 mailId, MailResponseType mailAction, MailResp
 }
 
 void Player::SendNewMail()
-{ 
+{
     // deliver undelivered mail
     WorldPacket data(SMSG_RECEIVED_MAIL, 4);
     data << (uint32) 0;
@@ -3629,7 +3629,7 @@ void Player::SendNewMail()
 }
 
 void Player::UpdateNextMailTimeAndUnreads()
-{ 
+{
     // calculate next delivery time (min. from non-delivered mails
     // and recalculate unReadMail
     time_t cTime = time(NULL);
@@ -3648,7 +3648,7 @@ void Player::UpdateNextMailTimeAndUnreads()
 }
 
 void Player::AddNewMailDeliverTime(time_t deliver_time)
-{ 
+{
     if (deliver_time <= time(NULL))                          // ready now
     {
         ++unReadMails;
@@ -3662,7 +3662,7 @@ void Player::AddNewMailDeliverTime(time_t deliver_time)
 }
 
 bool Player::addTalent(uint32 spellId, uint8 addSpecMask, uint8 oldTalentRank)
-{ 
+{
     SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
     if (!SpellMgr::CheckSpellValid(spellInfo, spellId, true))
         return false;
@@ -3717,7 +3717,7 @@ bool Player::addTalent(uint32 spellId, uint8 addSpecMask, uint8 oldTalentRank)
     {
         sLog->outError("Player (%u) tries to learn talent %u with covered specMask (curr: %u, add: %u)", GetGUIDLow(), spellId, itr->second->specMask, addSpecMask);
     }
-    
+
     return false;
 }
 
@@ -3790,7 +3790,7 @@ void Player::_addTalentAurasAndSpells(uint32 spellId)
     else if (spellInfo->IsPassive() || (spellInfo->HasAttribute(SPELL_ATTR0_HIDDEN_CLIENTSIDE) && spellInfo->Stances))
     {
         if (IsNeedCastPassiveSpellAtLearn(spellInfo))
-            CastSpell(this, spellId, true); 
+            CastSpell(this, spellId, true);
     }
 }
 
@@ -3808,11 +3808,11 @@ void Player::SendLearnPacket(uint32 spellId, bool learn)
         WorldPacket data(SMSG_REMOVED_SPELL, 4);
         data << uint32(spellId);
         GetSession()->SendPacket(&data);
-    }   
+    }
 }
 
 bool Player::addSpell(uint32 spellId, uint8 addSpecMask, bool updateActive, bool temporary)
-{ 
+{
     if (!_addSpell(spellId, addSpecMask, temporary))
         return false;
 
@@ -3859,7 +3859,7 @@ bool Player::addSpell(uint32 spellId, uint8 addSpecMask, bool updateActive, bool
 }
 
 bool Player::_addSpell(uint32 spellId, uint8 addSpecMask, bool temporary)
-{ 
+{
     // pussywizard: this can be called to OVERWRITE currently existing spell params! usually to set active = false for lower ranks of a spell
 
     SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
@@ -4043,7 +4043,7 @@ bool Player::_addSpell(uint32 spellId, uint8 addSpecMask, bool temporary)
 }
 
 bool Player::IsNeedCastPassiveSpellAtLearn(SpellInfo const* spellInfo) const
-{ 
+{
     // note: form passives activated with shapeshift spells be implemented by HandleShapeshiftBoosts instead of spell_learn_spell
     // talent dependent passives activated at form apply have proper stance data
     ShapeshiftForm form = GetShapeshiftForm();
@@ -4094,7 +4094,7 @@ void Player::learnSpell(uint32 spellId)
 }
 
 void Player::removeSpell(uint32 spellId, uint8 removeSpecMask, bool onlyTemporary)
-{ 
+{
     PlayerSpellMap::iterator itr = m_spells.find(spellId);
     if (itr == m_spells.end())
         return;
@@ -4225,7 +4225,7 @@ void Player::removeSpell(uint32 spellId, uint8 removeSpecMask, bool onlyTemporar
                 // not reset skills for professions and racial abilities
                 if ((pSkill->categoryId == SKILL_CATEGORY_SECONDARY || pSkill->categoryId == SKILL_CATEGORY_PROFESSION) && (IsProfessionSkill(pSkill->id) || _spell_idx->second->racemask != 0))
                     continue;
-                    
+
                 // pussywizard: this is needed for weapon/armor/language skills to remove them when loosing spell
                 SetSkill(pSkill->id, GetSkillStep(pSkill->id), 0, 0);
             }
@@ -4241,7 +4241,7 @@ void Player::removeSpell(uint32 spellId, uint8 removeSpecMask, bool onlyTemporar
 }
 
 bool Player::Has310Flyer(bool checkAllSpells, uint32 excludeSpellId)
-{ 
+{
     if (!checkAllSpells)
         return m_ExtraFlags & PLAYER_EXTRA_HAS_310_FLYER;
     else
@@ -4279,7 +4279,7 @@ bool Player::Has310Flyer(bool checkAllSpells, uint32 excludeSpellId)
 }
 
 void Player::RemoveSpellCooldown(uint32 spell_id, bool update /* = false */)
-{ 
+{
     m_spellCooldowns.erase(spell_id);
 
     if (update)
@@ -4288,7 +4288,7 @@ void Player::RemoveSpellCooldown(uint32 spell_id, bool update /* = false */)
 
 // I am not sure which one is more efficient
 void Player::RemoveCategoryCooldown(uint32 cat)
-{ 
+{
     SpellCategoryStore::const_iterator i_scstore = sSpellsByCategoryStore.find(cat);
     if (i_scstore != sSpellsByCategoryStore.end())
         for (SpellCategorySet::const_iterator i_scset = i_scstore->second.begin(); i_scset != i_scstore->second.end(); ++i_scset)
@@ -4296,7 +4296,7 @@ void Player::RemoveCategoryCooldown(uint32 cat)
 }
 
 void Player::RemoveArenaSpellCooldowns(bool removeActivePetCooldowns)
-{ 
+{
     // remove cooldowns on spells that have < 10 min CD
     uint32 infTime = World::GetGameTimeMS()+infinityCooldownDelayCheck;
     SpellCooldowns::iterator itr, next;
@@ -4329,7 +4329,7 @@ void Player::RemoveArenaSpellCooldowns(bool removeActivePetCooldowns)
 }
 
 void Player::RemoveAllSpellCooldown()
-{ 
+{
     uint32 infTime = World::GetGameTimeMS()+infinityCooldownDelayCheck;
     if (!m_spellCooldowns.empty())
     {
@@ -4342,7 +4342,7 @@ void Player::RemoveAllSpellCooldown()
 }
 
 void Player::_LoadSpellCooldowns(PreparedQueryResult result)
-{ 
+{
     // some cooldowns can be already set at aura loading...
 
     //QueryResult* result = CharacterDatabase.PQuery("SELECT spell, item, time FROM character_spell_cooldown WHERE guid = '%u'", GetGUIDLow());
@@ -4380,7 +4380,7 @@ void Player::_LoadSpellCooldowns(PreparedQueryResult result)
 }
 
 void Player::_SaveSpellCooldowns(SQLTransaction& trans, bool logout)
-{ 
+{
     PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_CHAR_SPELL_COOLDOWN);
     stmt->setUInt32(0, GetGUIDLow());
     trans->Append(stmt);
@@ -4428,7 +4428,7 @@ void Player::_SaveSpellCooldowns(SQLTransaction& trans, bool logout)
 }
 
 uint32 Player::resetTalentsCost() const
-{ 
+{
     // The first time reset costs 1 gold
     if (m_resetTalentsCost < 1*GOLD)
         return 1*GOLD;
@@ -4461,7 +4461,7 @@ uint32 Player::resetTalentsCost() const
 }
 
 bool Player::resetTalents(bool noResetCost)
-{ 
+{
     sScriptMgr->OnPlayerTalentsReset(this, noResetCost);
 
     // xinef: remove at login flag upon talents reset
@@ -4556,13 +4556,13 @@ bool Player::resetTalents(bool noResetCost)
 }
 
 void Player::SetFreeTalentPoints(uint32 points)
-{ 
+{
     sScriptMgr->OnPlayerFreeTalentPointsChanged(this, points);
     SetUInt32Value(PLAYER_CHARACTER_POINTS1, points);
 }
 
 Mail* Player::GetMail(uint32 id)
-{ 
+{
     for (PlayerMails::iterator itr = m_mail.begin(); itr != m_mail.end(); ++itr)
         if ((*itr)->messageID == id)
             return (*itr);
@@ -4571,7 +4571,7 @@ Mail* Player::GetMail(uint32 id)
 }
 
 void Player::BuildCreateUpdateBlockForPlayer(UpdateData* data, Player* target) const
-{ 
+{
     if (target == this)
     {
         for (uint8 i = 0; i < EQUIPMENT_SLOT_END; ++i)
@@ -4602,7 +4602,7 @@ void Player::BuildCreateUpdateBlockForPlayer(UpdateData* data, Player* target) c
 }
 
 void Player::DestroyForPlayer(Player* target, bool onDeath) const
-{ 
+{
     Unit::DestroyForPlayer(target, onDeath);
 
     for (uint8 i = 0; i < EQUIPMENT_SLOT_END; ++i) // xinef: previously INVENTORY_SLOT_BAG_END
@@ -4633,25 +4633,25 @@ void Player::DestroyForPlayer(Player* target, bool onDeath) const
 }
 
 bool Player::HasSpell(uint32 spell) const
-{ 
+{
     PlayerSpellMap::const_iterator itr = m_spells.find(spell);
     return (itr != m_spells.end() && itr->second->State != PLAYERSPELL_REMOVED && itr->second->IsInSpec(m_activeSpec));
 }
 
 bool Player::HasTalent(uint32 spell, uint8  /*spec*/) const
-{ 
+{
     PlayerTalentMap::const_iterator itr = m_talents.find(spell);
     return (itr != m_talents.end() && itr->second->State != PLAYERSPELL_REMOVED && itr->second->IsInSpec(m_activeSpec));
 }
 
 bool Player::HasActiveSpell(uint32 spell) const
-{ 
+{
     PlayerSpellMap::const_iterator itr = m_spells.find(spell);
     return (itr != m_spells.end() && itr->second->State != PLAYERSPELL_REMOVED && itr->second->Active && itr->second->IsInSpec(m_activeSpec));
 }
 
 TrainerSpellState Player::GetTrainerSpellState(TrainerSpell const* trainer_spell) const
-{ 
+{
     if (!trainer_spell)
         return TRAINER_SPELL_RED;
 
@@ -5106,7 +5106,7 @@ void Player::DeleteOldCharacters(uint32 keepDays)
 }
 
 void Player::SetMovement(PlayerMovementType pType)
-{ 
+{
     WorldPacket data;
     switch (pType)
     {
@@ -5128,7 +5128,7 @@ void Player::SetMovement(PlayerMovementType pType)
   - the player must be in world
 */
 void Player::BuildPlayerRepop()
-{ 
+{
     WorldPacket data(SMSG_PRE_RESURRECT, GetPackGUID().size());
     data.append(GetPackGUID());
     GetSession()->SendPacket(&data);
@@ -5185,7 +5185,7 @@ void Player::BuildPlayerRepop()
 }
 
 void Player::ResurrectPlayer(float restore_percent, bool applySickness)
-{ 
+{
     WorldPacket data(SMSG_DEATH_RELEASE_LOC, 4*4);          // remove spirit healer position
     data << uint32(-1);
     data << float(0);
@@ -5263,7 +5263,7 @@ void Player::ResurrectPlayer(float restore_percent, bool applySickness)
 }
 
 void Player::KillPlayer()
-{ 
+{
     if (IsFlying() && !GetTransport())
         GetMotionMaster()->MoveFall();
 
@@ -5294,7 +5294,7 @@ void Player::KillPlayer()
 }
 
 void Player::CreateCorpse()
-{ 
+{
     // prevent existence 2 corpse for player
     SpawnCorpseBones();
 
@@ -5337,7 +5337,7 @@ void Player::CreateCorpse()
         flags |= CORPSE_FLAG_LOOTABLE;
     Battlefield* Bf = sBattlefieldMgr->GetBattlefieldByBattleId(BATTLEFIELD_BATTLEID_WG);
     if (Bf && Bf->IsWarTime())
-        flags |= CORPSE_FLAG_LOOTABLE;   
+        flags |= CORPSE_FLAG_LOOTABLE;
 
     corpse->SetUInt32Value(CORPSE_FIELD_FLAGS, flags);
 
@@ -5369,7 +5369,7 @@ void Player::CreateCorpse()
 }
 
 void Player::SpawnCorpseBones()
-{ 
+{
     if (sObjectAccessor->ConvertCorpseForPlayer(GetGUID()))
         if (!GetSession()->PlayerLogoutWithSave())          // at logout we will already store the player
         {
@@ -5384,16 +5384,16 @@ void Player::SpawnCorpseBones()
             _SaveAuras(trans, false);
 
             CharacterDatabase.CommitTransaction(trans);
-        }                                    
+        }
 }
 
 Corpse* Player::GetCorpse() const
-{ 
+{
     return sObjectAccessor->GetCorpseForPlayerGUID(GetGUID());
 }
 
 void Player::DurabilityLossAll(double percent, bool inventory)
-{ 
+{
     for (uint8 i = EQUIPMENT_SLOT_START; i < EQUIPMENT_SLOT_END; i++)
         if (Item* pItem = GetItemByPos(INVENTORY_SLOT_BAG_0, i))
             DurabilityLoss(pItem, percent);
@@ -5419,7 +5419,7 @@ void Player::DurabilityLossAll(double percent, bool inventory)
 }
 
 void Player::DurabilityLoss(Item* item, double percent)
-{ 
+{
     if(!item)
         return;
 
@@ -5437,7 +5437,7 @@ void Player::DurabilityLoss(Item* item, double percent)
 }
 
 void Player::DurabilityPointsLossAll(int32 points, bool inventory)
-{ 
+{
     for (uint8 i = EQUIPMENT_SLOT_START; i < EQUIPMENT_SLOT_END; i++)
         if (Item* pItem = GetItemByPos(INVENTORY_SLOT_BAG_0, i))
             DurabilityPointsLoss(pItem, points);
@@ -5463,7 +5463,7 @@ void Player::DurabilityPointsLossAll(int32 points, bool inventory)
 }
 
 void Player::DurabilityPointsLoss(Item* item, int32 points)
-{ 
+{
     int32 pMaxDurability = item->GetUInt32Value(ITEM_FIELD_MAXDURABILITY);
     int32 pOldDurability = item->GetUInt32Value(ITEM_FIELD_DURABILITY);
     int32 pNewDurability = pOldDurability - points;
@@ -5490,13 +5490,13 @@ void Player::DurabilityPointsLoss(Item* item, int32 points)
 }
 
 void Player::DurabilityPointLossForEquipSlot(EquipmentSlots slot)
-{ 
+{
     if (Item* pItem = GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
         DurabilityPointsLoss(pItem, 1);
 }
 
 uint32 Player::DurabilityRepairAll(bool cost, float discountMod, bool guildBank)
-{ 
+{
     uint32 TotalCost = 0;
     // equipped, backpack, bags itself
     for (uint8 i = EQUIPMENT_SLOT_START; i < INVENTORY_SLOT_ITEM_END; i++)
@@ -5512,7 +5512,7 @@ uint32 Player::DurabilityRepairAll(bool cost, float discountMod, bool guildBank)
 }
 
 uint32 Player::DurabilityRepair(uint16 pos, bool cost, float discountMod, bool guildBank)
-{ 
+{
     Item* item = GetItemByPos(pos);
 
     uint32 TotalCost = 0;
@@ -5596,7 +5596,7 @@ uint32 Player::DurabilityRepair(uint16 pos, bool cost, float discountMod, bool g
 }
 
 void Player::RepopAtGraveyard()
-{ 
+{
     // note: this can be called also when the player is alive
     // for example from WorldSession::HandleMovementOpcodes
 
@@ -5649,7 +5649,7 @@ void Player::RepopAtGraveyard()
 
 bool Player::CanJoinConstantChannelInZone(ChatChannelsEntry const* channel, AreaTableEntry const* zone)
 {
-    // Player can join LFG anywhere  
+    // Player can join LFG anywhere
     if (channel->flags & CHANNEL_DBC_FLAG_LFG && sWorld->getBoolConfig(CONFIG_LFG_LOCATION_ALL))
         return true;
 
@@ -5666,17 +5666,17 @@ bool Player::CanJoinConstantChannelInZone(ChatChannelsEntry const* channel, Area
 }
 
 void Player::JoinedChannel(Channel* c)
-{ 
+{
     m_channels.push_back(c);
 }
 
 void Player::LeftChannel(Channel* c)
-{ 
+{
     m_channels.remove(c);
 }
 
 void Player::CleanupChannels()
-{ 
+{
     while (!m_channels.empty())
     {
         Channel* ch = *m_channels.begin();
@@ -5686,13 +5686,13 @@ void Player::CleanupChannels()
 }
 
 void Player::ClearChannelWatch()
-{ 
+{
     for (JoinedChannelsList::iterator itr = m_channels.begin(); itr != m_channels.end(); ++itr)
         (*itr)->RemoveWatching(this);
 }
 
 void Player::UpdateLocalChannels(uint32 newZone)
-{ 
+{
     // pussywizard: mutex needed (tc changed opcode to THREAD UNSAFE)
     static ACE_Thread_Mutex channelsLock;
     TRINITY_GUARD(ACE_Thread_Mutex, channelsLock);
@@ -5778,13 +5778,13 @@ void Player::UpdateLocalChannels(uint32 newZone)
 }
 
 void Player::UpdateDefense()
-{ 
+{
     if (UpdateSkill(SKILL_DEFENSE, sWorld->getIntConfig(CONFIG_SKILL_GAIN_DEFENSE)))
         UpdateDefenseBonusesMod(); // update dependent from defense skill part
 }
 
 void Player::HandleBaseModValue(BaseModGroup modGroup, BaseModType modType, float amount, bool apply)
-{ 
+{
     if (modGroup >= BASEMOD_END)
     {
         sLog->outError("ERROR in HandleBaseModValue(): non existed BaseModGroup!");
@@ -5815,7 +5815,7 @@ void Player::HandleBaseModValue(BaseModGroup modGroup, BaseModType modType, floa
 }
 
 float Player::GetBaseModValue(BaseModGroup modGroup, BaseModType modType) const
-{ 
+{
     if (modGroup >= BASEMOD_END)
     {
         sLog->outError("trial to access non existed BaseModGroup!");
@@ -5829,7 +5829,7 @@ float Player::GetBaseModValue(BaseModGroup modGroup, BaseModType modType) const
 }
 
 float Player::GetTotalBaseModValue(BaseModGroup modGroup) const
-{ 
+{
     if (modGroup >= BASEMOD_END)
     {
         sLog->outError("wrong BaseModGroup in GetTotalBaseModValue()!");
@@ -5843,7 +5843,7 @@ float Player::GetTotalBaseModValue(BaseModGroup modGroup) const
 }
 
 uint32 Player::GetShieldBlockValue() const
-{ 
+{
     float value = (m_auraBaseMod[SHIELD_BLOCK_VALUE][FLAT_MOD] + GetStat(STAT_STRENGTH) * 0.5f - 10)*m_auraBaseMod[SHIELD_BLOCK_VALUE][PCT_MOD];
 
     value = (value < 0) ? 0 : value;
@@ -5852,7 +5852,7 @@ uint32 Player::GetShieldBlockValue() const
 }
 
 float Player::GetMeleeCritFromAgility()
-{ 
+{
     uint8 level = getLevel();
     uint32 pclass = getClass();
 
@@ -5869,7 +5869,7 @@ float Player::GetMeleeCritFromAgility()
 }
 
 void Player::GetDodgeFromAgility(float &diminishing, float &nondiminishing)
-{ 
+{
     // Table for base dodge values
     const float dodge_base[MAX_CLASSES] =
     {
@@ -5922,7 +5922,7 @@ void Player::GetDodgeFromAgility(float &diminishing, float &nondiminishing)
 }
 
 float Player::GetSpellCritFromIntellect()
-{ 
+{
     uint8 level = getLevel();
     uint32 pclass = getClass();
 
@@ -5939,7 +5939,7 @@ float Player::GetSpellCritFromIntellect()
 }
 
 float Player::GetRatingMultiplier(CombatRating cr) const
-{ 
+{
     uint8 level = getLevel();
 
     if (level > GT_MAX_LEVEL)
@@ -5955,12 +5955,12 @@ float Player::GetRatingMultiplier(CombatRating cr) const
 }
 
 float Player::GetRatingBonusValue(CombatRating cr) const
-{ 
+{
     return float(GetUInt32Value(PLAYER_FIELD_COMBAT_RATING_1 + cr)) * GetRatingMultiplier(cr);
 }
 
 float Player::GetExpertiseDodgeOrParryReduction(WeaponAttackType attType) const
-{ 
+{
     switch (attType)
     {
         case BASE_ATTACK:
@@ -5974,7 +5974,7 @@ float Player::GetExpertiseDodgeOrParryReduction(WeaponAttackType attType) const
 }
 
 float Player::OCTRegenHPPerSpirit()
-{ 
+{
     uint8 level = getLevel();
     uint32 pclass = getClass();
 
@@ -5997,7 +5997,7 @@ float Player::OCTRegenHPPerSpirit()
 }
 
 float Player::OCTRegenMPPerSpirit()
-{ 
+{
     uint8 level = getLevel();
     uint32 pclass = getClass();
 
@@ -6041,7 +6041,7 @@ void Player::ApplyRatingMod(CombatRating cr, int32 value, bool apply)
                 ApplyCastTimePercentMod(oldVal, false);
                 ApplyCastTimePercentMod(newVal, true);
                 break;
-            default: 
+            default:
                 break;
         }
     }
@@ -6050,7 +6050,7 @@ void Player::ApplyRatingMod(CombatRating cr, int32 value, bool apply)
 }
 
 void Player::UpdateRating(CombatRating cr)
-{ 
+{
     int32 amount = m_baseRatingValue[cr];
     // Apply bonus from SPELL_AURA_MOD_RATING_FROM_STAT
     // stat used stored in miscValueB for this aura
@@ -6136,13 +6136,13 @@ void Player::UpdateRating(CombatRating cr)
 }
 
 void Player::UpdateAllRatings()
-{ 
+{
     for (int cr = 0; cr < MAX_COMBAT_RATING; ++cr)
         UpdateRating(CombatRating(cr));
 }
 
 void Player::SetRegularAttackTime()
-{ 
+{
     for (uint8 i = 0; i < MAX_ATTACK; ++i)
     {
         Item* tmpitem = GetWeaponForAttack(WeaponAttackType(i), true);
@@ -6159,7 +6159,7 @@ void Player::SetRegularAttackTime()
 
 //skill+step, checking for max value
 bool Player::UpdateSkill(uint32 skill_id, uint32 step)
-{ 
+{
     if (!skill_id)
         return false;
 
@@ -6207,7 +6207,7 @@ inline int SkillGainChance(uint32 SkillValue, uint32 GrayLevel, uint32 GreenLeve
 }
 
 bool Player::UpdateCraftSkill(uint32 spellid)
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_SKILLS, "UpdateCraftSkill spellid %d", spellid);
 #endif
@@ -6241,7 +6241,7 @@ bool Player::UpdateCraftSkill(uint32 spellid)
 }
 
 bool Player::UpdateGatherSkill(uint32 SkillId, uint32 SkillValue, uint32 RedLevel, uint32 Multiplicator)
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_SKILLS, "UpdateGatherSkill(SkillId %d SkillLevel %d RedLevel %d)", SkillId, SkillValue, RedLevel);
 #endif
@@ -6271,7 +6271,7 @@ bool Player::UpdateGatherSkill(uint32 SkillId, uint32 SkillValue, uint32 RedLeve
 }
 
 bool Player::UpdateFishingSkill()
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_SKILLS, "UpdateFishingSkill");
 #endif
@@ -6292,7 +6292,7 @@ static uint32 bonusSkillLevels[] = {75, 150, 225, 300, 375, 450};
 static const size_t bonusSkillLevelsSize = sizeof(bonusSkillLevels) / sizeof(uint32);
 
 bool Player::UpdateSkillPro(uint16 SkillId, int32 Chance, uint32 step)
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_SKILLS, "UpdateSkillPro(SkillId %d, Chance %3.1f%%)", SkillId, Chance / 10.0f);
 #endif
@@ -6356,7 +6356,7 @@ bool Player::UpdateSkillPro(uint16 SkillId, int32 Chance, uint32 step)
 }
 
 void Player::UpdateWeaponSkill(WeaponAttackType attType)
-{ 
+{
     // no skill gain in pvp
     Unit* victim = GetVictim();
     if (victim && victim->GetTypeId() == TYPEID_PLAYER)
@@ -6383,7 +6383,7 @@ void Player::UpdateWeaponSkill(WeaponAttackType attType)
 }
 
 void Player::UpdateCombatSkills(Unit* victim, WeaponAttackType attType, bool defence)
-{ 
+{
     uint8 plevel = getLevel();                              // if defense than victim == attacker
     uint8 greylevel = Trinity::XP::GetGrayLevel(plevel);
     uint8 moblevel = victim->getLevelForTarget(this);
@@ -6420,7 +6420,7 @@ void Player::UpdateCombatSkills(Unit* victim, WeaponAttackType attType, bool def
 }
 
 void Player::ModifySkillBonus(uint32 skillid, int32 val, bool talent)
-{ 
+{
     SkillStatusMap::const_iterator itr = mSkillStatus.find(skillid);
     if (itr == mSkillStatus.end() || itr->second.uState == SKILL_DELETED)
         return;
@@ -6438,7 +6438,7 @@ void Player::ModifySkillBonus(uint32 skillid, int32 val, bool talent)
 }
 
 void Player::UpdateSkillsForLevel()
-{ 
+{
     uint16 maxconfskill = sWorld->GetConfigMaxSkillValue();
     uint32 maxSkill = GetMaxSkillValueForLevel();
 
@@ -6483,7 +6483,7 @@ void Player::UpdateSkillsForLevel()
 }
 
 void Player::UpdateSkillsToMaxSkillsForLevel()
-{ 
+{
     for (SkillStatusMap::iterator itr = mSkillStatus.begin(); itr != mSkillStatus.end(); ++itr)
     {
         if (itr->second.uState == SKILL_DELETED)
@@ -6510,7 +6510,7 @@ void Player::UpdateSkillsToMaxSkillsForLevel()
 // This functions sets a skill line value (and adds if doesn't exist yet)
 // To "remove" a skill line, set it's values to zero
 void Player::SetSkill(uint16 id, uint16 step, uint16 newVal, uint16 maxVal)
-{ 
+{
     if (!id)
         return;
 
@@ -6612,7 +6612,7 @@ void Player::SetSkill(uint16 id, uint16 step, uint16 newVal, uint16 maxVal)
 }
 
 bool Player::HasSkill(uint32 skill) const
-{ 
+{
     if (!skill)
         return false;
 
@@ -6621,7 +6621,7 @@ bool Player::HasSkill(uint32 skill) const
 }
 
 uint16 Player::GetSkillStep(uint16 skill) const
-{ 
+{
     if (!skill)
         return 0;
 
@@ -6633,7 +6633,7 @@ uint16 Player::GetSkillStep(uint16 skill) const
 }
 
 uint16 Player::GetSkillValue(uint32 skill) const
-{ 
+{
     if (!skill)
         return 0;
 
@@ -6650,7 +6650,7 @@ uint16 Player::GetSkillValue(uint32 skill) const
 }
 
 uint16 Player::GetMaxSkillValue(uint32 skill) const
-{ 
+{
     if (!skill)
         return 0;
 
@@ -6667,7 +6667,7 @@ uint16 Player::GetMaxSkillValue(uint32 skill) const
 }
 
 uint16 Player::GetPureMaxSkillValue(uint32 skill) const
-{ 
+{
     if (!skill)
         return 0;
 
@@ -6679,7 +6679,7 @@ uint16 Player::GetPureMaxSkillValue(uint32 skill) const
 }
 
 uint16 Player::GetBaseSkillValue(uint32 skill) const
-{ 
+{
     if (!skill)
         return 0;
 
@@ -6693,7 +6693,7 @@ uint16 Player::GetBaseSkillValue(uint32 skill) const
 }
 
 uint16 Player::GetPureSkillValue(uint32 skill) const
-{ 
+{
     if (!skill)
         return 0;
 
@@ -6705,7 +6705,7 @@ uint16 Player::GetPureSkillValue(uint32 skill) const
 }
 
 int16 Player::GetSkillPermBonusValue(uint32 skill) const
-{ 
+{
     if (!skill)
         return 0;
 
@@ -6717,7 +6717,7 @@ int16 Player::GetSkillPermBonusValue(uint32 skill) const
 }
 
 int16 Player::GetSkillTempBonusValue(uint32 skill) const
-{ 
+{
     if (!skill)
         return 0;
 
@@ -6729,7 +6729,7 @@ int16 Player::GetSkillTempBonusValue(uint32 skill) const
 }
 
 void Player::SendActionButtons(uint32 state) const
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDetail("Sending Action Buttons for '%u' spec '%u'", GetGUIDLow(), m_activeSpec);
 #endif
@@ -6761,7 +6761,7 @@ void Player::SendActionButtons(uint32 state) const
 }
 
 bool Player::IsActionButtonDataValid(uint8 button, uint32 action, uint8 type)
-{ 
+{
     if (button >= MAX_ACTION_BUTTONS)
     {
         sLog->outError("Action %u not added into button %u for player %s: button must be < %u", action, button, GetName().c_str(), MAX_ACTION_BUTTONS);
@@ -6806,7 +6806,7 @@ bool Player::IsActionButtonDataValid(uint8 button, uint32 action, uint8 type)
 }
 
 ActionButton* Player::addActionButton(uint8 button, uint32 action, uint8 type)
-{ 
+{
     if (!IsActionButtonDataValid(button, action, type))
         return NULL;
 
@@ -6823,7 +6823,7 @@ ActionButton* Player::addActionButton(uint8 button, uint32 action, uint8 type)
 }
 
 void Player::removeActionButton(uint8 button)
-{ 
+{
     ActionButtonList::iterator buttonItr = m_actionButtons.find(button);
     if (buttonItr == m_actionButtons.end() || buttonItr->second.uState == ACTIONBUTTON_DELETED)
         return;
@@ -6839,7 +6839,7 @@ void Player::removeActionButton(uint8 button)
 }
 
 ActionButton const* Player::GetActionButton(uint8 button)
-{ 
+{
     ActionButtonList::iterator buttonItr = m_actionButtons.find(button);
     if (buttonItr == m_actionButtons.end() || buttonItr->second.uState == ACTIONBUTTON_DELETED)
         return NULL;
@@ -6848,7 +6848,7 @@ ActionButton const* Player::GetActionButton(uint8 button)
 }
 
 bool Player::UpdatePosition(float x, float y, float z, float orientation, bool teleport)
-{ 
+{
     if (!Unit::UpdatePosition(x, y, z, orientation, teleport))
         return false;
 
@@ -6864,7 +6864,7 @@ bool Player::UpdatePosition(float x, float y, float z, float orientation, bool t
 }
 
 void Player::SaveRecallPosition()
-{ 
+{
     m_recallMap = GetMapId();
     m_recallX = GetPositionX();
     m_recallY = GetPositionY();
@@ -6874,7 +6874,7 @@ void Player::SaveRecallPosition()
 
 // pussywizard!
 void Player::SendMessageToSetInRange(WorldPacket* data, float dist, bool self, bool includeMargin, Player const* skipped_rcvr)
-{ 
+{
     if (self)
         GetSession()->SendPacket(data);
 
@@ -6887,7 +6887,7 @@ void Player::SendMessageToSetInRange(WorldPacket* data, float dist, bool self, b
 
 // pussywizard!
 void Player::SendMessageToSetInRange_OwnTeam(WorldPacket* data, float dist, bool self)
-{ 
+{
     if (self)
         GetSession()->SendPacket(data);
 
@@ -6901,21 +6901,21 @@ void Player::SendDirectMessage(WorldPacket* data)
 }
 
 void Player::SendCinematicStart(uint32 CinematicSequenceId)
-{ 
+{
     WorldPacket data(SMSG_TRIGGER_CINEMATIC, 4);
     data << uint32(CinematicSequenceId);
     SendDirectMessage(&data);
 }
 
 void Player::SendMovieStart(uint32 MovieId)
-{ 
+{
     WorldPacket data(SMSG_TRIGGER_MOVIE, 4);
     data << uint32(MovieId);
     SendDirectMessage(&data);
 }
 
 void Player::CheckAreaExploreAndOutdoor()
-{ 
+{
     if (!IsAlive())
         return;
 
@@ -6925,7 +6925,7 @@ void Player::CheckAreaExploreAndOutdoor()
     bool isOutdoor = IsOutdoors();
     uint32 areaId = GetBaseMap()->GetAreaId(GetPositionX(), GetPositionY(), GetPositionZ(), &isOutdoor);
     AreaTableEntry const* areaEntry = sAreaTableStore.LookupEntry(areaId);
- 
+
     if (sWorld->getBoolConfig(CONFIG_VMAP_INDOOR_CHECK) && !isOutdoor)
         RemoveAurasWithAttribute(SPELL_ATTR0_OUTDOORS_ONLY);
 
@@ -7015,7 +7015,7 @@ TeamId Player::TeamIdForRace(uint8 race)
 }
 
 void Player::setFactionForRace(uint8 race)
-{ 
+{
     m_team = TeamIdForRace(race);
 
     sScriptMgr->OnPlayerUpdateFaction(this);
@@ -7028,14 +7028,14 @@ void Player::setFactionForRace(uint8 race)
 }
 
 ReputationRank Player::GetReputationRank(uint32 faction) const
-{ 
+{
     FactionEntry const* factionEntry = sFactionStore.LookupEntry(faction);
     return GetReputationMgr().GetRank(factionEntry);
 }
 
 // Calculate total reputation percent player gain with quest/creature level
 int32 Player::CalculateReputationGain(ReputationSource source, uint32 creatureOrQuestLevel, int32 rep, int32 faction, bool noQuestBonus)
-{ 
+{
     float percent = 100.0f;
 
     float repMod = noQuestBonus ? 0.0f : float(GetTotalAuraModifier(SPELL_AURA_MOD_REPUTATION_GAIN));
@@ -7044,7 +7044,7 @@ int32 Player::CalculateReputationGain(ReputationSource source, uint32 creatureOr
     if (source == REPUTATION_SOURCE_KILL)
         repMod += GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_FACTION_REPUTATION_GAIN, faction);
 
-    percent += rep > 0 ? repMod : -repMod;
+    percent += repMod;
 
     float rate;
     switch (source)
@@ -7067,9 +7067,6 @@ int32 Player::CalculateReputationGain(ReputationSource source, uint32 creatureOr
 
     if (rate != 1.0f && creatureOrQuestLevel <= Trinity::XP::GetGrayLevel(getLevel()))
         percent *= rate;
-
-    if (percent <= 0.0f)
-        return 0;
 
     // Multiply result with the faction specific rate
     if (RepRewardRate const* repData = sObjectMgr->GetRepRewardRate(faction))
@@ -7115,7 +7112,7 @@ int32 Player::CalculateReputationGain(ReputationSource source, uint32 creatureOr
 
 // Calculates how many reputation points player gains in victim's enemy factions
 void Player::RewardReputation(Unit* victim, float rate)
-{ 
+{
     if (!victim || victim->GetTypeId() == TYPEID_PLAYER)
         return;
 
@@ -7165,7 +7162,7 @@ void Player::RewardReputation(Unit* victim, float rate)
 
 // Calculate how many reputation points player gain with the quest
 void Player::RewardReputation(Quest const* quest)
-{ 
+{
     for (uint8 i = 0; i < QUEST_REPUTATIONS_COUNT; ++i)
     {
         if (!quest->RewardFactionId[i])
@@ -7209,7 +7206,7 @@ void Player::RewardReputation(Quest const* quest)
 }
 
 void Player::UpdateHonorFields()
-{ 
+{
     /// called when rewarding honor and at each save
     time_t now = time_t(time(NULL));
     time_t today = time_t(time(NULL) / DAY) * DAY;
@@ -7244,7 +7241,7 @@ void Player::UpdateHonorFields()
 ///and the size of the group for which the honor is divided
 ///An exact honor value can also be given (overriding the calcs)
 bool Player::RewardHonor(Unit* uVictim, uint32 groupsize, int32 honor, bool awardXP)
-{ 
+{
     // do not reward honor in arenas, but enable onkill spellproc
     if (InArena())
     {
@@ -7385,7 +7382,7 @@ bool Player::RewardHonor(Unit* uVictim, uint32 groupsize, int32 honor, bool awar
             bg->UpdatePlayerScore(this, SCORE_BONUS_HONOR, honor, false); //false: prevent looping
             // Xinef: Only for BG activities
             if (!uVictim)
-                GiveXP(uint32(honor*(3+getLevel()*0.30f)), NULL);   
+                GiveXP(uint32(honor*(3+getLevel()*0.30f)), NULL);
         }
 
     if (sWorld->getBoolConfig(CONFIG_PVP_TOKEN_ENABLE))
@@ -7409,12 +7406,12 @@ bool Player::RewardHonor(Unit* uVictim, uint32 groupsize, int32 honor, bool awar
                 ChatHandler(GetSession()).PSendSysMessage("You have been awarded a token for slaying another player.");
         }
     }
-    
+
     return true;
 }
 
 void Player::SetHonorPoints(uint32 value)
-{ 
+{
     if (value > sWorld->getIntConfig(CONFIG_MAX_HONOR_POINTS))
         value = sWorld->getIntConfig(CONFIG_MAX_HONOR_POINTS);
     SetUInt32Value(PLAYER_FIELD_HONOR_CURRENCY, value);
@@ -7423,7 +7420,7 @@ void Player::SetHonorPoints(uint32 value)
 }
 
 void Player::SetArenaPoints(uint32 value)
-{ 
+{
     if (value > sWorld->getIntConfig(CONFIG_MAX_ARENA_POINTS))
         value = sWorld->getIntConfig(CONFIG_MAX_ARENA_POINTS);
     SetUInt32Value(PLAYER_FIELD_ARENA_CURRENCY, value);
@@ -7432,7 +7429,7 @@ void Player::SetArenaPoints(uint32 value)
 }
 
 void Player::ModifyHonorPoints(int32 value, SQLTransaction* trans /*=NULL*/)
-{ 
+{
     int32 newValue = int32(GetHonorPoints()) + value;
     if (newValue < 0)
         newValue = 0;
@@ -7448,7 +7445,7 @@ void Player::ModifyHonorPoints(int32 value, SQLTransaction* trans /*=NULL*/)
 }
 
 void Player::ModifyArenaPoints(int32 value, SQLTransaction* trans /*=NULL*/)
-{ 
+{
     int32 newValue = int32(GetArenaPoints()) + value;
     if (newValue < 0)
         newValue = 0;
@@ -7554,11 +7551,11 @@ uint32 Player::GetLevelFromStorage(uint64 guid)
 }
 
 void Player::UpdateArea(uint32 newArea)
-{ 
+{
     // pussywizard: inform instance, needed for Icecrown Citadel
     if (InstanceScript* instance = GetInstanceScript())
         instance->OnPlayerAreaUpdate(this, m_areaUpdateId, newArea);
-    
+
     sScriptMgr->OnPlayerUpdateArea(this, m_areaUpdateId, newArea);
 
     // FFA_PVP flags are area and not zone id dependent
@@ -7579,7 +7576,7 @@ void Player::UpdateArea(uint32 newArea)
         for (AttackerSet::const_iterator itr = attackers.begin(); itr != attackers.end(); ++itr)
             if (!(*itr)->IsValidAttackTarget(this))
                 toRemove.insert(*itr);
-        
+
         for (AttackerSet::const_iterator itr = toRemove.begin(); itr != toRemove.end(); ++itr)
             (*itr)->AttackStop();
 
@@ -7666,7 +7663,7 @@ void Player::GetZoneAndAreaId(uint32& zoneid, uint32& areaid, bool forceRecalc) 
 }
 
 void Player::UpdateZone(uint32 newZone, uint32 newArea)
-{ 
+{
     if (m_zoneUpdateId != newZone)
     {
         sOutdoorPvPMgr->HandlePlayerLeaveZone(this, m_zoneUpdateId);
@@ -7751,7 +7748,7 @@ void Player::UpdateZone(uint32 newZone, uint32 newArea)
 
 //If players are too far away from the duel flag... they lose the duel
 void Player::CheckDuelDistance(time_t currTime)
-{ 
+{
     if (!duel)
         return;
 
@@ -7785,12 +7782,12 @@ void Player::CheckDuelDistance(time_t currTime)
 }
 
 bool Player::IsOutdoorPvPActive()
-{ 
+{
     return IsAlive() && !HasInvisibilityAura() && !HasStealthAura() && IsPvP() && !HasUnitMovementFlag(MOVEMENTFLAG_FLYING) && !IsInFlight();
 }
 
 void Player::DuelComplete(DuelCompleteType type)
-{ 
+{
     // duel not requested
     if (!duel)
         return;
@@ -7845,7 +7842,7 @@ void Player::DuelComplete(DuelCompleteType type)
             // Honor points after duel (the winner) - ImpConfig
             if (uint32 amount = sWorld->getIntConfig(CONFIG_HONOR_AFTER_DUEL))
                 duel->opponent->RewardHonor(NULL, 1, amount);
-                
+
             break;
         default:
             break;
@@ -7907,7 +7904,7 @@ void Player::DuelComplete(DuelCompleteType type)
 //---------------------------------------------------------//
 
 void Player::_ApplyItemMods(Item* item, uint8 slot, bool apply)
-{ 
+{
     if (slot >= INVENTORY_SLOT_BAG_END || !item)
         return;
 
@@ -7946,7 +7943,7 @@ void Player::_ApplyItemMods(Item* item, uint8 slot, bool apply)
 }
 
 void Player::_ApplyItemBonuses(ItemTemplate const* proto, uint8 slot, bool apply, bool only_level_scale /*= false*/)
-{ 
+{
     if (slot >= INVENTORY_SLOT_BAG_END || !proto)
         return;
 
@@ -8233,7 +8230,7 @@ void Player::_ApplyItemBonuses(ItemTemplate const* proto, uint8 slot, bool apply
 }
 
 void Player::_ApplyWeaponDamage(uint8 slot, ItemTemplate const* proto, ScalingStatValuesEntry const* ssv, bool apply)
-{ 
+{
     WeaponAttackType attType = BASE_ATTACK;
     float damage = 0.0f;
 
@@ -8294,7 +8291,7 @@ void Player::_ApplyWeaponDamage(uint8 slot, ItemTemplate const* proto, ScalingSt
 }
 
 void Player::_ApplyWeaponDependentAuraMods(Item* item, WeaponAttackType attackType, bool apply)
-{ 
+{
     AuraEffectList const& auraCritList = GetAuraEffectsByType(SPELL_AURA_MOD_WEAPON_CRIT_PERCENT);
     for (AuraEffectList::const_iterator itr = auraCritList.begin(); itr != auraCritList.end(); ++itr)
         _ApplyWeaponDependentAuraCritMod(item, attackType, *itr, apply);
@@ -8309,7 +8306,7 @@ void Player::_ApplyWeaponDependentAuraMods(Item* item, WeaponAttackType attackTy
 }
 
 void Player::_ApplyWeaponDependentAuraCritMod(Item* item, WeaponAttackType attackType, AuraEffect const* aura, bool apply)
-{ 
+{
     // don't apply mod if item is broken or cannot be used
     if (item->IsBroken() || !CanUseAttackType(attackType))
         return;
@@ -8332,7 +8329,7 @@ void Player::_ApplyWeaponDependentAuraCritMod(Item* item, WeaponAttackType attac
 }
 
 void Player::_ApplyWeaponDependentAuraDamageMod(Item* item, WeaponAttackType attackType, AuraEffect const* aura, bool apply)
-{ 
+{
     // don't apply mod if item is broken or cannot be used
     if (item->IsBroken() || !CanUseAttackType(attackType))
         return;
@@ -8376,7 +8373,7 @@ void Player::_ApplyWeaponDependentAuraDamageMod(Item* item, WeaponAttackType att
 }
 
 void Player::ApplyItemEquipSpell(Item* item, bool apply, bool form_change)
-{ 
+{
     if (!item)
         return;
 
@@ -8406,7 +8403,7 @@ void Player::ApplyItemEquipSpell(Item* item, bool apply, bool form_change)
 }
 
 void Player::ApplyEquipSpell(SpellInfo const* spellInfo, Item* item, bool apply, bool form_change)
-{ 
+{
     if (apply)
     {
         // Cannot be used in this stance/form
@@ -8456,7 +8453,7 @@ void Player::ApplyEquipSpell(SpellInfo const* spellInfo, Item* item, bool apply,
 }
 
 void Player::UpdateEquipSpellsAtFormChange()
-{ 
+{
     for (uint8 i = 0; i < INVENTORY_SLOT_BAG_END; ++i)
     {
         if (m_items[i] && !m_items[i]->IsBroken() && CanUseAttackType(GetAttackBySlot(i)))
@@ -8485,7 +8482,7 @@ void Player::UpdateEquipSpellsAtFormChange()
     }
 }
 void Player::CastItemCombatSpell(Unit* target, WeaponAttackType attType, uint32 procVictim, uint32 procEx)
-{ 
+{
     if (!target || !target->IsAlive() || target == this)
         return;
 
@@ -8523,7 +8520,7 @@ void Player::CastItemCombatSpell(Unit* target, WeaponAttackType attType, uint32 
 }
 
 void Player::CastItemCombatSpell(Unit* target, WeaponAttackType attType, uint32 procVictim, uint32 procEx, Item* item, ItemTemplate const* proto)
-{ 
+{
     // Can do effect if any damage done to target
     if (procVictim & PROC_FLAG_TAKEN_DAMAGE)
     //if (damageInfo->procVictim & PROC_FLAG_TAKEN_ANY_DAMAGE)
@@ -8552,7 +8549,7 @@ void Player::CastItemCombatSpell(Unit* target, WeaponAttackType attType, uint32 
                 return;
 
             float chance = (float)spellInfo->ProcChance;
-            
+
             if (spellData.SpellPPMRate)
             {
 
@@ -8647,7 +8644,7 @@ void Player::CastItemCombatSpell(Unit* target, WeaponAttackType attType, uint32 
 }
 
 void Player::CastItemUseSpell(Item* item, SpellCastTargets const& targets, uint8 cast_count, uint32 glyphIndex)
-{ 
+{
     ItemTemplate const* proto = item->GetTemplate();
     // special learning case
     if (proto->Spells[0].SpellId == 483 || proto->Spells[0].SpellId == 55884)
@@ -8773,7 +8770,7 @@ void Player::CastItemUseSpell(Item* item, SpellCastTargets const& targets, uint8
 }
 
 void Player::_RemoveAllItemMods()
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_ITEMS, "_RemoveAllItemMods start.");
 #endif
@@ -8825,7 +8822,7 @@ void Player::_RemoveAllItemMods()
 }
 
 void Player::_ApplyAllItemMods()
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_ITEMS, "_ApplyAllItemMods start.");
 #endif
@@ -8878,7 +8875,7 @@ void Player::_ApplyAllItemMods()
 }
 
 void Player::_ApplyAllLevelScaleItemMods(bool apply)
-{ 
+{
     for (uint8 i = 0; i < INVENTORY_SLOT_BAG_END; ++i)
     {
         if (m_items[i])
@@ -8896,7 +8893,7 @@ void Player::_ApplyAllLevelScaleItemMods(bool apply)
 }
 
 void Player::_ApplyAmmoBonuses()
-{ 
+{
     // check ammo
     uint32 ammo_id = GetUInt32Value(PLAYER_AMMO_ID);
     if (!ammo_id)
@@ -8920,7 +8917,7 @@ void Player::_ApplyAmmoBonuses()
 }
 
 bool Player::CheckAmmoCompatibility(const ItemTemplate* ammo_proto) const
-{ 
+{
     if (!ammo_proto)
         return false;
 
@@ -8955,7 +8952,7 @@ bool Player::CheckAmmoCompatibility(const ItemTemplate* ammo_proto) const
 /*  If in a battleground a player dies, and an enemy removes the insignia, the player's bones is lootable
     Called by remove insignia spell effect    */
 void Player::RemovedInsignia(Player* looterPlr)
-{ 
+{
     // Xinef: If player is not in battleground and not in wintergrasp
     if (!GetBattlegroundId() && GetZoneId() != AREA_WINTERGRASP)
         return;
@@ -8985,14 +8982,14 @@ void Player::RemovedInsignia(Player* looterPlr)
 }
 
 void Player::SendLootRelease(uint64 guid)
-{ 
+{
     WorldPacket data(SMSG_LOOT_RELEASE_RESPONSE, (8+1));
     data << uint64(guid) << uint8(1);
     SendDirectMessage(&data);
 }
 
 void Player::SendLoot(uint64 guid, LootType loot_type)
-{ 
+{
     if (uint64 lguid = GetLootGUID())
         m_session->DoLootRelease(lguid);
 
@@ -9176,7 +9173,7 @@ void Player::SendLoot(uint64 guid, LootType loot_type)
         {
             uint32 pLevel = bones->loot.gold;
             bones->loot.clear();
-            
+
             // Xinef: For AV Achievement
             if (Battleground* bg = GetBattleground())
             {
@@ -9360,7 +9357,7 @@ void Player::SendLoot(uint64 guid, LootType loot_type)
 
         // add 'this' player as one of the players that are looting 'loot'
         loot->AddLooter(GetGUID());
-        
+
         if (loot_type == LOOT_CORPSE && !IS_ITEM_GUID(guid))
             SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_LOOTING);
     }
@@ -9378,13 +9375,13 @@ void Player::SendLootError(uint64 guid, LootError error)
 }
 
 void Player::SendNotifyLootMoneyRemoved()
-{ 
+{
     WorldPacket data(SMSG_LOOT_CLEAR_MONEY, 0);
     GetSession()->SendPacket(&data);
 }
 
 void Player::SendNotifyLootItemRemoved(uint8 lootSlot)
-{ 
+{
     WorldPacket data(SMSG_LOOT_REMOVED, 1);
     data << uint8(lootSlot);
     GetSession()->SendPacket(&data);
@@ -9399,7 +9396,7 @@ void Player::SendUpdateWorldState(uint32 Field, uint32 Value)
 }
 
 void Player::SendInitWorldStates(uint32 zoneid, uint32 areaid)
-{ 
+{
     // data depends on zoneid/mapid...
     Battleground* bg = GetBattleground();
     uint32 mapid = GetMapId();
@@ -10033,7 +10030,7 @@ void Player::SendInitWorldStates(uint32 zoneid, uint32 areaid)
 }
 
 void Player::SendBGWeekendWorldStates()
-{ 
+{
     for (uint32 i = 1; i < sBattlemasterListStore.GetNumRows(); ++i)
     {
         BattlemasterListEntry const* bl = sBattlemasterListStore.LookupEntry(i);
@@ -10048,7 +10045,7 @@ void Player::SendBGWeekendWorldStates()
 }
 
 void Player::SendBattlefieldWorldStates()
-{ 
+{
     /// Send misc stuff that needs to be sent on every login, like the battle timers.
     if (sWorld->getBoolConfig(CONFIG_WINTERGRASP_ENABLE))
     {
@@ -10062,11 +10059,11 @@ void Player::SendBattlefieldWorldStates()
             for (uint32 i = 0; i < 2; ++i)
                 SendUpdateWorldState(ClockWorldState[i], uint32(time(NULL) + (wg->GetTimer() / 1000)));
         }
-    }   
+    }
 }
 
 uint32 Player::GetXPRestBonus(uint32 xp)
-{ 
+{
     uint32 rested_bonus = (uint32)GetRestBonus();           // xp for each rested bonus
 
     if (rested_bonus > xp)                                   // max rested_bonus == xp or (r+x) = 200% xp
@@ -10081,14 +10078,14 @@ uint32 Player::GetXPRestBonus(uint32 xp)
 }
 
 void Player::SetBindPoint(uint64 guid)
-{ 
+{
     WorldPacket data(SMSG_BINDER_CONFIRM, 8);
     data << uint64(guid);
     GetSession()->SendPacket(&data);
 }
 
 void Player::SendTalentWipeConfirm(uint64 guid)
-{ 
+{
     WorldPacket data(MSG_TALENT_WIPE_CONFIRM, (8+4));
     data << uint64(guid);
     uint32 cost = sWorld->getBoolConfig(CONFIG_NO_RESET_TALENT_COST) ? 0 : resetTalentsCost();
@@ -10097,7 +10094,7 @@ void Player::SendTalentWipeConfirm(uint64 guid)
 }
 
 void Player::ResetPetTalents()
-{ 
+{
     // This needs another gossip option + NPC text as a confirmation.
     // The confirmation gossip listid has the text: "Yes, please do."
     Pet* pet = GetPet();
@@ -10120,7 +10117,7 @@ void Player::ResetPetTalents()
 /*********************************************************/
 
 void Player::SetVirtualItemSlot(uint8 i, Item* item)
-{ 
+{
     ASSERT(i < 3);
     if (i < 2 && item)
     {
@@ -10140,7 +10137,7 @@ void Player::SetVirtualItemSlot(uint8 i, Item* item)
 }
 
 void Player::SetSheath(SheathState sheathed)
-{ 
+{
     switch (sheathed)
     {
         case SHEATH_STATE_UNARMED:                          // no prepared weapon
@@ -10168,7 +10165,7 @@ void Player::SetSheath(SheathState sheathed)
 }
 
 uint8 Player::FindEquipSlot(ItemTemplate const* proto, uint32 slot, bool swap) const
-{ 
+{
     uint8 playerClass = getClass();
 
     uint8 slots[4];
@@ -10345,7 +10342,7 @@ uint8 Player::FindEquipSlot(ItemTemplate const* proto, uint32 slot, bool swap) c
 }
 
 InventoryResult Player::CanUnequipItems(uint32 item, uint32 count) const
-{ 
+{
     uint32 tempcount = 0;
 
     InventoryResult res = EQUIP_ERR_OK;
@@ -10399,7 +10396,7 @@ InventoryResult Player::CanUnequipItems(uint32 item, uint32 count) const
 }
 
 uint32 Player::GetItemCount(uint32 item, bool inBankAlso, Item* skipItem) const
-{ 
+{
     uint32 count = 0;
     for (uint8 i = EQUIPMENT_SLOT_START; i < INVENTORY_SLOT_ITEM_END; i++)
         if (Item* pItem = GetItemByPos(INVENTORY_SLOT_BAG_0, i))
@@ -10444,7 +10441,7 @@ uint32 Player::GetItemCount(uint32 item, bool inBankAlso, Item* skipItem) const
 }
 
 uint32 Player::GetItemCountWithLimitCategory(uint32 limitCategory, Item* skipItem) const
-{ 
+{
     uint32 count = 0;
     for (int i = EQUIPMENT_SLOT_START; i < INVENTORY_SLOT_ITEM_END; ++i)
         if (Item* pItem = GetItemByPos(INVENTORY_SLOT_BAG_0, i))
@@ -10479,7 +10476,7 @@ uint32 Player::GetItemCountWithLimitCategory(uint32 limitCategory, Item* skipIte
 }
 
 Item* Player::GetItemByGuid(uint64 guid) const
-{ 
+{
     for (uint8 i = EQUIPMENT_SLOT_START; i < INVENTORY_SLOT_ITEM_END; ++i)
         if (Item* pItem = GetItemByPos(INVENTORY_SLOT_BAG_0, i))
             if (pItem->GetGUID() == guid)
@@ -10513,14 +10510,14 @@ Item* Player::GetItemByGuid(uint64 guid) const
 }
 
 Item* Player::GetItemByPos(uint16 pos) const
-{ 
+{
     uint8 bag = pos >> 8;
     uint8 slot = pos & 255;
     return GetItemByPos(bag, slot);
 }
 
 Item* Player::GetItemByPos(uint8 bag, uint8 slot) const
-{ 
+{
     if (bag == INVENTORY_SLOT_BAG_0 && (slot < BANK_SLOT_BAG_END || (slot >= KEYRING_SLOT_START && slot < CURRENCYTOKEN_SLOT_END)))
         return m_items[slot];
     else if (Bag* pBag = GetBagByPos(bag))
@@ -10529,7 +10526,7 @@ Item* Player::GetItemByPos(uint8 bag, uint8 slot) const
 }
 
 Bag* Player::GetBagByPos(uint8 bag) const
-{ 
+{
     if ((bag >= INVENTORY_SLOT_BAG_START && bag < INVENTORY_SLOT_BAG_END)
         || (bag >= BANK_SLOT_BAG_START && bag < BANK_SLOT_BAG_END))
         if (Item* item = GetItemByPos(INVENTORY_SLOT_BAG_0, bag))
@@ -10538,7 +10535,7 @@ Bag* Player::GetBagByPos(uint8 bag) const
 }
 
 Item* Player::GetWeaponForAttack(WeaponAttackType attackType, bool useable /*= false*/) const
-{ 
+{
     uint8 slot;
     switch (attackType)
     {
@@ -10566,7 +10563,7 @@ Item* Player::GetWeaponForAttack(WeaponAttackType attackType, bool useable /*= f
 }
 
 Item* Player::GetShield(bool useable) const
-{ 
+{
     Item* item = NULL;
     if (useable)
         item = GetUseableItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
@@ -10640,7 +10637,7 @@ bool Player::IsBagPos(uint16 pos)
 }
 
 bool Player::IsValidPos(uint8 bag, uint8 slot, bool explicit_pos)
-{ 
+{
     // post selected
     if (bag == NULL_BAG && !explicit_pos)
         return true;
@@ -10694,7 +10691,7 @@ bool Player::IsValidPos(uint8 bag, uint8 slot, bool explicit_pos)
 }
 
 bool Player::HasItemCount(uint32 item, uint32 count, bool inBankAlso) const
-{ 
+{
     uint32 tempcount = 0;
     for (uint8 i = EQUIPMENT_SLOT_START; i < INVENTORY_SLOT_ITEM_END; i++)
     {
@@ -10767,7 +10764,7 @@ bool Player::HasItemCount(uint32 item, uint32 count, bool inBankAlso) const
 }
 
 bool Player::HasItemOrGemWithIdEquipped(uint32 item, uint32 count, uint8 except_slot) const
-{ 
+{
     uint32 tempcount = 0;
     for (uint8 i = EQUIPMENT_SLOT_START; i < EQUIPMENT_SLOT_END; ++i)
     {
@@ -10805,7 +10802,7 @@ bool Player::HasItemOrGemWithIdEquipped(uint32 item, uint32 count, uint8 except_
 }
 
 bool Player::HasItemOrGemWithLimitCategoryEquipped(uint32 limitCategory, uint32 count, uint8 except_slot) const
-{ 
+{
     uint32 tempcount = 0;
     for (uint8 i = EQUIPMENT_SLOT_START; i < EQUIPMENT_SLOT_END; ++i)
     {
@@ -10839,7 +10836,7 @@ bool Player::HasItemOrGemWithLimitCategoryEquipped(uint32 limitCategory, uint32 
 }
 
 InventoryResult Player::CanTakeMoreSimilarItems(uint32 entry, uint32 count, Item* pItem, uint32* no_space_count) const
-{ 
+{
     ItemTemplate const* pProto = sObjectMgr->GetItemTemplate(entry);
     if (!pProto)
     {
@@ -10893,7 +10890,7 @@ InventoryResult Player::CanTakeMoreSimilarItems(uint32 entry, uint32 count, Item
 }
 
 bool Player::HasItemTotemCategory(uint32 TotemCategory) const
-{ 
+{
     Item* pItem;
     for (uint8 i = EQUIPMENT_SLOT_START; i < INVENTORY_SLOT_ITEM_END; ++i)
     {
@@ -10923,7 +10920,7 @@ bool Player::HasItemTotemCategory(uint32 TotemCategory) const
 }
 
 bool Player::IsTotemCategoryCompatiableWith(const ItemTemplate* pProto, uint32 requiredTotemCategoryId) const
-{ 
+{
     if (requiredTotemCategoryId == 0)
         return true;
     if (pProto->TotemCategory == 0)
@@ -10951,7 +10948,7 @@ bool Player::IsTotemCategoryCompatiableWith(const ItemTemplate* pProto, uint32 r
 }
 
 InventoryResult Player::CanStoreItem_InSpecificSlot(uint8 bag, uint8 slot, ItemPosCountVec &dest, ItemTemplate const* pProto, uint32& count, bool swap, Item* pSrcItem) const
-{ 
+{
     Item* pItem2 = GetItemByPos(bag, slot);
 
     // ignore move item (this slot will be empty at move)
@@ -11025,7 +11022,7 @@ InventoryResult Player::CanStoreItem_InSpecificSlot(uint8 bag, uint8 slot, ItemP
 }
 
 InventoryResult Player::CanStoreItem_InBag(uint8 bag, ItemPosCountVec &dest, ItemTemplate const* pProto, uint32& count, bool merge, bool non_specialized, Item* pSrcItem, uint8 skip_bag, uint8 skip_slot) const
-{ 
+{
     // skip specific bag already processed in first called CanStoreItem_InBag
     if (bag == skip_bag)
         return EQUIP_ERR_ITEM_DOESNT_GO_INTO_BAG;
@@ -11095,7 +11092,7 @@ InventoryResult Player::CanStoreItem_InBag(uint8 bag, ItemPosCountVec &dest, Ite
 }
 
 InventoryResult Player::CanStoreItem_InInventorySlots(uint8 slot_begin, uint8 slot_end, ItemPosCountVec &dest, ItemTemplate const* pProto, uint32& count, bool merge, Item* pSrcItem, uint8 skip_bag, uint8 skip_slot) const
-{ 
+{
     //this is never called for non-bag slots so we can do this
     if (pSrcItem && pSrcItem->IsNotEmptyBag())
         return EQUIP_ERR_CAN_ONLY_DO_WITH_EMPTY_BAGS;
@@ -11146,7 +11143,7 @@ InventoryResult Player::CanStoreItem_InInventorySlots(uint8 slot_begin, uint8 sl
 }
 
 InventoryResult Player::CanStoreItem(uint8 bag, uint8 slot, ItemPosCountVec &dest, uint32 entry, uint32 count, Item* pItem, bool swap, uint32* no_space_count) const
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_ITEMS, "STORAGE: CanStoreItem bag = %u, slot = %u, item = %u, count = %u", bag, slot, entry, count);
 #endif
@@ -11586,7 +11583,7 @@ InventoryResult Player::CanStoreItem(uint8 bag, uint8 slot, ItemPosCountVec &des
 
 //////////////////////////////////////////////////////////////////////////
 InventoryResult Player::CanStoreItems(Item** pItems, int count) const
-{ 
+{
     Item* pItem2;
 
     // fill space table
@@ -11840,7 +11837,7 @@ InventoryResult Player::CanStoreItems(Item** pItems, int count) const
 
 //////////////////////////////////////////////////////////////////////////
 InventoryResult Player::CanEquipNewItem(uint8 slot, uint16 &dest, uint32 item, bool swap) const
-{ 
+{
     dest = 0;
     Item* pItem = Item::CreateItem(item, 1, this);
     if (pItem)
@@ -11854,7 +11851,7 @@ InventoryResult Player::CanEquipNewItem(uint8 slot, uint16 &dest, uint32 item, b
 }
 
 InventoryResult Player::CanEquipItem(uint8 slot, uint16 &dest, Item* pItem, bool swap, bool not_loading) const
-{ 
+{
     dest = 0;
     if (pItem)
     {
@@ -12024,7 +12021,7 @@ InventoryResult Player::CanEquipItem(uint8 slot, uint16 &dest, Item* pItem, bool
 }
 
 InventoryResult Player::CanUnequipItem(uint16 pos, bool swap) const
-{ 
+{
     // Applied only to equipped items and bank bags
     if (!IsEquipmentPos(pos) && !IsBagPos(pos))
         return EQUIP_ERR_OK;
@@ -12071,7 +12068,7 @@ InventoryResult Player::CanUnequipItem(uint16 pos, bool swap) const
 }
 
 InventoryResult Player::CanBankItem(uint8 bag, uint8 slot, ItemPosCountVec &dest, Item* pItem, bool swap, bool not_loading) const
-{ 
+{
     if (!pItem)
         return swap ? EQUIP_ERR_ITEMS_CANT_BE_SWAPPED : EQUIP_ERR_ITEM_NOT_FOUND;
 
@@ -12260,7 +12257,7 @@ InventoryResult Player::CanBankItem(uint8 bag, uint8 slot, ItemPosCountVec &dest
 }
 
 InventoryResult Player::CanUseItem(Item* pItem, bool not_loading) const
-{ 
+{
     if (pItem)
     {
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
@@ -12321,7 +12318,7 @@ InventoryResult Player::CanUseItem(Item* pItem, bool not_loading) const
 }
 
 InventoryResult Player::CanUseItem(ItemTemplate const* proto) const
-{ 
+{
     // Used by group, function NeedBeforeGreed, to know if a prototype can be used by a player
 
     if (proto)
@@ -12364,7 +12361,7 @@ InventoryResult Player::CanUseItem(ItemTemplate const* proto) const
 }
 
 InventoryResult Player::CanRollForItemInLFG(ItemTemplate const* proto, WorldObject const* lootedObject) const
-{ 
+{
     if (!GetGroup() || !GetGroup()->isLFGGroup())
         return EQUIP_ERR_OK;    // not in LFG group
 
@@ -12441,7 +12438,7 @@ InventoryResult Player::CanRollForItemInLFG(ItemTemplate const* proto, WorldObje
 }
 
 InventoryResult Player::CanUseAmmo(uint32 item) const
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_ITEMS, "STORAGE: CanUseAmmo item = %u", item);
 #endif
@@ -12473,7 +12470,7 @@ InventoryResult Player::CanUseAmmo(uint32 item) const
 }
 
 void Player::SetAmmo(uint32 item)
-{ 
+{
     if (!item)
         return;
 
@@ -12498,7 +12495,7 @@ void Player::SetAmmo(uint32 item)
 }
 
 void Player::RemoveAmmo()
-{ 
+{
     SetUInt32Value(PLAYER_AMMO_ID, 0);
 
     m_ammoDPS = 0.0f;
@@ -12508,14 +12505,14 @@ void Player::RemoveAmmo()
 }
 
 Item* Player::StoreNewItem(ItemPosCountVec const& dest, uint32 item, bool update, int32 randomPropertyId)
-{ 
+{
     AllowedLooterSet allowedLooters;
     return StoreNewItem(dest, item, update, randomPropertyId, allowedLooters);
 }
 
 // Return stored item (if stored to stack, it can diff. from pItem). And pItem ca be deleted in this case.
 Item* Player::StoreNewItem(ItemPosCountVec const& dest, uint32 item, bool update, int32 randomPropertyId, AllowedLooterSet& allowedLooters)
-{ 
+{
     uint32 count = 0;
     for (ItemPosCountVec::const_iterator itr = dest.begin(); itr != dest.end(); ++itr)
         count += itr->count;
@@ -12559,7 +12556,7 @@ Item* Player::StoreNewItem(ItemPosCountVec const& dest, uint32 item, bool update
 }
 
 Item* Player::StoreItem(ItemPosCountVec const& dest, Item* pItem, bool update)
-{ 
+{
     if (!pItem)
         return NULL;
 
@@ -12594,7 +12591,7 @@ Item* Player::StoreItem(ItemPosCountVec const& dest, Item* pItem, bool update)
 
 // Return stored item (if stored to stack, it can diff. from pItem). And pItem ca be deleted in this case.
 Item* Player::_StoreItem(uint16 pos, Item* pItem, uint32 count, bool clone, bool update)
-{ 
+{
     if (!pItem)
         return NULL;
 
@@ -12694,7 +12691,7 @@ Item* Player::_StoreItem(uint16 pos, Item* pItem, uint32 count, bool clone, bool
 }
 
 Item* Player::EquipNewItem(uint16 pos, uint32 item, bool update)
-{ 
+{
     if (Item* pItem = Item::CreateItem(item, 1, this))
     {
         // pussywizard: obtaining blue or better items saves to db
@@ -12711,7 +12708,7 @@ Item* Player::EquipNewItem(uint16 pos, uint32 item, bool update)
 }
 
 Item* Player::EquipItem(uint16 pos, Item* pItem, bool update)
-{ 
+{
     AddEnchantmentDurations(pItem);
     AddItemDurations(pItem);
 
@@ -12824,7 +12821,7 @@ Item* Player::EquipItem(uint16 pos, Item* pItem, bool update)
 }
 
 void Player::QuickEquipItem(uint16 pos, Item* pItem)
-{ 
+{
     if (pItem)
     {
         AddEnchantmentDurations(pItem);
@@ -12866,7 +12863,7 @@ void Player::SetVisibleItemSlot(uint8 slot, Item* pItem)
 }
 
 void Player::VisualizeItem(uint8 slot, Item* pItem)
-{ 
+{
     if (!pItem)
         return;
 
@@ -12892,7 +12889,7 @@ void Player::VisualizeItem(uint8 slot, Item* pItem)
 }
 
 void Player::RemoveItem(uint8 bag, uint8 slot, bool update, bool swap)
-{ 
+{
     // note: removeitem does not actually change the item
     // it only takes the item out of storage temporarily
     // note2: if removeitem is to be used for delinking
@@ -12978,7 +12975,7 @@ void Player::RemoveItem(uint8 bag, uint8 slot, bool update, bool swap)
 
 // Common operation need to remove item from inventory without delete in trade, auction, guild bank, mail....
 void Player::MoveItemFromInventory(uint8 bag, uint8 slot, bool update)
-{ 
+{
     if (Item* it = GetItemByPos(bag, slot))
     {
         ItemRemovedQuestCheck(it->GetEntry(), it->GetCount());
@@ -12998,7 +12995,7 @@ void Player::MoveItemFromInventory(uint8 bag, uint8 slot, bool update)
 
 // Common operation need to add item from inventory without delete in trade, guild bank, mail....
 void Player::MoveItemToInventory(ItemPosCountVec const& dest, Item* pItem, bool update, bool in_characterInventoryDB)
-{ 
+{
     // update quest counters
     ItemAddedQuestCheck(pItem->GetEntry(), pItem->GetCount());
     UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_RECEIVE_EPIC_ITEM, pItem->GetEntry(), pItem->GetCount());
@@ -13023,7 +13020,7 @@ void Player::MoveItemToInventory(ItemPosCountVec const& dest, Item* pItem, bool 
 }
 
 void Player::DestroyItem(uint8 bag, uint8 slot, bool update)
-{ 
+{
     Item* pItem = GetItemByPos(bag, slot);
     if (pItem)
     {
@@ -13125,7 +13122,7 @@ void Player::DestroyItem(uint8 bag, uint8 slot, bool update)
 }
 
 void Player::DestroyItemCount(uint32 itemEntry, uint32 count, bool update, bool unequip_check)
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_ITEMS, "STORAGE: DestroyItemCount item = %u, count = %u", itemEntry, count);
 #endif
@@ -13318,7 +13315,7 @@ void Player::DestroyItemCount(uint32 itemEntry, uint32 count, bool update, bool 
 }
 
 void Player::DestroyZoneLimitedItem(bool update, uint32 new_zone)
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_ITEMS, "STORAGE: DestroyZoneLimitedItem in map %u and area %u", GetMapId(), new_zone);
 #endif
@@ -13350,7 +13347,7 @@ void Player::DestroyZoneLimitedItem(bool update, uint32 new_zone)
 }
 
 void Player::DestroyConjuredItems(bool update)
-{ 
+{
     // used when entering arena
     // destroys all conjured items
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
@@ -13379,7 +13376,7 @@ void Player::DestroyConjuredItems(bool update)
 }
 
 Item* Player::GetItemByEntry(uint32 entry) const
-{ 
+{
     // in inventory
     for (int i = INVENTORY_SLOT_ITEM_START; i < INVENTORY_SLOT_ITEM_END; ++i)
         if (Item* pItem = GetItemByPos(INVENTORY_SLOT_BAG_0, i))
@@ -13407,7 +13404,7 @@ Item* Player::GetItemByEntry(uint32 entry) const
 }
 
 void Player::DestroyItemCount(Item* pItem, uint32 &count, bool update)
-{ 
+{
     if (!pItem)
         return;
 
@@ -13433,7 +13430,7 @@ void Player::DestroyItemCount(Item* pItem, uint32 &count, bool update)
 }
 
 void Player::SplitItem(uint16 src, uint16 dst, uint32 count)
-{ 
+{
     uint8 srcbag = src >> 8;
     uint8 srcslot = src & 255;
 
@@ -13550,7 +13547,7 @@ void Player::SplitItem(uint16 src, uint16 dst, uint32 count)
 }
 
 void Player::SwapItem(uint16 src, uint16 dst)
-{ 
+{
     uint8 srcbag = src >> 8;
     uint8 srcslot = src & 255;
 
@@ -13873,7 +13870,7 @@ void Player::SwapItem(uint16 src, uint16 dst)
         BankItem(sDest2, pDstItem, true);
     else if (IsEquipmentPos(src))
         EquipItem(eDest2, pDstItem, true);
-    
+
     // Xinef: Call this here after all needed items are equipped
     RemoveItemDependentAurasAndCasts((Item*)NULL);
 
@@ -13923,7 +13920,7 @@ void Player::SwapItem(uint16 src, uint16 dst)
 }
 
 void Player::AddItemToBuyBackSlot(Item* pItem)
-{ 
+{
     if (pItem)
     {
         uint32 slot = m_currentBuybackSlot;
@@ -13979,7 +13976,7 @@ void Player::AddItemToBuyBackSlot(Item* pItem)
 }
 
 Item* Player::GetItemFromBuyBackSlot(uint32 slot)
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_ITEMS, "STORAGE: GetItemFromBuyBackSlot slot = %u", slot);
 #endif
@@ -13989,7 +13986,7 @@ Item* Player::GetItemFromBuyBackSlot(uint32 slot)
 }
 
 void Player::RemoveItemFromBuyBackSlot(uint32 slot, bool del)
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_ITEMS, "STORAGE: RemoveItemFromBuyBackSlot slot = %u", slot);
 #endif
@@ -14017,7 +14014,7 @@ void Player::RemoveItemFromBuyBackSlot(uint32 slot, bool del)
 }
 
 void Player::SendEquipError(InventoryResult msg, Item* pItem, Item* pItem2, uint32 itemid)
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_NETWORKIO, "WORLD: Sent SMSG_INVENTORY_CHANGE_FAILURE (%u)", msg);
 #endif
@@ -14062,7 +14059,7 @@ void Player::SendEquipError(InventoryResult msg, Item* pItem, Item* pItem2, uint
 }
 
 void Player::SendBuyError(BuyResult msg, Creature* creature, uint32 item, uint32 param)
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_NETWORKIO, "WORLD: Sent SMSG_BUY_FAILED");
 #endif
@@ -14076,7 +14073,7 @@ void Player::SendBuyError(BuyResult msg, Creature* creature, uint32 item, uint32
 }
 
 void Player::SendSellError(SellResult msg, Creature* creature, uint64 guid, uint32 param)
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_NETWORKIO, "WORLD: Sent SMSG_SELL_ITEM");
 #endif
@@ -14090,7 +14087,7 @@ void Player::SendSellError(SellResult msg, Creature* creature, uint64 guid, uint
 }
 
 void Player::TradeCancel(bool sendback)
-{ 
+{
     if (m_trade)
     {
         Player* trader = m_trade->GetTrader();
@@ -14110,7 +14107,7 @@ void Player::TradeCancel(bool sendback)
 }
 
 void Player::UpdateSoulboundTradeItems()
-{  
+{
     TRINITY_GUARD(ACE_Thread_Mutex, m_soulboundTradableLock);
     if (m_itemSoulboundTradeable.empty())
         return;
@@ -14134,20 +14131,20 @@ void Player::UpdateSoulboundTradeItems()
 }
 
 void Player::AddTradeableItem(Item* item)
-{  
+{
     TRINITY_GUARD(ACE_Thread_Mutex, m_soulboundTradableLock);
     m_itemSoulboundTradeable.push_back(item);
 }
 
 //TODO: should never allow an item to be added to m_itemSoulboundTradeable twice
 void Player::RemoveTradeableItem(Item* item)
-{  
+{
     TRINITY_GUARD(ACE_Thread_Mutex, m_soulboundTradableLock);
     m_itemSoulboundTradeable.remove(item);
 }
 
 void Player::UpdateItemDuration(uint32 time, bool realtimeonly)
-{ 
+{
     if (m_itemDuration.empty())
         return;
 
@@ -14166,7 +14163,7 @@ void Player::UpdateItemDuration(uint32 time, bool realtimeonly)
 }
 
 void Player::UpdateEnchantTime(uint32 time)
-{ 
+{
     for (EnchantDurationList::iterator itr = m_enchantDuration.begin(), next; itr != m_enchantDuration.end(); itr=next)
     {
         ASSERT(itr->item);
@@ -14190,7 +14187,7 @@ void Player::UpdateEnchantTime(uint32 time)
 }
 
 void Player::AddEnchantmentDurations(Item* item)
-{ 
+{
     for (int x = 0; x < MAX_ENCHANTMENT_SLOT; ++x)
     {
         if (!item->GetEnchantmentId(EnchantmentSlot(x)))
@@ -14203,7 +14200,7 @@ void Player::AddEnchantmentDurations(Item* item)
 }
 
 void Player::RemoveEnchantmentDurations(Item* item)
-{ 
+{
     for (EnchantDurationList::iterator itr = m_enchantDuration.begin(); itr != m_enchantDuration.end();)
     {
         if (itr->item == item)
@@ -14218,7 +14215,7 @@ void Player::RemoveEnchantmentDurations(Item* item)
 }
 
 void Player::RemoveEnchantmentDurationsReferences(Item* item)
-{ 
+{
     for (EnchantDurationList::iterator itr = m_enchantDuration.begin(); itr != m_enchantDuration.end();)
     {
         if (itr->item == item)
@@ -14229,7 +14226,7 @@ void Player::RemoveEnchantmentDurationsReferences(Item* item)
 }
 
 void Player::RemoveArenaEnchantments(EnchantmentSlot slot)
-{ 
+{
     // remove enchantments from equipped items first to clean up the m_enchantDuration list
     for (EnchantDurationList::iterator itr = m_enchantDuration.begin(), next; itr != m_enchantDuration.end(); itr = next)
     {
@@ -14278,7 +14275,7 @@ void Player::RemoveArenaEnchantments(EnchantmentSlot slot)
 
 // duration == 0 will remove item enchant
 void Player::AddEnchantmentDuration(Item* item, EnchantmentSlot slot, uint32 duration)
-{ 
+{
     if (!item)
         return;
 
@@ -14302,13 +14299,13 @@ void Player::AddEnchantmentDuration(Item* item, EnchantmentSlot slot, uint32 dur
 }
 
 void Player::ApplyEnchantment(Item* item, bool apply)
-{ 
+{
     for (uint32 slot = 0; slot < MAX_ENCHANTMENT_SLOT; ++slot)
         ApplyEnchantment(item, EnchantmentSlot(slot), apply);
 }
 
 void Player::ApplyEnchantment(Item* item, EnchantmentSlot slot, bool apply, bool apply_dur, bool ignore_condition)
-{ 
+{
     if (!item || !item->IsEquipped())
         return;
 
@@ -14744,7 +14741,7 @@ void Player::ApplyEnchantment(Item* item, EnchantmentSlot slot, bool apply, bool
 }
 
 void Player::UpdateSkillEnchantments(uint16 skill_id, uint16 curr_value, uint16 new_value)
-{ 
+{
     for (uint8 i = 0; i < INVENTORY_SLOT_BAG_END; ++i)
     {
         if (m_items[i])
@@ -14789,7 +14786,7 @@ void Player::UpdateSkillEnchantments(uint16 skill_id, uint16 curr_value, uint16 
 }
 
 void Player::SendEnchantmentDurations()
-{ 
+{
     for (EnchantDurationList::const_iterator itr = m_enchantDuration.begin(); itr != m_enchantDuration.end(); ++itr)
     {
         GetSession()->SendItemEnchantTimeUpdate(GetGUID(), itr->item->GetGUID(), itr->slot, uint32(itr->leftduration) / 1000);
@@ -14797,7 +14794,7 @@ void Player::SendEnchantmentDurations()
 }
 
 void Player::SendItemDurations()
-{ 
+{
     for (ItemDurationList::const_iterator itr = m_itemDuration.begin(); itr != m_itemDuration.end(); ++itr)
     {
         (*itr)->SendTimeUpdate(this);
@@ -14805,7 +14802,7 @@ void Player::SendItemDurations()
 }
 
 void Player::SendNewItem(Item* item, uint32 count, bool received, bool created, bool broadcast, bool sendChatMessage)
-{ 
+{
     if (!item)                                               // prevent crash
         return;
 
@@ -14835,7 +14832,7 @@ void Player::SendNewItem(Item* item, uint32 count, bool received, bool created, 
 /*********************************************************/
 
 void Player::PrepareGossipMenu(WorldObject* source, uint32 menuId /*= 0*/, bool showQuests /*= false*/)
-{  
+{
     PlayerMenu* menu = PlayerTalkClass;
     menu->ClearMenus();
 
@@ -14991,7 +14988,7 @@ void Player::PrepareGossipMenu(WorldObject* source, uint32 menuId /*= 0*/, bool 
 }
 
 void Player::SendPreparedGossip(WorldObject* source)
-{ 
+{
     if (!source)
         return;
 
@@ -15026,7 +15023,7 @@ void Player::SendPreparedGossip(WorldObject* source)
 }
 
 void Player::OnGossipSelect(WorldObject* source, uint32 gossipListId, uint32 menuId)
-{ 
+{
     GossipMenu& gossipMenu = PlayerTalkClass->GetGossipMenu();
 
     // if not same, then something funky is going on
@@ -15162,7 +15159,7 @@ void Player::OnGossipSelect(WorldObject* source, uint32 gossipListId, uint32 men
 }
 
 uint32 Player::GetGossipTextId(WorldObject* source)
-{ 
+{
     if (!source)
         return DEFAULT_GOSSIP_MESSAGE;
 
@@ -15170,7 +15167,7 @@ uint32 Player::GetGossipTextId(WorldObject* source)
 }
 
 uint32 Player::GetGossipTextId(uint32 menuId, WorldObject* source)
-{ 
+{
     uint32 textId = DEFAULT_GOSSIP_MESSAGE;
 
     if (!menuId)
@@ -15207,7 +15204,7 @@ uint32 Player::GetDefaultGossipMenuForSource(WorldObject* source)
 /*********************************************************/
 
 void Player::PrepareQuestMenu(uint64 guid)
-{  
+{
     QuestRelationBounds objectQR;
     QuestRelationBounds objectQIR;
 
@@ -15267,7 +15264,7 @@ void Player::PrepareQuestMenu(uint64 guid)
 }
 
 void Player::SendPreparedQuest(uint64 guid)
-{ 
+{
     QuestMenu& questMenu = PlayerTalkClass->GetQuestMenu();
     if (questMenu.Empty())
         return;
@@ -15353,12 +15350,12 @@ void Player::SendPreparedQuest(uint64 guid)
 }
 
 bool Player::IsActiveQuest(uint32 quest_id) const
-{ 
+{
     return m_QuestStatus.find(quest_id) != m_QuestStatus.end();
 }
 
 Quest const* Player::GetNextQuest(uint64 guid, Quest const* quest)
-{ 
+{
     QuestRelationBounds objectQR;
 
     Creature* creature = ObjectAccessor::GetCreatureOrPetOrVehicle(*this, guid);
@@ -15388,7 +15385,7 @@ Quest const* Player::GetNextQuest(uint64 guid, Quest const* quest)
 }
 
 bool Player::CanSeeStartQuest(Quest const* quest)
-{ 
+{
     if (!DisableMgr::IsDisabledFor(DISABLE_TYPE_QUEST, quest->GetQuestId(), this) && SatisfyQuestClass(quest, false) && SatisfyQuestRace(quest, false) &&
         SatisfyQuestSkill(quest, false) && SatisfyQuestExclusiveGroup(quest, false) && SatisfyQuestReputation(quest, false) &&
         SatisfyQuestPreviousQuest(quest, false) && SatisfyQuestNextChain(quest, false) &&
@@ -15402,7 +15399,7 @@ bool Player::CanSeeStartQuest(Quest const* quest)
 }
 
 bool Player::CanTakeQuest(Quest const* quest, bool msg)
-{ 
+{
     return !DisableMgr::IsDisabledFor(DISABLE_TYPE_QUEST, quest->GetQuestId(), this)
         && SatisfyQuestStatus(quest, msg) && SatisfyQuestExclusiveGroup(quest, msg)
         && SatisfyQuestClass(quest, msg) && SatisfyQuestRace(quest, msg) && SatisfyQuestLevel(quest, msg)
@@ -15415,7 +15412,7 @@ bool Player::CanTakeQuest(Quest const* quest, bool msg)
 }
 
 bool Player::CanAddQuest(Quest const* quest, bool msg)
-{ 
+{
     if (!SatisfyQuestLog(msg))
         return false;
 
@@ -15439,7 +15436,7 @@ bool Player::CanAddQuest(Quest const* quest, bool msg)
 }
 
 bool Player::CanCompleteQuest(uint32 quest_id, const QuestStatusData* q_savedStatus)
-{  
+{
     if (quest_id)
     {
         Quest const* qInfo = sObjectMgr->GetQuestTemplate(quest_id);
@@ -15516,7 +15513,7 @@ bool Player::CanCompleteQuest(uint32 quest_id, const QuestStatusData* q_savedSta
 }
 
 bool Player::CanCompleteRepeatableQuest(Quest const* quest)
-{ 
+{
     // Solve problem that player don't have the quest and try complete it.
     // if repeatable she must be able to complete event if player don't have it.
     // Seem that all repeatable quest are DELIVER Flag so, no need to add more.
@@ -15535,7 +15532,7 @@ bool Player::CanCompleteRepeatableQuest(Quest const* quest)
 }
 
 bool Player::CanRewardQuest(Quest const* quest, bool msg)
-{ 
+{
     // not auto complete quest and not completed quest (only cheating case, then ignore without message)
     if (!quest->IsDFQuest() && !quest->IsAutoComplete() && !(quest->GetFlags() & QUEST_FLAGS_AUTOCOMPLETE) && GetQuestStatus(quest->GetQuestId()) != QUEST_STATUS_COMPLETE)
         return false;
@@ -15571,7 +15568,7 @@ bool Player::CanRewardQuest(Quest const* quest, bool msg)
 }
 
 void Player::AddQuestAndCheckCompletion(Quest const* quest, Object* questGiver)
-{ 
+{
     AddQuest(quest, questGiver);
 
     if (CanCompleteQuest(quest->GetQuestId()))
@@ -15624,7 +15621,7 @@ void Player::AddQuestAndCheckCompletion(Quest const* quest, Object* questGiver)
 }
 
 bool Player::CanRewardQuest(Quest const* quest, uint32 reward, bool msg)
-{ 
+{
     // prevent receive reward with quest items in bank or for not completed quest
     if (!CanRewardQuest(quest, msg))
         return false;
@@ -15663,7 +15660,7 @@ bool Player::CanRewardQuest(Quest const* quest, uint32 reward, bool msg)
 }
 
 void Player::AddQuest(Quest const* quest, Object* questGiver)
-{ 
+{
     uint16 log_slot = FindQuestSlot(0);
 
     if (log_slot >= MAX_QUEST_LOG_SIZE) // Player does not have any free slot in the quest log
@@ -15754,7 +15751,7 @@ void Player::AddQuest(Quest const* quest, Object* questGiver)
 }
 
 void Player::CompleteQuest(uint32 quest_id)
-{ 
+{
     if (quest_id)
     {
         SetQuestStatus(quest_id, QUEST_STATUS_COMPLETE);
@@ -15791,7 +15788,7 @@ void Player::CompleteQuest(uint32 quest_id)
 }
 
 void Player::IncompleteQuest(uint32 quest_id)
-{ 
+{
     if (quest_id)
     {
         SetQuestStatus(quest_id, QUEST_STATUS_INCOMPLETE);
@@ -15808,7 +15805,7 @@ void Player::IncompleteQuest(uint32 quest_id)
 }
 
 void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, bool announce)
-{ 
+{
     //this THING should be here to protect code from quest, which cast on player far teleport as a reward
     //should work fine, cause far teleport will be executed in Player::Update()
     SetMustDelayTeleport(true);
@@ -15849,7 +15846,7 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
             {
                 Item* item = StoreNewItem(dest, itemId, true, Item::GenerateItemRandomPropertyId(itemId));
                 SendNewItem(item, quest->RewardChoiceItemCount[reward], true, false, false, false);
-                
+
                 sScriptMgr->OnQuestRewardItem(this, item, quest->RewardChoiceItemCount[reward]);
             }
             else
@@ -15868,7 +15865,7 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
                 {
                     Item* item = StoreNewItem(dest, itemId, true, Item::GenerateItemRandomPropertyId(itemId));
                     SendNewItem(item, quest->RewardItemIdCount[i], true, false, false, false);
-                    
+
                     sScriptMgr->OnQuestRewardItem(this, item, quest->RewardItemIdCount[i]);
                 }
                 else
@@ -15883,7 +15880,7 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
         SQLTransaction trans = CharacterDatabase.BeginTransaction();
         MailSender sender(MAIL_CREATURE, 34337 /* The Postmaster */ );
         MailDraft draft("Recovered Item", "We recovered a lost item in the twisting nether and noted that it was yours.$B$BPlease find said object enclosed."); // This is the text used in Cataclysm, it probably wasn't changed.
-        
+
         for (std::vector<std::pair<uint32, uint32> >::const_iterator itr = problematicItems.begin(); itr != problematicItems.end(); ++itr)
         {
             if(Item* item = Item::CreateItem(itr->first, itr->second))
@@ -16032,12 +16029,12 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
     // Xinef: area auras may change on quest completion!
     UpdateZoneDependentAuras(GetZoneId());
     UpdateAreaDependentAuras(GetAreaId());
-    
+
     sScriptMgr->OnPlayerCompleteQuest(this, quest);
 }
 
 void Player::FailQuest(uint32 questId)
-{ 
+{
     if (Quest const* quest = sObjectMgr->GetQuestTemplate(questId))
     {
         QuestStatus qStatus = GetQuestStatus(questId);
@@ -16098,7 +16095,7 @@ void Player::AbandonQuest(uint32 questId)
 }
 
 bool Player::SatisfyQuestSkill(Quest const* qInfo, bool msg) const
-{ 
+{
     uint32 skill = qInfo->GetRequiredSkill();
 
     // skip 0 case RequiredSkill
@@ -16118,7 +16115,7 @@ bool Player::SatisfyQuestSkill(Quest const* qInfo, bool msg) const
 }
 
 bool Player::SatisfyQuestLevel(Quest const* qInfo, bool msg) const
-{ 
+{
     if (getLevel() < qInfo->GetMinLevel())
     {
         if (msg)
@@ -16135,7 +16132,7 @@ bool Player::SatisfyQuestLevel(Quest const* qInfo, bool msg) const
 }
 
 bool Player::SatisfyQuestLog(bool msg)
-{ 
+{
     // exist free slot
     if (FindQuestSlot(0) < MAX_QUEST_LOG_SIZE)
         return true;
@@ -16152,7 +16149,7 @@ bool Player::SatisfyQuestLog(bool msg)
 }
 
 bool Player::SatisfyQuestPreviousQuest(Quest const* qInfo, bool msg) const
-{ 
+{
     // No previous quest (might be first quest in a series)
     if (qInfo->prevQuests.empty())
         return true;
@@ -16238,7 +16235,7 @@ bool Player::SatisfyQuestPreviousQuest(Quest const* qInfo, bool msg) const
 }
 
 bool Player::SatisfyQuestClass(Quest const* qInfo, bool msg) const
-{ 
+{
     uint32 reqClass = qInfo->GetRequiredClasses();
 
     if (reqClass == 0)
@@ -16256,7 +16253,7 @@ bool Player::SatisfyQuestClass(Quest const* qInfo, bool msg) const
 }
 
 bool Player::SatisfyQuestRace(Quest const* qInfo, bool msg) const
-{ 
+{
     uint32 reqraces = qInfo->GetAllowableRaces();
     if (reqraces == 0)
         return true;
@@ -16270,7 +16267,7 @@ bool Player::SatisfyQuestRace(Quest const* qInfo, bool msg) const
 }
 
 bool Player::SatisfyQuestReputation(Quest const* qInfo, bool msg) const
-{ 
+{
     uint32 fIdMin = qInfo->GetRequiredMinRepFaction();      //Min required rep
     if (fIdMin && GetReputationMgr().GetReputation(fIdMin) < qInfo->GetRequiredMinRepValue())
     {
@@ -16301,7 +16298,7 @@ bool Player::SatisfyQuestReputation(Quest const* qInfo, bool msg) const
 }
 
 bool Player::SatisfyQuestStatus(Quest const* qInfo, bool msg) const
-{ 
+{
     if (GetQuestStatus(qInfo->GetQuestId()) != QUEST_STATUS_NONE)
     {
         if (msg)
@@ -16312,7 +16309,7 @@ bool Player::SatisfyQuestStatus(Quest const* qInfo, bool msg) const
 }
 
 bool Player::SatisfyQuestConditions(Quest const* qInfo, bool msg)
-{ 
+{
     ConditionList conditions = sConditionMgr->GetConditionsForNotGroupedEntry(CONDITION_SOURCE_TYPE_QUEST_ACCEPT, qInfo->GetQuestId());
     if (!sConditionMgr->IsObjectMeetToConditions(this, conditions))
     {
@@ -16327,7 +16324,7 @@ bool Player::SatisfyQuestConditions(Quest const* qInfo, bool msg)
 }
 
 bool Player::SatisfyQuestTimed(Quest const* qInfo, bool msg) const
-{ 
+{
     if (!m_timedquests.empty() && qInfo->HasSpecialFlag(QUEST_SPECIAL_FLAGS_TIMED))
     {
         if (msg)
@@ -16338,7 +16335,7 @@ bool Player::SatisfyQuestTimed(Quest const* qInfo, bool msg) const
 }
 
 bool Player::SatisfyQuestExclusiveGroup(Quest const* qInfo, bool msg) const
-{ 
+{
     // non positive exclusive group, if > 0 then can be start if any other quest in exclusive group already started/completed
     if (qInfo->GetExclusiveGroup() <= 0)
         return true;
@@ -16375,7 +16372,7 @@ bool Player::SatisfyQuestExclusiveGroup(Quest const* qInfo, bool msg) const
 }
 
 bool Player::SatisfyQuestNextChain(Quest const* qInfo, bool msg) const
-{ 
+{
     uint32 nextQuest = qInfo->GetNextQuestInChain();
     if (!nextQuest)
         return true;
@@ -16395,7 +16392,7 @@ bool Player::SatisfyQuestNextChain(Quest const* qInfo, bool msg) const
 }
 
 bool Player::SatisfyQuestPrevChain(Quest const* qInfo, bool msg) const
-{ 
+{
     // No previous quest in chain
     if (qInfo->prevChainQuests.empty())
         return true;
@@ -16423,7 +16420,7 @@ bool Player::SatisfyQuestPrevChain(Quest const* qInfo, bool msg) const
 }
 
 bool Player::SatisfyQuestDay(Quest const* qInfo, bool msg) const
-{ 
+{
     if (!qInfo->IsDaily() && !qInfo->IsDFQuest())
         return true;
 
@@ -16457,7 +16454,7 @@ bool Player::SatisfyQuestDay(Quest const* qInfo, bool msg) const
 }
 
 bool Player::SatisfyQuestWeek(Quest const* qInfo, bool /*msg*/) const
-{ 
+{
     if (!qInfo->IsWeekly() || m_weeklyquests.empty())
         return true;
 
@@ -16466,7 +16463,7 @@ bool Player::SatisfyQuestWeek(Quest const* qInfo, bool /*msg*/) const
 }
 
 bool Player::SatisfyQuestSeasonal(Quest const* qInfo, bool /*msg*/) const
-{ 
+{
     if (!qInfo->IsSeasonal() || m_seasonalquests.empty())
         return true;
 
@@ -16480,7 +16477,7 @@ bool Player::SatisfyQuestSeasonal(Quest const* qInfo, bool /*msg*/) const
 }
 
 bool Player::SatisfyQuestMonth(Quest const* qInfo, bool /*msg*/) const
-{ 
+{
     if (!qInfo->IsMonthly() || m_monthlyquests.empty())
         return true;
 
@@ -16489,7 +16486,7 @@ bool Player::SatisfyQuestMonth(Quest const* qInfo, bool /*msg*/) const
 }
 
 bool Player::GiveQuestSourceItem(Quest const* quest)
-{ 
+{
     uint32 srcitem = quest->GetSrcItemId();
     if (srcitem > 0)
     {
@@ -16517,7 +16514,7 @@ bool Player::GiveQuestSourceItem(Quest const* quest)
 }
 
 bool Player::TakeQuestSourceItem(uint32 questId, bool msg)
-{ 
+{
     Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
     if (quest)
     {
@@ -16556,7 +16553,7 @@ bool Player::TakeQuestSourceItem(uint32 questId, bool msg)
 }
 
 bool Player::GetQuestRewardStatus(uint32 quest_id) const
-{ 
+{
     Quest const* qInfo = sObjectMgr->GetQuestTemplate(quest_id);
     if (qInfo)
     {
@@ -16571,7 +16568,7 @@ bool Player::GetQuestRewardStatus(uint32 quest_id) const
 }
 
 QuestStatus Player::GetQuestStatus(uint32 quest_id) const
-{ 
+{
     if (quest_id)
     {
         QuestStatusMap::const_iterator itr = m_QuestStatus.find(quest_id);
@@ -16591,7 +16588,7 @@ QuestStatus Player::GetQuestStatus(uint32 quest_id) const
 }
 
 bool Player::CanShareQuest(uint32 quest_id) const
-{ 
+{
     Quest const* qInfo = sObjectMgr->GetQuestTemplate(quest_id);
     if (qInfo && qInfo->HasFlag(QUEST_FLAGS_SHARABLE))
     {
@@ -16612,7 +16609,7 @@ bool Player::CanShareQuest(uint32 quest_id) const
 }
 
 void Player::SetQuestStatus(uint32 questId, QuestStatus status, bool update /*= true*/)
-{ 
+{
     if (sObjectMgr->GetQuestTemplate(questId))
     {
         m_QuestStatus[questId].Status = status;
@@ -16624,7 +16621,7 @@ void Player::SetQuestStatus(uint32 questId, QuestStatus status, bool update /*= 
 }
 
 void Player::RemoveActiveQuest(uint32 questId, bool update /*= true*/)
-{ 
+{
     QuestStatusMap::iterator itr = m_QuestStatus.find(questId);
     if (itr != m_QuestStatus.end())
     {
@@ -16642,7 +16639,7 @@ void Player::RemoveActiveQuest(uint32 questId, bool update /*= true*/)
 }
 
 void Player::RemoveRewardedQuest(uint32 questId, bool update /*= true*/)
-{ 
+{
     RewardedQuestSet::iterator rewItr = m_RewardedQuests.find(questId);
     if (rewItr != m_RewardedQuests.end())
     {
@@ -16655,11 +16652,11 @@ void Player::RemoveRewardedQuest(uint32 questId, bool update /*= true*/)
 }
 
 void Player::SendQuestUpdate(uint32 questId)
-{ 
+{
     uint32 zone = 0, area = 0;
     // xinef: shittness fixup
     uint32 oldSpellId = 0;
-    
+
     SpellAreaForQuestMapBounds saBounds = sSpellMgr->GetSpellAreaForQuestMapBounds(questId);
     if (saBounds.first != saBounds.second)
     {
@@ -16678,7 +16675,7 @@ void Player::SendQuestUpdate(uint32 questId)
                 }
         }
     }
-    
+
     saBounds = sSpellMgr->GetSpellAreaForQuestEndMapBounds(questId);
 
     // xinef: shittness fixup
@@ -16724,7 +16721,7 @@ void Player::SendQuestUpdate(uint32 questId)
 }
 
 QuestGiverStatus Player::GetQuestDialogStatus(Object* questgiver)
-{ 
+{
     QuestRelationBounds qr;
     QuestRelationBounds qir;
 
@@ -16835,7 +16832,7 @@ QuestGiverStatus Player::GetQuestDialogStatus(Object* questgiver)
 
 // not used in Trinity, but used in scripting code
 uint16 Player::GetReqKillOrCastCurrentCount(uint32 quest_id, int32 entry)
-{ 
+{
     Quest const* qInfo = sObjectMgr->GetQuestTemplate(quest_id);
     if (!qInfo)
         return 0;
@@ -16848,7 +16845,7 @@ uint16 Player::GetReqKillOrCastCurrentCount(uint32 quest_id, int32 entry)
 }
 
 void Player::AdjustQuestReqItemCount(Quest const* quest, QuestStatusData& questStatusData)
-{ 
+{
     if (quest->HasSpecialFlag(QUEST_SPECIAL_FLAGS_DELIVER))
     {
         for (uint8 i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; ++i)
@@ -16866,7 +16863,7 @@ void Player::AdjustQuestReqItemCount(Quest const* quest, QuestStatusData& questS
 }
 
 uint16 Player::FindQuestSlot(uint32 quest_id) const
-{ 
+{
     for (uint16 i = 0; i < MAX_QUEST_LOG_SIZE; ++i)
         if (GetQuestSlotQuestId(i) == quest_id)
             return i;
@@ -16875,7 +16872,7 @@ uint16 Player::FindQuestSlot(uint32 quest_id) const
 }
 
 void Player::AreaExploredOrEventHappens(uint32 questId)
-{ 
+{
     if (questId)
     {
         uint16 log_slot = FindQuestSlot(questId);
@@ -16904,7 +16901,7 @@ void Player::AreaExploredOrEventHappens(uint32 questId)
 
 //not used in Trinityd, function for external script library
 void Player::GroupEventHappens(uint32 questId, WorldObject const* pEventObject)
-{ 
+{
     if (Group* group = GetGroup())
     {
         for (GroupReference* itr = group->GetFirstMember(); itr != NULL; itr = itr->next())
@@ -16921,7 +16918,7 @@ void Player::GroupEventHappens(uint32 questId, WorldObject const* pEventObject)
 }
 
 void Player::ItemAddedQuestCheck(uint32 entry, uint32 count)
-{ 
+{
     for (uint8 i = 0; i < MAX_QUEST_LOG_SIZE; ++i)
     {
         uint32 questid = GetQuestSlotQuestId(i);
@@ -16961,7 +16958,7 @@ void Player::ItemAddedQuestCheck(uint32 entry, uint32 count)
 }
 
 void Player::ItemRemovedQuestCheck(uint32 entry, uint32 count)
-{ 
+{
     for (uint8 i = 0; i < MAX_QUEST_LOG_SIZE; ++i)
     {
         uint32 questid = GetQuestSlotQuestId(i);
@@ -17003,7 +17000,7 @@ void Player::ItemRemovedQuestCheck(uint32 entry, uint32 count)
 }
 
 void Player::KilledMonster(CreatureTemplate const* cInfo, uint64 guid)
-{ 
+{
     ASSERT(cInfo);
 
     if (cInfo->Entry)
@@ -17015,7 +17012,7 @@ void Player::KilledMonster(CreatureTemplate const* cInfo, uint64 guid)
 }
 
 void Player::KilledMonsterCredit(uint32 entry, uint64 guid)
-{ 
+{
     uint16 addkillcount = 1;
     uint32 real_entry = entry;
     if (guid)
@@ -17080,7 +17077,7 @@ void Player::KilledMonsterCredit(uint32 entry, uint64 guid)
 }
 
 void Player::KilledPlayerCredit()
-{ 
+{
     uint16 addkillcount = 1;
 
     for (uint8 i = 0; i < MAX_QUEST_LOG_SIZE; ++i)
@@ -17121,7 +17118,7 @@ void Player::KilledPlayerCredit()
 }
 
 void Player::KillCreditGO(uint32 entry, uint64 guid)
-{ 
+{
     uint16 addCastCount = 1;
     for (uint8 i = 0; i < MAX_QUEST_LOG_SIZE; ++i)
     {
@@ -17177,7 +17174,7 @@ void Player::KillCreditGO(uint32 entry, uint64 guid)
 }
 
 void Player::TalkedToCreature(uint32 entry, uint64 guid)
-{ 
+{
     uint16 addTalkCount = 1;
     for (uint8 i = 0; i < MAX_QUEST_LOG_SIZE; ++i)
     {
@@ -17236,7 +17233,7 @@ void Player::TalkedToCreature(uint32 entry, uint64 guid)
 }
 
 void Player::MoneyChanged(uint32 count)
-{ 
+{
     for (uint8 i = 0; i < MAX_QUEST_LOG_SIZE; ++i)
     {
         uint32 questid = GetQuestSlotQuestId(i);
@@ -17266,7 +17263,7 @@ void Player::MoneyChanged(uint32 count)
 }
 
 void Player::ReputationChanged(FactionEntry const* factionEntry)
-{ 
+{
     for (uint8 i = 0; i < MAX_QUEST_LOG_SIZE; ++i)
     {
         if (uint32 questid = GetQuestSlotQuestId(i))
@@ -17294,7 +17291,7 @@ void Player::ReputationChanged(FactionEntry const* factionEntry)
 }
 
 void Player::ReputationChanged2(FactionEntry const* factionEntry)
-{ 
+{
     for (uint8 i = 0; i < MAX_QUEST_LOG_SIZE; ++i)
     {
         if (uint32 questid = GetQuestSlotQuestId(i))
@@ -17322,7 +17319,7 @@ void Player::ReputationChanged2(FactionEntry const* factionEntry)
 }
 
 bool Player::HasQuestForItem(uint32 itemid, uint32 excludeQuestId /* 0 */, bool turnIn /* false */) const
-{ 
+{
     for (uint8 i = 0; i < MAX_QUEST_LOG_SIZE; ++i)
     {
         uint32 questid = GetQuestSlotQuestId(i);
@@ -17381,7 +17378,7 @@ bool Player::HasQuestForItem(uint32 itemid, uint32 excludeQuestId /* 0 */, bool 
 }
 
 void Player::SendQuestComplete(uint32 quest_id)
-{ 
+{
     if (quest_id)
     {
         WorldPacket data(SMSG_QUESTUPDATE_COMPLETE, 4);
@@ -17394,7 +17391,7 @@ void Player::SendQuestComplete(uint32 quest_id)
 }
 
 void Player::SendQuestReward(Quest const* quest, uint32 XP)
-{ 
+{
     uint32 questid = quest->GetQuestId();
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_NETWORKIO, "WORLD: Sent SMSG_QUESTGIVER_QUEST_COMPLETE quest = %u", questid);
@@ -17421,7 +17418,7 @@ void Player::SendQuestReward(Quest const* quest, uint32 XP)
 }
 
 void Player::SendQuestFailed(uint32 questId, InventoryResult reason)
-{ 
+{
     if (questId)
     {
         WorldPacket data(SMSG_QUESTGIVER_QUEST_FAILED, 4 + 4);
@@ -17435,7 +17432,7 @@ void Player::SendQuestFailed(uint32 questId, InventoryResult reason)
 }
 
 void Player::SendQuestTimerFailed(uint32 quest_id)
-{ 
+{
     if (quest_id)
     {
         WorldPacket data(SMSG_QUESTUPDATE_FAILEDTIMER, 4);
@@ -17448,7 +17445,7 @@ void Player::SendQuestTimerFailed(uint32 quest_id)
 }
 
 void Player::SendCanTakeQuestResponse(uint32 msg) const
-{ 
+{
     WorldPacket data(SMSG_QUESTGIVER_QUEST_INVALID, 4);
     data << uint32(msg);
     GetSession()->SendPacket(&data);
@@ -17458,7 +17455,7 @@ void Player::SendCanTakeQuestResponse(uint32 msg) const
 }
 
 void Player::SendQuestConfirmAccept(const Quest* quest, Player* pReceiver)
-{ 
+{
     if (pReceiver)
     {
         //load locale from db
@@ -17468,7 +17465,7 @@ void Player::SendQuestConfirmAccept(const Quest* quest, Player* pReceiver)
         if (loc_idx >= 0)
             if (const QuestLocale* pLocale = sObjectMgr->GetQuestLocale(quest->GetQuestId()))
                 ObjectMgr::GetLocaleString(pLocale->Title, loc_idx, strTitle);
-			
+
         WorldPacket data(SMSG_QUEST_CONFIRM_ACCEPT, (4 + quest->GetTitle().size() + 8));
         data << uint32(quest->GetQuestId());
         data << quest->GetTitle();
@@ -17482,7 +17479,7 @@ void Player::SendQuestConfirmAccept(const Quest* quest, Player* pReceiver)
 }
 
 void Player::SendPushToPartyResponse(Player* player, uint8 msg)
-{ 
+{
     if (player)
     {
         WorldPacket data(MSG_QUEST_PUSH_RESULT, (8+1));
@@ -17496,7 +17493,7 @@ void Player::SendPushToPartyResponse(Player* player, uint8 msg)
 }
 
 void Player::SendQuestUpdateAddItem(Quest const* /*quest*/, uint32 /*item_idx*/, uint16 /*count*/)
-{ 
+{
     WorldPacket data(SMSG_QUESTUPDATE_ADD_ITEM, 0);
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_NETWORKIO, "WORLD: Sent SMSG_QUESTUPDATE_ADD_ITEM");
@@ -17507,7 +17504,7 @@ void Player::SendQuestUpdateAddItem(Quest const* /*quest*/, uint32 /*item_idx*/,
 }
 
 void Player::SendQuestUpdateAddCreatureOrGo(Quest const* quest, uint64 guid, uint32 creatureOrGO_idx, uint16 old_count, uint16 add_count)
-{ 
+{
     ASSERT(old_count + add_count < 65536 && "mob/GO count store in 16 bits 2^16 = 65536 (0..65536)");
 
     int32 entry = quest->RequiredNpcOrGo[ creatureOrGO_idx ];
@@ -17532,7 +17529,7 @@ void Player::SendQuestUpdateAddCreatureOrGo(Quest const* quest, uint64 guid, uin
 }
 
 void Player::SendQuestUpdateAddPlayer(Quest const* quest, uint16 old_count, uint16 add_count)
-{ 
+{
     ASSERT(old_count + add_count < 65536 && "player count store in 16 bits");
 
     WorldPacket data(SMSG_QUESTUPDATE_ADD_PVP_KILL, (3*4));
@@ -17550,7 +17547,7 @@ void Player::SendQuestUpdateAddPlayer(Quest const* quest, uint16 old_count, uint
 }
 
 bool Player::HasPvPForcingQuest() const
-{ 
+{
     for (uint8 i = 0; i < MAX_QUEST_LOG_SIZE; ++i)
     {
         uint32 questId = GetQuestSlotQuestId(i);
@@ -17573,12 +17570,12 @@ bool Player::HasPvPForcingQuest() const
 /*********************************************************/
 
 void Player::Initialize(uint32 guid)
-{ 
+{
     Object::_Create(guid, 0, HIGHGUID_PLAYER);
 }
 
 void Player::_LoadDeclinedNames(PreparedQueryResult result)
-{ 
+{
     if (!result)
         return;
 
@@ -17589,7 +17586,7 @@ void Player::_LoadDeclinedNames(PreparedQueryResult result)
 }
 
 void Player::_LoadArenaTeamInfo()
-{ 
+{
     memset((void*)&m_uint32Values[PLAYER_FIELD_ARENA_TEAM_INFO_1_1], 0, sizeof(uint32) * MAX_ARENA_SLOT * ARENA_TEAM_END);
 
     for (uint8 slot = 0; slot <= 2; ++slot)
@@ -17613,7 +17610,7 @@ void Player::_LoadArenaTeamInfo()
 }
 
 void Player::_LoadEquipmentSets(PreparedQueryResult result)
-{ 
+{
     // SetPQuery(PLAYER_LOGIN_QUERY_LOADEQUIPMENTSETS,   "SELECT setguid, setindex, name, iconname, item0, item1, item2, item3, item4, item5, item6, item7, item8, item9, item10, item11, item12, item13, item14, item15, item16, item17, item18 FROM character_equipmentsets WHERE guid = '%u' ORDER BY setindex", GUID_LOPART(m_guid));
     if (!result)
         return;
@@ -17645,7 +17642,7 @@ void Player::_LoadEquipmentSets(PreparedQueryResult result)
 }
 
 void Player::_LoadEntryPointData(PreparedQueryResult result)
-{ 
+{
     if (!result)
         return;
 
@@ -17696,7 +17693,7 @@ bool Player::LoadPositionFromDB(uint32& mapid, float& x, float& y, float& z, flo
 }
 
 void Player::SetHomebind(WorldLocation const& loc, uint32 areaId)
-{ 
+{
     loc.GetPosition(m_homebindX, m_homebindY, m_homebindZ);
     m_homebindMapId = loc.GetMapId();
     m_homebindAreaId = areaId;
@@ -17730,12 +17727,12 @@ float Player::GetFloatValueFromArray(Tokenizer const& data, uint16 index)
 }
 
 bool Player::isBeingLoaded() const
-{ 
+{
     return GetSession()->PlayerLoading();
 }
 
 bool Player::LoadFromDB(uint32 guid, SQLQueryHolder *holder)
-{ 
+{
     ////                                                     0     1        2     3     4        5      6    7      8     9    10    11         12         13           14         15         16
     //QueryResult* result = CharacterDatabase.PQuery("SELECT guid, account, name, race, class, gender, level, xp, money, skin, face, hairStyle, hairColor, facialStyle, bankSlots, restState, playerFlags, "
      // 17          18          19          20   21           22        23        24         25         26          27           28                 29
@@ -17984,7 +17981,7 @@ bool Player::LoadFromDB(uint32 guid, SQLQueryHolder *holder)
             if (transGO->IsInWorld() && transGO->FindMap()) // pussywizard: must be on map, for one world tick transport is not in map and has old GetMapId(), player would be added to old map and to the transport, multithreading crashfix
                 m_transport = transGO->ToTransport();
 
-        if (m_transport) 
+        if (m_transport)
         {
             float x = fields[31].GetFloat(), y = fields[32].GetFloat(), z = fields[33].GetFloat(), o = fields[34].GetFloat();
             m_movementInfo.transport.guid = transGUID;
@@ -18380,7 +18377,7 @@ bool Player::LoadFromDB(uint32 guid, SQLQueryHolder *holder)
         SetFlag(UNIT_FIELD_AURASTATE, 1<<(AURA_STATE_HEALTHLESS_35_PERCENT-1));
     if (HealthAbovePct(75))
         SetFlag(UNIT_FIELD_AURASTATE, 1<<(AURA_STATE_HEALTH_ABOVE_75_PERCENT-1));
-    
+
     // unapply aura stats if dont meet requirements
      AuraApplicationMap const& Auras = GetAppliedAuras();
     for (AuraApplicationMap::const_iterator itr = Auras.begin(); itr != Auras.end(); ++itr)
@@ -18400,7 +18397,7 @@ bool Player::LoadFromDB(uint32 guid, SQLQueryHolder *holder)
 }
 
 bool Player::isAllowedToLoot(const Creature* creature)
-{ 
+{
     if (!creature->isDead() || !creature->IsDamageEnoughForLootingAndReward())
         return false;
 
@@ -18447,7 +18444,7 @@ bool Player::isAllowedToLoot(const Creature* creature)
 }
 
 void Player::_LoadActions(PreparedQueryResult result)
-{ 
+{
     m_actionButtons.clear();
 
     if (result)
@@ -18475,7 +18472,7 @@ void Player::_LoadActions(PreparedQueryResult result)
 }
 
 void Player::_LoadAuras(PreparedQueryResult result, uint32 timediff)
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PLAYER_LOADING, "Loading auras for player %u", GetGUIDLow());
 #endif
@@ -18562,7 +18559,7 @@ void Player::_LoadAuras(PreparedQueryResult result, uint32 timediff)
 }
 
 void Player::_LoadGlyphAuras()
-{ 
+{
     for (uint8 i = 0; i < MAX_GLYPH_SLOT_INDEX; ++i)
     {
         if (uint32 glyph = GetGlyph(i))
@@ -18594,7 +18591,7 @@ void Player::_LoadGlyphAuras()
 }
 
 void Player::LoadCorpse()
-{ 
+{
     if (IsAlive())
         sObjectAccessor->ConvertCorpseForPlayer(GetGUID());
     else
@@ -18608,7 +18605,7 @@ void Player::LoadCorpse()
 }
 
 void Player::_LoadInventory(PreparedQueryResult result, uint32 timeDiff)
-{ 
+{
     //QueryResult* result = CharacterDatabase.PQuery("SELECT data, text, bag, slot, item, item_template FROM character_inventory JOIN item_instance ON character_inventory.item = item_instance.guid WHERE character_inventory.guid = '%u' ORDER BY bag, slot", GetGUIDLow());
     //NOTE: the "order by `bag`" is important because it makes sure
     //the bagMap is filled before items in the bags are loaded
@@ -18739,7 +18736,7 @@ void Player::_LoadInventory(PreparedQueryResult result, uint32 timeDiff)
 }
 
 Item* Player::_LoadItem(SQLTransaction& trans, uint32 zoneId, uint32 timeDiff, Field* fields)
-{ 
+{
     Item* item = NULL;
     uint32 itemGuid  = fields[13].GetUInt32();
     uint32 itemEntry = fields[14].GetUInt32();
@@ -18877,7 +18874,7 @@ Item* Player::_LoadItem(SQLTransaction& trans, uint32 zoneId, uint32 timeDiff, F
 
 // load mailed item which should receive current player
 void Player::_LoadMailedItems(Mail* mail)
-{ 
+{
     // data needs to be at first place for Item::LoadFromDB
     PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_MAILITEMS);
     stmt->setUInt32(0, mail->messageID);
@@ -18933,7 +18930,7 @@ void Player::_LoadMailedItems(Mail* mail)
 }
 
 void Player::_LoadMailInit(PreparedQueryResult resultUnread, PreparedQueryResult resultDelivery)
-{ 
+{
     //set a count of unread mails
     //QueryResult* resultMails = CharacterDatabase.PQuery("SELECT COUNT(id) FROM mail WHERE receiver = '%u' AND (checked & 1)=0 AND deliver_time <= '" UI64FMTD "'", GUID_LOPART(playerGuid), (uint64)cTime);
     if (resultUnread)
@@ -18946,7 +18943,7 @@ void Player::_LoadMailInit(PreparedQueryResult resultUnread, PreparedQueryResult
 }
 
 void Player::_LoadMailAsynch(PreparedQueryResult result)
-{ 
+{
     m_mail.clear();
     uint32 prevMailID = 0;
     Mail* m = NULL;
@@ -19042,7 +19039,7 @@ void Player::_LoadMailAsynch(PreparedQueryResult result)
 }
 
 void Player::_LoadMail()
-{ 
+{
     m_mail.clear();
 
     PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_MAIL);
@@ -19090,7 +19087,7 @@ void Player::_LoadMail()
 }
 
 void Player::LoadPet()
-{ 
+{
     //fixme: the pet should still be loaded if the player is not in world
     // just not added to the map
     if (IsInWorld())
@@ -19100,7 +19097,7 @@ void Player::LoadPet()
 }
 
 void Player::_LoadQuestStatus(PreparedQueryResult result)
-{ 
+{
     uint16 slot = 0;
 
     ////                                                       0      1       2        3        4           5          6         7           8           9           10
@@ -19190,7 +19187,7 @@ void Player::_LoadQuestStatus(PreparedQueryResult result)
 }
 
 void Player::_LoadQuestStatusRewarded(PreparedQueryResult result)
-{ 
+{
     // SELECT quest FROM character_queststatus_rewarded WHERE guid = ?
 
     if (result)
@@ -19226,7 +19223,7 @@ void Player::_LoadQuestStatusRewarded(PreparedQueryResult result)
 }
 
 void Player::_LoadDailyQuestStatus(PreparedQueryResult result)
-{ 
+{
     for (uint32 quest_daily_idx = 0; quest_daily_idx < PLAYER_MAX_DAILY_QUESTS; ++quest_daily_idx)
         SetUInt32Value(PLAYER_FIELD_DAILY_QUESTS_1+quest_daily_idx, 0);
 
@@ -19280,7 +19277,7 @@ void Player::_LoadDailyQuestStatus(PreparedQueryResult result)
 }
 
 void Player::_LoadWeeklyQuestStatus(PreparedQueryResult result)
-{ 
+{
     m_weeklyquests.clear();
 
     if (result)
@@ -19305,7 +19302,7 @@ void Player::_LoadWeeklyQuestStatus(PreparedQueryResult result)
 }
 
 void Player::_LoadSeasonalQuestStatus(PreparedQueryResult result)
-{ 
+{
     m_seasonalquests.clear();
 
     if (result)
@@ -19331,7 +19328,7 @@ void Player::_LoadSeasonalQuestStatus(PreparedQueryResult result)
 }
 
 void Player::_LoadMonthlyQuestStatus(PreparedQueryResult result)
-{ 
+{
     m_monthlyquests.clear();
 
     if (result)
@@ -19354,7 +19351,7 @@ void Player::_LoadMonthlyQuestStatus(PreparedQueryResult result)
 }
 
 void Player::_LoadSpells(PreparedQueryResult result)
-{ 
+{
     //QueryResult* result = CharacterDatabase.PQuery("SELECT spell, specMask FROM character_spell WHERE guid = '%u'", GetGUIDLow());
 
     if (result)
@@ -19388,7 +19385,7 @@ void Player::_LoadGroup()
 }
 
 void Player::BindToInstance()
-{ 
+{
     InstanceSave* mapSave = sInstanceSaveMgr->GetInstanceSave(_pendingBindId);
     if (!mapSave) //it seems sometimes mapSave is NULL, but I did not check why
         return;
@@ -19400,7 +19397,7 @@ void Player::BindToInstance()
 }
 
 void Player::SendRaidInfo()
-{ 
+{
     uint32 counter = 0;
 
     WorldPacket data(SMSG_RAID_INSTANCE_INFO, 4);
@@ -19437,7 +19434,7 @@ void Player::SendRaidInfo()
 - called on every successful teleportation to a map
 */
 void Player::SendSavedInstances()
-{ 
+{
     bool hasBeenSaved = false;
     WorldPacket data;
 
@@ -19478,7 +19475,7 @@ void Player::SendSavedInstances()
 }
 
 bool Player::Satisfy(AccessRequirement const* ar, uint32 target_map, bool report)
-{ 
+{
     if (!IsGameMaster() && ar)
     {
         uint8 LevelMin = 0;
@@ -19550,7 +19547,7 @@ bool Player::Satisfy(AccessRequirement const* ar, uint32 target_map, bool report
 }
 
 bool Player::CheckInstanceLoginValid()
-{ 
+{
     if (!GetMap())
         return false;
 
@@ -19579,14 +19576,14 @@ bool Player::CheckInstanceLoginValid()
 }
 
 bool Player::CheckInstanceCount(uint32 instanceId) const
-{ 
+{
     if (_instanceResetTimes.size() < sWorld->getIntConfig(CONFIG_MAX_INSTANCES_PER_HOUR))
         return true;
     return _instanceResetTimes.find(instanceId) != _instanceResetTimes.end();
 }
 
 bool Player::_LoadHomeBind(PreparedQueryResult result)
-{ 
+{
     PlayerInfo const* info = sObjectMgr->GetPlayerInfo(getRace(true), getClass());
     if (!info)
     {
@@ -19650,7 +19647,7 @@ bool Player::_LoadHomeBind(PreparedQueryResult result)
 /*********************************************************/
 
 void Player::SaveToDB(bool create, bool logout)
-{ 
+{
     //lets allow only players in world to be saved
     if (IsBeingTeleportedFar())
     {
@@ -19724,13 +19721,13 @@ void Player::SaveToDB(bool create, bool logout)
 
 // fast save function for item/money cheating preventing - save only inventory and money state
 void Player::SaveInventoryAndGoldToDB(SQLTransaction& trans)
-{ 
+{
     _SaveInventory(trans);
     SaveGoldToDB(trans);
 }
 
 void Player::SaveGoldToDB(SQLTransaction& trans)
-{ 
+{
     PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UDP_CHAR_MONEY);
     stmt->setUInt32(0, GetMoney());
     stmt->setUInt32(1, GetGUIDLow());
@@ -19738,7 +19735,7 @@ void Player::SaveGoldToDB(SQLTransaction& trans)
 }
 
 void Player::_SaveActions(SQLTransaction& trans)
-{ 
+{
     PreparedStatement* stmt = NULL;
 
     for (ActionButtonList::iterator itr = m_actionButtons.begin(); itr != m_actionButtons.end();)
@@ -19786,7 +19783,7 @@ void Player::_SaveActions(SQLTransaction& trans)
 }
 
 void Player::_SaveAuras(SQLTransaction& trans, bool logout)
-{ 
+{
     PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_CHAR_AURA);
     stmt->setUInt32(0, GetGUIDLow());
     trans->Append(stmt);
@@ -19844,7 +19841,7 @@ void Player::_SaveAuras(SQLTransaction& trans, bool logout)
 }
 
 void Player::_SaveInventory(SQLTransaction& trans)
-{ 
+{
     PreparedStatement* stmt = NULL;
     // force items in buyback slots to new state
     // and remove those that aren't already
@@ -19853,7 +19850,7 @@ void Player::_SaveInventory(SQLTransaction& trans)
         Item* item = m_items[i];
         if (!item)
             continue;
-        
+
         if (item->GetState() == ITEM_NEW)
         {
             // Xinef: item is removed, remove loot from storage if any
@@ -19980,7 +19977,7 @@ void Player::_SaveInventory(SQLTransaction& trans)
 }
 
 void Player::_SaveMail(SQLTransaction& trans)
-{ 
+{
     if (!m_mailsLoaded)
         return;
 
@@ -20053,7 +20050,7 @@ void Player::_SaveMail(SQLTransaction& trans)
 }
 
 void Player::_SaveQuestStatus(SQLTransaction& trans)
-{ 
+{
     bool isTransaction = !trans.null();
     if (!isTransaction)
         trans = CharacterDatabase.BeginTransaction();
@@ -20120,7 +20117,7 @@ void Player::_SaveQuestStatus(SQLTransaction& trans)
 }
 
 void Player::_SaveDailyQuestStatus(SQLTransaction& trans)
-{ 
+{
     if (!m_DailyQuestChanged)
         return;
 
@@ -20158,7 +20155,7 @@ void Player::_SaveDailyQuestStatus(SQLTransaction& trans)
 }
 
 void Player::_SaveWeeklyQuestStatus(SQLTransaction& trans)
-{ 
+{
     if (!m_WeeklyQuestChanged || m_weeklyquests.empty())
         return;
 
@@ -20181,7 +20178,7 @@ void Player::_SaveWeeklyQuestStatus(SQLTransaction& trans)
 }
 
 void Player::_SaveSeasonalQuestStatus(SQLTransaction& trans)
-{ 
+{
     if (!m_SeasonalQuestChanged || m_seasonalquests.empty())
         return;
 
@@ -20209,7 +20206,7 @@ void Player::_SaveSeasonalQuestStatus(SQLTransaction& trans)
 }
 
 void Player::_SaveMonthlyQuestStatus(SQLTransaction& trans)
-{ 
+{
     if (!m_MonthlyQuestChanged || m_monthlyquests.empty())
         return;
 
@@ -20231,7 +20228,7 @@ void Player::_SaveMonthlyQuestStatus(SQLTransaction& trans)
 }
 
 void Player::_SaveSkills(SQLTransaction& trans)
-{ 
+{
     PreparedStatement* stmt = NULL;
     // we don't need transactions here.
     for (SkillStatusMap::iterator itr = mSkillStatus.begin(); itr != mSkillStatus.end();)
@@ -20287,7 +20284,7 @@ void Player::_SaveSkills(SQLTransaction& trans)
 }
 
 void Player::_SaveSpells(SQLTransaction& trans)
-{ 
+{
     PreparedStatement* stmt = NULL;
 
     for (PlayerSpellMap::iterator itr = m_spells.begin(); itr != m_spells.end();)
@@ -20334,7 +20331,7 @@ void Player::_SaveSpells(SQLTransaction& trans)
 // save player stats -- only for external usage
 // real stats will be recalculated on player login
 void Player::_SaveStats(SQLTransaction& trans)
-{ 
+{
     // check if stat saving is enabled and if char level is high enough
     if (!sWorld->getIntConfig(CONFIG_MIN_LEVEL_STAT_SAVE) || getLevel() < sWorld->getIntConfig(CONFIG_MIN_LEVEL_STAT_SAVE))
         return;
@@ -20375,7 +20372,7 @@ void Player::_SaveStats(SQLTransaction& trans)
 }
 
 void Player::outDebugValues() const
-{ 
+{
     if (!sLog->IsOutDebug())                                  // optimize disabled debug output
         return;
 
@@ -20400,7 +20397,7 @@ void Player::outDebugValues() const
 /*********************************************************/
 
 void Player::UpdateSpeakTime(uint32 specialMessageLimit)
-{ 
+{
     // ignore chat spam protection for GMs in any mode
     if (!AccountMgr::IsPlayerAccount(GetSession()->GetSecurity()))
         return;
@@ -20430,7 +20427,7 @@ void Player::UpdateSpeakTime(uint32 specialMessageLimit)
 }
 
 bool Player::CanSpeak() const
-{ 
+{
     return  GetSession()->m_muteTime <= time (NULL);
 }
 
@@ -20439,7 +20436,7 @@ bool Player::CanSpeak() const
 /*********************************************************/
 
 void Player::SendAttackSwingNotInRange()
-{ 
+{
     WorldPacket data(SMSG_ATTACKSWING_NOTINRANGE, 0);
     GetSession()->SendPacket(&data);
 }
@@ -20487,38 +20484,38 @@ void Player::Customize(uint64 guid, uint8 gender, uint8 skin, uint8 face, uint8 
 }
 
 void Player::SendAttackSwingDeadTarget()
-{ 
+{
     WorldPacket data(SMSG_ATTACKSWING_DEADTARGET, 0);
     GetSession()->SendPacket(&data);
 }
 
 void Player::SendAttackSwingCantAttack()
-{ 
+{
     WorldPacket data(SMSG_ATTACKSWING_CANT_ATTACK, 0);
     GetSession()->SendPacket(&data);
 }
 
 void Player::SendAttackSwingCancelAttack()
-{ 
+{
     WorldPacket data(SMSG_CANCEL_COMBAT, 0);
     GetSession()->SendPacket(&data);
 }
 
 void Player::SendAttackSwingBadFacingAttack()
-{ 
+{
     WorldPacket data(SMSG_ATTACKSWING_BADFACING, 0);
     GetSession()->SendPacket(&data);
 }
 
 void Player::SendAutoRepeatCancel(Unit* target)
-{ 
+{
     WorldPacket data(SMSG_CANCEL_AUTO_REPEAT, target->GetPackGUID().size());
     data.append(target->GetPackGUID());                     // may be it's target guid
     SendMessageToSet(&data, true);
 }
 
 void Player::SendExplorationExperience(uint32 Area, uint32 Experience)
-{ 
+{
     WorldPacket data(SMSG_EXPLORATION_EXPERIENCE, 8);
     data << uint32(Area);
     data << uint32(Experience);
@@ -20526,7 +20523,7 @@ void Player::SendExplorationExperience(uint32 Area, uint32 Experience)
 }
 
 void Player::SendDungeonDifficulty(bool IsInGroup)
-{ 
+{
     uint8 val = 0x00000001;
     WorldPacket data(MSG_SET_DUNGEON_DIFFICULTY, 12);
     data << (uint32)GetDungeonDifficulty();
@@ -20536,7 +20533,7 @@ void Player::SendDungeonDifficulty(bool IsInGroup)
 }
 
 void Player::SendRaidDifficulty(bool IsInGroup, int32 forcedDifficulty)
-{ 
+{
     uint8 val = 0x00000001;
     WorldPacket data(MSG_SET_RAID_DIFFICULTY, 12);
     data << uint32(forcedDifficulty == -1 ? GetRaidDifficulty() : forcedDifficulty);
@@ -20546,7 +20543,7 @@ void Player::SendRaidDifficulty(bool IsInGroup, int32 forcedDifficulty)
 }
 
 void Player::SendResetFailedNotify(uint32 mapid)
-{ 
+{
     WorldPacket data(SMSG_RESET_FAILED_NOTIFY, 4);
     data << uint32(mapid);
     GetSession()->SendPacket(&data);
@@ -20669,14 +20666,14 @@ void Player::ResetInstances(uint64 guid, uint8 method, bool isRaid)
 }
 
 void Player::SendResetInstanceSuccess(uint32 MapId)
-{ 
+{
     WorldPacket data(SMSG_INSTANCE_RESET, 4);
     data << uint32(MapId);
     GetSession()->SendPacket(&data);
 }
 
 void Player::SendResetInstanceFailed(uint32 reason, uint32 MapId)
-{ 
+{
     /*reasons for instance reset failure:
     // 0: There are players inside the instance.
     // 1: There are players offline in your party.
@@ -20694,7 +20691,7 @@ void Player::SendResetInstanceFailed(uint32 reason, uint32 MapId)
 
 ///checks the 15 afk reports per 5 minutes limit
 void Player::UpdateAfkReport(time_t currTime)
-{ 
+{
     if (m_bgData.bgAfkReportedTimer <= currTime)
     {
         m_bgData.bgAfkReportedCount = 0;
@@ -20703,7 +20700,7 @@ void Player::UpdateAfkReport(time_t currTime)
 }
 
 void Player::UpdateContestedPvP(uint32 diff)
-{ 
+{
     if (!m_contestedPvPTimer||IsInCombat())
         return;
     if (m_contestedPvPTimer <= diff)
@@ -20715,7 +20712,7 @@ void Player::UpdateContestedPvP(uint32 diff)
 }
 
 void Player::UpdatePvPFlag(time_t currTime)
-{ 
+{
     if (!IsPvP())
         return;
     if (pvpInfo.EndTimer == 0 || pvpInfo.IsHostile)
@@ -20731,7 +20728,7 @@ void Player::UpdatePvPFlag(time_t currTime)
 }
 
 void Player::UpdateDuelFlag(time_t currTime)
-{ 
+{
     if (!duel || duel->startTimer == 0 || currTime < duel->startTimer + 3)
         return;
 
@@ -20747,7 +20744,7 @@ void Player::UpdateDuelFlag(time_t currTime)
 }
 
 Pet* Player::GetPet() const
-{ 
+{
     if (uint64 pet_guid = GetPetGUID())
     {
         if (!IS_PET_GUID(pet_guid))
@@ -20844,7 +20841,7 @@ void Player::RemovePet(Pet* pet, PetSaveMode mode, bool returnreagent)
 }
 
 void Player::StopCastingCharm()
-{ 
+{
     Unit* charm = GetCharm();
     if (!charm)
         return;
@@ -20914,7 +20911,7 @@ void Player::TextEmote(const std::string& text)
 }
 
 void Player::Whisper(const std::string& text, uint32 language, uint64 receiver)
-{ 
+{
     bool isAddonMessage = language == LANG_ADDON;
 
     if (!isAddonMessage)                                    // if not addon data
@@ -20954,7 +20951,7 @@ void Player::Whisper(const std::string& text, uint32 language, uint64 receiver)
 }
 
 void Player::PetSpellInitialize()
-{ 
+{
     Pet* pet = GetPet();
 
     if (!pet)
@@ -21017,7 +21014,7 @@ void Player::PetSpellInitialize()
 }
 
 void Player::PossessSpellInitialize()
-{ 
+{
     Unit* charm = GetCharm();
     if (!charm)
         return;
@@ -21045,7 +21042,7 @@ void Player::PossessSpellInitialize()
 }
 
 void Player::VehicleSpellInitialize()
-{ 
+{
     Creature* vehicle = GetVehicleCreatureBase();
     if (!vehicle)
         return;
@@ -21110,7 +21107,7 @@ void Player::VehicleSpellInitialize()
 }
 
 void Player::CharmSpellInitialize()
-{ 
+{
     Unit* charm = GetFirstControlled();
     if (!charm)
         return;
@@ -21164,14 +21161,14 @@ void Player::CharmSpellInitialize()
 }
 
 void Player::SendRemoveControlBar()
-{ 
+{
     WorldPacket data(SMSG_PET_SPELLS, 8);
     data << uint64(0);
     GetSession()->SendPacket(&data);
 }
 
 bool Player::HasSpellMod(SpellModifier* mod, Spell* spell)
-{ 
+{
     if (!mod || !spell)
         return false;
 
@@ -21179,7 +21176,7 @@ bool Player::HasSpellMod(SpellModifier* mod, Spell* spell)
 }
 
 bool Player::IsAffectedBySpellmod(SpellInfo const* spellInfo, SpellModifier* mod, Spell* spell)
-{ 
+{
     if (!mod || !spellInfo)
         return false;
 
@@ -21223,7 +21220,7 @@ class MageSpellModPred
 };
 
 void Player::AddSpellMod(SpellModifier* mod, bool apply)
-{ 
+{
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_SPELLS_AURAS, "Player::AddSpellMod %d", mod->spellId);
 #endif
@@ -21273,7 +21270,7 @@ void Player::AddSpellMod(SpellModifier* mod, bool apply)
 
 // Restore spellmods in case of failed cast
 void Player::RestoreSpellMods(Spell* spell, uint32 ownerAuraId, Aura* aura)
-{ 
+{
     if (!spell || spell->m_appliedMods.empty())
         return;
 
@@ -21340,14 +21337,14 @@ void Player::RestoreSpellMods(Spell* spell, uint32 ownerAuraId, Aura* aura)
 }
 
 void Player::RestoreAllSpellMods(uint32 ownerAuraId, Aura* aura)
-{ 
+{
     for (uint32 i = 0; i < CURRENT_MAX_SPELL; ++i)
         if (m_currentSpells[i])
             RestoreSpellMods(m_currentSpells[i], ownerAuraId, aura);
 }
 
 void Player::RemoveSpellMods(Spell* spell)
-{ 
+{
     if (!spell)
         return;
 
@@ -21397,7 +21394,7 @@ void Player::RemoveSpellMods(Spell* spell)
 }
 
 void Player::DropModCharge(SpellModifier* mod, Spell* spell)
-{ 
+{
     // don't handle spells with proc_event entry defined
     // this is a temporary workaround, because all spellmods should be handled like that
     if (sSpellMgr->GetSpellProcEvent(mod->spellId))
@@ -21413,7 +21410,7 @@ void Player::DropModCharge(SpellModifier* mod, Spell* spell)
 }
 
 void Player::SetSpellModTakingSpell(Spell* spell, bool apply)
-{ 
+{
     if (apply && m_spellModTakingSpell != NULL)
     {
         sLog->outMisc("Player::SetSpellModTakingSpell (A1) - %u, %u", spell->m_spellInfo->Id, m_spellModTakingSpell->m_spellInfo->Id);
@@ -21437,7 +21434,7 @@ void Player::SetSpellModTakingSpell(Spell* spell, bool apply)
 
 // send Proficiency
 void Player::SendProficiency(ItemClass itemClass, uint32 itemSubclassMask)
-{ 
+{
     WorldPacket data(SMSG_SET_PROFICIENCY, 1 + 4);
     data << uint8(itemClass) << uint32(itemSubclassMask);
     GetSession()->SendPacket(&data);
@@ -21468,7 +21465,7 @@ void Player::RemovePetitionsAndSigns(uint64 guid, uint32 type)
             if (owner)
                 owner->GetSession()->SendPetitionQueryOpcode(petitionguid);
         }
-    } 
+    }
 
     if (type == 10)
     {
@@ -21541,7 +21538,7 @@ void Player::LeaveAllArenaTeams(uint64 guid)
 }
 
 void Player::SetRestBonus(float rest_bonus_new)
-{ 
+{
     // Prevent resting on max level
     if (getLevel() >= sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL))
         rest_bonus_new = 0;
@@ -21572,7 +21569,7 @@ void Player::SetRestBonus(float rest_bonus_new)
 }
 
 bool Player::ActivateTaxiPathTo(std::vector<uint32> const& nodes, Creature* npc /*= NULL*/, uint32 spellid /*= 1*/)
-{ 
+{
     if (nodes.size() < 2)
         return false;
 
@@ -21759,7 +21756,7 @@ bool Player::ActivateTaxiPathTo(std::vector<uint32> const& nodes, Creature* npc 
 }
 
 bool Player::ActivateTaxiPathTo(uint32 taxi_path_id, uint32 spellid /*= 1*/)
-{ 
+{
     TaxiPathEntry const* entry = sTaxiPathStore.LookupEntry(taxi_path_id);
     if (!entry)
         return false;
@@ -21774,7 +21771,7 @@ bool Player::ActivateTaxiPathTo(uint32 taxi_path_id, uint32 spellid /*= 1*/)
 }
 
 void Player::CleanupAfterTaxiFlight()
-{ 
+{
     m_taxi.ClearTaxiDestinations();        // not destinations, clear source node
     Dismount();
     RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_DISABLE_MOVE | UNIT_FLAG_TAXI_FLIGHT);
@@ -21782,7 +21779,7 @@ void Player::CleanupAfterTaxiFlight()
 }
 
 void Player::ContinueTaxiFlight()
-{ 
+{
     uint32 sourceNode = m_taxi.GetTaxiSource();
     if (!sourceNode)
         return;
@@ -21834,7 +21831,7 @@ void Player::ContinueTaxiFlight()
 }
 
 void Player::ProhibitSpellSchool(SpellSchoolMask idSchoolMask, uint32 unTimeMs)
-{ 
+{
     PacketCooldowns cooldowns;
     WorldPacket data;
 
@@ -21872,7 +21869,7 @@ void Player::ProhibitSpellSchool(SpellSchoolMask idSchoolMask, uint32 unTimeMs)
 }
 
 void Player::InitDataForForm(bool reapplyMods)
-{ 
+{
     ShapeshiftForm form = GetShapeshiftForm();
 
     SpellShapeshiftEntry const* ssEntry = sSpellShapeshiftStore.LookupEntry(form);
@@ -21919,7 +21916,7 @@ void Player::InitDataForForm(bool reapplyMods)
 }
 
 void Player::InitDisplayIds()
-{ 
+{
     PlayerInfo const* info = sObjectMgr->GetPlayerInfo(getRace(true), getClass());
     if (!info)
     {
@@ -21945,7 +21942,7 @@ void Player::InitDisplayIds()
 }
 
 inline bool Player::_StoreOrEquipNewItem(uint32 vendorslot, uint32 item, uint8 count, uint8 bag, uint8 slot, int32 price, ItemTemplate const* pProto, Creature* pVendor, VendorItem const* crItem, bool bStore)
-{ 
+{
     ItemPosCountVec vDest;
     uint16 uiDest = 0;
     InventoryResult msg = bStore ?
@@ -22008,7 +22005,7 @@ inline bool Player::_StoreOrEquipNewItem(uint32 vendorslot, uint32 item, uint8 c
 
 // Return true is the bought item has a max count to force refresh of window by caller
 bool Player::BuyItemFromVendorSlot(uint64 vendorguid, uint32 vendorslot, uint32 item, uint8 count, uint8 bag, uint8 slot)
-{ 
+{
     sScriptMgr->OnBeforeBuyItemFromVendor(this, vendorguid,vendorslot,item,count,bag,slot);
 
     // this check can be used from the hook to implement a custom vendor process
@@ -22184,7 +22181,7 @@ bool Player::BuyItemFromVendorSlot(uint64 vendorguid, uint32 vendorslot, uint32 
 }
 
 uint32 Player::GetMaxPersonalArenaRatingRequirement(uint32 minarenaslot) const
-{ 
+{
     // returns the maximal personal arena rating that can be used to purchase items requiring this condition
     // the personal rating of the arena team must match the required limit as well
     // so return max[in arenateams](min(personalrating[teamtype], teamrating[teamtype]))
@@ -22204,7 +22201,7 @@ uint32 Player::GetMaxPersonalArenaRatingRequirement(uint32 minarenaslot) const
 }
 
 void Player::UpdateHomebindTime(uint32 time)
-{ 
+{
     // GMs never get homebind timer online
     if (m_InstanceValid || IsGameMaster())
     {
@@ -22245,7 +22242,7 @@ void Player::UpdateHomebindTime(uint32 time)
 }
 
 void Player::UpdatePvPState(bool onlyFFA)
-{ 
+{
     // TODO: should we always synchronize UNIT_FIELD_BYTES_2, 1 of controller and controlled?
     // no, we shouldn't, those are checked for affecting player by client
     if (!pvpInfo.IsInNoPvPArea && !IsGameMaster()
@@ -22281,7 +22278,7 @@ void Player::UpdatePvPState(bool onlyFFA)
 }
 
 void Player::UpdatePvP(bool state, bool _override)
-{ 
+{
     if (!state || _override)
     {
         SetPvP(state);
@@ -22296,7 +22293,7 @@ void Player::UpdatePvP(bool state, bool _override)
 }
 
 void Player::AddSpellAndCategoryCooldowns(SpellInfo const* spellInfo, uint32 itemId, Spell* spell, bool infinityCooldown)
-{ 
+{
     // init cooldown values
     uint32 cat   = 0;
     int32 rec    = -1;
@@ -22411,7 +22408,7 @@ void Player::AddSpellAndCategoryCooldowns(SpellInfo const* spellInfo, uint32 ite
 }
 
 void Player::AddSpellCooldown(uint32 spellid, uint32 itemid, uint32 end_time, bool needSendToClient, bool forceSendToSpectator)
-{ 
+{
     SpellCooldown sc;
     sc.end = World::GetGameTimeMS()+end_time;
     sc.itemid = itemid;
@@ -22444,7 +22441,7 @@ void Player::ModifySpellCooldown(uint32 spellId, int32 cooldown)
 }
 
 void Player::SendCooldownEvent(SpellInfo const* spellInfo, uint32 itemId /*= 0*/, Spell* spell /*= NULL*/, bool setCooldown /*= true*/)
-{ 
+{
     // start cooldowns at server side, if any
     if (setCooldown)
         AddSpellAndCategoryCooldowns(spellInfo, itemId, spell);
@@ -22457,7 +22454,7 @@ void Player::SendCooldownEvent(SpellInfo const* spellInfo, uint32 itemId /*= 0*/
 }
 
 void Player::UpdatePotionCooldown()
-{ 
+{
     // no potion used i combat or still in combat
     if (!GetLastPotionId() || IsInCombat())
         return;
@@ -22474,7 +22471,7 @@ void Player::UpdatePotionCooldown()
 
                                                            //slot to be excluded while counting
 bool Player::EnchantmentFitsRequirements(uint32 enchantmentcondition, int8 slot)
-{ 
+{
     if (!enchantmentcondition)
         return true;
 
@@ -22563,7 +22560,7 @@ bool Player::EnchantmentFitsRequirements(uint32 enchantmentcondition, int8 slot)
 }
 
 void Player::CorrectMetaGemEnchants(uint8 exceptslot, bool apply)
-{ 
+{
                                                             //cycle all equipped items
     for (uint32 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; ++slot)
     {
@@ -22605,7 +22602,7 @@ void Player::CorrectMetaGemEnchants(uint8 exceptslot, bool apply)
 
                                                             //if false -> then toggled off if was on| if true -> toggled on if was off AND meets requirements
 void Player::ToggleMetaGemsActive(uint8 exceptslot, bool apply)
-{ 
+{
     //cycle all equipped items
     for (int slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; ++slot)
     {
@@ -22638,7 +22635,7 @@ void Player::ToggleMetaGemsActive(uint8 exceptslot, bool apply)
 }
 
 void Player::SetEntryPoint()
-{ 
+{
     m_entryPointData.joinPos.m_mapId = MAPID_INVALID;
     m_entryPointData.ClearTaxiPath();
 
@@ -22678,7 +22675,7 @@ void Player::SetEntryPoint()
 }
 
 void Player::LeaveBattleground(Battleground* bg)
-{ 
+{
     if (!bg)
         bg = GetBattleground();
 
@@ -22686,7 +22683,7 @@ void Player::LeaveBattleground(Battleground* bg)
         return;
 
     // Deserter tracker - leave BG
-    if (bg->isBattleground() && sWorld->getBoolConfig(CONFIG_BATTLEGROUND_TRACK_DESERTERS) 
+    if (bg->isBattleground() && sWorld->getBoolConfig(CONFIG_BATTLEGROUND_TRACK_DESERTERS)
         && (bg->GetStatus() == STATUS_IN_PROGRESS || bg->GetStatus() == STATUS_WAIT_JOIN))
     {
         PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_DESERTER_TRACK);
@@ -22705,7 +22702,7 @@ void Player::LeaveBattleground(Battleground* bg)
 }
 
 bool Player::CanJoinToBattleground() const
-{ 
+{
     // check Deserter debuff
     if (HasAura(26013))
         return false;
@@ -22714,7 +22711,7 @@ bool Player::CanJoinToBattleground() const
 }
 
 bool Player::CanReportAfkDueToLimit()
-{ 
+{
     // a player can complain about 15 people per 5 minutes
     if (m_bgData.bgAfkReportedCount++ >= 15)
         return false;
@@ -22724,7 +22721,7 @@ bool Player::CanReportAfkDueToLimit()
 
 ///This player has been blamed to be inactive in a battleground
 void Player::ReportedAfkBy(Player* reporter)
-{ 
+{
     Battleground* bg = GetBattleground();
     // Battleground also must be in progress!
     if (!bg || bg != reporter->GetBattleground() || GetTeamId() != reporter->GetTeamId() || bg->GetStatus() != STATUS_IN_PROGRESS)
@@ -22749,7 +22746,7 @@ void Player::ReportedAfkBy(Player* reporter)
 }
 
 WorldLocation Player::GetStartPosition() const
-{ 
+{
     PlayerInfo const* info = sObjectMgr->GetPlayerInfo(getRace(true), getClass());
     uint32 mapId = info->mapId;
     if (getClass() == CLASS_DEATH_KNIGHT && HasSpell(50977))
@@ -22758,7 +22755,7 @@ WorldLocation Player::GetStartPosition() const
 }
 
 bool Player::IsNeverVisible() const
-{ 
+{
     if (Unit::IsNeverVisible())
         return true;
 
@@ -22769,7 +22766,7 @@ bool Player::IsNeverVisible() const
 }
 
 bool Player::CanAlwaysSee(WorldObject const* obj) const
-{ 
+{
     // Always can see self
     if (m_mover == obj)
         return true;
@@ -22782,7 +22779,7 @@ bool Player::CanAlwaysSee(WorldObject const* obj) const
 }
 
 bool Player::IsAlwaysDetectableFor(WorldObject const* seer) const
-{ 
+{
     if (Unit::IsAlwaysDetectableFor(seer))
         return true;
 
@@ -22855,7 +22852,7 @@ inline void BeforeVisibilityDestroy<Creature>(Creature* t, Player* p)
 }
 
 void Player::UpdateVisibilityOf(WorldObject* target)
-{ 
+{
     if (HaveAtClient(target))
     {
         if (!CanSeeOrDetect(target, false, true))
@@ -22883,7 +22880,7 @@ void Player::UpdateVisibilityOf(WorldObject* target)
 }
 
 void Player::UpdateTriggerVisibility()
-{ 
+{
     if (m_clientGUIDs.empty())
         return;
 
@@ -22925,7 +22922,7 @@ void Player::UpdateTriggerVisibility()
 }
 
 void Player::GetInitialVisiblePackets(Unit* target)
-{ 
+{
     GetAurasForTarget(target);
     if (target->IsAlive())
     {
@@ -22936,7 +22933,7 @@ void Player::GetInitialVisiblePackets(Unit* target)
 
 template<class T>
 void Player::UpdateVisibilityOf(T* target, UpdateData& data, std::vector<Unit*>& visibleNow)
-{ 
+{
     if (HaveAtClient(target))
     {
         if (!CanSeeOrDetect(target, false, true))
@@ -22964,7 +22961,7 @@ template void Player::UpdateVisibilityOf(GameObject*    target, UpdateData& data
 template void Player::UpdateVisibilityOf(DynamicObject* target, UpdateData& data, std::vector<Unit*>& visibleNow);
 
 void Player::UpdateObjectVisibility(bool forced, bool fromUpdate)
-{ 
+{
     if (!forced)
         AddToNotify(NOTIFY_VISIBILITY_CHANGED);
     else if (!isBeingLoaded())
@@ -22980,7 +22977,7 @@ void Player::UpdateObjectVisibility(bool forced, bool fromUpdate)
 }
 
 void Player::UpdateVisibilityForPlayer(bool mapChange)
-{ 
+{
     Trinity::VisibleNotifier notifier(*this, mapChange);
     m_seer->VisitNearbyObject(GetSightRange()+VISIBILITY_INC_FOR_GOBJECTS, notifier);
     notifier.SendToSelf();
@@ -22990,12 +22987,12 @@ void Player::UpdateVisibilityForPlayer(bool mapChange)
 }
 
 void Player::InitPrimaryProfessions()
-{ 
+{
     SetFreePrimaryProfessions(sWorld->getIntConfig(CONFIG_MAX_PRIMARY_TRADE_SKILL));
 }
 
 bool Player::ModifyMoney(int32 amount, bool sendError /*= true*/)
-{ 
+{
     if (!amount)
         return true;
 
@@ -23019,21 +23016,21 @@ bool Player::ModifyMoney(int32 amount, bool sendError /*= true*/)
 }
 
 Unit* Player::GetSelectedUnit() const
-{ 
+{
     if (uint64 selectionGUID = GetUInt64Value(UNIT_FIELD_TARGET))
         return ObjectAccessor::GetUnit(*this, selectionGUID);
     return NULL;
 }
 
 Player* Player::GetSelectedPlayer() const
-{ 
+{
     if (uint64 selectionGUID = GetUInt64Value(UNIT_FIELD_TARGET))
         return ObjectAccessor::GetPlayer(*this, selectionGUID);
     return NULL;
 }
 
 void Player::SetSelection(uint64 guid)
-{ 
+{
     SetUInt64Value(UNIT_FIELD_TARGET, guid);
 
     if (NeedSendSpectatorData())
@@ -23041,7 +23038,7 @@ void Player::SetSelection(uint64 guid)
 }
 
 void Player::SendComboPoints()
-{ 
+{
     Unit* combotarget = ObjectAccessor::GetUnit(*this, m_comboTarget);
     if (combotarget)
     {
@@ -23060,7 +23057,7 @@ void Player::SendComboPoints()
 }
 
 void Player::AddComboPoints(Unit* target, int8 count)
-{ 
+{
     if (!count)
         return;
 
@@ -23093,7 +23090,7 @@ void Player::AddComboPoints(Unit* target, int8 count)
 }
 
 void Player::ClearComboPoints()
-{ 
+{
     if (!m_comboTarget)
         return;
 
@@ -23111,7 +23108,7 @@ void Player::ClearComboPoints()
 }
 
 void Player::SetGroup(Group* group, int8 subgroup)
-{ 
+{
     if (group == NULL)
         m_group.unlink();
     else
@@ -23126,7 +23123,7 @@ void Player::SetGroup(Group* group, int8 subgroup)
 }
 
 void Player::SendInitialPacketsBeforeAddToMap()
-{ 
+{
     /// Pass 'this' as argument because we're not stored in ObjectAccessor yet
     GetSocial()->SendSocialList(this);
 
@@ -23181,7 +23178,7 @@ void Player::SendInitialPacketsBeforeAddToMap()
 }
 
 void Player::SendInitialPacketsAfterAddToMap()
-{ 
+{
     UpdateVisibilityForPlayer(true);
 
     ResetTimeSync();
@@ -23249,7 +23246,7 @@ void Player::SendInitialPacketsAfterAddToMap()
 }
 
 void Player::SendUpdateToOutOfRangeGroupMembers()
-{ 
+{
     if (m_groupUpdateMask == GROUP_UPDATE_FLAG_NONE)
         return;
     if (Group* group = GetGroup())
@@ -23281,7 +23278,7 @@ void Player::SendTransferAborted(uint32 mapid, TransferAbortReason reason, uint8
 }
 
 void Player::SendInstanceResetWarning(uint32 mapid, Difficulty difficulty, uint32 time, bool onEnterMap)
-{ 
+{
     // pussywizard:
     InstancePlayerBind* bind = sInstanceSaveMgr->PlayerGetBoundInstance(GetGUIDLow(), mapid, difficulty);
     if (bind && bind->extended)
@@ -23316,7 +23313,7 @@ void Player::SendInstanceResetWarning(uint32 mapid, Difficulty difficulty, uint3
 }
 
 void Player::ApplyEquipCooldown(Item* pItem)
-{ 
+{
     if (pItem->HasFlag(ITEM_FIELD_FLAGS, ITEM_PROTO_FLAG_NO_EQUIP_COOLDOWN))
         return;
 
@@ -23364,7 +23361,7 @@ void Player::ApplyEquipCooldown(Item* pItem)
 }
 
 void Player::resetSpells()
-{ 
+{
     // not need after this call
     if (HasAtLoginFlag(AT_LOGIN_RESET_SPELLS))
         RemoveAtLoginFlag(AT_LOGIN_RESET_SPELLS, true);
@@ -23381,7 +23378,7 @@ void Player::resetSpells()
 }
 
 void Player::learnDefaultSpells()
-{ 
+{
     // xinef: learn default race/class spells
     PlayerInfo const* info = sObjectMgr->GetPlayerInfo(getRace(true), getClass());
     for (PlayerCreateInfoSpells::const_iterator itr = info->spell.begin(); itr != info->spell.end(); ++itr)
@@ -23389,7 +23386,7 @@ void Player::learnDefaultSpells()
 }
 
 void Player::learnQuestRewardedSpells(Quest const* quest)
-{ 
+{
     // xinef: quest does not learn anything
     int32 spellId = quest->GetRewSpellCast();
     if (!spellId)
@@ -23421,7 +23418,7 @@ void Player::learnQuestRewardedSpells(Quest const* quest)
 }
 
 void Player::learnQuestRewardedSpells()
-{ 
+{
     // learn spells received from quest completing
     for (RewardedQuestSet::const_iterator itr = m_RewardedQuests.begin(); itr != m_RewardedQuests.end(); ++itr)
     {
@@ -23434,7 +23431,7 @@ void Player::learnQuestRewardedSpells()
 }
 
 void Player::learnSkillRewardedSpells(uint32 skill_id, uint32 skill_value)
-{ 
+{
     uint32 raceMask  = getRaceMask();
     uint32 classMask = getClassMask();
     for (uint32 j=0; j<sSkillLineAbilityStore.GetNumRows(); ++j)
@@ -23509,7 +23506,7 @@ void Player::GetAurasForTarget(Unit* target) // pussywizard: contact before chan
 }
 
 void Player::SetDailyQuestStatus(uint32 quest_id)
-{ 
+{
     if (Quest const* qQuest = sObjectMgr->GetQuestTemplate(quest_id))
     {
         if (!qQuest->IsDFQuest())
@@ -23534,13 +23531,13 @@ void Player::SetDailyQuestStatus(uint32 quest_id)
 }
 
 void Player::SetWeeklyQuestStatus(uint32 quest_id)
-{ 
+{
     m_weeklyquests.insert(quest_id);
     m_WeeklyQuestChanged = true;
 }
 
 void Player::SetSeasonalQuestStatus(uint32 quest_id)
-{ 
+{
     Quest const* quest = sObjectMgr->GetQuestTemplate(quest_id);
     if (!quest)
         return;
@@ -23550,13 +23547,13 @@ void Player::SetSeasonalQuestStatus(uint32 quest_id)
 }
 
 void Player::SetMonthlyQuestStatus(uint32 quest_id)
-{ 
+{
     m_monthlyquests.insert(quest_id);
     m_MonthlyQuestChanged = true;
 }
 
 void Player::ResetDailyQuestStatus()
-{ 
+{
     for (uint32 quest_daily_idx = 0; quest_daily_idx < PLAYER_MAX_DAILY_QUESTS; ++quest_daily_idx)
         SetUInt32Value(PLAYER_FIELD_DAILY_QUESTS_1+quest_daily_idx, 0);
 
@@ -23568,7 +23565,7 @@ void Player::ResetDailyQuestStatus()
 }
 
 void Player::ResetWeeklyQuestStatus()
-{ 
+{
     if (m_weeklyquests.empty())
         return;
 
@@ -23578,7 +23575,7 @@ void Player::ResetWeeklyQuestStatus()
 }
 
 void Player::ResetSeasonalQuestStatus(uint16 event_id)
-{ 
+{
     if (m_seasonalquests.empty() || m_seasonalquests[event_id].empty())
         return;
 
@@ -23588,7 +23585,7 @@ void Player::ResetSeasonalQuestStatus(uint16 event_id)
 }
 
 void Player::ResetMonthlyQuestStatus()
-{ 
+{
     if (m_monthlyquests.empty())
         return;
 
@@ -23607,7 +23604,7 @@ Battleground* Player::GetBattleground(bool create) const
 }
 
 bool Player::InArena() const
-{ 
+{
     Battleground* bg = GetBattleground();
     if (!bg || !bg->isArena())
         return false;
@@ -23638,7 +23635,7 @@ void Player::SetBattlegroundId(uint32 id, BattlegroundTypeId bgTypeId, uint32 qu
 }
 
 bool Player::GetBGAccessByLevel(BattlegroundTypeId bgTypeId) const
-{ 
+{
     // get a template bg instead of running one
     Battleground* bgt = sBattlegroundMgr->GetBattlegroundTemplate(bgTypeId);
     if (!bgt)
@@ -23656,7 +23653,7 @@ bool Player::GetBGAccessByLevel(BattlegroundTypeId bgTypeId) const
 }
 
 float Player::GetReputationPriceDiscount(Creature const* creature) const
-{ 
+{
     FactionTemplateEntry const* vendor_faction = creature->GetFactionTemplateEntry();
     if (!vendor_faction || !vendor_faction->faction)
         return 1.0f;
@@ -23669,7 +23666,7 @@ float Player::GetReputationPriceDiscount(Creature const* creature) const
 }
 
 bool Player::IsSpellFitByClassAndRace(uint32 spell_id) const
-{ 
+{
     uint32 racemask  = getRaceMask();
     uint32 classmask = getClassMask();
 
@@ -23694,7 +23691,7 @@ bool Player::IsSpellFitByClassAndRace(uint32 spell_id) const
 }
 
 bool Player::HasQuestForGO(int32 GOId) const
-{ 
+{
     for (uint8 i = 0; i < MAX_QUEST_LOG_SIZE; ++i)
     {
         uint32 questid = GetQuestSlotQuestId(i);
@@ -23730,7 +23727,7 @@ bool Player::HasQuestForGO(int32 GOId) const
 }
 
 void Player::UpdateForQuestWorldObjects()
-{ 
+{
     if (m_clientGUIDs.empty())
         return;
 
@@ -23801,7 +23798,7 @@ void Player::SummonIfPossible(bool agree, uint32 summoner_guid)
 }
 
 void Player::RemoveItemDurations(Item* item)
-{ 
+{
     for (ItemDurationList::iterator itr = m_itemDuration.begin(); itr != m_itemDuration.end(); ++itr)
     {
         if (*itr == item)
@@ -23813,7 +23810,7 @@ void Player::RemoveItemDurations(Item* item)
 }
 
 void Player::AddItemDurations(Item* item)
-{ 
+{
     if (item->GetUInt32Value(ITEM_FIELD_DURATION))
     {
         m_itemDuration.push_back(item);
@@ -23831,7 +23828,7 @@ void Player::UpdateTitansGrip()
 }
 
 void Player::AutoUnequipOffhandIfNeed(bool force /*= false*/)
-{ 
+{
     Item* offItem = GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
     if (!offItem)
     {
@@ -23873,12 +23870,12 @@ void Player::AutoUnequipOffhandIfNeed(bool force /*= false*/)
 }
 
 OutdoorPvP* Player::GetOutdoorPvP() const
-{ 
+{
     return sOutdoorPvPMgr->GetOutdoorPvPToZoneId(GetZoneId());
 }
 
 bool Player::HasItemFitToSpellRequirements(SpellInfo const* spellInfo, Item const* ignoreItem) const
-{ 
+{
     if (spellInfo->EquippedItemClass < 0)
         return true;
 
@@ -23923,7 +23920,7 @@ bool Player::HasItemFitToSpellRequirements(SpellInfo const* spellInfo, Item cons
 }
 
 bool Player::CanNoReagentCast(SpellInfo const* spellInfo) const
-{ 
+{
     // don't take reagents for spells with SPELL_ATTR5_NO_REAGENT_WHILE_PREP
     if (spellInfo->HasAttribute(SPELL_ATTR5_NO_REAGENT_WHILE_PREP) && HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PREPARATION))
         return true;
@@ -23940,7 +23937,7 @@ bool Player::CanNoReagentCast(SpellInfo const* spellInfo) const
 }
 
 void Player::RemoveItemDependentAurasAndCasts(Item* pItem)
-{ 
+{
     for (AuraMap::iterator itr = m_ownedAuras.begin(); itr != m_ownedAuras.end();)
     {
         Aura* aura = itr->second;
@@ -23972,7 +23969,7 @@ void Player::RemoveItemDependentAurasAndCasts(Item* pItem)
 }
 
 uint32 Player::GetResurrectionSpellId()
-{ 
+{
     // search priceless resurrection possibilities
     uint32 prio = 0;
     uint32 spell_id = 0;
@@ -24015,7 +24012,7 @@ uint32 Player::GetResurrectionSpellId()
 
 // Used in triggers for check "Only to targets that grant experience or honor" req
 bool Player::isHonorOrXPTarget(Unit* victim) const
-{ 
+{
     uint8 v_level = victim->getLevel();
     uint8 k_grey  = Trinity::XP::GetGrayLevel(getLevel());
 
@@ -24034,7 +24031,7 @@ bool Player::isHonorOrXPTarget(Unit* victim) const
 }
 
 bool Player::GetsRecruitAFriendBonus(bool forXP)
-{ 
+{
     bool recruitAFriend = false;
     if (getLevel() <= sWorld->getIntConfig(CONFIG_MAX_RECRUIT_A_FRIEND_BONUS_PLAYER_LEVEL) || !forXP)
     {
@@ -24075,12 +24072,12 @@ bool Player::GetsRecruitAFriendBonus(bool forXP)
 }
 
 void Player::RewardPlayerAndGroupAtKill(Unit* victim, bool isBattleGround)
-{ 
+{
     KillRewarder(this, victim, isBattleGround).Reward();
 }
 
 void Player::RewardPlayerAndGroupAtEvent(uint32 creature_id, WorldObject* pRewardSource)
-{ 
+{
     if (!pRewardSource)
         return;
     uint64 creature_guid = (pRewardSource->GetTypeId() == TYPEID_UNIT) ? pRewardSource->GetGUID() : uint64(0);
@@ -24121,7 +24118,7 @@ bool Player::IsAtGroupRewardDistance(WorldObject const* pRewardSource) const
 }
 
 bool Player::IsAtRecruitAFriendDistance(WorldObject const* pOther) const
-{ 
+{
     if (!pOther)
         return false;
     const WorldObject* player = GetCorpse();
@@ -24135,7 +24132,7 @@ bool Player::IsAtRecruitAFriendDistance(WorldObject const* pOther) const
 }
 
 uint32 Player::GetBaseWeaponSkillValue (WeaponAttackType attType) const
-{ 
+{
     Item* item = GetWeaponForAttack(attType, true);
 
     // unarmed only with base attack
@@ -24148,7 +24145,7 @@ uint32 Player::GetBaseWeaponSkillValue (WeaponAttackType attType) const
 }
 
 void Player::ResurectUsingRequestData()
-{ 
+{
     /// Teleport before resurrecting by player, otherwise the player might get attacked from creatures near his corpse
     TeleportTo(m_resurrectMap, m_resurrectX, m_resurrectY, m_resurrectZ, GetOrientation());
 
@@ -24178,7 +24175,7 @@ void Player::ResurectUsingRequestData()
 }
 
 void Player::SetClientControl(Unit* target, bool allowMove, bool packetOnly /*= false*/)
-{ 
+{
     WorldPacket data(SMSG_CLIENT_CONTROL_UPDATE, target->GetPackGUID().size()+1);
     data.append(target->GetPackGUID());
     data << uint8((allowMove && !target->HasUnitState(UNIT_STATE_FLEEING|UNIT_STATE_CONFUSED)) ? 1 : 0);
@@ -24219,7 +24216,7 @@ void Player::SetClientControl(Unit* target, bool allowMove, bool packetOnly /*= 
 }
 
 void Player::SetMover(Unit* target)
-{ 
+{
     if (this != target && target->m_movedByPlayer && target->m_movedByPlayer != target && target->m_movedByPlayer != this)
     {
         sLog->outMisc("Player::SetMover (A1) - %u, %u, %u, %u, %u, %u, %u, %u", GetGUIDLow(), GetMapId(), GetInstanceId(), FindMap()->GetId(), IsInWorld() ? 1 : 0, IsDuringRemoveFromWorld() ? 1 : 0, IsBeingTeleported() ? 1 : 0, isBeingLoaded() ? 1 : 0);
@@ -24237,7 +24234,7 @@ void Player::SetMover(Unit* target)
 }
 
 void Player::UpdateZoneDependentAuras(uint32 newZone)
-{ 
+{
     // Some spells applied at enter into zone (with subzones), aura removed in UpdateAreaDependentAuras that called always at zone->area update
     SpellAreaForAreaMapBounds saBounds = sSpellMgr->GetSpellAreaForAreaMapBounds(newZone);
     for (SpellAreaForAreaMap::const_iterator itr = saBounds.first; itr != saBounds.second; ++itr)
@@ -24247,7 +24244,7 @@ void Player::UpdateZoneDependentAuras(uint32 newZone)
 }
 
 void Player::UpdateAreaDependentAuras(uint32 newArea)
-{ 
+{
     // remove auras from spells with area limitations
     for (AuraMap::iterator iter = m_ownedAuras.begin(); iter != m_ownedAuras.end();)
     {
@@ -24298,7 +24295,7 @@ void Player::UpdateAreaDependentAuras(uint32 newArea)
 }
 
 uint32 Player::GetCorpseReclaimDelay(bool pvp) const
-{ 
+{
     if (pvp)
     {
         if (!sWorld->getBoolConfig(CONFIG_DEATH_CORPSE_RECLAIM_DELAY_PVP))
@@ -24315,7 +24312,7 @@ uint32 Player::GetCorpseReclaimDelay(bool pvp) const
 }
 
 void Player::UpdateCorpseReclaimDelay()
-{ 
+{
     bool pvp = m_ExtraFlags & PLAYER_EXTRA_PVP_DEATH;
 
     if ((pvp && !sWorld->getBoolConfig(CONFIG_DEATH_CORPSE_RECLAIM_DELAY_PVP)) ||
@@ -24339,7 +24336,7 @@ void Player::UpdateCorpseReclaimDelay()
 }
 
 int32 Player::CalculateCorpseReclaimDelay(bool load)
-{ 
+{
     Corpse* corpse = GetCorpse();
 
     if (load && !corpse)
@@ -24380,14 +24377,14 @@ int32 Player::CalculateCorpseReclaimDelay(bool load)
 }
 
 void Player::SendCorpseReclaimDelay(uint32 delay)
-{ 
+{
     WorldPacket data(SMSG_CORPSE_RECLAIM_DELAY, 4);
     data << uint32(delay);
     GetSession()->SendPacket(&data);
 }
 
 Player* Player::GetNextRandomRaidMember(float radius)
-{ 
+{
     Group* group = GetGroup();
     if (!group)
         return NULL;
@@ -24413,7 +24410,7 @@ Player* Player::GetNextRandomRaidMember(float radius)
 }
 
 PartyResult Player::CanUninviteFromGroup() const
-{ 
+{
     Group const* grp = GetGroup();
     if (!grp)
         return ERR_NOT_IN_GROUP;
@@ -24460,12 +24457,12 @@ PartyResult Player::CanUninviteFromGroup() const
 }
 
 bool Player::isUsingLfg()
-{ 
+{
     return sLFGMgr->GetState(GetGUID()) != lfg::LFG_STATE_NONE;
 }
 
 bool Player::inRandomLfgDungeon()
-{ 
+{
     if (sLFGMgr->selectedRandomLfgDungeon(GetGUID()))
     {
         Map const* map = GetMap();
@@ -24476,7 +24473,7 @@ bool Player::inRandomLfgDungeon()
 }
 
 void Player::SetBattlegroundOrBattlefieldRaid(Group *group, int8 subgroup)
-{ 
+{
     //we must move references from m_group to m_originalGroup
     if (GetGroup() && (GetGroup()->isBGGroup() || GetGroup()->isBFGroup()))
     {
@@ -24492,7 +24489,7 @@ void Player::SetBattlegroundOrBattlefieldRaid(Group *group, int8 subgroup)
 }
 
 void Player::RemoveFromBattlegroundOrBattlefieldRaid()
-{ 
+{
     //remove existing reference
     m_group.unlink();
     if (Group* group = GetOriginalGroup())
@@ -24504,7 +24501,7 @@ void Player::RemoveFromBattlegroundOrBattlefieldRaid()
 }
 
 void Player::SetOriginalGroup(Group* group, int8 subgroup)
-{ 
+{
     if (group == NULL)
         m_originalGroup.unlink();
     else
@@ -24517,7 +24514,7 @@ void Player::SetOriginalGroup(Group* group, int8 subgroup)
 }
 
 void Player::UpdateUnderwaterState(Map* m, float x, float y, float z)
-{ 
+{
     // pussywizard: optimization
     if (GetExactDistSq(&m_last_underwaterstate_position) < 3.0f*3.0f)
         return;
@@ -24598,7 +24595,7 @@ void Player::UpdateUnderwaterState(Map* m, float x, float y, float z)
 }
 
 void Player::SetCanParry(bool value)
-{ 
+{
     if (m_canParry == value)
         return;
 
@@ -24607,7 +24604,7 @@ void Player::SetCanParry(bool value)
 }
 
 void Player::SetCanBlock(bool value)
-{ 
+{
     if (m_canBlock == value)
         return;
 
@@ -24629,7 +24626,7 @@ bool ItemPosCount::isContainedIn(ItemPosCountVec const& vec) const
 }
 
 void Player::StopCastingBindSight()
-{ 
+{
     if (WorldObject* target = GetViewpoint())
     {
         if (target->isType(TYPEMASK_UNIT))
@@ -24642,7 +24639,7 @@ void Player::StopCastingBindSight()
 }
 
 void Player::SetViewpoint(WorldObject* target, bool apply)
-{ 
+{
     if (apply)
     {
         // target must be in world
@@ -24692,14 +24689,14 @@ void Player::SetViewpoint(WorldObject* target, bool apply)
 }
 
 WorldObject* Player::GetViewpoint() const
-{ 
+{
     if (uint64 guid = GetUInt64Value(PLAYER_FARSIGHT))
         return (WorldObject*)ObjectAccessor::GetObjectByTypeMask(*this, guid, TYPEMASK_SEER);
     return NULL;
 }
 
 bool Player::CanUseBattlegroundObject(GameObject* gameobject) const
-{ 
+{
     // It is possible to call this method will a null pointer, only skipping faction check.
     if (gameobject)
     {
@@ -24718,7 +24715,7 @@ bool Player::CanUseBattlegroundObject(GameObject* gameobject) const
 }
 
 bool Player::CanCaptureTowerPoint() const
-{ 
+{
     return (!HasStealthAura() &&                            // not stealthed
              !HasInvisibilityAura() &&                      // not invisible
              IsAlive()                                      // live player
@@ -24726,7 +24723,7 @@ bool Player::CanCaptureTowerPoint() const
 }
 
 uint32 Player::GetBarberShopCost(uint8 newhairstyle, uint8 newhaircolor, uint8 newfacialhair, BarberShopStyleEntry const* newSkin)
-{ 
+{
     uint8 level = getLevel();
 
     if (level > GT_MAX_LEVEL)
@@ -24763,7 +24760,7 @@ uint32 Player::GetBarberShopCost(uint8 newhairstyle, uint8 newhaircolor, uint8 n
 }
 
 void Player::InitGlyphsForLevel()
-{ 
+{
     for (uint32 i = 0; i < sGlyphSlotStore.GetNumRows(); ++i)
         if (GlyphSlotEntry const* gs = sGlyphSlotStore.LookupEntry(i))
             if (gs->Order)
@@ -24788,7 +24785,7 @@ void Player::InitGlyphsForLevel()
 }
 
 bool Player::isTotalImmune() const
-{ 
+{
     AuraEffectList const& immune = GetAuraEffectsByType(SPELL_AURA_SCHOOL_IMMUNITY);
 
     uint32 immuneMask = 0;
@@ -24802,7 +24799,7 @@ bool Player::isTotalImmune() const
 }
 
 bool Player::HasTitle(uint32 bitIndex) const
-{ 
+{
     if (bitIndex > MAX_TITLE_INDEX)
         return false;
 
@@ -24812,7 +24809,7 @@ bool Player::HasTitle(uint32 bitIndex) const
 }
 
 void Player::SetTitle(CharTitlesEntry const* title, bool lost)
-{ 
+{
     uint32 fieldIndexOffset = title->bit_index / 32;
     uint32 flag = 1 << (title->bit_index % 32);
 
@@ -24838,7 +24835,7 @@ void Player::SetTitle(CharTitlesEntry const* title, bool lost)
 }
 
 void Player::UpdateCharmedAI()
-{ 
+{
     // Xinef: maybe passed as argument?
     Unit* charmer = GetCharmer();
     CharmInfo* charmInfo = GetCharmInfo();
@@ -24897,7 +24894,7 @@ void Player::UpdateCharmedAI()
         else if (target && GetMotionMaster()->GetCurrentMovementGeneratorType() != CHASE_MOTION_TYPE)
             GetMotionMaster()->MoveChase(target, Mages ? 15 : 4);
     }
-    
+
     if (!target || !IsValidAttackTarget(target))
     {
         target = SelectNearbyTarget(NULL, 30);
@@ -24959,7 +24956,7 @@ void Player::UpdateCharmedAI()
                     if (m_charmAISpells[SPELL_HIGH_DAMAGE1+rnd] && !HasSpellCooldown(m_charmAISpells[SPELL_HIGH_DAMAGE1+rnd]))
                         CastSpell(target, m_charmAISpells[SPELL_HIGH_DAMAGE1+rnd], false);
                     break;
-                case 1:         
+                case 1:
                     if (m_charmAISpells[SPELL_INSTANT_DAMAGE+rnd] && !HasSpellCooldown(m_charmAISpells[SPELL_INSTANT_DAMAGE+rnd]))
                         CastSpell(target, m_charmAISpells[SPELL_INSTANT_DAMAGE+rnd], false);
                     break;
@@ -25004,7 +25001,7 @@ void Player::UpdateCharmedAI()
 }
 
 uint32 Player::GetRuneBaseCooldown(uint8 index, bool skipGrace)
-{ 
+{
     uint8 rune = GetBaseRune(index);
     uint32 cooldown = RUNE_BASE_COOLDOWN;
     if (!skipGrace)
@@ -25021,7 +25018,7 @@ uint32 Player::GetRuneBaseCooldown(uint8 index, bool skipGrace)
 }
 
 void Player::RemoveRunesByAuraEffect(AuraEffect const* aura)
-{ 
+{
     for (uint8 i = 0; i < MAX_RUNES; ++i)
     {
         if (m_runes->runes[i].ConvertAura == aura)
@@ -25033,7 +25030,7 @@ void Player::RemoveRunesByAuraEffect(AuraEffect const* aura)
 }
 
 void Player::RestoreBaseRune(uint8 index)
-{ 
+{
     AuraEffect const* aura = m_runes->runes[index].ConvertAura;
     // If rune was converted by a non-pasive aura that still active we should keep it converted
     if (aura && !aura->GetSpellInfo()->HasAttribute(SPELL_ATTR0_PASSIVE))
@@ -25052,7 +25049,7 @@ void Player::RestoreBaseRune(uint8 index)
 }
 
 void Player::ConvertRune(uint8 index, RuneType newType)
-{ 
+{
     SetCurrentRune(index, newType);
 
     WorldPacket data(SMSG_CONVERT_RUNE, 2);
@@ -25062,7 +25059,7 @@ void Player::ConvertRune(uint8 index, RuneType newType)
 }
 
 void Player::ResyncRunes(uint8 count)
-{ 
+{
     WorldPacket data(SMSG_RESYNC_RUNES, 4 + count * 2);
     data << uint32(count);
     for (uint32 i = 0; i < count; ++i)
@@ -25074,7 +25071,7 @@ void Player::ResyncRunes(uint8 count)
 }
 
 void Player::AddRunePower(uint8 index)
-{ 
+{
     WorldPacket data(SMSG_ADD_RUNE_POWER, 4);
     data << uint32(1 << index);                             // mask (0x00-0x3F probably)
     GetSession()->SendPacket(&data);
@@ -25091,7 +25088,7 @@ static RuneType runeSlotTypes[MAX_RUNES] =
 };
 
 void Player::InitRunes()
-{ 
+{
     if (getClass() != CLASS_DEATH_KNIGHT)
         return;
 
@@ -25115,7 +25112,7 @@ void Player::InitRunes()
 }
 
 bool Player::IsBaseRuneSlotsOnCooldown(RuneType runeType) const
-{ 
+{
     for (uint8 i = 0; i < MAX_RUNES; ++i)
         if (GetBaseRune(i) == runeType && GetRuneCooldown(i) == 0)
             return false;
@@ -25124,7 +25121,7 @@ bool Player::IsBaseRuneSlotsOnCooldown(RuneType runeType) const
 }
 
 void Player::AutoStoreLoot(uint8 bag, uint8 slot, uint32 loot_id, LootStore const& store, bool broadcast)
-{ 
+{
     Loot loot;
     loot.FillLoot (loot_id, store, this, true);
 
@@ -25151,7 +25148,7 @@ void Player::AutoStoreLoot(uint8 bag, uint8 slot, uint32 loot_id, LootStore cons
 }
 
 void Player::StoreLootItem(uint8 lootSlot, Loot* loot)
-{ 
+{
     QuestItem* qitem = NULL;
     QuestItem* ffaitem = NULL;
     QuestItem* conditem = NULL;
@@ -25249,14 +25246,14 @@ void Player::StoreLootItem(uint8 lootSlot, Loot* loot)
 }
 
 void Player::UpdateLootAchievements(LootItem *item, Loot* loot)
-{ 
+{
     UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_LOOT_ITEM, item->itemid, item->count);
     UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_LOOT_TYPE, loot->loot_type, item->count);
     UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_LOOT_EPIC_ITEM, item->itemid, item->count);
 }
 
 uint32 Player::CalculateTalentsPoints() const
-{ 
+{
     uint32 base_talent = getLevel() < 10 ? 0 : getLevel()-9;
 
     if (getClass() != CLASS_DEATH_KNIGHT || GetMapId() != 609)
@@ -25279,7 +25276,7 @@ bool Player::canFlyInZone(uint32 mapid, uint32 zone) const
 }
 
 void Player::learnSpellHighRank(uint32 spellid)
-{ 
+{
     learnSpell(spellid);
 
     if (uint32 next = sSpellMgr->GetNextSpellInChain(spellid))
@@ -25287,7 +25284,7 @@ void Player::learnSpellHighRank(uint32 spellid)
 }
 
 void Player::_LoadSkills(PreparedQueryResult result)
-{ 
+{
     //                                                           0      1      2
     // SetPQuery(PLAYER_LOGIN_QUERY_LOADSKILLS,          "SELECT skill, value, max FROM character_skills WHERE guid = '%u'", GUID_LOPART(m_guid));
 
@@ -25411,7 +25408,7 @@ uint32 Player::GetPhaseMaskForSpawn() const
 }
 
 InventoryResult Player::CanEquipUniqueItem(Item* pItem, uint8 eslot, uint32 limit_count) const
-{ 
+{
     ItemTemplate const* pProto = pItem->GetTemplate();
 
     // proto based limitations
@@ -25444,7 +25441,7 @@ InventoryResult Player::CanEquipUniqueItem(Item* pItem, uint8 eslot, uint32 limi
 }
 
 InventoryResult Player::CanEquipUniqueItem(ItemTemplate const* itemProto, uint8 except_slot, uint32 limit_count) const
-{ 
+{
     // check unique-equipped on item
     if (itemProto->Flags & ITEM_PROTO_FLAG_UNIQUE_EQUIPPED)
     {
@@ -25474,7 +25471,7 @@ InventoryResult Player::CanEquipUniqueItem(ItemTemplate const* itemProto, uint8 
 }
 
 void Player::HandleFall(MovementInfo const& movementInfo)
-{ 
+{
     // calculate total z distance of the fall
     float z_diff = m_lastFallZ - movementInfo.pos.GetPositionZ();
     //sLog->outDebug("zDiff = %f", z_diff);
@@ -25524,52 +25521,52 @@ void Player::HandleFall(MovementInfo const& movementInfo)
 }
 
 void Player::CheckAllAchievementCriteria()
-{ 
+{
     m_achievementMgr->CheckAllAchievementCriteria();
 }
 
 void Player::ResetAchievements()
-{ 
+{
     m_achievementMgr->Reset();
 }
 
 void Player::SendRespondInspectAchievements(Player* player) const
-{ 
+{
     m_achievementMgr->SendRespondInspectAchievements(player);
 }
 
 bool Player::HasAchieved(uint32 achievementId) const
-{ 
+{
     return m_achievementMgr->HasAchieved(achievementId);
 }
 
 void Player::StartTimedAchievement(AchievementCriteriaTimedTypes type, uint32 entry, uint32 timeLost/* = 0*/)
-{ 
+{
     m_achievementMgr->StartTimedAchievement(type, entry, timeLost);
 }
 
 void Player::RemoveTimedAchievement(AchievementCriteriaTimedTypes type, uint32 entry)
-{ 
+{
     m_achievementMgr->RemoveTimedAchievement(type, entry);
 }
 
 void Player::ResetAchievementCriteria(AchievementCriteriaCondition condition, uint32 value, bool evenIfCriteriaComplete /* = false*/)
-{ 
+{
     m_achievementMgr->ResetAchievementCriteria(condition, value, evenIfCriteriaComplete);
 }
 
 void Player::UpdateAchievementCriteria(AchievementCriteriaTypes type, uint32 miscValue1 /*= 0*/, uint32 miscValue2 /*= 0*/, Unit* unit /*= NULL*/)
-{ 
+{
     m_achievementMgr->UpdateAchievementCriteria(type, miscValue1, miscValue2, unit);
 }
 
 void Player::CompletedAchievement(AchievementEntry const* entry)
-{ 
+{
     m_achievementMgr->CompletedAchievement(entry);
 }
 
 void Player::LearnTalent(uint32 talentId, uint32 talentRank)
-{ 
+{
     uint32 CurTalentPoints = GetFreeTalentPoints();
 
     // xinef: check basic data
@@ -25688,7 +25685,7 @@ void Player::LearnTalent(uint32 talentId, uint32 talentRank)
 }
 
 void Player::LearnPetTalent(uint64 petGuid, uint32 talentId, uint32 talentRank)
-{ 
+{
     Pet* pet = GetPet();
 
     if (!pet)
@@ -25825,19 +25822,19 @@ void Player::LearnPetTalent(uint64 petGuid, uint32 talentId, uint32 talentRank)
 }
 
 void Player::AddKnownCurrency(uint32 itemId)
-{ 
+{
     if (CurrencyTypesEntry const* ctEntry = sCurrencyTypesStore.LookupEntry(itemId))
         SetFlag64(PLAYER_FIELD_KNOWN_CURRENCIES, (1LL << (ctEntry->BitIndex-1)));
 }
 
 void Player::UpdateFallInformationIfNeed(MovementInfo const& minfo, uint16 opcode)
-{ 
+{
     if (m_lastFallTime >= minfo.fallTime || m_lastFallZ <= minfo.pos.GetPositionZ() || opcode == MSG_MOVE_FALL_LAND)
         SetFallInformation(minfo.fallTime, minfo.pos.GetPositionZ());
 }
 
 void Player::UnsummonPetTemporaryIfAny()
-{ 
+{
     Pet* pet = GetPet();
     if (!pet || !pet->IsInWorld())
         return;
@@ -25852,7 +25849,7 @@ void Player::UnsummonPetTemporaryIfAny()
 }
 
 void Player::ResummonPetTemporaryUnSummonedIfAny()
-{ 
+{
     if (!m_temporaryUnsummonedPetNumber || IsSpectator())
         return;
 
@@ -25871,7 +25868,7 @@ void Player::ResummonPetTemporaryUnSummonedIfAny()
 }
 
 bool Player::CanResummonPet(uint32 spellid)
-{ 
+{
     if (getClass() == CLASS_DEATH_KNIGHT)
     {
         if (CanSeeDKPet())
@@ -25889,7 +25886,7 @@ bool Player::CanResummonPet(uint32 spellid)
 }
 
 bool Player::CanSeeSpellClickOn(Creature const* c) const
-{ 
+{
     if (!c->HasFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_SPELLCLICK))
         return false;
 
@@ -25912,7 +25909,7 @@ bool Player::CanSeeSpellClickOn(Creature const* c) const
 }
 
 void Player::BuildPlayerTalentsInfoData(WorldPacket* data)
-{ 
+{
     *data << uint32(GetFreeTalentPoints());                 // unspentTalentPoints
     *data << uint8(m_specsCount);                           // talent group count (0, 1 or 2)
     *data << uint8(m_activeSpec);                           // talent group index (0 or 1)
@@ -25946,7 +25943,7 @@ void Player::BuildPlayerTalentsInfoData(WorldPacket* data)
 }
 
 void Player::BuildPetTalentsInfoData(WorldPacket* data)
-{ 
+{
     uint32 unspentTalentPoints = 0;
     size_t pointsPos = data->wpos();
     *data << uint32(unspentTalentPoints);                   // [PH], unspentTalentPoints
@@ -26018,7 +26015,7 @@ void Player::BuildPetTalentsInfoData(WorldPacket* data)
 }
 
 void Player::SendTalentsInfoData(bool pet)
-{ 
+{
     WorldPacket data(SMSG_TALENTS_INFO, 50);
     data << uint8(pet ? 1 : 0);
     if (pet)
@@ -26029,7 +26026,7 @@ void Player::SendTalentsInfoData(bool pet)
 }
 
 void Player::BuildEnchantmentsInfoData(WorldPacket* data)
-{ 
+{
     uint32 slotUsedMask = 0;
     size_t slotUsedMaskPos = data->wpos();
     *data << uint32(slotUsedMask);                          // slotUsedMask < 0x80000
@@ -26072,7 +26069,7 @@ void Player::BuildEnchantmentsInfoData(WorldPacket* data)
 }
 
 void Player::SendEquipmentSetList()
-{ 
+{
     uint32 count = 0;
     WorldPacket data(SMSG_EQUIPMENT_SET_LIST, 4);
     size_t count_pos = data.wpos();
@@ -26102,7 +26099,7 @@ void Player::SendEquipmentSetList()
 }
 
 void Player::SetEquipmentSet(uint32 index, EquipmentSet eqset)
-{ 
+{
     if (eqset.Guid != 0)
     {
         bool found = false;
@@ -26143,7 +26140,7 @@ void Player::SetEquipmentSet(uint32 index, EquipmentSet eqset)
 }
 
 void Player::_SaveEquipmentSets(SQLTransaction& trans)
-{ 
+{
     for (EquipmentSets::iterator itr = m_EquipmentSets.begin(); itr != m_EquipmentSets.end();)
     {
         uint32 index = itr->first;
@@ -26194,7 +26191,7 @@ void Player::_SaveEquipmentSets(SQLTransaction& trans)
 }
 
 void Player::_SaveEntryPoint(SQLTransaction& trans)
-{ 
+{
     // xinef: dont save joinpos with invalid mapid
     MapEntry const* mEntry = sMapStore.LookupEntry(m_entryPointData.joinPos.GetMapId());
     if (!mEntry)
@@ -26224,7 +26221,7 @@ void Player::_SaveEntryPoint(SQLTransaction& trans)
 }
 
 void Player::DeleteEquipmentSet(uint64 setGuid)
-{ 
+{
     for (EquipmentSets::iterator itr = m_EquipmentSets.begin(); itr != m_EquipmentSets.end(); ++itr)
     {
         if (itr->second.Guid == setGuid)
@@ -26239,7 +26236,7 @@ void Player::DeleteEquipmentSet(uint64 setGuid)
 }
 
 void Player::RemoveAtLoginFlag(AtLoginFlags flags, bool persist /*= false*/)
-{ 
+{
     m_atLoginFlags &= ~flags;
 
     if (persist)
@@ -26254,7 +26251,7 @@ void Player::RemoveAtLoginFlag(AtLoginFlags flags, bool persist /*= false*/)
 }
 
 void Player::SendClearCooldown(uint32 spell_id, Unit* target)
-{ 
+{
     WorldPacket data(SMSG_CLEAR_COOLDOWN, 4+8);
     data << uint32(spell_id);
     data << uint64(target->GetGUID());
@@ -26265,7 +26262,7 @@ void Player::SendClearCooldown(uint32 spell_id, Unit* target)
 }
 
 void Player::ResetMap()
-{ 
+{
     // this may be called during Map::Update
     // after decrement+unlink, ++m_mapRefIter will continue correctly
     // when the first element of the list is being removed
@@ -26277,13 +26274,13 @@ void Player::ResetMap()
 }
 
 void Player::SetMap(Map* map)
-{ 
+{
     Unit::SetMap(map);
     m_mapRef.link(map, this);
 }
 
 void Player::_SaveCharacter(bool create, SQLTransaction& trans)
-{ 
+{
     PreparedStatement* stmt = NULL;
     uint8 index = 0;
 
@@ -26541,7 +26538,7 @@ void Player::_SaveCharacter(bool create, SQLTransaction& trans)
 }
 
 void Player::_LoadGlyphs(PreparedQueryResult result)
-{ 
+{
     // SELECT talentGroup, glyph1, glyph2, glyph3, glyph4, glyph5, glyph6 from character_glyphs WHERE guid = '%u'
     if (!result)
         return;
@@ -26565,7 +26562,7 @@ void Player::_LoadGlyphs(PreparedQueryResult result)
 }
 
 void Player::_SaveGlyphs(SQLTransaction& trans)
-{ 
+{
     if (!NeedToSaveGlyphs())
         return;
 
@@ -26589,7 +26586,7 @@ void Player::_SaveGlyphs(SQLTransaction& trans)
 }
 
 void Player::_LoadTalents(PreparedQueryResult result)
-{ 
+{
     // SetPQuery(PLAYER_LOGIN_QUERY_LOADTALENTS, "SELECT spell, specMask FROM character_talent WHERE guid = '%u'", GUID_LOPART(m_guid));
     if (result)
     {
@@ -26611,11 +26608,11 @@ void Player::_LoadTalents(PreparedQueryResult result)
 }
 
 void Player::_SaveTalents(SQLTransaction& trans)
-{ 
+{
     PreparedStatement* stmt = NULL;
 
     for (PlayerTalentMap::iterator itr = m_talents.begin(); itr != m_talents.end();)
-    {       
+    {
         // xinef: skip temporary spells
         if (itr->second->State == PLAYERSPELL_TEMPORARY)
         {
@@ -26656,7 +26653,7 @@ void Player::_SaveTalents(SQLTransaction& trans)
 }
 
 void Player::UpdateSpecCount(uint8 count)
-{ 
+{
     uint32 curCount = GetSpecsCount();
     if (curCount == count)
         return;
@@ -26865,7 +26862,7 @@ void Player::GetTalentTreePoints(uint8 (&specPoints)[3]) const
 }
 
 uint8 Player::GetMostPointsTalentTree() const
-{ 
+{
     uint32 specPoints[3] = {0, 0, 0};
     const PlayerTalentMap& talentMap = GetTalentMap();
     for (PlayerTalentMap::const_iterator itr = talentMap.begin(); itr != talentMap.end(); ++itr)
@@ -26896,7 +26893,7 @@ uint8 Player::GetMostPointsTalentTree() const
 }
 
 bool Player::IsHealerTalentSpec() const
-{ 
+{
     uint8 tree = GetMostPointsTalentTree();
     return ((getClass() == CLASS_DRUID && tree == 2) || (getClass() == CLASS_PALADIN && tree == 0) || (getClass() == CLASS_PRIEST && tree <= 1) || (getClass() == CLASS_SHAMAN && tree == 2));
 }
@@ -26908,7 +26905,7 @@ bool Player::IsTankTalentSpec() const
 }
 
 void Player::ResetTimeSync()
-{ 
+{
     m_timeSyncCounter = 0;
     m_timeSyncTimer = 0;
     m_timeSyncClient = 0;
@@ -26916,7 +26913,7 @@ void Player::ResetTimeSync()
 }
 
 void Player::SendTimeSync()
-{ 
+{
     WorldPacket data(SMSG_TIME_SYNC_REQ, 4);
     data << uint32(m_timeSyncCounter++);
     GetSession()->SendPacket(&data);
@@ -26927,28 +26924,28 @@ void Player::SendTimeSync()
 }
 
 void Player::SetReputation(uint32 factionentry, uint32 value)
-{ 
+{
     GetReputationMgr().SetReputation(sFactionStore.LookupEntry(factionentry), value);
 }
 uint32 Player::GetReputation(uint32 factionentry) const
-{ 
+{
     return GetReputationMgr().GetReputation(sFactionStore.LookupEntry(factionentry));
 }
 
 std::string const& Player::GetGuildName()
-{ 
+{
     return sGuildMgr->GetGuildById(GetGuildId())->GetName();
 }
 
 void Player::SendDuelCountdown(uint32 counter)
-{ 
+{
     WorldPacket data(SMSG_DUEL_COUNTDOWN, 4);
     data << uint32(counter);                                // seconds
     GetSession()->SendPacket(&data);
 }
 
 void Player::SetIsSpectator(bool on)
-{ 
+{
     if (on)
     {
         AddAura(SPECTATOR_SPELL_SPEED, this);
@@ -26982,7 +26979,7 @@ void Player::SetIsSpectator(bool on)
 }
 
 bool Player::NeedSendSpectatorData() const
-{ 
+{
     if (FindMap() && FindMap()->IsBattleArena() && !IsSpectator())
     {
         Battleground* bg = ((BattlegroundMap*)FindMap())->GetBG();
@@ -26994,7 +26991,7 @@ bool Player::NeedSendSpectatorData() const
 }
 
 void Player::PrepareCharmAISpells()
-{ 
+{
     for (int i = 0; i < NUM_CAI_SPELLS; ++i)
         m_charmAISpells[i] = 0;
 
@@ -27089,19 +27086,19 @@ void Player::PrepareCharmAISpells()
 }
 
 void Player::AddRefundReference(uint32 it)
-{ 
+{
     m_refundableItems.insert(it);
 }
 
 void Player::DeleteRefundReference(uint32 it)
-{ 
+{
     RefundableItemsSet::iterator itr = m_refundableItems.find(it);
     if (itr != m_refundableItems.end())
         m_refundableItems.erase(itr);
 }
 
 void Player::SendRefundInfo(Item* item)
-{ 
+{
     // This function call unsets ITEM_FLAGS_REFUNDABLE if played time is over 2 hours.
     item->UpdatePlayedTime(this);
 
@@ -27147,7 +27144,7 @@ void Player::SendRefundInfo(Item* item)
 }
 
 bool Player::AddItem(uint32 itemId, uint32 count)
-{ 
+{
     uint32 noSpaceForCount = 0;
     ItemPosCountVec dest;
     InventoryResult msg = CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, itemId, count, &noSpaceForCount);
@@ -27170,7 +27167,7 @@ bool Player::AddItem(uint32 itemId, uint32 count)
 }
 
 void Player::RefundItem(Item* item)
-{ 
+{
     if (!item->HasFlag(ITEM_FIELD_FLAGS, ITEM_FLAG_REFUNDABLE))
     {
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
@@ -27291,7 +27288,7 @@ void Player::RefundItem(Item* item)
 }
 
 void Player::SetRandomWinner(bool isWinner)
-{ 
+{
     m_IsBGRandomWinner = isWinner;
     if (m_IsBGRandomWinner)
     {
@@ -27302,13 +27299,13 @@ void Player::SetRandomWinner(bool isWinner)
 }
 
 void Player::_LoadRandomBGStatus(PreparedQueryResult result)
-{ 
+{
     if (result)
         m_IsBGRandomWinner = true;
 }
 
 float Player::GetAverageItemLevel()
-{ 
+{
     float sum = 0;
     uint32 count = 0;
     uint8 level = getLevel();
@@ -27329,7 +27326,7 @@ float Player::GetAverageItemLevel()
 }
 
 float Player::GetAverageItemLevelForDF()
-{ 
+{
     float sum = 0;
     uint32 count = 0;
     uint8 level = getLevel();
@@ -27355,7 +27352,7 @@ float Player::GetAverageItemLevelForDF()
 }
 
 void Player::_LoadInstanceTimeRestrictions(PreparedQueryResult result)
-{ 
+{
     if (!result)
         return;
 
@@ -27408,7 +27405,7 @@ void Player::_LoadBrewOfTheMonth(PreparedQueryResult result)
 }
 
 void Player::_SaveInstanceTimeRestrictions(SQLTransaction& trans)
-{ 
+{
     if (_instanceResetTimes.empty())
         return;
 
@@ -27427,7 +27424,7 @@ void Player::_SaveInstanceTimeRestrictions(SQLTransaction& trans)
 }
 
 bool Player::IsInWhisperWhiteList(uint64 guid)
-{ 
+{
     for (WhisperListContainer::const_iterator itr = WhisperList.begin(); itr != WhisperList.end(); ++itr)
         if (*itr == guid)
             return true;
@@ -27436,7 +27433,7 @@ bool Player::IsInWhisperWhiteList(uint64 guid)
 }
 
 bool Player::SetDisableGravity(bool disable, bool packetOnly /*= false*/)
-{ 
+{
     if (!packetOnly && !Unit::SetDisableGravity(disable))
         return false;
 
@@ -27473,7 +27470,7 @@ bool Player::SetCanFly(bool apply, bool packetOnly /*= false*/)
 }
 
 bool Player::SetHover(bool apply, bool packetOnly /*= false*/)
-{ 
+{
     if (!packetOnly && !Unit::SetHover(apply))
         return false;
 
@@ -27490,7 +27487,7 @@ bool Player::SetHover(bool apply, bool packetOnly /*= false*/)
 }
 
 bool Player::SetWaterWalking(bool apply, bool packetOnly /*= false*/)
-{ 
+{
     if (!packetOnly && !Unit::SetWaterWalking(apply))
         return false;
 
@@ -27507,7 +27504,7 @@ bool Player::SetWaterWalking(bool apply, bool packetOnly /*= false*/)
 }
 
 bool Player::SetFeatherFall(bool apply, bool packetOnly /*= false*/)
-{ 
+{
     // Xinef: moved inside, flag can be removed on landing and wont send appropriate packet to client when aura is removed
     if (!packetOnly/* && !Unit::SetFeatherFall(apply)*/)
     {
@@ -27528,7 +27525,7 @@ bool Player::SetFeatherFall(bool apply, bool packetOnly /*= false*/)
 }
 
 Guild* Player::GetGuild() const
-{ 
+{
     uint32 guildId = GetGuildId();
     return guildId ? sGuildMgr->GetGuildById(guildId) : NULL;
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  Can create custom spell that modifies reputation gain that will work correctly
-  Can also stack more than 10 times the spell "Diplomacy" and it will work as it should lol (yeah, never gonna happen)

This is mostly for custom usage but it wasn't working logically.

###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Before that commit, when you killed a mob that earned reputation but also made you lose some
reputation, the reputation loss didn't occur. Same for quest reputation reward.

It worked like that:
If main reputation = positive
And secondary reputation = positive
--> Both reputation increased by X%

If main reputation = positive
And secondary reputation = negative
--> Main reputation increased by X%
--> Secondary reputation set to 0


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
I did booty bay quests and it worked fine, I killed pirates and it worked fine.


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
Before fix:
-  `.go creature 2596` Kill a pirate near booty bay and look at the reputation gain and loss
- `.aura 20599` 9 times and kill a pirate and look at reputation
- `.aura 20599` 10 times and kill a pirate (0 reputation loss)
- `.aura 20599` 11 times and kill a pirate (0 reputation loss)

After fix:
- `.aura 20599` 11 times and kill a pirate -> you lose more reputation thanks to the 110% reputation modifier


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
