### PR TITLE
feat(Core/AuthServer) Added check for AuthFlooder, now the server stop it!

### DIFF
--- a/src/server/authserver/Server/AuthSocket.cpp
+++ b/src/server/authserver/Server/AuthSocket.cpp
@@ -208,6 +208,10 @@ void AuthSocket::OnRead()
 {
     #define MAX_AUTH_LOGON_CHALLENGES_IN_A_ROW 3
     uint32 challengesInARow = 0;
+
+    #define MAX_AUTH_GET_REALM_LIST 10
+    uint32 challengesInARowRealmList = 0;
+
     uint8 _cmd;
     while (1)
     {
@@ -223,6 +227,15 @@ void AuthSocket::OnRead()
                 socket().shutdown();
                 return;
             }
+        }
+        else if (_cmd == REALM_LIST) {
+          challengesInARowRealmList++;
+          if (challengesInARowRealmList == MAX_AUTH_GET_REALM_LIST)
+          {
+              sLog->outString("Got %u REALM_LIST in a row from '%s', possible ongoing DoS", challengesInARowRealmList, socket().getRemoteAddress().c_str());
+              socket().shutdown();
+              return;
+          }
         }
 
         size_t i;


### PR DESCRIPTION
There is a public tool, AuthFlooder that DDOS the authserver with multiple requests, this little fix can easily stop it.

##### CHANGES PROPOSED:
-  Added a MAX request REALMLIST quantity in a row to 10, this will STOP the AuthFlooder

##### ISSUES ADDRESSED:
- This is a critical issue, a member can lock the client log in if open multiple AuthFlooder and target a victim server

##### TESTS PERFORMED:
- I used AuthFlooder with and without the fix, the fix stop it

Before the PR, I opened 3 AuthFlooder and in any I got this output in console:
![immagine](https://user-images.githubusercontent.com/519778/67618487-91182080-f7f0-11e9-811c-f94e54c0078f.png)

The client wait in the "Authenticating" phase:
![immagine](https://user-images.githubusercontent.com/519778/67618510-c7ee3680-f7f0-11e9-82e3-72c9509dbccc.png)

After the PR, here the AuthFlooder output text:
![immagine](https://user-images.githubusercontent.com/519778/67618545-2e735480-f7f1-11e9-935e-1040a0f2c700.png)

In the AuthServer console you will get `Got 10 REALM_LIST in a row from '127.0.0.1', possible ongoing DoS`.

I tried also to log in with my client 10 times, it works perfectly, the problem is make it "in a row", so multiple times in less than 1-5 seconds, hence, the normal using of the client is not affected from this check.

##### HOW TO TEST THE CHANGES:
- [Download AuthFlooder](https://mega.nz/#!ExpSwSJJ!fc8wauzmiI_RB-UlZ7nYWzMuYT0uq_gbCx2XijSWxX8)
- Open AuthFlooder.exe, put the realmlist, example `localhost` and then username and password (in my example above they where username: gm, password: gm).

On **Linux** use `mono` instead of Wine.

##### Target branch(es):
- [x] Master
