### PR TITLE
fix(Core/DK): Don't allow starter dk to queue bg

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1876,7 +1876,7 @@ GroupJoinBattlegroundResult Group::CanJoinBattlegroundQueue(Battleground const* 
         if (bgTemplate->GetBgTypeID() == BATTLEGROUND_RB && member->InBattlegroundQueue())
             return ERR_IN_NON_RANDOM_BG;
 
-        // don't let join starter dk when they're not allowed to get teleported
+        // don't let Death Knights join BG queues when they are not allowed to be teleported yet
         if (member->getClass() == CLASS_DEATH_KNIGHT && member->GetMapId() == 609 && !member->IsGameMaster() && !member->HasSpell(50977))
             return ERR_BATTLEGROUND_JOIN_TIMED_OUT;
     }

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1878,7 +1878,7 @@ GroupJoinBattlegroundResult Group::CanJoinBattlegroundQueue(Battleground const* 
 
         // don't let Death Knights join BG queues when they are not allowed to be teleported yet
         if (member->getClass() == CLASS_DEATH_KNIGHT && member->GetMapId() == 609 && !member->IsGameMaster() && !member->HasSpell(50977))
-            return ERR_BATTLEGROUND_JOIN_TIMED_OUT;
+            return ERR_GROUP_JOIN_BATTLEGROUND_FAIL;
     }
 
     // for arenas: check party size is proper
@@ -2339,4 +2339,3 @@ void Group::ToggleGroupMemberFlag(member_witerator slot, uint8 flag, bool apply)
     else
         slot->flags &= ~flag;
 }
-

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1875,6 +1875,10 @@ GroupJoinBattlegroundResult Group::CanJoinBattlegroundQueue(Battleground const* 
         // don't let join to bg queue random if someone from the group is already in bg queue
         if (bgTemplate->GetBgTypeID() == BATTLEGROUND_RB && member->InBattlegroundQueue())
             return ERR_IN_NON_RANDOM_BG;
+
+        // don't let join starter dk when they're not allowed to get teleported
+        if (member->getClass() == CLASS_DEATH_KNIGHT && member->GetMapId() == 609 && !member->IsGameMaster() && !member->HasSpell(50977))
+            return ERR_BATTLEGROUND_JOIN_TIMED_OUT;
     }
 
     // for arenas: check party size is proper

--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -158,6 +158,8 @@ void WorldSession::HandleBattlemasterJoinOpcode(WorldPacket & recvData)
                  _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_3v3) ||
                  _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5)) // can't be already queued for arenas
             err = ERR_BATTLEGROUND_QUEUED_FOR_RATED;
+        else if (_player->getClass() == CLASS_DEATH_KNIGHT && _player->GetMapId() == 609 && !_player->IsGameMaster() && !_player->HasSpell(50977)) // don't allow starter dk to queue
+            err = ERR_BATTLEGROUND_NONE;
 
         if (err <= 0)
         {

--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -158,7 +158,8 @@ void WorldSession::HandleBattlemasterJoinOpcode(WorldPacket & recvData)
                  _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_3v3) ||
                  _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5)) // can't be already queued for arenas
             err = ERR_BATTLEGROUND_QUEUED_FOR_RATED;
-        else if (_player->getClass() == CLASS_DEATH_KNIGHT && _player->GetMapId() == 609 && !_player->IsGameMaster() && !_player->HasSpell(50977)) // don't allow starter dk to queue
+        // don't let Death Knights join BG queues when they are not allowed to be teleported yet
+        else if (_player->getClass() == CLASS_DEATH_KNIGHT && _player->GetMapId() == 609 && !_player->IsGameMaster() && !_player->HasSpell(50977))
             err = ERR_BATTLEGROUND_NONE;
 
         if (err <= 0)


### PR DESCRIPTION
## CHANGES PROPOSED:
-  Disallow starter dk to join battleground queue


## ISSUES ADDRESSED:
According to 
https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Entities/Player/Player.cpp#L2321

Death-knights aren't allowed to get teleported out of their starting zone until they didn't got their "Death gate" spell (dk quest lines).

Currently, they can't get teleported but they still can queue bg, and when the queue pops, they can click on "enter". 
The issue is that they're not teleported and still considered "in bg" (according to the Battleground queue icon that pops near the minimap circle). They can click on the "Leave battleground" option, but nothing happens.

Commit : 70170f0bbd767c7d4656b9a3e33b7e21429f00ab

PS : Confirmed by [ Stevej [es] - @pangolp ] on Discord

## TESTS PERFORMED:
- Tried to queue bg with dk (solo) -> don't work (intended)
- Tried to queue bg in group (dk + druid, same level) -> don't work (intended)
- Tried to queue bg in group (druid + warrior, same level) -> works (intended)
- Tried to queue bg with dk (solo and in group) once the dk have the "Death Gate" spell

Tested on Windows 10.

## HOW TO TEST THE CHANGES:
- Try to queue bg with a dk (solo and in group)

## Target branch(es):
- [x] Master

## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
