### PR TITLE
fix(DB): Dismiss Frenzyheart companion

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1559684382046240375.sql
+++ b/data/sql/updates/pending_db_world/rev_1559684382046240375.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1559684382046240375');
+
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (51186,51188,51189);
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`)
+VALUES
+(51186,'spell_item_summon_or_dismiss'),
+(51188,'spell_item_summon_or_dismiss'),
+(51189,'spell_item_summon_or_dismiss');


### PR DESCRIPTION
##### CHANGES PROPOSED:
Allow to dismiss the Frenzyheart companions by using their respective items:
- Goregek's Shackles
- Dajik's Worn Chalk
- Zepik's Hunting Horn

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.additem 38619
.additem 38621
.additem 38512
.tele SholazarBasin
```
- use each of the items to call or dismiss the companion.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master