### PR TITLE
test: add code coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ nbproject/
 .idea
 cmake-build-debug/*
 cmake-build-debug-coverage/*
+coverage_report/
 
 #
 # Eclipse

--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ nbproject/
 .idea
 cmake-build-debug/*
 cmake-build-debug-coverage/*
-coverage_report/
+coverage-report/
 
 #
 # Eclipse

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,4 +154,16 @@ if( UNIT_TESTS )
 
     enable_testing()
     add_subdirectory(src/test)
+
+    add_custom_target(coverage DEPENDS coverage_command)
+
+    add_custom_command(OUTPUT coverage_command
+        # Run unit tests.
+        COMMAND ctest
+        # Run the graphical front-end for code coverage.
+        COMMAND lcov    --directory src --capture --output-file coverage.info
+    	COMMAND lcov    --remove coverage.info '/usr/*' '${CMAKE_BINARY_DIR}/googletest/*' --output-file coverage.info
+        COMMAND genhtml -o ${CMAKE_CURRENT_SOURCE_DIR}/coverage_report coverage.info
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+        )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ if( UNIT_TESTS )
         COMMAND ctest
         # Run the graphical front-end for code coverage.
         COMMAND lcov    --directory src --capture --output-file coverage.info
-        COMMAND lcov    --remove coverage.info '/usr/*' '${CMAKE_BINARY_DIR}/googletest/*' --output-file coverage.info
+        COMMAND lcov    --remove coverage.info '/usr/*' '${CMAKE_BINARY_DIR}/googletest/*' '${CMAKE_CURRENT_SOURCE_DIR}/src/test/*' --output-file coverage.info
         COMMAND genhtml -o ${CMAKE_CURRENT_SOURCE_DIR}/coverage_report coverage.info
         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,11 +140,16 @@ add_subdirectory(src)
 CU_RUN_HOOK("AFTER_SRC_LOAD")
 
 if( UNIT_TESTS )
-    # we use this to get code coverage
-    if(CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
-        message("Unit tests code coverage: enabling -fprofile-arcs -ftest-coverage")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+    # we use these flags to get code coverage
+    set(UNIT_TEST_CXX_FLAGS "-fprofile-arcs -ftest-coverage -fno-inline")
+
+    # enable additional flags for GCC.
+    if ( CMAKE_CXX_COMPILER_ID MATCHES GNU )
+        set(UNIT_TEST_CXX_FLAGS "${UNIT_TEST_CXX_FLAGS} -fno-inline-small-functions -fno-default-inline")
     endif()
+
+    message("Unit tests code coverage: enabling ${UNIT_TEST_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${UNIT_TEST_CXX_FLAGS}")
 
     include(src/cmake/googletest.cmake)
     fetch_googletest(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ if( UNIT_TESTS )
         COMMAND ctest
         # Run the graphical front-end for code coverage.
         COMMAND lcov    --directory src --capture --output-file coverage.info
-    	COMMAND lcov    --remove coverage.info '/usr/*' '${CMAKE_BINARY_DIR}/googletest/*' --output-file coverage.info
+        COMMAND lcov    --remove coverage.info '/usr/*' '${CMAKE_BINARY_DIR}/googletest/*' --output-file coverage.info
         COMMAND genhtml -o ${CMAKE_CURRENT_SOURCE_DIR}/coverage_report coverage.info
         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ if( UNIT_TESTS )
         # Run the graphical front-end for code coverage.
         COMMAND lcov    --directory src --capture --output-file coverage.info
         COMMAND lcov    --remove coverage.info '/usr/*' '${CMAKE_BINARY_DIR}/googletest/*' '${CMAKE_CURRENT_SOURCE_DIR}/src/test/*' --output-file coverage.info
-        COMMAND genhtml -o ${CMAKE_CURRENT_SOURCE_DIR}/coverage_report coverage.info
+        COMMAND genhtml -o ${CMAKE_CURRENT_SOURCE_DIR}/coverage-report coverage.info
         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
         )
 endif()

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -19,5 +19,5 @@ add_test(
         NAME
         unit
         COMMAND
-        ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/unit_tests
+        ${CMAKE_BINARY_DIR}/src/test/unit_tests
 )


### PR DESCRIPTION
**Add code coverage report**

 Code coverage report generation becomes possible with this MR. After a successful build with unit tests enabled, the report generation can be triggered via 'make coverage' command under the build directory. Finally, the report becomes available under <project dir>/coverage_report.

@FrancescoBorzi 