### PR TITLE
fix(DB/gossip_menu_option): Quest "The Exorcism of Colonel Jules"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1571179939629745569.sql
+++ b/data/sql/updates/pending_db_world/rev_1571179939629745569.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1571179939629745569');
+
+-- Quest "The Exorcism of Colonel Jules": Remove duplicate gossip entry
+DELETE FROM `gossip_menu_option` WHERE `MenuID` = 8539;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`, `BoxBroadcastTextID`, `VerifiedBuild`)
+VALUES
+(8539,0,0,'I am ready, Anchorite.  Let us begin the exorcism.',20396,1,3,0,0,0,0,NULL,0,0);


### PR DESCRIPTION
##### CHANGES PROPOSED:
Remove a duplicate gossip option while on quest "The Exorcism of Colonel Jules".

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.q rem 10935
.q a 10935
.go -710.799 2745.24 101.591 530
```
- talk to Anchorite Barada, he should now only have 1 gossip option

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
