### PR TITLE
fix(Core/Spells): Correct ID of Warlock spellscript

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1560493947655900000.sql
+++ b/data/sql/updates/pending_db_world/rev_1560493947655900000.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1560493947655900000');
+
+UPDATE `spell_script_names` SET `spell_id`=-6229 WHERE `ScriptName`='spell_warl_shadow_ward';

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -1310,7 +1310,7 @@ class spell_warl_health_funnel : public SpellScriptLoader
         }
 };
 
-// -7235 - Shadow Ward
+// -6229 - Shadow Ward
 class spell_warl_shadow_ward : public SpellScriptLoader
 {
     public:


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
Use correct spell ID for Shadow Ward (Warlock spell)

##### CHANGES PROPOSED:

-  Set correct ID of warlock spell Shadow Ward.  It was set to -7235(Shadow Protection) which is wrong
https://wotlk.evowow.com/?spell=7235
-  Correct is to use -6229 (Shadow Ward)
https://wotlk.evowow.com/?spell=6229
- Also updated DB `world` -> `spell_script_names` to match these changes


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes 


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Yes, everything fine.


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->



##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
