### PR TITLE
fix(DB/Core): "Battle for the Undercity" buffs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1560980987673005006.sql
+++ b/data/sql/updates/pending_db_world/rev_1560980987673005006.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1560980987673005006');
+
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_undercity_buffs';

--- a/src/server/scripts/EasternKingdoms/zone_undercity.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_undercity.cpp
@@ -1006,6 +1006,24 @@ public:
 
         EventMap _events;
 
+        void EnterEvadeMode() override
+        {
+            me->DeleteThreatList();
+            me->CombatStop(true);
+            me->SetLootRecipient(NULL);
+
+            if (HasEscortState(STATE_ESCORT_ESCORTING))
+            {
+                AddEscortState(STATE_ESCORT_RETURNING);
+                ReturnToLastPoint();
+            }
+            else
+            {
+                me->GetMotionMaster()->MoveTargetedHome();
+                Reset();
+            }
+        }
+
         void Reset() override
         {
             if (!HasEscortState(STATE_ESCORT_ESCORTING))
@@ -1541,8 +1559,7 @@ public:
                             JumpToNextStep(10 * IN_MILLISECONDS);
                             break;
                         case 5:
-                            if (Player* player = GetPlayerForEscort())
-                                player->CastSpell(player, SPELL_WRYNN_BUFF);
+                            DoCast(me, SPELL_WRYNN_BUFF);
                             JumpToNextStep(3 * IN_MILLISECONDS);
                             break;
                         case 6:
@@ -2040,8 +2057,7 @@ public:
                         _events.ScheduleEvent(EVENT_AGGRO_JAINA, 2 * IN_MILLISECONDS);
                         break;
                     case EVENT_WRYNN_BUFF:
-                        if (Player* player = GetPlayerForEscort())
-                            player->CastSpell(player, SPELL_WRYNN_BUFF);
+                        DoCast(me, SPELL_WRYNN_BUFF);
                         _events.ScheduleEvent(EVENT_WRYNN_BUFF, 10 * IN_MILLISECONDS);
                         break;
                     default:
@@ -2238,44 +2254,6 @@ public:
     }
 };
 
-class spell_undercity_buffs : public SpellScriptLoader
-{
-public:
-    spell_undercity_buffs() : SpellScriptLoader("spell_undercity_buffs") { }
-
-    class spell_undercity_buffs_AuraScript : public AuraScript
-    {
-        PrepareAuraScript(spell_undercity_buffs_AuraScript);
-
-        // Add Update for Areacheck
-        void CalcPeriodic(AuraEffect const* /*effect*/, bool& isPeriodic, int32& amplitude)
-        {
-            isPeriodic = true;
-            amplitude = 5 * IN_MILLISECONDS;
-        }
-
-        void Update(AuraEffect* /*effect*/)
-        {
-            if (Player* owner = GetUnitOwner()->ToPlayer())
-            {
-                if (owner->GetZoneId() != ZONE_TIRISFAL && owner->GetZoneId() != ZONE_UNDERCITY)
-                    owner->RemoveAura(GetSpellInfo()->Id);
-            }
-        }
-
-        void Register()
-        {
-            DoEffectCalcPeriodic += AuraEffectCalcPeriodicFn(spell_undercity_buffs_AuraScript::CalcPeriodic, EFFECT_0, SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
-            OnEffectUpdatePeriodic += AuraEffectUpdatePeriodicFn(spell_undercity_buffs_AuraScript::Update, EFFECT_0, SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
-        }
-    };
-
-    AuraScript* GetAuraScript() const
-    {
-        return new spell_undercity_buffs_AuraScript();
-    }
-};
-
 /*######
 ## HORDE
 #######*/
@@ -2367,6 +2345,25 @@ public:
         std::vector<uint64> hordeGuardsGUID;
 
         EventMap _events;
+
+        void EnterEvadeMode() override
+        {
+            me->RemoveAura(SPELL_HEROIC_VANGUARD);
+            me->DeleteThreatList();
+            me->CombatStop(true);
+            me->SetLootRecipient(NULL);
+
+            if (HasEscortState(STATE_ESCORT_ESCORTING))
+            {
+                AddEscortState(STATE_ESCORT_RETURNING);
+                ReturnToLastPoint();
+            }
+            else
+            {
+                me->GetMotionMaster()->MoveTargetedHome();
+                Reset();
+            }
+        }
 
         void Reset() override
         {
@@ -3004,8 +3001,7 @@ public:
                             JumpToNextStep(6 * IN_MILLISECONDS);
                             break;
                         case 10:
-                            if (Player* player = GetPlayerForEscort())
-                                player->CastSpell(player, SPELL_THRALL_BUFF);
+                            DoCast(me, SPELL_THRALL_BUFF);
                             JumpToNextStep(10 * IN_MILLISECONDS);
                             break;
                             // Start Event
@@ -3953,8 +3949,7 @@ public:
                         _events.ScheduleEvent(EVENT_AGGRO_SYLVANAS, 2 * IN_MILLISECONDS);
                         break;
                     case EVENT_THRALL_BUFF:
-                        if (Player* player = GetPlayerForEscort())
-                            player->CastSpell(player, SPELL_THRALL_BUFF);
+                        DoCast(me, SPELL_THRALL_BUFF);
                         _events.ScheduleEvent(EVENT_THRALL_BUFF, 10 * IN_MILLISECONDS);
                         break;
                     default:
@@ -4091,5 +4086,4 @@ void AddSC_undercity()
     new npc_lady_sylvanas_windrunner_bfu();
     new boss_blight_worm();
     new spell_blight_worm_ingest();
-    new spell_undercity_buffs();
 }


### PR DESCRIPTION
##### CHANGES PROPOSED:
- Cast the buffs from Thrall and Wrynn on themselves instead of the player. This prevents interrupting spellcasting of the player during battle.
- Override "EnterEvadeMode" for Thrall and Wrynn AI in order to prevent removing their auras on evade.
- Remove the spell script "spell_undercity_buffs" as it is not needed anymore (the players only get the aura when near Thrall or Wrynn)

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
**Horde version**
- preparation:
 ```
.quest remove 13266
.quest remove 13267
.quest add 13266
.go 1955.33 242.527 41.5081 0
```
- proceed with the quest

**Alliance version**
- preparation:
```
.quest remove 13371
.quest remove 13377
.quest add 13371
.go 1774.72 770.518 55.3043 0
```
- proceed with the quest

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master