### PR TITLE
fix(DB/SAI): Fel Reaver

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1569531971839824730.sql
+++ b/data/sql/updates/pending_db_world/rev_1569531971839824730.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1569531971839824730');
+
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 18733 AND `id` = 1;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(18733,0,1,0,0,0,100,0,12000,25000,12000,25000,0,11,36835,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Fel Reaver - In Combat - Cast ''War Stomp''');


### PR DESCRIPTION
##### CHANGES PROPOSED:
The Fel Reaver should use War Stomp in combat.

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- `.go creature id 18733`
- fight against the Fel Reaver; he should now use War Stomp every 12-25 seconds

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
