### PR TITLE
feat(cmake/macro): Allow scripts to lower prioritize other scripts

### DIFF
--- a/src/cmake/ac_macros.cmake
+++ b/src/cmake/ac_macros.cmake
@@ -9,8 +9,26 @@ ENDMACRO()
 # AC_ADD_SCRIPT_LOADER
 #
 MACRO(AC_ADD_SCRIPT_LOADER script_dec include)
-    CU_ADD_GLOBAL("AC_ADD_SCRIPTS_LIST" "Add${script_dec}Scripts()\;")
-    
+    set (lower_prio_scripts ${ARGN})
+    list(LENGTH lower_prio_scripts num_lower_prio_scripts)
+    if (${num_lower_prio_scripts} GREATER 0)
+        CU_GET_GLOBAL("AC_ADD_SCRIPTS_LIST")
+        foreach(lower_prio_script ${lower_prio_scripts})
+            if ("${AC_ADD_SCRIPTS_LIST}" MATCHES "Add${lower_prio_script}Scripts()")
+                message("-- ${script_dec} demands lower priority: ${lower_prio_script} --")
+                list(REMOVE_ITEM AC_ADD_SCRIPTS_LIST "Add${lower_prio_script}Scripts()")
+                CU_SET_GLOBAL("AC_ADD_SCRIPTS_LIST" "${AC_ADD_SCRIPTS_LIST}")
+                list(APPEND removed_lower_prio_scripts ${lower_prio_script})
+            endif()
+        endforeach()
+        CU_ADD_GLOBAL("AC_ADD_SCRIPTS_LIST" "Add${script_dec}Scripts()\;")
+        foreach(lower_prio_script ${removed_lower_prio_scripts})
+            CU_ADD_GLOBAL("AC_ADD_SCRIPTS_LIST" "Add${lower_prio_script}Scripts()\;")
+        endforeach()
+    else()
+        CU_ADD_GLOBAL("AC_ADD_SCRIPTS_LIST" "Add${script_dec}Scripts()\;")
+    endif()
+
 
     if (NOT ${include} STREQUAL "")
         CU_GET_GLOBAL("AC_ADD_SCRIPTS_INCLUDE")


### PR DESCRIPTION
##### CHANGES PROPOSED:
Currently there are 2 conflicting modules:
mod-transmog
mod-weapon-visual

Both use "OnLogin" to apply their visual modifications, but the modifications of "mod-transmog" have to be executed before "mod-weapon-visual". This PR introduces additional optional arguments for the cmake macro "AC_ADD_SCRIPT_LOADER" which can contain script names which should be handled with lower priority. This way it is possible to ensure that the scripts of one module are always executed before the other specified module scripts.

This will in no way affect existing behaviour, only if the additional arguments are specified.

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully on Ubuntu 16.04 with cmake version 3.15.4

##### HOW TO TEST THE CHANGES:
I tested it using these modules, but it can be tested with any combination of modules:
- mod-autobalance
- mod-npc-beastmaster
- mod-transmog
- mod-weapon-visual

After running cmake the resulting "GenLoader.cpp" contains this order (this is also the case without this PR, see that "SC_Npc_VisualWeapon" is before "Transmog" which causes the error in the modules):
```cpp
void AddScripts() {
    AddSC_Npc_VisualWeaponScripts();AddTransmogScripts();AddBeastMasterScripts();AddAutoBalanceScripts();AddSpellScripts();AddSC_SmartScripts();AddCommandScripts();AddWorldScripts();AddOutdoorPvPScripts();AddEasternKingdomsScripts();AddKalimdorScripts();AddOutlandScripts();AddNorthrendScripts();AddEventScripts();AddPetScripts();
}
```

I then applied the following changes to the "CMakeLists.txt"-files of the modules:
**mod-transmog:**
```patch
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 3bc10bc..2c11c71 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 AC_ADD_SCRIPT("${CMAKE_CURRENT_LIST_DIR}/src/transmog_scripts.cpp")
 AC_ADD_SCRIPT("${CMAKE_CURRENT_LIST_DIR}/src/Transmogrification.cpp")
-AC_ADD_SCRIPT_LOADER("Transmog" "${CMAKE_CURRENT_LIST_DIR}/src/transmog_scripts_loader.h")
+AC_ADD_SCRIPT_LOADER("Transmog" "${CMAKE_CURRENT_LIST_DIR}/src/transmog_scripts_loader.h" "SC_Npc_VisualWeapon")

 AC_ADD_CONFIG_FILE("${CMAKE_CURRENT_LIST_DIR}/conf/transmog.conf.dist")
```

**mod-autobalance (just for testing):**
```patch
diff --git a/CMakeLists.txt b/CMakeLists.txt
index bfaec6a..6d5dc83 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 AC_ADD_SCRIPT("${CMAKE_CURRENT_LIST_DIR}/src/AutoBalance.cpp")
 AC_ADD_SCRIPT("${CMAKE_CURRENT_LIST_DIR}/src/AutoBalance.h")
-AC_ADD_SCRIPT_LOADER("AutoBalance" "${CMAKE_CURRENT_LIST_DIR}/src/loader.h")
+AC_ADD_SCRIPT_LOADER("AutoBalance" "${CMAKE_CURRENT_LIST_DIR}/src/loader.h" "Transmog" "SC_Npc_VisualWeapon" "BeastMaster")

 AC_ADD_CONFIG_FILE("${CMAKE_CURRENT_LIST_DIR}/conf/AutoBalance.conf.dist")
```

After a new cmake run the resultinig "GenLoader.cpp" contained this order:
```cpp
void AddScripts() {
    AddAutoBalanceScripts();AddTransmogScripts();AddSC_Npc_VisualWeaponScripts();AddBeastMasterScripts();AddSpellScripts();AddSC_SmartScripts();AddCommandScripts();AddWorldScripts();AddOutdoorPvPScripts();AddEasternKingdomsScripts();AddKalimdorScripts();AddOutlandScripts();AddNorthrendScripts();AddEventScripts();AddPetScripts();
}
```

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
