### PR TITLE
fix(db-assembler): error 'cant find any matching row in the user table'

### DIFF
--- a/conf/config.sh.dist
+++ b/conf/config.sh.dist
@@ -152,17 +152,17 @@ DB_MYSQL_DUMP_EXEC="mysqldump"
 
 DB_AUTH_CONF="MYSQL_USER='acore'; \
                     MYSQL_PASS='acore'; \
-                    MYSQL_HOST='127.0.0.1';\
+                    MYSQL_HOST='localhost';\
                     "
 
 DB_CHARACTERS_CONF="MYSQL_USER='acore'; \
                     MYSQL_PASS='acore'; \
-                    MYSQL_HOST='127.0.0.1';\
+                    MYSQL_HOST='localhost';\
                     "
 
 DB_WORLD_CONF="MYSQL_USER='acore'; \
                     MYSQL_PASS='acore'; \
-                    MYSQL_HOST='127.0.0.1';\
+                    MYSQL_HOST='localhost';\
                     "
 
 DB_AUTH_NAME="acore_auth"


### PR DESCRIPTION
##### CHANGES PROPOSED:

-  Replace '127.0.0.1' with 'localhost' in the db-assembler script to make MySQL happy

##### TESTS PERFORMED:

- Tested on a clean Ubuntu environment (with no initial DBs)
