### PR TITLE
[Spell/Core] Glyph of Shadow Word: Death

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10564,6 +10564,14 @@ float Unit::SpellPctDamageModsDone(Unit* victim, SpellInfo const* spellProto, Da
                     if (victim->GetAuraEffect(SPELL_AURA_PERIODIC_DAMAGE, SPELLFAMILY_PRIEST, 0x100000, 0, 0, GetGUID()))
                         AddPct(DoneTotalMod, aurEff->GetAmount());
             }
+            // Shadow Word: Death
+            else if (spellProto->SpellFamilyFlags[1] & 0x2)
+            {
+                // Glyph of Shadow Word: Death
+                if (AuraEffect* aurEff = GetAuraEffect(55682, 1))
+                    if (victim->HasAuraState(AURA_STATE_HEALTHLESS_35_PERCENT))
+                        AddPct(DoneTotalMod, aurEff->GetAmount());
+            }
 
             break;
         case SPELLFAMILY_PALADIN:


### PR DESCRIPTION
Glyph of Shadow Word: Death: Targets below 35% health take an additional 10% damage from your Shadow Word: Death spell.

https://wotlk-twinhead.twinstar.cz/?spell=55682

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  Objectives below 35% of life receive an additional 10% damage using the spell of the Word of Shadows: death.


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


The Report does not exist, the first thing you should do is the following:

- Get the glyph: Glyph of Shadow Word: Death

- Go to a Boss or Raid and cast the spell when the target is or is below 35%

- You are not respecting what the glyph indicates


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

- 

##### HOW TO TEST THE CHANGES:


- Get the glyph: Glyph of Shadow Word: Death

- Go to a Boss or Raid and cast the spell when the target is or is below 35%

- You are not respecting what the glyph indicates

##### Target branch(es):

Master
