### PR TITLE
fix(DB/gameobject): Adjust spawntimesecs for multiple GOs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1609009225243254400.sql
+++ b/data/sql/updates/pending_db_world/rev_1609009225243254400.sql
@@ -2,7 +2,7 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1609009225243254400');
 
 UPDATE `gameobject` SET `spawntimesecs` = 2 WHERE `id` IN
 (20691,  -- Cozzle's Footlocker
- 20925,  -- Captain's Footlocker
+20925,   -- Captain's Footlocker
 181110,  -- Soaked Tome
 181133,  -- Rathis Tomber's Supplies
 181238,  -- Dented Chest
@@ -10,7 +10,7 @@ UPDATE `gameobject` SET `spawntimesecs` = 2 WHERE `id` IN
 182011,  -- Crate of Ingots
 182804,  -- Mysteries of the Light
 183050,  -- The Saga of Terokk
-49828,   -- Tallonkai's Dresser
+126158,  -- Tallonkai's Dresser
 187980); -- First Aid Supplies
 
 -- Night Elf Plans: An'daroth, An'owyn, Scrying on the Sin'dorei

--- a/data/sql/updates/pending_db_world/rev_1609009225243254400.sql
+++ b/data/sql/updates/pending_db_world/rev_1609009225243254400.sql
@@ -1,0 +1,19 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1609009225243254400');
+
+UPDATE `gameobject` SET `spawntimesecs` = 2 WHERE `id` IN
+(20691,  -- Cozzle's Footlocker
+ 20925,  -- Captain's Footlocker
+181110,  -- Soaked Tome
+181133,  -- Rathis Tomber's Supplies
+181238,  -- Dented Chest
+181239,  -- Worn Chest
+182011,  -- Crate of Ingots
+182804,  -- Mysteries of the Light
+183050,  -- The Saga of Terokk
+187980); -- First Aid Supplies
+
+-- Night Elf Plans: An'daroth, An'owyn, Scrying on the Sin'dorei
+UPDATE `gameobject` SET `spawntimesecs` = 5 WHERE `id` IN (181138,181139,181140);
+-- Sealed Box (Investigate Tuurem), Dawn Runner Cargo/Warped Crates
+UPDATE `gameobject` SET `spawntimesecs` = 60 WHERE `id` IN (182542,181626);
+

--- a/data/sql/updates/pending_db_world/rev_1609009225243254400.sql
+++ b/data/sql/updates/pending_db_world/rev_1609009225243254400.sql
@@ -10,6 +10,7 @@ UPDATE `gameobject` SET `spawntimesecs` = 2 WHERE `id` IN
 182011,  -- Crate of Ingots
 182804,  -- Mysteries of the Light
 183050,  -- The Saga of Terokk
+49828,   -- Tallonkai's Dresser
 187980); -- First Aid Supplies
 
 -- Night Elf Plans: An'daroth, An'owyn, Scrying on the Sin'dorei


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

Imported from https://github.com/TrinityCore/TrinityCore/issues/20162

## Changes Proposed:
-  Adjust 'spawntimesecs' in 'gameobject' for:
Cozzle's Footlocker
Captain's Footlocker
Soaked Tome
Rathis Tomber's Supplies
Dented Chest
Worn Chest
Crate of Ingots
Mysteries of the Light
The Saga of Terokk
First Aid Supplies
Night Elf Plans: An'daroth
An'owyn
Scrying on the Sin'dorei
Sealed Box
Dawn Runner Cargo/Warped Crates

## Issues Addressed:
- Improve spawn time on multiple low/mid-level game objects

Close: https://github.com/azerothcore/azerothcore-wotlk/issues/4060

## Tests Performed:
- **Tested in-game**
- **SQL query applied:** /* Affected rows: 17  Found rows: 0  Warnings: 0  Duration for 3 queries: 0.125 sec. */
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->

## How to Test the Changes:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

Same as described in https://github.com/TrinityCore/TrinityCore/issues/20162

## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- N/A

## Target Branch(es):
- [x] Master

<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
