### PR TITLE
fix(DB/Creature): High Overlord Saurfang

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1561967531437429600.sql
+++ b/data/sql/updates/pending_db_world/rev_1561967531437429600.sql
@@ -1,3 +1,11 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561967531437429600');
 
 UPDATE `creature` SET `unit_flags` = 512 WHERE `guid` = 200984;
+
+DELETE FROM `creature_text` WHERE `CreatureID` = 32315 AND `GroupID` BETWEEN 15 AND 18;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`)
+VALUES
+(32315,15,0,'The paladin still lives? Is it possible, Highlord? Could he have survived?',12,0,0,6,0,17107,37051,0,'High Overlord Saurfang - SAY_SAURFANG_INTRO_1'),
+(32315,16,0,'Then we must save him! If we rescue Bolvar Fordragon, we may quell the unrest between the Alliance and the Horde.',12,0,0,5,0,17108,37053,0,'High Overlord Saurfang - SAY_SAURFANG_INTRO_2'),
+(32315,17,0,'Our mission is now clear: The Lich King will answer for his crimes and we will save Highlord Bolvar Fordragon!',12,0,0,15,0,17109,37054,0,'High Overlord Saurfang - SAY_SAURFANG_INTRO_3'),
+(32315,18,0,'Kor\'kron, prepare Orgrim\'s Hammer for its final voyage! Champions, our gunship will find a point to dock on the upper reaches of the citadel. Meet us there!',14,0,0,22,0,17110,37055,0,'High Overlord Saurfang - SAY_SAURFANG_INTRO_4');

--- a/data/sql/updates/pending_db_world/rev_1561967531437429600.sql
+++ b/data/sql/updates/pending_db_world/rev_1561967531437429600.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561967531437429600');
+
+UPDATE `creature` SET `unit_flags` = 512 WHERE `guid` = 200984;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
High Overlord Saurfang

##### CHANGES PROPOSED:

-  Adding UNIT_FLAG_IMMUNE_TO_NPC (disables combat/assistance with NonPlayerCharacters (NPC)) to creature High Overlord Saurfang in icc.
-  


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1990


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Yes, the creature is fine now. No more DB errors, no more combat with mobs around.


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
1. .go c 200984
2. Pull mobs there, and move to Saurfang
3. Before when we do that, he enter in combat, and giving us DB errors about wrong text.
4. Now, he's unable to enter in combat, and we don't have anymore this issue.


##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
