### PR TITLE
fix(Core): check quest conditions on item equip

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -12820,6 +12820,7 @@ Item* Player::EquipItem(uint16 pos, Item* pItem, bool update)
 #endif
 
     sScriptMgr->OnEquip(this, pItem, bag, slot, update);
+    UpdateForQuestWorldObjects();
     return pItem;
 }
 


### PR DESCRIPTION
##### CHANGES PROPOSED:
Check quest conditions after items are equipped.

###### ISSUES ADDRESSED:
Closes #1932 

##### TESTS PERFORMED:
- build was successful on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
test the quest mentioned in #1932, when you equip the lance while in the area "Court of Bones" you can now mount the horses, if you unequip it you cannot.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master