### PR TITLE
chore: add ./apps/joiner/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ docker/worldserver/logs/
 docker/worldserver/data/
 !docker/build
 .env
-/apps/joiner/
+apps/joiner/
 
 !.gitkeep
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ docker/worldserver/logs/
 docker/worldserver/data/
 !docker/build
 .env
+/apps/joiner/
 
 !.gitkeep
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ docker/worldserver/logs/
 docker/worldserver/data/
 !docker/build
 .env
-apps/joiner/
+apps/joiner
 
 !.gitkeep
 


### PR DESCRIPTION
This directory is generated whenever you use `./acore.sh`, so I guess it should be gitignored too.

cc @Yehonal 