### PR TITLE
fix(Core/npc_professions): Swordsmith specialization

### DIFF
--- a/src/server/scripts/World/npc_professions.cpp
+++ b/src/server/scripts/World/npc_professions.cpp
@@ -734,7 +734,7 @@ public:
                                                                 //unknown textID (TALK_AXE_LEARN)
                     SendGossipMenuFor(player, player->GetGossipTextId(creature), creature->GetGUID());
                     break;
-                    player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, GOSSIP_LEARN_SWORD,  GOSSIP_SENDER_CHECK, action);
+                case N_TRAINER_SWORD:
                     AddGossipItemFor(player, GOSSIP_ICON_CHAT, GOSSIP_LEARN_SWORD,  GOSSIP_SENDER_CHECK, action);
                                                                 //unknown textID (TALK_SWORD_LEARN)
                     SendGossipMenuFor(player, player->GetGossipTextId(creature), creature->GetGUID());


### PR DESCRIPTION
Fix for master blacksmithing trainer not teaching master swordsmith closes https://github.com/azerothcore/azerothcore-wotlk/issues/1965

To test , pull pr and follow testing instructions on issues post 

Tested and working on Debian 9 AzerothCore rev.  #b96a31e8+ 