### PR TITLE
fix(Core/Pet): only show pet details for hunter pets and demons

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -2189,8 +2189,11 @@ void Pet::HandleAsynchLoadFailed(AsynchPetSummon* info, Player* player, uint8 as
 
         if (info->m_petType == SUMMON_PET)
         {
-            // this enables pet details window (Shift+P)
-            pet->GetCharmInfo()->SetPetNumber(pet_number, true);
+            if (pet->GetCreatureTemplate()->type == CREATURE_TYPE_DEMON)
+                pet->GetCharmInfo()->SetPetNumber(pet_number, true); // Show pet details tab (Shift+P) only for demons
+            else
+                pet->GetCharmInfo()->SetPetNumber(pet_number, false);
+
             pet->SetUInt32Value(UNIT_FIELD_BYTES_0, 2048);
             pet->SetUInt32Value(UNIT_FIELD_PETEXPERIENCE, 0);
             pet->SetUInt32Value(UNIT_FIELD_PETNEXTLEVELEXP, 1000);

--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -160,7 +160,10 @@ uint8 WorldSession::HandleLoadPetFromDBFirstCallback(PreparedQueryResult result,
         return PET_LOAD_OK;
     }
 
-    pet->GetCharmInfo()->SetPetNumber(pet_number, pet->IsPermanentPetFor(owner));
+    if (pet->getPetType() == HUNTER_PET || pet->GetCreatureTemplate()->type == CREATURE_TYPE_DEMON)
+        pet->GetCharmInfo()->SetPetNumber(pet_number, pet->IsPermanentPetFor(owner)); // Show pet details tab (Shift+P) only for hunter pets or demons
+    else
+        pet->GetCharmInfo()->SetPetNumber(pet_number, false);
 
     pet->SetDisplayId(fields[3].GetUInt32());
     pet->SetNativeDisplayId(fields[3].GetUInt32());


### PR DESCRIPTION
## CHANGES PROPOSED:
Only show pet details (Shift+P) for the Hunter pets and Warlock demons, not for the Death Knight's permanent ghoul or the Mage's permanent water elemental.

## ISSUES ADDRESSED:
Closes #2414

## TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

## HOW TO TEST THE CHANGES:
- pet details should show normally for Hunter pets and Warlock demons, just as it was before
- pet details should not show for the Death Knight's permanent ghoul or the Mage's permanent water elemental

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
