### PR TITLE
fix(CI): Enable Travis modules check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,7 @@ jobs:
           - source ./apps/ci/ci-before_install.sh
       install:
         - source ./apps/ci/ci-install.sh OFF
-        # compilation with modules temporarily disabled until PR 2454 is merged and the modules are fixed
-        # - source ./apps/ci/ci-install-modules.sh
+        - source ./apps/ci/ci-install-modules.sh
       script:
         - source ./apps/ci/ci-compile.sh
 
@@ -50,8 +49,7 @@ jobs:
         - source ./apps/ci/ci-before_install.sh
       install:
         - source ./apps/ci/ci-install.sh ON
-        # compilation with modules temporarily disabled until PR 2454 is merged and the modules are fixed
-        # - source ./apps/ci/ci-install-modules.sh
+        - source ./apps/ci/ci-install-modules.sh
         - source ./apps/ci/ci-import-db.sh
       script:
         - source ./apps/ci/ci-compile.sh
@@ -63,8 +61,7 @@ jobs:
           - source ./apps/ci/ci-before_install.sh
       install:
         - source ./apps/ci/ci-install.sh OFF
-        # compilation with modules temporarily disabled until PR 2454 is merged and the modules are fixed
-        # - source ./apps/ci/ci-install-modules.sh
+        - source ./apps/ci/ci-install-modules.sh
       script:
         - source ./apps/ci/ci-compile.sh
 
@@ -74,8 +71,7 @@ jobs:
         - source ./apps/ci/ci-before_install.sh
       install:
         - source ./apps/ci/ci-install.sh ON
-        # compilation with modules temporarily disabled until PR 2454 is merged and the modules are fixed
-        # - source ./apps/ci/ci-install-modules.sh
+        - source ./apps/ci/ci-install-modules.sh
       script:
         - source ./apps/ci/ci-compile.sh
 

--- a/apps/ci/ci-install-modules.sh
+++ b/apps/ci/ci-install-modules.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "install modules"
 git clone --depth=1 --branch=master --recursive https://github.com/azerothcore/mod-eluna-lua-engine.git modules/mod-eluna-lua-engine
-git clone --depth=1 --branch=master https://github.com/azerothcore/mod-autobalance.git modules/mod-vas-autobalance
+git clone --depth=1 --branch=master https://github.com/azerothcore/mod-autobalance.git modules/mod-autobalance
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-transmog.git modules/mod-transmog
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-npc-beastmaster.git modules/mod-npc-beastmaster
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-duel-reset.git modules/mod-duel-reset

--- a/apps/ci/ci-install-modules.sh
+++ b/apps/ci/ci-install-modules.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "install modules"
 git clone --depth=1 --branch=master --recursive https://github.com/azerothcore/mod-eluna-lua-engine.git modules/mod-eluna-lua-engine
-git clone --depth=1 --branch=master https://github.com/azerothcore/mod-vas-autobalance.git modules/mod-vas-autobalance
+git clone --depth=1 --branch=master https://github.com/azerothcore/mod-autobalance.git modules/mod-vas-autobalance
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-transmog.git modules/mod-transmog
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-npc-beastmaster.git modules/mod-npc-beastmaster
 git clone --depth=1 --branch=master https://github.com/azerothcore/mod-duel-reset.git modules/mod-duel-reset


### PR DESCRIPTION
##### CHANGES PROPOSED:
The PRs #2454 and #2455 have been merged and the modules fixed accordingly, so the modules check executed by Travis should be enabled again. The module "mod-vas-autobalance" has been renamed to "mod-autobalance" so I also updated the appropriate script.

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
see Travis run

##### HOW TO TEST THE CHANGES:
see Travis run

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
