### PR TITLE
fix(DB/Creature): position of guid 17952

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1609414989791132104.sql
+++ b/data/sql/updates/pending_db_world/rev_1609414989791132104.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1609414989791132104');
+DELETE FROM `creature` WHERE (`id` = 1766) AND (`guid` IN (17952));
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(17952, 1766, 0, 0, 0, 1, 1, 246, 0, 1016.2447, 1489.1141, 41.584156, 0.199946, 275, 5, 0, 222, 0, 1, 0, 0, 0, '', 0);
+


### PR DESCRIPTION
Moved the position of the NPC, fixed created by [Keira3](https://azerothcore.org/Keira3).
## Changes Proposed:
-  Move the position of the NPC 1766, guid 17952

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4116


## Tests Performed:
- tested in-game
![image](https://user-images.githubusercontent.com/519778/103409315-88df1200-4b66-11eb-9ca8-3d7bd48335a0.png)


## How to Test the Changes:
`.go c 17952`
now, it should not be inside a tree

## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
