### PR TITLE
fix(Core/Spell): Spell logic

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -785,7 +785,7 @@ void Spell::SelectExplicitTargets()
                 m_targets.SetUnitTarget(redirect);
                 m_spellFlags |= SPELL_FLAG_REDIRECTED;
             }
-               
+
         }
     }
 }
@@ -1438,7 +1438,7 @@ void Spell::SelectImplicitCasterDestTargets(SpellEffIndex effIndex, SpellImplici
                         // if (j < 2)
                         //    TC_LOG_ERROR("server", "(start in water) step in water, number of cycle = %i , distance of step = %f, total path = %f", j, srange, totalpath);
                         // else
-                        //    TC_LOG_ERROR("server", "step in water, number of cycle = %i , distance of step = %f, total path = %f", j, srange, totalpath);                   
+                        //    TC_LOG_ERROR("server", "step in water, number of cycle = %i , distance of step = %f, total path = %f", j, srange, totalpath);
                     }
 
                     if ((!map->IsInWater(tstX, tstY, tstZ) && tstZ != beforewaterz) || wcol)  // second safety check z for blink way if on the ground
@@ -1534,7 +1534,7 @@ void Spell::SelectImplicitCasterDestTargets(SpellEffIndex effIndex, SpellImplici
 
                         if (inwater && destz < prevZ && !wcol)
                             destz = prevZ;
-                        //TC_LOG_ERROR("server", "(collision) destZ rewrited in prevZ");                         
+                        //TC_LOG_ERROR("server", "(collision) destZ rewrited in prevZ");
 
                         break;
                     }
@@ -1584,7 +1584,7 @@ void Spell::SelectImplicitCasterDestTargets(SpellEffIndex effIndex, SpellImplici
                 // xinef: give the summon some space (eg. totems)
                 if (m_caster->GetTypeId() == TYPEID_PLAYER && m_spellInfo->Effects[effIndex].IsEffect(SPELL_EFFECT_SUMMON))
                     dist += objSize;
-            }        
+            }
             else if (targetType.GetTarget() == TARGET_DEST_CASTER_RANDOM)
                 dist = objSize + (dist - objSize) * (float)rand_norm();
 
@@ -1882,7 +1882,7 @@ void Spell::SelectImplicitTrajTargets(SpellEffIndex effIndex, SpellImplicitTarge
                 bestDist = dist;
                 break;
             }
-                
+
             continue;
         }
 
@@ -2424,7 +2424,7 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
         targetInfo.timeDelay += targetInfo.timeDelay >> 1;
 
         m_spellFlags |= SPELL_FLAG_REFLECTED;
-        
+
         // HACK: workaround check for succubus seduction case
         // TODO: seduction should be casted only on humanoids (not demons)
         if (m_caster->IsPet())
@@ -2585,7 +2585,7 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
         return;
 
     // Xinef: absorb delayed projectiles for 500ms
-    if (getState() == SPELL_STATE_DELAYED && !m_spellInfo->IsTargetingArea() && !m_spellInfo->IsPositive() && 
+    if (getState() == SPELL_STATE_DELAYED && !m_spellInfo->IsTargetingArea() && !m_spellInfo->IsPositive() &&
         (World::GetGameTimeMS() - target->timeDelay) <= effectUnit->m_lastSanctuaryTime && World::GetGameTimeMS() < (effectUnit->m_lastSanctuaryTime + 500) &&
         effectUnit->FindMap() && !effectUnit->FindMap()->IsDungeon()
         )
@@ -2833,7 +2833,7 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
             caster->ProcDamageAndSpell(unitTarget, procAttacker, procVictim, procEx, 0, m_attackType, m_spellInfo, m_triggeredByAuraSpell);
             // Xinef: eg. rogue poisions can proc off cheap shot, etc. so this block should be here also
             // Xinef: ofc count only spells that HIT the target, little hack used to fool the system
-            if (((procEx & PROC_EX_NORMAL_HIT)|PROC_EX_CRITICAL_HIT) && caster->GetTypeId() == TYPEID_PLAYER && m_spellInfo->HasAttribute(SPELL_ATTR0_STOP_ATTACK_TARGET) == 0 &&
+            if ((procEx & (PROC_EX_NORMAL_HIT|PROC_EX_CRITICAL_HIT)) && caster->GetTypeId() == TYPEID_PLAYER && m_spellInfo->HasAttribute(SPELL_ATTR0_STOP_ATTACK_TARGET) == 0 &&
                 m_spellInfo->HasAttribute(SPELL_ATTR4_CANT_TRIGGER_ITEM_SPELLS) == 0 && (m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_MELEE || m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_RANGED))
                 caster->ToPlayer()->CastItemCombatSpell(unitTarget, m_attackType, procVictim|PROC_FLAG_TAKEN_DAMAGE, procEx);
         }
@@ -3038,7 +3038,7 @@ SpellMissInfo Spell::DoSpellHitOnUnit(Unit* unit, uint32 effectMask, bool scaleA
         if (m_originalCaster)
         {
             bool refresh = false;
-            m_spellAura = Aura::TryRefreshStackOrCreate(aurSpellInfo, effectMask, unit, m_originalCaster, 
+            m_spellAura = Aura::TryRefreshStackOrCreate(aurSpellInfo, effectMask, unit, m_originalCaster,
                 (aurSpellInfo == m_spellInfo)? &m_spellValue->EffectBasePoints[0] : &basePoints[0], m_CastItem, 0, &refresh, !(_triggeredCastFlags & TRIGGERED_NO_PERIODIC_RESET));
 
             // xinef: if aura was not refreshed, add proc ex
@@ -3398,7 +3398,7 @@ void Spell::prepare(SpellCastTargets const* targets, AuraEffect const* triggered
     LoadScripts();
 
     OnSpellLaunch();
-    
+
     m_powerCost = m_CastItem ? 0 : m_spellInfo->CalcPowerCost(m_caster, m_spellSchoolMask, this);
 
     // Set combo point requirement
@@ -3453,7 +3453,7 @@ void Spell::prepare(SpellCastTargets const* targets, AuraEffect const* triggered
         {
             if (!m_spellInfo->Effects[i].IsEffect())
                 continue;
-            
+
             if (m_spellInfo->Effects[i].TargetA.GetSelectionCategory() != TARGET_SELECT_CATEGORY_NEARBY || m_spellInfo->Effects[i].TargetA.GetCheckType() != TARGET_CHECK_ENTRY)
             {
                 selectTargets = false;
@@ -3529,7 +3529,7 @@ void Spell::prepare(SpellCastTargets const* targets, AuraEffect const* triggered
         // set target for proper facing
         if ((m_casttime || m_spellInfo->IsChanneled()) && !(_triggeredCastFlags & TRIGGERED_IGNORE_SET_FACING))
         {
-            if (m_caster->GetTypeId() == TYPEID_UNIT && !m_caster->ToCreature()->IsInEvadeMode() && 
+            if (m_caster->GetTypeId() == TYPEID_UNIT && !m_caster->ToCreature()->IsInEvadeMode() &&
                 ((m_targets.GetObjectTarget() && m_caster != m_targets.GetObjectTarget()) || m_spellInfo->IsPositive()))
             {
                 // Xinef: Creature should focus to cast target if there is explicit target or self if casting positive spell
@@ -3676,7 +3676,7 @@ void Spell::_cast(bool skipCheck)
                 for (Unit::ControlSet::iterator itr = playerCaster->m_Controlled.begin(); itr != playerCaster->m_Controlled.end(); ++itr)
                     if (Unit* pet = *itr)
                         if (pet->IsAlive() && pet->GetTypeId() == TYPEID_UNIT)
-                            pet->ToCreature()->AI()->OwnerAttacked(m_targets.GetUnitTarget());     
+                            pet->ToCreature()->AI()->OwnerAttacked(m_targets.GetUnitTarget());
     }
 
     SetExecutedCurrently(true);
@@ -5738,7 +5738,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                     Pet *pet = m_caster->ToPlayer()->GetPet();
                     if (!target || !pet || pet->isDead() || target->isDead())
                         return SPELL_FAILED_BAD_TARGETS;
-                    
+
                     if (!pet->IsWithinLOSInMap(target, LINEOFSIGHT_ALL_CHECKS))
                         return SPELL_FAILED_LINE_OF_SIGHT;
                 }
@@ -6036,7 +6036,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                         return SPELL_FAILED_ALREADY_HAVE_CHARM;
                 }
 
-                if (m_caster->GetTypeId() == TYPEID_PLAYER && m_caster->getClass() == CLASS_WARLOCK && strict)                  
+                if (m_caster->GetTypeId() == TYPEID_PLAYER && m_caster->getClass() == CLASS_WARLOCK && strict)
                     if (Pet* pet = m_caster->ToPlayer()->GetPet())
                         pet->CastSpell(pet, 32752, true, NULL, NULL, pet->GetGUID()); //starting cast, trigger pet stun (cast by pet so it doesn't attack player)
                 break;
@@ -6233,7 +6233,7 @@ SpellCastResult Spell::CheckCast(bool strict)
 
                     if (target->GetCharmerGUID())
                         return SPELL_FAILED_CHARMED;
-                        
+
                     if (target->GetOwnerGUID() && IS_PLAYER_GUID(target->GetOwnerGUID()))
                         return SPELL_FAILED_TARGET_IS_PLAYER_CONTROLLED;
 
@@ -7824,13 +7824,13 @@ void Spell::DoAllEffectOnLaunchTarget(TargetInfo& targetInfo, float* multiplier,
     }
     else if (m_originalCaster)
         caster = m_originalCaster;
-    
+
     float critChance = caster->SpellDoneCritChance(unit, m_spellInfo, m_spellSchoolMask, m_attackType, false);
     critChance = unit->SpellTakenCritChance(caster, m_spellInfo, m_spellSchoolMask, critChance, m_attackType, false);
     targetInfo.crit = roll_chance_f(std::max(0.0f, critChance));
 
     // Sweeping strikes wtf shit ;d
-    if (m_caster->getClass() == CLASS_WARRIOR && ssEffect < MAX_SPELL_EFFECTS && m_spellInfo->SpellFamilyName == SPELLFAMILY_WARRIOR && 
+    if (m_caster->getClass() == CLASS_WARRIOR && ssEffect < MAX_SPELL_EFFECTS && m_spellInfo->SpellFamilyName == SPELLFAMILY_WARRIOR &&
         ((m_spellInfo->Id != 50622 && m_spellInfo->Id != 44949) || firstTarget))
     {
         if (Aura* aur = m_caster->GetAura(12328))
@@ -8208,7 +8208,7 @@ bool Spell::CheckScriptEffectImplicitTargets(uint32 effIndex, uint32 effIndexToC
             if (((*targetSelectHookItr).IsEffectAffected(m_spellInfo, effIndex) && !(*targetSelectHookItr).IsEffectAffected(m_spellInfo, effIndexToCheck)) ||
                 (!(*targetSelectHookItr).IsEffectAffected(m_spellInfo, effIndex) && (*targetSelectHookItr).IsEffectAffected(m_spellInfo, effIndexToCheck)))
                 return false;
-        
+
         std::list<SpellScript::ObjectAreaTargetSelectHandler>::iterator areaTargetSelectHookEnd = (*itr)->OnObjectAreaTargetSelect.end(), areaTargetSelectHookItr = (*itr)->OnObjectAreaTargetSelect.begin();
         for (; areaTargetSelectHookItr != areaTargetSelectHookEnd; ++areaTargetSelectHookItr)
             if (((*areaTargetSelectHookItr).IsEffectAffected(m_spellInfo, effIndex) && !(*areaTargetSelectHookItr).IsEffectAffected(m_spellInfo, effIndexToCheck)) ||
@@ -8562,4 +8562,3 @@ bool WorldObjectSpellTrajTargetCheck::operator()(WorldObject* target)
 }
 
 } //namespace acore
-


### PR DESCRIPTION
Closes AzerothCore issue 2961
https://github.com/azerothcore/azerothcore-wotlk/issues/2961
Fixes spell hit/ critical hit validation. PROCEX_ const values
checked, bitwise logic is applicable for defines const values.
Affects spell effects where damage <=0, and healing <= 0.
As per comments in source:
> // Do triggers for unit (reflect triggers passed on hit phase for correct drop charge)
> // Xinef: eg. rogue poisions can proc off cheap shot, etc. so this block should be here also
> // Xinef: ofc count only spells that HIT the target, little hack used to fool the system

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->
fix(CORE): Spell logic fix
## CHANGES PROPOSED:
-  Line 2836
-  before: ((procEx_zero & PROC_EX_NORMAL_HIT) | PROC_EX_CRITICAL_HIT)
-  fix: (procEx_zero & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT))


## ISSUES ADDRESSED:
- Closes 
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->
Closes https://github.com/azerothcore/azerothcore-wotlk/issues/2961

## TESTS PERFORMED:
- logic validated in separate testing program:
**Program:**
```
int main()
{
    int PROC_EX_NORMAL_HIT = 1;   // 00000001
    int PROC_EX_CRITICAL_HIT = 2; // 00000010
    int procEx_zero = 0;          // 00000000
    int procEx_norm = 1;          // 00000001
    int procEx_crit = 2;          // 00000010
    int procEx_bad = 4;           // 00000100
    printf("PROC_EX_NORMAL_HIT:%d | PROC_EX_CRITICAL_HIT:%d | procEx_zero:%d | procEx_norm:%d | procEx_crit:%d | procEx_bad:%d\n",PROC_EX_NORMAL_HIT,PROC_EX_CRITICAL_HIT,procEx_zero,procEx_norm,procEx_crit,procEx_bad);
    // current behaviour
    printf("procEx_zero:%d | procEx_norm:%d | procEx_crit:%d | procEx_bad:%d\n",
    ((procEx_zero & PROC_EX_NORMAL_HIT) | PROC_EX_CRITICAL_HIT),
    ((procEx_norm & PROC_EX_NORMAL_HIT) | PROC_EX_CRITICAL_HIT),
    ((procEx_crit & PROC_EX_NORMAL_HIT) | PROC_EX_CRITICAL_HIT),
    ((procEx_bad & PROC_EX_NORMAL_HIT) | PROC_EX_CRITICAL_HIT));
    //proposed:
    printf("procEx_zero:%d | procEx_norm:%d | procEx_crit:%d | procEx_bad:%d\n",
    (procEx_zero & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)),
    (procEx_norm & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)),
    (procEx_crit & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)),
    (procEx_bad & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)));
    return 0;
}
```
**Output:**

> PROC_EX_NORMAL_HIT:1 | PROC_EX_CRITICAL_HIT:2 | procEx_zero:0 | procEx_norm:1 | procEx_crit:2 | procEx_bad:4
> procEx_zero:2 | procEx_norm:3 | procEx_crit:2 | procEx_bad:2
> procEx_zero:0 | procEx_norm:1 | procEx_crit:2 | procEx_bad:0

- Tests performed on OpenSuse Tumpleweed (Linux)
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
Affects 
- [ ] Spell that do not heal or damage (mb stun, cc, buffs, debuffs?)
- [ ] Testing needs to be performed in game to validate that spells with no heal or damage that miss, do not interrupt the target.

## KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->
- [ ] Needs in-game testing.


## Target branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
