### PR TITLE
test: fix unit test linking problem in ubuntu 18.04

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -10,8 +10,8 @@ add_executable(
 
 target_link_libraries(
         unit_tests
-        gtest_main
         game
+        gtest_main
         game-interface
 )
 


### PR DESCRIPTION
**Unit Test Linking Problem**

Here is my build machine information: 
OS: Ubuntu 18.04.4 LTS
Compiler: GCC 7.5.0
Make: v4.1
CMake: 3.17.2

Currently, the build fails on my machine when the unit tests are enabled. The order of the libraries matters, and I got linking errors when the unit tests are being built. (These dependencies will probably be stubbed out or mocked in the future, but the current situation creates a build problem.) 

This tiny change in the MR solves the issue.

@FrancescoBorzi 