### PR TITLE
Fix:(Core/Gameobjects) Fix so non-consumable goobers don't despawn on use

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ This project exists thanks to:
 - [Module template / Module skeleton](https://github.com/azerothcore/skeleton-module/)
 - [Our community hub (Discord)](https://discord.gg/gkt4y2x)
 - [Our wiki](http://www.azerothcore.org/wiki "Easy to use and developed by AzerothCore founder")
-- [Our facebook page](https://www.facebook.com/AzerothCore/)
+- [Our Facebook page](https://www.facebook.com/AzerothCore/)
+- [Our LinkedIn page](https://www.linkedin.com/company/azerothcore/)
 
 
 ## SPONSORS


### PR DESCRIPTION
Fixes #2658 

Test performed:

- [x] Builds

- [x] In-game

Branch: Master

How to test:
1. Use any consumable goober without the change and with the change.

**I want to state that this is NOT my doing, it was taken from these commits originally made by Wyrserth on TrinityCore https://github.com/TrinityCore/TrinityCore/commit/50c5d30d13fe12af2a2028baf845fb6eab329a57 & https://github.com/TrinityCore/TrinityCore/commit/2b1e8d135bd3f3a3ddf7f29471cf6116da223175**