### PR TITLE
fix(Core/SAI): fix parameters for action type "SMART_ACTION_UPDATE_TEMPLATE"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1563920358511875161.sql
+++ b/data/sql/updates/pending_db_world/rev_1563920358511875161.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1563920358511875161');
+
+UPDATE `smart_scripts` SET `action_param2` = NOT `action_param3` WHERE `action_type` = 36;
+UPDATE `smart_scripts` SET `action_param3` = 0 WHERE `action_type` = 36;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1299,7 +1299,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
         for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
             if (IsCreature(*itr))
-                (*itr)->ToCreature()->UpdateEntry(e.action.updateTemplate.creature, NULL, !e.action.updateTemplate.doNotChangeLevel);
+                (*itr)->ToCreature()->UpdateEntry(e.action.updateTemplate.creature, NULL, e.action.updateTemplate.updateLevel != 0);
 
         delete targets;
         break;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -466,7 +466,7 @@ enum SMART_ACTION
     SMART_ACTION_CALL_KILLEDMONSTER                 = 33,     // CreatureId,
     SMART_ACTION_SET_INST_DATA                      = 34,     // Field, Data
     SMART_ACTION_SET_INST_DATA64                    = 35,     // Field,
-    SMART_ACTION_UPDATE_TEMPLATE                    = 36,     // Entry, Team, doNotChangeLevel
+    SMART_ACTION_UPDATE_TEMPLATE                    = 36,     // Entry, UpdateLevel
     SMART_ACTION_DIE                                = 37,     // No Params
     SMART_ACTION_SET_IN_COMBAT_WITH_ZONE            = 38,     // No Params
     SMART_ACTION_CALL_FOR_HELP                      = 39,     // Radius, With Emote
@@ -810,8 +810,7 @@ struct SmartAction
         struct
         {
             uint32 creature;
-            uint32 team;
-            uint32 doNotChangeLevel;
+            uint32 updateLevel;
         } updateTemplate;
 
         struct


### PR DESCRIPTION
##### CHANGES PROPOSED:
- Remove unused parameter "team" (action_param2) from action type "SMART_ACTION_UPDATE_TEMPLATE"
- invert parameter "doNotChangeLevel" (now: updateLevel) and move it from action_param3 to action_param2 (which is now equal to TC's version of the action type)

###### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
- ```.go -346.584 1402.88 30.2519 0```
- switch the event "Pyrewood Village" on and off:
```.event start 25```
```.event stop 25```
- the transforming Pyrewood Villagers should always stay on the same level
- ```.go -3542.92 2642.02 88.6888 1```
- cast "Transmogrify!" on the Mountain Giants:
```.cast 23359```
- they should sometimes change their level after becoming non-elite

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
