### PR TITLE
Add code to ensure low-level quests have blue exclamation marks when …

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16808,23 +16808,23 @@ QuestGiverStatus Player::GetQuestDialogStatus(Object* questgiver)
             if (CanSeeStartQuest(quest))
             {
                 if (SatisfyQuestLevel(quest, false)) {
-                    bool bLowLevel = (getLevel() > (GetQuestLevel(quest) + sWorld->getIntConfig(CONFIG_QUEST_LOW_LEVEL_HIDE_DIFF)));
+                    bool isLowLevel = (getLevel() > (GetQuestLevel(quest) + sWorld->getIntConfig(CONFIG_QUEST_LOW_LEVEL_HIDE_DIFF)));
 
                     if (quest->IsAutoComplete()) {
-                        if (bLowLevel)
+                        if (isLowLevel)
                             result2 = DIALOG_STATUS_LOW_LEVEL_REWARD_REP;
                         else
                             result2 = DIALOG_STATUS_REWARD_REP;
                     }
                     else {
                         if (quest->IsDaily()) {
-                            if (bLowLevel)
+                            if (isLowLevel)
                                 result2 = DIALOG_STATUS_LOW_LEVEL_AVAILABLE_REP;
                             else
                                 result2 = DIALOG_STATUS_AVAILABLE_REP;
                         }
                         else {
-                            if (bLowLevel)
+                            if (isLowLevel)
                                 result2 = DIALOG_STATUS_LOW_LEVEL_AVAILABLE;
                             else
                                 result2 = DIALOG_STATUS_AVAILABLE;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16807,19 +16807,29 @@ QuestGiverStatus Player::GetQuestDialogStatus(Object* questgiver)
         {
             if (CanSeeStartQuest(quest))
             {
-                if (SatisfyQuestLevel(quest, false))
-                {
-                    if (quest->IsAutoComplete())
-                        result2 = DIALOG_STATUS_REWARD_REP;
-                    else if (getLevel() <= (GetQuestLevel(quest) + sWorld->getIntConfig(CONFIG_QUEST_LOW_LEVEL_HIDE_DIFF)))
-                    {
-                        if (quest->IsDaily())
-                            result2 = DIALOG_STATUS_AVAILABLE_REP;
+                if (SatisfyQuestLevel(quest, false)) {
+                    bool bLowLevel = (getLevel() > (GetQuestLevel(quest) + sWorld->getIntConfig(CONFIG_QUEST_LOW_LEVEL_HIDE_DIFF)));
+
+                    if (quest->IsAutoComplete()) {
+                        if (bLowLevel)
+                            result2 = DIALOG_STATUS_LOW_LEVEL_REWARD_REP;
                         else
-                            result2 = DIALOG_STATUS_AVAILABLE;
+                            result2 = DIALOG_STATUS_REWARD_REP;
                     }
-                    else
-                        result2 = DIALOG_STATUS_LOW_LEVEL_AVAILABLE;
+                    else {
+                        if (quest->IsDaily()) {
+                            if (bLowLevel)
+                                result2 = DIALOG_STATUS_LOW_LEVEL_AVAILABLE_REP;
+                            else
+                                result2 = DIALOG_STATUS_AVAILABLE_REP;
+                        }
+                        else {
+                            if (bLowLevel)
+                                result2 = DIALOG_STATUS_LOW_LEVEL_AVAILABLE;
+                            else
+                                result2 = DIALOG_STATUS_AVAILABLE;
+                        }
+                    }
                 }
                 else
                     result2 = DIALOG_STATUS_UNAVAILABLE;


### PR DESCRIPTION
…using tracker

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
Ensure low-level quest markers are blue when using map tracker

##### CHANGES PROPOSED:

-  Break apart logic checking for low level quest and if quest is repeatable

###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1862


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

No errors on build. Ran through debugger to make sure variables were being set correctly.

##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

Bring 80 level character to Isle of Quel'Danas and use "Low Level Quests" tracker on mini map to see all the dailies. Without the fix, they will be yellow. With the fix, they will be blue - the correct color for dailies.

##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

None


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
