### PR TITLE
fix(Core/GridNotifiers): increased visibility for large creatures, part 2

### DIFF
--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -974,7 +974,7 @@ class WorldObject : public Object, public WorldLocation
 
         bool isActiveObject() const { return m_isActive; }
         void setActive(bool isActiveObject);
-        bool IsVisibilityOverridden() const { return m_isVisibilityDistanceOverride; }
+        bool IsVisibilityOverridden() const { return m_isVisibilityDistanceOverride || m_isActive; }
         void SetVisibilityDistanceOverride(bool isVisibilityDistanceOverride);
         void SetWorldObject(bool apply);
         bool IsPermanentWorldObject() const { return m_isWorldObject; }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23042,9 +23042,12 @@ void Player::UpdateObjectVisibility(bool forced, bool fromUpdate)
 
 void Player::UpdateVisibilityForPlayer(bool mapChange)
 { 
-    Trinity::VisibleNotifier notifier(*this, mapChange);
-    m_seer->VisitNearbyObject(GetSightRange()+VISIBILITY_INC_FOR_GOBJECTS, notifier);
-    notifier.SendToSelf();
+    Trinity::VisibleNotifier notifierNoLarge(*this, mapChange, false); // visit only objects which are not large; default distance
+    m_seer->VisitNearbyObject(GetSightRange()+VISIBILITY_INC_FOR_GOBJECTS, notifierNoLarge);
+    notifierNoLarge.SendToSelf();
+    Trinity::VisibleNotifier notifierLarge(*this, mapChange, true);    // visit only large objects; maximum distance
+    m_seer->VisitNearbyObject(MAX_VISIBILITY_DISTANCE, notifierLarge);
+    notifierLarge.SendToSelf();
 
     if (mapChange)
         m_last_notify_position.Relocate(-5000.0f, -5000.0f, -5000.0f, 0.0f);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -19032,9 +19032,12 @@ void Unit::ExecuteDelayedUnitRelocationEvent()
                     //active->m_last_notify_position.Relocate(active->GetPositionX(), active->GetPositionY(), active->GetPositionZ());
                 }
 
-                Trinity::PlayerRelocationNotifier relocate(*player);
-                viewPoint->VisitNearbyObject(player->GetSightRange()+VISIBILITY_INC_FOR_GOBJECTS, relocate);
-                relocate.SendToSelf();
+                Trinity::PlayerRelocationNotifier relocateNoLarge(*player, false); // visit only objects which are not large; default distance
+                viewPoint->VisitNearbyObject(player->GetSightRange()+VISIBILITY_INC_FOR_GOBJECTS, relocateNoLarge);
+                relocateNoLarge.SendToSelf();
+                Trinity::PlayerRelocationNotifier relocateLarge(*player, true);    // visit only large objects; maximum distance
+                viewPoint->VisitNearbyObject(MAX_VISIBILITY_DISTANCE, relocateLarge);
+                relocateLarge.SendToSelf();
             }
 
     if (Player* player = this->ToPlayer())
@@ -19063,9 +19066,12 @@ void Unit::ExecuteDelayedUnitRelocationEvent()
             active->m_last_notify_position.Relocate(active->GetPositionX(), active->GetPositionY(), active->GetPositionZ());
         }
 
-        Trinity::PlayerRelocationNotifier relocate(*player);
-        viewPoint->VisitNearbyObject(player->GetSightRange()+VISIBILITY_INC_FOR_GOBJECTS, relocate);
-        relocate.SendToSelf();
+        Trinity::PlayerRelocationNotifier relocateNoLarge(*player, false); // visit only objects which are not large; default distance
+        viewPoint->VisitNearbyObject(player->GetSightRange()+VISIBILITY_INC_FOR_GOBJECTS, relocateNoLarge);
+        relocateNoLarge.SendToSelf();
+        Trinity::PlayerRelocationNotifier relocateLarge(*player, true);    // visit only large objects; maximum distance
+        viewPoint->VisitNearbyObject(MAX_VISIBILITY_DISTANCE, relocateLarge);
+        relocateLarge.SendToSelf();
 
         this->AddToNotify(NOTIFY_AI_RELOCATION);
     }
@@ -19085,7 +19091,7 @@ void Unit::ExecuteDelayedUnitRelocationEvent()
         unit->m_last_notify_position.Relocate(unit->GetPositionX(), unit->GetPositionY(), unit->GetPositionZ());
 
         Trinity::CreatureRelocationNotifier relocate(*unit);
-        unit->VisitNearbyObject(unit->GetMap()->GetVisibilityRange(), relocate);
+        unit->VisitNearbyObject(unit->GetVisibilityRange()+VISIBILITY_COMPENSATION, relocate);
 
         this->AddToNotify(NOTIFY_AI_RELOCATION);
     }

--- a/src/server/game/Grids/Notifiers/GridNotifiers.cpp
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.cpp
@@ -23,6 +23,8 @@ void VisibleNotifier::Visit(GameObjectMapType &m)
 {
     for (GameObjectMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
+        if (i_largeOnly != iter->GetSource()->IsVisibilityOverridden())
+            continue;
         vis_guids.erase(iter->GetSource()->GetGUID());
         i_player.UpdateVisibilityOf(iter->GetSource(), i_data, i_visibleNow);
     }
@@ -35,6 +37,9 @@ void VisibleNotifier::SendToSelf()
     if (Transport* transport = i_player.GetTransport())
         for (Transport::PassengerSet::const_iterator itr = transport->GetPassengers().begin(); itr != transport->GetPassengers().end();++itr)
         {
+            if (i_largeOnly != (*itr)->IsVisibilityOverridden())
+                continue;
+
             if (vis_guids.find((*itr)->GetGUID()) != vis_guids.end())
             {
                 vis_guids.erase((*itr)->GetGUID());
@@ -59,6 +64,9 @@ void VisibleNotifier::SendToSelf()
 
     for (Player::ClientGUIDs::const_iterator it = vis_guids.begin();it != vis_guids.end(); ++it)
     {
+        if (i_largeOnly != ObjectAccessor::GetWorldObject(i_player, *it)->IsVisibilityOverridden())
+            continue;
+
         // pussywizard: static transports are removed only in RemovePlayerFromMap and here if can no longer detect (eg. phase changed)
         if (IS_TRANSPORT_GUID(*it))
             if (GameObject* staticTrans = i_player.GetMap()->GetGameObject(*it))
@@ -84,7 +92,11 @@ void VisibleNotifier::SendToSelf()
     i_player.GetSession()->SendPacket(&packet);
 
     for (std::vector<Unit*>::const_iterator it = i_visibleNow.begin(); it != i_visibleNow.end(); ++it)
+    {
+        if (i_largeOnly != (*it)->IsVisibilityOverridden())
+            continue;
         i_player.GetInitialVisiblePackets(*it);
+    }
 }
 
 void VisibleChangesNotifier::Visit(PlayerMapType &m)

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -32,9 +32,10 @@ namespace Trinity
         Player::ClientGUIDs vis_guids;
         std::vector<Unit*> &i_visibleNow;
         bool i_gobjOnly;
+        bool i_largeOnly;
         UpdateData i_data;
 
-        VisibleNotifier(Player &player, bool gobjOnly) : i_player(player), vis_guids(player.m_clientGUIDs), i_visibleNow(player.m_newVisible), i_gobjOnly(gobjOnly)
+        VisibleNotifier(Player &player, bool gobjOnly, bool largeOnly) : i_player(player), vis_guids(player.m_clientGUIDs), i_visibleNow(player.m_newVisible), i_gobjOnly(gobjOnly), i_largeOnly(largeOnly)
         {
             i_visibleNow.clear();
         }
@@ -57,7 +58,7 @@ namespace Trinity
 
     struct PlayerRelocationNotifier : public VisibleNotifier
     {
-        PlayerRelocationNotifier(Player &player) : VisibleNotifier(player, false) {}
+        PlayerRelocationNotifier(Player &player, bool largeOnly) : VisibleNotifier(player, false, largeOnly) {}
 
         template<class T> void Visit(GridRefManager<T> &m) { VisibleNotifier::Visit(m); }
         void Visit(PlayerMapType &);

--- a/src/server/game/Grids/Notifiers/GridNotifiersImpl.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiersImpl.h
@@ -25,6 +25,8 @@ inline void Trinity::VisibleNotifier::Visit(GridRefManager<T> &m)
 
     for (typename GridRefManager<T>::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
+        if (i_largeOnly != iter->GetSource()->IsVisibilityOverridden())
+            continue;
         vis_guids.erase(iter->GetSource()->GetGUID());
         i_player.UpdateVisibilityOf(iter->GetSource(), i_data, i_visibleNow);
     }


### PR DESCRIPTION
##### CHANGES PROPOSED:
This is a follow-up to PR #2304. Currently there exist two problems with large objects:
- They don't initially appear at their full range.
- As for creatures, they don't disappear if the player stands still and just watches them moving (see #2323)

I tried to fix this by adjusting the VisibleNotifier to either handle only non-large or only large objects. The visibility check is then split into two parts: Default distance for non-large, maximum distance for large objects. So far my tests where successful and it looks much better now as large creatures and game objects are now appearing at full distance.

##### ISSUES ADDRESSED:
Closes #2323

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
- Check one of the Fel Reavers (`.go creature fel_reaver`) and then just wait doing nothing while it moves away. It should disappear after reaching maximum visibility distance.
- Teleport to Icecrown (`.go 6904.96 2323.82 474.47 571`) and fly around a bit, there are many large creatures there.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
