### PR TITLE
fix(DB/SAI): Death Knight Adept mass spawn

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1560292934254034937.sql
+++ b/data/sql/updates/pending_db_world/rev_1560292934254034937.sql
@@ -1,0 +1,16 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1560292934254034937');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 31318;
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 31318 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(31318,0,0,0,54,0,100,0,0,0,0,0,0,49,0,0,0,0,0,0,23,0,0,0,0,0,0,0,0,'Death Knight Adept - On Just Summoned - Start Attack Owner'),
+(31318,0,1,0,6,0,100,0,0,0,0,0,0,41,5000,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Death Knight Adept - On Death - Force Despawn After 5 Seconds');
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 31316 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(31316,0,0,1,25,0,100,0,0,0,0,0,0,8,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Ebon Blade Reaper - On Reset - Set Defensive'),
+(31316,0,1,0,61,0,100,0,0,0,0,0,0,67,1,5000,10000,0,0,0,1,0,0,0,0,0,0,0,0,'Ebon Blade Reaper - Linked - Create Timed Event ID 1'),
+(31316,0,2,0,59,0,100,0,1,0,0,0,0,11,58962,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Ebon Blade Reaper - On Timed Event ID 1 - Cast Summon Death Knight Adept');


### PR DESCRIPTION
##### CHANGES PROPOSED:
This concerns the quest "The Fate of Bloodbane": The Death Knight Adepts just spawn here continuously without fighting the Ebon Blade Reapers. This is fixed through this PR:
- the Death Knight Adepts attack their owners at once after they are summoned by the Ebon Blade Reapers
- the Ebon Blade Reapers only summon a new adept on reset (after a fight and on respawn); this should prevent summoning too many adepts

###### ISSUES ADDRESSED:
Closes #1941 

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.quest remove 13164
.quest add 13164
.go 5839.84 2082.33 503.951 571
```
- watch the fight; the adepts should now spawn, fight and die one after another for each Ebon Blade Reaper

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master