### PR TITLE
Core/Auction: Fix client crashes on lists of bids and own auctions

### DIFF
--- a/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -499,31 +499,37 @@ void AuctionHouseObject::Update()
     CharacterDatabase.CommitTransaction(trans);
 }
 
-void AuctionHouseObject::BuildListBidderItems(WorldPacket& data, Player* player, uint32& count, uint32& totalcount)
+void AuctionHouseObject::BuildListBidderItems(WorldPacket& data, Player* player, uint32 listfrom, uint32& count, uint32& totalcount)
 {
     for (AuctionEntryMap::const_iterator itr = AuctionsMap.begin(); itr != AuctionsMap.end(); ++itr)
     {
         AuctionEntry* Aentry = itr->second;
         if (Aentry && Aentry->bidder == player->GetGUIDLow())
         {
-            if (itr->second->BuildAuctionInfo(data))
+            if (count < MAX_AUCTION_ITEMS_CLIENT_PAGE && totalcount >= listfrom)
+            {
+                if (!Aentry->BuildAuctionInfo(data))
+                    continue;
                 ++count;
-
+            }
             ++totalcount;
         }
     }
 }
 
-void AuctionHouseObject::BuildListOwnerItems(WorldPacket& data, Player* player, uint32& count, uint32& totalcount)
+void AuctionHouseObject::BuildListOwnerItems(WorldPacket& data, Player* player, uint32 listfrom, uint32& count, uint32& totalcount)
 {
     for (AuctionEntryMap::const_iterator itr = AuctionsMap.begin(); itr != AuctionsMap.end(); ++itr)
     {
         AuctionEntry* Aentry = itr->second;
         if (Aentry && Aentry->owner == player->GetGUIDLow())
         {
-            if (Aentry->BuildAuctionInfo(data))
+            if (count < MAX_AUCTION_ITEMS_CLIENT_PAGE && totalcount >= listfrom)
+            {
+                if (!Aentry->BuildAuctionInfo(data))
+                    continue;
                 ++count;
-
+            }
             ++totalcount;
         }
     }
@@ -547,7 +553,7 @@ bool AuctionHouseObject::BuildListAuctionItems(WorldPacket& data, Player* player
             for (; itr != AuctionsMap.end(); ++itr)
             {
                 itr->second->BuildAuctionInfo(data);
-                if ((++count) >= 50)
+                if ((++count) >= MAX_AUCTION_ITEMS_CLIENT_PAGE)
                     break;
             }
         }
@@ -661,7 +667,7 @@ bool AuctionHouseObject::BuildListAuctionItems(WorldPacket& data, Player* player
         }
 
         // Add the item if no search term or if entered search term was found
-        if (count < 50 && totalcount >= listfrom)
+        if (count < MAX_AUCTION_ITEMS_CLIENT_PAGE && totalcount >= listfrom)
         {
             ++count;
             Aentry->BuildAuctionInfo(data);

--- a/src/server/game/AuctionHouse/AuctionHouseMgr.h
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.h
@@ -18,6 +18,7 @@ class Player;
 
 #define MIN_AUCTION_TIME (12*HOUR)
 #define MAX_AUCTION_ITEMS 160
+#define MAX_AUCTION_ITEMS_CLIENT_PAGE 50
 
 enum AuctionError
 {
@@ -113,8 +114,8 @@ class AuctionHouseObject
 
     void Update();
 
-    void BuildListBidderItems(WorldPacket& data, Player* player, uint32& count, uint32& totalcount);
-    void BuildListOwnerItems(WorldPacket& data, Player* player, uint32& count, uint32& totalcount);
+    void BuildListBidderItems(WorldPacket& data, Player* player, uint32 listfrom, uint32& count, uint32& totalcount);
+    void BuildListOwnerItems(WorldPacket& data, Player* player, uint32 listfrom, uint32& count, uint32& totalcount);
     bool BuildListAuctionItems(WorldPacket& data, Player* player,
         std::wstring const& searchedname, uint32 listfrom, uint8 levelmin, uint8 levelmax, uint8 usable,
         uint32 inventoryType, uint32 itemClass, uint32 itemSubClass, uint32 quality,

--- a/src/server/game/Handlers/AuctionHouseHandler.cpp
+++ b/src/server/game/Handlers/AuctionHouseHandler.cpp
@@ -594,7 +594,7 @@ void WorldSession::HandleAuctionListBidderItems(WorldPacket & recvData)
     uint32 outbiddedCount;                                  //count of outbidded auctions
 
     recvData >> guid;
-    recvData >> listfrom;                                  // not used in fact (this list not have page control in client)
+    recvData >> listfrom;                                  // start, used for page control listing by 50 elements
     recvData >> outbiddedCount;
     if (recvData.size() != (16 + outbiddedCount * 4))
     {
@@ -636,7 +636,7 @@ void WorldSession::HandleAuctionListBidderItems(WorldPacket & recvData)
         }
     }
 
-    auctionHouse->BuildListBidderItems(data, player, count, totalcount);
+    auctionHouse->BuildListBidderItems(data, player, listfrom, count, totalcount);
     data.put<uint32>(0, count);                           // add count to placeholder
     data << totalcount;
     data << (uint32)300;                                    //unk 2.3.0
@@ -651,7 +651,7 @@ void WorldSession::HandleAuctionListOwnerItems(WorldPacket & recvData)
     uint32 listfrom;
 
     recvData >> guid;
-    recvData >> listfrom;
+    recvData >> listfrom; // used for page control listing by 50 elements
 
     // pussywizard:
     const uint32 delay = 4500;
@@ -695,8 +695,9 @@ void WorldSession::HandleAuctionListOwnerItemsEvent(uint64 creatureGuid)
 
     uint32 count = 0;
     uint32 totalcount = 0;
+    uint32 listfrom = MAX_AUCTION_ITEMS_CLIENT_PAGE;
 
-    auctionHouse->BuildListOwnerItems(data, _player, count, totalcount);
+    auctionHouse->BuildListOwnerItems(data, _player, listfrom, count, totalcount);
     data.put<uint32>(0, count);
     data << (uint32) totalcount;
     data << (uint32) 0;


### PR DESCRIPTION
## CHANGES PROPOSED:
-  Previous behavior was dumping too much to data to client and caused crashes. 
- To see more than last 50 auctions and bids, consider using UI addons.  
thx to Warlockbugs and mangos team

## TESTS PERFORMED:
- build only
## HOW TO TEST THE CHANGES:
 - Use AuctionHouse
## Target branch(es):
- [x] Master

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
