### PR TITLE
fix(DB/Creature): Invisibility Creature Trigger HC Boss Shirrak the Dead Watcher HC

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1559394390864887200.sql
+++ b/data/sql/updates/pending_db_world/rev_1559394390864887200.sql
@@ -1,3 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1559394390864887200');
 
-UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 128 WHERE (entry = 20308);
+UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 128 WHERE `entry` = 20308;

--- a/data/sql/updates/pending_db_world/rev_1559394390864887200.sql
+++ b/data/sql/updates/pending_db_world/rev_1559394390864887200.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1559394390864887200');
+
+UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 128 WHERE (entry = 20308);

--- a/data/sql/updates/pending_db_world/rev_1559394390864887200.sql
+++ b/data/sql/updates/pending_db_world/rev_1559394390864887200.sql
@@ -1,3 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1559394390864887200');
 
-UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 128 WHERE `entry` = 20308;
+UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 128 WHERE `entry` IN (20308,23920,18095);


### PR DESCRIPTION
Fixes the visibility of the Creature HC Id 20308 because this is a trigger
Boss Shirrak the Dead Watcher HC Id 20318
Zul'Aman - Jan'alai (Dragonhawk boss): Firebomb (Zul'Aman) 23920
Mount Hyjal - Archimonde: Doomfire  18095

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/897

TESTS PERFORMED:
I tested it myself and it worked.
Fix is not on the server https://youtu.be/4mlLfyIoaN8
Fix on Server https://youtu.be/uFkdy-0-8ms

HOW TO TEST THE CHANGES:
Attack the Boss and wait for him to cast the spell.
Focus fire on you sets a flame appears below you

Switch the instance to HC beforehand.
.go c 83388

Target branch(es):
Master