### PR TITLE
[Dungeon] Stormwind Stockade

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1588336549910193100.sql
+++ b/data/sql/updates/pending_db_world/rev_1588336549910193100.sql
@@ -1,1 +1,23 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1588336549910193100');
+
+/*
+ * Dungeon: Stormwind Stockade
+ * Update by Knindza | <www.azerothcore.org>
+*/
+
+/* REGULAR */ 
+UPDATE `creature_template` SET `mindmg` = 60, `maxdmg` = 80, `DamageModifier` = 1.03 WHERE `entry` = 1707;
+UPDATE `creature_template` SET `mindmg` = 60, `maxdmg` = 80, `DamageModifier` = 1.03 WHERE `entry` = 1706;
+UPDATE `creature_template` SET `mindmg` = 60, `maxdmg` = 84, `DamageModifier` = 1.03 WHERE `entry` = 1708;
+UPDATE `creature_template` SET `mindmg` = 60, `maxdmg` = 84, `DamageModifier` = 1.03 WHERE `entry` = 1711;
+UPDATE `creature_template` SET `mindmg` = 82, `maxdmg` = 109, `DamageModifier` = 1.03 WHERE `entry` = 1715;
+
+/* RARE */
+UPDATE `creature_template` SET `rank` = 2, `mindmg` = 116, `maxdmg` = 149, `DamageModifier` = 1.02 WHERE `entry` = 1720;
+
+/* BOSS */
+UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 106, `maxdmg` = 166, `DamageModifier` = 1.01 WHERE `entry` = 1696;
+UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 129, `maxdmg` = 166, `DamageModifier` = 1.01 WHERE `entry` = 1666;
+UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 129, `maxdmg` = 166, `DamageModifier` = 1.01 WHERE `entry` = 1663;
+UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 129, `maxdmg` = 166, `DamageModifier` = 1.01 WHERE `entry` = 1716;
+UPDATE `creature_template` SET `type_flags` = 4, `mindmg` = 134, `maxdmg` = 173, `DamageModifier` = 1.01 WHERE `entry` = 1717;

--- a/data/sql/updates/pending_db_world/rev_1588336549910193100.sql
+++ b/data/sql/updates/pending_db_world/rev_1588336549910193100.sql
@@ -1,0 +1,1 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1588336549910193100');


### PR DESCRIPTION
Changes:

Min, Max & Modifier Damage for whole Dungeon.
Added flags for each boss, so they will appear with skull instead regular level elite.

All checks have been done trough Classic Realms and Youtube videos.

How to test:
Apply SQL
Restart Server and delete your Cache.

Make sure to add very very basic gear towards each Dungeon.
