### PR TITLE
fix(Core/GridNotifiers): Fix crash

### DIFF
--- a/src/server/game/Grids/Notifiers/GridNotifiers.cpp
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.cpp
@@ -64,8 +64,9 @@ void VisibleNotifier::SendToSelf()
 
     for (Player::ClientGUIDs::const_iterator it = vis_guids.begin();it != vis_guids.end(); ++it)
     {
-        if (i_largeOnly != ObjectAccessor::GetWorldObject(i_player, *it)->IsVisibilityOverridden())
-            continue;
+        if (WorldObject* obj = ObjectAccessor::GetWorldObject(i_player, *it))
+            if (i_largeOnly != obj->IsVisibilityOverridden())
+                continue;
 
         // pussywizard: static transports are removed only in RemovePlayerFromMap and here if can no longer detect (eg. phase changed)
         if (IS_TRANSPORT_GUID(*it))


### PR DESCRIPTION
##### CHANGES PROPOSED:
In PR #2378 I forgot to include a check for existence of the world object which can cause a server crash. I sadly did not see this in my tests because I'm only playing alone on my server, sorry.

##### ISSUES ADDRESSED:
- Closes #2441

##### TESTS PERFORMED:
Tested build on Ubuntu 16.04 / clang 7

##### HOW TO TEST THE CHANGES:
Nothing to test, can be merged after a successful Travis run.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
