### PR TITLE
fix(DB/GameEvent/CreatureSpawns): Hallow's-End-NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1615132077108569700.sql
+++ b/data/sql/updates/pending_db_world/rev_1615132077108569700.sql
@@ -1,0 +1,25 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1615132077108569700');
+
+--Draenei Commoner BloodElf Commoner--
+DELETE FROM `creature` WHERE (`id` = 19171) AND (`guid` IN (91587));
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(91587, 19171, 530, 0, 0, 1, 1, 18842, 1, -3807.906738, -11710.348633, -106.454651, 3.477165, 180, 0, 0, 42, 0, 0, 0, 0, 0, '', 0);
+
+DELETE FROM `creature` WHERE (`id` = 19171) AND (`guid` IN (91588));
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(91588, 19171, 530, 0, 0, 1, 1, 18842, 1, -3812.004639, -11712.501953, -106.513107, 0.934427, 180, 0, 0, 42, 0, 0, 0, 0, 0, '', 0);
+
+DELETE FROM `game_event_creature` WHERE (`eventEntry` = 12) AND (`guid` IN (84418,84419,84423,84424,84400,84402,84409,84410,84430,84435,84440,84441));
+INSERT INTO `game_event_creature` VALUES
+(12, 84418),
+(12, 84419),
+(12, 84423),
+(12, 84424),
+(12, 84400),
+(12, 84402),
+(12, 84409),
+(12, 84410),
+(12, 84430),
+(12, 84435),
+(12, 84440),
+(12, 84441);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## Changes Proposed:
-  Inserting some NPCs from the Halloween event that were out of the **game_event_creature** table

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/94
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4654
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## Tests Performed:
- Tested in game and working
- Tested on Windows 10 (64)
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## How to Test the Changes:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->


## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
