### PR TITLE
fix(DB/SAI): fix a few issues for Jotunheim

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1562149079104513383.sql
+++ b/data/sql/updates/pending_db_world/rev_1562149079104513383.sql
@@ -1,0 +1,10 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1562149079104513383');
+
+-- The Ebon Blade Prisoners should not be attackable
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` | 2 WHERE `entry` IN (30186,30194,30196,30195);
+
+-- The Jotunheim Cage should reset after 5 minutes instead of 10 in order to sync with the Ebon Blade Prisoner respawn
+UPDATE `gameobject_template` SET `Data3` = 300000 WHERE `entry` = 192135;
+
+-- Jotunheim Warrior, Njorndar Spear-Sister and Mjordin Water Magus have to use "SMART_TARGET_SELF" instead of "SMART_TARGET_ACTION_INVOKER" for their talk action
+UPDATE `smart_scripts` SET `target_type` = 1 WHERE `entryorguid` IN (30243,30632,29880) AND `source_type` = 0 AND `action_type` = 1 AND `target_type` = 7;


### PR DESCRIPTION
##### CHANGES PROPOSED:
- make the Ebon Blade Prisoners non-attackable
- reset Jotunheim Cage after 5 minutes instead of 10 in order to sync with the Ebon Blade Prisoner respawn
- Jotunheim Warrior, Njorndar Spear-Sister and Mjordin Water Magus have to use "SMART_TARGET_SELF" instead of "SMART_TARGET_ACTION_INVOKER" for their talk action

###### ISSUES ADDRESSED:
fixes part of #1062 

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.go 7706.52 3439.86 656.132 571
.additem 42422
```
- the Mjordin Water Magus should no longer attack the Ebon Blade Prisoner
- after opening the cage and freeing the Ebon Blade Prisoner the cage and the prisoner should respawn at the same time (ca. 5 minutes)
- there should be no errors like this anymore:
```
CreatureTextMgr: Could not find Text for Creature(Ebon Blade Prisoner) Entry 30186 in 'creature_text' table. Ignoring.
```

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
