### PR TITLE
fix(DB/Text): chicken text for CLUCK special quest

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1614901038211344456.sql
+++ b/data/sql/updates/pending_db_world/rev_1614901038211344456.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1614901038211344456');
+
+DELETE FROM `broadcast_text` WHERE `ID`=5140;
+DELETE FROM `broadcast_text_locale` WHERE `ID`=5140;
+DELETE FROM `creature_text` WHERE `CreatureID`=620 AND `GroupID`=1 AND `BroadcastTextId`=5140;
+UPDATE `creature_text` SET `comment`='cluck EMOTE_HELLO' WHERE `CreatureID`=620 AND `GroupID`=0;
+

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -678,8 +678,7 @@ public:
 
 enum ChickenCluck
 {
-    EMOTE_HELLO_A       = 0,
-    EMOTE_HELLO_H       = 1,
+    EMOTE_HELLO         = 0,
     EMOTE_CLUCK_TEXT    = 2,
 
     QUEST_CLUCK         = 3861,
@@ -734,7 +733,7 @@ public:
                     {
                         me->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
                         me->setFaction(FACTION_FRIENDLY);
-                        Talk(player->GetTeamId() == TEAM_HORDE ? EMOTE_HELLO_H : EMOTE_HELLO_A);
+                        Talk(EMOTE_HELLO);
                     }
                     break;
                 case TEXT_EMOTE_CHEER:


### PR DESCRIPTION
## Changes Proposed:
-  make the same text of the chicken for alliance and horde as it should be
- remove the old and useless text

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4712
- https://github.com/chromiecraft/chromiecraft/issues/127


## Tests Performed:
- tested in-game


## How to Test the Changes:
- .go cr id 620
- /chicken
- do /chicken a lot of time (use a macro maybe). the chicken will say `Chicken looks up at you quizzically. Maybe you should inspect it"` alliance and horde side (now), be friendly and give you the quest "CLUCK"


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
