### PR TITLE
fix(DB/gameobject): Band-aid fix for Malygos platform

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1560396171418694700.sql
+++ b/data/sql/updates/pending_db_world/rev_1560396171418694700.sql
@@ -1,4 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1560396171418694700');
 
-UPDATE `gameobject_template_addon` SET `faction`='35' WHERE `entry`=193070; -- Nexus Raid Platform now has faction 35, instead of 0 and is friendly to players.
-UPDATE `gameobject_template` SET `Data0`='6000000' WHERE `entry`=193070; -- Nexus Raid Platform has a lot more hp in order not to break in case any siege damage is taken, initial value was 100. (double safety)
+UPDATE `gameobject_template_addon` SET `faction`=35 WHERE `entry`=193070; -- Nexus Raid Platform now has faction 35, instead of 0 and is friendly to players.
+UPDATE `gameobject_template` SET `Data0`=6000000 WHERE `entry`=193070;    -- Nexus Raid Platform has a lot more hp in order not to break in case any siege damage is taken, initial value was 100. (double safety)

--- a/data/sql/updates/pending_db_world/rev_1560396171418694700.sql
+++ b/data/sql/updates/pending_db_world/rev_1560396171418694700.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1560396171418694700');
+
+UPDATE `gameobject_template_addon` SET `faction`='35' WHERE `entry`=193070; -- Nexus Raid Platform now has faction 35, instead of 0 and is friendly to players.
+UPDATE `gameobject_template` SET `Data0`='6000000' WHERE `entry`=193070; -- Nexus Raid Platform has a lot more hp in order not to break in case any siege damage is taken, initial value was 100. (double safety)

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/instance_eye_of_eternity.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/instance_eye_of_eternity.cpp
@@ -190,7 +190,7 @@ public:
                     if (GameObject* go = instance->GetGameObject(GO_PlatformGUID))
                         if (Creature* c = instance->GetCreature(NPC_MalygosGUID))
                         {
-                            go->ModifyHealth(-1000000, c);
+                            go->ModifyHealth(-6500000, c); // We have HP 6 million in the database... So we have to do at least that
                             go->EnableCollision(false);
                         }
                     break;


### PR DESCRIPTION
Co-authored-by: Andrei-UPB Andrei-UPB@users.noreply.github.com
Co-authored-by: GMKyle GMKyle@users.noreply.github.com

Nexus Raid Platform no longer collapses on the first Saronite Bomb use

CHANGES PROPOSED:
Modify Nexus Raid Platform's health from 100 to 6.000.000, thus making it way harder to break

ISSUES ADDRESSED:
Closes #1948

TESTS PERFORMED:
Tested, the platform now breaks upon taking 6.000.000 damage ( an unreachable ammount by normal standards) rather than on 100 damage.

A saronite bomb does 150 siege damage, 25 players using Saronite Bombs on cooldown and considering 11 saronite bombs can be used before Malygos enters berserk mode (10 min), the maximum damage that will be dealt to the platform will be 41.250, if we add in Global Thermal Sapper Charges -250 siege damage per use, it will still take an unimaginable amount of pulls to actually break the platform if the platform does not recover hp between pulls (not tested yet, i'll keep working on it).
The fix is not perfect and is a band-aid solution , I will probably return with the proper one once I figure a way to make the platform immune to siege damage caused by bombs, Global Thermal Sapper Charge and the likes.

HOW TO TEST THE CHANGES:
Enter the Eye of Eternity on 10 or 25 man modes.
`.tele nexus` or `.go creature id 28859` with `.gm fly on` enabled (you might fall to your death otherwise)
`.learn 61766` - Saronite Bomb or `.learn 56488` Global Thermal Sapper Charge
Use the learned spell on the platform, notice that it does take damage but no longer breaks due to the way higher HP threshold.

KNOWN ISSUES AND TODO LIST:
  Make the platform unable to be broken by players accidentally in the first place.

Thanks to @Andei-UPB
