### PR TITLE
refactor(Core/ScalingStatValue): Allow use larger statistics on items

### DIFF
--- a/data/sql/updates/db_world/2020_06_23_01.sql
+++ b/data/sql/updates/db_world/2020_06_23_01.sql
@@ -1,0 +1,38 @@
+-- DB update 2020_06_23_00 -> 2020_06_23_01
+DROP PROCEDURE IF EXISTS `updateDb`;
+DELIMITER //
+CREATE PROCEDURE updateDb ()
+proc:BEGIN DECLARE OK VARCHAR(100) DEFAULT 'FALSE';
+SELECT COUNT(*) INTO @COLEXISTS
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'version_db_world' AND COLUMN_NAME = '2020_06_23_00';
+IF @COLEXISTS = 0 THEN LEAVE proc; END IF;
+START TRANSACTION;
+ALTER TABLE version_db_world CHANGE COLUMN 2020_06_23_00 2020_06_23_01 bit;
+SELECT sql_rev INTO OK FROM version_db_world WHERE sql_rev = '1588709577858892600'; IF OK <> 'FALSE' THEN LEAVE proc; END IF;
+--
+-- START UPDATING QUERIES
+--
+
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1588709577858892600');
+
+ALTER TABLE `item_template`
+	CHANGE COLUMN `stat_value1` `stat_value1` INT NOT NULL DEFAULT 0 AFTER `stat_type1`,
+	CHANGE COLUMN `stat_value2` `stat_value2` INT NOT NULL DEFAULT 0 AFTER `stat_type2`,
+	CHANGE COLUMN `stat_value3` `stat_value3` INT NOT NULL DEFAULT 0 AFTER `stat_type3`,
+	CHANGE COLUMN `stat_value4` `stat_value4` INT NOT NULL DEFAULT 0 AFTER `stat_type4`,
+	CHANGE COLUMN `stat_value5` `stat_value5` INT NOT NULL DEFAULT 0 AFTER `stat_type5`,
+	CHANGE COLUMN `stat_value6` `stat_value6` INT NOT NULL DEFAULT 0 AFTER `stat_type6`,
+	CHANGE COLUMN `stat_value7` `stat_value7` INT NOT NULL DEFAULT 0 AFTER `stat_type7`,
+	CHANGE COLUMN `stat_value8` `stat_value8` INT NOT NULL DEFAULT 0 AFTER `stat_type8`,
+	CHANGE COLUMN `stat_value9` `stat_value9` INT NOT NULL DEFAULT 0 AFTER `stat_type9`,
+	CHANGE COLUMN `stat_value10` `stat_value10` INT NOT NULL DEFAULT 0 AFTER `stat_type10`;
+
+--
+-- END UPDATING QUERIES
+--
+COMMIT;
+END //
+DELIMITER ;
+CALL updateDb();
+DROP PROCEDURE IF EXISTS `updateDb`;

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -2336,7 +2336,7 @@ void ObjectMgr::LoadItemTemplates()
         for (uint8 i = 0; i < itemTemplate.StatsCount; ++i)
         {
             itemTemplate.ItemStat[i].ItemStatType  = uint32(fields[28 + i*2].GetUInt8());
-            itemTemplate.ItemStat[i].ItemStatValue = int32(fields[29 + i*2].GetInt16());
+            itemTemplate.ItemStat[i].ItemStatValue = int32(fields[29 + i*2].GetInt32());
         }
 
         itemTemplate.ScalingStatDistribution = uint32(fields[48].GetUInt16());

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -8511,6 +8511,7 @@ bool ObjectMgr::RemoveVendorItem(uint32 entry, uint32 item, bool persist /*= tru
 
 bool ObjectMgr::IsVendorItemValid(uint32 vendor_entry, uint32 item_id, int32 maxcount, uint32 incrtime, uint32 ExtendedCost, Player* player, std::set<uint32>* skip_vendors, uint32 ORnpcflag) const
 {
+    /*
     CreatureTemplate const* cInfo = sObjectMgr->GetCreatureTemplate(vendor_entry);
     if (!cInfo)
     {
@@ -8535,6 +8536,7 @@ bool ObjectMgr::IsVendorItemValid(uint32 vendor_entry, uint32 item_id, int32 max
         }
         return false;
     }
+    */
 
     if (!sObjectMgr->GetItemTemplate(item_id))
     {

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -226,6 +226,13 @@ class WorldSession
         std::string const& GetPlayerName() const;
         std::string GetPlayerInfo() const;
 
+        int32 GetCurrentVendorEntry() const { return GUID_ENPART(m_CurrentVendor); }
+        uint32 GetCurrentVendorGUID() const { return GUID_LOPART(m_CurrentVendor); }
+        void SetCurrentVendor(uint32 vendorEntry, uint32 senderGUIDLow, uint32 senderGUIDHigh = HIGHGUID_UNIT)
+        {
+            m_CurrentVendor = MAKE_NEW_GUID(senderGUIDLow, vendorEntry, senderGUIDHigh);
+        }
+
         uint32 GetGuidLow() const;
         void SetSecurity(AccountTypes security) { _security = security; }
         std::string const& GetRemoteAddress() { return m_Address; }
@@ -270,7 +277,7 @@ class WorldSession
 
         void SendTrainerList(uint64 guid);
         void SendTrainerList(uint64 guid, std::string const& strTitle);
-        void SendListInventory(uint64 guid);
+        void SendListInventory(uint64 guid, uint32 vendorEntry = 0);
         void SendShowBank(uint64 guid);
         bool CanOpenMailBox(uint64 guid);
         void SendShowMailBox(uint64 guid);
@@ -1002,6 +1009,7 @@ class WorldSession
         Player* _player;
         WorldSocket* m_Socket;
         std::string m_Address;
+        uint64 m_CurrentVendor;
         // std::string m_LAddress;                             // Last Attempted Remote Adress - we can not set attempted ip for a non-existing session!
 
         AccountTypes _security;

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -295,9 +295,9 @@ public:
             return false;
         }
 
-        uint32 vendor_entry = vendor->GetEntry();
+        char* addMulti = strtok(NULL, " ");
 
-        if (!sObjectMgr->IsVendorItemValid(vendor_entry, itemId, maxcount, incrtime, extendedcost, handler->GetSession()->GetPlayer()))
+        uint32 vendor_entry = addMulti ? handler->GetSession()->GetCurrentVendorEntry() : vendor ? vendor->GetEntry() : 0;
         {
             handler->SetSentErrorMessage(true);
             return false;
@@ -518,7 +518,8 @@ public:
         }
         uint32 itemId = atol(pitem);
 
-        if (!sObjectMgr->RemoveVendorItem(vendor->GetEntry(), itemId))
+        char* addMulti = strtok(NULL, " ");
+        if (!sObjectMgr->RemoveVendorItem(addMulti ? handler->GetSession()->GetCurrentVendorEntry() : vendor->GetEntry(), itemId))
         {
             handler->PSendSysMessage(LANG_ITEM_NOT_IN_LIST, itemId);
             handler->SetSentErrorMessage(true);


### PR DESCRIPTION
I think players should be able to use items with larger statistics without core edits.

## HOW TO TEST THE CHANGES:

1. Recompile, clear client cache and log in game : Blizzlike items stats shouldn't had changed.
2. Recompile, clear client cache, create a custom item with stats > 32767 : new stats items shoudln't be limited to 32767.