### PR TITLE
fix(Core/Spell): Big Blizzard Bear

### DIFF
--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -4374,7 +4374,10 @@ enum Mounts
 
     // Big Blizzard Bear
     SPELL_BIG_BLIZZARD_BEAR_60          = 58997,
-    SPELL_BIG_BLIZZARD_BEAR_100         = 58999
+    SPELL_BIG_BLIZZARD_BEAR_100         = 58999,
+    SPELL_BIG_BLIZZARD_BEAR_150         = 58999,
+    SPELL_BIG_BLIZZARD_BEAR_280         = 58999,
+    SPELL_BIG_BLIZZARD_BEAR_310         = 58999
 };
 
 class spell_gen_mount : public SpellScriptLoader
@@ -4935,7 +4938,7 @@ void AddSC_generic_spell_scripts()
     new spell_gen_disabled_above_63();
     new spell_gen_black_magic_enchant();
     new spell_gen_area_aura_select_players();
-    new spell_gen_mount("spell_big_blizzard_bear", 0, SPELL_BIG_BLIZZARD_BEAR_60, SPELL_BIG_BLIZZARD_BEAR_100, 0, 0);
+    new spell_gen_mount("spell_big_blizzard_bear", 0, SPELL_BIG_BLIZZARD_BEAR_60, SPELL_BIG_BLIZZARD_BEAR_100, SPELL_BIG_BLIZZARD_BEAR_150, SPELL_BIG_BLIZZARD_BEAR_280, SPELL_BIG_BLIZZARD_BEAR_310);
     new spell_gen_select_target_count("spell_gen_select_target_count_15_1", TARGET_UNIT_SRC_AREA_ENEMY, 1);
     new spell_gen_select_target_count("spell_gen_select_target_count_15_2", TARGET_UNIT_SRC_AREA_ENEMY, 2);
     new spell_gen_select_target_count("spell_gen_select_target_count_15_5", TARGET_UNIT_SRC_AREA_ENEMY, 5);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
Fix for mount Big Blizzard Bear

##### CHANGES PROPOSED:

- Correctly apply 60% & 100% speed for mounts based on riding skill
-  


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1896


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Yes, builded without errors. Tested in game, now everything is fine.


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
Read this issue : https://github.com/azerothcore/azerothcore-wotlk/issues/1896


##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
