### PR TITLE
fix(GameObject/Quest): GameObject quest / gossip window

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1582041321256109939.sql
+++ b/data/sql/updates/pending_db_world/rev_1582041321256109939.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1582041321256109939');
+
+UPDATE `gameobject_template_addon` SET `flags` = `flags` | 4 WHERE `entry` IN (SELECT `entry` FROM `gameobject_template` WHERE `type` = 2 AND `data3` = 0);

--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -316,7 +316,7 @@ void WorldSession::HandleQuestgiverChooseRewardOpcode(WorldPacket & recvData)
                         // Send next quest
                         if (Quest const* nextQuest = _player->GetNextQuest(guid, quest))
                         {
-                            if (_player->CanAddQuest(nextQuest, false) && _player->CanTakeQuest(quest, false))
+                            if (_player->CanAddQuest(nextQuest, false) && _player->CanTakeQuest(nextQuest, false))
                             {
                                 if (nextQuest->IsAutoAccept())
                                     _player->AddQuestAndCheckCompletion(nextQuest, object);


### PR DESCRIPTION
## CHANGES PROPOSED:
- Fix a small typo in the QuestHandler which caused the quest window to stay on screen after clicking on "Complete Quest".
- Add the flag "GO_FLAG_INTERACT_COND" to all game objects of type "GAMEOBJECT_TYPE_QUESTGIVER" which don't have their gossip ID set (data3 = 0). This ensures that the player is not able to interact with them if he doesn't meet the quest conditions. The SQL statement is taken from this TC commit: https://github.com/TrinityCore/TrinityCore/commit/7d723665218e0881903ff46c39416e4f6405892c

## ISSUES ADDRESSED:
none

## TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

## HOW TO TEST THE CHANGES:
- preparation:
```
.q rem 460
.ad 3317
.go 968.422 587.302 53.6713 0
```
- ensure that you cannot interact with the Shallow Grave
- accept the quest "Resting in Pieces" from the talking head in the inventory
- proceed with the quest; after "Resting in Pieces" is rewarded the following quest "The Hidden Niche" should automatically be shown.

There are many other such quests which could also be used for testing, e.g.:
- "Border Crossings" (game object "Dalaran Crate")
- "Rin'ji is Trapped!" (game object "Rin'ji's Secret")
- "The Bloodsail Buccaneers" (game object "Bloodsail Correspondence")
- "The Dormant Shade" (game object "Lillith's Dinner Table")

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
