### PR TITLE
Core/Misc: utf8 improvments, prevent possible money dupe in mailhandler and also change damage to float

### DIFF
--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -295,14 +295,42 @@ size_t utf8length(std::string& utf8str)
 {
     try
     {
-        return utf8::distance(utf8str.c_str(), utf8str.c_str()+utf8str.size());
+        return utf8::distance(utf8str.c_str(), utf8str.c_str() + utf8str.size());
     }
-    catch(std::exception const&)
+    catch (std::exception const&)
     {
         utf8str.clear();
-        return 0;
     }
+    return 0;
 }
+
+size_t utf8limit(std::string& utf8str, size_t bytes)
+{
+    if (utf8str.size() > bytes)
+    {
+        try
+        {
+            auto end = (utf8str.cbegin() + bytes);
+            auto itr = utf8::find_invalid(utf8str.cbegin(), end);
+
+            // Fix UTF8 if it was corrupted by bytes truncated
+            if (itr != end)
+                bytes = std::distance(utf8str.cbegin(), itr);
+
+            utf8str.resize(bytes);
+            utf8str.shrink_to_fit();
+
+            return bytes;
+        }
+        catch (std::exception const&)
+        {
+            utf8str.clear();
+        }
+    }
+
+    return 0;
+}
+
 
 void utf8truncate(std::string& utf8str, size_t len)
 {
@@ -319,7 +347,7 @@ void utf8truncate(std::string& utf8str, size_t len)
         char* oend = utf8::utf16to8(wstr.c_str(), wstr.c_str()+wstr.size(), &utf8str[0]);
         utf8str.resize(oend-(&utf8str[0]));                 // remove unused tail
     }
-    catch(std::exception const&)
+    catch (std::exception const&)
     {
         utf8str.clear();
     }
@@ -334,7 +362,7 @@ bool Utf8toWStr(char const* utf8str, size_t csize, wchar_t* wstr, size_t& wsize)
         wsize -= out.remaining(); // remaining unused space
         wstr[wsize] = L'\0';
     }
-    catch(std::exception const&)
+    catch (std::exception const&)
     {
         // Replace the converted string with an error message if there is enough space
         // Otherwise just return an empty string
@@ -366,7 +394,7 @@ bool Utf8toWStr(const std::string& utf8str, std::wstring& wstr)
     {
         utf8::utf8to16(utf8str.c_str(), utf8str.c_str()+utf8str.size(), std::back_inserter(wstr));
     }
-    catch(std::exception const&)
+    catch (std::exception const&)
     {
         wstr.clear();
         return false;
@@ -375,49 +403,24 @@ bool Utf8toWStr(const std::string& utf8str, std::wstring& wstr)
     return true;
 }
 
-bool WStrToUtf8(wchar_t* wstr, size_t size, std::string& utf8str)
+bool WStrToUtf8(const std::wstring& wstr, std::string& utf8str)
 {
     try
     {
         std::string utf8str2;
-        utf8str2.resize(size*4);                            // allocate for most long case
+        utf8str2.resize(wstr.size() * 4);                   // allocate for most long case
 
-        if (size)
-        {
-            char* oend = utf8::utf16to8(wstr, wstr+size, &utf8str2[0]);
-            utf8str2.resize(oend-(&utf8str2[0]));               // remove unused tail
-        }
+        auto end = utf8::utf16to8(wstr.cbegin(), wstr.cend(), utf8str2.begin());
+        if (end != utf8str2.end())
+            utf8str2.erase(end, utf8str2.end());
+
         utf8str = utf8str2;
     }
-    catch(std::exception const&)
+    catch (std::exception const&)
     {
         utf8str.clear();
         return false;
     }
-
-    return true;
-}
-
-bool WStrToUtf8(std::wstring const& wstr, std::string& utf8str)
-{
-    try
-    {
-        std::string utf8str2;
-        utf8str2.resize(wstr.size()*4);                     // allocate for most long case
-
-        if (wstr.size())
-        {
-            char* oend = utf8::utf16to8(wstr.c_str(), wstr.c_str()+wstr.size(), &utf8str2[0]);
-            utf8str2.resize(oend-(&utf8str2[0]));                // remove unused tail
-        }
-        utf8str = utf8str2;
-    }
-    catch(std::exception const&)
-    {
-        utf8str.clear();
-        return false;
-    }
-
     return true;
 }
 
@@ -541,19 +544,26 @@ void utf8printf(FILE* out, const char *str, ...)
 void vutf8printf(FILE* out, const char *str, va_list* ap)
 {
 #if AC_PLATFORM == AC_PLATFORM_WINDOWS
-    char temp_buf[32 * 1024];
-    wchar_t wtemp_buf[32 * 1024];
+    std::string temp_buf;
+    temp_buf.resize(32 * 1024);
+    std::wstring wtemp_buf;
 
-    size_t temp_len = vsnprintf(temp_buf, 32 * 1024, str, *ap);
-    //vsnprintf returns -1 if the buffer is too small
-    if (temp_len == size_t(-1))
-        temp_len = 32*1024-1;
+    size_t temp_len = vsnprintf(&temp_buf[0], 32 * 1024, str, *ap);
+    temp_buf.resize(strlen(temp_buf.c_str())); // Resize to match the formatted string
 
-    size_t wtemp_len = 32*1024-1;
-    Utf8toWStr(temp_buf, temp_len, wtemp_buf, wtemp_len);
+    if (!temp_buf.empty())
+    {
+        Utf8toWStr(temp_buf, wtemp_buf, 32 * 1024);
+        wtemp_buf.push_back('\0');
 
-    CharToOemBuffW(&wtemp_buf[0], &temp_buf[0], uint32(wtemp_len + 1));
-    fprintf(out, "%s", temp_buf);
+    if (!temp_buf.empty())
+    {
+        Utf8toWStr(temp_buf, wtemp_buf, 32 * 1024);
+        wtemp_buf.push_back('\0');
+
+        CharToOemBuffW(&wtemp_buf[0], &temp_buf[0], wtemp_buf.size());
+    }
+    fprintf(out, "%s", temp_buf.c_str());
 #else
     vfprintf(out, str, *ap);
 #endif

--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -548,8 +548,8 @@ void vutf8printf(FILE* out, const char *str, va_list* ap)
     temp_buf.resize(32 * 1024);
     std::wstring wtemp_buf;
 
-    size_t temp_len = vsnprintf(&temp_buf[0], 32 * 1024, str, *ap);
-    temp_buf.resize(strlen(temp_buf.c_str())); // Resize to match the formatted string
+    std::size_t temp_len = vsnprintf(&temp_buf[0], 32 * 1024, str, *ap);
+    temp_buf.resize(strnlen_s(temp_buf.c_str())); // Resize to match the formatted string
 
     if (!temp_buf.empty())
     {

--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -549,6 +549,8 @@ void vutf8printf(FILE* out, const char *str, va_list* ap)
     std::wstring wtemp_buf;
 
     std::size_t temp_len = vsnprintf(&temp_buf[0], 32 * 1024, str, *ap);
+    if (temp_len == size_t(-1)) //vsnprintf returns -1 if the buffer is too small
+        temp_len = 32*1024-1;
     temp_buf.resize(strnlen_s(temp_buf.c_str())); // Resize to match the formatted string
 
     if (!temp_buf.empty())

--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -556,11 +556,6 @@ void vutf8printf(FILE* out, const char *str, va_list* ap)
         Utf8toWStr(temp_buf, wtemp_buf, 32 * 1024);
         wtemp_buf.push_back('\0');
 
-    if (!temp_buf.empty())
-    {
-        Utf8toWStr(temp_buf, wtemp_buf, 32 * 1024);
-        wtemp_buf.push_back('\0');
-
         CharToOemBuffW(&wtemp_buf[0], &temp_buf[0], wtemp_buf.size());
     }
     fprintf(out, "%s", temp_buf.c_str());

--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -140,11 +140,9 @@ inline bool Utf8toWStr(const std::string& utf8str, wchar_t* wstr, size_t& wsize)
 }
 
 bool WStrToUtf8(std::wstring const& wstr, std::string& utf8str);
-// size==real string size
-bool WStrToUtf8(wchar_t* wstr, size_t size, std::string& utf8str);
 
-// set string to "" if invalid utf8 sequence
-size_t utf8length(std::string& utf8str);
+size_t utf8length(std::string& utf8str);                    // returns string's length in utf8 chars, sets string to "" on invalid utf8 sequence
+size_t utf8limit(std::string& utf8str, size_t bytes);       // returns string's new size in bytes, sets string to "" on invalid utf8 sequence
 void utf8truncate(std::string& utf8str, size_t len);
 
 inline bool isBasicLatinCharacter(wchar_t wchar)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1614,9 +1614,9 @@ bool Unit::IsDamageReducedByArmor(SpellSchoolMask schoolMask, SpellInfo const* s
     return true;
 }
 
-uint32 Unit::CalcArmorReducedDamage(Unit const* attacker, Unit const* victim, const uint32 damage, SpellInfo const* spellInfo, uint8 attackerLevel, WeaponAttackType /*attackType*/)
+float Unit::CalcArmorReducedDamage(Unit const* attacker, Unit const* victim, const float damage, SpellInfo const* spellInfo, uint8 attackerLevel, WeaponAttackType /*attackType*/)
 {
-    uint32 newdamage = 0;
+    float newdamage = 0;
     float armor = float(victim->GetArmor());
 
     // Ignore enemy armor by SPELL_AURA_MOD_TARGET_RESISTANCE aura
@@ -1694,9 +1694,9 @@ uint32 Unit::CalcArmorReducedDamage(Unit const* attacker, Unit const* victim, co
     if (tmpvalue > 0.75f)
         tmpvalue = 0.75f;
 
-    newdamage = uint32(damage - (damage * tmpvalue));
+    newdamage = damage - (damage * tmpvalue);
 
-    return (newdamage > 1) ? newdamage : 1;
+    return (newdamage > 1) ? newdamage : 1.0f;
 }
 
 float Unit::GetEffectiveResistChance(Unit const* owner, SpellSchoolMask schoolMask, Unit const* victim, SpellInfo const* spellInfo)

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2233,7 +2233,7 @@ class Unit : public WorldObject
         virtual bool IsImmunedToSpellEffect(SpellInfo const* spellInfo, uint32 index) const;
                                                             // redefined in Creature
         static bool IsDamageReducedByArmor(SpellSchoolMask damageSchoolMask, SpellInfo const* spellInfo = NULL, uint8 effIndex = MAX_SPELL_EFFECTS);
-        static uint32 CalcArmorReducedDamage(Unit const* attacker, Unit const* victim, const uint32 damage, SpellInfo const* spellInfo, uint8 attackerLevel = 0, WeaponAttackType attackType=MAX_ATTACK);
+        static float CalcArmorReducedDamage(Unit const* attacker, Unit const* victim, const float damage, SpellInfo const* spellInfo, uint8 attackerLevel = 0, WeaponAttackType attackType=MAX_ATTACK);
         static void CalcAbsorbResist(Unit* attacker, Unit* victim, SpellSchoolMask schoolMask, DamageEffectType damagetype, const uint32 damage, uint32 *absorb, uint32 *resist, SpellInfo const* spellInfo = NULL, bool Splited = false);
         static void CalcHealAbsorb(Unit const* victim, const SpellInfo* spellProto, uint32 &healAmount, uint32 &absorb);
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -118,13 +118,17 @@ std::string ScriptInfo::GetDebugInfo() const
     return std::string(sz);
 }
 
-bool normalizePlayerName(std::string& name)
+bool normalizePlayerName(std::string& name, size_t max_len)
 {
     if (name.empty())
         return false;
 
     std::wstring tmp;
     if (!Utf8toWStr(name, tmp))
+        return false;
+
+    size_t len = tmp.size();
+    if (len > max_len)
         return false;
 
     wstrToLower(tmp);

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -656,7 +656,7 @@ SkillRangeType GetSkillRangeType(SkillLineEntry const* pSkill, bool racial);
 #define MAX_CHARTER_NAME         24                         // max allowed by client name length
 #define MAX_CHANNEL_NAME         50                         // pussywizard
 
-bool normalizePlayerName(std::string& name);
+bool normalizePlayerName(std::string& name, size_t max_len = MAX_INTERNAL_PLAYER_NAME);
 
 struct LanguageDesc
 {

--- a/src/server/game/Handlers/MailHandler.cpp
+++ b/src/server/game/Handlers/MailHandler.cpp
@@ -118,7 +118,14 @@ void WorldSession::HandleSendMail(WorldPacket & recvData)
         return;
     }
 
-    uint32 cost = items_count ? 30 * items_count : 30;  // price hardcoded in client
+    if (money && COD) // cannot send money in a COD mail
+    {
+        sLog->outError("%s attempt to dupe money!!!.", receiver.c_str());
+        player->SendMailResult(0, MAIL_SEND, MAIL_ERR_INTERNAL_ERROR);
+        return;
+    }
+
+    uint32 cost = items_count ? 30 * items_count : 30; // price hardcoded in client
 
     uint32 reqmoney = cost + money;
   

--- a/src/server/worldserver/CommandLine/CliRunnable.cpp
+++ b/src/server/worldserver/CommandLine/CliRunnable.cpp
@@ -80,14 +80,21 @@ int cli_hook_func()
 void utf8print(void* /*arg*/, const char* str)
 {
 #if AC_PLATFORM == AC_PLATFORM_WINDOWS
-    wchar_t wtemp_buf[6000];
-    size_t wtemp_len = 6000-1;
-    if (!Utf8toWStr(str, strlen(str), wtemp_buf, wtemp_len))
+    std::wstring wtemp_buf;
+    std::string temp_buf(str);
+
+    if (!Utf8toWStr(temp_buf, wtemp_buf, 6000))
         return;
 
-    char temp_buf[6000];
-    CharToOemBuffW(&wtemp_buf[0], &temp_buf[0], wtemp_len+1);
-    printf(temp_buf);
+    // Guarantee null termination
+    if (!temp_buf.empty())
+    {
+        wtemp_buf.push_back('\0');
+        temp_buf.resize(wtemp_buf.size());
+        CharToOemBuffW(&wtemp_buf[0], &temp_buf[0], wtemp_buf.size());
+    }
+
+    printf("%s", temp_buf.c_str());
 #else
 {
     printf("%s", str);


### PR DESCRIPTION
https://youtu.be/ttJBdr6eBuo
## CHANGES PROPOSED:
-  Add utf8limit helper function for truncating UTF8 strings by bytes count without corruption(Warlockbugs )
-  cleanup in utf8length
-  limit NormalizePlayerName by  MAX_INTERNAL_PLAYER_NAME
- other cleanups in utf8handle code
-  prevent possible money dupe in mailhandler
- change damage var to float

## HOW TO TEST THE CHANGES:
try to use limiter in code...   
test mails and damage

## Target branch(es):
- [x] Master
