### PR TITLE
chore(APPS/Installer): Pull from config branch

### DIFF
--- a/apps/installer/includes/functions.sh
+++ b/apps/installer/includes/functions.sh
@@ -30,16 +30,16 @@ function inst_updateRepo() {
     AC_REPO_CONFIG="$AC_PATH_CONF/config.sh"
     AC_REPO_CONFIG_DIST="$AC_PATH_CONF/config.sh.dist"
     if [[ -f "$AC_REPO_CONFIG" ]]; then
-	echo "Configuration $AC_REPO_CONFIG found."
-	source "$AC_REPO_CONFIG"
+        echo "Configuration $AC_REPO_CONFIG found."
+        source "$AC_REPO_CONFIG"
     else
-	echo "Configuration $AC_REPO_CONFIG not found. Looking for DIST."
-	if [[ -f "AC_REPO_CONFIG_DIST" ]]; then
-	    echo "Configuration $AC_REPO_CONFIG_DIST found."
+        echo "Configuration $AC_REPO_CONFIG not found. Looking for DIST."
+        if [[ -f "AC_REPO_CONFIG_DIST" ]]; then
+            echo "Configuration $AC_REPO_CONFIG_DIST found."
             source "$AC_REPO_CONFIG_DIST"
-	else
-	    INSTALLER_PULL_FROM="master"
-	fi
+        else
+            INSTALLER_PULL_FROM="master"
+        fi
     fi
     echo "Pulling from $INSTALLER_PULL_FROM branch."
     git pull origin $INSTALLER_PULL_FROM

--- a/apps/installer/includes/functions.sh
+++ b/apps/installer/includes/functions.sh
@@ -27,8 +27,21 @@ function inst_configureOS() {
 
 function inst_updateRepo() {
     cd "$AC_PATH_ROOT"
-    source "$AC_PATH_CONF/config.sh.dist" #hack to get the parameter for the branch name
-    echo "Pulling from $INSTALLER_PULL_FROM branch defined in config.sh.dist"
+    AC_REPO_CONFIG="$AC_PATH_CONF/config.sh"
+    AC_REPO_CONFIG_DIST="$AC_PATH_CONF/config.sh.dist"
+    if [[ -f "$AC_REPO_CONFIG" ]]; then
+	echo "Configuration $AC_REPO_CONFIG found."
+	source "$AC_REPO_CONFIG"
+    else
+	echo "Configuration $AC_REPO_CONFIG not found. Looking for DIST."
+	if [[ -f "AC_REPO_CONFIG_DIST" ]]; then
+	    echo "Configuration $AC_REPO_CONFIG_DIST found."
+            source "$AC_REPO_CONFIG_DIST"
+	else
+	    INSTALLER_PULL_FROM="master"
+	fi
+    fi
+    echo "Pulling from $INSTALLER_PULL_FROM branch."
     git pull origin $INSTALLER_PULL_FROM
 }
 

--- a/apps/installer/includes/functions.sh
+++ b/apps/installer/includes/functions.sh
@@ -27,7 +27,9 @@ function inst_configureOS() {
 
 function inst_updateRepo() {
     cd "$AC_PATH_ROOT"
-    git pull origin $(git rev-parse --abbrev-ref HEAD)
+    source "$AC_PATH_CONF/config.sh.dist" #hack to get the parameter for the branch name
+    echo "Pulling from $INSTALLER_PULL_FROM branch defined in config.sh.dist"
+    git pull origin $INSTALLER_PULL_FROM
 }
 
 function inst_resetRepo() {

--- a/conf/config.sh.dist
+++ b/conf/config.sh.dist
@@ -170,3 +170,6 @@ DB_AUTH_NAME="acore_auth"
 DB_CHARACTERS_NAME="acore_characters"
 
 DB_WORLD_NAME="acore_world"
+
+# Branch configuration for installer to pull from
+INSTALLER_PULL_FROM="master"


### PR DESCRIPTION
# Script is guessing what is the branch/remote to pull.
<!-- WRITE A RELEVANT TITLE -->

## CHANGES PROPOSED:
-  Added INSTALLER_PULL_FROM in conf/config.sh.dist.
-  Default value of INSTALLER_PULL_FROM is "master".


## ISSUES ADDRESSED:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/1064

## TESTS PERFORMED:
- Tested on ubuntu 20.04 

## HOW TO TEST THE CHANGES:
- Change remote origin to something else
- Choose option 3) of installer.sh
- It will pull from the branch defined in config

## Target branch(es):
- [x] Master


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
