### PR TITLE
feat(Core/Hook): New PlayerScript hooks

### DIFF
--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -11,6 +11,7 @@
 #include "TemporarySummon.h"
 #include "Pet.h"
 #include "Player.h"
+#include "ScriptMgr.h"
 
 TempSummon::TempSummon(SummonPropertiesEntry const* properties, uint64 owner, bool isWorldObject) :
 Creature(isWorldObject), m_Properties(properties), m_type(TEMPSUMMON_MANUAL_DESPAWN),
@@ -147,13 +148,16 @@ void TempSummon::InitStats(uint32 duration)
 { 
     ASSERT(!IsPet());
 
+    Unit* owner = GetSummoner();
+    if (Player* player = owner->ToPlayer())
+        sScriptMgr->OnBeforeTempSummonInitStats(player, this, duration);
+
     m_timer = duration;
     m_lifetime = duration;
 
     if (m_type == TEMPSUMMON_MANUAL_DESPAWN)
         m_type = (duration == 0) ? TEMPSUMMON_DEAD_DESPAWN : TEMPSUMMON_TIMED_DESPAWN;
 
-    Unit* owner = GetSummoner();
     if (owner)
     {
         if (IsTrigger() && m_spells[0])

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -731,6 +731,7 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
         {
             if (petType == MAX_PET_TYPE)
             {
+                // The petType was not overwritten by the hook, continue with default initialization
                 if (owner->getClass() == CLASS_WARLOCK ||
                     owner->getClass() == CLASS_SHAMAN ||          // Fire Elemental
                     owner->getClass() == CLASS_DEATH_KNIGHT ||    // Risen Ghoul

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1653,9 +1653,24 @@ bool ScriptMgr::CanJoinInBattlegroundQueue(Player* player, uint64 BattlemasterGu
     return ret;
 }
 
-void ScriptMgr::OnPetInitStatsForLevel(Pet* pet)
+void ScriptMgr::OnBeforeTempSummonInitStats(Player* player, TempSummon* tempSummon, uint32& duration)
 {
-    FOREACH_SCRIPT(PlayerScript)->OnPetInitStatsForLevel(pet);
+    FOREACH_SCRIPT(PlayerScript)->OnBeforeTempSummonInitStats(player, tempSummon, duration);
+}
+
+void ScriptMgr::OnBeforeGuardianInitStatsForLevel(Player* player, Guardian* guardian, CreatureTemplate const* cinfo, PetType& petType)
+{
+    FOREACH_SCRIPT(PlayerScript)->OnBeforeGuardianInitStatsForLevel(player, guardian, cinfo, petType);
+}
+
+void ScriptMgr::OnAfterGuardianInitStatsForLevel(Player* player, Guardian* guardian)
+{
+    FOREACH_SCRIPT(PlayerScript)->OnAfterGuardianInitStatsForLevel(player, guardian);
+}
+
+void ScriptMgr::OnBeforeLoadPetFromDB(Player* player, uint32& petentry, uint32& petnumber, bool& current, bool& forceLoadFromDB)
+{
+    FOREACH_SCRIPT(PlayerScript)->OnBeforeLoadPetFromDB(player, petentry, petnumber, current, forceLoadFromDB);
 }
 
 // Account

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -18,6 +18,7 @@
 #include "DynamicObject.h"
 #include "ArenaTeam.h"
 #include "GameEventMgr.h"
+#include "PetDefines.h"
 #include <atomic>
 
 class AuctionHouseObject;
@@ -962,8 +963,17 @@ class PlayerScript : public ScriptObject
 
         virtual bool CanJoinInBattlegroundQueue(Player* /*player*/, uint64 /*BattlemasterGuid*/, BattlegroundTypeId /*BGTypeID*/, uint8 /*joinAsGroup*/, GroupJoinBattlegroundResult& /*err*/) { return true; }
 
-        // Called after the player's pet has been loaded and initialized
-        virtual void OnPetInitStatsForLevel(Pet* /*pet*/) { }
+        // Called before the player's temporary summoned creature has initialized it's stats
+        virtual void OnBeforeTempSummonInitStats(Player* /*player*/, TempSummon* /*tempSummon*/, uint32& /*duration*/) { }
+
+        // Called before the player's guardian / pet has initialized it's stats for the player's level
+        virtual void OnBeforeGuardianInitStatsForLevel(Player* /*player*/, Guardian* /*guardian*/, CreatureTemplate const* /*cinfo*/, PetType& /*petType*/) { }
+
+        // Called after the player's guardian / pet has initialized it's stats for the player's level
+        virtual void OnAfterGuardianInitStatsForLevel(Player* /*player*/, Guardian* /*guardian*/) { }
+
+        // Called before loading a player's pet from the DB
+        virtual void OnBeforeLoadPetFromDB(Player* /*player*/, uint32& /*petentry*/, uint32& /*petnumber*/, bool& /*current*/, bool& /*forceLoadFromDB*/) { }
 };
 
 class AccountScript : public ScriptObject
@@ -1415,7 +1425,10 @@ class ScriptMgr
         void OnFirstLogin(Player* player);
         void OnPlayerCompleteQuest(Player* player, Quest const* quest);
         bool CanJoinInBattlegroundQueue(Player* player, uint64 BattlemasterGuid, BattlegroundTypeId BGTypeID, uint8 joinAsGroup, GroupJoinBattlegroundResult& err);
-        void OnPetInitStatsForLevel(Pet* pet);
+        void OnBeforeTempSummonInitStats(Player* player, TempSummon* tempSummon, uint32& duration);
+        void OnBeforeGuardianInitStatsForLevel(Player* player, Guardian* guardian, CreatureTemplate const* cinfo, PetType& petType);
+        void OnAfterGuardianInitStatsForLevel(Player* player, Guardian* guardian);
+        void OnBeforeLoadPetFromDB(Player* player, uint32& petentry, uint32& petnumber, bool& current, bool& forceLoadFromDB);
 
     public: /* AccountScript */
 


### PR DESCRIPTION
## CHANGES PROPOSED:
Provide new PlayerScript hooks which can be used to access and manipulate player's pets, guardians, non-combat pets etc. at different states of their initialization:
- OnBeforeTempSummonInitStats
- OnBeforeGuardianInitStatsForLevel
- OnAfterGuardianInitStatsForLevel (replaces OnPetInitStatsForLevel)
- OnBeforeLoadPetFromDB

Thanks for your feedback @Yehonal on #2600, I hope that I got it right this time.

## ISSUES ADDRESSED:
none

## TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game using modified versions of [mod-npc-beastmaster](https://github.com/azerothcore/mod-npc-beastmaster) and [mod-morphsummon](https://github.com/azerothcore/mod-morphsummon) and a small test-module.

## HOW TO TEST THE CHANGES:
Example for a PlayerScript:
```cpp
class Test_PlayerScript : public PlayerScript
{
public:
    Test_PlayerScript() : PlayerScript("Test_PlayerScript") { }

    // Cause all non-combat pets to be 5 times bigger
    void OnBeforeTempSummonInitStats(Player* /*player*/, TempSummon* tempSummon, uint32& /*duration*/) override
    {
        if (tempSummon->GetCreatureType() == CREATURE_TYPE_NON_COMBAT_PET)
            tempSummon->SetObjectScale(5.0f);
    }

    // Change the pet type before proceeding with the initialization
    void OnBeforeGuardianInitStatsForLevel(Player* /*player*/, Guardian* /*guardian*/, CreatureTemplate const* cinfo, PetType& petType) override
    {
        if (cinfo->IsTameable(true))
        {
            petType = HUNTER_PET;
        }
        else
        {
            petType = SUMMON_PET;
        }
    }

    // Spirit Wolves will stay forever, but have no healing aura and deal less damage
    void OnAfterGuardianInitStatsForLevel(Player* /*player*/, Guardian* guardian) override
    {
        if (guardian->GetEntry() == NPC_FERAL_SPIRIT)
        {
            uint8 guardianLevel = guardian->getLevel();
            guardian->SetBaseWeaponDamage(BASE_ATTACK, MINDAMAGE, float(guardianLevel * 2.0f - guardianLevel));
            guardian->SetBaseWeaponDamage(BASE_ATTACK, MAXDAMAGE, float(guardianLevel * 2.0f + guardianLevel));
            guardian->RemoveAurasDueToSpell(SPELL_FERAL_SPIRIT_SPIRIT_HUNT);
            guardian->SetTempSummonType(TEMPSUMMON_DEAD_DESPAWN);
            guardian->SetTimer(0);
        }
    }

    // Always load pets from the DB
    void OnBeforeLoadPetFromDB(Player* /*player*/, uint32& /*petentry*/, uint32& /*petnumber*/, bool& /*current*/, bool& forceLoadFromDB) override
    {
        forceLoadFromDB = true;
    }
};
```

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
