### PR TITLE
fix (Core/Commands) remove character creation flag from .save command

### DIFF
--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -1093,11 +1093,11 @@ public:
         {
             if (Player* target = handler->getSelectedPlayer())
             {
-                target->SaveToDB(true, false);
+                target->SaveToDB(false, false);
             }
             else
             {
-                player->SaveToDB(true, false);
+                player->SaveToDB(false, false);
             }
             handler->SendSysMessage(LANG_PLAYER_SAVED);
             return true;
@@ -1107,7 +1107,7 @@ public:
         uint32 saveInterval = sWorld->getIntConfig(CONFIG_INTERVAL_SAVE);
         if (saveInterval == 0 || (saveInterval > 20 * IN_MILLISECONDS && player->GetSaveTimer() <= saveInterval - 20 * IN_MILLISECONDS))
         {
-            player->SaveToDB(true, false);
+            player->SaveToDB(false, false);
         }
 
         return true;


### PR DESCRIPTION
## Changes Proposed:
The .save command has a `true` flag which claims it should create a character. It should be changed to `false` because the character obviously already exists at the time the command is used.

See https://github.com/azerothcore/azerothcore-wotlk/blob/0a8a7ef1494b1dcc43bdf5134f7c4836acc66f4e/src/server/game/Entities/Player/Player.cpp#L26487 regarding the syntax of the arguments.


## Issues Addressed:
Insert statement erroring out because character already exists. No saves to db happening.
![image](https://user-images.githubusercontent.com/71938210/106368238-782de180-6348-11eb-80a6-399d5e06ece0.png)


## Tests Performed:
- Built on Win10 64 with MySQL 5.7.18
- Tested on default account test1 and test10. .save works


## How to Test the Changes:
- .save
- Watch worldserver console not erroring
- Possibly watch the db prior to and after the .save and see if e.g. level gains were saved to the `characters` table.


## Known Issues and TODO List:


## Target Branch(es):
- [x] Master

 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
