### PR TITLE
fix(DB/Core): Play "Lament of the Highborne" as music instead of sound

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1559456042362460279.sql
+++ b/data/sql/updates/pending_db_world/rev_1559456042362460279.sql
@@ -1,7 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1559456042362460279');
 
--- use "SMART_ACTION_MUSIC" instead of "SMART_ACTION_SOUND" to play "Lament of the Highborne" as music for the players in the area
-UPDATE `smart_scripts` SET `action_type` = 216, `action_param2` = 1, `action_param3` = 2, `target_type` = 1, `target_param1` = 0, `comment` = 'Sylvanas Lamenter - On Update - Play Area Music' WHERE `entryorguid` = 39048 AND `source_type` = 0 AND `id` = 1;
+-- use "SMART_ACTION_MUSIC" instead of "SMART_ACTION_SOUND" to play "Lament of the Highborne" as music for all players within 50 yards distance
+UPDATE `smart_scripts` SET `action_type` = 216, `action_param2` = 1, `action_param3` = 0, `target_type` = 18, `target_param1` = 50, `comment` = 'Sylvanas Lamenter - On Update - Play Area Music' WHERE `entryorguid` = 39048 AND `source_type` = 0 AND `id` = 1;
 
 -- use "onlySelf" 1 for Thrall event as the music needs to be played only for the players directly
 UPDATE `smart_scripts` SET `action_param2` = 1 WHERE `entryorguid` = 19556 AND `source_type` = 0 AND `action_type` = 216;

--- a/data/sql/updates/pending_db_world/rev_1559456042362460279.sql
+++ b/data/sql/updates/pending_db_world/rev_1559456042362460279.sql
@@ -5,7 +5,7 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1559456042362460279');
 DELETE FROM `smart_scripts` WHERE `entryorguid` = 39048 AND `source_type` = 0;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
 VALUES
-(39048,0,0,0,60,0,100,1,200,200,0,0,0,11,37090,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Sylvanas Lamenter - On Update - Cast Spell ''Lament of the Highborne: Highborne Aura'''),
+(39048,0,0,0,60,0,100,1,200,200,0,0,0,11,37090,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Sylvanas Lamenter - On Update - Cast Spell ''Lament of the Highborne: Highborne Aura'' (No Repeat)'),
 (39048,0,1,0,1,0,100,0,0,0,5000,5000,0,216,15095,1,0,0,0,0,18,50,0,0,0,0,0,0,0,'Sylvanas Lamenter - OOC - Play music for players within 50 yards (Repeat every 5 seconds)'),
 (39048,0,2,3,60,0,100,1,1000,1000,0,0,0,60,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Sylvanas Lamenter - On Update - Set Fly (No Repeat)'),
 (39048,0,3,0,61,0,100,0,0,0,0,0,0,69,1,0,0,0,0,0,1,0,0,0,0,0,0,6,0,'Sylvanas Lamenter - Linked - Move Pos To Self offset Z');

--- a/data/sql/updates/pending_db_world/rev_1559456042362460279.sql
+++ b/data/sql/updates/pending_db_world/rev_1559456042362460279.sql
@@ -1,7 +1,14 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1559456042362460279');
 
 -- use "SMART_ACTION_MUSIC" instead of "SMART_ACTION_SOUND" to play "Lament of the Highborne" as music for all players within 50 yards distance
-UPDATE `smart_scripts` SET `action_type` = 216, `action_param2` = 1, `action_param3` = 0, `target_type` = 18, `target_param1` = 50, `comment` = 'Sylvanas Lamenter - On Update - Play music for players within 50 yards' WHERE `entryorguid` = 39048 AND `source_type` = 0 AND `id` = 1;
+-- changed the comments of the other SAI entries slightly
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 39048 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(39048,0,0,0,60,0,100,1,200,200,0,0,0,11,37090,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Sylvanas Lamenter - On Update - Cast Spell ''Lament of the Highborne: Highborne Aura'''),
+(39048,0,1,0,1,0,100,0,0,0,5000,5000,0,216,15095,1,0,0,0,0,18,50,0,0,0,0,0,0,0,'Sylvanas Lamenter - OOC - Play music for players within 50 yards (Repeat every 5 seconds)'),
+(39048,0,2,3,60,0,100,1,1000,1000,0,0,0,60,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Sylvanas Lamenter - On Update - Set Fly (No Repeat)'),
+(39048,0,3,0,61,0,100,0,0,0,0,0,0,69,1,0,0,0,0,0,1,0,0,0,0,0,0,6,0,'Sylvanas Lamenter - Linked - Move Pos To Self offset Z');
 
 -- use "onlySelf" 1 for Thrall event as the music needs to be played only for the players directly
 UPDATE `smart_scripts` SET `action_param2` = 1 WHERE `entryorguid` = 19556 AND `source_type` = 0 AND `action_type` = 216;

--- a/data/sql/updates/pending_db_world/rev_1559456042362460279.sql
+++ b/data/sql/updates/pending_db_world/rev_1559456042362460279.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1559456042362460279');
+
+-- use "SMART_ACTION_MUSIC" instead of "SMART_ACTION_SOUND" to play "Lament of the Highborne" as music for the players in the area
+UPDATE `smart_scripts` SET `action_type` = 216, `action_param2` = 1, `action_param3` = 2, `target_type` = 1, `target_param1` = 0, `comment` = 'Sylvanas Lamenter - On Update - Play Area Music' WHERE `entryorguid` = 39048 AND `source_type` = 0 AND `id` = 1;
+
+-- use "onlySelf" 1 for Thrall event as the music needs to be played only for the players directly
+UPDATE `smart_scripts` SET `action_param2` = 1 WHERE `entryorguid` = 19556 AND `source_type` = 0 AND `action_type` = 216;

--- a/data/sql/updates/pending_db_world/rev_1559456042362460279.sql
+++ b/data/sql/updates/pending_db_world/rev_1559456042362460279.sql
@@ -1,7 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1559456042362460279');
 
 -- use "SMART_ACTION_MUSIC" instead of "SMART_ACTION_SOUND" to play "Lament of the Highborne" as music for all players within 50 yards distance
-UPDATE `smart_scripts` SET `action_type` = 216, `action_param2` = 1, `action_param3` = 0, `target_type` = 18, `target_param1` = 50, `comment` = 'Sylvanas Lamenter - On Update - Play Area Music' WHERE `entryorguid` = 39048 AND `source_type` = 0 AND `id` = 1;
+UPDATE `smart_scripts` SET `action_type` = 216, `action_param2` = 1, `action_param3` = 0, `target_type` = 18, `target_param1` = 50, `comment` = 'Sylvanas Lamenter - On Update - Play music for players within 50 yards' WHERE `entryorguid` = 39048 AND `source_type` = 0 AND `id` = 1;
 
 -- use "onlySelf" 1 for Thrall event as the music needs to be played only for the players directly
 UPDATE `smart_scripts` SET `action_param2` = 1 WHERE `entryorguid` = 19556 AND `source_type` = 0 AND `action_type` = 216;

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -228,7 +228,7 @@ void ScriptedAI::DoPlayMusic(uint32 soundId, bool zone)
                         }
                         else
                             targets->push_back(player);
-                   }
+                    }
                 }
         }
     }

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -205,6 +205,45 @@ void ScriptedAI::DoPlaySoundToSet(WorldObject* source, uint32 soundId)
     source->PlayDirectSound(soundId);
 }
 
+void ScriptedAI::DoPlayMusic(uint32 soundId, bool zone)
+{
+    ObjectList* targets = NULL;
+
+    if (me && me->FindMap())
+    {
+        Map::PlayerList const &players = me->GetMap()->GetPlayers();
+        targets = new ObjectList();
+
+        if (!players.isEmpty())
+        {
+            for (Map::PlayerList::const_iterator i = players.begin(); i != players.end(); ++i)
+                if (Player* player = i->GetSource())
+                {
+                    if (player->GetZoneId() == me->GetZoneId())
+                    {
+                        if (!zone)
+                        {
+                            if (player->GetAreaId() == me->GetAreaId())
+                                targets->push_back(player);
+                        }
+                        else
+                            targets->push_back(player);
+                   }
+                }
+        }
+    }
+
+    if (targets)
+    {
+        for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
+        {
+            (*itr)->SendPlayMusic(soundId, true);
+        }
+
+        delete targets;
+    }
+}
+
 Creature* ScriptedAI::DoSpawnCreature(uint32 entry, float offsetX, float offsetY, float offsetZ, float angle, uint32 type, uint32 despawntime)
 {
     return me->SummonCreature(entry, me->GetPositionX() + offsetX, me->GetPositionY() + offsetY, me->GetPositionZ() + offsetZ, angle, TempSummonType(type), despawntime);

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -14,6 +14,8 @@
 
 #define CAST_AI(a, b)   (dynamic_cast<a*>(b))
 
+typedef std::list<WorldObject*> ObjectList;
+
 class InstanceScript;
 
 class SummonList
@@ -236,6 +238,9 @@ struct ScriptedAI : public CreatureAI
 
     //Plays a sound to all nearby players
     void DoPlaySoundToSet(WorldObject* source, uint32 soundId);
+
+    //Plays music for all players in the zone (zone = true) or the area (zone = false)
+    void DoPlayMusic(uint32 soundId, bool zone);
 
     //Drops all threat to 0%. Does not remove players from the threat list
     void DoResetThreat();

--- a/src/server/scripts/EasternKingdoms/zone_undercity.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_undercity.cpp
@@ -125,7 +125,7 @@ public:
             if (type == GUID_EVENT_INVOKER)
             {
                 Talk(EMOTE_LAMENT);
-                DoPlaySoundToSet(me, SOUND_CREDIT);
+                DoPlayMusic(SOUND_CREDIT, true);
                 DoCast(me, SPELL_SYLVANAS_CAST, false);
                 playerGUID = guid;
                 LamentEvent = true;


### PR DESCRIPTION
##### CHANGES PROPOSED:
- Play "Lament of the Highborne" as music for all players in the area if "Sylvanas's Music Box" (item ID 52253) is used
- Play "Lament of the Highborne" as music for all players in the Undercity zone if the quest "Journey to Undercity" (ID 9180) is finished
- Small adjustment for the Thrall event ("Hero of the Mag'har"), which also uses "SMART_ACTION_MUSIC": Set "onlySelf" to 1 as the music should be played directly for all players in the zone. Does not need to be tested, as there is no difference, just should make it clear in the SAI script that the music is played directly.

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested in-game

##### HOW TO TEST THE CHANGES:
"Sylvanas's Music Box":
- Either use the item
```.additem 52253```
or cast one of the summon spells directly:
```.cast 73332```
```.cast 73333```
- the music should be played for each player in the same area instead of the normal soundtrack

"Journey to Undercity"
- preparation:
```
.quest remove 9180
.quest add 9180
.tele RoyalQuarter
```
- finish quest "Journey to Undercity"
- the music should be played for each player in the Undercity zone instead of the normal soundtrack

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master