### PR TITLE
refactor(Core): apply clang-tidy modernize-use-emplace

### DIFF
--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -197,7 +197,7 @@ namespace MMAP
 
         for (unsigned int i = 0; i < threads; ++i)
         {
-            _workerThreads.push_back(std::thread(&MapBuilder::WorkerThread, this));
+            _workerThreads.emplace_back(&MapBuilder::WorkerThread, this);
         }
 
         m_tiles.sort([](MapTiles a, MapTiles b)

--- a/src/tools/mmaps_generator/PathCommon.h
+++ b/src/tools/mmaps_generator/PathCommon.h
@@ -108,7 +108,7 @@ namespace MMAP
             if ((dp = readdir(dirp)) != nullptr)
             {
                 if (matchWildcardFilter(filter.c_str(), dp->d_name))
-                    fileList.push_back(std::string(dp->d_name));
+                    fileList.emplace_back(dp->d_name);
             }
             else
                 break;

--- a/src/tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap4_extractor/vmapexport.cpp
@@ -283,7 +283,7 @@ bool scan_patches(char* scanmatch, std::vector<std::string>& pArchiveNames)
         {
             fclose(h);
             //matches.push_back(path);
-            pArchiveNames.push_back(path);
+            pArchiveNames.emplace_back(path);
         }
     }
 
@@ -301,18 +301,18 @@ bool fillArchiveNameVector(std::vector<std::string>& pArchiveNames)
     string in_path(input_path);
     std::vector<std::string> locales, searchLocales;
 
-    searchLocales.push_back("enGB");
-    searchLocales.push_back("enUS");
-    searchLocales.push_back("deDE");
-    searchLocales.push_back("esES");
-    searchLocales.push_back("frFR");
-    searchLocales.push_back("koKR");
-    searchLocales.push_back("zhCN");
-    searchLocales.push_back("zhTW");
-    searchLocales.push_back("enCN");
-    searchLocales.push_back("enTW");
-    searchLocales.push_back("esMX");
-    searchLocales.push_back("ruRU");
+    searchLocales.emplace_back("enGB");
+    searchLocales.emplace_back("enUS");
+    searchLocales.emplace_back("deDE");
+    searchLocales.emplace_back("esES");
+    searchLocales.emplace_back("frFR");
+    searchLocales.emplace_back("koKR");
+    searchLocales.emplace_back("zhCN");
+    searchLocales.emplace_back("zhTW");
+    searchLocales.emplace_back("enCN");
+    searchLocales.emplace_back("enTW");
+    searchLocales.emplace_back("esMX");
+    searchLocales.emplace_back("ruRU");
 
     for (std::vector<std::string>::iterator i = searchLocales.begin(); i != searchLocales.end(); ++i)
     {


### PR DESCRIPTION
- Part of https://github.com/azerothcore/azerothcore-wotlk/issues/3820
- Apply `clang-tidy` with `modernize-use-emplace`
https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html

### How to test the changes

This PR is only about refactoring, it is then not meant to change anything of the program behaviour.
To test this, it is sufficient to:

- (Not mandatory but would be nice to build with `-DTOOLS=1` [extract the client files](https://www.azerothcore.org/wiki/Extract-Client-Data) and use the newly extracted data to run the server)
- Run the server
- Access the game and play around a bit
- All good so far? Then this should be good to go

## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR- Part of https://github.com/azerothcore/azerothcore-wotlk/issues/3820
- Apply `clang-tidy` with `modernize-use-nullptr`
https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-nullptr.html

### How to test the changes

This PR is only about refactoring, it is then not meant to change anything of the program behaviour.
To test this, it is sufficient to:

- Build with `-DTOOLS=1`
- [Extract the client files](https://www.azerothcore.org/wiki/Extract-Client-Data)
- Run the server
- Access the game
- All good so far? Then this should be good to go

## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR