### PR TITLE
fix(Core/Pet): Risen Ghoul random name & pet detail

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -2205,8 +2205,8 @@ void Pet::HandleAsynchLoadFailed(AsynchPetSummon* info, Player* player, uint8 as
 
         if (info->m_petType == SUMMON_PET)
         {
-            if (pet->GetCreatureTemplate()->type == CREATURE_TYPE_DEMON)
-                pet->GetCharmInfo()->SetPetNumber(pet_number, true); // Show pet details tab (Shift+P) only for demons
+            if (pet->GetCreatureTemplate()->type == CREATURE_TYPE_DEMON || pet->GetCreatureTemplate()->type == CREATURE_TYPE_UNDEAD)
+                pet->GetCharmInfo()->SetPetNumber(pet_number, true); // Show pet details tab (Shift+P) only for demons & undead
             else
                 pet->GetCharmInfo()->SetPetNumber(pet_number, false);
 

--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -160,11 +160,11 @@ uint8 WorldSession::HandleLoadPetFromDBFirstCallback(PreparedQueryResult result,
         return PET_LOAD_OK;
     }
 
-    if (pet->getPetType() == HUNTER_PET || pet->GetCreatureTemplate()->type == CREATURE_TYPE_DEMON)
-        pet->GetCharmInfo()->SetPetNumber(pet_number, pet->IsPermanentPetFor(owner)); // Show pet details tab (Shift+P) only for hunter pets or demons
+    if (pet->getPetType() == HUNTER_PET || pet->GetCreatureTemplate()->type == CREATURE_TYPE_DEMON || pet->GetCreatureTemplate()->type == CREATURE_TYPE_UNDEAD)
+        pet->GetCharmInfo()->SetPetNumber(pet_number, pet->IsPermanentPetFor(owner)); // Show pet details tab (Shift+P) only for hunter pets, demons or undead
     else
         pet->GetCharmInfo()->SetPetNumber(pet_number, false);
-
+	
     pet->SetDisplayId(fields[3].GetUInt32());
     pet->SetNativeDisplayId(fields[3].GetUInt32());
     uint32 petlevel = fields[4].GetUInt16();

--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -164,7 +164,6 @@ uint8 WorldSession::HandleLoadPetFromDBFirstCallback(PreparedQueryResult result,
         pet->GetCharmInfo()->SetPetNumber(pet_number, pet->IsPermanentPetFor(owner)); // Show pet details tab (Shift+P) only for hunter pets, demons or undead
     else
         pet->GetCharmInfo()->SetPetNumber(pet_number, false);
-	
     pet->SetDisplayId(fields[3].GetUInt32());
     pet->SetNativeDisplayId(fields[3].GetUInt32());
     uint32 petlevel = fields[4].GetUInt16();


### PR DESCRIPTION
## CHANGES PROPOSED:
-  Shows an unique name & pet details for a permanent "Risen Ghoul" created with the spell "Raise Dead" and the unholy talent "Master of Ghouls" (which makes the pet permanent)

## ISSUES ADDRESSED:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/2942 while still preserving the changes concerning the bug with permanent water elementals in https://github.com/azerothcore/azerothcore-wotlk/pull/2637

## TESTS PERFORMED:
- tested build on Windows 10
- tested successfully in-game (works on permanent ghouls, ignores temporary ones or those summoned by the spell "Army Of The Dead" and the pet details of permanent Water Elementals are still hidden)

## HOW TO TEST THE CHANGES:
- play death knight
- activate the talent "Master of Ghouls" in the unholy tree
- Learn & use the spell "Raise Dead"

If you want to check, if the pet details of the permanent Water Elemental are still hidden
- play mage
- insert major glyph "Glyph of Eternal Water" (id: 50045)
- learn spell "Summon Water Elemental" (id: 31687) and use it

## KNOWN ISSUES AND TODO LIST:
none

## Target branch(es):
- [x] Master

## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
