### PR TITLE
fix(Core/Quest): Scratches

### DIFF
--- a/src/server/scripts/Outland/zone_blades_edge_mountains.cpp
+++ b/src/server/scripts/Outland/zone_blades_edge_mountains.cpp
@@ -323,7 +323,9 @@ enum Daranelle
 {
     SAY_SPELL_INFLUENCE       = 0,
     SPELL_LASHHAN_CHANNEL     = 36904,
-    SPELL_DISPELLING_ANALYSIS = 37028
+    SPELL_DISPELLING_ANALYSIS = 37028,
+	
+    NPC_KALIRI_TOTEM          = 21468
 };
 
 class npc_daranelle : public CreatureScript
@@ -346,9 +348,13 @@ public:
             {
                 if (who->HasAura(SPELL_LASHHAN_CHANNEL) && me->IsWithinDistInMap(who, 10.0f))
                 {
-                    Talk(SAY_SPELL_INFLUENCE, who);
-                    /// @todo Move the below to updateAI and run if this statement == true
-                    DoCast(who, SPELL_DISPELLING_ANALYSIS, true);
+                    if (Creature * bird = who->FindNearestCreature(NPC_KALIRI_TOTEM, 10.0f))
+                    {
+                        Talk(SAY_SPELL_INFLUENCE, who);
+                        /// @todo Move the below to updateAI and run if this statement == true
+                        DoCast(who, SPELL_DISPELLING_ANALYSIS, true);
+                        bird->DespawnOrUnsummon(2000);
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
NPC Kaliri totem despawn on [Quest](https://wotlk.evowow.com/?quest=10556) complete

##### CHANGES PROPOSED:

- Correctly despawn NPC Kaliri totem when the quest is completed.
-  


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes Nothing. Issue is next, when you do this quest, and complete it, the Quest NPC remain to player which is incorrect. NPC should be despawned on quest complete.


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Yes, builded without errors on Win. Tested in game. the Creature is correctly despawned now.


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
1. .quest add 10556
2. .go xyz 1613.3148 6935.7812 159.1015
3. Use there [Quest Item](https://wotlk.evowow.com/?item=30530), in that circle.
4. Now escort that NPC to the Quest location -> (Check without/with this commit).


##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
