### PR TITLE
fix(Core/CreatureScript): Ormorok log errors

### DIFF
--- a/src/server/scripts/Northrend/Nexus/Nexus/boss_ormorok.cpp
+++ b/src/server/scripts/Northrend/Nexus/Nexus/boss_ormorok.cpp
@@ -153,7 +153,10 @@ class boss_ormorok : public CreatureScript
                             float o = rand_norm()*2.0f*M_PI;
                             float x = me->GetPositionX()+5.0f*_spikesCount*cos(o);
                             float y = me->GetPositionY()+5.0f*_spikesCount*sin(o);
-                            me->SummonCreature(NPC_CRYSTAL_SPIKE, x, y, me->GetMap()->GetHeight(x, y, me->GetPositionZ()+5.0f), 0, TEMPSUMMON_TIMED_DESPAWN, 7000);
+                            float h = me->GetMap()->GetHeight(x, y, me->GetPositionZ()+5.0f);
+
+                            if (h != INVALID_HEIGHT)
+                                me->SummonCreature(NPC_CRYSTAL_SPIKE, x, y, h, 0, TEMPSUMMON_TIMED_DESPAWN, 7000);
                         }
                         events.ScheduleEvent(EVENT_ORMOROK_SUMMON_SPIKES, 200);
                         break;


### PR DESCRIPTION
##### CHANGES PROPOSED:
Check that each of the summoned Crystal Spikes has a valid height in order to prevent the following errors in the server log:
```
ERROR: Creature::Create(): given coordinates for creature (guidlow 5014921, entry 27099) are not valid (X: 239.317596, Y: -254.272583, Z: -100000.000000, O: 0.000000)
```

##### ISSUES ADDRESSED:
https://github.com/azerothcore/azerothcore-wotlk/issues/2233#issuecomment-524667544

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
- ```.go 248.236 -210.706 -8.25404 576```
- fight against Ormorok
- the error mentioned above should not occur anymore

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
