### PR TITLE
refactor(HandleAuctionListOwnerItems): prevent crash

### DIFF
--- a/src/server/game/Handlers/AuctionHouseHandler.cpp
+++ b/src/server/game/Handlers/AuctionHouseHandler.cpp
@@ -653,15 +653,6 @@ void WorldSession::HandleAuctionListOwnerItems(WorldPacket & recvData)
     recvData >> guid;
     recvData >> listfrom;
 
-    Creature* creature = GetPlayer()->GetNPCIfCanInteractWith(guid, UNIT_NPC_FLAG_AUCTIONEER);
-    if (!creature)
-    {
-#if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
-        sLog->outDebug(LOG_FILTER_NETWORKIO, "WORLD: HandleAuctionListOwnerItems - Unit (GUID: %u) not found or you can't interact with him.", uint32(GUID_LOPART(guid)));
-#endif
-        return;
-    }
-
     // pussywizard:
     const uint32 delay = 4500;
     const uint32 now = World::GetGameTimeMS();
@@ -672,11 +663,11 @@ void WorldSession::HandleAuctionListOwnerItems(WorldPacket & recvData)
         diff = delay;
 
     _lastAuctionListOwnerItemsMSTime = now + delay; // set longest possible here, actual exectuing will change this to getMSTime of that moment
-    _player->m_Events.AddEvent(new AuctionListOwnerItemsDelayEvent(_player->GetGUID(), true), _player->m_Events.CalculateTime(delay-diff));
+    _player->m_Events.AddEvent(new AuctionListOwnerItemsDelayEvent(guid, _player->GetGUID(), true), _player->m_Events.CalculateTime(delay-diff));
 }
 
 
-void WorldSession::HandleAuctionListOwnerItemsEvent(uint64 guid)
+void WorldSession::HandleAuctionListOwnerItemsEvent(uint64 creatureGuid)
 {
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_NETWORKIO, "WORLD: Received CMSG_AUCTION_LIST_OWNER_ITEMS");
@@ -684,7 +675,7 @@ void WorldSession::HandleAuctionListOwnerItemsEvent(uint64 guid)
 
     _lastAuctionListOwnerItemsMSTime = World::GetGameTimeMS(); // pussywizard
 
-    Creature* creature = GetPlayer()->GetNPCIfCanInteractWith(guid, UNIT_NPC_FLAG_AUCTIONEER);
+    Creature* creature = GetPlayer()->GetNPCIfCanInteractWith(creatureGuid, UNIT_NPC_FLAG_AUCTIONEER);
     if (!creature)
     {
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)

--- a/src/server/game/Handlers/AuctionHouseHandler.cpp
+++ b/src/server/game/Handlers/AuctionHouseHandler.cpp
@@ -676,7 +676,7 @@ void WorldSession::HandleAuctionListOwnerItems(WorldPacket & recvData)
    if (diff > delay)
        diff = delay;
 
-   _lastAuctionListOwnerItemsMSTime = now + delay; // set longest possible here, actual exectuing will change this to getMSTime of that moment
+   _lastAuctionListOwnerItemsMSTime = now + delay - diff; // set longest possible here, actual exectuing will change this to getMSTime of that moment
 
     AuctionHouseObject* auctionHouse = sAuctionMgr->GetAuctionsMap(creature->getFaction());
 

--- a/src/server/game/Handlers/AuctionHouseHandler.cpp
+++ b/src/server/game/Handlers/AuctionHouseHandler.cpp
@@ -648,9 +648,10 @@ void WorldSession::HandleAuctionListOwnerItems(WorldPacket & recvData)
 {
     // prevent crash caused by malformed packet
     uint64 guid;
-    WorldPacket* data = new WorldPacket(recvData);
-    *data >> guid;
-    delete(data);
+    uint32 listfrom;
+
+    recvData >> guid;
+    recvData >> listfrom;
 
     Creature* creature = GetPlayer()->GetNPCIfCanInteractWith(guid, UNIT_NPC_FLAG_AUCTIONEER);
     if (!creature)
@@ -671,23 +672,17 @@ void WorldSession::HandleAuctionListOwnerItems(WorldPacket & recvData)
         diff = delay;
 
     _lastAuctionListOwnerItemsMSTime = now + delay; // set longest possible here, actual exectuing will change this to getMSTime of that moment
-    _player->m_Events.AddEvent(new AuctionListOwnerItemsDelayEvent(recvData, _player->GetGUID(), true), _player->m_Events.CalculateTime(delay-diff));
+    _player->m_Events.AddEvent(new AuctionListOwnerItemsDelayEvent(_player->GetGUID(), true), _player->m_Events.CalculateTime(delay-diff));
 }
 
 
-void WorldSession::HandleAuctionListOwnerItemsEvent(WorldPacket & recvData)
+void WorldSession::HandleAuctionListOwnerItemsEvent(uint64 guid)
 {
 #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
     sLog->outDebug(LOG_FILTER_NETWORKIO, "WORLD: Received CMSG_AUCTION_LIST_OWNER_ITEMS");
 #endif
 
     _lastAuctionListOwnerItemsMSTime = World::GetGameTimeMS(); // pussywizard
-
-    uint32 listfrom;
-    uint64 guid;
-
-    recvData >> guid;
-    recvData >> listfrom;                                  // not used in fact (this list not have page control in client)
 
     Creature* creature = GetPlayer()->GetNPCIfCanInteractWith(guid, UNIT_NPC_FLAG_AUCTIONEER);
     if (!creature)

--- a/src/server/game/Handlers/AuctionHouseHandler.cpp
+++ b/src/server/game/Handlers/AuctionHouseHandler.cpp
@@ -218,7 +218,7 @@ void WorldSession::HandleAuctionSellItem(WorldPacket & recvData)
         SendAuctionCommandResult(0, AUCTION_SELL_ITEM, ERR_AUCTION_DATABASE_ERROR);
         return;
     }
- 
+
     // check if there are 2 identical guids, in this case user is most likely cheating
     for (uint32 i = 0; i < itemsCount - 1; ++i)
     {
@@ -646,17 +646,51 @@ void WorldSession::HandleAuctionListBidderItems(WorldPacket & recvData)
 //this void sends player info about his auctions
 void WorldSession::HandleAuctionListOwnerItems(WorldPacket & recvData)
 {
-    // pussywizard:
-    const uint32 delay = 4500;
-    const uint32 now = World::GetGameTimeMS();
-    if (_lastAuctionListOwnerItemsMSTime > now) // list is pending
-        return;
-    uint32 diff = getMSTimeDiff(_lastAuctionListOwnerItemsMSTime, now);
-    if (diff > delay)
-        diff = delay;
+    uint64 guid;
+    uint32 listfrom;
 
-    _lastAuctionListOwnerItemsMSTime = now + delay; // set longest possible here, actual exectuing will change this to getMSTime of that moment
-    _player->m_Events.AddEvent(new AuctionListOwnerItemsDelayEvent(recvData, _player->GetGUID(), true), _player->m_Events.CalculateTime(delay-diff));
+    recvData >> guid;
+    recvData >> listfrom;                                  // not used in fact (this list not have page control in client)
+
+    Creature* creature = GetPlayer()->GetNPCIfCanInteractWith(guid, UNIT_NPC_FLAG_AUCTIONEER);
+    if (!creature)
+    {
+        #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS)
+        sLog->outDebug(LOG_FILTER_NETWORKIO, "WORLD: HandleAuctionListOwnerItems - Unit (GUID: %u) not found or you can't interact with him.", uint32(GUID_LOPART(guid)));
+        #endif
+        return;
+    }
+
+    // remove fake death
+    if (GetPlayer()->HasUnitState(UNIT_STATE_DIED))
+        GetPlayer()->RemoveAurasByType(SPELL_AURA_FEIGN_DEATH);
+
+   // pussywizard:
+   const uint32 delay = 4500;
+   const uint32 now = World::GetGameTimeMS();
+   if (_lastAuctionListOwnerItemsMSTime > now) // list is pending
+       return;
+
+   uint32 diff = getMSTimeDiff(_lastAuctionListOwnerItemsMSTime, now);
+
+   if (diff > delay)
+       diff = delay;
+
+   _lastAuctionListOwnerItemsMSTime = now + delay; // set longest possible here, actual exectuing will change this to getMSTime of that moment
+
+    AuctionHouseObject* auctionHouse = sAuctionMgr->GetAuctionsMap(creature->getFaction());
+
+    WorldPacket data(SMSG_AUCTION_OWNER_LIST_RESULT, (4+4+4)); // pussywizard: ensure there is enough memory
+    data << (uint32) 0;             // amount place holder
+
+    uint32 count = 0;
+    uint32 totalcount = 0;
+
+    auctionHouse->BuildListOwnerItems(data, _player, count, totalcount);
+    data.put<uint32>(0, count);
+    data << (uint32) totalcount;
+    data << (uint32) 0;
+    SendPacket(&data);
 }
 
 void WorldSession::HandleAuctionListOwnerItemsEvent(WorldPacket & recvData)

--- a/src/server/game/Misc/AsyncAuctionListing.cpp
+++ b/src/server/game/Misc/AsyncAuctionListing.cpp
@@ -16,7 +16,7 @@ ACE_Thread_Mutex AsyncAuctionListingMgr::auctionListingTempLock;
 bool AuctionListOwnerItemsDelayEvent::Execute(uint64  /*e_time*/, uint32  /*p_time*/)
 {
     if (Player* plr = ObjectAccessor::FindPlayer(playerguid))
-        plr->GetSession()->HandleAuctionListOwnerItemsEvent(data);
+        plr->GetSession()->HandleAuctionListOwnerItemsEvent(playerguid);
     return true;
 }
 

--- a/src/server/game/Misc/AsyncAuctionListing.cpp
+++ b/src/server/game/Misc/AsyncAuctionListing.cpp
@@ -16,7 +16,7 @@ ACE_Thread_Mutex AsyncAuctionListingMgr::auctionListingTempLock;
 bool AuctionListOwnerItemsDelayEvent::Execute(uint64  /*e_time*/, uint32  /*p_time*/)
 {
     if (Player* plr = ObjectAccessor::FindPlayer(playerguid))
-        plr->GetSession()->HandleAuctionListOwnerItemsEvent(playerguid);
+        plr->GetSession()->HandleAuctionListOwnerItemsEvent(creatureGuid);
     return true;
 }
 

--- a/src/server/game/Misc/AsyncAuctionListing.h
+++ b/src/server/game/Misc/AsyncAuctionListing.h
@@ -8,7 +8,7 @@
 class AuctionListOwnerItemsDelayEvent : public BasicEvent
 {
     public:
-        AuctionListOwnerItemsDelayEvent(uint64 guid, bool o) : playerguid(guid), owner(o) {}
+        AuctionListOwnerItemsDelayEvent(uint64 _creatureGuid, uint64 guid, bool o) : creatureGuid(_creatureGuid), playerguid(guid), owner(o) {}
         virtual ~AuctionListOwnerItemsDelayEvent() {}
 
         virtual bool Execute(uint64 e_time, uint32 p_time);
@@ -16,6 +16,7 @@ class AuctionListOwnerItemsDelayEvent : public BasicEvent
         bool getOwner() { return owner; }
 
     private:
+        uint64 creatureGuid;
         uint64 playerguid;
         bool owner;
 };

--- a/src/server/game/Misc/AsyncAuctionListing.h
+++ b/src/server/game/Misc/AsyncAuctionListing.h
@@ -8,7 +8,7 @@
 class AuctionListOwnerItemsDelayEvent : public BasicEvent
 {
     public:
-        AuctionListOwnerItemsDelayEvent(WorldPacket& d, uint64 guid, bool o) : data(d), playerguid(guid), owner(o) {}
+        AuctionListOwnerItemsDelayEvent(uint64 guid, bool o) : playerguid(guid), owner(o) {}
         virtual ~AuctionListOwnerItemsDelayEvent() {}
 
         virtual bool Execute(uint64 e_time, uint32 p_time);
@@ -16,7 +16,6 @@ class AuctionListOwnerItemsDelayEvent : public BasicEvent
         bool getOwner() { return owner; }
 
     private:
-        WorldPacket data;
         uint64 playerguid;
         bool owner;
 };

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -606,7 +606,7 @@ class WorldSession
         void HandleAuctionSellItem(WorldPacket& recvData);
         void HandleAuctionRemoveItem(WorldPacket& recvData);
         void HandleAuctionListOwnerItems(WorldPacket& recvData);
-        void HandleAuctionListOwnerItemsEvent(WorldPacket & recvData);
+        void HandleAuctionListOwnerItemsEvent(uint64 guid);
         void HandleAuctionPlaceBid(WorldPacket& recvData);
         void HandleAuctionListPendingSales(WorldPacket& recvData);
 

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -606,7 +606,7 @@ class WorldSession
         void HandleAuctionSellItem(WorldPacket& recvData);
         void HandleAuctionRemoveItem(WorldPacket& recvData);
         void HandleAuctionListOwnerItems(WorldPacket& recvData);
-        void HandleAuctionListOwnerItemsEvent(uint64 guid);
+        void HandleAuctionListOwnerItemsEvent(uint64 creatureGuid);
         void HandleAuctionPlaceBid(WorldPacket& recvData);
         void HandleAuctionListPendingSales(WorldPacket& recvData);
 


### PR DESCRIPTION
## CHANGES PROPOSED:
-  Refactor the function HandleAuctionListOwnerItems to prevent crash from malformed packet (opcode **CMSG_AUCTION_LIST_OWNER_ITEMS**).
  

## ISSUES ADDRESSED:
- Closes #2683 
- probably related to #2666

## TESTS PERFORMED:
- I tested it as the issue show
- after the refactor I also tested several times the function during the "normal" play, I put on the auction some items and in "Auctions" I can see all my own items in the auction.

[chardump](https://paste.ubuntu.com/p/QdHgD8FgDt/)

## HOW TO TEST THE CHANGES:
- To reproduce the sending of the malformed packet just follow the instructions in issue #2683.
- To verify the normal play in wow just open an auction house in-game, put something in the Auction and see in the "Auction" frame if you can see your own items in the Auction.

Thx @SolidMaxtor who reported to me this issue.

## Target branch(es):
- [x] Master

## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
