### PR TITLE
fix(Core/CreatureScript): Quest "Kindness"

### DIFF
--- a/src/server/scripts/Outland/zone_shadowmoon_valley.cpp
+++ b/src/server/scripts/Outland/zone_shadowmoon_valley.cpp
@@ -348,7 +348,7 @@ public:
 
         void JustReachedHome() override
         {
-            me->GetMotionMaster()->Clear();
+            me->GetMotionMaster()->InitDefault();
         }
 
         void UpdateAI(uint32 diff) override


### PR DESCRIPTION
##### CHANGES PROPOSED:
After feeding a drake during the quest "Kindness" it should fly away and continue it's waypoint movement instead of just hovering in the air.

##### ISSUES ADDRESSED:
#2267

##### TESTS PERFORMED:
Tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.q rem 10804
.q a 10804
.ad 31372 8
.go -4095.99 809.262 2.43068 530
```
- just proceed with the quest; after being fed the drakes should now continue their waypoint movement; please note that after feeding a drake it gets the aura "Has Eaten Recently" preventing it to be fed for 1 minute

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
