### PR TITLE
fix(DB/Item): Tome of Tranquilizing Shot

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1584387270154812400.sql
+++ b/data/sql/updates/pending_db_world/rev_1584387270154812400.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1584387270154812400');
+
+UPDATE `item_template` SET `flags`=`flags`|16 WHERE `entry` = 16665;
+
+DELETE FROM `creature_loot_template` WHERE `Item`=16665;


### PR DESCRIPTION
https://wow.gamepedia.com/Tome_of_Tranquilizing_Shot

>The subject of this article was removed from World of Warcraft in patch 3.0.2.

Removed from creature_loot_template and added deprecated flag in item_template

This means:
Can't drop and can't be used