### PR TITLE
fix (Core/Boss Scripts) Update boss_hodir.cpp - Fix ice shards cast speed in 10 man

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -10,7 +10,6 @@
 #include "SpellAuras.h"
 #include "PassiveAI.h"
 #include "Player.h"
-#include "MapManager.h"
 
 enum HodirSpellData
 {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -416,7 +416,7 @@ public:
                         me->PlayDirectSound(SOUND_HODIR_FLASH_FREEZE, 0);
                         SmallIcicles(false);
                         events.RepeatEvent(55000 + urand(0,10000));
-                        ((InstanceMap*)sMapMgr->FindMap(me->GetMapId(), me->GetInstanceId()))->GetMaxPlayers() > 15 ? events.ScheduleEvent(EVENT_SMALL_ICICLES_ENABLE, 12000) : events.ScheduleEvent(EVENT_SMALL_ICICLES_ENABLE, 24000);
+                        events.ScheduleEvent(EVENT_SMALL_ICICLES_ENABLE, Is25ManRaid() ? 12000 : 24000);
                         events.ScheduleEvent(EVENT_FROZEN_BLOWS, 15000);
                         events.RescheduleEvent(EVENT_FREEZE, 20000);
                     }


### PR DESCRIPTION
Fixes cast speed of Hodir ice shards in 10 man

CHANGES PROPOSED:
Adjust cast cooldown of ice shards based on 10 or 25 man (really a toggle based on if it is greater than 15 man)
Imports mapManager.h to identify the maximum players
ISSUES ADDRESSED:
Closes azerothcore#1938

TESTS PERFORMED:
Compiled on windows 7 64 bit, tested fighting hodir, saw the icicle spawn rate was approximately once every 4 seconds like on the linked video from official

HOW TO TEST THE CHANGES:
Go fight hodir in ulduar, watch the spawn speed of the ice shards

KNOWN ISSUES AND TODO LIST:
[ ]
[ ]

Target branch(es):
Master