### PR TITLE
fix(DB/Quest): prevQuest

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1614968849352707375.sql
+++ b/data/sql/updates/pending_db_world/rev_1614968849352707375.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1614968849352707375');
+
+-- Fix prerequisite for quests "Hallowed Scroll" & "Glyphic Scroll"
+UPDATE `quest_template_addon` SET `PrevQuestID`=364 WHERE `ID` IN (3097,3098);


### PR DESCRIPTION
## Changes Proposed:
-  add prevQuest 364 for 3098 Glyphic Scroll & 3097 Hallowed Scroll


## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4726
- Closes https://github.com/chromiecraft/chromiecraft/issues/126


## Tests Performed:
- tested in-game



## How to Test the Changes:
create a mage
.q add 364
complete and see if the quests 3098 and 3097 are available


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
