### PR TITLE
(Core/SpellInfo.cpp) Magmadar's Enrage dispel fix

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2569,6 +2569,7 @@ bool SpellInfo::_IsPositiveEffect(uint8 effIndex, bool deep) const
                 case 62344: // Fists of Stone
                 case 61819: // Manabonked! (item)
                 case 61834: // Manabonked! (minigob)
+                case 19451: // Enrage (Magmadar)
                     return true;
                 default:
                     break;


### PR DESCRIPTION
Fixing Magmadar's Enrage spell

##### CHANGES PROPOSED:
-  Putting the Magmadar's Enrage spell as a Buff to make it dispelable.

Closes #2129 

##### TESTS PERFORMED:
Dispelled Magmadar's Enrage successfully with Tranquilizing shot.
Windows 10.

##### Target branch(es):
Master

 ## How to test AzerothCore PRs 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
