### PR TITLE
WIP: feat(CI): Enable GCC support on the CI

### DIFF
--- a/.github/workflows/core_build.yml
+++ b/.github/workflows/core_build.yml
@@ -13,12 +13,15 @@ jobs:
       matrix:
         # the result of the matrix will be the combination of all attributes, so we get os*compiler*modules builds
         os: [ubuntu-20.04]
-        compiler: [clang6, clang9, clang10]
+        compiler: [clang6, clang9, clang10, gcc, gcc10]
         modules: [with, without]
         # we can include specific combinations here
         include:
           - os: ubuntu-18.04
             compiler: clang
+            modules: without
+          - os: ubuntu-18.04
+            compiler: gcc
             modules: without
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.modules }}-modules

--- a/apps/ci/ci-install.sh
+++ b/apps/ci/ci-install.sh
@@ -2,7 +2,61 @@
 
 set -e
 
-cat >>conf/config.sh <<CONFIG_SH
+COMPILATION_OPTIONS='-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
+# These flags below are disabled for gcc, gcc 10 and clang 10.
+ADDITIONAL_OPTIONS='-DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror"'
+C_COMP=Unknown
+CPP_COMP=Unknown
+
+case $COMPILER in
+  # this is in order to use the "default" gcc version of the OS, without forcing a specific version
+  "gcc" )
+    time sudo apt-get install -y gcc g++
+    C_COMP=gcc
+    CPP_COMP=g++
+    ;;
+
+  "gcc10" )
+    time sudo apt-get install -y gcc-10 g++-10
+    C_COMP=gcc-10
+    CPP_COMP=g++-10
+    ;;
+
+  # this is in order to use the "default" clang version of the OS, without forcing a specific version
+  "clang" )
+    time sudo apt-get install -y clang
+    C_COMP=clang
+    CPP_COMP=clang++
+    COMPILATION_OPTIONS="${COMPILATION_OPTIONS} ${ADDITIONAL_OPTIONS}"
+    ;;
+
+  "clang6" )
+    time sudo apt-get install -y clang-6.0
+    C_COMP=clang-6
+    CPP_COMP=clang++-6
+    COMPILATION_OPTIONS="${COMPILATION_OPTIONS} ${ADDITIONAL_OPTIONS}"
+    ;;
+
+  "clang9" )
+    time sudo apt-get install -y clang-9
+    C_COMP=clang-9
+    CPP_COMP=clang++-9
+    COMPILATION_OPTIONS="${COMPILATION_OPTIONS} ${ADDITIONAL_OPTIONS}"
+    ;;
+
+  "clang10" )
+    time sudo apt-get install -y clang-10
+    C_COMP=clang-10
+    CPP_COMP=clang++-10
+    ;;
+
+  * )
+    echo "Unknown compiler $COMPILER"
+    exit 1
+    ;;
+esac
+
+cat > conf/config.sh <<CONFIG_SH
 MTHREADS=$(expr $(grep -c ^processor /proc/cpuinfo) + 2)
 CWARNINGS=ON
 CDEBUG=OFF
@@ -13,10 +67,12 @@ CSERVERS=ON
 CTOOLS=ON
 CSCRIPTPCH=OFF
 CCOREPCH=OFF
-CCUSTOMOPTIONS='-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror"'
 DB_CHARACTERS_CONF="MYSQL_USER='root'; MYSQL_PASS='root'; MYSQL_HOST='localhost';"
 DB_AUTH_CONF="MYSQL_USER='root'; MYSQL_PASS='root'; MYSQL_HOST='localhost';"
 DB_WORLD_CONF="MYSQL_USER='root'; MYSQL_PASS='root'; MYSQL_HOST='localhost';"
+CCOMPILERC="${C_COMP}"
+CCOMPILERCXX="${CPP_COMP}"
+CCUSTOMOPTIONS="${COMPILATION_OPTIONS}"
 CONFIG_SH
 
 time sudo apt-get update -y
@@ -24,37 +80,4 @@ time sudo apt-get update -y
 time sudo apt-get install -y git lsb-release sudo ccache
 time ./acore.sh install-deps
 
-case $COMPILER in
 
-  # this is in order to use the "default" clang version of the OS, without forcing a specific version
-  "clang" )
-    time sudo apt-get install -y clang
-    echo "CCOMPILERC=\"clang\"" >> ./conf/config.sh
-    echo "CCOMPILERCXX=\"clang++\"" >> ./conf/config.sh
-    ;;
-
-  "clang6" )
-    time sudo apt-get install -y clang-6.0
-    echo "CCOMPILERC=\"clang-6.0\"" >> ./conf/config.sh
-    echo "CCOMPILERCXX=\"clang++-6.0\"" >> ./conf/config.sh
-    ;;
-
-  "clang9" )
-    time sudo apt-get install -y clang-9
-    echo "CCOMPILERC=\"clang-9\"" >> ./conf/config.sh
-    echo "CCOMPILERCXX=\"clang++-9\"" >> ./conf/config.sh
-    ;;
-
-  "clang10" )
-    time sudo apt-get install -y clang-10
-    echo "CCOMPILERC=\"clang-10\"" >> ./conf/config.sh
-    echo "CCOMPILERCXX=\"clang++-10\"" >> ./conf/config.sh
-    # disable -Werror for clang-10 TODO: remove when this is fixed https://github.com/azerothcore/azerothcore-wotlk/issues/3108
-    echo "CCUSTOMOPTIONS='-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'" >> ./conf/config.sh
-    ;;
-
-  * )
-    echo "Unknown compiler $COMPILER"
-    exit 1
-    ;;
-esac

--- a/apps/ci/ci-install.sh
+++ b/apps/ci/ci-install.sh
@@ -32,8 +32,8 @@ case $COMPILER in
 
   "clang6" )
     time sudo apt-get install -y clang-6.0
-    C_COMP=clang-6
-    CPP_COMP=clang++-6
+    C_COMP=clang-6.0
+    CPP_COMP=clang++-6.0
     COMPILATION_OPTIONS="${COMPILATION_OPTIONS} ${ADDITIONAL_OPTIONS}"
     ;;
 


### PR DESCRIPTION
The build system doesn't finalize successfully with up to date GCC versions because of the warnings that are treated as errors. This MR enables the GCC support back again.

EDIT by Shin:

there is a cyclic dependency that is causing a linking error when using GCC, the line is `GetCaster()->VisitNearbyObject(15.0f, searcher);` from `instance_zulfarrak.cpp`. According to @meerd, this is caused by:

> instance_zulfarrak.cpp L144 has a dependency to a module from game library, 
> and 
> MovementHandler.cpp L727 (ArenaSpectator::HandleSpectatorSpectateCommand(&chc, summoner->GetName().c_str())) also relies on the script module.