### PR TITLE
fix: revert unwanted Spell changes

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -1844,16 +1844,8 @@ void Spell::SelectImplicitTrajTargets(SpellEffIndex effIndex, SpellImplicitTarge
     for (; itr != targets.end(); ++itr)
     {
         if (Unit* unitTarget = (*itr)->ToUnit())
-        {
             if (m_caster == *itr || m_caster->IsOnVehicle(unitTarget) || (unitTarget)->GetVehicle())//(*itr)->IsOnVehicle(m_caster))
                 continue;
-
-            if (Creature * creatureTarget = unitTarget->ToCreature())
-            {
-                if (!(creatureTarget->GetCreatureTemplate()->type_flags & CREATURE_TYPE_FLAG_CAN_COLLIDE_WITH_MISSILES))
-                    continue;
-            }
-        }
 
         const float size = std::max((*itr)->GetObjectSize() * 0.7f, 1.0f); // 1/sqrt(3)
         // TODO: all calculation should be based on src instead of m_caster


### PR DESCRIPTION
- Partially reverts https://github.com/azerothcore/azerothcore-wotlk/commit/7954a2a07ed1af2eb050f9252d3d2c3d7dab7e1f

(such Spell changes were commited by mistake)

![image](https://user-images.githubusercontent.com/75517/63222608-a2b6c980-c1aa-11e9-99dc-3411f44e7ad2.png)
