### PR TITLE
fix(Core/CreatureAI): Skip creatures in evade mode for DoZoneInCombat

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -36,7 +36,7 @@ void CreatureAI::DoZoneInCombat(Creature* creature /*= NULL*/, float maxRangeToN
     if (!creature)
         creature = me;
 
-    if (!creature->CanHaveThreatList())
+    if (!creature->CanHaveThreatList() || creature->IsInEvadeMode())
         return;
 
     Map* map = creature->GetMap();
@@ -46,8 +46,7 @@ void CreatureAI::DoZoneInCombat(Creature* creature /*= NULL*/, float maxRangeToN
         return;
     }
 
-    // Xinef: Skip creatures in evade mode
-    if (!creature->HasReactState(REACT_PASSIVE) && !creature->GetVictim() && !creature->IsInEvadeMode())
+    if (!creature->HasReactState(REACT_PASSIVE) && !creature->GetVictim())
     {
         if (Unit* nearTarget = creature->SelectNearestTarget(maxRangeToNearestTarget))
             creature->AI()->AttackStart(nearTarget);


### PR DESCRIPTION
## CHANGES PROPOSED:
Skip creatures in evade mode if DoZoneInCombat is called. This prevents error messages similar to this:
```
ERROR: DoZoneInCombat called for creature that has empty threat list (creature entry = 18831)
```

## ISSUES ADDRESSED:
part of #2536

## TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

## HOW TO TEST THE CHANGES:
- `.tele GruulsLair`
- pull High King Maulgar to the entrance of the dungeon
- leave the dungeon and enter it again
- run past the mobs (they're in evade mode), wait until the first one returned to it's home position and attack him while the other mobs are still returning
- the error message mentioned above should not occur anymore

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
