### PR TITLE
fix(DB/Creature); Kelgruk Bloodaxe

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1557742774901700400.sql
+++ b/data/sql/updates/pending_db_world/rev_1557742774901700400.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1557742774901700400');
+
+UPDATE `creature_template` SET `npcflag`=16 WHERE `entry`=7231;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  Set correct npc flags to 16
-  The creature is Weaponsmith Trainer (Should just teach)  [Kelgruk Bloodaxe](https://www.wowdb.com/npcs/7231-kelgruk-bloodaxe)


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->
Related to this report : https://github.com/azerothcore/azerothcore-wotlk/issues/1824
Closes 


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Yes, there is no more DB errors while interacting with this NPC.


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
First, test without this commit
1. Creature Horde character
2. .go creature 6613
3. Click on him (Open menu)
4. Check your DB log. 
5. Apply now commit and test again.


##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
