### PR TITLE
fix(DB/Quest): Lumber Hack

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1567608091409034200.sql
+++ b/data/sql/updates/pending_db_world/rev_1567608091409034200.sql
@@ -1,0 +1,20 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1567608091409034200');
+
+-- Prevent casting "Twisting Blade" on self ("Xink's Shredder") or on the player
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 17 AND `SourceEntry` = 47938;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`)
+VALUES
+(17,0,47938,0,0,33,1,0,0,0,1,0,0,'','Spell ''Twisting Blade'' - Invalid Target - Self'),
+(17,0,47938,0,0,31,1,4,0,0,1,0,0,'','Spell ''Twisting Blade'' - Invalid Target - Player');
+
+-- Disable random movement for "Zivlix's Destruction Machine"
+UPDATE `creature` SET `spawndist` = 0, `MovementType` = 0 WHERE `guid` = 100815;
+
+-- Xink's Shredder SAI
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 27061;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 27061 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(27061,0,0,0,54,0,100,0,0,0,0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Xink''s Shredder - On Just Summoned - Say Line 0'),
+(27061,0,1,2,28,0,100,0,0,0,0,0,0,1,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Xink''s Shredder - On Passenger Removed - Say Line 1'),
+(27061,0,2,0,61,0,100,0,0,0,0,0,0,41,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Xink''s Shredder - Linked - Force Despawn');


### PR DESCRIPTION
##### CHANGES PROPOSED:
- Fix some issues concerning the vehicle "Xink's Shredder" provided for the Quest "Lumber Hack":
  - Ensure that the vehicle spell "Twisting Blade" cannot target itself or the player.
  - Add emotes when summoning and dismissing the shredder.
- Disable random movement for "Zivlix's Destruction Machine" at Nozzlerust Post.

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.q rem 12050
.q a 12050
.go c id 26660
```
- proceed with the quest, check the emotes of the shredder and try to use "Twisting Blade" without a target
- also check "Zivlix's Destruction Machine" at Nozzlerust Post

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
