### PR TITLE
fix(Core/Quest): The Lich, Ras Frostwhisper

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1571737953110374673.sql
+++ b/data/sql/updates/pending_db_world/rev_1571737953110374673.sql
@@ -9,3 +9,8 @@ DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 1 AND `SourceGroup` =
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`)
 VALUES
 (1,10508,13626,0,0,13,0,2,1,0,0,0,0,'','Instance - Get Data - Can only loot ''Human Head of Ras Frostwhisper'' if Ras is in human form');
+
+DELETE FROM `creature_text` WHERE `CreatureID` = 10508;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`)
+VALUES
+(10508,0,0,'THIS CANNOT BE!!',14,0,100,0,0,0,6371,0,'Ras Frostwhisper');

--- a/data/sql/updates/pending_db_world/rev_1571737953110374673.sql
+++ b/data/sql/updates/pending_db_world/rev_1571737953110374673.sql
@@ -1,0 +1,11 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1571737953110374673');
+
+DELETE FROM `spell_script_names` WHERE `spell_id` = 17179;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`)
+VALUES
+(17179,'spell_scholomance_boon_of_life');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 1 AND `SourceGroup` = 10508 AND `SourceEntry` = 13626 AND `ConditionTypeOrReference` = 13;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`)
+VALUES
+(1,10508,13626,0,0,13,0,2,1,0,0,0,0,'','Instance - Get Data - Can only loot ''Human Head of Ras Frostwhisper'' if Ras is in human form');

--- a/src/server/scripts/EasternKingdoms/Scholomance/instance_scholomance.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/instance_scholomance.cpp
@@ -22,19 +22,18 @@ class instance_scholomance : public InstanceMapScript
 
         struct instance_scholomance_InstanceMapScript : public InstanceScript
         {
-            instance_scholomance_InstanceMapScript(Map* map) : InstanceScript(map)
-            {
-                GateKirtonosGUID        = 0;
-                GateMiliciaGUID         = 0;
-                GateTheolenGUID         = 0;
-                GatePolkeltGUID         = 0;
-                GateRavenianGUID        = 0;
-                GateBarovGUID           = 0;
-                GateIlluciaGUID         = 0;
-                _kirtonosState          = 0;
-                _miniBosses             = 0;
-                _rasHuman               = 0;
-            }
+            instance_scholomance_InstanceMapScript(Map* map) : InstanceScript(map),
+                GateKirtonosGUID { 0 },
+                GateMiliciaGUID  { 0 },
+                GateTheolenGUID  { 0 },
+                GatePolkeltGUID  { 0 },
+                GateRavenianGUID { 0 },
+                GateBarovGUID    { 0 },
+                GateIlluciaGUID  { 0 },
+                _kirtonosState   { 0 },
+                _miniBosses      { 0 },
+                _rasHuman        { 0 }
+            { }
 
             void OnGameObjectCreate(GameObject* go)
             {

--- a/src/server/scripts/EasternKingdoms/Scholomance/instance_scholomance.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/instance_scholomance.cpp
@@ -485,12 +485,14 @@ class spell_scholomance_boon_of_life : public SpellScriptLoader
             void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
                 if (Unit* target = GetTarget())
-                    if (GetTargetApplication()->GetRemoveMode() != AURA_REMOVE_BY_CANCEL)
-                    {
-                        target->SetDisplayId(MODEL_RAS_HUMAN);
-                        target->SetHealth(target->GetMaxHealth());
-                        if (InstanceScript* instance = target->GetInstanceScript())
-                            instance->SetData(DATA_RAS_HUMAN,1);
+                    if (Creature* creature = target->ToCreature())
+                        if (GetTargetApplication()->GetRemoveMode() != AURA_REMOVE_BY_CANCEL)
+                        {
+                            creature->AI()->Talk(TALK_RAS_HUMAN);
+                            creature->SetDisplayId(MODEL_RAS_HUMAN);
+                            creature->SetHealth(target->GetMaxHealth());
+                            if (InstanceScript* instance = creature->GetInstanceScript())
+                                instance->SetData(DATA_RAS_HUMAN,1);
                     }
             }
 

--- a/src/server/scripts/EasternKingdoms/Scholomance/scholomance.h
+++ b/src/server/scripts/EasternKingdoms/Scholomance/scholomance.h
@@ -17,6 +17,11 @@ enum ModelIds
     MODEL_RAS_HUMAN                     = 3975
 };
 
+enum TalkGroupIds
+{
+    TALK_RAS_HUMAN                      = 0
+};
+
 enum CreatureIds
 {
     NPC_RISEN_GUARDIAN                  = 11598

--- a/src/server/scripts/EasternKingdoms/Scholomance/scholomance.h
+++ b/src/server/scripts/EasternKingdoms/Scholomance/scholomance.h
@@ -8,7 +8,13 @@
 enum DataTypes
 {
     DATA_KIRTONOS_THE_HERALD            = 0,
-    DATA_MINI_BOSSES                    = 1
+    DATA_MINI_BOSSES                    = 1,
+    DATA_RAS_HUMAN                      = 2
+};
+
+enum ModelIds
+{
+    MODEL_RAS_HUMAN                     = 3975
 };
 
 enum CreatureIds


### PR DESCRIPTION
##### CHANGES PROPOSED:
- While on the quest "The Lich, Ras Frostwhisper" the item "Soulbound Keepsake" will now correctly transform Ras into a human after finishing the 20 seconds channel of the spell "Boon of Life".
- The loot item "Human Head of Ras Frostwhisper" will now only drop if Ras has been transformed into his human form.
- Ras attacks the caster of "Boon of Life" and gains additional threat.
- After being transformed into a human Ras is set to full health.

##### ISSUES ADDRESSED:
Closes #2364

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
- Preparation:
```
.q rem 5466
.q a 5466
.go cr id 10508
```
- Use "Soulbound Keepsake" on Ras to transform him into a human.
- Ensure that the item "Human Head of Ras Frostwhisper" can only be looted after he is in human form.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
