### PR TITLE
fix(DB/Quest) Some Deprecated quests

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1584388487036984300.sql
+++ b/data/sql/updates/pending_db_world/rev_1584388487036984300.sql
@@ -1,7 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1584388487036984300');
 
 UPDATE `creature_template` SET `npcflag`=`npcflag`&~2 WHERE `entry` IN (15350,15351);
-DELETE FROM `creature_queststarter` WHERE `quset` IN (8388,13475,8371,8385,13477,13478,13476,8367);
+DELETE FROM `creature_queststarter` WHERE `quest` IN (8388,13475,8371,8385,13477,13478,13476,8367);
 DELETE FROM `creature_questender` WHERE `quest` IN (8388,13475,8371,8385,13477,13478,13476,8367);
 DELETE FROM `disables` WHERE `sourceType`=1 AND `entry` IN (8388,13475,8371,8385,13477,13478,13476,8367);
 INSERT INTO `disables` (`sourceType`,`entry`,`flags`,`params_0`,`params_1`,`comment`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1584388487036984300.sql
+++ b/data/sql/updates/pending_db_world/rev_1584388487036984300.sql
@@ -1,6 +1,5 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1584388487036984300');
 
-UPDATE `creature_template` SET `npcflag`=`npcflag`&~2 WHERE `entry` IN (15350,15351);
 DELETE FROM `creature_queststarter` WHERE `quest` IN (8388,13475,8371,8385,13477,13478,13476,8367);
 DELETE FROM `creature_questender` WHERE `quest` IN (8388,13475,8371,8385,13477,13478,13476,8367);
 DELETE FROM `disables` WHERE `sourceType`=1 AND `entry` IN (8388,13475,8371,8385,13477,13478,13476,8367);

--- a/data/sql/updates/pending_db_world/rev_1584388487036984300.sql
+++ b/data/sql/updates/pending_db_world/rev_1584388487036984300.sql
@@ -1,0 +1,15 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1584388487036984300');
+
+UPDATE `creature_template` SET `npcflag`=`npcflag`&~2 WHERE `entry` IN (15350,15351);
+DELETE FROM `creature_queststarter` WHERE `quset` IN (8388,13475,8371,8385,13477,13478,13476,8367);
+DELETE FROM `creature_questender` WHERE `quest` IN (8388,13475,8371,8385,13477,13478,13476,8367);
+DELETE FROM `disables` WHERE `sourceType`=1 AND `entry` IN (8388,13475,8371,8385,13477,13478,13476,8367);
+INSERT INTO `disables` (`sourceType`,`entry`,`flags`,`params_0`,`params_1`,`comment`) VALUES
+(1,8388,0,'','','Deprecated Quest: For Great Honor'),
+(1,13475,0,'','','Deprecated Quest: For Great Honor'),
+(1,13476,0,'','','Deprecated Quest: For Great Honor'),
+(1,8367,0,'','','Deprecated Quest: For Great Honor'),
+(1,8371,0,'','','Deprecated Quest: Concerted Efforts'),
+(1,8385,0,'','','Deprecated Quest: Concerted Efforts'),
+(1,13477,0,'','','Deprecated Quest: Concerted Efforts'),
+(1,13478,0,'','','Deprecated Quest: Concerted Efforts');


### PR DESCRIPTION
According to https://wow.gamepedia.com/Category:Removed_in_patch_3.3.3 these quests got deprecated in patch 3.3.3:

For Great Honor
Concerted Efforts

Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1133

How to test:
Try to pick them up at the quest givers (15350,15351);