### PR TITLE
fix(DB/creature_template): TBC raid bosses damage output

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1584415633310849000.sql
+++ b/data/sql/updates/pending_db_world/rev_1584415633310849000.sql
@@ -1,0 +1,220 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1584415633310849000');
+
+-- =--------------------------------------------------------------------------------------------------------------------------------=
+-- All boss/creature DMG Values and additional changes enlisted below were gathered from the official 'World of Warcraft: Beastiary'
+-- =--------------------------------------------------------------------------------------------------------------------------------=
+
+
+-- Black Temple (70 - 73)
+-- -------------------------------------------------------------------------------------------------------------------
+-- High Warlord Naj'entus
+UPDATE `creature_template` SET `mindmg` = 11152, `maxdmg` = 15768, `DamageModifier` = 1 WHERE `entry` = 22887;
+-- Supremus
+UPDATE `creature_template` SET `mindmg` = 14936, `maxdmg` = 21118, `DamageModifier` = 1 WHERE `entry` = 22898;
+-- Shade of Akama
+UPDATE `creature_template` SET `mindmg` = 23898, `maxdmg` = 33789, `DamageModifier` = 1 WHERE `entry` = 22841;
+-- Teron Gorefiend
+UPDATE `creature_template` SET `mindmg` = 19702, `maxdmg` = 27828, `DamageModifier` = 1 WHERE `entry` = 22871;
+-- Gurtogg Bloodboil
+UPDATE `creature_template` SET `mindmg` = 11949, `maxdmg` = 16895, `DamageModifier` = 1 WHERE `entry` = 22948;
+-- Mother Shahraz
+UPDATE `creature_template` SET `mindmg` = 22165, `maxdmg` = 31306, `DamageModifier` = 1 WHERE `entry` = 22947;
+
+-- | - - - - - - - - - - - - - T h e  I l l i d a r i  C o u n c i l - - - - - - - - - - -  - - - - - - - - - - |
+-- Gathios the Shatterer
+UPDATE `creature_template` SET `mindmg` = 18470, `maxdmg` = 26088, `DamageModifier` = 1 WHERE `entry` = 22949;
+-- High Nethermancer Zerevor
+UPDATE `creature_template` SET `mindmg` = 3940, `maxdmg` = 5565, `DamageModifier` = 1 WHERE `entry` = 22950;
+-- Lady Malande
+UPDATE `creature_template` SET `mindmg` = 6156, `maxdmg` = 8696, `DamageModifier` = 1 WHERE `entry` = 22951;
+-- Veras Darkshadow
+UPDATE `creature_template` SET `mindmg` = 10621, `maxdmg` = 15017, `DamageModifier` = 1 WHERE `entry` = 22952;
+-- | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - |
+
+-- Illidan Stormrage
+UPDATE `creature_template` SET `mindmg` = 19914, `maxdmg` = 28157, `DamageModifier` = 1 WHERE `entry` = 22917;
+-- ===================================================================================================================
+
+
+-- Coilfang: Serpentshrine Cavern (70 - 73)
+-- -------------------------------------------------------------------------------------------------------------------
+-- Hydross the Unstable
+UPDATE `creature_template` SET `mindmg` = 5974, `maxdmg` = 8447, `DamageModifier` = 1 WHERE `entry` = 21216;
+-- The Lurker Below
+UPDATE `creature_template` SET `mindmg` = 11949, `maxdmg` = 16895, `DamageModifier` = 1 WHERE `entry` = 21217;
+-- Leotheras the Blind
+UPDATE `creature_template` SET `mindmg` = 7169, `maxdmg` = 10136, `DamageModifier` = 1 WHERE `entry` = 21215;
+-- Shadow of Leotheras
+UPDATE `creature_template` SET `mindmg` = 7169, `maxdmg` = 10136, `DamageModifier` = 1 WHERE `entry` = 21875;
+-- Fathom-Lord Karathress
+UPDATE `creature_template` SET `mindmg` = 8866, `maxdmg` = 12522, `DamageModifier` = 1 WHERE `entry` = 21214;
+
+-- | - - - - - - - - - - - - - G u a r d s  o f  K a r a t h r e s s - - - - - - - - -  - - - -  - - - - - - - - - |
+-- Fathom-Guard Sharkkis
+UPDATE `creature_template` SET `mindmg` = 5956, `maxdmg` = 8416, `DamageModifier` = 1 WHERE `entry` = 21966;
+-- Fathom-Guard Tidalvess
+UPDATE `creature_template` SET `mindmg` = 10005, `maxdmg` = 14138, `DamageModifier` = 1 WHERE `entry` = 21965;
+-- Fathom-Guard Caribdis
+UPDATE `creature_template` SET `mindmg` = 5956, `maxdmg` = 8416, `DamageModifier` = 1 WHERE `entry` = 21964;
+-- | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - |
+
+-- Morogrim Tidewalker
+UPDATE `creature_template` SET `mindmg` = 12745, `maxdmg` = 18021, `DamageModifier` = 1 WHERE `entry` = 21213;
+-- Lady Vashj
+UPDATE `creature_template` SET `mindmg` = 11082, `maxdmg` = 15653, `DamageModifier` = 1 WHERE `entry` = 21212;
+-- Tainted Elemental [Lady Vashj encounter]
+UPDATE `creature_template` SET `mindmg` = 770, `maxdmg` = 1089, `DamageModifier` = 1 WHERE `entry` = 22009;
+-- ===================================================================================================================
+
+
+-- Gruul's Lair (70 - 73)
+-- -------------------------------------------------------------------------------------------------------------------
+-- High King Maulgar
+UPDATE `creature_template` SET `mindmg` = 12214, `maxdmg` = 17270, `DamageModifier` = 1 WHERE `entry` = 18831;
+
+-- | - - - - - - - - - - - - - C o u n c i l  M e m b e r s - - - - - - - - - - -  - - - -  - - - - - - - - - |
+-- Kiggler the Crazed
+UPDATE `creature_template` SET `mindmg` = 6834, `maxdmg` = 9653, `DamageModifier` = 1 WHERE `entry` = 18835;
+-- Blindeye the Seer
+UPDATE `creature_template` SET `mindmg` = 1724, `maxdmg` = 2435, `DamageModifier` = 1 WHERE `entry` = 18836;
+-- Olm the Summoner
+UPDATE `creature_template` SET `mindmg` = 4101, `maxdmg` = 5792, `DamageModifier` = 1 WHERE `entry` = 18834;
+-- Krosh Firehand
+UPDATE `creature_template` SET `mindmg` = 4101, `maxdmg` = 5792, `DamageModifier` = 1 WHERE `entry` = 18832;
+-- | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - |
+
+-- Gruul the Dragonkiller
+UPDATE `creature_template` SET `mindmg` = 6904, `maxdmg` = 9761, `DamageModifier` = 1 WHERE `entry` = 19044;
+-- Lair Brute [Gruul minion]
+UPDATE `creature_template` SET `mindmg` = 7842, `maxdmg` = 11090, `DamageModifier` = 1 WHERE `entry` = 19389;
+-- ===================================================================================================================
+
+
+-- Karazhan (70 - 73)
+-- -------------------------------------------------------------------------------------------------------------------
+
+-- | - - - - - - - - - - - - - S e r v a n t  Q u a r t e r s - - - - - - - - - - -  - - - -  - - - - - - - - - |
+-- Rokad the Ravager
+UPDATE `creature_template` SET `mindmg` = 3585, `maxdmg` = 5068, `DamageModifier` = 1 WHERE `entry` = 16181;
+-- Shadikith the Glider
+UPDATE `creature_template` SET `mindmg` = 4780, `maxdmg` = 6758, `DamageModifier` = 1 WHERE `entry` = 16180;
+-- Hyakiss the Lurker
+UPDATE `creature_template` SET `mindmg` = 4780, `maxdmg` = 6758, `DamageModifier` = 1 WHERE `entry` = 16179;
+-- | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - |
+
+-- Attumen the Huntsman
+UPDATE `creature_template` SET `mindmg` = 4715, `maxdmg` = 7508, `DamageModifier` = 1 WHERE `entry` = 16152;
+-- Midnight
+UPDATE `creature_template` SET `mindmg` = 4248, `maxdmg` = 6007, `DamageModifier` = 1 WHERE `entry` = 16151;
+
+-- Moroes
+UPDATE `creature_template` SET `mindmg` = 4780, `maxdmg` = 6758, `DamageModifier` = 1 WHERE `entry` = 15687;
+
+-- | - - - - - - - - - - - - - M o r o e s'  D i n n e r  G u e s t s - - - - - - -  - - - -  - - - - - - - - - |
+-- Baroness Dorothea Millstipe
+UPDATE `creature_template` SET `mindmg` = 2109, `maxdmg` = 2980, `DamageModifier` = 1 WHERE `entry` = 19875;
+-- Baron Rafe Dreuger
+UPDATE `creature_template` SET `mindmg` = 2109, `maxdmg` = 2980, `DamageModifier` = 1 WHERE `entry` = 19874;
+-- Lady Catriona Von'Indi
+UPDATE `creature_template` SET `mindmg` = 2109, `maxdmg` = 2980, `DamageModifier` = 1 WHERE `entry` = 19872;
+-- Lady Keira Berrybuck
+UPDATE `creature_template` SET `mindmg` = 2109, `maxdmg` = 2980, `DamageModifier` = 1 WHERE `entry` = 17007;
+-- Lord Robin Daris
+UPDATE `creature_template` SET `mindmg` = 2272, `maxdmg` = 3213, `DamageModifier` = 1 WHERE `entry` = 19876;
+-- Lord Crispin Ference
+UPDATE `creature_template` SET `mindmg` = 2272, `maxdmg` = 3213, `DamageModifier` = 1 WHERE `entry` = 19873;
+-- | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - |
+
+-- Maiden of Virtue
+UPDATE `creature_template` SET `mindmg` = 6157, `maxdmg` = 8696, `DamageModifier` = 1 WHERE `entry` = 16457;
+
+-- | - - - - - - - - - - - - - T h e  O p e r a  E v e n t - - - - - - -  - - - -  - - - - - - - - - |
+
+-- = = = = W i z a r d  o f  O z = = = =
+-- Dorothee
+UPDATE `creature_template` SET `mindmg` = 2463, `maxdmg` = 3478, `DamageModifier` = 1 WHERE `entry` = 17535;
+-- Tito
+UPDATE `creature_template` SET `mindmg` = 841, `maxdmg` = 1189, `DamageModifier` = 1 WHERE `entry` = 17548;
+-- Strawman
+UPDATE `creature_template` SET `mindmg` = 4182, `maxdmg` = 5915, `DamageModifier` = 1 WHERE `entry` = 17543;
+-- Tinhead
+UPDATE `creature_template` SET `mindmg` = 4182, `maxdmg` = 5915, `DamageModifier` = 1 WHERE `entry` = 17547;
+-- Roar
+UPDATE `creature_template` SET `mindmg` = 2509, `maxdmg` = 3549, `DamageModifier` = 1 WHERE `entry` = 17546;
+-- The Crone
+UPDATE `creature_template` SET `mindmg` = 4925, `maxdmg` = 6957, `DamageModifier` = 1 WHERE `entry` = 18168;
+-- = = = = = = = = = = = = = = = = = =
+
+-- = = = = R e d  R i d i n g  H o o d = = = =
+-- The Big Bad Wolf
+UPDATE `creature_template` SET `mindmg` = 4142, `maxdmg` = 5857, `DamageModifier` = 1 WHERE `entry` = 17521;
+-- = = = = = = = = = = = = = = = = = = = = = =
+
+-- = = = = W i z a r d  o f  O z = = = =
+-- Romulo
+UPDATE `creature_template` SET `mindmg` = 3983, `maxdmg` = 5632, `DamageModifier` = 1 WHERE `entry` = 17533;
+-- Julianne
+UPDATE `creature_template` SET `mindmg` = 2955, `maxdmg` = 4174, `DamageModifier` = 1 WHERE `entry` = 17534;
+-- = = = = = = = = = = = = = = = = = = =
+-- | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - |
+
+-- The Curator
+UPDATE `creature_template` SET `mindmg` = 5467, `maxdmg` = 7722, `DamageModifier` = 1 WHERE `entry` = 15691;
+-- Terestian Illhoof
+UPDATE `creature_template` SET `mindmg` = 5050, `maxdmg` = 7140, `DamageModifier` = 1 WHERE `entry` = 15688;
+-- Kil'rek [Minion of Terestian]
+UPDATE `creature_template` SET `mindmg` = 1874, `maxdmg` = 2852, `DamageModifier` = 1 WHERE `entry` = 17229;
+-- Shade of Aran
+UPDATE `creature_template` SET `mindmg` = 2063, `maxdmg` = 2992, `DamageModifier` = 1 WHERE `entry` = 16524;
+-- Netherspite
+UPDATE `creature_template` SET `mindmg` = 7515, `maxdmg` = 8186, `DamageModifier` = 1 WHERE `entry` = 15689;
+-- Nightbane
+UPDATE `creature_template` SET `mindmg` = 9028, `maxdmg` = 12765, `DamageModifier` = 1 WHERE `entry` = 17225;
+-- Prince Malchezaar
+UPDATE `creature_template` SET `mindmg` = 6638, `maxdmg` = 9386, `DamageModifier` = 1 WHERE `entry` = 15690;
+-- ===================================================================================================================
+
+
+-- Magtheridon Lair (70 - 73)
+-- -------------------------------------------------------------------------------------------------------------------
+-- Magtheridon
+UPDATE `creature_template` SET `mindmg` = 14604, `maxdmg` = 20649, `DamageModifier` = 1 WHERE `entry` = 17257;
+-- ===================================================================================================================
+
+
+-- Tempest Keep (70 - 73)
+-- -------------------------------------------------------------------------------------------------------------------
+-- Void Reaver
+UPDATE `creature_template` SET `mindmg` = 8866, `maxdmg` = 12522, `DamageModifier` = 1 WHERE `entry` = 19516;
+-- High Astromancer Solarian
+UPDATE `creature_template` SET `mindmg` = 6157, `maxdmg` = 8696, `DamageModifier` = 1 WHERE `entry` = 18805;
+
+-- | - - - - - - - - - - - - - K a e l' t h a s  A d v i s o r s - - - - - - -  - - - -  - - - - - - - - - |
+-- Thaladred the Darkener
+UPDATE `creature_template` SET `mindmg` = 9559, `maxdmg` = 13516, `DamageModifier` = 1 WHERE `entry` = 20064;
+-- Lord Sanguinar
+UPDATE `creature_template` SET `mindmg` = 8497, `maxdmg` = 12014, `DamageModifier` = 1 WHERE `entry` = 20060;
+-- Grand Astromancer Capernian
+UPDATE `creature_template` SET `mindmg` = 2475, `maxdmg` = 3590, `DamageModifier` = 1 WHERE `entry` = 20062;
+-- Master Engineer Telonicus
+UPDATE `creature_template` SET `mindmg` = 2475, `maxdmg` = 3590, `DamageModifier` = 1 WHERE `entry` = 20062;
+-- | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - |
+
+-- Kael'thas Sunstrider
+UPDATE `creature_template` SET `mindmg` = 11083, `maxdmg` = 15653, `DamageModifier` = 1 WHERE `entry` = 19622;
+-- ===================================================================================================================
+
+
+-- Hyjal Summit (66 - 73)
+-- -------------------------------------------------------------------------------------------------------------------
+-- Rage Winterchill
+UPDATE `creature_template` SET `mindmg` = 11082, `maxdmg` = 15653, `DamageModifier` = 1 WHERE `entry` = 17767;
+-- Anetheron
+UPDATE `creature_template` SET `mindmg` = 12314, `maxdmg` = 17392, `DamageModifier` = 1 WHERE `entry` = 17808;
+-- Kaz'rogal
+UPDATE `creature_template` SET `mindmg` = 12314, `maxdmg` = 17392, `DamageModifier` = 1 WHERE `entry` = 17888;
+-- Azgalor
+UPDATE `creature_template` SET `mindmg` = 20934, `maxdmg` = 29567, `DamageModifier` = 1 WHERE `entry` = 17842;
+-- Archimonde
+UPDATE `creature_template` SET `mindmg` = 20318, `maxdmg` = 28697, `DamageModifier` = 1 WHERE `entry` = 17968;
+-- ===================================================================================================================


### PR DESCRIPTION
What you can find in this PR is a general adjustment for TBC raid bosses, their values were sometimes lower or "imbalanced", the adjustment done here will adjust the melee damage for TBC raid bosses based on the 'World of Warcraft Official strategy guide: Bestiary" an official source of data about many creatures in World of Warcraft.

Related to this project:
PR for TBC dungeon bosses damage, here -> #2766 
PR for Classic dungeon bosses damage, here -> #2742 

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## CHANGES PROPOSED:
-  Update mindmg and maxdmg based on the official wow bestiary in creature_template
-  Update DamageModifier for all creatures to 1 in creature_template (this will allow better understanding and control on dmg values)


## ISSUES ADDRESSED:
- Continues the work done in #2766 
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## TESTS PERFORMED:
- SQL changes implemented on last rev/hash, no errors found.
- I have reviewed the old and new values, damage expected is correct.
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
- Import the SQL script and check that no error occurs during the implementation into the DB
- Go to any TBC raid where the changes will take effect and check for melee damage values before and after the update

## KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->
The following TBC bosses were not found in the Bestiary and further research is required to update their damage values with official data.
- [ ] Reliquary of the Lost 22856 (and its Essences)
- [ ] Al'ar 19514
- [ ] Master Engineer Telonicus 20063

**[Sunwell Plateau]**
- [ ] Kalecgos 24850
- [ ] Sathrovarr the Corruptor 24892
- [ ] Brutallus 24882
- [ ] Felmyst 25038
- [ ] Grand Warlock Alythess 25166
- [ ] Lady Sacrolash 25165
- [ ] M'uru 25741
- [ ] Entropius 25840
- [ ] Kil'jaeden 25315

**[Zul'Aman]**
- [ ] Akil'zon 23574
- [ ] Nalorakk 23576
- [ ] Jan'alai 23578
- [ ] Halazzi 23577
- [ ] Hex Lord Malacrass 24239
- [ ]  Daakara 23863


## Target branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR