### PR TITLE
fix(scripts/Felmyst): Adjust beam target

### DIFF
--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_felmyst.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_felmyst.cpp
@@ -325,7 +325,7 @@ public:
                     me->GetMotionMaster()->MovePoint(POINT_AIR, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 15.0f, false, true);
                     break;
                 case EVENT_FLIGHT_VAPOR:
-                    me->CastSpell(me, SPELL_SUMMON_DEMONIC_VAPOR, true);
+                    me->CastCustomSpell(SPELL_SUMMON_DEMONIC_VAPOR, SPELLVALUE_MAX_TARGETS, 1, me, true);
                     break;
                 case EVENT_FLIGHT_BREATH1:
                     {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

Change the way Felmyst selects the target for the beam which summons skeletons at the encounter.

All available players get one beam ❌ 
Only one player gets one beam ✔️ 

Sources:
- https://www.youtube.com/watch?v=zKIepv2-Yjo    (since 1:45: Only one target runs from the beam)
- https://wowwiki.fandom.com/wiki/Felmyst    "She will target **a** random player for a couple of seconds"

## Changes Proposed:
-  Convert CastSpell to CastCustomSpell in order to prevent AOE targets and just pick one valid target

## Issues Addressed:
- Felmyst currently summons one beam per player available in the encounter instead of pick just one as the expected blizzlike behavior
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

## Tests Performed:
- Tested in-game locally and with a production/live server in the past.
![image](https://user-images.githubusercontent.com/61223313/103146434-ee6a7300-470e-11eb-8ee9-5f222e927a30.png)

<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

## How to Test the Changes:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

You will need to bring 2 accounts  and make a raid group
.go c felmyst
Kill Brutallus
Wait for >1 minute until Felmyst spawns
Engage Felmyst and wait for her Phase 2 -> She will target only 1 of your 2 characters as the blizzlike behavior.

## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- N/A

## Target Branch(es):
- [x] Master

<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
