### PR TITLE
feat(Core/Hook): New PlayerScript hook "OnPetInitStatsForLevel"

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1065,6 +1065,10 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
 
     SetFullHealth();
     SetPower(POWER_MANA, GetMaxPower(POWER_MANA));
+
+    if (Pet* pet = ToPet())
+        sScriptMgr->OnPetInitStatsForLevel(pet);
+
     return true;
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21019,8 +21019,6 @@ void Player::PetSpellInitialize()
     if (!pet)
         return;
 
-    sScriptMgr->OnPetSpellInitialize(pet);
-
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PETS, "Pet Spells Groups");
 #endif

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21019,6 +21019,8 @@ void Player::PetSpellInitialize()
     if (!pet)
         return;
 
+    sScriptMgr->OnPetSpellInitialize(pet);
+
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_PETS, "Pet Spells Groups");
 #endif

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1750,6 +1750,11 @@ bool ScriptMgr::CanJoinInBattlegroundQueue(Player* player, uint64 BattlemasterGu
     return ret;
 }
 
+void ScriptMgr::OnPetSpellInitialize(Pet* pet)
+{
+    FOREACH_SCRIPT(PlayerScript)->OnPetSpellInitialize(pet);
+}
+
 // Account
 void ScriptMgr::OnAccountLogin(uint32 accountId)
 {

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1750,9 +1750,9 @@ bool ScriptMgr::CanJoinInBattlegroundQueue(Player* player, uint64 BattlemasterGu
     return ret;
 }
 
-void ScriptMgr::OnPetSpellInitialize(Pet* pet)
+void ScriptMgr::OnPetInitStatsForLevel(Pet* pet)
 {
-    FOREACH_SCRIPT(PlayerScript)->OnPetSpellInitialize(pet);
+    FOREACH_SCRIPT(PlayerScript)->OnPetInitStatsForLevel(pet);
 }
 
 // Account

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -963,7 +963,7 @@ class PlayerScript : public ScriptObject
         virtual bool CanJoinInBattlegroundQueue(Player* /*player*/, uint64 /*BattlemasterGuid*/, BattlegroundTypeId /*BGTypeID*/, uint8 /*joinAsGroup*/, GroupJoinBattlegroundResult& /*err*/) { return true; }
 
         // Called after the player's pet has been loaded and initialized
-        virtual void OnPetSpellInitialize(Pet* /*pet*/) { }
+        virtual void OnPetInitStatsForLevel(Pet* /*pet*/) { }
 };
 
 class AccountScript : public ScriptObject
@@ -1415,7 +1415,7 @@ class ScriptMgr
         void OnFirstLogin(Player* player);
         void OnPlayerCompleteQuest(Player* player, Quest const* quest);
         bool CanJoinInBattlegroundQueue(Player* player, uint64 BattlemasterGuid, BattlegroundTypeId BGTypeID, uint8 joinAsGroup, GroupJoinBattlegroundResult& err);
-        void OnPetSpellInitialize(Pet* pet);
+        void OnPetInitStatsForLevel(Pet* pet);
 
     public: /* AccountScript */
 

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -961,6 +961,9 @@ class PlayerScript : public ScriptObject
         virtual void OnFirstLogin(Player* /*player*/) { }
 
         virtual bool CanJoinInBattlegroundQueue(Player* /*player*/, uint64 /*BattlemasterGuid*/, BattlegroundTypeId /*BGTypeID*/, uint8 /*joinAsGroup*/, GroupJoinBattlegroundResult& /*err*/) { return true; }
+
+        // Called after the player's pet has been loaded and initialized
+        virtual void OnPetSpellInitialize(Pet* /*pet*/) { }
 };
 
 class AccountScript : public ScriptObject
@@ -1412,6 +1415,7 @@ class ScriptMgr
         void OnFirstLogin(Player* player);
         void OnPlayerCompleteQuest(Player* player, Quest const* quest);
         bool CanJoinInBattlegroundQueue(Player* player, uint64 BattlemasterGuid, BattlegroundTypeId BGTypeID, uint8 joinAsGroup, GroupJoinBattlegroundResult& err);
+        void OnPetSpellInitialize(Pet* pet);
 
     public: /* AccountScript */
 


### PR DESCRIPTION
## CHANGES PROPOSED:
Add a new PlayerScript hook "OnPetInitStatsForLevel" which is called after the player's pet has been loaded and initialized. This can be used to get access to the player's pet object and alter it's values, e.g. "SetObjectScale".

## ISSUES ADDRESSED:
none

## TESTS PERFORMED:
tested build on Ubuntu 16.04 / clang 7

## HOW TO TEST THE CHANGES:
Can be tested using this simple PlayerScript which sets all pets half their normal size:
```cpp
class PetInit_PlayerScript : public PlayerScript
{
public:
    PetInit_PlayerScript() : PlayerScript("PetInit_PlayerScript") { }

    void OnPetInitStatsForLevel(Pet* pet) override
    {
        pet->SetObjectScale(0.5f * pet->GetFloatValue(OBJECT_FIELD_SCALE_X));
    }
};
```

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
