### PR TITLE
fix(Core/Spell): Haunted Memento

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1561127338947558444.sql
+++ b/data/sql/updates/pending_db_world/rev_1561127338947558444.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561127338947558444');
+
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES (53768,'spell_gen_haunted');

--- a/data/sql/updates/pending_db_world/rev_1561127338947558444.sql
+++ b/data/sql/updates/pending_db_world/rev_1561127338947558444.sql
@@ -1,3 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561127338947558444');
 
+DELETE FROM `spell_script_names` WHERE `spell_id` = 53768;
 INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES (53768,'spell_gen_haunted');


### PR DESCRIPTION
##### CHANGES PROPOSED:
As it is now the Haunted Memento just spawns a ghost who stands there, does nothing, and also never despawns. Through this PR the Spell "Haunted" (53768) is changed so it will spawn a ghost who will follow the player around slowly for a few seconds and then despawns. It will respawn every few minutes as long as the player has the aura "Haunted".

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
Just add the item:
```.additem 40110```

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
