### PR TITLE
fix(Core/Pet): Pet chase range check for melee ranged spells

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -443,6 +443,8 @@ void Pet::Update(uint32 diff)
                     if (!spellInfo)
                         return;
                     float max_range = GetSpellMaxRangeForTarget(tempspellTarget, spellInfo);
+                    if (spellInfo->RangeEntry->type == SPELL_RANGE_MELEE)
+                        max_range -= 2*MIN_MELEE_REACH;
 
                     if (IsWithinLOSInMap(tempspellTarget) && GetDistance(tempspellTarget) < max_range)
                     {


### PR DESCRIPTION
## CHANGES PROPOSED:
As it is now the pet stops before getting in range of it's target if commanded to use melee ranged spells (like "Bite"). This PR fixes the range check while the pet is chasing it's target in order to be equal to the actual spell range check:
https://github.com/azerothcore/azerothcore-wotlk/blob/999d588c37ef0e56d9043f1aa33ad5e9796f74ca/src/server/game/Spells/Spell.cpp#L6637

## ISSUES ADDRESSED:
Closes #2440

## TESTS PERFORMED:
- tested build on Ubuntu 16.04 / clang 7
- tested successfully in-game

## HOW TO TEST THE CHANGES:
- set "follow" mode for the pet and switch to "passive"
- disable auto-casting for all pet spells
- stand far away from a target dummy and command the pet to use for example "Bite" on the target dummy
- without this PR the pet stops near the target dummy, doing nothing; with this PR it uses the commanded melee ranged spell and engages in combat.

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
