### PR TITLE
Fix client game crash with invite player to invalid name for Channel.

### DIFF
--- a/src/server/game/Handlers/ChannelHandler.cpp
+++ b/src/server/game/Handlers/ChannelHandler.cpp
@@ -9,7 +9,7 @@
 #include "Player.h"
 
 #include <cctype>
-#include <utf8.h>
+#include "utf8.h"
 
 void WorldSession::HandleJoinChannel(WorldPacket& recvPacket)
 {

--- a/src/server/game/Handlers/ChannelHandler.cpp
+++ b/src/server/game/Handlers/ChannelHandler.cpp
@@ -9,6 +9,7 @@
 #include "Player.h"
 
 #include <cctype>
+#include <utf8.h>
 
 void WorldSession::HandleJoinChannel(WorldPacket& recvPacket)
 {
@@ -40,7 +41,7 @@ void WorldSession::HandleJoinChannel(WorldPacket& recvPacket)
 
     // pussywizard: restrict allowed characters in channel name to avoid |0 and possibly other exploits
     //if (!ObjectMgr::IsValidChannelName(channelName))
-    if (channelName.find("|") != std::string::npos || channelName.size() >= 100)
+    if (channelName.find("|") != std::string::npos || channelName.size() >= 100 || !utf8::is_valid(channelName.begin(), channelName.end()))
         return;
 
     if (ChannelMgr* cMgr = ChannelMgr::forTeam(GetPlayer()->GetTeamId()))


### PR DESCRIPTION
Fix client game crash with invite player to invalid name for Channel.


```CMSG_JOIN_CHANNEL [Player: Testguys GUID Full: 0x00000000000042f0 Type: Player Low: 17136, Account: 6287] Channel: 1, unk1: 1, unk2: 0, channel: ÐžÐ±Ñ‰Ð¸Ð¹: ÐŸÐ¾Ð»ÑƒÐ¾ÑÑ‚Ñ€Ð¾Ð² ÐÐ´ÑÐºÐ¾Ð³Ð¾ ÐŸÐ»Ð°Ð¼ÐµÐ½Ð¸, password: 
CMSG_JOIN_CHANNEL [Player: Testguys GUID Full: 0x00000000000042f0 Type: Player Low: 17136, Account: 6287] Channel: 2, unk1: 1, unk2: 0, channel: Ð¢Ð¾Ñ€Ð³Ð¾Ð²Ð»Ñ: ÐŸÐ¾Ð»ÑƒÐ¾ÑÑ‚Ñ€Ð¾Ð² ÐÐ´ÑÐºÐ¾Ð³Ð¾ ÐŸÐ»Ð°Ð¼ÐµÐ½Ð¸, password: 
CMSG_JOIN_CHANNEL [Player: Testguys GUID Full: 0x00000000000042f0 Type: Player Low: 17136, Account: 6287] Channel: 22, unk1: 1, unk2: 0, channel: ÐžÐ±Ð¾Ñ€Ð¾Ð½Ð°: ÐŸÐ¾Ð»ÑƒÐ¾ÑÑ‚Ñ€Ð¾Ð² ÐÐ´ÑÐºÐ¾Ð³Ð¾ ÐŸÐ»Ð°Ð¼ÐµÐ½Ð¸, password: 
CMSG_JOIN_CHANNEL [Player: Testguys GUID Full: 0x00000000000042f0 Type: Player Low: 17136, Account: 6287] Channel: 26, unk1: 1, unk2: 0, channel: ÐŸÐ¾Ð¸ÑÐº ÑÐ¿ÑƒÑ‚Ð½Ð¸ÐºÐ¾Ð², password: 
CMSG_JOIN_CHANNEL [Player: Testguys GUID Full: 0x00000000000042f0 Type: Player Low: 17136, Account: 6287] Channel: 25, unk1: 1, unk2: 0, channel: Ð“Ð¸Ð»ÑŒÐ´Ð¸Ð¸: ÐŸÐ¾Ð»ÑƒÐ¾ÑÑ‚Ñ€Ð¾Ð² ÐÐ´ÑÐºÐ¾Ð³Ð¾ ÐŸÐ»Ð°Ð¼ÐµÐ½Ð¸, password: 
CMSG_JOIN_CHANNEL [Player: Testguys GUID Full: 0x00000000000042f0 Type: Player Low: 17136, Account: 6287] Channel: 0, unk1: 0, unk2: 0, channel: |01fffff1f|cffffff1f|cfffff1ff|cffff1fff|cfff1ffff|cff1fffff|cffffffff|c1fffffff|cf1ffffff|r, password: 123asd
Channel(|01fffff1f|cffffff1f|cfffff1ff|cffff1fff|cfff1ffff|cff1fffff|cffffffff|c1fffffff|cf1ffffff|r) updated in database
CMSG_CHANNEL_INVITE [Player: Testguys GUID Full: 0x00000000000042f0 Type: Player Low: 17136, Account: 6287] Channel: |01fffff1f|cffffff1f|cfffff1ff|cffff1fff|cfff1ffff|cff1fffff|cffffffff|c1fffffff|cf1ffffff|r, Target: Lichwow
CMSG_CHANNEL_INVITE [Player: Testguys GUID Full: 0x00000000000042f0 Type: Player Low: 17136, Account: 6287] Channel: |01fffff1f|cffffff1f|cfffff1ff|cffff1fff|cfff1ffff|cff1fffff|cffffffff|c1fffffff|cf1ffffff|r, Target: Lichwow
CMSG_CHANNEL_INVITE [Player: Testguys GUID Full: 0x00000000000042f0 Type: Player Low: 17136, Account: 6287] Channel: |01fffff1f|cffffff1f|cfffff1ff|cffff1fff|cfff1ffff|cff1fffff|cffffffff|c1fffffff|cf1ffffff|r, Target: Lichwow
```

https://github.com/TrinityCore/TrinityCore/commit/7b8f294c024230451f82ff67150e11fc31b61293
https://github.com/TrinityCore/TrinityCore/issues/23215


