### PR TITLE
fix(DB/SAI): Battle beneath the Dark Portal, part 2

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1568644505350490588.sql
+++ b/data/sql/updates/pending_db_world/rev_1568644505350490588.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1568644505350490588');
+
+UPDATE `smart_scripts` SET `link` = 10 WHERE `source_type` = 0 AND `entryorguid` = -68744 AND `id` = 9;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = -68744 AND `id` = 10;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`)
+VALUES
+(-68744,0,10,0,61,0,100,0,0,0,0,0,0,48,1,0,0,0,0,0,11,19005,50,1,0,0,0,0,0,'Infernal Relay (Hellfire) - Linked - Set Active On - All Wrath Masters Within 50 Yards');


### PR DESCRIPTION
##### CHANGES PROPOSED:
This is related to PR #1719. The initial wave of demons did not attack if the player just triggered the spawn, but then moves out of reach. This is fixed by setting the initial Wrath Masters active.

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- ```.go -248.322 934.786 84.3793 530```
- just fly as GM over the intial wave of demons and continue to the Path of Glory until out of reach; wait a bit and return: The battle should have been started even without a player around.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
