### PR TITLE
Fix (DB/gameobject): Faction+flags ID 184632

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1561905129740963200.sql
+++ b/data/sql/updates/pending_db_world/rev_1561905129740963200.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561905129740963200');
+
+UPDATE `gameobject_template_addon` SET `faction` = 1375, `flags` = 32 WHERE (entry = 184632);


### PR DESCRIPTION
**CHANGES PROPOSED:**
This fix should prevent the player from opening or closing the gates with a right click.
Since the gates open when the gatekeepers die. 

**ISSUES ADDRESSED:**
none

**TESTS PERFORMED:**
tested successfully in-game

Before and after https://youtu.be/pG7YPZw7Szk

**HOW TO TEST THE CHANGES:**
.go c 83173 gates

.go c 83239 gatekeepers 
.go c 83240 gatekeepers 


**KNOWN ISSUES AND TODO LIST:**
none

**Target branch(es):**
Master