### PR TITLE
fix(DB/Quest) Solved bug: A Spirit Ally? id 9847

### DIFF
--- a/Quest: "A Spirit Ally?" id 9847
+++ b/Quest: "A Spirit Ally?" id 9847
@@ -1,0 +1,1 @@
+UPDATE `item_template` SET `spellcharges_1` = 1 WHERE `entry` = 24498;


### PR DESCRIPTION
Quest: "A Spirit Ally?" id 9847
Questitem: "Feralfen Totem" id 24498

Error: The mission item has no cd and infinite snakes can be invoked.

Simple solved:


Thanks to @solidmaxtor for the fix

Closes 1822


##### TESTS PERFORMED:
I tested it myself and it worked.



##### HOW TO TEST THE CHANGES:
Give yourself the quest quest: "A Spirit Ally?" id 9847

go to the place of the quest 

try to use the quest item more than once


##### Target branch(es):

Master

