### PR TITLE
fix(db/GameObject): Adjust XYZ of Copper Vein

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1613357478020500900.sql
+++ b/data/sql/updates/pending_db_world/rev_1613357478020500900.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1613357478020500900');
+
+/* Move Copper Vein GUID 4788 to avoid being spawned inside of a map object
+*/
+
+DELETE FROM `gameobject` WHERE (`id` = 1731) AND (`guid` IN (4788));
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(4788, 1731, 1, 0, 0, 1, 1, 1125.928345, -4498.002441, 20.325047, 4.777278, 0, 0, 0.704938, 0.709268, 900, 100, 1, '', 0);


### PR DESCRIPTION
## Changes Proposed:
-  Move Copper Vein GUID 4788 a few feet from its original position to avoid spawning inside of a map object


## Issues Addressed:
- Closes #4574 

After SQL:

![aftersql](https://i.imgur.com/ZXV9qgu.jpg)

## How to Test the Changes
- .go gob 4788



## Target Branch(es):
- [x] Master