### PR TITLE
fix(DB/SAI): Zergling vs Grunty

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1561242305351726648.sql
+++ b/data/sql/updates/pending_db_world/rev_1561242305351726648.sql
@@ -1,0 +1,29 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561242305351726648');
+
+DELETE FROM `creature_template_addon` WHERE `entry` = 11327;
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `auras`)
+VALUES
+(11327,0,0,0,0,0,'19226'); -- Zergling aura
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 11327;
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (1132700,1132701) AND `source_type` = 9;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+-- Zergling wins
+(1132700,9,0,0,0,0,100,0,0,0,0,0,0,64,1,0,0,0,0,0,19,34694,15,0,0,0,0,0,0,'Zergling - On Script - Store Target ''Grunty'''),
+(1132700,9,1,0,0,0,100,0,0,0,0,0,0,97,15,5,1,0,0,0,12,1,0,0,0,0,0,0,0,'Zergling - On Script - Self-Jump To Pos ''Grunty'''),
+(1132700,9,2,0,0,0,100,0,0,0,0,0,0,11,67400,2,0,0,0,0,12,1,0,0,0,0,0,0,0,'Zergling - On Script - Cast ''Zergling Attack'''),
+(1132700,9,3,0,0,0,100,0,1000,1000,0,0,0,11,67400,2,0,0,0,0,12,1,0,0,0,0,0,0,0,'Zergling - On Script - Cast ''Zergling Attack'''),
+(1132700,9,4,0,0,0,100,0,500,500,0,0,0,51,0,0,0,0,0,0,12,1,0,0,0,0,0,0,0,'Zergling - On Script - Kill ''Grunty'''),
+-- Grunty wins
+(1132701,9,0,0,0,0,100,0,0,0,0,0,0,64,1,0,0,0,0,0,19,34694,15,0,0,0,0,0,0,'Zergling - On Script - Store Target ''Grunty'''),
+(1132701,9,1,0,0,0,100,0,500,500,0,0,0,86,67366,0,12,1,0,0,1,0,0,0,0,0,0,0,0,'Zergling - On Script - Cross Cast ''C-14 Gauss Rifle'''),
+(1132701,9,2,0,0,0,100,0,2300,2300,0,0,0,17,36,0,0,0,0,0,12,1,0,0,0,0,0,0,0,'Zergling - On Script - Set Emote State ''ONESHOT_ATTACK1H'''),
+(1132701,9,3,0,0,0,100,0,2300,2300,0,0,0,17,0,0,0,0,0,0,12,1,0,0,0,0,0,0,0,'Zergling - On Script - Set Emote State ''ONESHOT_NONE'''),
+(1132701,9,4,0,0,0,100,0,0,0,0,0,0,37,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Zergling - On Script - Die');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 34694;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 34694 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(34694,0,0,0,1,0,100,0,5500,5500,5500,5500,0,87,1132700,1132701,0,0,0,0,19,11327,15,0,0,0,0,0,0,'Grunty - OOC - Call Random Timed Action List For ''Zergling''');

--- a/data/sql/updates/pending_db_world/rev_1561242305351726648.sql
+++ b/data/sql/updates/pending_db_world/rev_1561242305351726648.sql
@@ -3,7 +3,7 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561242305351726648');
 DELETE FROM `creature_template_addon` WHERE `entry` = 11327;
 INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `auras`)
 VALUES
-(11327,0,0,0,0,0,'19226'); -- Zergling aura
+(11327,0,0,0,0,0,'19226'); -- Zergling aura (attack emote every 20 seconds)
 
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 11327;
 DELETE FROM `smart_scripts` WHERE `entryorguid` IN (1132700,1132701) AND `source_type` = 9;


### PR DESCRIPTION
##### CHANGES PROPOSED:
- let the Zergling fight against Grunty (50% win chance)
- add Zergling aura (will trigger attack emote every 20 seconds)

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- First player: ```.additem 13582 (Zergling Leash)```
- Second player: ```.additem 46802 (Heavy Murloc Egg)```
- learn and summon both pets

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master