### PR TITLE
fix(DB/Quest): A Spirit Ally QuestId 9847

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1557939799614685700.sql
+++ b/data/sql/updates/pending_db_world/rev_1557939799614685700.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1557939799614685700');
+
+UPDATE `item_template` SET `spellcharges_1` = 1 WHERE `entry` = 24498;

--- a/data/sql/updates/pending_db_world/rev_1557939799614685700.sql
+++ b/data/sql/updates/pending_db_world/rev_1557939799614685700.sql
@@ -1,3 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1557939799614685700');
 
-UPDATE `item_template` SET `spellcharges_1` = 1 WHERE `entry` = 24498;
+UPDATE `item_template` SET `spellcharges_1`=1 WHERE `entry`=24498;


### PR DESCRIPTION
Quest: "A Spirit Ally?" id 9847
Questitem: "Feralfen Totem" id 24498

Error: The mission item has no cd and infinite snakes can be invoked.

Simple solved:

Thanks to @solidmaxtor for the fix

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1822

TESTS PERFORMED:
I tested it myself and it worked.

HOW TO TEST THE CHANGES:
Give yourself the quest quest: "A Spirit Ally?" id 9847

go to the place of the quest

try to use the quest item more than once


I hope it's all correct now.


Target branch(es):
Master