### PR TITLE
fix(Core/spell_item): Fix a few items with spell effects

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1568988467237730140.sql
+++ b/data/sql/updates/pending_db_world/rev_1568988467237730140.sql
@@ -1,0 +1,12 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1568988467237730140');
+
+UPDATE `broadcast_text` SET `MaleText` = REPLACE(`MaleText`,'%s','$n'), `FemaleText` = REPLACE(`FemaleText`,'%s','$n') WHERE `ID` = 31843;
+UPDATE `broadcast_text_locale` SET `MaleText` = REPLACE(`MaleText`,'%s','$n'), `FemaleText` = REPLACE(`FemaleText`,'%s','$n') WHERE `ID` = 31843;
+
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (57426,57301,58474,58465);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`)
+VALUES
+(57426,'spell_item_feast'),
+(57301,'spell_item_feast'),
+(58474,'spell_item_feast'),
+(58465,'spell_item_feast');

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -48,6 +48,13 @@ class spell_item_massive_seaforium_charge : public SpellScriptLoader
         }
 };
 
+enum TitaniumSealOfDalaran
+{
+    TITANIUM_SEAL_OF_DALARAN_BROADCAST_TEXT_ID_FLIP      = 32638,
+    TITANIUM_SEAL_OF_DALARAN_BROADCAST_TEXT_ID_HEADS_UP  = 32663,
+    TITANIUM_SEAL_OF_DALARAN_BROADCAST_TEXT_ID_FACE_DOWN = 32664
+};
+
 class spell_item_titanium_seal_of_dalaran : public SpellScriptLoader
 {
     public:
@@ -64,12 +71,19 @@ class spell_item_titanium_seal_of_dalaran : public SpellScriptLoader
                 Unit* caster = GetCaster();
                 if (Player* player = caster->ToPlayer())
                 {
-                    std::string name = player->GetName();
-                    player->TextEmote("casually flips his Titanium Seal of Dalaran");
+                    LocaleConstant loc_idx = player->GetSession()->GetSessionDbLocaleIndex();
+                    if (BroadcastText const* bct = sObjectMgr->GetBroadcastText(TITANIUM_SEAL_OF_DALARAN_BROADCAST_TEXT_ID_FLIP))
+                        player->TextEmote(bct->GetText(loc_idx, player->getGender()));
                     if (urand(0,1))
-                        player->TextEmote("finds the coin face down for tails!");
+                    {
+                        if (BroadcastText const* bct = sObjectMgr->GetBroadcastText(TITANIUM_SEAL_OF_DALARAN_BROADCAST_TEXT_ID_FACE_DOWN))
+                            player->TextEmote(bct->GetText(loc_idx, player->getGender()));
+                    }
                     else
-                        player->TextEmote("catches the coin heads up!");
+                    {
+                        if (BroadcastText const* bct = sObjectMgr->GetBroadcastText(TITANIUM_SEAL_OF_DALARAN_BROADCAST_TEXT_ID_HEADS_UP))
+                            player->TextEmote(bct->GetText(loc_idx, player->getGender()));
+                    }
                 }
             }
 
@@ -734,14 +748,27 @@ public:
     }
 };
 
-class spell_item_fish_feast : public SpellScriptLoader
+enum Feast
+{
+    SPELL_GREAT_FEAST                        = 57301,
+    SPELL_FISH_FEAST                         = 57426,
+    SPELL_SMALL_FEAST                        = 58474,
+    SPELL_GIGANTIC_FEAST                     = 58465,
+
+    GREAT_FEAST_BROADCAST_TEXT_ID_PREPARE    = 31843,
+    FISH_FEAST_BROADCAST_TEXT_ID_PREPARE     = 31844,
+    SMALL_FEAST_BROADCAST_TEXT_ID_PREPARE    = 31845,
+    GIGANTIC_FEAST_BROADCAST_TEXT_ID_PREPARE = 31846
+};
+
+class spell_item_feast : public SpellScriptLoader
 {
     public:
-        spell_item_fish_feast() : SpellScriptLoader("spell_item_fish_feast") {}
+        spell_item_feast() : SpellScriptLoader("spell_item_feast") {}
 
-        class spell_item_fish_feast_SpellScript : public SpellScript
+        class spell_item_feast_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_fish_feast_SpellScript);
+            PrepareSpellScript(spell_item_feast_SpellScript);
 
             bool Load()
             {
@@ -751,18 +778,43 @@ class spell_item_fish_feast : public SpellScriptLoader
             void HandleScriptEffect(SpellEffIndex effIndex)
             {
                 PreventHitDefaultEffect(effIndex);
-                GetCaster()->ToPlayer()->TextEmote("prepares a Fish Feast!");
+
+                Unit* caster = GetCaster();
+                if (Player* player = caster->ToPlayer())
+                {
+                    LocaleConstant loc_idx = player->GetSession()->GetSessionDbLocaleIndex();
+
+                    switch(GetSpellInfo()->Id)
+                    {
+                        case SPELL_GREAT_FEAST:
+                            if (BroadcastText const* bct = sObjectMgr->GetBroadcastText(GREAT_FEAST_BROADCAST_TEXT_ID_PREPARE))
+                                player->MonsterTextEmote(bct->GetText(loc_idx, player->getGender()).c_str(), player, false);
+                            break;
+                        case SPELL_FISH_FEAST:
+                            if (BroadcastText const* bct = sObjectMgr->GetBroadcastText(FISH_FEAST_BROADCAST_TEXT_ID_PREPARE))
+                                player->MonsterTextEmote(bct->GetText(loc_idx, player->getGender()).c_str(), player, false);
+                            break;
+                        case SPELL_SMALL_FEAST:
+                            if (BroadcastText const* bct = sObjectMgr->GetBroadcastText(SMALL_FEAST_BROADCAST_TEXT_ID_PREPARE))
+                                player->MonsterTextEmote(bct->GetText(loc_idx, player->getGender()).c_str(), player, false);
+                            break;
+                        case SPELL_GIGANTIC_FEAST:
+                            if (BroadcastText const* bct = sObjectMgr->GetBroadcastText(GIGANTIC_FEAST_BROADCAST_TEXT_ID_PREPARE))
+                                player->MonsterTextEmote(bct->GetText(loc_idx, player->getGender()).c_str(), player, false);
+                            break;
+                    }
+                }
             }
 
             void Register()
             {
-                OnEffectHitTarget += SpellEffectFn(spell_item_fish_feast_SpellScript::HandleScriptEffect, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+                OnEffectHitTarget += SpellEffectFn(spell_item_feast_SpellScript::HandleScriptEffect, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
             }
         };
 
         SpellScript* GetSpellScript() const
         {
-            return new spell_item_fish_feast_SpellScript();
+            return new spell_item_feast_SpellScript();
         }
 };
 
@@ -1055,15 +1107,6 @@ class spell_item_oracle_ablutions : public SpellScriptLoader
                         break;
                     default:
                         break;
-                }
-                if (Player* player = caster->ToPlayer())
-                {
-                    std::string name = player->GetName();
-                    player->TextEmote("casually flips his Titanium Seal of Dalaran");
-                    if (urand(0,1))
-                        player->TextEmote("finds the coin face down for tails!");
-                    else
-                        player->TextEmote("catches the coin heads up!");
                 }
             }
 
@@ -3987,7 +4030,7 @@ void AddSC_item_spell_scripts()
     new spell_item_crazy_alchemists_potion();
     new spell_item_skull_of_impeding_doom();
     new spell_item_carrot_on_a_stick();
-    new spell_item_fish_feast();
+    new spell_item_feast();
     new spell_item_gnomish_universal_remote();
     new spell_item_strong_anti_venom();
     new spell_item_gnomish_shrink_ray();


### PR DESCRIPTION
##### CHANGES PROPOSED:
- Remove a wrong emote played while using the "Oracle Talisman of Ablution" (every time you kill an enemy which grants the spell effect the emote about the "Titanium Seal of Dalaran" was played).
- Use broadcast text for the emotes of the "Titanium Seal of Dalaran" (text was hard-coded before).
- Use broadcast text for the emotes of "Fish Feast", "Great Feast", "Small Feast" and "Gigantic Feast".

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
- ```.au 59787``` (or alternatively use "Oracle Talisman of Ablution", ID 44074):
  - there should no longer occur an emote about the "Titanium Seal of Dalaran" if you kill enemies.
- ```.ad 44430```:
  - use the item: It should now display the emotes in the correct language with the correct gender.
- Use each of the feasts:
  ```
  .additem 43015
  .additem 43480
  .additem 43478
  .additem 34753
  ```
  - They should now display the emote in the correct language.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
