### PR TITLE
fix(DB/Gameobject): spawn position

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1615504923515644278.sql
+++ b/data/sql/updates/pending_db_world/rev_1615504923515644278.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1615504923515644278');
+
+DELETE FROM `gameobject` WHERE (`id` = 2008) AND (`guid` IN (17154));
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(17154, 2008, 0, 0, 0, 1, 1, -19.5537, -935.304, 58.0971, 2.6529, -0.046553, 0.011607, 0.969178, 0.241643, 7200, 100, 1, '', 0);
+


### PR DESCRIPTION
## Changes Proposed:
-  move position of the gameobject


## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/188
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4796


## Tests Performed:
- now the gamoebject is positioned correctly as the wowhead picture shows https://classic.wowhead.com/quest=567/dangerous


## How to Test the Changes:
.go object 17154


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
