### PR TITLE
fix(Core/locales): Achievement reward locales text display

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -366,7 +366,7 @@ bool AchievementCriteriaData::Meets(uint32 criteria_id, Player const* source, Un
                 if (source->GetMap()->Is25ManRaid() != ((difficulty.difficulty & RAID_DIFFICULTY_MASK_25MAN) != 0))
                     return false;
 
-            AchievementCriteriaEntry const* criteria = sAchievementCriteriaStore.LookupEntry(criteria_id); 
+            AchievementCriteriaEntry const* criteria = sAchievementCriteriaStore.LookupEntry(criteria_id);
             uint8 spawnMode = source->GetMap()->GetSpawnMode();
             // Dungeons completed on heroic mode count towards both in general achievement, but not in statistics.
             return sAchievementMgr->IsStatisticCriteria(criteria) ? spawnMode == difficulty.difficulty : spawnMode >= difficulty.difficulty;
@@ -662,7 +662,7 @@ void AchievementMgr::SendAchievementEarned(AchievementEntry const* achievement) 
     if (achievement->flags & ACHIEVEMENT_FLAG_HIDDEN)
         return;
 
-    #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS) && defined(ACORE_DEBUG) 
+    #if defined(ENABLE_EXTRAS) && defined(ENABLE_EXTRA_LOGS) && defined(ACORE_DEBUG)
         sLog->outDebug(LOG_FILTER_ACHIEVEMENTSYS, "AchievementMgr::SendAchievementEarned(%u)", achievement->ID);
     #endif
 
@@ -763,7 +763,7 @@ void AchievementMgr::UpdateAchievementCriteria(AchievementCriteriaTypes type, ui
         sLog->outDebug(LOG_FILTER_ACHIEVEMENTSYS, "UpdateAchievementCriteria: Wrong criteria type %u", type);
         return;
     }
-    
+
     sLog->outDebug(LOG_FILTER_ACHIEVEMENTSYS, "AchievementMgr::UpdateAchievementCriteria(%u, %u, %u)", type, miscValue1, miscValue2);
 #endif
 
@@ -2150,7 +2150,7 @@ void AchievementMgr::CompletedAchievement(AchievementEntry const* achievement)
     if (m_player->IsGameMaster())
     {
         sLog->outString("Not available in GM mode.");
-        ChatHandler(m_player->GetSession()).PSendSysMessage("Not available in GM mode");        
+        ChatHandler(m_player->GetSession()).PSendSysMessage("Not available in GM mode");
         return;
     }
 
@@ -2215,11 +2215,27 @@ void AchievementMgr::CompletedAchievement(AchievementEntry const* achievement)
 
     // mail
     if (reward->sender)
-    {        
+    {
         MailDraft draft(reward->mailTemplate);
 
         if (!reward->mailTemplate)
-            draft = MailDraft(reward->subject, reward->text);
+        {
+            // subject and text
+            std::string subject = reward->subject;
+            std::string text = reward->text;
+
+            LocaleConstant localeConstant = GetPlayer()->GetSession()->GetSessionDbLocaleIndex();
+            if (localeConstant != LOCALE_enUS)
+            {
+                if (AchievementRewardLocale const* loc = sAchievementMgr->GetAchievementRewardLocale(achievement))
+                {
+                    ObjectMgr::GetLocaleString(loc->Subject, localeConstant, subject);
+                    ObjectMgr::GetLocaleString(loc->Text,    localeConstant, text);
+                }
+            }
+
+            draft = MailDraft(subject, text);
+        }
 
         SQLTransaction trans = CharacterDatabase.BeginTransaction();
 


### PR DESCRIPTION
## CHANGES PROPOSED:
-  If there is text in the achievement_reward_locale table, it should be displayed first.

## ISSUES ADDRESSED:
The system automatically sends messages without using the data in the "achievement_reward_locale" table when the player reaches the corresponding achievement.


## TESTS PERFORMED:
-It has been tested on LINUX systems with no problems.

## HOW TO TEST THE CHANGES:

- Insert the test data in the table first. (for example: update achievement_reward_locale set subject='80 test', Text='Congratulations! here's the test data.' where locale='deDE' and ID=13;)
- See if it can display the test text properly before updating this PR：

 1. Change the configuration file and switch the language to German. Restart the server and delete the client cache.
 2. Create a character and up to level 80 (.character level 80)
 3. Check the mailbox and to see if the message is text for testing.

- Update this PR and repeat the steps above. You can see the content of the message displayed as test content.

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master

## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
