### PR TITLE
fix(scripts/Ulduar): Assembly of Iron - interrupt immune effect

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
@@ -89,9 +89,8 @@ enum eEnums
     EVENT_LIGHTNING_TENDRILS    = 24,
     EVENT_LIGHTNING_LAND        = 25,
     EVENT_LAND_LAND             = 26,
-    EVENT_IMMUNE                = 27,
 
-    EVENT_ENRAGE                = 30,
+    EVENT_ENRAGE                = 30
 };
 
 enum AssemblyYells
@@ -623,8 +622,6 @@ public:
             me->SetDisableGravity(false);
             me->SetRegeneratingHealth(true);
             me->SetReactState(REACT_AGGRESSIVE);
-            me->ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_INTERRUPT_CAST, false);
-
             if (pInstance)
                 pInstance->SetData(TYPE_ASSEMBLY, NOT_STARTED);
         }
@@ -768,15 +765,10 @@ public:
 
                     events.RepeatEvent(urand(9000, 17000));
                     break;
-                case EVENT_IMMUNE:
-                    me->ApplySpellImmune(1, IMMUNITY_EFFECT, SPELL_EFFECT_INTERRUPT_CAST, false);
-                    break;
                 case EVENT_OVERLOAD:
-                    me->ApplySpellImmune(1, IMMUNITY_EFFECT, SPELL_EFFECT_INTERRUPT_CAST, true);
                     Talk(EMOTE_BRUNDIR_OVERLOAD);
                     me->CastSpell(me, SPELL_OVERLOAD, true);
                     events.RescheduleEvent(EVENT_OVERLOAD, urand(25000, 40000));
-                    events.RescheduleEvent(EVENT_IMMUNE, 5999);
                     break;
                 case EVENT_LIGHTNING_WHIRL:
                     Talk(SAY_BRUNDIR_SPECIAL);
@@ -805,8 +797,6 @@ public:
                         me->CastSpell(me, SPELL_LIGHTNING_TENDRILS, true);
                         me->CastSpell(me, 61883, true);
                         events.ScheduleEvent(EVENT_LIGHTNING_LAND, 16000);
-
-                        me->ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_INTERRUPT_CAST, true);
                         break;
                     }
                 case EVENT_LIGHTNING_LAND:
@@ -829,7 +819,6 @@ public:
                     me->RemoveAura(SPELL_LIGHTNING_TENDRILS);
                     me->RemoveAura(61883);
                     DoResetThreat();
-                    me->ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_INTERRUPT_CAST, false);
                     break;
                 case EVENT_ENRAGE:
                     Talk(SAY_BRUNDIR_BERSERK);


### PR DESCRIPTION
This change deletes the immune effect applied by script.

The intention is to remove the immune event which is triggered by the overload event, the immunity is not needed at all, seems it was implemented to prevent players to interrupt the Overload spell:

![image](https://user-images.githubusercontent.com/61223313/100252460-7fc6a980-2f05-11eb-95e1-f43b845de1d2.png)

This spell by default cannot be interrupted so the immunity by script is useless and is just generating the issue #3728 

I have tried to interrupt with spell classes such as
[Shield Bash](https://wotlkdb.com/?spell=72)
[Kick](https://wotlkdb.com/?spell=1766)
[Mind Freeze](https://wotlkdb.com/?spell=47528)
none of them interrupted the spell (as expected)

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## CHANGES PROPOSED:
-  Delete EVENT_IMMUNE
-  Remove ApplySpellImmune

## ISSUES ADDRESSED:
- Closes #3728 
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## TESTS PERFORMED:
- Tested in-game:  Took 2 (big and mid bosses) down and left Brundir (small) alive, when he casts Overload, I tried to interrupt which failed (correct). All attempts to interrupt "Lightning Whirl" are successful
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

.cheat god
Set raid to 25-normal
.go xyz 1642.31 120.07 427.29 603 3.07
Engage combat
Kill Big and mid bosses, left just the small one
Try to interrupt "Overload" and "Lightning Whirl"

Overload: ❌
Lightning Whirl: ✔️
🐱 


## KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->
- N/A

## Target branch(es):
- [x] Master

<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
