### PR TITLE
fix(DB/Quest): make quest 75 not repeatable

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1614727322797515143.sql
+++ b/data/sql/updates/pending_db_world/rev_1614727322797515143.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1614727322797515143');
+UPDATE `quest_template_addon` SET `SpecialFlags` = 0 WHERE `ID` = 75;
+


### PR DESCRIPTION

<!-- WRITE A RELEVANT TITLE -->

## Changes Proposed:
-  make the quest 75 not repeatable

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4680


## Tests Performed:
- tested in-game


## How to Test the Changes:
- .q add 74
- .go cr id 294
- .q reward 74
- you will be able to take the quest "the legend of stalvan" (75), take it
- .q complete 75
- complete the quest, do not accept the next one, speak again with the NPC you will get 2 "the legend of stalvan" quests listed before this PR and only one later

## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
