### PR TITLE
fix(Core/Spell): Target "TARGET_DEST_CHANNEL_TARGET"

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -1023,6 +1023,11 @@ void Spell::SelectImplicitChannelTargets(SpellEffIndex effIndex, SpellImplicitTa
                 if (target)
                     m_targets.SetDst(*target);
             }
+            else if (Spell* channeledSpell = m_originalCaster->GetCurrentSpell(CURRENT_CHANNELED_SPELL))
+            {
+                if (channeledSpell->m_targets.GetUnitTarget())
+                    m_targets.SetDst(*channeledSpell->m_targets.GetUnitTarget());
+            }
             else //if (!m_targets.HasDst())
             {
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)


### PR DESCRIPTION
##### CHANGES PROPOSED:
Spells with target "TARGET_DEST_CHANNEL_TARGET" should take over the target from the channeled spell.

###### ISSUES ADDRESSED:
Closes #1082 

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
- ```.tele VaultOfArchavon```
- fight against Archavon
- his spell "Rock Shards" should now follow and cause damage to a random player

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master