### PR TITLE
fix(DB): Defendo-tank 66D - fix target of "say" action

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1557489332825322207.sql
+++ b/data/sql/updates/pending_db_world/rev_1557489332825322207.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1557489332825322207');
+
+UPDATE `smart_scripts` SET `target_type` = 1 WHERE `entryorguid` = 25758 AND `source_type` = 0 AND `id` = 0;


### PR DESCRIPTION
##### CHANGES PROPOSED:
The Defendo-tank 66D talks on aggro, but uses "SMART_TARGET_ACTION_INVOKER" instead of "SMART_TARGET_SELF". This is corrected through this PR.

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested in-game

##### HOW TO TEST THE CHANGES:
- ```.go creature id 25758```
- attack the creature

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master