### PR TITLE
fix(DB/reference_loot_template): Loot error

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1562421937870171000.sql
+++ b/data/sql/updates/pending_db_world/rev_1562421937870171000.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1562421937870171000');
+
+DELETE FROM `reference_loot_template` WHERE  `Entry`=34215 AND `Item`=40811;


### PR DESCRIPTION
This its fix to: #2045 Thanks to solidmaxtor for the fix

CHANGES PROPOSED:

Fix Deletes false prey from Emalon Storm Watcher

ISSUES ADDRESSED:

Closes #2045

TESTS PERFORMED:

I tested it, and the loot's gone.

HOW TO TEST THE CHANGES:

How reproduce
Tele Vault to Archavon
kill emalon
well loot its random for many items check id in DB its more fast =)


Target branch(es):

Master