### PR TITLE
fix(DB/gameobject) Strange lockbox position and add Bubbly Fissure

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1612566366687490200.sql
+++ b/data/sql/updates/pending_db_world/rev_1612566366687490200.sql
@@ -3,6 +3,7 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1612566366687490200');
 -- Relocate Strange Lockbox and add Bubbly Fissure near it.
 
 UPDATE `gameobject` SET `position_x` = 842.715, `position_y` = 2208.32, `position_z` = -136.765 WHERE `guid` = 27813;
-INSERT INTO `gameobject` (`id`, `position_x`, `position_y`, `position_z`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`) VALUES
-(177524, 838.26, 2208.14, -136.906, -0.753998, -0.656877, 900, 100, 1);
+DELETE FROM `gameobject` WHERE (`id` = 177524) AND (`guid` = 2134520);
+INSERT INTO `gameobject` (`guid`, `id`, `position_x`, `position_y`, `position_z`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`) VALUES
+(2134520, 177524, 838.26, 2208.14, -136.906, -0.753998, -0.656877, 900, 100, 1);
 

--- a/data/sql/updates/pending_db_world/rev_1612566366687490200.sql
+++ b/data/sql/updates/pending_db_world/rev_1612566366687490200.sql
@@ -2,8 +2,7 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1612566366687490200');
 
 -- Relocate Strange Lockbox and add Bubbly Fissure near it.
 
-DELETE FROM `gameobject` WHERE (`id` = 177790) AND (`guid` IN (27813));
-INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
-(27813, 177790, 0, 0, 0, 1, 1, 842.715, 2208.32, -136.765, 1.57, 0, 0, 0.994174, -0.107791, 50, 100, 1, '', 0);
-INSERT INTO `gameobject` (`id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
-(177524, 0, 0, 0, 1, 1, 838.26, 2208.14, -136.906, 0, 0, 0, -0.753998, -0.656877, 300, 0, 1, '', 0);
+UPDATE `gameobject` SET `position_x` = 842.715, `position_y` = 2208.32, `position_z` = -136.765 WHERE `guid` = 27813;
+INSERT INTO `gameobject` (`id`, `position_x`, `position_y`, `position_z`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`) VALUES
+(177524, 838.26, 2208.14, -136.906, -0.753998, -0.656877, 900, 100, 1);
+

--- a/data/sql/updates/pending_db_world/rev_1612566366687490200.sql
+++ b/data/sql/updates/pending_db_world/rev_1612566366687490200.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1612566366687490200');
+
+-- Relocate Strange Lockbox and add Bubbly Fissure near it.
+
+DELETE FROM `gameobject` WHERE (`id` = 177790) AND (`guid` IN (27813));
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(27813, 177790, 0, 0, 0, 1, 1, 842.715, 2208.32, -136.765, 1.57, 0, 0, 0.994174, -0.107791, 50, 100, 1, '', 0);
+INSERT INTO `gameobject` (`id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(177524, 0, 0, 0, 1, 1, 838.26, 2208.14, -136.906, 0, 0, 0, -0.753998, -0.656877, 300, 0, 1, '', 0);


### PR DESCRIPTION
Fix position of Strange Lockbox for quest https://classic.wowhead.com/quest=30/trial-of-the-sea-lion
Actual position was based on classic content, after TBC the position was moved from fatigue zone and added a Bubbly Fissure.

Closes AzerothCore issue #4352

More info: https://wowwiki-archive.fandom.com/wiki/Quest:Trial_of_the_Sea_Lion_(Horde) and https://www.wowhead.com/quest=30/trial-of-the-sea-lion

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## Changes Proposed:
-  Move from fatigue zone the Strange Lockbox
-  Add Bubbly fissure near the lockbox.


## Issues Addressed:
- Closes #4352
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## Tests Performed:
- Applied the SQL
- Then `.go o 27813`
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## How to Test the Changes:
- Take the quest [Trial of the sea lion](https://www.wowhead.com/quest=30/trial-of-the-sea-lion)
- Then `.go o 27813`
- There should be the Strange Lockbox near a Bubbly Fissure (no fatigue zone).
- Loot the pendant inside.
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->


## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
