### PR TITLE
feat(Core/CommandScript): New GM command "player learn"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1575409612123583009.sql
+++ b/data/sql/updates/pending_db_world/rev_1575409612123583009.sql
@@ -3,5 +3,5 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1575409612123583009');
 DELETE FROM `command` WHERE `name` IN ('player learn','player unlearn');
 INSERT INTO `command` (`name`, `security`, `help`)
 VALUES
-('player learn',2,'Syntax: .player learn #playername #spell.'),
-('player unlearn',2,'Syntax: .player unlearn #playername #spell.');
+('player learn',2,'Syntax: .player learn #playername #spell [all].'),
+('player unlearn',2,'Syntax: .player unlearn #playername #spell [all].');

--- a/data/sql/updates/pending_db_world/rev_1575409612123583009.sql
+++ b/data/sql/updates/pending_db_world/rev_1575409612123583009.sql
@@ -1,7 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1575409612123583009');
 
-DELETE FROM `command` WHERE `name` IN ('playerlearnspell','playerunlearnspell');
+DELETE FROM `command` WHERE `name` IN ('player learn','player unlearn');
 INSERT INTO `command` (`name`, `security`, `help`)
 VALUES
-('playerlearnspell',2,'Syntax: .playerlearnspell #playername #spell.'),
-('playerunlearnspell',2,'Syntax: .playerunlearnspell #playername #spell.');
+('player learn',2,'Syntax: .player learn #playername #spell.'),
+('player unlearn',2,'Syntax: .player unlearn #playername #spell.');

--- a/data/sql/updates/pending_db_world/rev_1575409612123583009.sql
+++ b/data/sql/updates/pending_db_world/rev_1575409612123583009.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1575409612123583009');
+
+DELETE FROM `command` WHERE `name` IN ('playerlearnspell','playerunlearnspell');
+INSERT INTO `command` (`name`, `security`, `help`)
+VALUES
+('playerlearnspell',2,'Syntax: .playerlearnspell #playername #spell.'),
+('playerunlearnspell',2,'Syntax: .playerunlearnspell #playername #spell.');

--- a/src/server/scripts/Commands/CMakeLists.txt
+++ b/src/server/scripts/Commands/CMakeLists.txt
@@ -10,6 +10,7 @@
 
 set(scripts_STAT_SRCS
   ${scripts_STAT_SRCS}
+  Commands/PlayerCommand.cpp
   Commands/cs_account.cpp
   Commands/cs_achievement.cpp
   Commands/cs_arena.cpp

--- a/src/server/scripts/Commands/CMakeLists.txt
+++ b/src/server/scripts/Commands/CMakeLists.txt
@@ -46,6 +46,7 @@ set(scripts_STAT_SRCS
   Commands/cs_titles.cpp
   Commands/cs_wp.cpp
   Commands/cs_spectator.cpp
+  Commands/cs_player.cpp
 #  Commands/cs_pdump.cpp
 #  Commands/cs_channel.cpp
 #  Commands/cs_pet.cpp

--- a/src/server/scripts/Commands/PlayerCommand.cpp
+++ b/src/server/scripts/Commands/PlayerCommand.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+*/
+
+#include "Chat.h"
+#include "ScriptMgr.h"
+#include "Language.h"
+#include "Player.h"
+#include "PlayerCommand.h"
+
+bool PlayerCommand::Learn(ChatHandler* handler, Player* targetPlayer, uint32 spell, char const* all)
+{
+    if (!spell)
+        return false;
+
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spell);
+    if (!spellInfo)
+    {
+        handler->PSendSysMessage(LANG_COMMAND_NOSPELLFOUND);
+        handler->SetSentErrorMessage(true);
+        return false;
+    }
+
+    if (!SpellMgr::IsSpellValid(spellInfo))
+    {
+        handler->PSendSysMessage(LANG_COMMAND_SPELL_BROKEN, spell);
+        handler->SetSentErrorMessage(true);
+        return false;
+    }
+
+    if (handler->GetSession())
+    {
+        SpellScriptsBounds bounds = sObjectMgr->GetSpellScriptsBounds(spell);
+        uint32 spellDifficultyId = sSpellMgr->GetSpellDifficultyId(spell);
+        if (handler->GetSession() && handler->GetSession()->GetSecurity() < SEC_ADMINISTRATOR && (bounds.first != bounds.second || spellDifficultyId))
+        {
+            handler->PSendSysMessage("Spell %u cannot be learnt using a command!", spell);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+    }
+
+    bool allRanks = all ? (strncmp(all, "all", 3) == 0) : false;
+
+    if (!allRanks && targetPlayer->HasSpell(spell))
+    {
+        if (targetPlayer == handler->GetSession()->GetPlayer())
+            handler->SendSysMessage(LANG_YOU_KNOWN_SPELL);
+        else
+            handler->PSendSysMessage(LANG_TARGET_KNOWN_SPELL, handler->GetNameLink(targetPlayer).c_str());
+        handler->SetSentErrorMessage(true);
+        return false;
+    }
+
+    if (allRanks)
+        targetPlayer->learnSpellHighRank(spell);
+    else
+        targetPlayer->learnSpell(spell);
+
+    uint32 firstSpell = sSpellMgr->GetFirstSpellInChain(spell);
+    if (GetTalentSpellCost(firstSpell))
+        targetPlayer->SendTalentsInfoData(false);
+
+    return true;
+}
+
+bool PlayerCommand::UnLearn(ChatHandler* handler, Player* target, uint32 spellId, char const* allStr)
+{
+    if (!spellId)
+        return false;
+
+    bool allRanks = allStr ? (strncmp(allStr, "all", 3) == 0) : false;
+
+    if (allRanks)
+        spellId = sSpellMgr->GetFirstSpellInChain (spellId);
+
+    if (target->HasSpell(spellId))
+        target->removeSpell(spellId, SPEC_MASK_ALL, false);
+    else
+        handler->SendSysMessage(LANG_FORGET_SPELL);
+
+    if (GetTalentSpellCost(spellId))
+        target->SendTalentsInfoData(false);
+
+    return true;
+}

--- a/src/server/scripts/Commands/PlayerCommand.h
+++ b/src/server/scripts/Commands/PlayerCommand.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+*/
+
+class PlayerCommand
+{
+public:
+    static bool Learn(ChatHandler* handler, Player* targetPlayer, uint32 spell, char const* all);
+    static bool UnLearn(ChatHandler* handler, Player* targetPlayer, uint32 spell, char const* all);
+};

--- a/src/server/scripts/Commands/cs_learn.cpp
+++ b/src/server/scripts/Commands/cs_learn.cpp
@@ -29,34 +29,32 @@ public:
     {
         static std::vector<ChatCommand> learnAllMyCommandTable =
         {
-            { "class",              SEC_GAMEMASTER,  false, &HandleLearnAllMyClassCommand,       "" },
-            { "pettalents",         SEC_GAMEMASTER,  false, &HandleLearnAllMyPetTalentsCommand,  "" },
-            { "spells",             SEC_GAMEMASTER,  false, &HandleLearnAllMySpellsCommand,      "" },
-            { "talents",            SEC_GAMEMASTER,  false, &HandleLearnAllMyTalentsCommand,     "" }
+            { "class",          SEC_GAMEMASTER,  false, &HandleLearnAllMyClassCommand,       "" },
+            { "pettalents",     SEC_GAMEMASTER,  false, &HandleLearnAllMyPetTalentsCommand,  "" },
+            { "spells",         SEC_GAMEMASTER,  false, &HandleLearnAllMySpellsCommand,      "" },
+            { "talents",        SEC_GAMEMASTER,  false, &HandleLearnAllMyTalentsCommand,     "" }
         };
 
         static std::vector<ChatCommand> learnAllCommandTable =
         {
-            { "my",                 SEC_GAMEMASTER,  false, nullptr,                             "", learnAllMyCommandTable },
-            { "gm",                 SEC_GAMEMASTER,  false, &HandleLearnAllGMCommand,            "" },
-            { "crafts",             SEC_GAMEMASTER,  false, &HandleLearnAllCraftsCommand,        "" },
-            { "default",            SEC_GAMEMASTER,  false, &HandleLearnAllDefaultCommand,       "" },
-            { "lang",               SEC_GAMEMASTER,  false, &HandleLearnAllLangCommand,          "" },
-            { "recipes",            SEC_GAMEMASTER,  false, &HandleLearnAllRecipesCommand,       "" }
+            { "my",             SEC_GAMEMASTER,  false, nullptr,                                "",  learnAllMyCommandTable },
+            { "gm",             SEC_GAMEMASTER,  false, &HandleLearnAllGMCommand,            "" },
+            { "crafts",         SEC_GAMEMASTER,  false, &HandleLearnAllCraftsCommand,        "" },
+            { "default",        SEC_GAMEMASTER,  false, &HandleLearnAllDefaultCommand,       "" },
+            { "lang",           SEC_GAMEMASTER,  false, &HandleLearnAllLangCommand,          "" },
+            { "recipes",        SEC_GAMEMASTER,  false, &HandleLearnAllRecipesCommand,       "" }
         };
 
         static std::vector<ChatCommand> learnCommandTable =
         {
-            { "all",                SEC_GAMEMASTER,  false, nullptr,                             "", learnAllCommandTable },
-            { "",                   SEC_GAMEMASTER,  false, &HandleLearnCommand,                 "" }
+            { "all",            SEC_GAMEMASTER,  false, nullptr,                                "",  learnAllCommandTable },
+            { "",               SEC_GAMEMASTER,  false, &HandleLearnCommand,                 "" }
         };
 
         static std::vector<ChatCommand> commandTable =
         {
-            { "learn",              SEC_GAMEMASTER,  false, nullptr,                             "", learnCommandTable },
-            { "unlearn",            SEC_GAMEMASTER,  false, &HandleUnLearnCommand,               "" },
-            { "playerlearnspell",   SEC_GAMEMASTER,  true,  &HandlePlayerLearnCommand,           "" },
-            { "playerunlearnspell", SEC_GAMEMASTER,  true,  &HandlePlayerUnLearnCommand,         "" }
+            { "learn",          SEC_GAMEMASTER,  false, nullptr,                                "", learnCommandTable },
+            { "unlearn",        SEC_GAMEMASTER,  false, &HandleUnLearnCommand,               "" }
         };
         return commandTable;
     }
@@ -110,72 +108,6 @@ public:
                 handler->SendSysMessage(LANG_YOU_KNOWN_SPELL);
             else
                 handler->PSendSysMessage(LANG_TARGET_KNOWN_SPELL, handler->GetNameLink(targetPlayer).c_str());
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        if (allRanks)
-            targetPlayer->learnSpellHighRank(spell);
-        else
-            targetPlayer->learnSpell(spell);
-
-        uint32 firstSpell = sSpellMgr->GetFirstSpellInChain(spell);
-        if (GetTalentSpellCost(firstSpell))
-            targetPlayer->SendTalentsInfoData(false);
-
-        return true;
-    }
-
-    static bool HandlePlayerLearnCommand(ChatHandler* handler, char const* args)
-    {
-        if (!*args)
-            return false;
-
-        char* playerName = strtok((char*)args, " ");
-        char* spellid = strtok(nullptr, " ");
-        char* all = strtok(nullptr, " ");
-        if (!playerName)
-            return false;
-
-        Player* targetPlayer;
-        uint64 targetGuid;
-        if (!handler->extractPlayerTarget(playerName, &targetPlayer, &targetGuid))
-            return false;
-
-        if (!targetPlayer)
-        {
-            handler->SendSysMessage(LANG_PLAYER_NOT_FOUND);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        if (!spellid)
-            return false;
-
-        uint32 spell = handler->extractSpellIdFromLink(spellid);
-        if (!spell)
-            return false;
-
-        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spell);
-        if (!spellInfo)
-        {
-            handler->PSendSysMessage(LANG_COMMAND_NOSPELLFOUND);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        if (!SpellMgr::IsSpellValid(spellInfo))
-        {
-            handler->PSendSysMessage(LANG_COMMAND_SPELL_BROKEN, spell);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        bool allRanks = all ? (strncmp(all, "all", strlen(all)) == 0) : false;
-
-        if (!allRanks && targetPlayer->HasSpell(spell))
-        {
-            handler->PSendSysMessage(LANG_TARGET_KNOWN_SPELL, handler->GetNameLink(targetPlayer).c_str());
             handler->SetSentErrorMessage(true);
             return false;
         }
@@ -570,52 +502,6 @@ public:
 
         if (GetTalentSpellCost(spellId))
             target->SendTalentsInfoData(false);
-
-        return true;
-    }
-
-    static bool HandlePlayerUnLearnCommand(ChatHandler* handler, char const* args)
-    {
-        if (!*args)
-            return false;
-
-        char* playerName = strtok((char*)args, " ");
-        char* spellid = strtok(nullptr, " ");
-        char* all = strtok(nullptr, " ");
-        if (!playerName)
-            return false;
-
-        Player* targetPlayer;
-        uint64 targetGuid;
-        if (!handler->extractPlayerTarget(playerName, &targetPlayer, &targetGuid))
-            return false;
-
-        if (!targetPlayer)
-        {
-            handler->SendSysMessage(LANG_PLAYER_NOT_FOUND);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        if (!spellid)
-            return false;
-
-        uint32 spell = handler->extractSpellIdFromLink(spellid);
-        if (!spell)
-            return false;
-
-        bool allRanks = all ? (strncmp(all, "all", strlen(all)) == 0) : false;
-
-        if (allRanks)
-            spell = sSpellMgr->GetFirstSpellInChain (spell);
-
-        if (targetPlayer->HasSpell(spell))
-            targetPlayer->removeSpell(spell, SPEC_MASK_ALL, false);
-        else
-            handler->SendSysMessage(LANG_FORGET_SPELL);
-
-        if (GetTalentSpellCost(spell))
-            targetPlayer->SendTalentsInfoData(false);
 
         return true;
     }

--- a/src/server/scripts/Commands/cs_player.cpp
+++ b/src/server/scripts/Commands/cs_player.cpp
@@ -97,7 +97,7 @@ public:
         if (!spell)
             return false;
 
-        bool allRanks = all ? (strncmp(all, "all", strlen(all)) == 0) : false;
+        bool allRanks = all ? (strncmp(all, "all", 3) == 0) : false;
 
         if (allRanks)
             spell = sSpellMgr->GetFirstSpellInChain (spell);

--- a/src/server/scripts/Commands/cs_player.cpp
+++ b/src/server/scripts/Commands/cs_player.cpp
@@ -100,7 +100,7 @@ public:
         bool allRanks = all ? (strncmp(all, "all", 3) == 0) : false;
 
         if (allRanks)
-            spell = sSpellMgr->GetFirstSpellInChain (spell);
+            spell = sSpellMgr->GetFirstSpellInChain(spell);
 
         if (targetPlayer->HasSpell(spell))
             targetPlayer->removeSpell(spell, SPEC_MASK_ALL, false);

--- a/src/server/scripts/Commands/cs_player.cpp
+++ b/src/server/scripts/Commands/cs_player.cpp
@@ -1,8 +1,6 @@
 /*
- * Copyright (C) 2016+     AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-GPL2
- * Copyright (C) 2008-2016 TrinityCore <http://www.trinitycore.org/>
- * Copyright (C) 2005-2009 MaNGOS <http://getmangos.com/>
- */
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
+*/
 
 #include "Chat.h"
 #include "ScriptMgr.h"

--- a/src/server/scripts/Commands/cs_player.cpp
+++ b/src/server/scripts/Commands/cs_player.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2016+     AzerothCore <www.azerothcore.org>, released under GNU GPL v2 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-GPL2
+ * Copyright (C) 2008-2016 TrinityCore <http://www.trinitycore.org/>
+ * Copyright (C) 2005-2009 MaNGOS <http://getmangos.com/>
+ */
+
+#include "Chat.h"
+#include "ScriptMgr.h"
+#include "Language.h"
+#include "Player.h"
+
+class player_commandscript : public CommandScript
+{
+public:
+    player_commandscript() : CommandScript("player_commandscript") { }
+
+    std::vector<ChatCommand> GetCommands() const override
+    {
+        static std::vector<ChatCommand> playerCommandTable =
+        {
+            { "learn",               SEC_GAMEMASTER,  true, &HandlePlayerLearnCommand,           "" },
+            { "unlearn",             SEC_GAMEMASTER,  true, &HandlePlayerUnLearnCommand,         "" }
+        };
+
+        static std::vector<ChatCommand> commandTable =
+        {
+            { "player",              SEC_GAMEMASTER,  true, nullptr,                             "", playerCommandTable }
+        };
+        return commandTable;
+    }
+
+    static bool HandlePlayerLearnCommand(ChatHandler* handler, char const* args)
+    {
+        if (!*args)
+            return false;
+
+        char* playerName = strtok((char*)args, " ");
+        char* spellid = strtok(nullptr, " ");
+        char* all = strtok(nullptr, " ");
+        Player* targetPlayer = FindPlayer(handler, playerName);
+        if (!spellid || !targetPlayer)
+            return false;
+
+        uint32 spell = handler->extractSpellIdFromLink(spellid);
+        if (!spell)
+            return false;
+
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spell);
+        if (!spellInfo)
+        {
+            handler->PSendSysMessage(LANG_COMMAND_NOSPELLFOUND);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        if (!SpellMgr::IsSpellValid(spellInfo))
+        {
+            handler->PSendSysMessage(LANG_COMMAND_SPELL_BROKEN, spell);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        bool allRanks = all ? (strncmp(all, "all", strlen(all)) == 0) : false;
+
+        if (!allRanks && targetPlayer->HasSpell(spell))
+        {
+            handler->PSendSysMessage(LANG_TARGET_KNOWN_SPELL, handler->GetNameLink(targetPlayer).c_str());
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        if (allRanks)
+            targetPlayer->learnSpellHighRank(spell);
+        else
+            targetPlayer->learnSpell(spell);
+
+        uint32 firstSpell = sSpellMgr->GetFirstSpellInChain(spell);
+        if (GetTalentSpellCost(firstSpell))
+            targetPlayer->SendTalentsInfoData(false);
+
+        return true;
+    }
+
+    static bool HandlePlayerUnLearnCommand(ChatHandler* handler, char const* args)
+    {
+        if (!*args)
+            return false;
+
+        char* playerName = strtok((char*)args, " ");
+        char* spellid = strtok(nullptr, " ");
+        char* all = strtok(nullptr, " ");
+        Player* targetPlayer = FindPlayer(handler, playerName);
+        if (!spellid || !targetPlayer)
+            return false;
+
+        uint32 spell = handler->extractSpellIdFromLink(spellid);
+        if (!spell)
+            return false;
+
+        bool allRanks = all ? (strncmp(all, "all", strlen(all)) == 0) : false;
+
+        if (allRanks)
+            spell = sSpellMgr->GetFirstSpellInChain (spell);
+
+        if (targetPlayer->HasSpell(spell))
+            targetPlayer->removeSpell(spell, SPEC_MASK_ALL, false);
+        else
+            handler->SendSysMessage(LANG_FORGET_SPELL);
+
+        if (GetTalentSpellCost(spell))
+            targetPlayer->SendTalentsInfoData(false);
+
+        return true;
+    }
+
+private:
+    static Player* FindPlayer(ChatHandler* handler, char* playerName)
+    {
+        if (!playerName)
+            return nullptr;
+
+        Player* targetPlayer;
+        if (!handler->extractPlayerTarget(playerName, &targetPlayer))
+            return nullptr;
+
+        if (!targetPlayer)
+        {
+            handler->SendSysMessage(LANG_PLAYER_NOT_FOUND);
+            handler->SetSentErrorMessage(true);
+            return nullptr;
+        }
+
+        return targetPlayer;
+    }
+};
+
+void AddSC_player_commandscript()
+{
+    new player_commandscript();
+}

--- a/src/server/scripts/Commands/cs_player.cpp
+++ b/src/server/scripts/Commands/cs_player.cpp
@@ -60,7 +60,7 @@ public:
             return false;
         }
 
-        bool allRanks = all ? (strncmp(all, "all", strlen(all)) == 0) : false;
+        bool allRanks = all ? (strncmp(all, "all", 3) == 0) : false;
 
         if (!allRanks && targetPlayer->HasSpell(spell))
         {

--- a/src/server/scripts/ScriptLoader.cpp
+++ b/src/server/scripts/ScriptLoader.cpp
@@ -62,6 +62,7 @@ void AddSC_tele_commandscript();
 void AddSC_ticket_commandscript();
 void AddSC_titles_commandscript();
 void AddSC_wp_commandscript();
+void AddSC_player_commandscript();
 
 #ifdef SCRIPTS
 //world
@@ -613,7 +614,7 @@ void AddCommandScripts()
     AddSC_character_commandscript();
     AddSC_cheat_commandscript();
     AddSC_debug_commandscript();
-	AddSC_deserter_commandscript();
+    AddSC_deserter_commandscript();
     AddSC_disable_commandscript();
     AddSC_event_commandscript();
     AddSC_gm_commandscript();
@@ -639,6 +640,7 @@ void AddCommandScripts()
     AddSC_ticket_commandscript();
     AddSC_titles_commandscript();
     AddSC_wp_commandscript();
+    AddSC_player_commandscript();
 }
 
 void AddWorldScripts()


### PR DESCRIPTION
##### CHANGES PROPOSED:
Don't know if it's actually needed, but I created two new GM commands to learn or unlearn spells for players without targeting the player directly:
```
.player learn #playername #spell
.player unlearn #playername #spell
```
I use them on my own server for some time now and just want to share the code. If not needed this PR can be closed.

##### ISSUES ADDRESSED:
none

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
Just use the commands with a GM account or via server console, e.g.:
```
.player learn Testplayer 23223
.player unlearn Testplayer 23223
```
This will learn / unlearn "Swift White Mechanostrider" for the player "Testplayer". Also try the existing commands (you need another player as target):
```
.learn 23223
.unlearn 23223
```

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
