### PR TITLE
fix(DB/Quest): Old Whitebark's Pendant

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1584389363968563900.sql
+++ b/data/sql/updates/pending_db_world/rev_1584389363968563900.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1584389363968563900');
+
+UPDATE `quest_offer_reward` SET `RewardText`= "This... this pendant.  I gave it to Old Whitebark after his people helped us rebuild our village.$B$BI guess this means he's...$B$B<The blood elf clears her throat as she regains her composure.>$B$BI appreciate you bringing this to me, $N.  There is something I'd like to ask of you." WHERE `ID`=8474;

--- a/data/sql/updates/pending_db_world/rev_1584389363968563900.sql
+++ b/data/sql/updates/pending_db_world/rev_1584389363968563900.sql
@@ -1,3 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1584389363968563900');
 
-UPDATE `quest_offer_reward` SET `RewardText`= "This... this pendant.  I gave it to Old Whitebark after his people helped us rebuild our village.$B$BI guess this means he's...$B$B<The blood elf clears her throat as she regains her composure.>$B$BI appreciate you bringing this to me, $N.  There is something I'd like to ask of you." WHERE `ID`=8474;
+UPDATE `quest_offer_reward` SET `RewardText`= 'This... this pendant.  I gave it to Old Whitebark after his people helped us rebuild our village.$B$BI guess this means he\'s...$B$B<The blood elf clears her throat as she regains her composure.>$B$BI appreciate you bringing this to me, $N.  There is something I\'d like to ask of you.' WHERE `ID`=8474;

--- a/data/sql/updates/pending_db_world/rev_1584389363968563900.sql
+++ b/data/sql/updates/pending_db_world/rev_1584389363968563900.sql
@@ -1,3 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1584389363968563900');
 
-UPDATE `quest_offer_reward` SET `RewardText`= 'This... this pendant.  I gave it to Old Whitebark after his people helped us rebuild our village.$B$BI guess this means he\'s...$B$B<The blood elf clears her throat as she regains her composure.>$B$BI appreciate you bringing this to me, $N.  There is something I\'d like to ask of you.' WHERE `ID`=8474;
+UPDATE `quest_offer_reward` SET `RewardText`= 'This... this pendant.  I gave it to Old Whitebark after his people helped us rebuild our village.$B$BI guess this means he''s...$B$B<The blood elf clears her throat as she regains her composure.>$B$BI appreciate you bringing this to me, $N.  There is something I''d like to ask of you.' WHERE `ID`=8474;


### PR DESCRIPTION
Currently, in the quest_offer_reward it is missing some spaces and is wrongly written compared to https://classic.wowhead.com/quest=8474/old-whitebarks-pendant

How to test:
1. .q add 8474
2. .q comp 8474
3. .go c id 15398
4. Hand in the quest 