### PR TITLE
fix(Core/CreatureScript): fix Skadi / Grauf text error

### DIFF
--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
@@ -17,8 +17,7 @@ enum Misc
     SAY_KILL                            = 1,
     EMOTE_RANGE                         = 2,
     SAY_DEATH                           = 3,
-    SAY_DRAKE_DEATH                     = 4,
-    EMOTE_BREATH                        = 5,
+    SAY_DRAKE_DEATH                     = 5,
     SAY_DRAKE_BREATH                    = 6,
 
     // SPELLS
@@ -297,7 +296,9 @@ public:
             }
             else if (param == ACTION_REMOVE_SKADI)
             {
-                Talk(SAY_DRAKE_DEATH);
+                if (Unit *passenger = me->GetVehicleKit()->GetPassenger(0))
+                    if (Creature *skadi = passenger->ToCreature())
+                        skadi->AI()->Talk(SAY_DRAKE_DEATH);
                 me->GetMotionMaster()->MovePoint(10, 480.0f, -513.0f, 108.0f);
                 events.ScheduleEvent(EVENT_GRAUF_REMOVE_SKADI, 2000);
             }


### PR DESCRIPTION
##### CHANGES PROPOSED:
Fix text error when Grauf ist taken down with the harpoons.

###### ISSUES ADDRESSED:
This PR together with #2022, #2041 and #2047 should finally conclude #1062

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
- ```.go creature id 26693```
- fight against Skadi
- after killing Grauf Skadi should now yell "You motherless knaves! Your corpses will make fine morsels for my new drake!"
- there should be no errors like this anymore:
```
CreatureTextMgr: Could not find TextGroup 4 for Creature(Grauf) GuidLow 2029953 Entry 26893. Ignoring.
```

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master