### PR TITLE
fix(DB/Core): Fix some issues concerning "Thorim's Charm of Earth" (Mending Fences)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1559215442284268490.sql
+++ b/data/sql/updates/pending_db_world/rev_1559215442284268490.sql
@@ -41,4 +41,5 @@ DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 29927;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
 VALUES
 (29927,0,0,0,54,0,100,0,0,0,0,0,0,49,0,0,0,0,0,0,19,29375,30,0,0,0,0,0,0,'Earthen Ironbane - Is Summoned - Attack Start (Stormforged Iron Giant)'),
-(29927,0,1,0,54,0,100,0,0,0,0,0,0,49,0,0,0,0,0,0,19,29503,30,0,0,0,0,0,0,'Earthen Ironbane - Is Summoned - Attack Start (Fjorn)');
+(29927,0,1,0,54,0,100,0,0,0,0,0,0,49,0,0,0,0,0,0,19,29503,30,0,0,0,0,0,0,'Earthen Ironbane - Is Summoned - Attack Start (Fjorn)'),
+(29927,0,2,0,1,0,100,0,0,0,0,0,0,41,10000,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Earthen Ironbane - Out of Combat - Despawn After 10 Seconds');

--- a/data/sql/updates/pending_db_world/rev_1559215442284268490.sql
+++ b/data/sql/updates/pending_db_world/rev_1559215442284268490.sql
@@ -1,6 +1,42 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1559215442284268490');
 
+-- allow Fjorn to be targeted by "Hurl Boulder"
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 17 AND `SourceGroup` = 0 AND `SourceEntry` = 55818 AND `ConditionTypeOrReference` = 31 AND `ConditionValue2` = 29503;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`)
 VALUES
 (17,0,55818,0,1,31,1,3,29503,0,0,0,0,'','Requires Fjorn');
+
+-- remove references for spell "Hurl Boulder" as they are not needed anymore
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 55818;
+DELETE FROM `spell_scripts` WHERE `id` = 55818;
+DELETE FROM `spell_script_names` WHERE `spell_id` = 55818;
+
+-- Stormforged Iron Giant
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 29375;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(29375,0,0,0,0,0,100,0,6000,12000,20000,26000,0,11,57741,0,0,0,0,0,2,0,0,0,0,0,0,0,0,'Stormforged Iron Giant - In Combat - Cast ''Shockwave'''),
+(29375,0,1,2,8,0,100,0,55818,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stormforged Iron Giant - On Spellhit ''Hurl Boulder'' - Cast ''Summon Earthen'''),
+(29375,0,2,3,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stormforged Iron Giant - Linked - Cast ''Summon Earthen'''),
+(29375,0,3,4,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stormforged Iron Giant - Linked - Cast ''Summon Earthen'''),
+(29375,0,4,5,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stormforged Iron Giant - Linked - Cast ''Summon Earthen'''),
+(29375,0,5,0,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stormforged Iron Giant - Linked - Cast ''Summon Earthen''');
+
+-- Fjorn
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 29503;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(29503,0,0,0,0,0,100,0,7000,11000,9000,23000,0,11,57801,0,0,0,0,0,2,0,0,0,0,0,0,0,0,'Fjorn - In Combat - Cast ''Flame Breath'''),
+(29503,0,1,0,0,0,100,0,12000,15000,30000,35000,0,11,55512,0,0,0,0,0,2,0,0,0,0,0,0,0,0,'Fjorn - In Combat - Cast ''Call of Earth'''),
+(29503,0,2,3,8,0,100,0,55818,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Fjorn - On Spellhit ''Hurl Boulder'' - Cast ''Summon Earthen'''),
+(29503,0,3,4,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Fjorn - Linked - Cast ''Summon Earthen'''),
+(29503,0,4,5,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Fjorn - Linked - Cast ''Summon Earthen'''),
+(29503,0,5,6,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Fjorn - Linked - Cast ''Summon Earthen'''),
+(29503,0,6,0,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Fjorn - Linked - Cast ''Summon Earthen''');
+
+-- Earthen Ironbane
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 29927;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(29927,0,0,0,54,0,100,0,0,0,0,0,0,49,0,0,0,0,0,0,19,29375,30,0,0,0,0,0,0,'Earthen Ironbane - Is Summoned - Attack Start (Stormforged Iron Giant)'),
+(29927,0,1,0,54,0,100,0,0,0,0,0,0,49,0,0,0,0,0,0,19,29503,30,0,0,0,0,0,0,'Earthen Ironbane - Is Summoned - Attack Start (Fjorn)');

--- a/data/sql/updates/pending_db_world/rev_1559215442284268490.sql
+++ b/data/sql/updates/pending_db_world/rev_1559215442284268490.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1559215442284268490');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 17 AND `SourceGroup` = 0 AND `SourceEntry` = 55818 AND `ConditionTypeOrReference` = 31 AND `ConditionValue2` = 29503;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`)
+VALUES
+(17,0,55818,0,1,31,1,3,29503,0,0,0,0,'','Requires Fjorn');

--- a/data/sql/updates/pending_db_world/rev_1559215442284268490.sql
+++ b/data/sql/updates/pending_db_world/rev_1559215442284268490.sql
@@ -20,7 +20,8 @@ VALUES
 (29375,0,2,3,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stormforged Iron Giant - Linked - Cast ''Summon Earthen'''),
 (29375,0,3,4,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stormforged Iron Giant - Linked - Cast ''Summon Earthen'''),
 (29375,0,4,5,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stormforged Iron Giant - Linked - Cast ''Summon Earthen'''),
-(29375,0,5,0,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stormforged Iron Giant - Linked - Cast ''Summon Earthen''');
+(29375,0,5,0,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stormforged Iron Giant - Linked - Cast ''Summon Earthen'''),
+(29375,0,6,0,0,0,100,0,1000,1000,5000,5000,0,123,5000,0,0,0,0,0,11,29927,10,0,0,0,0,0,0,'Stormforged Iron Giant - In Combat - Add Threat (Earthen Ironbane)');
 
 -- Fjorn
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 29503;
@@ -32,7 +33,8 @@ VALUES
 (29503,0,3,4,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Fjorn - Linked - Cast ''Summon Earthen'''),
 (29503,0,4,5,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Fjorn - Linked - Cast ''Summon Earthen'''),
 (29503,0,5,6,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Fjorn - Linked - Cast ''Summon Earthen'''),
-(29503,0,6,0,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Fjorn - Linked - Cast ''Summon Earthen''');
+(29503,0,6,0,61,0,100,0,0,0,0,0,0,11,55528,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Fjorn - Linked - Cast ''Summon Earthen'''),
+(29503,0,7,0,0,0,100,0,1000,1000,5000,5000,0,123,5000,0,0,0,0,0,11,29927,10,0,0,0,0,0,0,'Fjorn - In Combat - Add Threat (Earthen Ironbane)');
 
 -- Earthen Ironbane
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 29927;

--- a/src/server/scripts/Northrend/zone_sholazar_basin.cpp
+++ b/src/server/scripts/Northrend/zone_sholazar_basin.cpp
@@ -522,43 +522,6 @@ public:
     }
 };
 
-enum Q12915MendingFences
-{
-    SPELL_SUMMON_EARTHEN            = 55528
-};
-
-class spell_q12915_mending_fences : public SpellScriptLoader
-{
-    public:
-        spell_q12915_mending_fences() : SpellScriptLoader("spell_q12915_mending_fences") { }
-
-        class spell_q12915_mending_fences_SpellScript : public SpellScript
-        {
-            PrepareSpellScript(spell_q12915_mending_fences_SpellScript);
-
-            void HandleDummy(SpellEffIndex /*effIndex*/)
-            {
-                Unit* target = GetHitUnit();
-                if (!target)
-                    return;
-
-                for (uint8 i = 0; i < 4; ++i)
-                    GetCaster()->CastSpell(GetCaster(), SPELL_SUMMON_EARTHEN, true);
-            }
-
-            void Register()
-            {
-                OnEffectHitTarget += SpellEffectFn(spell_q12915_mending_fences_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
-            }
-        };
-
-        SpellScript* GetSpellScript() const
-        {
-            return new spell_q12915_mending_fences_SpellScript();
-        };
-};
-
-
 
 // Theirs
 /*######
@@ -1523,7 +1486,6 @@ void AddSC_sholazar_basin()
     new npc_mcmanus();
     new go_pressure_valve();
     new go_brazier();
-    new spell_q12915_mending_fences();
 
     // Theirs
     new npc_vekjik();


### PR DESCRIPTION
##### CHANGES PROPOSED:
Apply the following fixes to "Thorim's Charm of Earth" (ID 41050, provided for quest "Mending Fences"):
- allow Fjorn to be targeted by the spell "Hurl Boulder"
- summon exactly 5 dwarves at the target of "Hurl Boulder"
- the dwarves will attack Stormforged Iron Giants and Fjorn
- remove the cpp spell script and all references for "Hurl Boulder" as they are not needed anymore

###### ISSUES ADDRESSED:
Closes #1897 

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.quest remove 12915
.quest add 12915
.go 7209.15 -3363.71 845.991 571
```
- pick up granite boulders
- use the item "Thorim's Charm of Earth" against Stormforged Iron Giants and Fjorn, it should now work on both NPCs

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master