### PR TITLE
fix(Core/Spell): Divine Protection reduces fall damage

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -25718,6 +25718,10 @@ void Player::HandleFall(MovementInfo const& movementInfo)
                 if (HasAura(43621))
                     damage = GetMaxHealth() / 2;
 
+                // Divine Protection
+                if (HasAura(498))
+                    damage /= 2;
+
                 final_damage = EnvironmentalDamage(DAMAGE_FALL, damage);
             }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -25720,7 +25720,9 @@ void Player::HandleFall(MovementInfo const& movementInfo)
 
                 // Divine Protection
                 if (HasAura(498))
+                {
                     damage /= 2;
+                }
 
                 final_damage = EnvironmentalDamage(DAMAGE_FALL, damage);
             }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## Changes Proposed:
-  Reduce fall damage if player have aura Divine Protection (498) [Paladin]


## Issues Addressed:
- Closes [4610](https://github.com/azerothcore/azerothcore-wotlk/issues/4610)
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## Tests Performed:
**Don't use Divine Protection:**
![Снимок экрана 2021-02-21 в 10 56 56](https://user-images.githubusercontent.com/40755539/108621543-9eb8d700-7433-11eb-8e2d-165a51feec02.png)

**Use Divine Protection:**
![Снимок экрана 2021-02-21 в 10 57 11](https://user-images.githubusercontent.com/40755539/108621568-b42e0100-7433-11eb-952c-9f2162eee019.png)

<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## How to Test the Changes:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

1) use Divine Protection, look damage fall
    **.go xyz 2700 6081 100 571**
2) Don't use Divine Protection, look damage fall
    **.go xyz 2700 6081 100 571**
3) Compare

## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
