### PR TITLE
fix(DB/gossip_menu_option): Gossip Dalaran NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1568644079531382202.sql
+++ b/data/sql/updates/pending_db_world/rev_1568644079531382202.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1568644079531382202');
+
+DELETE FROM `gossip_menu_option` WHERE `MenuID` = 10097 AND `OptionID` = 2;


### PR DESCRIPTION
##### CHANGES PROPOSED:
Remove one of the two duplicate gossip options "The Horde Quarter" when asking NPCs about class trainers.

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- ```.tele dalaran```
- just speak with the NPCs, asking for directions to the class trainers; there should now be no duplicate entry anymore concerning the Horde quarter

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
