### PR TITLE
fix(Core/Crash): Improved Utf8toWStr() function to prevent crashes

### DIFF
--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -333,17 +333,14 @@ bool Utf8toWStr(char const* utf8str, size_t csize, wchar_t* wstr, size_t& wsize)
 
 bool Utf8toWStr(const std::string& utf8str, std::wstring& wstr)
 {
+    wstr.clear();
     try
     {
-        if (size_t len = utf8::distance(utf8str.c_str(), utf8str.c_str()+utf8str.size()))
-        {
-            wstr.resize(len);
-            utf8::utf8to16(utf8str.c_str(), utf8str.c_str()+utf8str.size(), &wstr[0]);
-        }
+        utf8::utf8to16(utf8str.c_str(), utf8str.c_str()+utf8str.size(), std::back_inserter(wstr));
     }
-    catch(std::exception)
+    catch(std::exception const&)
     {
-        wstr = L"";
+        wstr.clear();
         return false;
     }
 


### PR DESCRIPTION
Me and @Stoabrogga figure out that `Utf8toWStr()` is responsible for server crashes when a malformed opcode and special characters are sent to the server.

##### CHANGES PROPOSED:
-  improved Utf8toWStr() like TC-335a do


##### ISSUES ADDRESSED:
- #2077
- #2043
- #2170
- #2198
- #2345
- other issues about exploiting crashes which functions turn on `Utf8toWStr()`

related to this PR https://github.com/azerothcore/azerothcore-wotlk/pull/2374

##### TESTS PERFORMED:
- I used AccLeito addon to send malformed CSMG_ADD_FRIEND opcode and special character to the server, with this PR the server does not crash.

##### HOW TO TEST THE CHANGES:
- use AccLeito Addon and try to get down the server with the Crash button


##### Target branch(es):
- [x] Master
