### PR TITLE
Fix building with gcc-8.x on debian 10

### DIFF
--- a/src/cmake/platform/unix/settings.cmake
+++ b/src/cmake/platform/unix/settings.cmake
@@ -44,3 +44,10 @@ else()
     INTERFACE
       -D_BUILD_DIRECTIVE="${CMAKE_BUILD_TYPE}")
 endif()
+
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1.0)
+  message(STATUS "UNIX: Older stdc++ library requires stdc++fs, too")
+  target_link_libraries(acore-default-interface
+    INTERFACE
+      stdc++fs)
+endif()


### PR DESCRIPTION
## Changes Proposed:
Fix building on systems with older versions of gcc, e. g. debian 10 with gcc 8.3

## Tests Performed:
- Now builds on `debian 10` with `gcc-8.3` and `-DTOOLS=1`
- Reportedly builds on `Ubuntgu 20.04` with `gcc-9.3.0` and `DTOOLS=1`, too 

## Target Branch(es):
- [x] Master
