### PR TITLE
fix(DB/creature_template): Set RangeAttackTime to default value

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1615275106559909076.sql
+++ b/data/sql/updates/pending_db_world/rev_1615275106559909076.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1615275106559909076');
+
+-- Reset ranged attack times
+UPDATE `creature_template` SET `RangeAttackTime` = 2000 WHERE `RangeAttackTime` > 0;

--- a/data/sql/updates/pending_db_world/rev_1615275106559909076.sql
+++ b/data/sql/updates/pending_db_world/rev_1615275106559909076.sql
@@ -1,4 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1615275106559909076');
 
 -- Reset ranged attack times
-UPDATE `creature_template` SET `RangeAttackTime` = 2000 WHERE `RangeAttackTime` > 0;
+UPDATE `creature_template` SET `RangeAttackTime` = 2000;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## Changes Proposed:
- Set  ranged attack times to default for all creatures
- Suggested here: https://github.com/azerothcore/azerothcore-wotlk/pull/4637

## Issues Addressed:
- This was done by TC here: https://github.com/TrinityCore/TrinityCore/commit/b7b1c2df790f1eb9203f084045e90ee5f9e1ebb5
- ~~I'm not sure if we should do the same, so marking this for in need of feedback~~
- This is just to take the discussion, you are very welcome to disagree
- It could be relevant for https://github.com/azerothcore/azerothcore-wotlk/pull/4749
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## Tests Performed:
- None
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## How to Test the Changes:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->


## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
