### PR TITLE
fix(DB/Quest): "Hot and Cold" quest item

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1572128545565068694.sql
+++ b/data/sql/updates/pending_db_world/rev_1572128545565068694.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1572128545565068694');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 1 AND `SourceGroup` = 30160 AND `SourceEntry` = 42246 AND `ConditionTypeOrReference` = 9;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`)
+VALUES
+(1,30160,42246,0,0,9,0,12981,0,0,0,0,0,'','Can only loot ''Essence of Ice'' if quest ''Hot and Cold'' taken');


### PR DESCRIPTION
##### CHANGES PROPOSED:
Drop the quest item "Essence of Ice" only if the quest "Hot and Cold" has been taken.

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.q rem 12981
.go 7485.24 -3287.78 876.769 571
.mo p 4
```
- kill the Brittle Revenants and ensure that the quest item does not drop anymore
- add the quest "Hot and Cold": `.q a 12981`
- kill again Brittle Revenants: The quest item "Essence of Ice" should now drop

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
