### PR TITLE
fix(DB/Disables): Disable the Spell Saronite Bomb in Eye of Eternity …

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1562509195181388404.sql
+++ b/data/sql/updates/pending_db_world/rev_1562509195181388404.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1562509195181388404');
+
+-- Disable the Saronite Bomb Spell for Eye of Eternity and Trial of the Crusader Maps https://www.wowhead.com/item=41119/saronite-bomb
+DELETE FROM `disables` WHERE `sourceType` = 0 AND `entry` = 61766;
+INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, `comment`) VALUES
+(0, 61766, 17, '616,649', '', 'Disable Spell Saronite Bomb for Eye of Eternity & Trial of the Crusader');


### PR DESCRIPTION
…& Trial of the Crusader Maps. This prevents destroying them

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  Disable the Trigger Missile Spell from Saronite Bomb for Eye of Eternity and Trial of the Crusader

-  Both Platforms are safe now from the Damage 


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes #1948


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

works as it should

##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

Go to Eye of Eternity and Trial of the Crusader and use: https://www.wowhead.com/item=41119/saronite-bomb

##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
