### PR TITLE
chore(authserver): improve startup console logs

### DIFF
--- a/src/server/authserver/Main.cpp
+++ b/src/server/authserver/Main.cpp
@@ -171,7 +171,7 @@ extern int main(int argc, char** argv)
     int32 rmport = sConfigMgr->GetIntDefault("RealmServerPort", 3724);
     if (rmport < 0 || rmport > 0xFFFF)
     {
-        sLog->outError("Specified port out of allowed range (1-65535)");
+        sLog->outError("The specified RealmServerPort (%d) is out of the allowed range (1-65535)", rmport);
         return 1;
     }
 
@@ -184,6 +184,8 @@ extern int main(int argc, char** argv)
         sLog->outError("Auth server can not bind to %s:%d", bind_ip.c_str(), rmport);
         return 1;
     }
+
+    sLog->outString("Authserver listening to port %d", rmport);
 
     // Initialize the signal handlers
     AuthServerSignalHandler SignalINT, SignalTERM;

--- a/src/server/authserver/Main.cpp
+++ b/src/server/authserver/Main.cpp
@@ -185,7 +185,7 @@ extern int main(int argc, char** argv)
         return 1;
     }
 
-    sLog->outString("Authserver listening to port %d", rmport);
+    sLog->outString("Authserver listening to %s:%d", bind_ip.c_str(), rmport);
 
     // Initialize the signal handlers
     AuthServerSignalHandler SignalINT, SignalTERM;


### PR DESCRIPTION
Changes:

- improved the error shown when the authserver port is invalid (showing the name of the parameter and the actual invalid value)
- showing the bind ip address and the port that the authserver is listening to

There is no need to test since these are cosmetic changes that just add some logs, there is no way they break anything (and I have tested them locally).