### PR TITLE
fix(Core/Player): Only save players glyphs when needed

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -26648,6 +26648,8 @@ void Player::_SaveGlyphs(SQLTransaction& trans)
 
         trans->Append(stmt);
     }
+
+    SetNeedToSaveGlyphs(false);
 }
 
 void Player::_LoadTalents(PreparedQueryResult result)


### PR DESCRIPTION
I posted it on Discord : 
I found out that for optimization reasons, AC use `NeedToSaveGlyphs()` to know if glyphs should be re-saved into db or not. So, according to `SetGlyph` function, `NeedToSaveGlyphs()` is becoming `true` (called by `SetNeedToSaveGlyph(true)`) when the player add/change a glyph. (That's pretty normal)
But, my question is, why is `SetNeedToSaveGlyph(false)` never called ? Even after save ? It means that it'll continue to re-save player's glyphs into db even if they were already saved and unchanged.

## CHANGES PROPOSED:
-  Add `SetNeedToSaveGlyph(false)` after Glyphs got saved 


## ISSUES ADDRESSED:
Commit : 70170f0bbd767c7d4656b9a3e33b7e21429f00ab
- `SetNeedToSaveGlyph(false)` was never used


## TESTS PERFORMED:
- Checked if glyphs are still saved
- Checked if the `Player::_SaveGlyphs()` function was NOT called when the player didn't rechange his glyphs (after a save).

Tested on Windows 10.

## HOW TO TEST THE CHANGES:
1. Add/Update glyph to your player
2. .saveall, wait for save or restart the server
3. Log into the game and check if the glyph is still there (and makes effect) or not.

## Target branch(es):
- [x] Master


## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
