### PR TITLE
fix(Core/Spells): Shaman Reincarnation

### DIFF
--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -586,7 +586,7 @@ void WorldSession::HandleSelfResOpcode(WorldPacket & /*recvData*/)
         SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(_player->GetUInt32Value(PLAYER_SELF_RES_SPELL));
         if (spellInfo)
         {
-            _player->CastSpell(_player, spellInfo, true, 0);
+            _player->CastSpell(_player, spellInfo, false, 0);
             _player->AddSpellAndCategoryCooldowns(spellInfo, 0);
         }
 


### PR DESCRIPTION
This commit is related to this issue : "Chaman Reincarnation does not consume ankh #1843"
It fixed it for me.

##### CHANGES PROPOSED:
-  Make the self_ressurection spells not triggered so it can consume reagents etc like Chaman Reincarnation spell


###### ISSUES ADDRESSED:
Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1843


##### TESTS PERFORMED:
Tested on Win10 x64, on master branch.

1. Died, used reincarnation. `Ankh is consumed`
2. Applied Reincarnation Glyph (itemID : 43385), died, used reincarnation. `Ankh isn't consumed`

I've also compared the `WorldSession::HandleSelfResOpcode` code with TrinityCore one, and on TC the spell isn't triggered.
`_player->CastSpell(_player, spellInfo, false, nullptr);`


##### HOW TO TEST THE CHANGES:
Make sure that the Reincarnation Glyph isn't applied (itemID : 43385).

_Before this commit :_
Go ingame with a shaman, die and use "reincarnation" with a Ankh (itemID : 17030) in your bags.
Observe that this Ankh isn't consumed.

_After this commit :_ 
Go ingame with a shaman, die and use "reincarnation" with a Ankh (itemID : 17030) in your bags.
Observe that this Ankh is consumed.


##### Target branch(es):
Master
