### PR TITLE
fix(Core/Commands): debug send opcode

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1570916858306186295.sql
+++ b/data/sql/updates/pending_db_world/rev_1570916858306186295.sql
@@ -3,4 +3,4 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1570916858306186295');
 DELETE FROM `trinity_string` WHERE `entry` = 30080;
 INSERT INTO `trinity_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`)
 VALUES
-(30080,'The file ''opcode.txt'' is missing in the server working directory.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);
+(30080,'The file ''opcode.txt'' is missing in the server working directory.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Файл ''opcode.txt'' не найден в рабочей директории сервера');

--- a/data/sql/updates/pending_db_world/rev_1570916858306186295.sql
+++ b/data/sql/updates/pending_db_world/rev_1570916858306186295.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1570916858306186295');
+
+DELETE FROM `trinity_string` WHERE `entry` = 30080;
+INSERT INTO `trinity_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`)
+VALUES
+(30080,'The file ''opcode.txt'' is missing in the server working directory.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -1312,6 +1312,8 @@ enum TrinityStrings
     // Instant Flight
     LANG_TOGGLE_INSTANT_FLIGHT                    = 30077,
     LANG_INSTANT_FLIGHT_ON                        = 30078,
-    LANG_INSTANT_FLIGHT_OFF                       = 30079
+    LANG_INSTANT_FLIGHT_OFF                       = 30079,
+
+    LANG_DEBUG_OPCODE_FILE_MISSING                = 30080
 };
 #endif

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -250,7 +250,7 @@ public:
             unit = player;
 
         std::ifstream ifs("opcode.txt");
-        if (ifs.bad())
+        if (!ifs.is_open())
             return false;
 
         // remove comments from file

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -251,7 +251,11 @@ public:
 
         std::ifstream ifs("opcode.txt");
         if (!ifs.is_open())
+        {
+            handler->SendSysMessage(LANG_DEBUG_OPCODE_FILE_MISSING);
+            handler->SetSentErrorMessage(true);
             return false;
+        }
 
         // remove comments from file
         std::stringstream parsedStream;


### PR DESCRIPTION
##### CHANGES PROPOSED:
The GM command `.debug send opcode` can be used to send opcodes to the client by storing a file "opcode.txt" in the working directory of the server. If this file is missing and a GM executes the command the server will (at least on Linux) allocate more and more memory until the OS kills the process. The cause of this is an incorrect check if the file is open for reading:
https://github.com/azerothcore/azerothcore-wotlk/blob/0651e771231ca2a3ccf23cb141cb51ddf5152667/src/server/scripts/Commands/cs_debug.cpp#L252-L254
If the file is missing, "bad" returns false, so use "is_open" instead.

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
- execute `.debug send opcode` without the file "opcode.txt": This should now result in an error message "Incorrect syntax".
- save a new file "opcode.txt" into the working directory of the server with the following content:
`631 uint32 6146`
- execute `.debug send opcode`: The background music on the client should now change.

Explanation:
- 631 (hex 277) is the opcode "SMSG_PLAY_MUSIC":
https://github.com/azerothcore/azerothcore-wotlk/blob/0651e771231ca2a3ccf23cb141cb51ddf5152667/src/server/game/Server/Protocol/Opcodes.h#L656
- the opcode takes an uint32 containing the soundid (in this case soundid 6146: "Zone - Orgrimmar02")

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
