### PR TITLE
fix(Core/Object): Increase wg object visibility

### DIFF
--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -28,11 +28,11 @@ class ElunaEventProcessor;
 #define INTERACTION_DISTANCE        5.5f
 #define ATTACK_DISTANCE             5.0f
 #define MAX_SEARCHER_DISTANCE       150.0f // pussywizard: replace the use of MAX_VISIBILITY_DISTANCE in searchers, because MAX_VISIBILITY_DISTANCE is quite too big for this purpose
-#define MAX_VISIBILITY_DISTANCE     300.0f // max distance for visible objects, experimental
+#define MAX_VISIBILITY_DISTANCE     250.0f // max distance for visible objects, experimental
 #define VISIBILITY_INC_FOR_GOBJECTS 300.0f // pussywizard
 #define VISIBILITY_COMPENSATION     15.0f // increase searchers
 #define SPELL_SEARCHER_COMPENSATION 30.0f // increase searchers size in case we have large npc near cell border
-#define VISIBILITY_DIST_WINTERGRASP 280.0f
+#define VISIBILITY_DIST_WINTERGRASP 175.0f
 #define SIGHT_RANGE_UNIT            50.0f
 #define DEFAULT_VISIBILITY_DISTANCE 90.0f // default visible distance, 90 yards on continents
 #define DEFAULT_VISIBILITY_INSTANCE 120.0f // default visible distance in instances, 120 yards

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -28,11 +28,11 @@ class ElunaEventProcessor;
 #define INTERACTION_DISTANCE        5.5f
 #define ATTACK_DISTANCE             5.0f
 #define MAX_SEARCHER_DISTANCE       150.0f // pussywizard: replace the use of MAX_VISIBILITY_DISTANCE in searchers, because MAX_VISIBILITY_DISTANCE is quite too big for this purpose
-#define MAX_VISIBILITY_DISTANCE     250.0f // max distance for visible objects, experimental
+#define MAX_VISIBILITY_DISTANCE     300.0f // max distance for visible objects, experimental
 #define VISIBILITY_INC_FOR_GOBJECTS 300.0f // pussywizard
 #define VISIBILITY_COMPENSATION     15.0f // increase searchers
 #define SPELL_SEARCHER_COMPENSATION 30.0f // increase searchers size in case we have large npc near cell border
-#define VISIBILITY_DIST_WINTERGRASP 175.0f
+#define VISIBILITY_DIST_WINTERGRASP 280.0f
 #define SIGHT_RANGE_UNIT            50.0f
 #define DEFAULT_VISIBILITY_DISTANCE 90.0f // default visible distance, 90 yards on continents
 #define DEFAULT_VISIBILITY_INSTANCE 120.0f // default visible distance in instances, 120 yards

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -29,7 +29,7 @@ class ElunaEventProcessor;
 #define ATTACK_DISTANCE             5.0f
 #define MAX_SEARCHER_DISTANCE       150.0f // pussywizard: replace the use of MAX_VISIBILITY_DISTANCE in searchers, because MAX_VISIBILITY_DISTANCE is quite too big for this purpose
 #define MAX_VISIBILITY_DISTANCE     250.0f // max distance for visible objects, experimental
-#define VISIBILITY_INC_FOR_GOBJECTS 30.0f // pussywizard
+#define VISIBILITY_INC_FOR_GOBJECTS 300.0f // pussywizard
 #define VISIBILITY_COMPENSATION     15.0f // increase searchers
 #define SPELL_SEARCHER_COMPENSATION 30.0f // increase searchers size in case we have large npc near cell border
 #define VISIBILITY_DIST_WINTERGRASP 175.0f


### PR DESCRIPTION
## Changes Proposed:
-  Wintergrasp game objects like Towers and Walls have low visibility distance. Therefore the Cannons on the Towers appears before the Towers itselves.
-  This is not a permanent solution, but it has done the job.


## Issues Addressed:
- Closes  https://github.com/azerothcore/azerothcore-wotlk/issues/4057


## Tests Performed:
- tested on windows
- built without errors


## How to Test the Changes:
- .gm on
- .tele wintergrasp
- .gm fly on
- .mod speed 10
- fly to the Wintergrasp Fortress
- check towers and cannons (towers should render, before cannons)


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
