### PR TITLE
fix(DB/creature_text): "Scarlet Medic" / "Scarlet Infantryman"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1561842370323631350.sql
+++ b/data/sql/updates/pending_db_world/rev_1561842370323631350.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561842370323631350');
+
+DELETE FROM `creature_text` WHERE `CreatureID` IN (28608,28609) AND `id` = 6;


### PR DESCRIPTION
##### CHANGES PROPOSED:
Remove on aggro text "Light bless you, my child." for "Scarlet Medic" and "Scarlet Infantryman".

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
either
- ```.go creature id 28608```
- ```.go creature id 28609```

or
- ```.npc add temp 28608```
- ```.npc add temp 28609```

None of the creatures should say the text "Light bless you, my child." on aggro anymore.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master