### PR TITLE
fix(DB/game_event): use another default minimum date to avoid import errors

### DIFF
--- a/data/sql/updates/db_world/2019_11_09_00.sql
+++ b/data/sql/updates/db_world/2019_11_09_00.sql
@@ -16,10 +16,10 @@ SELECT sql_rev INTO OK FROM version_db_world WHERE sql_rev = '157167293368191681
 
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1571672933681916812');
 
-ALTER TABLE `game_event` ALTER COLUMN `start_time` SET DEFAULT '1970-01-01 08:00:00',
-                         ALTER COLUMN `end_time`   SET DEFAULT '1970-01-01 08:00:00';
+ALTER TABLE `game_event` ALTER COLUMN `start_time` SET DEFAULT '2000-01-01 08:00:00',
+                         ALTER COLUMN `end_time`   SET DEFAULT '2000-01-01 08:00:00';
 
-UPDATE `game_event` SET `start_time` = '1970-01-01 08:00:00', `end_time` = '1970-01-01 08:00:00' WHERE `eventEntry` IN
+UPDATE `game_event` SET `start_time` = '2000-01-01 08:00:00', `end_time` = '2000-01-01 08:00:00' WHERE `eventEntry` IN
 (13, 17, 22, 31, 48, 49, 55, 56, 57, 58, 59, 60, 65, 66);
 
 UPDATE `game_event` SET `end_time` = NULL WHERE `eventEntry` IN


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

import error for 1970 date to old for updated maria

##### CHANGES PROPOSED:
-  change date to 2000 
-  


##### ISSUES ADDRESSED:
- error in sql insert about 1970 sql is skipped and arena tournament has no start date 
##### TESTS PERFORMED:
-  game_event now has adequate start times and no error in sql import must be a Debian 10 buster mariadb latest issue 
-
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps

***** IMPORTANT: *****
The people who are going to test PRs are not necessarily coders,
so they might have no idea about what the code changes can affect.
For this reason the developer should at least explain what aspects 
of the game can be affected by the changes, especially when doing 
C++ changes on generic parts of the code. 
-->

##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 

##### Target branch(es):
- [x] Master

<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
 
<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
