### PR TITLE
fix(Core/CreatureGroups): Fix "MoveSplineInitArgs::Validate" errors

### DIFF
--- a/src/server/game/Entities/Creature/CreatureGroups.cpp
+++ b/src/server/game/Entities/Creature/CreatureGroups.cpp
@@ -279,9 +279,13 @@ void CreatureGroup::LeaderMoveTo(float x, float y, float z, bool run)
         // xinef: if we move members to position without taking care of sizes, we should compare distance without sizes
         // xinef: change members speed basing on distance - if too far speed up, if too close slow down
         UnitMoveType mtype = Movement::SelectSpeedType(member->GetUnitMovementFlags());
-        member->SetSpeedRate(mtype, m_leader->GetSpeedRate(mtype) * member->GetExactDist(dx, dy, dz) / pathDist);
+        float speedRate = m_leader->GetSpeedRate(mtype) * member->GetExactDist(dx, dy, dz) / pathDist;
 
-        member->GetMotionMaster()->MovePoint(0, dx, dy, dz);
-        member->SetHomePosition(dx, dy, dz, pathAngle);
+        if (speedRate > 0.01f) // don't move if speed rate is too low
+        {
+            member->SetSpeedRate(mtype, speedRate);
+            member->GetMotionMaster()->MovePoint(0, dx, dy, dz);
+            member->SetHomePosition(dx, dy, dz, pathAngle);
+        }
     }
 }


### PR DESCRIPTION
## CHANGES PROPOSED:
Prevent the speed rate of the formation movement of members from getting too low which otherwise leads to errors similar to these:
```
ERROR: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID: 57968 Entry: 16843
ERROR: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID: 101655 Entry: 32572
ERROR: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID: 4479 Entry: 727
ERROR: MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID: 4480 Entry: 727
```
The error happens after the creatures finish combat and the member has to wait for the leader.

## ISSUES ADDRESSED:
none

## TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

## HOW TO TEST THE CHANGES:
- follow these creatures:
```
.go cr 4479
.go cr 57968
.go cr 101655
```
- the errors mentioned above should not occur anymore.

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
