### PR TITLE
fix(DB/Creature): Razorscale Harpoon Fire State

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1561997614685609600.sql
+++ b/data/sql/updates/pending_db_world/rev_1561997614685609600.sql
@@ -1,4 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561997614685609600');
 
 -- Razorscale Harpoon Fire State creature is trigger-NPC (invisible to players only)
-UPDATE `creature_template` SET `flags_extra`='130' WHERE `entry`=33282;
+UPDATE `creature_template` SET `flags_extra` = 130 WHERE `entry` = 33282;

--- a/data/sql/updates/pending_db_world/rev_1561997614685609600.sql
+++ b/data/sql/updates/pending_db_world/rev_1561997614685609600.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1561997614685609600');
+
+-- Razorscale Harpoon Fire State creature is trigger-NPC (invisible to players only)
+UPDATE `creature_template` SET `flags_extra`='130' WHERE `entry`=33282;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
Razorscale Harpoon Fire State

##### CHANGES PROPOSED:

- Adding flags_extra 128	CREATURE_FLAG_EXTRA_TRIGGER creature is trigger-NPC (invisible to players only). 
-  It already have flags_extra set to 2 | CREATURE_FLAG_EXTRA_CIVILIAN | 0x00000002 | creature does not aggro (ignore faction/reputation hostility)
- At the end it's set to flags_extra=130.


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/2035


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Yes, it should be invisible to players. It's trigger


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->



##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
