### PR TITLE
Fix Svala Sorrowgrave despawning too quickly after opening loot.

### DIFF
--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -235,6 +235,7 @@ public:
                 {
                     me->CastSpell(me, SPELL_SVALA_TRANSFORMING1, true);
                     me->UpdateEntry(NPC_SVALA_SORROWGRAVE);
+                    me->SetCorpseDelay(300);
                     me->SetFloatValue(UNIT_FIELD_HOVERHEIGHT, 6.0f);
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC|UNIT_FLAG_IMMUNE_TO_NPC);
                     if (Creature* Arthas = ObjectAccessor::GetCreature(*me, ArthasGUID))


### PR DESCRIPTION
Signed-off-by: Chris <chriscgalbraith@gmail.com>

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## CHANGES PROPOSED:
-  Svala Sorrowgrave->SetCorpseDelay = 300 seconds


## ISSUES ADDRESSED:
- Svala Sorrowgrave id = 26668 despawns too quickly upon opening her loot.
- I believe this to be a result of how she does an UpdateEntry(), swapping from one creature to another,  she does not inherit the 5 minute default despawn time for elite mobs of 5 minutes.
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## TESTS PERFORMED:
- Kill Svala Sorrowgrave, open loot window, do not take any of the loot, keep loot window open.
- Wait for corpse to despawn.
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
-->
- Go to Utgarde Pinnacle, kill Svala Sorrowgrave.
- Time how long you can hold the loot window open before she despawns.

## KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 


## Target branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
