### PR TITLE
fix(DB/Quest): "Defeat the Gearmaster" / "The Gearmaster"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1558943884011471260.sql
+++ b/data/sql/updates/pending_db_world/rev_1558943884011471260.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1558943884011471260');
+
+-- Despawn "Gearmaster Mechazod" after 300 seconds (was 3000 seconds before)
+UPDATE `event_scripts` SET `datalong2` = 300000 WHERE `id` = 17209 AND `command` = 10;
+
+-- Ensure that "The Gearmaster's Manual" is consumable (both Horde and Alliance version)
+UPDATE `gameobject_template` SET `Data5` = 1 WHERE `entry` IN (190334,190335);


### PR DESCRIPTION
##### CHANGES PROPOSED:
- despawn game object "The Gearmaster's Manual" after usage
- Despawn "Gearmaster Mechazod" after 300 seconds instead of 3000 seconds as it was before

###### ISSUES ADDRESSED:
Closes #1850 

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
Horde:
```
.quest remove 11909
.quest add 11909
.go 4000.06 4853.55 25.9698 571
```
- use the manual (it should despawn and respawn after ca. 5 minutes)

Alliance:
```
.quest remove 11798
.quest add 11798
.go 4000.06 4853.55 25.9698 571
```
- use the manual (it should despawn and respawn after ca. 5 minutes)

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master