### PR TITLE
fix(DB/Loot): Naxxramas 25

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1601269291015416700.sql
+++ b/data/sql/updates/pending_db_world/rev_1601269291015416700.sql
@@ -1,0 +1,92 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1601269291015416700');
+
+-- = Thaddius 25 = 29448 -------------------------------------------------------------------------------
+
+-- Create referenced tokens into the reference table
+DELETE FROM `reference_loot_template` WHERE `Entry`=34380;
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
+('34380', '40634', '0', '0', '0', '1', '1', '1', '1'),
+('34380', '40635', '0', '0', '0', '1', '1', '1', '1'),
+('34380', '40636', '0', '0', '0', '1', '1', '1', '1');
+
+-- Insert reference loot into the creature loot temlate
+DELETE FROM `creature_loot_template` WHERE `Entry`=29448 AND `Reference`=34380;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
+('29448', '2', '34380', '100', '0', '1', '0', '1', '2');
+
+-- Delete old tokens which are separetely placed
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29448 AND `Item`=40634;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29448 AND `Item`=40635;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29448 AND `Item`=40636;
+
+
+-- = Loatheb 25 = 29718 -------------------------------------------------------------------------------
+
+-- Create referenced tokens into the reference table
+DELETE FROM `reference_loot_template` WHERE `Entry`=34381;
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
+('34381', '40637', '0', '0', '0', '1', '1', '1', '1'),
+('34381', '40638', '0', '0', '0', '1', '1', '1', '1'),
+('34381', '40639', '0', '0', '0', '1', '1', '1', '1');
+
+-- Insert reference loot into the creature loot temlate
+DELETE FROM `creature_loot_template` WHERE `Entry`=29718 AND `Reference`=34381;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
+('29718', '2', '34381', '100', '0', '1', '0', '1', '2');
+
+-- Delete old tokens which are separetely placed
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29718 AND `Item`=40637;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29718 AND `Item`=40638;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29718 AND `Item`=40639;
+
+
+-- = Four horsemen 25 = 25193 (data1)
+
+-- Create referenced tokens into the reference table
+DELETE FROM `reference_loot_template` WHERE `Entry`=34382;
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
+('34382', '40625', '0', '0', '0', '1', '1', '1', '1'),
+('34382', '40626', '0', '0', '0', '1', '1', '1', '1'),
+('34382', '40627', '0', '0', '0', '1', '1', '1', '1');
+
+-- Insert reference loot into the creature loot temlate
+DELETE FROM `gameobject_loot_template` WHERE `Entry`=25193 AND `Reference`=34382;
+INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
+('25193', '2', '34382', '100', '0', '1', '0', '1', '2');
+
+-- Delete tokens which are separetely placed
+DELETE FROM `gameobject_loot_template` WHERE  `Entry`=25193 AND `Item`=40625;
+DELETE FROM `gameobject_loot_template` WHERE  `Entry`=25193 AND `Item`=40626;
+DELETE FROM `gameobject_loot_template` WHERE  `Entry`=25193 AND `Item`=40627;
+
+
+-- = Gluth 25 = 29417
+
+-- Create referenced tokens into the reference table
+DELETE FROM `reference_loot_template` WHERE `Entry`=34383;
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
+('34383', '40625', '0', '0', '0', '1', '1', '1', '1'),
+('34383', '40626', '0', '0', '0', '1', '1', '1', '1'),
+('34383', '40627', '0', '0', '0', '1', '1', '1', '1'),
+('34383', '40634', '0', '0', '0', '1', '1', '1', '1'),
+('34383', '40635', '0', '0', '0', '1', '1', '1', '1'),
+('34383', '40636', '0', '0', '0', '1', '1', '1', '1'),
+('34383', '40637', '0', '0', '0', '1', '1', '1', '1'),
+('34383', '40638', '0', '0', '0', '1', '1', '1', '1'),
+('34383', '40639', '0', '0', '0', '1', '1', '1', '1');
+
+-- Insert reference loot into the creature loot temlate
+DELETE FROM `creature_loot_template` WHERE `Entry`=29417 AND `Reference`=34383;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
+('29417', '2', '34383', '100', '0', '1', '0', '1', '2');
+
+-- Delete tokens which are separetely placed
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40625;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40626;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40627;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40634;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40635;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40636;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40637;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40638;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40639;

--- a/data/sql/updates/pending_db_world/rev_1601269291015416700.sql
+++ b/data/sql/updates/pending_db_world/rev_1601269291015416700.sql
@@ -67,7 +67,7 @@ INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `
 (34383, 40636, 0, 0, 0, 1, 1, 1, 1),
 (34383, 40637, 0, 0, 0, 1, 1, 1, 1),
 (34383, 40638, 0, 0, 0, 1, 1, 1, 1),
-(34383, 40639, 0, 0, 0, 1, 1, 1, 1),
+(34383, 40639, 0, 0, 0, 1, 1, 1, 1);
 
 -- Insert reference loot into the creature loot temlate
 DELETE FROM `creature_loot_template` WHERE `Entry`=29417 AND `Reference`=34383;

--- a/data/sql/updates/pending_db_world/rev_1601269291015416700.sql
+++ b/data/sql/updates/pending_db_world/rev_1601269291015416700.sql
@@ -5,19 +5,17 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1601269291015416700');
 -- Create referenced tokens into the reference table
 DELETE FROM `reference_loot_template` WHERE `Entry`=34380;
 INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
-('34380', '40634', '0', '0', '0', '1', '1', '1', '1'),
-('34380', '40635', '0', '0', '0', '1', '1', '1', '1'),
-('34380', '40636', '0', '0', '0', '1', '1', '1', '1');
+(34380, 40634, 0, 0, 0, 1, 1, 1, 1),
+(34380, 40635, 0, 0, 0, 1, 1, 1, 1),
+(34380, 40636, 0, 0, 0, 1, 1, 1, 1);
 
 -- Insert reference loot into the creature loot temlate
 DELETE FROM `creature_loot_template` WHERE `Entry`=29448 AND `Reference`=34380;
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
-('29448', '2', '34380', '100', '0', '1', '0', '1', '2');
+(29448, 2, 34380, 100, 0, 1, 0, 1, 2);
 
 -- Delete old tokens which are separetely placed
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29448 AND `Item`=40634;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29448 AND `Item`=40635;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29448 AND `Item`=40636;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29448 AND `Item` IN (40634, 40635, 40636);
 
 
 -- = Loatheb 25 = 29718 -------------------------------------------------------------------------------
@@ -25,19 +23,17 @@ DELETE FROM `creature_loot_template` WHERE  `Entry`=29448 AND `Item`=40636;
 -- Create referenced tokens into the reference table
 DELETE FROM `reference_loot_template` WHERE `Entry`=34381;
 INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
-('34381', '40637', '0', '0', '0', '1', '1', '1', '1'),
-('34381', '40638', '0', '0', '0', '1', '1', '1', '1'),
-('34381', '40639', '0', '0', '0', '1', '1', '1', '1');
+(34381, 40637, 0, 0, 0, 1, 1, 1, 1),
+(34381, 40638, 0, 0, 0, 1, 1, 1, 1),
+(34381, 40639, 0, 0, 0, 1, 1, 1, 1);
 
 -- Insert reference loot into the creature loot temlate
 DELETE FROM `creature_loot_template` WHERE `Entry`=29718 AND `Reference`=34381;
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
-('29718', '2', '34381', '100', '0', '1', '0', '1', '2');
+(29718, 2, 34381, 100, 0, 1, 0, 1, 2);
 
 -- Delete old tokens which are separetely placed
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29718 AND `Item`=40637;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29718 AND `Item`=40638;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29718 AND `Item`=40639;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29718 AND `Item` IN (40637, 40638, 40639);
 
 
 -- = Four horsemen 25 = 25193 (data1)
@@ -45,19 +41,17 @@ DELETE FROM `creature_loot_template` WHERE  `Entry`=29718 AND `Item`=40639;
 -- Create referenced tokens into the reference table
 DELETE FROM `reference_loot_template` WHERE `Entry`=34382;
 INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
-('34382', '40625', '0', '0', '0', '1', '1', '1', '1'),
-('34382', '40626', '0', '0', '0', '1', '1', '1', '1'),
-('34382', '40627', '0', '0', '0', '1', '1', '1', '1');
+(34382, 40625, 0, 0, 0, 1, 1, 1, 1),
+(34382, 40626, 0, 0, 0, 1, 1, 1, 1),
+(34382, 40627, 0, 0, 0, 1, 1, 1, 1);
 
 -- Insert reference loot into the creature loot temlate
 DELETE FROM `gameobject_loot_template` WHERE `Entry`=25193 AND `Reference`=34382;
 INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
-('25193', '2', '34382', '100', '0', '1', '0', '1', '2');
+(25193, 2, 34382, 100, 0, 1, 0, 1, 2);
 
 -- Delete tokens which are separetely placed
-DELETE FROM `gameobject_loot_template` WHERE  `Entry`=25193 AND `Item`=40625;
-DELETE FROM `gameobject_loot_template` WHERE  `Entry`=25193 AND `Item`=40626;
-DELETE FROM `gameobject_loot_template` WHERE  `Entry`=25193 AND `Item`=40627;
+DELETE FROM `gameobject_loot_template` WHERE  `Entry`=25193 AND `Item` IN (40625, 40626, 40627);
 
 
 -- = Gluth 25 = 29417
@@ -65,28 +59,20 @@ DELETE FROM `gameobject_loot_template` WHERE  `Entry`=25193 AND `Item`=40627;
 -- Create referenced tokens into the reference table
 DELETE FROM `reference_loot_template` WHERE `Entry`=34383;
 INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
-('34383', '40625', '0', '0', '0', '1', '1', '1', '1'),
-('34383', '40626', '0', '0', '0', '1', '1', '1', '1'),
-('34383', '40627', '0', '0', '0', '1', '1', '1', '1'),
-('34383', '40634', '0', '0', '0', '1', '1', '1', '1'),
-('34383', '40635', '0', '0', '0', '1', '1', '1', '1'),
-('34383', '40636', '0', '0', '0', '1', '1', '1', '1'),
-('34383', '40637', '0', '0', '0', '1', '1', '1', '1'),
-('34383', '40638', '0', '0', '0', '1', '1', '1', '1'),
-('34383', '40639', '0', '0', '0', '1', '1', '1', '1');
+(34383, 40625, 0, 0, 0, 1, 1, 1, 1),
+(34383, 40626, 0, 0, 0, 1, 1, 1, 1),
+(34383, 40627, 0, 0, 0, 1, 1, 1, 1),
+(34383, 40634, 0, 0, 0, 1, 1, 1, 1),
+(34383, 40635, 0, 0, 0, 1, 1, 1, 1),
+(34383, 40636, 0, 0, 0, 1, 1, 1, 1),
+(34383, 40637, 0, 0, 0, 1, 1, 1, 1),
+(34383, 40638, 0, 0, 0, 1, 1, 1, 1),
+(34383, 40639, 0, 0, 0, 1, 1, 1, 1),
 
 -- Insert reference loot into the creature loot temlate
 DELETE FROM `creature_loot_template` WHERE `Entry`=29417 AND `Reference`=34383;
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`) VALUES 
-('29417', '2', '34383', '100', '0', '1', '0', '1', '2');
+(29417, 2, 34383, 100, 0, 1, 0, 1, 2);
 
 -- Delete tokens which are separetely placed
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40625;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40626;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40627;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40634;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40635;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40636;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40637;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40638;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item`=40639;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item` IN (40625, 40626, 40627, 40634, 40635, 40636, 40637, 40638, 40639);

--- a/data/sql/updates/pending_db_world/rev_1601269291015416700.sql
+++ b/data/sql/updates/pending_db_world/rev_1601269291015416700.sql
@@ -1,5 +1,9 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1601269291015416700');
 
+/*
+ * Update by Silker | <www.azerothcore.org> | Copyright (C)
+*/
+
 -- = Thaddius 25 = 29448 -------------------------------------------------------------------------------
 
 -- Create referenced tokens into the reference table
@@ -76,3 +80,4 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 
 -- Delete tokens which are separetely placed
 DELETE FROM `creature_loot_template` WHERE  `Entry`=29417 AND `Item` IN (40625, 40626, 40627, 40634, 40635, 40636, 40637, 40638, 40639);
+


### PR DESCRIPTION
This will fix the Naxxarmas 25 loot on Thaddius, Four Horsemen, Gluth and Loatheb as their current loot values are wrong.

(In 25 mode)
End wing bosses should drop 2 items + 2 tokens
Non-end wing bosses should drop 4 items
Gluth is a rare case, its loot is like an end wing bosses without being one: 2 items + 2 tokens

References:

End wing bosses like Thaddius
(at 2:55)  https://www.youtube.com/watch?v=WMVGZNe-cbo

Non-end wing bosses like Gluth:
(at 3:35)  https://www.youtube.com/watch?v=6_jUTBGQJew
(at 4:00)  https://www.youtube.com/watch?v=Yi85pjYGg0c

![image](https://user-images.githubusercontent.com/61223313/94398809-7bf3f200-0123-11eb-8dd0-dc84620eb2cb.png)

Source: https://www.mmo-champion.com/threads/625542-Simple-Question-How-many-items-per-Heoric-Naxx-Boss

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## CHANGES PROPOSED:
-  Rebuild the looting system on these 4 bosses in order to make them work properly as they were at retail


## ISSUES ADDRESSED:
- Never reported at AzerothCore
- Special thanks to Nemesis#6869 for his direct report
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## TESTS PERFORMED:
- Applied SQL
- Tested in-game
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

**Before applying the SQL changes:**
- .gm on
- .go c loatheb -> kill him -> see the loot (1 item missing)
- .go c gluth -> kill him -> see the loot (1 item extra)
- .go c thaddius -> .damage 9999999 -> see the loot (1 item missing)
- .go c 130962 -> pull and kill them all -> see the loot into the chest (1 item missing)

**After applying the SQL changes:**
- Restart the server
- Repeat the process above but you will notice this:
Loatheb: 2 items + 2 tokens
Thaddius: 2 items + 2 tokens
Four Horsemen: 2 items + 2 tokens
Gluth: 2 items + 2 tokens

## KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->
- There is a similar issue on Sartharion 25 loot. I will take care of it in the near future.
Private report at [BlackFrost Bug-tracker](https://github.com/blackfrost-server/BlackFrost-Server/issues/4) .

## Target branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
