### PR TITLE
fix(DB/Creature): FixCreature Sporebat+Greater Sporebat+Young Sporebat+Sporewing

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1560028006349950800.sql
+++ b/data/sql/updates/pending_db_world/rev_1560028006349950800.sql
@@ -13,3 +13,16 @@ DELETE FROM `smart_scripts` WHERE (source_type = 0 AND entryorguid = 18129);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (18129, 0, 0, 0, 6, 0, 75, 1, 0, 0, 0, 0, 0, 11, 35336, 7, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Greater Sporebat - On Just Died - Cast \'Energizing Spores\' (Phase 1) (No Repeat)'),
 (18129, 0, 1, 0, 0, 0, 100, 0, 1000, 1000, 15000, 15000, 0, 11, 35394, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Greater Sporebat - In Combat - Cast \'Spore Cloud\' (Phase 1) (No Repeat)');
+
+--  Young Sporebat SAI (20387)
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 20387; 
+DELETE FROM `smart_scripts` WHERE (source_type = 0 AND entryorguid = 20387);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(20387, 0, 0, 0, 6, 0, 75, 1, 0, 0, 0, 0, 0, 11, 35336, 7, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Young Sporebat - On Just Died - Cast \'Energizing Spores\' (No Repeat)');
+
+-- Sporewing SAI (18280)
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 18280; 
+DELETE FROM `smart_scripts` WHERE (source_type = 0 AND entryorguid = 18280);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(18280, 0, 0, 0, 6, 0, 75, 1, 0, 0, 0, 0, 0, 11, 35336, 7, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Sporewing - On Just Died - Cast \'Energizing Spores\''),
+(18280, 0, 1, 0, 0, 0, 100, 0, 1000, 1000, 15000, 15000, 0, 11, 35394, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Sporewing - In Combat - Cast \'Spore Cloud\'');

--- a/data/sql/updates/pending_db_world/rev_1560028006349950800.sql
+++ b/data/sql/updates/pending_db_world/rev_1560028006349950800.sql
@@ -1,0 +1,15 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1560028006349950800');
+
+-- Sporebat SAI (18128)
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 18128; 
+DELETE FROM `smart_scripts` WHERE (source_type = 0 AND entryorguid = 18128);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(18128, 0, 0, 0, 6, 0, 75, 1, 0, 0, 0, 0, 0, 11, 35336, 7, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Sporebat - On Just Died - Cast \'Energizing Spores\' (Phase 1) (No Repeat)'),
+(18128, 0, 1, 0, 0, 0, 100, 0, 1000, 1000, 15000, 15000, 0, 11, 35394, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Sporebat - In Combat - Cast \'Spore Cloud\' (Phase 1) (No Repeat)');
+
+-- Greater Sporebat SAI (18129)
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 18129; 
+DELETE FROM `smart_scripts` WHERE (source_type = 0 AND entryorguid = 18129);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(18129, 0, 0, 0, 6, 0, 75, 1, 0, 0, 0, 0, 0, 11, 35336, 7, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Greater Sporebat - On Just Died - Cast \'Energizing Spores\' (Phase 1) (No Repeat)'),
+(18129, 0, 1, 0, 0, 0, 100, 0, 1000, 1000, 15000, 15000, 0, 11, 35394, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Greater Sporebat - In Combat - Cast \'Spore Cloud\' (Phase 1) (No Repeat)');


### PR DESCRIPTION
The creatures Sporebat+Greater Sporebat+Young Sporebat+Sporewing should occupy the player with the spell Energizing Spores at death

Creatur ID 18128,18129,18280,20387


https://db.rising-gods.de/?spell=35336#used-by-npc

https://de.wowhead.com/spell=35336/energiereiche-sporen

Closes nothing

TESTS PERFORMED:
I tested it myself and it worked.

HOW TO TEST THE CHANGES:
.go c 64455
.go c 64559
.go c 72265
.go c 65571
Kill the creature and see if you got the buff.

Target branch(es):
Master

