### PR TITLE
feat(docker): allow building without scripts

### DIFF
--- a/bin/acore-docker-build-no-scripts
+++ b/bin/acore-docker-build-no-scripts
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+docker build --build-arg ENABLE_SCRIPTS=0 -t acbuild -f docker/build/Dockerfile .
+
+docker run \
+    -v /$(pwd)/docker/build/cache:/azerothcore/build \
+    -v /$(pwd)/docker/worldserver/bin:/binworldserver \
+    -v /$(pwd)/docker/authserver/bin:/binauthserver \
+    acbuild

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -11,9 +11,12 @@ ADD src /azerothcore/src
 ADD modules /azerothcore/modules
 ADD CMakeLists.txt /azerothcore/CMakeLists.txt
 
+ARG ENABLE_SCRIPTS=1
+ENV ENABLE_SCRIPTS=$ENABLE_SCRIPTS
+
 ENTRYPOINT  cd azerothcore/build && \
             # run cmake
-            cmake ../ -DCMAKE_INSTALL_PREFIX=/azeroth-server -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DTOOLS=0 -DSCRIPTS=1 && \
+            cmake ../ -DCMAKE_INSTALL_PREFIX=/azeroth-server -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DTOOLS=0 -DSCRIPTS=$ENABLE_SCRIPTS && \
             # calculate the optimal number of threads
             MTHREADS=`grep -c ^processor /proc/cpuinfo`; MTHREADS=$(($MTHREADS + 2)) && \
             # run compilation


### PR DESCRIPTION
This PR allows to build AC in Docker having scripts disabled.

This can be useful for a faster build for a non-production server, that can be used in travis or for any other reason.