### PR TITLE
Fix Baron Rivendale loot, close #2349

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1570979437296560126.sql
+++ b/data/sql/updates/pending_db_world/rev_1570979437296560126.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1570979437296560126');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 10440) AND (`Item` IN (13340));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(10440, 13340, 0, 8.7, 0, 1, 0, 1, 1, '');
+


### PR DESCRIPTION
##### CHANGES PROPOSED:
-  Added item Cape of the Black Baron (13340) to the creature loot of  Baron Rivendale (10440)

The loot chance is 8.7%, source: [wotlk.evowow](https://wotlk.evowow.com/item=13340?npc=10440) and [AoWoW live demo](https://db.rising-gods.de/Item=13340?npc=10440) from sarjuk

I made this fix using the [Keira3 editor ](https://github.com/azerothcore/Keira3/),

##### ISSUES ADDRESSED:
- Closes  #2349

##### TESTS PERFORMED:
- The creature Baron Rivendale (10440) now drop the item Cape of the Black Baron (13340)
![immagine](https://user-images.githubusercontent.com/519778/66717873-14dc1100-edde-11e9-8de0-6bb36c728406.png)

##### HOW TO TEST THE CHANGES:
```
log in game
.go creature id 10440
kill the NPC multiple times
```

##### Target branch(es):
- [x] Master

## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
