### PR TITLE
fix(README): catalogue link

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -154,7 +154,7 @@ This project exists thanks to:
 - [Code of Conduct](https://github.com/azerothcore-wotlk/.github/code_of_conduct.md
 -->
 - [Website](http://www.azerothcore.org/)
-- [AzerothCore catalogue](http://www.azerothcore.org/catalogue/  "Modules, tools, and other things for AzerothCore") (modules, tools, etc...)
+- [AzerothCore catalogue](http://www.azerothcore.org/catalogue.html  "Modules, tools, and other stuff for AzerothCore") (modules, tools, etc...)
 - [Module template / Module skeleton](https://github.com/azerothcore/skeleton-module/)
 - [Our community hub (Discord)](https://discord.gg/gkt4y2x)
 - [Our wiki](http://www.azerothcore.org/wiki "Easy to use and developed by AzerothCore founder")


### PR DESCRIPTION
Changed the catalogue link from catalogue/ to the new integrated page: catalogue.hml