### PR TITLE
fix(DB/Item): Chest of Spoils

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1584388048550524100.sql
+++ b/data/sql/updates/pending_db_world/rev_1584388048550524100.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1584388048550524100');
+
+UPDATE `item_template` SET `minMoneyLoot` = 600000, `maxMoneyLoot` = 1000000 WHERE `entry` = 20602;


### PR DESCRIPTION
Currently has no gold loot.

https://www.wowhead.com/item=20602/chest-of-spoils
https://classic.wowhead.com/item=20602/chest-of-spoils#comments

Checking Wowhead comments I estimate that it contains around 60 to 100 gold since there have been no comments of lower or above those values