### PR TITLE
fix(DB/Gameobject): Secret Safe loot

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1583690478008671900.sql
+++ b/data/sql/updates/pending_db_world/rev_1583690478008671900.sql
@@ -1,9 +1,13 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1583690478008671900');
 
-DELETE FROM `gameobject_loot_template` WHERE `entry` IN (11104); -- Secret Safe
+-- Set logic ID number
+UPDATE `gameobject_template` SET `Data1` = '161495' WHERE `entry` = '161495';
+
+-- Delete old entry and add new one with correct ID
+DELETE FROM `gameobject_loot_template` WHERE `entry` IN (11104,161495); -- Secret Safe
 INSERT INTO `gameobject_loot_template` (`entry`, `item`, `chance`, `questrequired`,  `groupid`, `mincount`, `maxcount`) VALUES
-(11104, 22205, 25, 0, 1, 1, 1),
-(11104, 22255, 25, 0, 1, 1, 1),
-(11104, 22256, 25, 0, 1, 1, 1),
-(11104, 22254, 25, 0, 1, 1, 1),
-(11104, 11309, 100, 1, 0, 1, 1);
+(161495, 22205, 0, 0, 1, 1, 1),
+(161495, 22255, 0, 0, 1, 1, 1),
+(161495, 22256, 0, 0, 1, 1, 1),
+(161495, 22254, 0, 0, 1, 1, 1),
+(161495, 11309, 100, 1, 0, 1, 1);

--- a/data/sql/updates/pending_db_world/rev_1583690478008671900.sql
+++ b/data/sql/updates/pending_db_world/rev_1583690478008671900.sql
@@ -1,4 +1,4 @@
-INSERT INTO `version_db_world` (`sql_rev`) VALUES ('XXXXXXXXXXXX');
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1583690478008671900');
 
 DELETE FROM `gameobject_loot_template` WHERE `entry` IN (11104); -- Secret Safe
 INSERT INTO `gameobject_loot_template` (`entry`, `item`, `chance`, `questrequired`,  `groupid`, `mincount`, `maxcount`) VALUES
@@ -6,4 +6,4 @@ INSERT INTO `gameobject_loot_template` (`entry`, `item`, `chance`, `questrequire
 (11104, 22255, 25, 0, 1, 1, 1),
 (11104, 22256, 25, 0, 1, 1, 1),
 (11104, 22254, 25, 0, 1, 1, 1),
-(11104, 11309, 100, 1, 1, 1, 1);
+(11104, 11309, 100, 1, 0, 1, 1);

--- a/data/sql/updates/pending_db_world/rev_XXXXXXXXXXXX.sql
+++ b/data/sql/updates/pending_db_world/rev_XXXXXXXXXXXX.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('XXXXXXXXXXXX');
+
+DELETE FROM `gameobject_loot_template` WHERE `entry` IN (161495); -- Secret Safe
+INSERT INTO `gameobject_loot_template` (`entry`, `item`, `chance`, `questrequired`,  `groupid`, `mincount`, `maxcount`) VALUES
+(161495, 22205, 25, 0, 1, 1, 1),
+(161495, 22255, 25, 0, 1, 1, 1),
+(161495, 22256, 25, 0, 1, 1, 1),
+(161495, 22254, 25, 0, 1, 1, 1),
+(161495, 11309, 100, 1, 1, 1, 1);

--- a/data/sql/updates/pending_db_world/rev_XXXXXXXXXXXX.sql
+++ b/data/sql/updates/pending_db_world/rev_XXXXXXXXXXXX.sql
@@ -1,9 +1,9 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('XXXXXXXXXXXX');
 
-DELETE FROM `gameobject_loot_template` WHERE `entry` IN (161495); -- Secret Safe
+DELETE FROM `gameobject_loot_template` WHERE `entry` IN (11104); -- Secret Safe
 INSERT INTO `gameobject_loot_template` (`entry`, `item`, `chance`, `questrequired`,  `groupid`, `mincount`, `maxcount`) VALUES
-(161495, 22205, 25, 0, 1, 1, 1),
-(161495, 22255, 25, 0, 1, 1, 1),
-(161495, 22256, 25, 0, 1, 1, 1),
-(161495, 22254, 25, 0, 1, 1, 1),
-(161495, 11309, 100, 1, 1, 1, 1);
+(11104, 22205, 25, 0, 1, 1, 1),
+(11104, 22255, 25, 0, 1, 1, 1),
+(11104, 22256, 25, 0, 1, 1, 1),
+(11104, 22254, 25, 0, 1, 1, 1),
+(11104, 11309, 100, 1, 1, 1, 1);


### PR DESCRIPTION
Ref https://github.com/azerothcore/azerothcore-wotlk/issues/2690

Fixed loot for gameobject = 161495

(I don't know the stuff with rev and shiz so feel free to edit it <3)

Tests: None