### PR TITLE
fix(CI): launch CI unit test with relative path

### DIFF
--- a/apps/ci/ci-run-unit-tests.sh
+++ b/apps/ci/ci-run-unit-tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-time /home/runner/work/azerothcore-wotlk/azerothcore-wotlk/var/build/obj/src/test/unit_tests
+time var/build/obj/src/test/unit_tests


### PR DESCRIPTION
## CHANGES PROPOSED:
-   Make the test CI run using relative path instead of hard-coded to avoid build problems in case of the path changing in any way, this includes the fork being named other than azerothcore-wotlk.

## Target branch(es):
- [x] Master