### PR TITLE
fix(DB/Spell): Missing spells, update table spell_group

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1557589006688722000.sql
+++ b/data/sql/updates/pending_db_world/rev_1557589006688722000.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1557589006688722000');
+
+INSERT INTO `spell_group` (`id`,`spell_id`) VALUES (1052,48384),(1058,20335),(1097,14892),(1098,16176);


### PR DESCRIPTION
http://wotlk.cavernoftime.com/spell=48384

http://wotlk.cavernoftime.com/spell=20335

http://wotlk.cavernoftime.com/spell=14892

http://wotlk.cavernoftime.com/spell=16176

UPDATE SPELL ID GROUP IN TABLE


##### CHANGES PROPOSED:

-  update table spell_group with spells


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

- the issue no exist !
- No exist spell id group in the table
- review table spell_group in acore_world and check it  the id's spell


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

- test with Mac, using docker .

##### HOW TO TEST THE CHANGES:


First, see if there are spell ids in the spell_group table
the second is, copy and paste the ids spells.
finally check if they were inserted well.



##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master
