### PR TITLE
fix(DB/gossip): remove cataclysm gossip/gossip flag from Anduin Wrynn

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1605586971095091500.sql
+++ b/data/sql/updates/pending_db_world/rev_1605586971095091500.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1605586971095091500');
+-- Remove Quest Giver & Gossip flags
+UPDATE `creature_template` SET `npcflag` = 0 WHERE (`entry` = 1747);
+-- Remove Cataclysm gossip from DB
+DELETE FROM `gossip_menu` WHERE (`MenuID` = 11874) AND (`TextID` IN (16642));
+


### PR DESCRIPTION
## CHANGES PROPOSED:
-  Remove Cataclysm gossip from Anduin Wrynn (id: 1747)
-  Remove quest giver and gossip flags from Anduin Wrynn (id: 1747)

## ISSUES ADDRESSED:
- Anduin currently has gossip from a Cataclysm quest: https://wow.gamepedia.com/My_Son,_the_Prince (added Patch 4.0.3a)
- In WotLK, Anduin should not have any gossip at all, in WotLK he was simply a static NPC standing next to his dad.  Gossip for Anduin Wrynn was added in 4.0.3a (cataclysm) and beyond - https://wow.gamepedia.com/Anduin_Wrynn#Quotes
- Does not have any quests attached to him in WotLK
- Should only have two on-click voice lines (third was removed in 3.0.2, this is all correct currently though)


## TESTS PERFORMED:
- Apply SQL
- Before: https://i.imgur.com/6fOVi7m.jpg
- After: no more gossip


## HOW TO TEST THE CHANGES:
1. Create Alliance Character
2. .tele stormwindkeep
3. Hover mouse over Anduin


## KNOWN ISSUES AND TODO LIST:
1.  NPC has one other gossip attached, need to find out if it belongs to any other NPC 


## Target branch(es):
- [x] Master