### PR TITLE
fix(CMake): Use cmake-generator-expressions for escaping quotes

### DIFF
--- a/src/cmake/showoptions.cmake
+++ b/src/cmake/showoptions.cmake
@@ -14,7 +14,7 @@ if( UNIX )
 endif()
 
 message("* Install configs to              : ${CONF_DIR}")
-add_definitions(-D_CONF_DIR="\\"${CONF_DIR}\\"")
+add_definitions(-D_CONF_DIR=$<1:"${CONF_DIR}">)
 
 message("")
 

--- a/src/server/worldserver/CMakeLists.txt
+++ b/src/server/worldserver/CMakeLists.txt
@@ -131,7 +131,7 @@ FOREACH(configFile ${MODULE_CONFIG_FILE_LIST})
     get_filename_component(file_name ${configFile} NAME_WE)
     set(CONFIG_LIST ${CONFIG_LIST}${file_name},)
 ENDFOREACH()
-add_definitions(-DCONFIG_FILE_LIST="\\"${CONFIG_LIST}\\"")
+add_definitions(-DCONFIG_FILE_LIST=$<1:"${CONFIG_LIST}">)
 # end handle config file
 
 CU_RUN_HOOK("AFTER_WORLDSERVER_CMAKE")


### PR DESCRIPTION
##### CHANGES PROPOSED:
Use [cmake-generator-expressions](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html) for escaping quotation marks. This should fix the latest compile errors and render the PRs #2303 and #2305 obsolete.

##### ISSUES ADDRESSED:
Closes #2306

##### TESTS PERFORMED:
tested build on Ubuntu 16.04 / clang 7 with PCH (pre-compiled headers) turned on via the following cmake options:
```-DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1```

##### HOW TO TEST THE CHANGES:
Compile using the following cmake options:
```-DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1```

##### KNOWN ISSUES AND TODO LIST:
- [ ] Build successful on Linux
- [ ] Build successful on Windows

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
