### PR TITLE
feat(Core/SAI): improve SAI logging for missing creature text

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -190,7 +190,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
         if (!sCreatureTextMgr->TextExist(talker->GetEntry(), uint8(e.action.talk.textGroupID)))
         {
-            sLog->outErrorDb("SmartScript::ProcessAction: SMART_ACTION_TALK: Entry %d SourceType %u Event %u using non-existent Text id %u for talker %u, ignored.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.action.talk.textGroupID,talker->GetEntry());
+            sLog->outErrorDb("SmartScript::ProcessAction: SMART_ACTION_TALK: EntryOrGuid %d SourceType %u EventType %u TargetType %u using non-existent Text id %u for talker %u, ignored.", e.entryOrGuid, e.GetScriptType(), e.GetEventType(), e.GetTargetType(), e.action.talk.textGroupID,talker->GetEntry());
             break;
         }
 

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -188,6 +188,12 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         if (!talker)
             break;
 
+        if (!sCreatureTextMgr->TextExist(talker->GetEntry(), uint8(e.action.talk.textGroupID)))
+        {
+            sLog->outErrorDb("SmartScript::ProcessAction: SMART_ACTION_TALK: Entry %d SourceType %u Event %u using non-existent Text id %u for talker %u, ignored.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.action.talk.textGroupID,talker->GetEntry());
+            break;
+        }
+
         mTalkerEntry = talker->GetEntry();
         mLastTextID = e.action.talk.textGroupID;
         mTextTimer = e.action.talk.duration;


### PR DESCRIPTION
##### CHANGES PROPOSED:
Improve the logging of SmartAI action "SMART_ACTION_TALK" in order to help identify missing or wrongly triggered creature talk text. This should generally help fixing issues like #1015 or #1062.

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.quest remove 12680
.quest add 12680
.go creature id 28653
```
- steal a horse and just run through the peasants / citizens
- in the server log similar error entries like the following should appear:
```
ERROR: SmartScript::ProcessAction: SMART_ACTION_TALK: EntryOrGuid 28608 SourceType 0 EventType 4 TargetType 2 using non-existent Text id 0 for talker 28606, ignored.
ERROR: SmartScript::ProcessAction: SMART_ACTION_TALK: EntryOrGuid 28557 SourceType 0 EventType 61 TargetType 7 using non-existent Text id 0 for talker 28606, ignored.
ERROR: SmartScript::ProcessAction: SMART_ACTION_TALK: EntryOrGuid 28576 SourceType 0 EventType 61 TargetType 7 using non-existent Text id 1 for talker 28605, ignored.
ERROR: SmartScript::ProcessAction: SMART_ACTION_TALK: EntryOrGuid 28577 SourceType 0 EventType 61 TargetType 7 using non-existent Text id 1 for talker 28605, ignored.
```

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
