### PR TITLE
fix(Core): Glyph of Eternal Water

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1576535250226124911.sql
+++ b/data/sql/updates/pending_db_world/rev_1576535250226124911.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1576535250226124911');
+
+DELETE FROM `spell_script_names` WHERE `spell_id` = 70937;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`)
+VALUES
+(70937, 'spell_mage_glyph_of_eternal_water');

--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -929,7 +929,18 @@ void WorldSession::SendPetNameQuery(uint64 petguid, uint32 petnumber)
         return;
     }
 
-    std::string name = pet->GetName();
+    std::string name;
+    if (pet->GetEntry() == NPC_WATER_ELEMENTAL_PERM)
+    {
+        // Use localized creature name for the mage pet
+        LocaleConstant loc_idx = GetSessionDbLocaleIndex();
+        if (loc_idx != DEFAULT_LOCALE)
+            name = pet->GetNameForLocaleIdx(loc_idx);
+        else
+            name = pet->GetCreatureTemplate()->Name;
+    }
+    else
+        name = pet->GetName();
 
     WorldPacket data(SMSG_PET_NAME_QUERY_RESPONSE, (4+4+name.size()+1));
     data << uint32(petnumber);

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -16,6 +16,7 @@
 #include "Player.h"
 #include "SpellMgr.h"
 #include "TemporarySummon.h"
+#include "Pet.h"
 
 enum MageSpells
 {
@@ -462,6 +463,36 @@ class spell_mage_brain_freeze : public SpellScriptLoader
         AuraScript* GetAuraScript() const
         {
             return new spell_mage_brain_freeze_AuraScript();
+        }
+};
+
+class spell_mage_glyph_of_eternal_water : public SpellScriptLoader
+{
+    public:
+        spell_mage_glyph_of_eternal_water() : SpellScriptLoader("spell_mage_glyph_of_eternal_water") { }
+
+        class spell_mage_glyph_of_eternal_water_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_mage_glyph_of_eternal_water_AuraScript);
+
+            void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+            {
+                if (Unit* target = GetTarget())
+                    if (Player* player = target->ToPlayer())
+                        if (Pet* pet = player->GetPet())
+                            if (pet->GetEntry() == NPC_WATER_ELEMENTAL_PERM)
+                                pet->Remove(PET_SAVE_NOT_IN_SLOT);
+            }
+
+            void Register()
+            {
+                OnEffectRemove += AuraEffectRemoveFn(spell_mage_glyph_of_eternal_water_AuraScript::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+            }
+        };
+
+        AuraScript* GetAuraScript() const
+        {
+            return new spell_mage_glyph_of_eternal_water_AuraScript();
         }
 };
 
@@ -1091,6 +1122,7 @@ void AddSC_mage_spell_scripts()
     new spell_mage_burnout_trigger();
     new spell_mage_pet_scaling();
     new spell_mage_brain_freeze();
+    new spell_mage_glyph_of_eternal_water();
 
     // Theirs
     new spell_mage_blast_wave();


### PR DESCRIPTION
##### CHANGES PROPOSED:
- Fix permanent Water Elemental not showing it's localized name.
- Despawn the permanent Water Elemental if the Glyph of Eternal Water is removed.

##### ISSUES ADDRESSED:
Closes #2503

##### TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

##### HOW TO TEST THE CHANGES:
- Create a mage who can summon a Water Elemental
- Add the Glyph of Eternal Water
- Summon the Water Elemental: It should now show the localized name (perhaps also test using a second player with a different client language watching the Water Elemental, it should show the name in the language of the client)
- Remove the Glyph of Eternal Water: The permanent Water Elemental should vanish.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
