### PR TITLE
fix(DB/SAI): Overseer Deathgaze SAI

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1557766899660556000.sql
+++ b/data/sql/updates/pending_db_world/rev_1557766899660556000.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1557766899660556000');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 27122;
+
+DELETE FROM `smart_scripts` WHERE (source_type = 0 AND entryorguid = 27122);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(27122, 0, 0, 0, 4, 0, 100, 0, 0, 0, 0, 0, 11, 12739, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Overseer Deathgaze - On Aggro - Cast \'12739\''),
+(27122, 0, 1, 0, 0, 0, 100, 0, 3300, 3300, 4600, 4600, 11, 12739, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Overseer Deathgaze - In Combat - Cast \'12739\''),
+(27122, 0, 2, 0, 0, 0, 100, 0, 10000, 10000, 45000, 45000, 11, 50659, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Overseer Deathgaze - In Combat - Cast \'50659\'');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
Fix DB errors with this creature

##### CHANGES PROPOSED:

-  Related to this quest - https://wotlk.evowow.com/npc=27807?quest=12459
-  Scripted AI for Weakened Overseer Deathgaze


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->
Related to this report : https://github.com/azerothcore/azerothcore-wotlk/issues/1824
```sql
2019-05-10 08:39:59 SmartScript: Action target Creature(entry: 27807) is not using SmartAI, action skipped to prevent crash.
```

Closes 


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Yes, the script is fine now. No more DB errors. Many thanks to @Knindzagxg 


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
1. Take this [Quest](https://wotlk.evowow.com/npc=27807?quest=12459)
2. Tele to Quest location.
3. Kill first required NPC, than second NPC
4. And on third NPC (Check will you get DB errors while fighting him) - Best to test, without commit than with this commit.


##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
