### PR TITLE
fix(Core/Boss): Boss Urom

### DIFF
--- a/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
@@ -6,6 +6,7 @@
 #include "ScriptedCreature.h"
 #include "oculus.h"
 #include "SpellInfo.h"
+#include "oculus.h"
 
 enum Spells
 {
@@ -265,8 +266,11 @@ public:
                     
                     Talk(SAY_ARCANE_EXPLOSION);
                     Talk(EMOTE_ARCANE_EXPLOSION);
-
-                    me->CastSpell(me, SPELL_EMPOWERED_ARCANE_EXPLOSION, false);
+					
+                    if (me->GetMap()->IsHeroic())
+						DoCastAOE(SPELL_EMPOWERED_ARCANE_EXPLOSION_H);
+					else
+					me->CastSpell(me, SPELL_EMPOWERED_ARCANE_EXPLOSION, false);
                     events.RescheduleEvent(EVENT_TELE_BACK, DUNGEON_MODE(9000, 7000));
                 default:
                     break;
@@ -314,6 +318,9 @@ public:
                     break;
                 case EVENT_TIME_BOMB:
                     if( Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100.0f, true) )
+						if (me->GetMap()->IsHeroic())
+							DoCast(target, SPELL_TIME_BOMB_H);
+						else
                         me->CastSpell(target, SPELL_TIME_BOMB, false);
                     events.RepeatEvent(urand(20000, 25000));
                     break;

--- a/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
@@ -6,7 +6,6 @@
 #include "ScriptedCreature.h"
 #include "oculus.h"
 #include "SpellInfo.h"
-#include "oculus.h"
 
 enum Spells
 {
@@ -267,10 +266,7 @@ public:
                     Talk(SAY_ARCANE_EXPLOSION);
                     Talk(EMOTE_ARCANE_EXPLOSION);
 					
-                    if (me->GetMap()->IsHeroic())
-                        DoCastAOE(SPELL_EMPOWERED_ARCANE_EXPLOSION_H);
-                    else
-                    me->CastSpell(me, SPELL_EMPOWERED_ARCANE_EXPLOSION, false);
+                    DoCastAOE(DUNGEON_MODE(SPELL_EMPOWERED_ARCANE_EXPLOSION_N, SPELL_EMPOWERED_ARCANE_EXPLOSION_H));
                     events.RescheduleEvent(EVENT_TELE_BACK, DUNGEON_MODE(9000, 7000));
                 default:
                     break;
@@ -318,14 +314,7 @@ public:
                     break;
                 case EVENT_TIME_BOMB:
                     if( Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100.0f, true) )
-                        if (me->GetMap()->IsHeroic())
-                        {
-                            DoCast(target, SPELL_TIME_BOMB_H);
-                        }
-                        else
-                        {
-                            me->CastSpell(target, SPELL_TIME_BOMB, false);
-                        }
+                        DoCast(target, DUNGEON_MODE(SPELL_TIME_BOMB_N, SPELL_TIME_BOMB_H));
                     events.RepeatEvent(urand(20000, 25000));
                     break;
                 case EVENT_TELEPORT_TO_CENTER:

--- a/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
@@ -268,9 +268,9 @@ public:
                     Talk(EMOTE_ARCANE_EXPLOSION);
 					
                     if (me->GetMap()->IsHeroic())
-						DoCastAOE(SPELL_EMPOWERED_ARCANE_EXPLOSION_H);
-					else
-					me->CastSpell(me, SPELL_EMPOWERED_ARCANE_EXPLOSION, false);
+                        DoCastAOE(SPELL_EMPOWERED_ARCANE_EXPLOSION_H);
+                    else
+                    me->CastSpell(me, SPELL_EMPOWERED_ARCANE_EXPLOSION, false);
                     events.RescheduleEvent(EVENT_TELE_BACK, DUNGEON_MODE(9000, 7000));
                 default:
                     break;
@@ -318,9 +318,9 @@ public:
                     break;
                 case EVENT_TIME_BOMB:
                     if( Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100.0f, true) )
-						if (me->GetMap()->IsHeroic())
-							DoCast(target, SPELL_TIME_BOMB_H);
-						else
+                        if (me->GetMap()->IsHeroic())
+                            DoCast(target, SPELL_TIME_BOMB_H);
+                        else
                         me->CastSpell(target, SPELL_TIME_BOMB, false);
                     events.RepeatEvent(urand(20000, 25000));
                     break;

--- a/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
@@ -265,7 +265,7 @@ public:
                     
                     Talk(SAY_ARCANE_EXPLOSION);
                     Talk(EMOTE_ARCANE_EXPLOSION);
-					
+
                     DoCastAOE(DUNGEON_MODE(SPELL_EMPOWERED_ARCANE_EXPLOSION_N, SPELL_EMPOWERED_ARCANE_EXPLOSION_H));
                     events.RescheduleEvent(EVENT_TELE_BACK, DUNGEON_MODE(9000, 7000));
                 default:

--- a/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
@@ -319,9 +319,13 @@ public:
                 case EVENT_TIME_BOMB:
                     if( Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100.0f, true) )
                         if (me->GetMap()->IsHeroic())
+                        {
                             DoCast(target, SPELL_TIME_BOMB_H);
+                        }
                         else
-                        me->CastSpell(target, SPELL_TIME_BOMB, false);
+                        {
+                            me->CastSpell(target, SPELL_TIME_BOMB, false);
+                        }
                     events.RepeatEvent(urand(20000, 25000));
                     break;
                 case EVENT_TELEPORT_TO_CENTER:


### PR DESCRIPTION
- Should fix issue with not spawned

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->
Boss Urom teleporting issue

##### CHANGES PROPOSED:

-  Updated
-  


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1957


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Yes, builded without errors. Tested in game 15 Runs, for me it works fine. In all 15 runs , the Boss is correctly teleported, spawned.


##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
1. Do 5H dungeon several times


##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
