### PR TITLE
Fix:(DB/Quest) Shadow's Edge quest_offer_reward

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1584052298613344800.sql
+++ b/data/sql/updates/pending_db_world/rev_1584052298613344800.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1584052298613344800');
+
+UPDATE `quest_offer_reward` SET `RewardText` = 'Listen well, $c. In accepting this weapon your fate is sealed.$B$BOvercome or succumb.$B$BI have placed your feet upon this path. You are therefore my personal responsibility. Should you failter, I am duty-bound to deliver you from this life.$B$BRemember my words, $r, and do not fail.' WHERE `id` = 24743;


### PR DESCRIPTION
Issue:
Currently the quest_offer_reward is like this
```
Listen well, $C. In accepting this weapon your fate is sealed.$B$BOvercome or succumb.$B$BI have placed your feet upon this path. You are therefore my personal responsibility. Should you falter, I am duty-bound to deliver you from this life.$B$BRemember my words, $C, and do not fail.
```

Which is wrong according to WoWHead where it should be 

```
Listen well, <class>. In accepting this weapon your fate is sealed.

Overcome or succumb.

I have placed your feet upon this path. You are therefore my personal responsibility. Should you failter, I am duty-bound to deliver you from this life.

Remember my words, <race>, and do not fail.
```

Tests:
Works

How to test:
1. .q add 24743
2. .go c 201042