### PR TITLE
Fix(DB/creature_loot_template) Emblem of Triumph

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1604736110768509700.sql
+++ b/data/sql/updates/pending_db_world/rev_1604736110768509700.sql
@@ -1,0 +1,12 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1604736110768509700');
+
+/* Raise MinCount to match MaxCount for [Emblem of Triumph] in boss loot. */
+
+UPDATE `creature_loot_template` SET `MinCount`=2 WHERE `Item`=47241 AND `Entry`= IN
+(
+15990, /* Kel'thuzad 10-man */
+33885, /* XT-002 Deconstructor 25-man */
+34175, /* Auriaya 25-man */
+33724, /* Razorscale 25-man */
+33694  /* Stormcaller Brundir 25-man */
+);

--- a/data/sql/updates/pending_db_world/rev_1604736110768509700.sql
+++ b/data/sql/updates/pending_db_world/rev_1604736110768509700.sql
@@ -2,8 +2,9 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1604736110768509700');
 
 /* Raise MinCount to match MaxCount for [Emblem of Triumph] in boss loot. */
 
-UPDATE `creature_loot_template` SET `MinCount`=2 WHERE `Item`=47241 AND `Entry`= IN
+UPDATE `creature_loot_template` SET `MinCount`=2 WHERE `MinCount`=1 AND `MaxCount`=2 AND `Item`=47241 AND `Entry` IN
 (
+15989, /* Sapphiron 10-man */
 15990, /* Kel'thuzad 10-man */
 33885, /* XT-002 Deconstructor 25-man */
 34175, /* Auriaya 25-man */


### PR DESCRIPTION
## CHANGES PROPOSED:
Raise MinCount to match MaxCount for [Emblem of Triumph] in boss loot.


## ISSUES ADDRESSED:
Some creatures have a chance to drop 1-2 Emblems of Triumph when it should be 2-2.


## HOW TO TEST THE CHANGES:
- Set raid mode 10-player
.go cre 133932
Kill Sapphiron
.go cre 133933
Kill Kel'thuzad

- Set raid mode 25-player
.go cre 136054
Kill XT-002
.go cre 137496
Kill Auriaya
.go cre 137611
Kill Razorscale
.go cre 136316
Kill Stormcaller Brundir LAST 

## Target branch(es):
- [x] Master


## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
