### PR TITLE
fix(Core/Spell): Restore Stealth remove check

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2808,7 +2808,8 @@ SpellMissInfo Spell::DoSpellHitOnUnit(Unit* unit, uint32 effectMask, bool scaleA
             unit->IncrDiminishing(m_diminishGroup);
     }
 
-    if (!m_spellInfo->HasAttribute(SPELL_ATTR0_CU_DONT_BREAK_STEALTH))
+    if (m_caster != unit && m_caster->IsHostileTo(unit) && !m_spellInfo->IsPositive() && !m_triggeredByAuraSpell && !m_spellInfo->HasAttribute(SPELL_ATTR0_CU_DONT_BREAK_STEALTH))
+
     {
         unit->RemoveAurasByType(SPELL_AURA_MOD_STEALTH);
     }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2809,7 +2809,6 @@ SpellMissInfo Spell::DoSpellHitOnUnit(Unit* unit, uint32 effectMask, bool scaleA
     }
 
     if (m_caster != unit && m_caster->IsHostileTo(unit) && !m_spellInfo->IsPositive() && !m_triggeredByAuraSpell && !m_spellInfo->HasAttribute(SPELL_ATTR0_CU_DONT_BREAK_STEALTH))
-
     {
         unit->RemoveAurasByType(SPELL_AURA_MOD_STEALTH);
     }


### PR DESCRIPTION
## Changes Proposed:
-  @Kitzunu helped me out by suggesting I add back a line of code that was removed in #4472 to make sure Stealth works properly.


## Issues Addressed:
- Closes #4489


## Tests Performed:
- Ensured that Sprint doesn't break stealth, ensure shadowmeld puts player in stealth, ensure that vanish puts player in stealth, ensure that druid cat form can prowl.


## How to Test the Changes:
1. Build
2. On Night Elf Rogue, Stealth and use Sprint.  Use Vanish.  Use Shadowmeld.
3. On Druid, use Cat form and then Prowl.


## Target Branch(es):
- [x] Master