### PR TITLE
fix(DB/SAI): Thalgran

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1559915961271940130.sql
+++ b/data/sql/updates/pending_db_world/rev_1559915961271940130.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1559915961271940130');
+
+UPDATE `smart_scripts` SET `action_param2` = 0 WHERE `entryorguid` = 28443 AND `source_type` = 0 AND `id` = 2;


### PR DESCRIPTION
##### CHANGES PROPOSED:
Thalgran is the objective of quest "Returned Sevenfold" (ID 12611). As it is now his spell "Rain of Fire" will always interrupt his spell "Deathbolt", which makes it impossible to use the provided quest item "Freya's Ward" to reflect his Deathbolts. This PR fixes this.

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.quest remove 12611
.quest add 12611
.go creature id 28443
```
- kill Thalgran by reflecting his Deathbolts

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master