### PR TITLE
fix(DB/Core): Dragonflayer Strategist spell "Hurl Dagger"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1562252728718185214.sql
+++ b/data/sql/updates/pending_db_world/rev_1562252728718185214.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1562252728718185214');
+
+-- Fix Dragonflayer Strategist throwing a throwing knife instead of a blue/white checkered cube when casting "Hurl Dagger"
+UPDATE `creature_equip_template` SET `ItemID3` = 29010 WHERE `CreatureID` = 23956;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -4602,6 +4602,10 @@ void SpellMgr::LoadDbcDataCorrections()
         case 42796:
             spellInfo->AttributesEx3 |= SPELL_ATTR3_DEATH_PERSISTENT;
             break;
+        case 42772: // Hurl Dagger (Normal)
+        case 59685: // Hurl Dagger (Heroic)
+            spellInfo->Attributes |= SPELL_ATTR0_REQ_AMMO;
+            break;
 
         //////////////////////////////////////////
         ////////// VIOLET HOLD


### PR DESCRIPTION
##### CHANGES PROPOSED:
Instead of a blue/white checkered cube the Dragonflayer Strategist now hurls a throwing knife if casting "Hurl Dagger".

###### ISSUES ADDRESSED:
Fixes part of #2101

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
- ```.go 325.466 247.177 30.7478 574```
- the Dragonflayer Strategist should know correctly hurl a throwing knife at the player when casting "Hurl Dagger"

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master