### PR TITLE
fix(DB/creature_template): Nerubian Burrower's immunity

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1601277180341917800.sql
+++ b/data/sql/updates/pending_db_world/rev_1601277180341917800.sql
@@ -1,5 +1,9 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1601277180341917800');
 
+/*
+ * Update by Silker | <www.azerothcore.org> | Copyright (C)
+*/
+
 UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|2|64|4096|8192|131072|524288 WHERE `entry` IN 
 (34607, 34648, 35655, 35656);
 

--- a/data/sql/updates/pending_db_world/rev_1601277180341917800.sql
+++ b/data/sql/updates/pending_db_world/rev_1601277180341917800.sql
@@ -1,8 +1,8 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1601277180341917800');
 
--- Immune to Spell IDs: 9484 / 3355 / 20066 / 57546 / 60192 / 339 / 33786
-UPDATE `creature_template` SET mechanic_immune_mask='550187859' WHERE  entry=34607; -- ToC 10-man Normal Raid
-UPDATE `creature_template` SET mechanic_immune_mask='550187859' WHERE  entry=34648; -- ToC 25-man Normal Raid 
-UPDATE `creature_template` SET mechanic_immune_mask='550187859' WHERE  entry=35655; -- ToC 10-man Heroic Raid
-UPDATE `creature_template` SET mechanic_immune_mask='550187859' WHERE  entry=35656; -- ToC 25-man Heroic Raid
+-- Immune to Spell IDs: 9484 / 3355 / 20066 / 10326 / 60192 / 339 / 33786
+UPDATE `creature_template` SET mechanic_immune_mask=550187859 WHERE  entry=34607; -- ToC 10-man Normal Raid
+UPDATE `creature_template` SET mechanic_immune_mask=550187859 WHERE  entry=34648; -- ToC 25-man Normal Raid 
+UPDATE `creature_template` SET mechanic_immune_mask=550187859 WHERE  entry=35655; -- ToC 10-man Heroic Raid
+UPDATE `creature_template` SET mechanic_immune_mask=550187859 WHERE  entry=35656; -- ToC 25-man Heroic Raid
 

--- a/data/sql/updates/pending_db_world/rev_1601277180341917800.sql
+++ b/data/sql/updates/pending_db_world/rev_1601277180341917800.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1601277180341917800');
+
+-- Immune to Spell IDs: 9484 / 3355 / 20066 / 57546 / 60192 / 339 / 33786
+UPDATE `creature_template` SET mechanic_immune_mask='550187859' WHERE  entry=34607; -- ToC 10-man Normal Raid
+UPDATE `creature_template` SET mechanic_immune_mask='550187859' WHERE  entry=34648; -- ToC 25-man Normal Raid 
+UPDATE `creature_template` SET mechanic_immune_mask='550187859' WHERE  entry=35655; -- ToC 10-man Heroic Raid
+UPDATE `creature_template` SET mechanic_immune_mask='550187859' WHERE  entry=35656; -- ToC 25-man Heroic Raid
+

--- a/data/sql/updates/pending_db_world/rev_1601277180341917800.sql
+++ b/data/sql/updates/pending_db_world/rev_1601277180341917800.sql
@@ -1,8 +1,8 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1601277180341917800');
 
 -- Immune to Spell IDs: 9484 / 3355 / 20066 / 10326 / 60192 / 339 / 33786
-UPDATE `creature_template` SET mechanic_immune_mask=550187859 WHERE  entry=34607; -- ToC 10-man Normal Raid
-UPDATE `creature_template` SET mechanic_immune_mask=550187859 WHERE  entry=34648; -- ToC 25-man Normal Raid 
-UPDATE `creature_template` SET mechanic_immune_mask=550187859 WHERE  entry=35655; -- ToC 10-man Heroic Raid
-UPDATE `creature_template` SET mechanic_immune_mask=550187859 WHERE  entry=35656; -- ToC 25-man Heroic Raid
+UPDATE `creature_template` SET `mechanic_immune_mask`=550187859 WHERE `entry`=34607; -- ToC 10-man Normal Raid
+UPDATE `creature_template` SET `mechanic_immune_mask`=550187859 WHERE `entry`=34648; -- ToC 25-man Normal Raid 
+UPDATE `creature_template` SET `mechanic_immune_mask`=550187859 WHERE `entry`=35655; -- ToC 10-man Heroic Raid
+UPDATE `creature_template` SET `mechanic_immune_mask`=550187859 WHERE `entry`=35656; -- ToC 25-man Heroic Raid
 

--- a/data/sql/updates/pending_db_world/rev_1601277180341917800.sql
+++ b/data/sql/updates/pending_db_world/rev_1601277180341917800.sql
@@ -1,8 +1,5 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1601277180341917800');
 
--- Immune to Spell IDs: 9484 / 3355 / 20066 / 10326 / 60192 / 339 / 33786
-UPDATE `creature_template` SET `mechanic_immune_mask`=550187859 WHERE `entry`=34607; -- ToC 10-man Normal Raid
-UPDATE `creature_template` SET `mechanic_immune_mask`=550187859 WHERE `entry`=34648; -- ToC 25-man Normal Raid 
-UPDATE `creature_template` SET `mechanic_immune_mask`=550187859 WHERE `entry`=35655; -- ToC 10-man Heroic Raid
-UPDATE `creature_template` SET `mechanic_immune_mask`=550187859 WHERE `entry`=35656; -- ToC 25-man Heroic Raid
+UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|2|64|4096|8192|131072|524288 WHERE `entry` IN 
+(34607, 34648, 35655, 35656);
 


### PR DESCRIPTION
This change will make the Nerubian Burrower immune to any cc effect, only interrupt or stun effects are allowed.

Reference is taken from retail videos and TankSpot guide at YouTube:

TankSpot's Guide to Heroic Anub'arak (25 Hard)
https://www.youtube.com/watch?v=zDmdb9RYecY

In the TankSpot video, they explain that only interrupt or stun effects are used to cut the cast of the adds, other cc's are never mentioned.
https://www.youtube.com/watch?v=PlMtNG8D2x0

= = = = = = = = = = = = = = = = = = = =

Original immune mask: 549520145
Fixed immune mask: 550187859


**Change makes immune to the following spells:**

-- 2094 | Blind
-- 339 | Entangling Roots
-- 60192 | Freezing Arrow
-- 3355 | Freezing Trap Effect
-- 49203 | Hungering Cold
-- 20066 | Repentance
-- 33786 | Cyclone
-- 9484 | Shackle Undead

**NPC per mode:**

-- 34607 | ToC 10-man Normal Raid
-- 34648 | ToC 25-man Normal Raid
-- 35655 | ToC 10-man Heroic Raid
-- 35656 | ToC 25-man Heroic Raid

**Mechanic_immune_mask added and what it blocks:**

MECHANIC_DISORIENTED = 2 | Prevents the spell 2094
MECHANIC_ROOT = 64 | Prevents the spell 339
MECHANIC_FREEZE = 4096 | Prevents the spell 60192, 3355 and 49203
MECHANIC_KNOCKOUT = 8192 | Prevents the spell 20066
MECHANIC_BANISH = 131072 | Prevents the spell 33786
MECHANIC_SHACKLE = 524288 | Prevents the spell 9484

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## CHANGES PROPOSED:
-  Make the Nerubian Burrower immune to any cc effect, only interrupt or stun effects are usable


## ISSUES ADDRESSED:
- Closes #3486 
- Without this change, you can easily win this encounter by using different types of CC on these adds which are an important mechanic of the encounter, you can leave them out of combat by using very long spell effects and focus on Anub'arak
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## TESTS PERFORMED:
- Applied SQL changes
- Tested in-game
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
**Before applying the SQL changes:**
- .npc add 34607
- Use any of the following spells against this add with .cast [Spell ID below]
9484 / 3355 / 20066 / 57546 / 60192 / 339 / 33786
- Any of these spells will take effect

**After applying the SQL changes:**
- Try to use any of the spells on the NPC while you combat with him, none of them will take effect
- Any stun or interrupt spell is still usable

## KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->
- This NPC has a debuff called "Expose Weakness" with Spell ID "67721" , when in combat, and after some time, it will stack up to 9 stacks. The problem is when another NPC like this one, uses the same debuff against a player, it resets the stacks.

In combat with 1 Nerubian Burrower: It will apply "Exose Weakness" until 9 stacks
In combat with 2 Nerubian Burrower: One will apply "Expose Weakness", at the second time, the debuff will increase to 2 stacks but when the other Nerubian Burrower applies "Expose Weakness" it resets the stacks to 1


## Target branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
