### PR TITLE
fix(DB/gossip): Fix several gossip options for NPCs in Un'Goro Crater

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1579770074985495361.sql
+++ b/data/sql/updates/pending_db_world/rev_1579770074985495361.sql
@@ -1,0 +1,43 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1579770074985495361');
+
+-- Spark Nilminer: Fix wrong gossip options by removing the obsolete gossip menu options for Ragged John
+DELETE FROM `gossip_menu_option` WHERE `MenuID` = 2061 AND `OptionID` = 1;
+DELETE FROM `gossip_menu_option` WHERE `MenuID` IN (2714,2715,2716,2717,2718,2719,2720,2721,2722,2723,2725);
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` = 2061 AND `SourceEntry` = 1;
+
+-- J.D. Collie: Gossip options and conditions
+DELETE FROM `gossip_menu` WHERE `MenuID` = 2184 AND `TextID` = 2833;
+DELETE FROM `gossip_menu` WHERE `MenuID` IN (2200,2202,2203,2204);
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`)
+VALUES
+(2184,2833),
+(2200,2834),
+(2202,2836),
+(2203,2837),
+(2204,2838);
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` IN (14,15) AND `SourceGroup` = 2184;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`)
+VALUES
+(14,2184,2833,0,0,8,0,4321,0,0,0,0,0,'','Show gossip text 2833 if quest ''Making Sense of It'' is rewarded'),
+(15,2184,0,0,0,8,0,4321,0,0,0,0,0,'','Show gossip option 0 if quest ''Making Sense of It'' is rewarded'),
+(15,2184,1,0,0,8,0,4321,0,0,0,0,0,'','Show gossip option 1 if quest ''Making Sense of It'' is rewarded'),
+(15,2184,2,0,0,8,0,4321,0,0,0,0,0,'','Show gossip option 2 if quest ''Making Sense of It'' is rewarded'),
+(15,2184,3,0,0,2,0,11482,1,1,1,0,0,'','Show gossip option 3 if player does not have item ''Crystal Pylon User''s Manual'''),
+(15,2184,3,0,0,8,0,4321,0,0,0,0,0,'','Show gossip option 3 if quest ''Making Sense of It'' is rewarded');
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 9117 AND `source_type` = 0 AND `id` = 1;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(9117,0,1,0,62,0,100,0,2184,3,0,0,0,11,15211,0,0,0,0,0,7,0,0,0,0,0,0,0,0,'J.D. Collie - On Gossip Option 3 Selected - Cast ''Create Pylon User''s Manual''');
+
+-- Karna Remtravel: Add Gossip Option
+DELETE FROM `gossip_menu` WHERE `MenuID` = 2082;
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`)
+VALUES
+(2082,2735);
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` = 2081;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`)
+VALUES
+(15,2081,0,0,0,9,0,4244,0,0,0,0,0,'','Show gossip option if quest ''Chasing A-Me 01 (Part 2)'' is taken');


### PR DESCRIPTION
## CHANGES PROPOSED:
Fix gossip options for the following NPCs in Un'Goro Crater:
- Spark Nilminer
- J.D. Collie
- Karna Remtravel

This is based on the following TC commits:
https://github.com/TrinityCore/TrinityCore/commit/d78b62f4372153b81b7539b54c0fcd8092858d47
https://github.com/TrinityCore/TrinityCore/commit/17ddc47577cfeb6218780b444ec0595eb47ac594
I adapted them to AC and only took over the necessary parts.

## ISSUES ADDRESSED:
none

## TESTS PERFORMED:
tested successfully in-game

## HOW TO TEST THE CHANGES:
**Spark Nilminer**
- `.go cr id 9272`
- ask him about Dadanga: there should not be any more gossip options following this

**J.D. Collie**
- step 1:
```
.q rem 4285
.q rem 4287
.q rem 4288
.q rem 4321
.go cr id 9117
```
- talk to J.D. Collie: she should not show any gossip options
- step 2:
```
.q a 4285
.q a 4287
.q a 4288
.q c 4285
.q c 4287
.q c 4288
.q rew 4285
.q rew 4287
.q rew 4288
```
- take the quest "Making Sense of It", wait a bit and turn in the quest; there should then be gossip options for each Crystal Pylon
- destroy the item "Crystal Pylon User's Manual": J.D. Collie should now offer a gossip option to get a new one

**Karna Remtravel:**
- step 1:
```
.q rem 4243
.q rem 4244
.go cr id 9618
```
- talk to Karna Remtravel: she should not show any gossip options
- step 2:
```
.q a 4243
.q c 4243
.q rew 4243
.q a 4244
```
- talk to Karna Remtravel: she should now offer the correct gossip option concerning mithril casings.

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
