### PR TITLE
fix(DB/reputation): Kurenai and Mag'har Reputation Rates

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1584790013870207000.sql
+++ b/data/sql/updates/pending_db_world/rev_1584790013870207000.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1584790013870207000');
+
+-- Set rates to 1 for faction "The Mag'har" & "Kurenai" to be blizzlike
+UPDATE `reputation_reward_rate` SET `quest_rate`=1, `quest_daily_rate`=1, `quest_repeatable_rate`=1 WHERE `faction`=941;
+UPDATE `reputation_reward_rate` SET `quest_daily_rate`=1, `quest_repeatable_rate`=1, `spell_rate`=1 WHERE `faction`=978;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->
The quest rates for faction 941 The Mag`har and 978 Kurenai were doubled. They should give a normal reputation reward. 

Example quests below rewarded before the PR 1.000 rep while they should give in WOTLK 500 rep. 

**Normal quests like:**

https://wowwiki.fandom.com/wiki/Quest:Fierce_Enemies
https://wowwiki.fandom.com/wiki/Quest:Proving_Your_Strength

**Repeatable quests like:** 

https://wowwiki.fandom.com/wiki/Quest:More_Warbeads
https://wowwiki.fandom.com/wiki/Quest:More_Warbeads

<!-- WRITE A RELEVANT TITLE -->

## CHANGES PROPOSED:
-  Update `reputation_reward_rates` to 1 for faction 941
-  Update `reputation_reward_rates` to 1 for faction 978
- Also update the `spell_rate` for faction 978 to 1


## ISSUES ADDRESSED:
- Closes 
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## TESTS PERFORMED:
- Imported SQL wihtout errors on Win 10 Pro x64 and HeidiSQL v11
- Tested successfully ingame
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

- Prepare:

`.modify rep 941 3000`
`.modify rep 978 3000`
`.ad 25433 100`

`.go c 65800`

- Accept quest 10476 and finish it. It should give 500 rep (`.q c 10476`)
- Finish repeatable quest 10477. It should give 500 rep


`.go c 65799`

- Accept quest 10479 and finish it. It should give 500 rep (`.q c 10479`)
- Finish repeatable quest 10478. It should give 500 rep

## KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 


## Target branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
  