### PR TITLE
feat(Core/DB): Add creation_date column to characters table

### DIFF
--- a/data/sql/updates/pending_db_characters/rev_1557608218190967100.sql
+++ b/data/sql/updates/pending_db_characters/rev_1557608218190967100.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_characters` (`sql_rev`) VALUES ('1557608218190967100');
+
+ALTER TABLE `characters`
+	ADD COLUMN `creation_date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER `grantableLevels`;


### PR DESCRIPTION
##### CHANGES PROPOSED:

-  Add a creation date column to the characters table to know when the character was created


###### ISSUES ADDRESSED:

Possible difficulties when you want to perform an action on characters created after X date.

##### TESTS PERFORMED:

- Added the column
- The current characters get assigned the timestamp on which the change is applied
- New characters get assigned the timestamp when they are created



##### HOW TO TEST THE CHANGES:

- Add the column to your table
- Check the current characters
- Create a new character

##### KNOWN ISSUES AND TODO LIST:

None

##### Target branch(es):

Master
