### PR TITLE
fix(Scripts/DB): Mimiron Computer NPC text

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1605661689213920900.sql
+++ b/data/sql/updates/pending_db_world/rev_1605661689213920900.sql
@@ -3,3 +3,4 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1605661689213920900');
 /* Copy FemaleText into missing MaleText for Computer NPC in Mimiron fight, Ulduar. */
 
 UPDATE `broadcast_text` SET `MaleText`=`FemaleText` WHERE `ID` IN (34284,34283,34282,34281,34280,34279,34278,34277,34276,34275,34274,34273,34268);
+UPDATE `broadcast_text_locale` SET `MaleText`=`FemaleText` WHERE `ID` IN (34284,34283,34282,34281,34280,34279,34278,34277,34276,34275,34274,34273,34268);

--- a/data/sql/updates/pending_db_world/rev_1605661689213920900.sql
+++ b/data/sql/updates/pending_db_world/rev_1605661689213920900.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1605661689213920900');
+
+/* Copy FemaleText into missing MaleText for Computer NPC in Mimiron fight, Ulduar. */
+
+UPDATE `broadcast_text` SET `MaleText`=`FemaleText` WHERE `ID` IN (34284,34283,34282,34281,34280,34279,34278,34277,34276,34275,34274,34273,34268);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -434,11 +434,11 @@ public:
                 case 0:
                     break;
                 case EVENT_COMPUTER_SAY_INITIATED:
-                    if( Creature* computer = me->SummonCreature(NPC_COMPUTER, 2790.0f, 2569.44f, 364.31f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 1000) )
+                    if( Creature* computer = me->SummonCreature(NPC_COMPUTER, 2746.7f, 2569.44f, 410.39f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 1000) )
                         computer->AI()->Talk(TALK_COMPUTER_INITIATED);
                     break;
                 case EVENT_COMPUTER_SAY_MINUTES:
-                    if( Creature* computer = me->SummonCreature(NPC_COMPUTER, 2790.0f, 2569.44f, 364.31f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 1000) )
+                    if( Creature* computer = me->SummonCreature(NPC_COMPUTER, 2746.7f, 2569.44f, 410.39f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 1000) )
                         computer->AI()->Talk(minutesTalkNum++);
                     break;
                 case EVENT_MIMIRON_SAY_HARDMODE:
@@ -801,7 +801,7 @@ public:
                             pInstance->DoUpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_KILL_CREATURE, NPC_LEVIATHAN_MKII, 1, me);
 
                         if (hardmode)
-                            if( Creature* computer = me->SummonCreature(NPC_COMPUTER, 2790.0f, 2569.44f, 364.31f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 1000) )
+                            if( Creature* computer = me->SummonCreature(NPC_COMPUTER, 2746.7f, 2569.44f, 410.39f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 1000) )
                                 computer->AI()->Talk(TALK_COMPUTER_TERMINATED);
 
                         events.Reset();


### PR DESCRIPTION
## CHANGES PROPOSED:
- DB: Add missing broadcast_text for Computer npc.
- Script: Change Computer npc position so players can't see the chat bubble.


## ISSUES ADDRESSED:
![image](https://user-images.githubusercontent.com/61268368/99471371-c7a16b80-291c-11eb-8f41-eb3276e433d5.png)


## TESTS PERFORMED:
<details>
<summary>Tested on 10 and 25-man</summary>

![image](https://user-images.githubusercontent.com/61268368/99472538-354e9700-291f-11eb-9564-d0b35427c8fd.png)

</details>

## HOW TO TEST THE CHANGES:
.go c 137630
Push the button


## Target branch(es):
- [x] Master


## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
