### PR TITLE
fix(DB/Spell): suicide saboteur on sapper explode

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1615506284007051682.sql
+++ b/data/sql/updates/pending_db_world/rev_1615506284007051682.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1615506284007051682');
+
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger`=3204;
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES
+(3204,8329,0,"Sapper Explode");
+


### PR DESCRIPTION
porting from https://github.com/TrinityCore/TrinityCore/issues/22195

## Changes Proposed:
-  link suicide spell to sapper explode spell


## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4798
- Closes https://github.com/chromiecraft/chromiecraft/issues/184

## Tests Performed:
- tested in-game


## How to Test the Changes:
- .go cr id 1052
- reduce him to 0-15% health, he will casts the sapper exclude and (after PR) die

## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
