### PR TITLE
fix(Core/BG): fix BG_QUEUE_INVITATION_TYPE_NO_BALANCE

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1310,8 +1310,11 @@ void Battleground::AddOrSetPlayerToCorrectBgGroup(Player* player, TeamId teamId)
 
 uint32 Battleground::GetFreeSlotsForTeam(TeamId teamId) const
 {
-    // if BG is starting and CONFIG_BATTLEGROUND_INVITATION_TYPE == BG_QUEUE_INVITATION_TYPE_NO_BALANCE, invite anyone
-    if (GetStatus() == STATUS_WAIT_JOIN && sWorld->getIntConfig(CONFIG_BATTLEGROUND_INVITATION_TYPE) == BG_QUEUE_INVITATION_TYPE_NO_BALANCE)
+    if (!(GetStatus() == STATUS_IN_PROGRESS || GetStatus() == STATUS_WAIT_JOIN))
+        return 0;
+
+    // if CONFIG_BATTLEGROUND_INVITATION_TYPE == BG_QUEUE_INVITATION_TYPE_NO_BALANCE, invite everyone unless the BG is full
+    if (sWorld->getIntConfig(CONFIG_BATTLEGROUND_INVITATION_TYPE) == BG_QUEUE_INVITATION_TYPE_NO_BALANCE)
         return (GetInvitedCount(teamId) < GetMaxPlayersPerTeam()) ? GetMaxPlayersPerTeam() - GetInvitedCount(teamId) : 0;
 
     // if BG is already started or CONFIG_BATTLEGROUND_INVITATION_TYPE != BG_QUEUE_INVITATION_TYPE_NO_BALANCE, do not allow to join too many players of one faction
@@ -1320,41 +1323,36 @@ uint32 Battleground::GetFreeSlotsForTeam(TeamId teamId) const
     uint32 otherTeamInvitedCount = teamId == TEAM_ALLIANCE ? GetInvitedCount(TEAM_HORDE) : GetInvitedCount(TEAM_ALLIANCE);
     uint32 otherTeamPlayersCount = teamId == TEAM_ALLIANCE ? GetPlayersCountByTeam(TEAM_HORDE) : GetPlayersCountByTeam(TEAM_ALLIANCE);
 
-    if (GetStatus() == STATUS_IN_PROGRESS || GetStatus() == STATUS_WAIT_JOIN)
-    {
-        // difference based on ppl invited (not necessarily entered battle)
-        // default: allow 0
-        uint32 diff = 0;
-        uint32 maxPlayersPerTeam = GetMaxPlayersPerTeam();
-        uint32 minPlayersPerTeam = GetMinPlayersPerTeam();
+    // difference based on ppl invited (not necessarily entered battle)
+    // default: allow 0
+    uint32 diff = 0;
+    uint32 maxPlayersPerTeam = GetMaxPlayersPerTeam();
+    uint32 minPlayersPerTeam = GetMinPlayersPerTeam();
 
-        // allow join one person if the sides are equal (to fill up bg to minPlayerPerTeam)
-        if (otherTeamInvitedCount == thisTeamInvitedCount)
-            diff = 1;
-        else if (otherTeamInvitedCount > thisTeamInvitedCount) // allow join more ppl if the other side has more players
-            diff = otherTeamInvitedCount - thisTeamInvitedCount;
+    // allow join one person if the sides are equal (to fill up bg to minPlayerPerTeam)
+    if (otherTeamInvitedCount == thisTeamInvitedCount)
+        diff = 1;
+    else if (otherTeamInvitedCount > thisTeamInvitedCount) // allow join more ppl if the other side has more players
+        diff = otherTeamInvitedCount - thisTeamInvitedCount;
 
-        // difference based on max players per team (don't allow inviting more)
-        uint32 diff2 = (thisTeamInvitedCount < maxPlayersPerTeam) ? maxPlayersPerTeam - thisTeamInvitedCount : 0;
+    // difference based on max players per team (don't allow inviting more)
+    uint32 diff2 = (thisTeamInvitedCount < maxPlayersPerTeam) ? maxPlayersPerTeam - thisTeamInvitedCount : 0;
 
-        // difference based on players who already entered
-        // default: allow 0
-        uint32 diff3 = 0;
+    // difference based on players who already entered
+    // default: allow 0
+    uint32 diff3 = 0;
 
-        // allow join one person if the sides are equal (to fill up bg minPlayerPerTeam)
-        if (otherTeamPlayersCount == thisTeamPlayersCount)
-            diff3 = 1;
-        else if (otherTeamPlayersCount > thisTeamPlayersCount) // allow join more ppl if the other side has more players
-            diff3 = otherTeamPlayersCount - thisTeamPlayersCount;
-        else if (thisTeamInvitedCount <= minPlayersPerTeam) // or other side has less than minPlayersPerTeam
-            diff3 = minPlayersPerTeam - thisTeamInvitedCount + 1;
+    // allow join one person if the sides are equal (to fill up bg minPlayerPerTeam)
+    if (otherTeamPlayersCount == thisTeamPlayersCount)
+        diff3 = 1;
+    else if (otherTeamPlayersCount > thisTeamPlayersCount) // allow join more ppl if the other side has more players
+        diff3 = otherTeamPlayersCount - thisTeamPlayersCount;
+    else if (thisTeamInvitedCount <= minPlayersPerTeam) // or other side has less than minPlayersPerTeam
+        diff3 = minPlayersPerTeam - thisTeamInvitedCount + 1;
 
-        // return the minimum of the 3 differences
-        // min of diff, diff2 and diff3
-        return std::min({ diff, diff2, diff3 });
-    }
-
-    return 0;
+    // return the minimum of the 3 differences
+    // min of diff, diff2 and diff3
+    return std::min({ diff, diff2, diff3 });
 }
 
 uint32 Battleground::GetMaxFreeSlots() const


### PR DESCRIPTION
## CHANGES PROPOSED:

If you set `Battleground.InvitationType = 0` the expected behaviour would be:

> Normal, Invite as much players to battlegrounds as queued, don't bother with balance

as described in `worldserver.conf`. However, it looks like that before this PR this only affected the **initial** invitation (when the BG starts). After the BG started, it kept balancing the teams even if `Battleground.InvitationType` was set to `0`.

This caused problems when using modules like [mod-cfbg](https://github.com/azerothcore/mod-cfbg) that has its own balancing system. So when using such modules, it's preferrable to disable the core's balance using `Battleground.InvitationType = 0`.

This PR makes sure that ``Battleground.InvitationType = 0` actually disables the core's balancing system, **always**.

This PR does **NOT** affect the behaviour when setting `Battleground.InvitationType` to a value different than `0`.

## ISSUES ADDRESSED:

-  Prevent new Battlegrounds to start if there are already other Battlegrounds that have free slots (when using CFBG module)

- Related with issues similar to the one reported here azerothcore/mod-cfbg#11 (however this is core's fault and not the module's)


## TESTS PERFORMED:

- Build, run, etc...
- Tested in game
- As the mod-cfbg is responsible to balance, I've tested that it keeps balancing even when setting `Battleground.InvitationType = 0`



## HOW TO TEST THE CHANGES:

- Play with Battlegrounds
- Try to change `Battleground.InvitationType` in your `worldserver.conf` and make sure that it still works as expected

## Target branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
