### PR TITLE
fix(Core): Rollback #3099 (Load npc_vendor items in the right order)

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -8338,7 +8338,7 @@ void ObjectMgr::LoadVendors()
 
     std::set<uint32> skip_vendors;
 
-    QueryResult result = WorldDatabase.Query("SELECT entry, item, maxcount, incrtime, ExtendedCost FROM npc_vendor ORDER BY entry, slot ASC, item, ExtendedCost");
+    QueryResult result = WorldDatabase.Query("SELECT entry, item, maxcount, incrtime, ExtendedCost FROM npc_vendor ORDER BY entry, slot ASC");
     if (!result)
     {
         sLog->outString();


### PR DESCRIPTION
Rollback https://github.com/azerothcore/azerothcore-wotlk/pull/3099 because after this PR all items in all vendors have randomly sorting. Original game items sorting have a certain exact sequence. https://github.com/azerothcore/azerothcore-wotlk/pull/3099 violates it.