### PR TITLE
fix(DB/creature): Gregory Victor Gossip Text

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1613510617294494000.sql
+++ b/data/sql/updates/pending_db_world/rev_1613510617294494000.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1613510617294494000');
+
+/* Update Doctor Gregory Victor's gossip to be blizzlike.  Change entry of unknown gossip to avoid conflict.
+*/
+
+UPDATE `creature_template` SET `gossip_menu_id` = 5381 WHERE (`entry` = 12920);
+UPDATE `npc_text` SET `ID`='999999' WHERE  `ID`=6573;

--- a/data/sql/updates/pending_db_world/rev_1613510617294494000.sql
+++ b/data/sql/updates/pending_db_world/rev_1613510617294494000.sql
@@ -5,3 +5,4 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1613510617294494000');
 
 UPDATE `creature_template` SET `gossip_menu_id` = 5381 WHERE (`entry` = 12920);
 UPDATE `npc_text` SET `ID`='999999' WHERE  `ID`=6573;
+DELETE FROM `gossip_menu` WHERE  `MenuID`=5381 AND `TextID`=6573;


### PR DESCRIPTION
## Changes Proposed:
-  Update Gregory Victor's gossip text to be blizzlike
-  Change ID of conflicting entry (not sure where it came from, but that's why the gossip menu didn't work.  Two on one entry)


## Issues Addressed:
- Closes #4458

## Tests Performed:
- Applied SQL and checked entry

## How to Test the Changes
- .go c id 12920
- Read gossip

## Target Branch(es):
- [x] Master