### PR TITLE
fix(DB/SAI): Snufflenose Gopher

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1576886642925348957.sql
+++ b/data/sql/updates/pending_db_world/rev_1576886642925348957.sql
@@ -3,7 +3,8 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1576886642925348957');
 -- Snufflenose Gopher: Render immune to PC and NPC
 UPDATE `creature_template` SET `unit_flags` = `unit_flags` | 256 | 512 WHERE `entry` = 4781;
 
--- Snufflenose Gopher: Ensure that the react state is always passive
+-- Snufflenose Gopher: Ensure that the react state is always passive; remove unnecessary entries
+UPDATE `smart_scripts` SET `link` = 0 WHERE `entryorguid` = 4781 AND `source_type` = 0 AND `id` = 5;
 DELETE FROM `smart_scripts` WHERE `entryorguid` = 4781 AND `source_type` = 0 AND `id` IN (6,8);
 DELETE FROM `smart_scripts` WHERE `entryorguid` = 478100 AND `source_type` = 9 AND `id` = 4;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)

--- a/data/sql/updates/pending_db_world/rev_1576886642925348957.sql
+++ b/data/sql/updates/pending_db_world/rev_1576886642925348957.sql
@@ -1,0 +1,11 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1576886642925348957');
+
+-- Snufflenose Gopher: Render immune to PC and NPC
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` | 256 | 512 WHERE `entry` = 4781;
+
+-- Snufflenose Gopher: Ensure that the react state is always passive
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 4781 AND `source_type` = 0 AND `id` IN (6,8);
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 478100 AND `source_type` = 9 AND `id` = 4;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(4781,0,8,0,11,0,100,0,0,0,0,0,0,8,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Snufflenose Gopher - On Respawn - Set React State ''Passive''');


### PR DESCRIPTION
##### CHANGES PROPOSED:
Fix the Snufflenose Gopher pulling mobs.

##### ISSUES ADDRESSED:
Closes #2415

##### TESTS PERFORMED:
tested successfully in-game

##### HOW TO TEST THE CHANGES:
- preparation:
```
.q rem 1221
.q a 1221
.ad 5880
.ad 5897
.ad 6684
.tele razorfenkraul
```
- proceed with the quest "Blueleaf Tubers". The Snufflenose Gopher should no longer cause aggro.

##### KNOWN ISSUES AND TODO LIST:
none

##### Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
