### PR TITLE
fix(DOCKER): Reduce context build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,10 @@
 build*/
 var/*
-data/
+data/contrib/
+data/dbc/
+data/maps/
+data/docs/
+data/vmaps/
 conf/*
 !conf/dist
 docker/worldserver/data/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,13 @@
 build*/
 var/*
-data/contrib/*
-data/doc/*
+data/
 conf/*
 !conf/dist
 docker/worldserver/data/*
-docker/build/cache
+docker/build/cache/
 .idea
 cmake-build-debug/*
+.git/
+deps/
+src/
+modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,5 @@ docker/build/cache/
 .idea
 cmake-build-debug/*
 .git/
-deps/
 src/
 modules/

--- a/.github/workflows/core_build.yml
+++ b/.github/workflows/core_build.yml
@@ -182,4 +182,4 @@ jobs:
           docker-compose --version
       - name: Build
         run: |
-          docker build -t azerothcore/database -f docker/database/Dockerfile .
+          docker-compose build ac-database

--- a/bin/acore-docker-build
+++ b/bin/acore-docker-build
@@ -7,7 +7,6 @@ docker run \
     -v /"$(pwd)"/conf/dist:/azerothcore/conf/dist \
     -v /"$(pwd)"/src:/azerothcore/src \
     -v /"$(pwd)"/modules:/azerothcore/modules \
-    -v /"$(pwd)"/CMakeLists.txt:/azerothcore/CMakeLists.txt \
     -v /"$(pwd)"/docker/build/cache:/azerothcore/build \
     -v /"$(pwd)"/docker/worldserver/bin:/binworldserver \
     -v /"$(pwd)"/docker/authserver/bin:/binauthserver \

--- a/bin/acore-docker-build
+++ b/bin/acore-docker-build
@@ -3,6 +3,11 @@
 docker build -t acbuild -f docker/build/Dockerfile .
 
 docker run \
+    -v /"$(pwd)"/deps:/azerothcore/deps \
+    -v /"$(pwd)"/conf/dist:/azerothcore/conf/dist \
+    -v /"$(pwd)"/src:/azerothcore/src \
+    -v /"$(pwd)"/modules:/azerothcore/modules \
+    -v /"$(pwd)"/CMakeLists.txt:/azerothcore/CMakeLists.txt \
     -v /"$(pwd)"/docker/build/cache:/azerothcore/build \
     -v /"$(pwd)"/docker/worldserver/bin:/binworldserver \
     -v /"$(pwd)"/docker/authserver/bin:/binauthserver \

--- a/bin/acore-docker-build-no-scripts
+++ b/bin/acore-docker-build-no-scripts
@@ -3,6 +3,10 @@
 docker build --build-arg ENABLE_SCRIPTS=0 -t acbuild -f docker/build/Dockerfile .
 
 docker run \
+    -v /"$(pwd)"/deps:/azerothcore/deps \
+    -v /"$(pwd)"/conf/dist:/azerothcore/conf/dist \
+    -v /"$(pwd)"/src:/azerothcore/src \
+    -v /"$(pwd)"/modules:/azerothcore/modules \
     -v /"$(pwd)"/docker/build/cache:/azerothcore/build \
     -v /"$(pwd)"/docker/worldserver/bin:/binworldserver \
     -v /"$(pwd)"/docker/authserver/bin:/binauthserver \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,21 @@ services:
       - type: volume
         source: ac-database
         target: /var/lib/mysql
+      - type: bind
+        source: ./apps
+        target: /azerothcore/apps
+      - type: bind
+        source: ./bin
+        target: /azerothcore/bin
+      - type: bind
+        source: ./conf
+        target: /azerothcore/conf
+      - type: bind
+        source: ./data
+        target: /azerothcore/data
+      - type: bind
+        source: ./deps
+        target: /azerothcore/deps
 
   ac-worldserver:
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,17 +19,8 @@ services:
         source: ac-database
         target: /var/lib/mysql
       - type: bind
-        source: ./apps
-        target: /azerothcore/apps
-      - type: bind
-        source: ./conf
-        target: /azerothcore/conf
-      - type: bind
         source: ./data
         target: /azerothcore/data
-      - type: bind
-        source: ./deps
-        target: /azerothcore/deps
 
   ac-worldserver:
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,6 @@ services:
         source: ./apps
         target: /azerothcore/apps
       - type: bind
-        source: ./bin
-        target: /azerothcore/bin
-      - type: bind
         source: ./conf
         target: /azerothcore/conf
       - type: bind

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -4,14 +4,6 @@ FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y git cmake make gcc g++ clang libmysqlclient-dev libssl-dev libbz2-dev libreadline-dev libncurses-dev libace-6.4.5 libace-dev
 
-# copy the sources from the host machine to the Docker container
-ADD .git /azerothcore/.git
-ADD deps /azerothcore/deps
-ADD conf/dist /azerothcore/conf/dist
-ADD src /azerothcore/src
-ADD modules /azerothcore/modules
-ADD CMakeLists.txt /azerothcore/CMakeLists.txt
-
 ARG ENABLE_SCRIPTS=1
 ENV ENABLE_SCRIPTS=$ENABLE_SCRIPTS
 

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -4,6 +4,8 @@ FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y git cmake make gcc g++ clang libmysqlclient-dev libssl-dev libbz2-dev libreadline-dev libncurses-dev libace-6.4.5 libace-dev
 
+ADD CMakeLists.txt /azerothcore/CMakeLists.txt
+
 ARG ENABLE_SCRIPTS=1
 ENV ENABLE_SCRIPTS=$ENABLE_SCRIPTS
 

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -4,10 +4,10 @@ FROM alpine:3.9 as builder
 RUN apk add --no-cache bash
 
 # copy the sources from the host machine
+COPY bin /azerothcore/bin
 COPY acore.json /azerothcore/acore.json
 
 # run the AzerothCore database assembler
-COPY bin /azerothcore/bin
 RUN ./azerothcore/bin/acore-db-asm 1
 
 FROM mysql:5.7

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -4,11 +4,6 @@ FROM alpine:3.9 as builder
 RUN apk add --no-cache bash
 
 # copy the sources from the host machine
-COPY apps /azerothcore/apps
-COPY bin /azerothcore/bin
-COPY conf /azerothcore/conf
-COPY data /azerothcore/data
-COPY deps /azerothcore/deps
 COPY acore.json /azerothcore/acore.json
 
 # run the AzerothCore database assembler

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -4,7 +4,10 @@ FROM alpine:3.9 as builder
 RUN apk add --no-cache bash
 
 # copy the sources from the host machine
+COPY apps /azerothcore/apps
 COPY bin /azerothcore/bin
+COPY conf /azerothcore/conf
+COPY deps /azerothcore/deps
 COPY acore.json /azerothcore/acore.json
 
 # run the AzerothCore database assembler

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache bash
 COPY acore.json /azerothcore/acore.json
 
 # run the AzerothCore database assembler
+COPY bin /azerothcore/bin
 RUN ./azerothcore/bin/acore-db-asm 1
 
 FROM mysql:5.7


### PR DESCRIPTION
This PR makes the docker initialization time less than 1 second, when it was between 1 - 3 minutes before, using a VPS with 4GZ 4 cores CPU.


## Changes Proposed:
-  removing all files copied (build cache, data, git files, sources)
-  creating new volumes mounted


## Issues Addressed:
- No issue. It was annoying to wait 2 minutes for the initialization time of docker everytime I made a change to the core.

## Tests Performed:
- I'm using this branch on my realm hosted on a machine
- It works.


## How to Test the Changes:
- just launch `./bin/acore-docker-build`


## Target Branch(es):
- [x] Rochet2-patch-1
