### PR TITLE
fix(Core/TempSummon): Fix crash concerning PlayerScript hook

### DIFF
--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -149,8 +149,9 @@ void TempSummon::InitStats(uint32 duration)
     ASSERT(!IsPet());
 
     Unit* owner = GetSummoner();
-    if (Player* player = owner->ToPlayer())
-        sScriptMgr->OnBeforeTempSummonInitStats(player, this, duration);
+    if (owner)
+        if (Player* player = owner->ToPlayer())
+            sScriptMgr->OnBeforeTempSummonInitStats(player, this, duration);
 
     m_timer = duration;
     m_lifetime = duration;


### PR DESCRIPTION
## CHANGES PROPOSED:
Fix a crash introduced with #2639 concerning the PlayerScript hook for TempSummon. I forgot to check if "owner" is null, sorry for that.

## ISSUES ADDRESSED:
Closes #2649

## TESTS PERFORMED:
tested build on Ubuntu 16.04 / clang 7

## HOW TO TEST THE CHANGES:
Don't know how to provoke the crash, but it should not happen anymore.

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
