### PR TITLE
feat(DB/game_tele): Added Emerald Dream game_tele

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1570401436494865858.sql
+++ b/data/sql/updates/pending_db_world/rev_1570401436494865858.sql
@@ -1,0 +1,12 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1570401436494865858');
+
+DELETE FROM `instance_template` WHERE `map` = 169;
+INSERT INTO `instance_template` (`map`, `parent`, `script`, `allowMount`) VALUES
+(169, 0, '', 0);
+
+DELETE FROM `game_tele` WHERE `id` IN  (1425, 1426, 1427, 1428);
+INSERT INTO `game_tele` (`id`, `position_x`, `position_y`, `position_z`, `orientation`, `map`, `name`) VALUES 
+(1425, -366.091, 3097.86, 92.317, 0.0487625, 169, 'EmeraldDream'),
+(1426, 2781.566406, 3006.763184, 23.221882, 0.5, 169, 'EmeraldStatue'),
+(1427, -2128.12, -1005.89, 132.213, 0.5, 169, 'VerdantFields'),
+(1428, 2732.93, -3319.63, 101.284, 0.5, 169, 'EmeraldForest');


### PR DESCRIPTION
Added Emerald Dream game_tele and the instance Emerald Dream ID:169

### How to test this PR

Apply the sql code in this PR.

Use the following commands:
```
.tele EmeraldDream
.tele EmeraldStatue
.tele VerdantFields
.tele EmeraldForest
```

See the different zones ;-)


To see the Emerald Dream zone with textures use [this patch](https://mega.nz/#!59gywQBZ!mH3-7pTW_MSDIi-Eayc-aXVnBC__NtHDEJwYgtVbqiE).

Source: https://github.com/TrinityCore/TrinityCore/issues/16131
