### PR TITLE
fix(DB/Spell): Argent Dawn trinkets

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1561387934007172065.sql
+++ b/data/sql/updates/pending_db_world/rev_1561387934007172065.sql
@@ -1,0 +1,27 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561387934007172065');
+
+-- Use SpellScript to summon the correct "Argent Knight" (Horde/Alliance) for "Argent War Horn"
+DELETE FROM `spell_script_names` WHERE `spell_id` = 54307;
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES (54307,'spell_item_summon_argent_knight');
+
+-- Set "Argent Dawn Banner (Visual)" not selectable
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` | 33554432 WHERE `entry` = 29443;
+
+-- Despawn "Argent Tome" after 10 seconds; not clickable by players
+UPDATE `gameobject_template` SET `type` = 5, `Data3` = 10000, `Data5` = 1 WHERE `entry` = 191312;
+
+-- Prevent the "Argent Tome" trigger creature from falling down
+UPDATE `creature_template` SET `InhabitType` = `InhabitType` | 4 WHERE `entry` = 29401;
+
+-- "Argent Tome" SAI
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 29401;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 29401 AND `source_type` = 0;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 2940100 AND `source_type` = 9;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(29401,0,0,1,54,0,100,0,0,0,0,0,0,103,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Argent Tome - On Just Summoned - Set Rooted On'),
+(29401,0,1,0,61,0,100,0,0,0,0,0,0,80,2940100,2,0,0,0,0,1,0,0,0,0,0,0,0,0,'Argent Tome - Linked - Call Timed Action List'),
+(2940100,9,0,0,0,0,100,0,0,0,0,0,0,20,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Argent Tome - Linked - Stop Auto Attack'),
+(2940100,9,1,0,0,0,100,0,0,0,0,0,0,50,191312,10,0,0,0,0,1,0,0,0,0,0,0,0,0,'Argent Tome - On Script - Summon GO ''Argent Tome'''),
+(2940100,9,2,0,0,0,100,0,1000,1000,0,0,0,9,0,0,0,0,0,0,15,191312,1,0,0,0,0,0,0,'Argent Tome - On Script - Activate GO ''Argent Tome'''),
+(2940100,9,3,0,0,0,100,0,500,500,0,0,0,11,54419,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Argent Tome - On Script - Cast ''Argent Wisdom''');

--- a/data/sql/updates/pending_db_world/rev_1561387934007172065.sql
+++ b/data/sql/updates/pending_db_world/rev_1561387934007172065.sql
@@ -1,7 +1,5 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561387934007172065');
 
--- trigger Travis
-
 -- Use SpellScript to summon the correct "Argent Knight" (Horde/Alliance) for "Argent War Horn"
 DELETE FROM `spell_script_names` WHERE `spell_id` = 54307;
 INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES (54307,'spell_item_summon_argent_knight');

--- a/data/sql/updates/pending_db_world/rev_1561387934007172065.sql
+++ b/data/sql/updates/pending_db_world/rev_1561387934007172065.sql
@@ -1,5 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561387934007172065');
 
+-- trigger Travis
+
 -- Use SpellScript to summon the correct "Argent Knight" (Horde/Alliance) for "Argent War Horn"
 DELETE FROM `spell_script_names` WHERE `spell_id` = 54307;
 INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES (54307,'spell_item_summon_argent_knight');

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -1386,6 +1386,49 @@ class spell_item_direbrew_remote : public SpellScriptLoader
         }
 };
 
+enum eArgentKnight
+{
+    SPELL_SUMMON_ARGENT_KNIGHT_ALLIANCE = 54296
+};
+
+class spell_item_summon_argent_knight :  public SpellScriptLoader
+{
+    public:
+        spell_item_summon_argent_knight() : SpellScriptLoader("spell_item_summon_argent_knight") { }
+
+        class spell_item_summon_argent_knight_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_item_summon_argent_knight_SpellScript);
+
+            void HandleOnEffectHit(SpellEffIndex effIndex)
+            {
+                if (Unit* caster = GetCaster())
+                {
+                    if (caster->GetTypeId() == TYPEID_PLAYER)
+                    {
+                        // summoning the "Argent Knight (Horde)" is default for spell 54307;
+                        if (caster->ToPlayer()->GetTeamId() == TEAM_ALLIANCE)
+                        {
+                            // prevent default summoning and summon "Argent Knight (Alliance)" instead
+                            PreventHitDefaultEffect(effIndex);
+                            caster->CastSpell(caster, SPELL_SUMMON_ARGENT_KNIGHT_ALLIANCE, true);
+                        }
+                    }
+                }
+            }
+
+            void Register()
+            {
+                OnEffectHit += SpellEffectFn(spell_item_summon_argent_knight_SpellScript::HandleOnEffectHit, EFFECT_0, SPELL_EFFECT_SUMMON);
+            }
+        };
+
+        SpellScript* GetSpellScript() const
+        {
+            return new spell_item_summon_argent_knight_SpellScript();
+        }
+};
+
 
 // Theirs
 // Generic script for handling item dummy effects which trigger another spell.
@@ -3960,6 +4003,7 @@ void AddSC_item_spell_scripts()
     new spell_item_summon_or_dismiss();
     new spell_item_draenic_pale_ale();
     new spell_item_direbrew_remote();
+    new spell_item_summon_argent_knight();
 
     // Theirs
     // 23074 Arcanite Dragonling


### PR DESCRIPTION
##### CHANGES PROPOSED:
- Argent War Horn: Summon correct version of "Argent Knight" for Horde / Alliance
- Argent Dawn Banner: Set "Argent Dawn Banner (Visual)" not selectable
- Argent Tome: Summon the Argent Tome and cast "Argent Wisdom" as it opens

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
Argent War Horn:
- ```.additem 40492```
- equip and use with Horde / Alliance player; it should summon a blood elf paladin for Horde and a human paladin for Alliance

Argent Dawn Banner:
- ```.additem 40601```
- equip and use the item; the banner should now be not selectable

Argent Tome:
- ```.additem 40593```
- equip and use the item; the tome should now appear and cast it's spell as it opens

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master