### PR TITLE
fix(Core): uint32 assignment, prevent crash, closes #2433

### DIFF
--- a/src/server/game/Chat/ChatLink.cpp
+++ b/src/server/game/Chat/ChatLink.cpp
@@ -333,7 +333,14 @@ bool SpellChatLink::ValidateName(char* buffer, const char* context)
             {
                 // found the prefix, remove it to perform spellname validation below
                 // -2 = strlen(": ")
-                uint32 spellNameLength = strlen(buffer) - skillLineNameLength - 2;
+                uint32 spellNameLength;
+
+                if (strlen(buffer) <= skillLineNameLength + 2) {
+                    spellNameLength = 0;
+                } else {
+                    spellNameLength = strlen(buffer) - skillLineNameLength - 2;
+                }
+
                 memmove(buffer, buffer + skillLineNameLength + 2, spellNameLength + 1);
                 break;
             }

--- a/src/server/game/Chat/ChatLink.cpp
+++ b/src/server/game/Chat/ChatLink.cpp
@@ -333,14 +333,7 @@ bool SpellChatLink::ValidateName(char* buffer, const char* context)
             {
                 // found the prefix, remove it to perform spellname validation below
                 // -2 = strlen(": ")
-                uint32 spellNameLength;
-
-                if (strlen(buffer) <= skillLineNameLength + 2) {
-                    spellNameLength = 0;
-                } else {
-                    spellNameLength = strlen(buffer) - skillLineNameLength - 2;
-                }
-
+                uint32 spellNameLength = (strlen(buffer) <= skillLineNameLength + 2) ? 0 : strlen(buffer) - skillLineNameLength - 2;
                 memmove(buffer, buffer + skillLineNameLength + 2, spellNameLength + 1);
                 break;
             }


### PR DESCRIPTION
##### CHANGES PROPOSED:
Add a check to `uint32` variable assignment to prevent that a negative value is assigned to an `unsigned int`, it causes that the variable assume the max value of `uint32` and make crash the server.

##### ISSUES ADDRESSED:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/2433

##### TESTS PERFORMED:
- I tested the command showed in https://github.com/azerothcore/azerothcore-wotlk/issues/2433 before and after the PR, after the PR the server does not crash.
I linked the `[Inscription]` spell in game, I didn't get any issues.

##### HOW TO TEST THE CHANGES:
- Read issue https://github.com/azerothcore/azerothcore-wotlk/issues/2433

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
