### PR TITLE
fix(DB/SAI): Wind Trader Marid

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1568383989969278689.sql
+++ b/data/sql/updates/pending_db_world/rev_1568383989969278689.sql
@@ -1,0 +1,20 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1568383989969278689');
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 20071 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(20071,0,0,1,62,0,100,0,8071,0,0,0,0,48,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Wind Trader Marid - On Gossip Select - Set Active On'),
+(20071,0,1,2,61,0,100,0,0,0,0,0,0,1,0,0,0,0,0,0,7,0,0,0,0,0,0,0,0,'Wind Trader Marid - Linked - Say Line 0'),
+(20071,0,2,3,61,0,100,0,0,0,0,0,0,72,0,0,0,0,0,0,7,0,0,0,0,0,0,0,0,'Wind Trader Marid - Linked - Close Gossip'),
+(20071,0,3,4,61,0,100,0,0,0,0,0,0,81,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Wind Trader Marid - Linked - Set NPC Flags'),
+(20071,0,4,0,61,0,100,0,0,0,0,0,0,67,1,3000,3000,0,0,0,1,0,0,0,0,0,0,0,0,'Wind Trader Marid - Linked - Create Timed Event ID 1'),
+(20071,0,5,0,59,0,100,0,1,0,0,0,0,53,0,20071,0,0,0,1,1,0,0,0,0,0,0,0,0,'Wind Trader Marid - On Timed Event ID 1 - Start WP'),
+(20071,0,6,7,40,0,100,0,15,0,0,0,0,66,0,0,0,0,0,0,8,0,0,0,0,0,0,0,0,'Wind Trader Marid - WP Reached - Set Orientation'),
+(20071,0,7,8,61,0,100,0,0,0,0,0,0,1,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Wind Trader Marid - Linked - Say Line 1'),
+(20071,0,8,9,61,0,100,0,0,0,0,0,0,67,2,4000,4000,0,0,0,1,0,0,0,0,0,0,0,0,'Wind Trader Marid - Linked - Create Timed Event ID 2'),
+(20071,0,9,0,61,0,100,0,0,0,0,0,0,41,30000,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Wind Trader Marid - Linked - Force Despawn After 5 Minutes'),
+(20071,0,10,11,59,0,100,0,2,0,0,0,0,2,14,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Wind Trader Marid - On Timed Event ID 2 - Set Faction'),
+(20071,0,11,12,61,0,100,0,0,0,0,0,0,12,20101,4,10000,0,0,0,8,0,0,0,0,4327.28,2133.79,126.42,2.88,'Wind Trader Marid - Linked - Summon Creature'),
+(20071,0,12,13,61,0,100,0,0,0,0,0,0,12,20101,4,10000,0,0,0,8,0,0,0,0,4328.97,2140.08,124.66,2.88,'Wind Trader Marid - Linked - Summon Creature'),
+(20071,0,13,14,61,0,100,0,0,0,0,0,0,19,768,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Wind Trader Marid - Linked - Remove Unit Flags'),
+(20071,0,14,0,61,0,100,0,0,0,0,0,0,49,0,0,0,0,0,0,21,20,0,0,0,0,0,0,0,'Wind Trader Marid - Linked - Attack Start');


### PR DESCRIPTION
##### CHANGES PROPOSED:
- Set Marid active after the player selects the gossip option concerning quest "Troublesome Distractions" and despawn him 5 minutes after he reached the destination of his path (this ensures that the NPC is reset if the player decides to just run away or log out).
- Cleaned up the SAI a bit and updated the comments.
- Prevent the following error in the server log, which was caused by a bug in the old SAI script:
```
ERROR: SmartScript::ProcessAction: Entry 20071 SourceType 0, Event 0, Link Event 1 not found or invalid, skipped.
```

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.q rem 10273
.q a 10273
.go 4285.85 2231.63 124.217 530
```
- proceed with the quest and just run away; Marid should reset after ca. 5 minutes

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
