### PR TITLE
fix(Core/Spells): Fix wintergrasp spells yards

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -4312,16 +4312,18 @@ void SpellMgr::LoadDbcDataCorrections()
             break;
         // Wintergrasp spells
         case 51422: // Cannon (Tower Cannon)
-            spellInfo->EffectRadiusIndex[EFFECT_0] = 13; // 10yd
+            spellInfo->EffectRadiusIndex[EFFECT_0] = 20; // Radius: 20 yards
             break;
         case 57610: // Cannon (Siege Turret)
-            spellInfo->EffectRadiusIndex[EFFECT_0] = 13; // 10yd
+            spellInfo->EffectRadiusIndex[EFFECT_0] = 20; // Radius: 20 yards
+            spellInfo->EffectRadiusIndex[EFFECT_1] = 10; // Radius: 10 yards
             break;
         case 50999: // Boulder (Demolisher)
-            spellInfo->EffectRadiusIndex[EFFECT_0] = 13; // 10yd
+            spellInfo->EffectRadiusIndex[EFFECT_0] = 20; // Radius: 20 yards
+            spellInfo->EffectRadiusIndex[EFFECT_1] = 3; // Radius: 3 yards
             break;
         case 50990: // Flame Breath (Catapult)
-            spellInfo->EffectRadiusIndex[EFFECT_0] = 19; // 18yd
+            spellInfo->EffectRadiusIndex[EFFECT_0] = 30; // Radius: 30 yards
             break;
 
         /////////////////////////////////


### PR DESCRIPTION
## Continuation of [xDevICCI](https://github.com/azerothcore/azerothcore-wotlk/pull/1327)'s work

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

Changed the radius spell effect of following spells:

- http://wotlk.cavernoftime.com//spell=51422
- http://wotlk.cavernoftime.com//spell=57610
- http://wotlk.cavernoftime.com//spell=50999
- http://wotlk.cavernoftime.com//spell=50990

###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes #1327 

##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

Didn't test.

##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

1. Go to Wintergrasp and use cannon, machines
2. Cast spells mentioned and see damage radius index.


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
