### PR TITLE
feat(Cmake/Build): Use interface targets for inheriting flags and definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ if( NOPCH )
   set(USE_SCRIPTPCH 0)
 endif()
 
+include(ConfigureBaseTargets)
 include(CheckPlatform)
 include(GroupSources)
 include(AutoCollect)

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,3 +1,4 @@
+#
 # Copyright (C) 2016+     AzerothCore <www.azerothcore.org>, released under GNU AGPL3 v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
 #
 # This file is free software; as a special exception the author gives
@@ -7,14 +8,7 @@
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-if( MSVC )
-  string(REGEX REPLACE "/W[0-4] " "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  string(REGEX REPLACE "/W[0-4] " "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-  add_definitions(/W0)
-else()
-  add_definitions(-w)
-endif()
+#
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   if(USE_MYSQL_SOURCES)

--- a/deps/acelite/ace/CMakeLists.txt
+++ b/deps/acelite/ace/CMakeLists.txt
@@ -348,6 +348,10 @@ if (MINGW) # GCC ignores "#prama comment"
   target_link_libraries(ace ws2_32 iphlpapi netapi32 mswsock)
 endif()
 
+target_link_libraries(ace
+  PRIVATE
+    acore-dependency-interface)
+
 # Generate precompiled header
 if(USE_COREPCH)
   add_cxx_pch(ace ${PRIVATE_PCH_HEADER})

--- a/deps/bzip2/CMakeLists.txt
+++ b/deps/bzip2/CMakeLists.txt
@@ -33,6 +33,10 @@ else()
     PUBLIC
       ${CMAKE_CURRENT_SOURCE_DIR})
 
+  target_link_libraries(bzip2
+    PRIVATE
+      trinity-dependency-interface)
+
   set_target_properties(bzip2
     PROPERTIES
       FOLDER

--- a/deps/bzip2/CMakeLists.txt
+++ b/deps/bzip2/CMakeLists.txt
@@ -35,7 +35,7 @@ else()
 
   target_link_libraries(bzip2
     PRIVATE
-      trinity-dependency-interface)
+      acore-dependency-interface)
 
   set_target_properties(bzip2
     PROPERTIES

--- a/deps/fmt/CMakeLists.txt
+++ b/deps/fmt/CMakeLists.txt
@@ -67,6 +67,10 @@ target_include_directories(fmt
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR})
 
+target_link_libraries(fmt
+  PRIVATE
+    acore-dependency-interface)
+
 set_target_properties(fmt
   PROPERTIES
     FOLDER

--- a/deps/g3dlite/CMakeLists.txt
+++ b/deps/g3dlite/CMakeLists.txt
@@ -63,6 +63,8 @@ target_include_directories(g3dlib
     ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 target_link_libraries(g3dlib
+  PRIVATE
+    acore-dependency-interface
   PUBLIC
     zlib
     threads)

--- a/deps/gsoap/CMakeLists.txt
+++ b/deps/gsoap/CMakeLists.txt
@@ -22,10 +22,14 @@ target_include_directories(gsoap
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR})
 
+target_link_libraries(gsoap
+  PRIVATE
+    acore-dependency-interface)
+
 set_target_properties(gsoap
-    PROPERTIES
-      FOLDER
-        "deps")
+  PROPERTIES
+    FOLDER
+      "deps")
 
 if (MSVC)
   # Little fix for MSVC / Windows platforms

--- a/deps/jemalloc/CMakeLists.txt
+++ b/deps/jemalloc/CMakeLists.txt
@@ -85,6 +85,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND SERVERS AND NOT NOJEM)
       -D_REENTRAN)
 
   target_link_libraries(jemalloc
+    PRIVATE
+      acore-dependency-interface
     PUBLIC
       threads
       ${CMAKE_DL_LIBS})

--- a/deps/libmpq/CMakeLists.txt
+++ b/deps/libmpq/CMakeLists.txt
@@ -29,6 +29,8 @@ target_include_directories(mpq
     ${CMAKE_SOURCE_DIR}/deps/bzip2)
 
 target_link_libraries(mpq
+  PRIVATE
+    acore-dependency-interface
   PUBLIC
     zlib
     bzip2)

--- a/deps/recastnavigation/Detour/CMakeLists.txt
+++ b/deps/recastnavigation/Detour/CMakeLists.txt
@@ -35,6 +35,8 @@ target_include_directories(Detour
 GroupSources(${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(Detour
+  PRIVATE
+    acore-dependency-interface
   PUBLIC
     zlib)
 

--- a/deps/recastnavigation/Recast/CMakeLists.txt
+++ b/deps/recastnavigation/Recast/CMakeLists.txt
@@ -39,6 +39,8 @@ target_include_directories(Recast
     ${CMAKE_CURRENT_SOURCE_DIR}/Include)
 
 target_link_libraries(Recast
+  PRIVATE
+    acore-dependency-interface
   PUBLIC
     zlib)
 

--- a/deps/zlib/CMakeLists.txt
+++ b/deps/zlib/CMakeLists.txt
@@ -47,6 +47,10 @@ else()
     PUBLIC
       ${CMAKE_CURRENT_SOURCE_DIR})
 
+  target_link_libraries(zlib
+    PRIVATE
+      acore-dependency-interface)
+
   set_target_properties(zlib
       PROPERTIES
         FOLDER

--- a/src/cmake/compiler/clang/settings.cmake
+++ b/src/cmake/compiler/clang/settings.cmake
@@ -1,20 +1,40 @@
+#
+# Copyright (C) 2016+     AzerothCore <www.azerothcore.org>, released under GNU AGPL3 v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+# Copyright (C) 2008-2019 TrinityCore <https://www.trinitycore.org/>
+#
+
 # Set build-directive (used in core to tell which buildtype we used)
-add_definitions(-D_BUILD_DIRECTIVE='"${CMAKE_BUILD_TYPE}"')
+target_compile_definitions(acore-compile-option-interface
+  INTERFACE
+    -D_BUILD_DIRECTIVE="${CMAKE_BUILD_TYPE}")
 
 if(WITH_WARNINGS)
-  set(WARNING_FLAGS "-W -Wall -Wextra -Winit-self -Wfatal-errors -Wno-mismatched-tags")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNING_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS} -Woverloaded-virtual")
+  target_compile_options(acore-warning-interface
+    INTERFACE
+      -W
+      -Wall
+      -Wextra
+      -Winit-self
+      -Wfatal-errors
+      -Wno-mismatched-tags
+      -Woverloaded-virtual)
   message(STATUS "Clang: All warnings enabled")
 endif()
 
 if(WITH_COREDEBUG)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g3")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3")
+  target_compile_options(acore-compile-option-interface
+    INTERFACE
+      -g3)
   message(STATUS "Clang: Debug-flags set (-g3)")
 endif()
 
 # -Wno-narrowing needed to suppress a warning in g3d
 # -Wno-deprecated-register is needed to suppress gsoap warnings on Unix systems.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17  -Wno-narrowing -Wno-deprecated-register")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG=1")
+target_compile_options(acore-compile-option-interface
+  INTERFACE
+    -Wno-narrowing
+    -Wno-deprecated-register)
+
+target_compile_definitions(acore-compile-option-interface
+  INTERFACE
+    -DDEBUG=1)

--- a/src/cmake/compiler/gcc/settings.cmake
+++ b/src/cmake/compiler/gcc/settings.cmake
@@ -1,5 +1,12 @@
+#
+# Copyright (C) 2016+     AzerothCore <www.azerothcore.org>, released under GNU AGPL3 v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+# Copyright (C) 2008-2019 TrinityCore <https://www.trinitycore.org/>
+#
+
 # Set build-directive (used in core to tell which buildtype we used)
-add_definitions(-D_BUILD_DIRECTIVE='"${CMAKE_BUILD_TYPE}"')
+target_compile_definitions(acore-compile-option-interface
+  INTERFACE
+    -D_BUILD_DIRECTIVE="${CMAKE_BUILD_TYPE}")
 
 set(GCC_EXPECTED_VERSION 4.8.2)
 
@@ -7,30 +14,36 @@ if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS GCC_EXPECTED_VERSION)
   message(FATAL_ERROR "GCC: This project requires version ${GCC_EXPECTED_VERSION} to build but found ${CMAKE_CXX_COMPILER_VERSION}")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-message(STATUS "GCC: Enabled c++17 support")
-
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
-message(STATUS "GCC: Enabled C99 support")
-
 if(PLATFORM EQUAL 32)
   # Required on 32-bit systems to enable SSE2 (standard on x64)
-  set(SSE_FLAGS "-msse2 -mfpmath=sse")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SSE_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SSE_FLAGS}")
+  target_compile_options(acore-compile-option-interface
+    INTERFACE
+      -msse2
+      -mfpmath=sse)
 endif()
-add_definitions(-DHAVE_SSE2 -D__SSE2__)
+
+target_compile_definitions(acore-compile-option-interface
+  INTERFACE
+    -DHAVE_SSE2
+    -D__SSE2__)
 message(STATUS "GCC: SFMT enabled, SSE2 flags forced")
 
 if( WITH_WARNINGS )
-  set(WARNING_FLAGS "-W -Wall -Wextra -Winit-self -Winvalid-pch -Wfatal-errors")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNING_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS} -Woverloaded-virtual")
+  target_compile_options(acore-warning-interface
+  INTERFACE
+    -W
+    -Wall
+    -Wextra
+    -Winit-self
+    -Winvalid-pch
+    -Wfatal-errors
+    -Woverloaded-virtual)
   message(STATUS "GCC: All warnings enabled")
 endif()
 
 if( WITH_COREDEBUG )
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g3")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3")
+  target_compile_options(acore-compile-option-interface
+  INTERFACE
+    -g3)
   message(STATUS "GCC: Debug-flags set (-g3)")
 endif()

--- a/src/cmake/compiler/icc/settings.cmake
+++ b/src/cmake/compiler/icc/settings.cmake
@@ -1,18 +1,33 @@
+#
+# Copyright (C) 2016+     AzerothCore <www.azerothcore.org>, released under GNU AGPL3 v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+# Copyright (C) 2008-2019 TrinityCore <https://www.trinitycore.org/>
+#
+
 # Set build-directive (used in core to tell which buildtype we used)
-add_definitions(-D_BUILD_DIRECTIVE="'${CMAKE_BUILD_TYPE}'")
+target_compile_definitions(acore-compile-option-interface
+  INTERFACE
+    -D_BUILD_DIRECTIVE="${CMAKE_BUILD_TYPE}")
 
 if(PLATFORM EQUAL 32)
-  add_definitions(-axSSE2)
+  target_compile_options(acore-compile-option-interface
+    INTERFACE
+      -axSSE2)
 else()
-  add_definitions(-xSSE2)
+  target_compile_options(acore-compile-option-interface
+    INTERFACE
+      -xSSE2)
 endif()
 
-if( WITH_WARNINGS )
-  add_definitions(-w1)
+if(WITH_WARNINGS)
+  target_compile_options(acore-warning-interface
+    INTERFACE
+      -w1)
   message(STATUS "ICC: All warnings enabled")
 endif()
 
-if( WITH_COREDEBUG )
-  add_definitions(-g)
+if(WITH_COREDEBUG)
+  target_compile_options(acore-compile-option-interface
+    INTERFACE
+      -g)
   message(STATUS "ICC: Debug-flag set (-g)")
 endif()

--- a/src/cmake/compiler/mingw/settings.cmake
+++ b/src/cmake/compiler/mingw/settings.cmake
@@ -1,27 +1,46 @@
+#
+# Copyright (C) 2016+     AzerothCore <www.azerothcore.org>, released under GNU AGPL3 v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+# Copyright (C) 2008-2019 TrinityCore <https://www.trinitycore.org/>
+#
+
 # set up output paths for executable binaries (.exe-files, and .dll-files on DLL-capable platforms)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 # Set build-directive (used in core to tell which buildtype we used)
-add_definitions(-D_BUILD_DIRECTIVE=\\"${CMAKE_BUILD_TYPE}\\")
+target_compile_definitions(acore-compile-option-interface
+  INTERFACE
+    -D_BUILD_DIRECTIVE="${CMAKE_BUILD_TYPE}")
 
 if(PLATFORM EQUAL 32)
   # Required on 32-bit systems to enable SSE2 (standard on x64)
-  set(SSE_FLAGS "-msse2 -mfpmath=sse")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SSE_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SSE_FLAGS}")
+  target_compile_options(acore-compile-option-interface
+    INTERFACE
+      -msse2
+      -mfpmath=sse)
 endif()
-add_definitions(-DHAVE_SSE2 -D__SSE2__)
+
+target_compile_definitions(acore-compile-option-interface
+  INTERFACE
+    -DHAVE_SSE2
+    -D__SSE2__)
 message(STATUS "GCC: SFMT enabled, SSE2 flags forced")
 
-if( WITH_WARNINGS )
-  set(WARNING_FLAGS "-W -Wall -Wextra -Winit-self -Winvalid-pch -Wfatal-errors")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNING_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS} -Woverloaded-virtual")
+if(WITH_WARNINGS)
+  target_compile_options(acore-warning-interface
+  INTERFACE
+    -W
+    -Wall
+    -Wextra
+    -Winit-self
+    -Winvalid-pch
+    -Wfatal-errors
+    -Woverloaded-virtual)
   message(STATUS "GCC: All warnings enabled")
 endif()
 
-if( WITH_COREDEBUG )
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g3")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3")
+if(WITH_COREDEBUG)
+  target_compile_options(acore-compile-option-interface
+    INTERFACE
+      -g3)
   message(STATUS "GCC: Debug-flags set (-g3)")
 endif()

--- a/src/cmake/compiler/msvc/settings.cmake
+++ b/src/cmake/compiler/msvc/settings.cmake
@@ -1,3 +1,8 @@
+#
+# Copyright (C) 2016+     AzerothCore <www.azerothcore.org>, released under GNU AGPL3 v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+# Copyright (C) 2008-2019 TrinityCore <https://www.trinitycore.org/>
+#
+
 # set up output paths for executable binaries (.exe-files, and .dll-files on DLL-capable platforms)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
@@ -5,14 +10,25 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 #set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 #set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+# CMake sets warning flags by default, however we manage it manually
+# for different core and dependency targets
+string(REGEX REPLACE "/W[0-4] " "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+# Search twice, once for space after /W argument,
+# once for end of line as CMake regex has no \b
+string(REGEX REPLACE "/W[0-4]$" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REGEX REPLACE "/W[0-4] " "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+string(REGEX REPLACE "/W[0-4]$" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+
 if(PLATFORM EQUAL 64)
   # This definition is necessary to work around a bug with Intellisense described
   # here: http://tinyurl.com/2cb428.  Syntax highlighting is important for proper
   # debugger functionality.
-  add_definitions("-D_WIN64")
+  target_compile_definitions(acore-compile-option-interface
+    INTERFACE
+      -D_WIN64)
   message(STATUS "MSVC: 64-bit platform, enforced -D_WIN64 parameter")
 
-  #Enable extended object support for debug compiles on X64 (not required on X86)
+  # Enable extended object support for debug compiles on X64 (not required on X86)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /bigobj")
   message(STATUS "MSVC: Enabled extended object-support for debug-compiles")
 else()
@@ -20,40 +36,67 @@ else()
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
   message(STATUS "MSVC: Enabled large address awareness")
 
-  add_definitions(/arch:SSE2)
+  target_compile_options(acore-compile-option-interface
+    INTERFACE
+      /arch:SSE2)
   message(STATUS "MSVC: Enabled SSE2 support")
 endif()
 
-message(STATUS "MSVC: Enabled С++17 support")
-set(CMAKE_CXX_STANDARD 17)
-
 # Set build-directive (used in core to tell which buildtype we used)
-add_definitions(-D_BUILD_DIRECTIVE=\\"$(ConfigurationName)\\")
+# msbuild/devenv don't set CMAKE_MAKE_PROGRAM, you can choose build type from a dropdown after generating projects
+if("${CMAKE_MAKE_PROGRAM}" MATCHES "MSBuild")
+  target_compile_definitions(acore-compile-option-interface
+    INTERFACE
+      -D_BUILD_DIRECTIVE="$(ConfigurationName)")
+else()
+  # while all make-like generators do (nmake, ninja)
+  target_compile_definitions(acore-compile-option-interface
+    INTERFACE
+      -D_BUILD_DIRECTIVE="${CMAKE_BUILD_TYPE}")
+endif()
 
 # multithreaded compiling on VS
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+target_compile_options(acore-compile-option-interface
+  INTERFACE
+    /MP)
 
 # Define _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES - eliminates the warning by changing the strcpy call to strcpy_s, which prevents buffer overruns
-add_definitions(-D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES)
+target_compile_definitions(acore-compile-option-interface
+  INTERFACE
+    -D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES)
 message(STATUS "MSVC: Overloaded standard names")
 
 # Ignore warnings about older, less secure functions
-add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+target_compile_definitions(acore-compile-option-interface
+  INTERFACE
+    -D_CRT_SECURE_NO_WARNINGS)
 message(STATUS "MSVC: Disabled NON-SECURE warnings")
 
-#Ignore warnings about POSIX deprecation
-add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
+# Ignore warnings about POSIX deprecation
+target_compile_definitions(acore-compile-option-interface
+  INTERFACE
+    -D_CRT_NONSTDC_NO_WARNINGS)
 message(STATUS "MSVC: Disabled POSIX warnings")
 
-#Ignore warnings about INTMAX_MAX
-add_definitions(-D__STDC_LIMIT_MACROS)
+# Ignore warnings about INTMAX_MAX
+target_compile_definitions(acore-compile-option-interface
+  INTERFACE
+    -D__STDC_LIMIT_MACROS)
 message(STATUS "MSVC: Disabled INTMAX_MAX warnings")
 
 # disable warnings in Visual Studio 8 and above if not wanted
 if(NOT WITH_WARNINGS)
   if(MSVC AND NOT CMAKE_GENERATOR MATCHES "Visual Studio 7")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4996 /wd4355 /wd4244 /wd4985 /wd4267 /wd4619")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4996 /wd4355 /wd4244 /wd4985 /wd4267 /wd4619")
+  target_compile_options(acore-warning-interface
+    INTERFACE
+      /wd4996
+      /wd4355
+      /wd4244
+      /wd4985
+      /wd4267
+      /wd4619
+      # /wd4512
+      )    
     message(STATUS "MSVC: Disabled generic compiletime warnings")
   endif()
 endif()
@@ -67,4 +110,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zm500")
 # Enable and treat as errors the following warnings to easily detect virtual function signature failures:
 # 'function' : member function does not override any base class virtual member function
 # 'virtual_function' : no override available for virtual member function from base 'class'; function is hidden
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /we4263 /we4264")
+target_compile_options(acore-warning-interface
+  INTERFACE
+    /we4263
+    /we4264)

--- a/src/cmake/macros/ConfigureBaseTargets.cmake
+++ b/src/cmake/macros/ConfigureBaseTargets.cmake
@@ -1,0 +1,78 @@
+#
+# Copyright (C) 2016+     AzerothCore <www.azerothcore.org>, released under GNU AGPL3 v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+# Copyright (C) 2008-2019 TrinityCore <https://www.trinitycore.org/>
+#
+
+# An interface library to make the target com available to other targets
+add_library(acore-compile-option-interface INTERFACE)
+
+# Use -std=c++11 instead of -std=gnu++11
+set(CXX_EXTENSIONS OFF)
+
+# Enable support С++17
+set(CMAKE_CXX_STANDARD 17)
+message(STATUS "Enabled С++17 support")
+
+# An interface library to make the target features available to other targets
+add_library(acore-feature-interface INTERFACE)
+
+target_compile_features(acore-feature-interface
+  INTERFACE
+    cxx_alias_templates
+    cxx_auto_type
+    cxx_constexpr
+    cxx_decltype
+    cxx_decltype_auto
+    cxx_final
+    cxx_lambdas
+    cxx_generic_lambdas
+    cxx_variadic_templates
+    cxx_defaulted_functions
+    cxx_nullptr
+    cxx_trailing_return_types
+    cxx_return_type_deduction)
+
+# An interface library to make the warnings level available to other targets
+# This interface taget is set-up through the platform specific script
+add_library(acore-warning-interface INTERFACE)
+
+# An interface used for all other interfaces
+add_library(acore-default-interface INTERFACE)
+target_link_libraries(acore-default-interface
+  INTERFACE
+    acore-compile-option-interface
+    acore-feature-interface)
+
+# An interface used for silencing all warnings
+add_library(acore-no-warning-interface INTERFACE)
+
+if (MSVC)
+  target_compile_options(acore-no-warning-interface
+    INTERFACE
+      /W0)
+else()
+  target_compile_options(acore-no-warning-interface
+    INTERFACE
+      -w)
+endif()
+
+# An interface library to change the default behaviour
+# to hide symbols automatically.
+add_library(acore-hidden-symbols-interface INTERFACE)
+
+# An interface amalgamation which provides the flags and definitions
+# used by the dependency targets.
+add_library(acore-dependency-interface INTERFACE)
+target_link_libraries(acore-dependency-interface
+  INTERFACE
+    acore-default-interface
+    acore-no-warning-interface
+    acore-hidden-symbols-interface)
+
+# An interface amalgamation which provides the flags and definitions
+# used by the core targets.
+add_library(acore-core-interface INTERFACE)
+target_link_libraries(acore-core-interface
+  INTERFACE
+    acore-default-interface
+    acore-warning-interface)

--- a/src/cmake/platform/unix/settings.cmake
+++ b/src/cmake/platform/unix/settings.cmake
@@ -40,5 +40,7 @@ elseif(CMAKE_C_COMPILER MATCHES "icc")
 elseif(CMAKE_C_COMPILER MATCHES "clang" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
   include(${CMAKE_SOURCE_DIR}/src/cmake/compiler/clang/settings.cmake)
 else()
-add_definitions(-D_BUILD_DIRECTIVE='"${CMAKE_BUILD_TYPE}"')
+  target_compile_definitions(acore-compile-option-interface
+    INTERFACE
+      -D_BUILD_DIRECTIVE="${CMAKE_BUILD_TYPE}")
 endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(common
   PRIVATE
     game-interface
   PUBLIC
+    acore-core-interface
     ace
     mysql
     g3dlib


### PR DESCRIPTION
Co-authored-by: Naios <Naios@users.noreply.github.com>

Based TC commit https://github.com/TrinityCore/TrinityCore/commit/e60c1f84a7e13577a82046b02b214f9466d20a7c

##### CHANGES PROPOSED:
- Remove the usage of global flags and definitions
  set through the CMAKE_CXX_FLAGS variable.
- Use cmake target compile features for setting the
  CXX standard automatically.

##### ISSUES ADDRESSED:
- Closes

##### TESTS PERFORMED:
- [x] Build in win VS 2019

##### HOW TO TEST THE CHANGES:
- Build this

##### KNOWN ISSUES AND TODO LIST:
- [x] Test build in Linux

##### Target branch(es):
- [x] Master

## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR