### PR TITLE
feat(Core/Hook): New GlobalScript hook

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1057,7 +1057,7 @@ void WorldObject::CleanupsBeforeDelete(bool /*finalCleanup*/)
 void WorldObject::_Create(uint32 guidlow, HighGuid guidhigh, uint32 phaseMask)
 { 
     Object::_Create(guidlow, 0, guidhigh);
-    m_phaseMask = phaseMask;
+    SetPhaseMask(phaseMask, false);
 }
 
 uint32 WorldObject::GetZoneId(bool /*forceRecalc*/) const

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -971,7 +971,7 @@ elunaEvents(NULL),
 #endif
 LastUsedScriptID(0), m_name(""), m_isActive(false), m_isVisibilityDistanceOverride(false), m_isWorldObject(isWorldObject), m_zoneScript(NULL),
 m_transport(NULL), m_currMap(NULL), m_InstanceId(0),
-m_phaseMask(PHASEMASK_NORMAL), m_notifyflags(0), m_executed_notifies(0)
+m_phaseMask(PHASEMASK_NORMAL), m_useCombinedPhases(true), m_notifyflags(0), m_executed_notifies(0)
 {
     m_serverSideVisibility.SetValue(SERVERSIDE_VISIBILITY_GHOST, GHOST_VISIBILITY_ALIVE | GHOST_VISIBILITY_GHOST);
     m_serverSideVisibilityDetect.SetValue(SERVERSIDE_VISIBILITY_GHOST, GHOST_VISIBILITY_ALIVE);
@@ -1058,12 +1058,6 @@ void WorldObject::_Create(uint32 guidlow, HighGuid guidhigh, uint32 phaseMask)
 { 
     Object::_Create(guidlow, 0, guidhigh);
     m_phaseMask = phaseMask;
-}
-
-bool WorldObject::InSamePhase(uint32 phasemask) const
-{
-    sScriptMgr->OnBeforeWorldObjectInSamePhase(this, phasemask);
-    return (GetPhaseMask() & phasemask);
 }
 
 uint32 WorldObject::GetZoneId(bool /*forceRecalc*/) const
@@ -2866,7 +2860,8 @@ void WorldObject::MovePositionToFirstCollisionForTotem(Position &pos, float dist
 }
 
 void WorldObject::SetPhaseMask(uint32 newPhaseMask, bool update)
-{ 
+{
+    sScriptMgr->OnBeforeWorldObjectSetPhaseMask(this, m_phaseMask, newPhaseMask, m_useCombinedPhases, update);
     m_phaseMask = newPhaseMask;
 
     if (update && IsInWorld())

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -40,6 +40,7 @@
 #include "Group.h"
 #include "Chat.h"
 #include "DynamicVisibility.h"
+#include "ScriptMgr.h"
 
 #ifdef ELUNA
 #include "LuaEngine.h"
@@ -1057,6 +1058,12 @@ void WorldObject::_Create(uint32 guidlow, HighGuid guidhigh, uint32 phaseMask)
 { 
     Object::_Create(guidlow, 0, guidhigh);
     m_phaseMask = phaseMask;
+}
+
+bool WorldObject::InSamePhase(uint32 phasemask) const
+{
+    sScriptMgr->OnBeforeWorldObjectInSamePhase(this, phasemask);
+    return (GetPhaseMask() & phasemask);
 }
 
 uint32 WorldObject::GetZoneId(bool /*forceRecalc*/) const

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -799,7 +799,7 @@ class WorldObject : public Object, public WorldLocation
         virtual void SetPhaseMask(uint32 newPhaseMask, bool update);
         uint32 GetPhaseMask() const { return m_phaseMask; }
         bool InSamePhase(WorldObject const* obj) const { return InSamePhase(obj->GetPhaseMask()); }
-        bool InSamePhase(uint32 phasemask) const;
+        bool InSamePhase(uint32 phasemask) const { return m_useCombinedPhases ? GetPhaseMask() & phasemask : GetPhaseMask() == phasemask; }
 
         virtual uint32 GetZoneId(bool forceRecalc = false) const;
         virtual uint32 GetAreaId(bool forceRecalc = false) const;
@@ -1047,6 +1047,8 @@ class WorldObject : public Object, public WorldLocation
         //uint32 m_mapId;                                     // object at map with map_id
         uint32 m_InstanceId;                                // in map copy with instance id
         uint32 m_phaseMask;                                 // in area phase state
+        bool m_useCombinedPhases;                           // true (default): use phaseMask as bit mask combining up to 32 phases
+                                                            // false: use phaseMask to represent single phases only (up to 4294967295 phases)
 
         uint16 m_notifyflags;
         uint16 m_executed_notifies;

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -799,7 +799,7 @@ class WorldObject : public Object, public WorldLocation
         virtual void SetPhaseMask(uint32 newPhaseMask, bool update);
         uint32 GetPhaseMask() const { return m_phaseMask; }
         bool InSamePhase(WorldObject const* obj) const { return InSamePhase(obj->GetPhaseMask()); }
-        bool InSamePhase(uint32 phasemask) const { return (GetPhaseMask() & phasemask); }
+        bool InSamePhase(uint32 phasemask) const;
 
         virtual uint32 GetZoneId(bool forceRecalc = false) const;
         virtual uint32 GetAreaId(bool forceRecalc = false) const;

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1840,6 +1840,7 @@ void ScriptMgr::OnGroupDisband(Group* group)
     FOREACH_SCRIPT(GroupScript)->OnDisband(group);
 }
 
+// Global
 void ScriptMgr::OnGlobalItemDelFromDB(SQLTransaction& trans, uint32 itemGuid)
 {
     ASSERT(trans);
@@ -1887,6 +1888,12 @@ void ScriptMgr::OnAfterUpdateEncounterState(Map* map, EncounterCreditType type, 
     FOREACH_SCRIPT(GlobalScript)->OnAfterUpdateEncounterState(map, type, creditEntry, source, difficulty_fixed, encounters, dungeonCompleted, updated);
 }
 
+void ScriptMgr::OnBeforeWorldObjectInSamePhase(WorldObject const* worldObject, uint32& phasemask)
+{
+    FOREACH_SCRIPT(GlobalScript)->OnBeforeWorldObjectInSamePhase(worldObject, phasemask);
+}
+
+// Unit
 uint32 ScriptMgr::DealDamage(Unit* AttackerUnit, Unit *pVictim, uint32 damage, DamageEffectType damagetype)
 {
     FOR_SCRIPTS_RET(UnitScript, itr, end, damage)

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1888,9 +1888,9 @@ void ScriptMgr::OnAfterUpdateEncounterState(Map* map, EncounterCreditType type, 
     FOREACH_SCRIPT(GlobalScript)->OnAfterUpdateEncounterState(map, type, creditEntry, source, difficulty_fixed, encounters, dungeonCompleted, updated);
 }
 
-void ScriptMgr::OnBeforeWorldObjectInSamePhase(WorldObject const* worldObject, uint32& phasemask)
+void ScriptMgr::OnBeforeWorldObjectSetPhaseMask(WorldObject const* worldObject, uint32& oldPhaseMask, uint32& newPhaseMask, bool& useCombinedPhases, bool& update)
 {
-    FOREACH_SCRIPT(GlobalScript)->OnBeforeWorldObjectInSamePhase(worldObject, phasemask);
+    FOREACH_SCRIPT(GlobalScript)->OnBeforeWorldObjectSetPhaseMask(worldObject, oldPhaseMask, newPhaseMask, useCombinedPhases, update);
 }
 
 // Unit

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -1104,8 +1104,8 @@ class GlobalScript : public ScriptObject
         // Called when a dungeon encounter is updated.
         virtual void OnAfterUpdateEncounterState(Map* /*map*/, EncounterCreditType /*type*/,  uint32 /*creditEntry*/, Unit* /*source*/, Difficulty /*difficulty_fixed*/, DungeonEncounterList const* /*encounters*/, uint32 /*dungeonCompleted*/, bool /*updated*/) { }
 
-        // Called before check if the WorldObject is in the same phase as the specified phasemask
-        virtual void OnBeforeWorldObjectInSamePhase(WorldObject const* /*worldObject*/, uint32& /*phasemask*/) { }
+        // Called before the phase for a WorldObject is set
+        virtual void OnBeforeWorldObjectSetPhaseMask(WorldObject const* /*worldObject*/, uint32& /*oldPhaseMask*/, uint32& /*newPhaseMask*/, bool& /*useCombinedPhases*/, bool& /*update*/) { }
 };
 
 class BGScript : public ScriptObject
@@ -1475,7 +1475,7 @@ class ScriptMgr
         void OnInitializeLockedDungeons(Player* player, uint8& level, uint32& lockData);
         void OnAfterInitializeLockedDungeons(Player* player);
         void OnAfterUpdateEncounterState(Map* map, EncounterCreditType type, uint32 creditEntry, Unit* source, Difficulty difficulty_fixed, DungeonEncounterList const* encounters, uint32 dungeonCompleted, bool updated);
-        void OnBeforeWorldObjectInSamePhase(WorldObject const* worldObject, uint32& phasemask);
+        void OnBeforeWorldObjectSetPhaseMask(WorldObject const* worldObject, uint32& oldPhaseMask, uint32& newPhaseMask, bool& useCombinedPhases, bool& update);
 
     public: /* Scheduled scripts */
 

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -1103,6 +1103,9 @@ class GlobalScript : public ScriptObject
 
         // Called when a dungeon encounter is updated.
         virtual void OnAfterUpdateEncounterState(Map* /*map*/, EncounterCreditType /*type*/,  uint32 /*creditEntry*/, Unit* /*source*/, Difficulty /*difficulty_fixed*/, DungeonEncounterList const* /*encounters*/, uint32 /*dungeonCompleted*/, bool /*updated*/) { }
+
+        // Called before check if the WorldObject is in the same phase as the specified phasemask
+        virtual void OnBeforeWorldObjectInSamePhase(WorldObject const* /*worldObject*/, uint32& /*phasemask*/) { }
 };
 
 class BGScript : public ScriptObject
@@ -1472,7 +1475,7 @@ class ScriptMgr
         void OnInitializeLockedDungeons(Player* player, uint8& level, uint32& lockData);
         void OnAfterInitializeLockedDungeons(Player* player);
         void OnAfterUpdateEncounterState(Map* map, EncounterCreditType type, uint32 creditEntry, Unit* source, Difficulty difficulty_fixed, DungeonEncounterList const* encounters, uint32 dungeonCompleted, bool updated);
-
+        void OnBeforeWorldObjectInSamePhase(WorldObject const* worldObject, uint32& phasemask);
 
     public: /* Scheduled scripts */
 


### PR DESCRIPTION
## CHANGES PROPOSED:
Introduce a new GlobalScript hook which is called before the WorldObject phasemask check. This can be used to get rid of the [Guildhouse module](https://github.com/azerothcore/mod-guildhouse) patch file, but also for other kind of stuff concerning the phases as you are able to access the WorldObject and can also update the phasemask against which the check is running later.

## ISSUES ADDRESSED:
none

## TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game using a small GlobalScript

## HOW TO TEST THE CHANGES:
I used this small GlobalScript to test the hook:
```cpp
class GuildHouseGlobal : public GlobalScript
{
public:
    GuildHouseGlobal() : GlobalScript("GuildHouseGlobal") {}

    void OnBeforeWorldObjectSetPhaseMask(WorldObject const* worldObject, uint32& /*oldPhaseMask*/, uint32& /*newPhaseMask*/, bool& useCombinedPhases, bool& /*update*/) override
    {
        if (worldObject->GetZoneId() == 876)
            useCombinedPhases = false;
        else
            useCombinedPhases = true;
    }
};
```
It ensures that if in the zone "GM Island" (876) the phaseMask is not treated as combined phases, but as single individual phases. This means you only see objects using the exact same phasemask value as the player, so combining phases is no longer possible in this area.

Test 1:
- go to any zone except GM Island
- ensure that GM mode is off and you are in phase 1 (normal phase): `.mod p 1`
- add a chicken: `.npc a t 620`
- target the chicken and set phase 6: `mod p 6` (the chicken will vanish)
- try setting you own phase to phases 1-9
- the chicken will only be visible if the phase mask contains phases 2 or 4, so phasemask values 2,3,4,5,6,7; it will not be visible for phasemask value 1,8,9

Test 2:
- go to GM Island: `.tele GMIsland`
- proceed with the same steps as above
- the chicken will now only be visible for phasemask value 6

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
