### PR TITLE
fix(DB/SAI): Overthane Balargarde

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1562237566436595766.sql
+++ b/data/sql/updates/pending_db_world/rev_1562237566436595766.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1562237566436595766');
+
+UPDATE `gameobject_template` SET `Data3` = 500000 WHERE `entry` = 193028;
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 31016 AND `source_type` = 0 AND `id` = 4;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(31016,0,4,0,54,0,100,0,0,0,0,0,0,48,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Overthane Balargarde - On Just Summoned - Set Active On');


### PR DESCRIPTION
##### CHANGES PROPOSED:
- Increase cooldown for "War Horn of Jotunheim" from 30 to 500 seconds to match the despawn timer from "Overthane Balargarde", which is also 500 seconds.
- Set "Overthane Balargarde" active after he is summoned to ensure that he will despawn after 500 seconds even if no player is around anymore.

###### ISSUES ADDRESSED:
Closes #2030 

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.quest remove 13142
.quest add 13142
.go 7073.64 4311.24 870.989 571
```
- use the War Horn; after using it it should not be possible to use it again for 500 seconds
- Overthane Balargarde should disappear after 500 seconds, no matter if a player is near or not

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master