### PR TITLE
Winter's Chill now stacks from multiple sources in the same manner as…

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3163,6 +3163,7 @@ void SpellMgr::LoadSpellCustomAttr()
             case 34655: // Snake Trap, Deadly Poison
             case 11971: // Sunder Armor
             case 58567: // Player Sunder Armor
+            case 12579: // Player Winter's Chill
             case 29306: // Naxxramas(Gluth's Zombies): Infected Wound
                 spellInfo->AttributesCu |= SPELL_ATTR0_CU_SINGLE_AURA_STACK;
                 break;


### PR DESCRIPTION
… Sunder Armor.

Signed-off-by: Chris <chriscgalbraith@gmail.com>

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## CHANGES PROPOSED:
-  Add Winter's Chill id 12579 to SpellMgr.cpp similar to Player Sunder Armor.


## ISSUES ADDRESSED:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1045
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## TESTS PERFORMED:
- Builds without errors.
- Tested in-game.
- Used multiple clients to use two mages to check for correct stacking.
- Only tested on Windows.
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
-->
- In-game, run two clients simultaneously.
- .learn Frostbolt, any rank will do. I used 27072 (rank 13).
- Mod level to 60, spend talent points down to Winter's Chill and take 3/3.
- Teleport to burning steppes, find nearest creature and cast a frostbolt from each client.
- Winter's Chill now stacks from multiple sources.

## KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]


## Target branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
