### PR TITLE
fix(DB/SAI): Scarlet Archive should be a party quest (not working, need help)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1613941609619938749.sql
+++ b/data/sql/updates/pending_db_world/rev_1613941609619938749.sql
@@ -1,0 +1,12 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1613941609619938749');
+
+-- Fix party credit for burning The Scarlet Archive
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 176245) AND (`source_type` = 1) AND (`id` IN (0, 1, 2, 3, 4, 5));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(176245, 1, 0, 1, 64, 0, 100, 0, 1, 0, 0, 0, 0, 9, 176245, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarlet Archive - On Gossip Hello - Activate Gameobject'),
+(176245, 1, 1, 2, 61, 0, 100, 0, 1, 0, 0, 0, 0, 50, 176747, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 3452.85, -3104.82, 136.54, 0, 'Scarlet Archive - On Gossip Hello - Summon Gameobject \'Small Barracks Flame\''),
+(176245, 1, 2, 3, 61, 0, 100, 0, 1, 0, 0, 0, 0, 50, 176747, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 3454.96, -3106.9, 136.54, 0, 'Scarlet Archive - On Gossip Hello - Summon Gameobject \'Small Barracks Flame\''),
+(176245, 1, 3, 4, 61, 0, 100, 0, 1, 0, 0, 0, 0, 50, 176747, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 3459.3, -3108.7, 136.54, 0, 'Scarlet Archive - On Gossip Hello - Summon Gameobject \'Small Barracks Flame\''),
+(176245, 1, 4, 5, 61, 0, 100, 0, 1, 0, 0, 0, 0, 50, 176747, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 3462.52, -3105.03, 136.54, 0, 'Scarlet Archive - On Gossip Hello - Summon Gameobject \'Small Barracks Flame\''),
+(176245, 1, 5, 0, 61, 0, 100, 0, 1, 0, 0, 0, 0, 50, 176747, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 3459.64, -3100.89, 136.54, 0, 'Scarlet Archive - On Gossip Hello - Summon Gameobject \'Small Barracks Flame\'');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## Changes Proposed:
- Improve SAI so the quest The Archivist is finished for the entire party
- But the version here doesn't work, can someone help me figure out why?

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4456
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## Tests Performed:
- Applied SQL, but it doesn't work - only the initial person interacting with the object get the quest objective
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## How to Test the Changes:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
1. You need 2 players present...
2. `.quest add 5251`
2. `.go c id 10811`
3. target Archivist Galford
4. `.die` - you get credit for the kill
5. click Scarlet Archive (gameobject_template entry=176245) - credit only goes to the clicker

## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->

So let me start by saying my understanding of SmartAI is limited. Here's a few notes of what I tried to do.

The quest can be found using:
`select * from quest_template where LogTitle="The Archivist";`,

where I believe the interesting parts are **RequiredNpcOrGo1: 10811** and **RequiredNpcOrGo2: -176245**. The first one is the kill on Archivist Galford (and that one works fine). The other is about gameobject 176245, which we can find here:

`select * from gameobject_template where entry=176245;`.

It has Data1 with a quest reference and Data2 is an event_scripts reference that doesn't exist? But the [documentation](https://www.azerothcore.org/wiki/event_scripts) didn't help me out much here...

So what I tried to do is add a line in SAI that says the gameobject should be activated for the entire party, as the first thing that happens... But that didn't work. It cannot be triggering a quest completion either, as burning it as a partial quest condition only. So I'm currently out of ideas.

A hack'y way of fixing it could be letting the book just respawn instantly so all party members can start different fires... It would be better than the version right now, but if possible, a "proper" solution would be preferred.

## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
