### PR TITLE
fix(DB/SAI): Citizen of New Avalon

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1574980316492398478.sql
+++ b/data/sql/updates/pending_db_world/rev_1574980316492398478.sql
@@ -1,0 +1,19 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1574980316492398478');
+
+-- Citizen of New Avalon: Delete redundant creature text entries
+DELETE FROM `creature_text` WHERE `CreatureID` = 28942 AND `GroupID` = 3;
+
+-- Citizen of New Avalon: Fix talk actions
+UPDATE `smart_scripts` SET `action_param1` = 2 WHERE `entryorguid` = 28942 AND `source_type` = 0 AND `id` = 2;
+UPDATE `smart_scripts` SET `action_param1` = 1, `action_param3` = 1 WHERE `entryorguid` = 2894200 AND `source_type` = 9 AND `id` = 0;
+UPDATE `smart_scripts` SET `action_param1` = 0, `action_param3` = 1 WHERE `entryorguid` = 2894201 AND `source_type` = 9 AND `id` = 0;
+UPDATE `smart_scripts` SET `action_param1` = 0, `action_param3` = 1 WHERE `entryorguid` = 2894202 AND `source_type` = 9 AND `id` = 0;
+
+-- Citizen of New Avalon: Move to another position as they are standing inside each other
+UPDATE `creature` SET `position_x` = 1614.72, `position_y` = -5724.37, `position_z` = 120.95, `orientation` = 3.19584 WHERE `guid` = 129804;
+UPDATE `creature` SET `position_x` = 1612.18, `position_y` = -5728.73, `position_z` = 120.118, `orientation` = 2.90132 WHERE `guid` = 129774;
+UPDATE `creature` SET `position_x` = 1619.92, `position_y` = -5734.29, `position_z` = 120.06, `orientation` = 2.58715 WHERE `guid` = 129733;
+UPDATE `creature` SET `position_x` = 1579.9, `position_y` = -5750.36, `position_z` = 120.256, `orientation` = 1.36978 WHERE `guid` = 129765;
+UPDATE `creature` SET `position_x` = 1575.3, `position_y` = -5747.62, `position_z` = 120.62, `orientation` = 0.94174 WHERE `guid` = 129767;
+UPDATE `creature` SET `position_x` = 1570.77, `position_y` = -5749.48, `position_z` = 120.949, `orientation` = 0.68647 WHERE `guid` = 129783;
+UPDATE `creature` SET `position_x` = 1578.68, `position_y` = -5754.74, `position_z` = 120.208, `orientation` = 1.04776 WHERE `guid` = 129750;


### PR DESCRIPTION
##### CHANGES PROPOSED:
- Fix SAI talk action for "Citizen of New Avalon", leading to the following error:
`ERROR: SmartScript::ProcessAction: SMART_ACTION_TALK: EntryOrGuid 2894202 SourceType 9 EventType 60 TargetType 7 using non-existent Text id 2 for talker 28897, ignored.`
- Fix positions of some of the citizens as they were standing inside each other
- Delete redundant creature text

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- create a new Death Knight
- `.go 1633.08 -5721.75 127.562 609`
- `.mo p 4`
- fly over the citizens and drop a ghoul on them: `.npc add temp 28897`
- ensure that the error mentioned above does not occur in the log anymore
- ensure that no citizens are standing inside each other

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
