### PR TITLE
fix(DB/Quest): Shaman quest "Earth Sapta"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1581463517639375967.sql
+++ b/data/sql/updates/pending_db_world/rev_1581463517639375967.sql
@@ -1,0 +1,24 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1581463517639375967');
+
+-- Only show both quests "Earth Sapta" as long as "Call of Earth" is neither rewarded nor completed
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` IN (19,20) AND `SourceEntry` IN (1463,1462);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`)
+VALUES
+(19,0,1463,0,0,8,0,1518,0,0,1,0,0,'','Quest ''Earth Sapta'' is only available as long as ''Call of Earth'' is not rewarded.'),
+(19,0,1463,0,0,28,0,1518,0,0,1,0,0,'','Quest ''Earth Sapta'' is only available as long as ''Call of Earth'' is not completed.'),
+(20,0,1463,0,0,8,0,1518,0,0,1,0,0,'','Quest ''Earth Sapta'' shows quest mark only as long as ''Call of Earth'' is not rewarded.'),
+(20,0,1463,0,0,28,0,1518,0,0,1,0,0,'','Quest ''Earth Sapta'' shows quest mark only as long as ''Call of Earth'' is not rewarded.'),
+(19,0,1462,0,0,8,0,1521,0,0,1,0,0,'','Quest ''Earth Sapta'' is only available as long as ''Call of Earth'' is not rewarded.'),
+(19,0,1462,0,0,28,0,1521,0,0,1,0,0,'','Quest ''Earth Sapta'' is only available as long as ''Call of Earth'' is not completed.'),
+(20,0,1462,0,0,8,0,1521,0,0,1,0,0,'','Quest ''Earth Sapta'' shows quest mark only as long as ''Call of Earth'' is not rewarded.'),
+(20,0,1462,0,0,28,0,1521,0,0,1,0,0,'','Quest ''Earth Sapta'' shows quest mark only as long as ''Call of Earth'' is not rewarded.');
+
+-- Add reward text to both quests "Earth Sapta"
+DELETE FROM `quest_offer_reward` WHERE `ID` IN (1463,1462);
+INSERT INTO `quest_offer_reward` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `RewardText`, `VerifiedBuild`)
+VALUES
+(1463,0,0,0,0,0,0,0,0,'I give you one in good faith. You already proved yourself once, but me tinkin'' you should be more careful in the future.',0),
+(1462,0,0,0,0,0,0,0,0,'Take this and remember, it is sacred.',0);
+
+-- Make both quests "Earth Sapta" repeatable and enable auto-accept
+UPDATE `quest_template_addon` SET `SpecialFlags` = 1 | 4 WHERE `ID` IN (1463,1462);


### PR DESCRIPTION
## CHANGES PROPOSED:
- Ensure that the quests "Earth Sapta" (IDs 1463 / 1462) are only available when "Call of Earth" was accepted but not completed.
- Make those quests repeatable and add the correct reward text

## ISSUES ADDRESSED:
none

## TESTS PERFORMED:
tested successfully in-game

## HOW TO TEST THE CHANGES:
**Troll Shaman:**
- preparation:
```
.q rem 1516
.q rem 1517
.q rem 1518
.q rem 1463
.go cr id 5887
```
- "Earth Sapta" should not be available
- Step 1:
```
.q a 1516
.q c 1516
.q rew 1516
```
- Accept "Call of Earth"
- "Earth Sapta" should be available and repeatable in case you loose the Earth Sapta
- Step 2:
```
.q c 1517
.q rew 1517
.q a 1518
.q c 1518
```
- "Earth Sapta" should not be available anymore

**Tauren Shaman:**
- preparation:
```
.q rem 1519
.q rem 1520
.q rem 1521
.q rem 1462
.go cr id 5888
```
- "Earth Sapta" should not be available
- Step 1:
```
.q a 1519
.q c 1519
.q rew 1519
```
- Accept "Call of Earth"
- "Earth Sapta" should be available and repeatable in case you loose the Earth Sapta
- Step 2:
```
.q c 1520
.q rew 1520
.q a 1521
.q c 1521
```
- "Earth Sapta" should not be available anymore

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
