### PR TITLE
fix(db): Missing creature_queststarter entry NPC Duke Hydraxis

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1573992675866478300.sql
+++ b/data/sql/updates/pending_db_world/rev_1573992675866478300.sql
@@ -1,4 +1,6 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1573992675866478300');
 
 DELETE FROM `creature_queststarter` WHERE `id` = 13278 AND `quest` = 6804;
+DELETE FROM `creature_questender` WHERE `id` = 13278 AND `quest` = 6804;
 INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (13278, 6804);
+INSERT INTO `creature_questender` (`id`, `quest`) VALUES (13278, 6804);

--- a/data/sql/updates/pending_db_world/rev_1573992675866478300.sql
+++ b/data/sql/updates/pending_db_world/rev_1573992675866478300.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1573992675866478300');
+
+DELETE FROM `creature_queststarter` WHERE `id` = 13278 AND `quest` = 6804;
+INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (13278, 6804);


### PR DESCRIPTION
NPC Duke Hydraxis 13278 was not starting the quest 6804


Closes AzerothCore issue #2447

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

##### CHANGES PROPOSED:
-  Added entry in world table creature_queststarter  id 13278 and quest 6804


##### ISSUES ADDRESSED:
- Closes #2447 
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

##### TESTS PERFORMED:
- Tested successfully ingame
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps

***** IMPORTANT: *****
The people who are going to test PRs are not necessarily coders,
so they might have no idea about what the code changes can affect.
For this reason the developer should at least explain what aspects 
of the game can be affected by the changes, especially when doing 
C++ changes on generic parts of the code. 
-->

- Import the sql file
- Go to NPC 13278 and check if he starts the quest 6804 'Poisoned Water'

##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 

##### Target branch(es):
- [x] Master

<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
 
<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
