### PR TITLE
fix(DB/gameobject): Tallonkai's Dresser

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1568496805410616069.sql
+++ b/data/sql/updates/pending_db_world/rev_1568496805410616069.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1568496805410616069');
+
+UPDATE `gameobject` SET `spawntimesecs` = 0 WHERE `guid` = 49828;


### PR DESCRIPTION
##### CHANGES PROPOSED:
Reduce the respawn time of "Tallonkai's Dresser" used for the quest "The Emerald Dreamcatcher" in order to allow other party members to loot the item.

##### ISSUES ADDRESSED:
Closes #2256

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.q rem 2438
.q a 2438
.go 9814.81 353.474 1308.46 1
```
- proceed with the quest; the game object should not vanish anymore

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
