### PR TITLE
fix(Core/SAI): SMARTCAST_COMBAT_MOVE

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -767,7 +767,10 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 if ((e.action.cast.flags & SMARTCAST_COMBAT_MOVE) && GetCasterMaxDist() > 0.0f && me->GetMaxPower(GetCasterPowerType()) > 0)
                 {
                     // Xinef: check mana case only and operate movement accordingly, LoS and range is checked in targetet movement generator
-                    if (me->GetPowerPct(GetCasterPowerType()) < 15.0f)
+                    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(e.action.cast.spell);
+                    int32 currentPower = me->GetPower(GetCasterPowerType());
+
+                    if ((spellInfo && (currentPower < spellInfo->CalcPowerCost(me, spellInfo->GetSchoolMask()))) || me->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SILENCED))
                     {
                         SetCasterActualDist(0);
                         CAST_AI(SmartAI, me->AI())->SetForcedCombatMove(0);


### PR DESCRIPTION
## CHANGES PROPOSED:
As it is now if using the cast flag "SMARTCAST_COMBAT_MOVE" the caster will move if his power is below 15%, no matter if he can cast his next spell or not. This is changed as follows:
- The caster will move if he has not enough power to cast his spell.
- The caster will also move if silenced.

## ISSUES ADDRESSED:
none

## TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

## HOW TO TEST THE CHANGES:
- `.go 5849.39 156.4 185.383 571`
- attack one of the Unbound Seers
- before: He casts until 15% mana and runs to the player although he as enough mana for another spell; if silenced (e.g. using "Strangulate") he just stands there doing nothing
- after: He casts until out of mana and then runs to the player; he also runs to the player if silenced

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
