### PR TITLE
fix(Core/Player): Fix incorrect mana regeneration at level 1

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6006,8 +6006,7 @@ float Player::OCTRegenMPPerSpirit()
     if (level > GT_MAX_LEVEL)
         level = GT_MAX_LEVEL;
 
-//    GtOCTRegenMPEntry     const* baseRatio = sGtOCTRegenMPStore.LookupEntry((pclass-1)*GT_MAX_LEVEL + level-1);
-    GtRegenMPPerSptEntry  const* moreRatio = sGtRegenMPPerSptStore.LookupEntry((pclass-1)*GT_MAX_LEVEL + level-1);
+    GtRegenMPPerSptEntry  const* moreRatio = sGtRegenMPPerSptStore.LookupEntry((pclass-1)*GT_MAX_LEVEL + level);
     if (moreRatio == NULL)
         return 0.0f;
 


### PR DESCRIPTION
## CHANGES PROPOSED:
- Edit Player::OCTRegenMPPerSpirit to correct an incorrect value

## ISSUES ADDRESSED:
- Closes #3237 

## TESTS PERFORMED:
- Tested in-game
- Tested only on Windows

## HOW TO TEST THE CHANGES:
- Create a level 1 character
- Use mana
- Watch if mana regeneration is correct

## KNOWN ISSUES AND TODO LIST:

## Target branch(es):
- [x] Master

## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
