### PR TITLE
fix(Core/Crash): remove unneeded hook OnPlayerChat

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -172,12 +172,8 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket & recvData)
 	            {
 		            std::string to, msg;
 		            recvData >> to >> msg;
-		            Player* receiver = ObjectAccessor::FindPlayerByName(to, false);
-
 		            if (msg.empty())
 			            return;
-
-		            sScriptMgr->OnPlayerChat(sender, type, lang, msg, receiver);
 	            }
 
 	            break;


### PR DESCRIPTION
According to #2407, We should use `normalizePlayerName` and UTF-8 check before using the player name when we take it from the client.

But, We already have `sScriptMgr->OnPlayerChat` for whsiper in [Player.cpp](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Entities/Player/Player.cpp#L20956)

That would be load the scripts if anything like the player name was valid and the player was online.
You can check `ChatHandler.cpp` file in TrinityCore, they don't have `OnPlayerChat` (for whisper) inside that file.

I think, If the server had any custom script for the whisper, like chat censure, Server can get Crash with WPS.

If you really want to keep that **[Not need that, That's duplicate!]**, You should validate the player name with `normalizePlayerName` function.

### How to test?
Use the last ver of AC or older versions.
Required chat censure or other scripts for chats. [[Chat Censure module](https://github.com/IntelligentQuantum/AzerothCore/blob/master/modules/IntelligentQuantum/PlayerScripts/Censure.cpp)]
Use this WPS (AccLeito). [DOWNLOAD](http://files.masterking32.com/wow-crashes/Azerothcore/25-feb-2020/MasterkinG32-WPS-Crash-1.rar)