### PR TITLE
fix(DB/Gossip): Corrupted Cat gossip

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1584233284203119000.sql
+++ b/data/sql/updates/pending_db_world/rev_1584233284203119000.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1584233284203119000');
+
+DELETE FROM `gossip_menu` WHERE `MenuID`=55002 AND `TextID`=3550;
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES 
+(55002, 3550);


### PR DESCRIPTION
@BarbzYHOOL found this bug, where the Corrupted Cat did not have a gossip.

This fixes the gossip thing 🗡 

How to reproduce:
1. `.qu add 4506`
1. `.go cr 40765`
1. Summon the tiger in the green well 
