### PR TITLE
fix(DB/Gameobject): Missing in DB (Giving conflicts on quest)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1557741075472498600.sql
+++ b/data/sql/updates/pending_db_world/rev_1557741075472498600.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1557741075472498600');
+
+DELETE FROM `gameobject_template` WHERE `entry`=184981;
+INSERT INTO `gameobject_template` (`entry`, `type`, `displayId`, `name`, `IconName`, `castBarCaption`, `unk1`, `size`, `Data0`, `Data1`, `Data2`, `Data3`, `Data4`, `Data5`, `Data6`, `Data7`, `Data8`, `Data9`, `Data10`, `Data11`, `Data12`, `Data13`, `Data14`, `Data15`, `Data16`, `Data17`, `Data18`, `Data19`, `Data20`, `Data21`, `Data22`, `Data23`, `AIName`, `ScriptName`, `VerifiedBuild`) VALUES 
+(184981, 6, 7244, 'Poodad Trap', '', '', '', 0.5, 1716, 0, 0, 37695, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', '', -18019);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
Adding missing gameobject

##### CHANGES PROPOSED:

-  Adding missing gameobject_template in DB. Entry 184981 (Poodad Trap)
-  Required for Quest https://wotlk.evowow.com/?quest=10629


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

The problem is that we missing creature in gameobject_template related to this quest. So, since this quest work like, yor pet have to summon gameobject after you kill creature there, and you loot them, until you loot quest item. On the first try you are able to loot it (Your pet will create it), if the quest item isn't droped, and you are trying to kill second mob, than your Pet spawn gameobject, but you are unable to loot it. Actually you are unable to click on it.
Related to this report: https://github.com/azerothcore/azerothcore-wotlk/issues/1824

```sql
2019-05-08 13:20:11 Gameobject (GUID: 2140565 Entry: 184981) not created: non-existing entry in `gameobject_template`. Map: 530 (X: 174.656204 Y: 2941.460449 Z: 24.702682)
2019-05-09 15:49:48 Gameobject (GUID: 2136466 Entry: 184981) not created: non-existing entry in `gameobject_template`. Map: 530 (X: 463.308716 Y: 2914.412109 Z: 41.515911)
2019-05-09 15:51:14 Gameobject (GUID: 2136492 Entry: 184981) not created: non-existing entry in `gameobject_template`. Map: 530 (X: 503.835632 Y: 2955.605225 Z: 32.195271)
2019-05-11 15:36:32 Gameobject (GUID: 2144716 Entry: 184981) not created: non-existing entry in `gameobject_template`. Map: 530 (X: 500.778961 Y: 2955.333740 Z: 32.511833)
2019-05-11 15:37:32 Gameobject (GUID: 2144810 Entry: 184981) not created: non-existing entry in `gameobject_template`. Map: 530 (X: 473.075165 Y: 2987.416260 Z: 23.230686)
```

Closes 


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Yes, everything work perfect now and no more DB errors


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
First test this without this commit:
1. Get this quest [Shizz Work](https://wotlk.evowow.com/?quest=10629)
2. Than .go c 58690
3. Use quest item, and summon your pet.
4. Than go at this creature and kill it .go c 58056
5. Your pet will spawn Gameobject (If you don't loot required object) try to kill another one.
6. Your pet will spawn another Gameobject (But you are unable to loot it) - Also check now your DB log, you will have some errors bcoz creature can't create it. 
7. Now when you see problem, apply commit ,and test with it. 



##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
