### PR TITLE
fix(Core/Unit): Fix Guardian Pets clearing combat state

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -384,7 +384,7 @@ void Unit::Update(uint32 p_time)
         SendThreatListUpdate();
 
     // update combat timer only for players and pets (only pets with PetAI)
-    if (IsInCombat() && (GetTypeId() == TYPEID_PLAYER || (IsPet() && IsControlledByPlayer())))
+    if (IsInCombat() && (GetTypeId() == TYPEID_PLAYER || ((IsPet() || HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN)) && IsControlledByPlayer())))
     {
         // Check UNIT_STATE_MELEE_ATTACKING or UNIT_STATE_CHASE (without UNIT_STATE_FOLLOW in this case) so pets can reach far away
         // targets without stopping half way there and running off.


### PR DESCRIPTION
## CHANGES PROPOSED:
As it is now the Guardian Pets, like the Mage's (temporary) Water Elemental or the Shaman's Spirit Wolves cannot clear their combat state after combat has ended. This can be tested like follows:
- create a Mage who can summon the temporary Water Elemental
- use "`.npc info`" on the Water Elemental: Unit Flag "UNIT_FLAG_IN_COMBAT" (0x00080000, 524288) is not set
- attack an enemy NPC
- after the combat the Unit Flag "UNIT_FLAG_IN_COMBAT" ist still there and won't be cleared.

After applying this PR the flag will be correctly cleared when combat ends.
## ISSUES ADDRESSED:
none

## TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

## HOW TO TEST THE CHANGES:
See the description above.

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
