### PR TITLE
feat(CI): update clang-7 to clang-9, add clang-10 build

### DIFF
--- a/.github/workflows/core_build.yml
+++ b/.github/workflows/core_build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [clang6, clang10]
+        compiler: [clang6, clang9, clang10]
         modules: [with, without]
     runs-on: ubuntu-20.04
     name: ${{ matrix.compiler }}-${{ matrix.modules }}-modules

--- a/.github/workflows/core_build.yml
+++ b/.github/workflows/core_build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [clang6, clang7]
+        compiler: [clang6, clang10]
         modules: [with, without]
     runs-on: ubuntu-18.04
     name: ${{ matrix.compiler }}-${{ matrix.modules }}-modules

--- a/apps/ci/ci-install.sh
+++ b/apps/ci/ci-install.sh
@@ -30,11 +30,17 @@ case $COMPILER in
     echo "CCOMPILERCXX=\"clang++-6.0\"" >> ./conf/config.sh
     ;;
 
+   "clang9" )
+    time sudo apt-get install -y clang-9
+    echo "CCOMPILERC=\"clang-9\"" >> ./conf/config.sh
+    echo "CCOMPILERCXX=\"clang++-9\"" >> ./conf/config.sh
+    ;;
+
   "clang10" )
     time sudo apt-get install -y clang-10
     echo "CCOMPILERC=\"clang-10\"" >> ./conf/config.sh
     echo "CCOMPILERCXX=\"clang++-10\"" >> ./conf/config.sh
-    # disable -Werror for clang-10
+    # disable -Werror for clang-10 TODO: remove when this is fixed https://github.com/azerothcore/azerothcore-wotlk/issues/3108
     echo "CCUSTOMOPTIONS='-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'" >> ./conf/config.sh
     ;;
 

--- a/apps/ci/ci-install.sh
+++ b/apps/ci/ci-install.sh
@@ -34,6 +34,8 @@ case $COMPILER in
     time sudo apt-get install -y clang-10
     echo "CCOMPILERC=\"clang-10\"" >> ./conf/config.sh
     echo "CCOMPILERCXX=\"clang++-10\"" >> ./conf/config.sh
+    # disable -Werror for clang-10
+    echo "CCUSTOMOPTIONS='-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'" >> ./conf/config.sh
     ;;
 
   * )

--- a/apps/ci/ci-install.sh
+++ b/apps/ci/ci-install.sh
@@ -31,7 +31,7 @@ case $COMPILER in
     ;;
 
   "clang10" )
-    time sudo apt-get install -y clang-7
+    time sudo apt-get install -y clang-10
     echo "CCOMPILERC=\"clang-10\"" >> ./conf/config.sh
     echo "CCOMPILERCXX=\"clang++-10\"" >> ./conf/config.sh
     ;;

--- a/apps/ci/ci-install.sh
+++ b/apps/ci/ci-install.sh
@@ -30,7 +30,7 @@ case $COMPILER in
     echo "CCOMPILERCXX=\"clang++-6.0\"" >> ./conf/config.sh
     ;;
 
-   "clang9" )
+  "clang9" )
     time sudo apt-get install -y clang-9
     echo "CCOMPILERC=\"clang-9\"" >> ./conf/config.sh
     echo "CCOMPILERCXX=\"clang++-9\"" >> ./conf/config.sh

--- a/apps/ci/ci-install.sh
+++ b/apps/ci/ci-install.sh
@@ -30,10 +30,10 @@ case $COMPILER in
     echo "CCOMPILERCXX=\"clang++-6.0\"" >> ./conf/config.sh
     ;;
 
-  "clang7" )
+  "clang10" )
     time sudo apt-get install -y clang-7
-    echo "CCOMPILERC=\"clang-7\"" >> ./conf/config.sh
-    echo "CCOMPILERCXX=\"clang++-7\"" >> ./conf/config.sh
+    echo "CCOMPILERC=\"clang-10\"" >> ./conf/config.sh
+    echo "CCOMPILERCXX=\"clang++-10\"" >> ./conf/config.sh
     ;;
 
   * )

--- a/deps/g3dlite/include/G3D/Vector3.h
+++ b/deps/g3dlite/include/G3D/Vector3.h
@@ -11,9 +11,6 @@
   All rights reserved.
  */
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-copy"
-
 #ifndef G3D_Vector3_h
 #define G3D_Vector3_h
 
@@ -799,5 +796,3 @@ template<> struct PositionTrait<class G3D::Vector3> {
 
 
 #endif
-
-#pragma clang diagnostic pop

--- a/deps/g3dlite/include/G3D/Vector3.h
+++ b/deps/g3dlite/include/G3D/Vector3.h
@@ -11,6 +11,9 @@
   All rights reserved.
  */
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy"
+
 #ifndef G3D_Vector3_h
 #define G3D_Vector3_h
 
@@ -796,3 +799,5 @@ template<> struct PositionTrait<class G3D::Vector3> {
 
 
 #endif
+
+#pragma clang diagnostic pop


### PR DESCRIPTION
After this PR, our CI will do the following checks

- clang-6 that also checks warnings **(no changes)**
- clang-9 that also checks warnings **(updated clang-7 to clang-9)**
- clang-10 **without** warnings check **(new)**

We can enable clang-10 warnings check (and remove clang-9) once all warnings of clang-10 are solved (see https://github.com/azerothcore/azerothcore-wotlk/issues/3108).