### PR TITLE
fix(DB/waypoint_scripts): Chilltusk

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1571215774635756412.sql
+++ b/data/sql/updates/pending_db_world/rev_1571215774635756412.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1571215774635756412');
+
+-- Chilltusk: Remove usage of spell "First Aid" during waypoint movement
+UPDATE `waypoint_data` SET `action` = 0 WHERE `id` = 1074120;
+DELETE FROM `waypoint_scripts` WHERE `id` IN (1046,1047);


### PR DESCRIPTION
##### CHANGES PROPOSED:
Remove waypoint scripts causing Chilltusk to cast "First Aid" which is obviously wrong and causes errors in the server log:
```
ERROR: SCRIPT_COMMAND_CAST_SPELL ('waypoint_scripts' script id: 1046) no target unit found for spell 746
ERROR: SCRIPT_COMMAND_CAST_SPELL ('waypoint_scripts' script id: 1047) no target unit found for spell 746
```

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- ```.go c id 27005```
- just follow Chilltusk around, the errors mentioned above should not show in the server log

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
