### PR TITLE
[Client/Crash] Fix exploit spam duel starting.

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7801,6 +7801,9 @@ void Player::DuelComplete(DuelCompleteType type)
     sLog->outDebug(LOG_FILTER_UNITS, "Duel Complete %s %s", GetName().c_str(), duel->opponent->GetName().c_str());
 #endif
 
+	duel->initiator->duel->underDuel = false;
+	duel->opponent->duel->underDuel = false;
+	
     WorldPacket data(SMSG_DUEL_COMPLETE, (1));
     data << (uint8)((type != DUEL_INTERRUPTED) ? 1 : 0);
     GetSession()->SendPacket(&data);

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -282,7 +282,7 @@ struct PvPInfo
 
 struct DuelInfo
 {
-    DuelInfo() : initiator(NULL), opponent(NULL), startTimer(0), startTime(0), outOfBound(0), isMounted(false) {}
+    DuelInfo() : initiator(NULL), opponent(NULL), startTimer(0), startTime(0), outOfBound(0), isMounted(false), underDuel(false) {}
 
     Player* initiator;
     Player* opponent;
@@ -290,6 +290,7 @@ struct DuelInfo
     time_t startTime;
     time_t outOfBound;
     bool isMounted;
+	bool underDuel;
 };
 
 struct Areas

--- a/src/server/game/Handlers/DuelHandler.cpp
+++ b/src/server/game/Handlers/DuelHandler.cpp
@@ -35,9 +35,16 @@ void WorldSession::HandleDuelAcceptedOpcode(WorldPacket& recvPacket)
     sLog->outStaticDebug("Player 2 is: %u (%s)", plTarget->GetGUIDLow(), plTarget->GetName().c_str());
 #endif
 
+	if(player->duel->underDuel || plTarget->duel->underDuel)
+	{
+		return;
+	}
+	
     time_t now = time(NULL);
     player->duel->startTimer = now;
     plTarget->duel->startTimer = now;
+    player->duel->underDuel = true;
+    plTarget->duel->underDuel = true;
 
     player->SendDuelCountdown(3000);
     plTarget->SendDuelCountdown(3000);


### PR DESCRIPTION
Check this issue: [https://github.com/TrinityCore/TrinityCore/issues/22374](https://github.com/TrinityCore/TrinityCore/issues/22374)

### How to test:
[https://github.com/tomrus88/WowAddin](https://github.com/tomrus88/WowAddin)
and use this script:
```
BOOL DuelAccept(char const*, char const* String)
{
	long Count = atoi(String);

	if (Count <= 0)
		Count += 1;

	for (long A = 0; A < Count; ++A)
	{
		if (Delay > 1)
			Sleep(Delay);

		CDataStore Data(CMSG_DUEL_ACCEPTED);
		Data.PutInt64(GetTargetGuid());
		Data.Finalize();
		ClientServices::SendPacket(&Data);
	}

	Console::Write("Packet Sent %u Times", ECHO_COLOR, Count);
	return true;
}
```
