### PR TITLE
fix(DB/creature_template): PvP flagged creatures in Talon Den

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1582129218605106158.sql
+++ b/data/sql/updates/pending_db_world/rev_1582129218605106158.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1582129218605106158');
+
+-- Mirkfallon Keeper, Mirkfallon Dryad, Gatekeeper Kordurus, Rynthariel the Keymaster:
+-- Use faction 124 instead of 79 (both Darnassus, but 79 has PvP flag)
+UPDATE `creature_template` SET `faction` = 124 WHERE `entry` IN (4056,4061,4409,8518);


### PR DESCRIPTION
## CHANGES PROPOSED:
Fix several creatures in the Talon Den (Stonetalon Peak) being PvP flagged because they use the wrong faction (79 instead of 124).

## ISSUES ADDRESSED:
none

## TESTS PERFORMED:
tested successfully in-game

## HOW TO TEST THE CHANGES:
- `.go 2427.97 1775.34 381.257 1`
- enter the Talon Den; there should not be any creatures anymore which are PvP flagged

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
