### PR TITLE
fix(Core/BG): prevent potential crash in BG

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -146,7 +146,7 @@ void BattlegroundMgr::Update(uint32 diff)
 void BattlegroundMgr::BuildBattlegroundStatusPacket(WorldPacket* data, Battleground* bg, uint8 QueueSlot, uint8 StatusID, uint32 Time1, uint32 Time2, uint8 arenatype, TeamId teamId, bool isRated, BattlegroundTypeId forceBgTypeId)
 {
     // pussywizard:
-    ASSERT(QueueSlot < PLAYER_MAX_BATTLEGROUND_QUEUES);
+    //ASSERT(QueueSlot < PLAYER_MAX_BATTLEGROUND_QUEUES);
 
     if (StatusID == STATUS_NONE || !bg)
     {


### PR DESCRIPTION
I'm really not sure about this `ASSERT` put there.

First of all, in TC there is no such assertion. It was added by pussywizard in SunwellCore.

Second, both in TC and AC there are cases where `QueueSlot`  can be exactly `PLAYER_MAX_BATTLEGROUND_QUEUES`, causing crash.

For example, in `Player.h`: 
- line 975: `struct BGData`  defaults `bgTeamId` to `PLAYER_MAX_BATTLEGROUND_QUEUES`
- liune 2232: `uint32 GetBattlegroundQueueIndex(BattlegroundQueueTypeId bgQueueTypeId) const` can return `PLAYER_MAX_BATTLEGROUND_QUEUES` or any lower value.

- Closes #1756


### How to test the changes:

- Make sure that BGs and their queue system still works fine
- Start, play and finish BGs

