### PR TITLE
fix(DB/Quest): prevquest for quest 872

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1614728683509630598.sql
+++ b/data/sql/updates/pending_db_world/rev_1614728683509630598.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1614728683509630598');
+
+UPDATE `quest_template_addon` SET `PrevQuestID` = 871 WHERE `ID` = 872;
+


### PR DESCRIPTION
## Changes Proposed:
-  change prev quest id to 871 for quest 872


## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4686

## Tests Performed:
- tested in-game
![image](https://user-images.githubusercontent.com/519778/109730839-701cc800-7bba-11eb-9d03-45baf79c36fd.png)


## How to Test the Changes:
.go cr id 3429
.q add 871
.q complete 871
complete the quest, now you can see the quest 871 the disruption ends and Supplies for the Crossroads


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
