### PR TITLE
fix(Core/Hook): OnFirstLogin can now make persistent changes.

### DIFF
--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -1070,12 +1070,6 @@ void WorldSession::HandlePlayerLoginFromDB(LoginQueryHolder* holder)
         SendNotification(LANG_RESET_TALENTS);
     }
 
-    if (pCurrChar->HasAtLoginFlag(AT_LOGIN_FIRST)) {
-        pCurrChar->RemoveAtLoginFlag(AT_LOGIN_FIRST);
-
-        sScriptMgr->OnFirstLogin(pCurrChar);
-    }
-
     if (pCurrChar->HasAtLoginFlag(AT_LOGIN_CHECK_ACHIEVS))
     {
         pCurrChar->RemoveAtLoginFlag(AT_LOGIN_CHECK_ACHIEVS, true);
@@ -1202,6 +1196,13 @@ void WorldSession::HandlePlayerLoginFromDB(LoginQueryHolder* holder)
     }
 
     sScriptMgr->OnPlayerLogin(pCurrChar);
+
+    if (pCurrChar->HasAtLoginFlag(AT_LOGIN_FIRST)) 
+    {
+        pCurrChar->RemoveAtLoginFlag(AT_LOGIN_FIRST);
+        sScriptMgr->OnFirstLogin(pCurrChar);
+    }
+
     delete holder;
 }
 


### PR DESCRIPTION
# fix(Core/Hook): OnFirstLogin can now make persistent changes.

Please see the commit message for extended details. 

## CHANGES PROPOSED:
-  push OnFirstLogin down, closer to the OnLogin callback 


## ISSUES ADDRESSED:
- OnFirstLogin can now make persistent changes

## TESTS PERFORMED:
- works on my personal server

## HOW TO TEST THE CHANGES:
- you would need to write your own PlayerScript that uses the OnFirstLogin hook and teach the player a spell within it. 
- ~~I will soon post a merge request to a module where I used it, which can be used for testing~~ https://github.com/azerothcore/mod-learn-spells/pull/9 


## Target branch(es):
- [x] Master

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
