### PR TITLE
[Dungeon] Ragefire Chasm

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1588335399793049400.sql
+++ b/data/sql/updates/pending_db_world/rev_1588335399793049400.sql
@@ -6,12 +6,9 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1588335399793049400');
 */
 
 /* REGULAR */ 
-UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 46, `DamageModifier` = 1.03 WHERE `entry` = 11320;
+UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 46, `DamageModifier` = 1.03 WHERE `entry` IN (11320, 11319, 11322);
 UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 42, `DamageModifier` = 1.03 WHERE `entry` = 11321;
-UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 50, `DamageModifier` = 1.03 WHERE `entry` = 11318;
-UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 46, `DamageModifier` = 1.03 WHERE `entry` = 11319;
-UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 46, `DamageModifier` = 1.03 WHERE `entry` = 11322;
-UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 50, `DamageModifier` = 1.03 WHERE `entry` = 11323;
+UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 50, `DamageModifier` = 1.03 WHERE `entry` IN (11318, 11323);
 UPDATE `creature_template` SET `mindmg` = 22, `maxdmg` = 38, `DamageModifier` = 1.03 WHERE `entry` = 11324;
 UPDATE `creature_template` SET `mindmg` = 38, `maxdmg` = 47, `DamageModifier` = 1.03 WHERE `entry` = 8996;
 UPDATE `creature_template` SET `mindmg` = 89, `maxdmg` = 113, `DamageModifier` = 1.03 WHERE `entry` = 17830;

--- a/data/sql/updates/pending_db_world/rev_1588335399793049400.sql
+++ b/data/sql/updates/pending_db_world/rev_1588335399793049400.sql
@@ -14,7 +14,5 @@ UPDATE `creature_template` SET `mindmg` = 38, `maxdmg` = 47, `DamageModifier` = 
 UPDATE `creature_template` SET `mindmg` = 89, `maxdmg` = 113, `DamageModifier` = 1.03 WHERE `entry` = 17830;
 
 /* BOSS */
-UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 74, `maxdmg` = 96, `DamageModifier` = 1.01 WHERE `entry` = 11520;
-UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 74, `maxdmg` = 96, `DamageModifier` = 1.01 WHERE `entry` = 11518;
-UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 74, `maxdmg` = 96, `DamageModifier` = 1.01 WHERE `entry` = 11519;
+UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 74, `maxdmg` = 96, `DamageModifier` = 1.01 WHERE `entry` IN (11520, 11518, 11519);
 UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 101, `maxdmg` = 130, `DamageModifier` = 1.01 WHERE `entry` = 11517;

--- a/data/sql/updates/pending_db_world/rev_1588335399793049400.sql
+++ b/data/sql/updates/pending_db_world/rev_1588335399793049400.sql
@@ -1,0 +1,23 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1588335399793049400');
+
+/*
+ * Dungeon: Ragefire Chasm
+ * Update by Knindza | <www.azerothcore.org>
+*/
+
+/* REGULAR */ 
+UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 46, `DamageModifier` = 1.03 WHERE `entry` = 11320;
+UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 42, `DamageModifier` = 1.03 WHERE `entry` = 11321;
+UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 50, `DamageModifier` = 1.03 WHERE `entry` = 11318;
+UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 46, `DamageModifier` = 1.03 WHERE `entry` = 11319;
+UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 46, `DamageModifier` = 1.03 WHERE `entry` = 11322;
+UPDATE `creature_template` SET `mindmg` = 31, `maxdmg` = 50, `DamageModifier` = 1.03 WHERE `entry` = 11323;
+UPDATE `creature_template` SET `mindmg` = 22, `maxdmg` = 38, `DamageModifier` = 1.03 WHERE `entry` = 11324;
+UPDATE `creature_template` SET `mindmg` = 38, `maxdmg` = 47, `DamageModifier` = 1.03 WHERE `entry` = 8996;
+UPDATE `creature_template` SET `mindmg` = 89, `maxdmg` = 113, `DamageModifier` = 1.03 WHERE `entry` = 17830;
+
+/* BOSS */
+UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 74, `maxdmg` = 96, `DamageModifier` = 1.01 WHERE `entry` = 11520;
+UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 74, `maxdmg` = 96, `DamageModifier` = 1.01 WHERE `entry` = 11518;
+UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 74, `maxdmg` = 96, `DamageModifier` = 1.01 WHERE `entry` = 11519;
+UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 101, `maxdmg` = 130, `DamageModifier` = 1.01 WHERE `entry` = 11517;

--- a/data/sql/updates/pending_db_world/rev_1588335399793049400.sql
+++ b/data/sql/updates/pending_db_world/rev_1588335399793049400.sql
@@ -14,5 +14,5 @@ UPDATE `creature_template` SET `mindmg` = 38, `maxdmg` = 47, `DamageModifier` = 
 UPDATE `creature_template` SET `mindmg` = 89, `maxdmg` = 113, `DamageModifier` = 1.03 WHERE `entry` = 17830;
 
 /* BOSS */
-UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 74, `maxdmg` = 96, `DamageModifier` = 1.01 WHERE `entry` IN (11520, 11518, 11519);
-UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 101, `maxdmg` = 130, `DamageModifier` = 1.01 WHERE `entry` = 11517;
+UPDATE `creature_template` SET `type_flags`=`type_flags`|4, `mindmg` = 74, `maxdmg` = 96, `DamageModifier` = 1.01 WHERE `entry` IN (11520, 11518, 11519);
+UPDATE `creature_template` SET `type_flags`=`type_flags`|4, `mindmg` = 101, `maxdmg` = 130, `DamageModifier` = 1.01 WHERE `entry` = 11517;


### PR DESCRIPTION
Changes:

Min, Max & Modifier Damage for whole Dungeon.
Added flags for each boss, so they will appear with skull instead regular level elite.

All checks have been done trough Classic Realms and Youtube videos.

How to test:
Apply SQL
Restart Server and delete your Cache.

Make sure to add very very basic gear (15 ilvl for example) towards each Dungeon.

