### PR TITLE
feat(Core/Hook): New PlayerScript hooks

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -154,7 +154,12 @@ bool Pet::LoadPetFromDB(Player* owner, uint8 asynchLoadType, uint32 petentry, ui
 
     // DK Pet exception
     if (owner->getClass() == CLASS_DEATH_KNIGHT && !owner->CanSeeDKPet())
-        return false;
+    {
+        if (!sScriptMgr->CustomPetAllowedForDeathKnight(owner))
+        {
+            return false;
+        }
+    }
 
     uint32 ownerid = owner->GetGUIDLow();
     PreparedStatement* stmt;
@@ -732,7 +737,19 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
             petType = HUNTER_PET;
             m_unitTypeMask |= UNIT_MASK_HUNTER_PET;
         }
-        else
+
+        switch (sScriptMgr->OverridePetType(m_owner->ToPlayer(), cinfo))
+        {
+            case SUMMON_PET:
+                petType = SUMMON_PET;
+                break;
+            case HUNTER_PET:
+                petType = HUNTER_PET;
+                m_unitTypeMask |= UNIT_MASK_HUNTER_PET;
+                break;
+        }
+
+        if (petType != SUMMON_PET && petType != HUNTER_PET)
             sLog->outError("Unknown type pet %u is summoned by player class %u", GetEntry(), m_owner->getClass());
     }
 

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -154,12 +154,8 @@ bool Pet::LoadPetFromDB(Player* owner, uint8 asynchLoadType, uint32 petentry, ui
 
     // DK Pet exception
     if (owner->getClass() == CLASS_DEATH_KNIGHT && !owner->CanSeeDKPet())
-    {
         if (!sScriptMgr->CustomPetAllowedForDeathKnight(owner))
-        {
             return false;
-        }
-    }
 
     uint32 ownerid = owner->GetGUIDLow();
     PreparedStatement* stmt;

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1755,6 +1755,32 @@ void ScriptMgr::OnPetInitStatsForLevel(Pet* pet)
     FOREACH_SCRIPT(PlayerScript)->OnPetInitStatsForLevel(pet);
 }
 
+bool ScriptMgr::CustomPetAllowedForDeathKnight(Player* player)
+{
+    bool ret = false;
+
+    FOR_SCRIPTS_RET(PlayerScript, itr, end, ret) // return false as default
+        if (itr->second->CustomPetAllowedForDeathKnight(player))
+            ret = true; // change ret value only if at least one script returns true
+
+    return ret;
+}
+
+uint8 ScriptMgr::OverridePetType(Player* player, CreatureTemplate const* cinfo)
+{
+    uint8 ret = MAX_PET_TYPE;
+
+    FOR_SCRIPTS_RET(PlayerScript, itr, end, ret) // return MAX_PET_TYPE as default
+    {
+        uint8 petType = itr->second->OverridePetType(player, cinfo);
+
+        if (petType != MAX_PET_TYPE)
+            ret = petType;
+    }
+
+    return ret;
+}
+
 // Account
 void ScriptMgr::OnAccountLogin(uint32 accountId)
 {

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1757,28 +1757,24 @@ void ScriptMgr::OnPetInitStatsForLevel(Pet* pet)
 
 bool ScriptMgr::CustomPetAllowedForDeathKnight(Player* player)
 {
-    bool ret = false;
-
-    FOR_SCRIPTS_RET(PlayerScript, itr, end, ret) // return false as default
+    FOR_SCRIPTS_RET(PlayerScript, itr, end, false) // return false as default
         if (itr->second->CustomPetAllowedForDeathKnight(player))
-            ret = true; // change ret value only if at least one script returns true
+            return true; // change ret value only if at least one script returns true
 
-    return ret;
+    return false;
 }
 
 uint8 ScriptMgr::OverridePetType(Player* player, CreatureTemplate const* cinfo)
 {
-    uint8 ret = MAX_PET_TYPE;
-
-    FOR_SCRIPTS_RET(PlayerScript, itr, end, ret) // return MAX_PET_TYPE as default
+    FOR_SCRIPTS_RET(PlayerScript, itr, end, MAX_PET_TYPE) // return MAX_PET_TYPE as default
     {
         uint8 petType = itr->second->OverridePetType(player, cinfo);
 
         if (petType != MAX_PET_TYPE)
-            ret = petType;
+            return petType;
     }
 
-    return ret;
+    return MAX_PET_TYPE;
 }
 
 // Account

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -18,6 +18,7 @@
 #include "DynamicObject.h"
 #include "ArenaTeam.h"
 #include "GameEventMgr.h"
+#include "PetDefines.h"
 #include <atomic>
 
 class AuctionHouseObject;
@@ -964,6 +965,10 @@ class PlayerScript : public ScriptObject
 
         // Called after the player's pet has been loaded and initialized
         virtual void OnPetInitStatsForLevel(Pet* /*pet*/) { }
+
+        virtual bool CustomPetAllowedForDeathKnight(Player* /*player*/) { return false; }
+
+        virtual uint8 OverridePetType(Player* /*player*/, CreatureTemplate const* /*cinfo*/) { return MAX_PET_TYPE; }
 };
 
 class AccountScript : public ScriptObject
@@ -1416,6 +1421,8 @@ class ScriptMgr
         void OnPlayerCompleteQuest(Player* player, Quest const* quest);
         bool CanJoinInBattlegroundQueue(Player* player, uint64 BattlemasterGuid, BattlegroundTypeId BGTypeID, uint8 joinAsGroup, GroupJoinBattlegroundResult& err);
         void OnPetInitStatsForLevel(Pet* pet);
+        bool CustomPetAllowedForDeathKnight(Player* /*player*/);
+        uint8 OverridePetType(Player* /*player*/, CreatureTemplate const* /*cinfo*/);
 
     public: /* AccountScript */
 


### PR DESCRIPTION
## CHANGES PROPOSED:
Two new PlayerScript hooks to use by the [BeastMaster module](https://github.com/azerothcore/mod-npc-beastmaster):
CustomPetAllowedForDeathKnight
OverridePetType

This way it is finally possible to get rid of the BeastMaster's [patch file](https://github.com/azerothcore/mod-npc-beastmaster/blob/77df961c0bcc5e2cad71421956549be6043c6626/Pet.cpp.beastmaster.patch).

## ISSUES ADDRESSED:
none

## TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested with and without a modified version of the BeastMaster module

## HOW TO TEST THE CHANGES:
This can be tested using this PlayerScript which enables the Death Knight for custom Pets and uses another algorithm to determine the pet type:
```cpp
class PetInit_PlayerScript : public PlayerScript
{
public:
    PetInit_PlayerScript() : PlayerScript("PetInit_PlayerScript") { }

    bool CustomPetAllowedForDeathKnight(Player* /*player*/) override
    {
        return true;
    }

    uint8 OverridePetType(Player* /*player*/, CreatureTemplate const* cinfo) override
    {
        if (cinfo->IsTameable(true))
        {
            return HUNTER_PET;
        }
        else
        {
            return SUMMON_PET;
        }
    }
};
```

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
