### PR TITLE
DB/Misc: fix error on default MySQL install

### DIFF
--- a/data/sql/base/db_world/npc_text_locale.sql
+++ b/data/sql/base/db_world/npc_text_locale.sql
@@ -28,7 +28,7 @@ CREATE TABLE `npc_text_locale`
   `Text7_0` longtext,
   `Text7_1` longtext,
   PRIMARY KEY (`ID`,`Locale`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPACT;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `npc_text_locale` WRITE;


### PR DESCRIPTION
## CHANGES PROPOSED:
-  fix `Row size too large (> 8126). Changing some columns to TEXT or BLOB or using ROW_FORMAT=DYNAMIC or ROW_FORMAT=COMPRESSED may help. In current row format, BLOB prefix of 768 bytes is stored inline.` on default MySQL install
## ISSUES ADDRESSED:
- Closes #2270
## TESTS PERFORMED:
- Run db_assembler after fresh MySQL/MariaDB install without this error
## HOW TO TEST THE CHANGES:
- Run db_assembler after fresh MySQL/MariaDB
## Target branch(es):
- [x] Master

## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
