### PR TITLE
fix(DB/SAI): Captured Scarlet Zealot should die

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1613853959150972140.sql
+++ b/data/sql/updates/pending_db_world/rev_1613853959150972140.sql
@@ -1,5 +1,5 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1613853959150972140');
 
--- Captured Scarlet Zealot should despawn himself
+-- Captured Scarlet Zealot should die when event is triggered
 
 UPDATE `smart_scripts` SET `action_type`=51, `action_param1`=0 WHERE `entryorguid`=193100 AND `id`=7;

--- a/data/sql/updates/pending_db_world/rev_1613853959150972140.sql
+++ b/data/sql/updates/pending_db_world/rev_1613853959150972140.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1613853959150972140');
+
+-- Captured Scarlet Zealot should despawn himself
+
+UPDATE `smart_scripts` SET `action_type`=51, `action_param1`=0 WHERE `entryorguid`=193100 AND `id`=7;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## Changes Proposed:
- Let the  Captured Scarlet Zealot die in the end of quest Fields of Grief
- Changes carried over from the TC database - I eventually found [this](https://github.com/TrinityCore/TrinityCore/pull/16960) and added a co-author
- Reference: https://youtu.be/zZIfXkIC4b8?t=60

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4540
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## Tests Performed:
- Applied SQL, tested.
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## How to Test the Changes:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

- `.quest add 407`
- (Remove the quest if done: `.quest remove 407`)
- `.go c id 1931`
- Click the zealot, watch him turn into a ghoul, run around and then die (when patched)

## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
