### PR TITLE
fix(Core/Gossip): Show title reward from quests in gossip

### DIFF
--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -658,7 +658,7 @@ void PlayerMenu::SendQuestGiverOfferReward(Quest const* quest, uint64 npcGUID, b
     data << uint32(0x08);                                   // unused by client?
     data << uint32(quest->GetRewSpell());                   // reward spell, this spell will display (icon) (casted if RewSpellCast == 0)
     data << int32(quest->GetRewSpellCast());                // casted spell
-    data << uint32(0);                                      // unknown
+    data << uint32(quest->GetCharTitleId());                // CharTitleId, new 2.4.0, player gets this title (id from CharTitles)
     data << uint32(quest->GetBonusTalents());               // bonus talents
     data << uint32(quest->GetRewArenaPoints());             // arena points
     data << uint32(0);


### PR DESCRIPTION
Original commit https://github.com/TrinityCore/TrinityCore/commit/61ba1351e0da10219877ad9761ab161e3de51c74

Before:
![image](https://user-images.githubusercontent.com/24550914/77300733-d3398580-6cee-11ea-9268-e90ae200e55f.png)

After:
![image](https://user-images.githubusercontent.com/24550914/77300723-ce74d180-6cee-11ea-8d44-93b02c0f4f7b.png)

Tests:
Builds, Tested in-game

How to test:
1. .go c id 25163
2. .q add 11549
3. .q comp 11549
4. open gossip