### PR TITLE
fix(Core/ObjectMgr): Avoid Global Storage issue

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -123,6 +123,9 @@ bool normalizePlayerName(std::string& name)
     if (name.empty())
         return false;
 
+    if (name.find(" ") != std::string::npos)
+        return false;    
+    
     std::wstring tmp;
     if (!Utf8toWStr(name, tmp))
         return false;


### PR DESCRIPTION

## CHANGES PROPOSED:
-  Add a condition for normalizePlayerName to not search for existing names with a blank space " " in the end of the string.
-  Prevents global storage to go nuts and overwrite player info with missing information, as detailed on issue #3151


## ISSUES ADDRESSED:
- Closes  #3151


## TESTS PERFORMED:
- Tested on Ubuntu 18.04 and Debian 10.


## HOW TO TEST THE CHANGES:
- Without this PR, create a character with guild and arena team. With other character, send a mail to the first character, but on the receiver's name, add the condition mentioned above (I don't want to explicitly say the process). The mail won't be sent, but try and see what happens on world console, and then relogin the first character. This will cause issue #3151.
- With this PR, this won't happen. The mail won't be sent, and that's it.


## KNOWN ISSUES AND TODO LIST:

- I've checked for other characters besides the space " ", but nothing happens with those. The condition of "not founding" the character on global storage but finding it on the database should, however, bring the right information, with no bugs or missing parts. 


## Target branch(es):
- [x] Master


## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
