### PR TITLE
fix(DB/Creature/Event): Arena Vendors & Creatures

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1561274158622782000.sql
+++ b/data/sql/updates/pending_db_world/rev_1561274158622782000.sql
@@ -1,0 +1,16 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561274158622782000');
+
+-- Adding two missing creatures Drolig and Drelig Blastpipe in Shattrah, They re located in the Scryer's Tier and Aldor Rise
+DELETE FROM `creature` WHERE `guid` IN (79018,75475);
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `spawndist`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(79018, 27722, 530, 0, 0, 1, 1, 0, 0, -2116.46, 5386.03, 53.8074, 0, 300, 0, 0, 6986, 0, 0, 0, 0, 0, '', 0),
+(75475, 27721, 530, 0, 0, 1, 1, 0, 0, -1877.61, 5650.35, 127.457, 1.45691, 300, 0, 0, 6986, 0, 0, 0, 0, 0, '', 0);
+
+-- Linking Arena vendors from the season 3 & 4 to game event
+DELETE FROM `game_event_creature` WHERE (`eventEntry`=55 AND `guid`=70996) OR (`eventEntry`=56 AND `guid` IN (75914, 79018, 75475, 88156));
+INSERT INTO `game_event_creature` (`eventEntry`, `guid`) VALUES
+(55, 70996),
+(56, 75914),
+(56, 79018),
+(56, 75475),
+(56, 88156);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
Adding missing Arena Vendors , linking creatures with Game Event ID's:
* ID: 55 - Arena Season 3
* ID: 56 - Arena Season 4

##### CHANGES PROPOSED:

- Adding two missing creatures Drolig (ID:27722) and Drelik Blastpipe (ID: 27721) in Shattrah, They re located in the Scryer's Tier and Aldor Rise. Using free Guid's from DB (Guids: 75475, 79018).
- Linking Arena vendors from the season 3 & 4 to game event.


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 --> We are missing two creatures Drolig (ID:27722 - Scryer's Tier) and Drelik Blastpipe (ID: 27721 - Aldor Rise) spawns in Shattrah. Also, others Vendors are always visible to players which is wrong. They should be linked with the Game_Event - Seasons. If the season(event) is active, the creatures should be visible too. If the season(event) is inactive they shouldn't be visible to players.

Closes 


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Yes, query imported without errors. Creatures spawned at correct positions, visible while the event is active-Invisible while the event is inactive.


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
1. Log with any character, and start the event using command 
* .event start 55
* .event start 56
2. Check these creatures guids  .go creature 70996,75914,79018,75475,88156
3. They should be visible to players.

4. Now repeat same steps, but with commands
* .event stop 55
* .event stop 56
5. Check same creatures guids  .go creature 70996,75914,79018,75475,88156 
6. They shouldn't be visible to players.


##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
