### PR TITLE
fix(DB/Event): Stranglethorn Vale Fishing Extravaganza wrong start time

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1609689072960937685.sql
+++ b/data/sql/updates/pending_db_world/rev_1609689072960937685.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1609689072960937685');
+
+UPDATE `acore_world`.`game_event` SET `start_time` = '2014-03-23 14:00:00' WHERE (`eventEntry` IN (15, 62));


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## Changes Proposed:
-  Change event start time from 3 PM to 2 PM server time.
https://classic.wowhead.com/guides/wow-classic-stranglethorn-vale-fishing-extravaganza

When: Every Sunday, 2 PM - 4 PM server time (pools become unavailable at 4; turn-in NPCs available until 5 PM server time)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4066 ?
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## Tests Performed:
- Well, you can't really test this until next week 😄 
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## How to Test the Changes:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
Apply the SQL and that's it.

## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
