### PR TITLE
fix(DB/creature): Adjust Position and remove piece of Ham from Reese Langston

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1613242843051334000.sql
+++ b/data/sql/updates/pending_db_world/rev_1613242843051334000.sql
@@ -1,0 +1,11 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1613242843051334000');
+
+/* Adjust Position and remove piece of Ham from Reese Langston
+   Source: https://wow.gamepedia.com/Reese_Langston
+*/
+
+UPDATE `creature_equip_template` SET `ItemID2` = 0 WHERE (`CreatureID` = 1327);
+
+DELETE FROM `creature` WHERE (`id` = 1327) AND (`guid` IN (79751));
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(79751, 1327, 0, 0, 0, 1, 1, 0, 1, -8606.001953, 383.925995, 102.923599, 3.79168, 310, 0, 0, 1003, 0, 0, 0, 0, 0, '', 0);


### PR DESCRIPTION
## Changes Proposed:
-  Adjust Position and remove piece of Ham from Reese Langston
-  Previously spawned somewhat in the bar table and had a piece of ham in the left hand which isn't blizzlike.  Source: https://wow.gamepedia.com/Reese_Langston

## How to Test the Changes:
- .go c 79751

Before SQL
![Before](https://i.imgur.com/Wp6MB5a.jpg)

After SQL
![After](https://i.imgur.com/1fOJgzP.jpg)


## Target Branch(es):
- [x] Master

