### PR TITLE
Make OnPlayerLeaveMap actually trigger

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -876,9 +876,9 @@ void Map::RemovePlayerFromMap(Player* player, bool remove)
     else
         ASSERT(remove); //maybe deleted in logoutplayer when player is not in a map
 
+    sScriptMgr->OnPlayerLeaveMap(this, player);
     if (remove)
     {
-        sScriptMgr->OnPlayerLeaveMap(this, player);
         DeleteFromWorld(player);
     }
 }


### PR DESCRIPTION
OnPlayerLeaveMap was previously inside the if(remove) block which only is called when the player is logging out, this moves it outside that block but still has it trigger in the same order, thus allowing OnPlayerLeaveMap scripts to fire properly (needed for AutoBalanceFix)

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## CHANGES PROPOSED:
-  
-  


## ISSUES ADDRESSED:
- Closes 
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## TESTS PERFORMED:
-
-
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->


## KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 


## Target branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
