### PR TITLE
fix(Core/Spell): Melee ranged spells

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6633,8 +6633,12 @@ SpellCastResult Spell::CheckRange(bool strict)
             // Xinef: WHAT DA FUCK IS THIS SHIT? Spells with 5yd range can hit target 9yd away? >.>
             if (range_type == SPELL_RANGE_MELEE)
             {
-                // Because of lag, we can not check too strictly here.
-                float real_max_range = m_caster->GetTypeId() == TYPEID_UNIT ? max_range - 2*MIN_MELEE_REACH : max_range - MIN_MELEE_REACH;
+                float real_max_range = max_range;
+                if (m_caster->GetTypeId() != TYPEID_UNIT && m_caster->isMoving() && target->isMoving() && !m_caster->IsWalking() && !target->IsWalking())
+                    real_max_range -= MIN_MELEE_REACH; // Because of lag, we can not check too strictly here (is only used if both caster and target are moving)
+                else
+                    real_max_range -= 2*MIN_MELEE_REACH;
+
                 if (!m_caster->IsWithinMeleeRange(target, std::max(real_max_range, 0.0f)))
                     return SPELL_FAILED_OUT_OF_RANGE;
             }


### PR DESCRIPTION
## CHANGES PROPOSED:
Try to fix issue #310 by only applying the increased range tolerance to melee ranged spells if both the caster and the target are fast moving (that means not walking). I tried to implement this in the least intrusive way possible, leaving the original logic mostly intact.

## ISSUES ADDRESSED:
- Closes #310
- Closes #2673

## TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game using manipulated client files

## HOW TO TEST THE CHANGES:
In order to test the hack you need to manipulate the client:
- Extract and open "SpellRange.dbc", for ID 2 "Combat Range" set "RangeMax_1" and "RangeMax_2" to 100 and "Flags" to 0.
- Create a new MPQ file, e.g. "patch-enUS-4.MPQ", include "SpellRange.dbc" and place the MPQ in the "Data/enUS" directory.

Without this PR you can now use melee ranged spells from a greater distance (7 yards), with this PR this is only possible if both caster and target are running, otherwise it is restricted to 5 yards.

Which should also be tested: Duels / PvP using several melee ranged spells (I cannot do this, sadly, playing alone).

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
