### PR TITLE
mysqladmin use the right credentials

### DIFF
--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -25,4 +25,4 @@ COPY --from=builder /azerothcore/env/dist/sql /sql
 # because all scripts included in that directory will automatically be executed when the docker container starts
 COPY docker/database/generate-databases.sh /docker-entrypoint-initdb.d
 
-HEALTHCHECK --interval=5s --timeout=15s --start-period=30s --retries=3 CMD mysqladmin ping -h localhost
+HEALTHCHECK --interval=5s --timeout=15s --start-period=30s --retries=3 CMD mysqladmin -uroot -p$MYSQL_ROOT_PASSWORD ping -h localhost


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 **Please fill this template unless your PR is very simple/straightforward.**
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

Mysqladmin use the right credentials so the error about not using password in the healthcheck is gone.

## CHANGES PROPOSED:
-  HEALTHCHECK --interval=5s --timeout=15s --start-period=30s --retries=3 CMD mysqladmin -uroot -p$MYSQL_ROOT_PASSWORD ping -h localhost

## ISSUES ADDRESSED:
[Note] Access denied for user 'root'@'localhost' (using password: NO)


## TESTS PERFORMED:
tested on local docker instance


## HOW TO TEST THE CHANGES:
Startup the db container


## KNOWN ISSUES AND TODO LIST:

## Target branch(es):
- [x] Master
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
