### PR TITLE
fix(Core): Removing auras from spells that trigger taxi

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -802,6 +802,8 @@ Player::Player(WorldSession* session): Unit(true), m_mover(this)
     m_deathTimer = 0;
     m_deathExpireTime = 0;
 
+    m_flightSpellActivated = 0;
+
     m_swingErrorMsg = 0;
 
     for (uint8 j = 0; j < PLAYER_MAX_BATTLEGROUND_QUEUES; ++j)
@@ -21928,6 +21930,7 @@ bool Player::ActivateTaxiPathTo(std::vector<uint32> const& nodes, Creature* npc 
     }
     else
     {
+        m_flightSpellActivated = spellid;
         GetSession()->SendActivateTaxiReply(ERR_TAXIOK);
         GetSession()->SendDoFlight(mount_display_id, sourcepath);
     }
@@ -21951,6 +21954,12 @@ bool Player::ActivateTaxiPathTo(uint32 taxi_path_id, uint32 spellid /*= 1*/)
 
 void Player::CleanupAfterTaxiFlight()
 {
+    // For spells that trigger flying paths remove them at arrival
+    if (m_flightSpellActivated)
+    {
+        this->RemoveAurasDueToSpell(m_flightSpellActivated);
+        m_flightSpellActivated = 0;
+    }
     m_taxi.ClearTaxiDestinations();        // not destinations, clear source node
     Dismount();
     RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_DISABLE_MOVE | UNIT_FLAG_TAXI_FLIGHT);

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2971,6 +2971,8 @@ private:
 
     bool m_isInstantFlightOn;
 
+    uint32 m_flightSpellActivated;
+
     // Remote location information
     uint32 m_cinematicDiff;
     uint32 m_lastCinematicCheck;


### PR DESCRIPTION
After certain spellcasts that trigger taxi paths such as 32474 on spellauras.cpp, these pending auras are supposed to be removed 
since they are supposed to substitute the model from the taxiID.

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## Changes Proposed:
-  Removing the auras triggered by spells at the end of taxi flypaths

## Issues Addressed:
Not reported but fixes part of https://github.com/azerothcore/azerothcore-wotlk/pull/4819
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## Tests Performed:
- Compiled and tested on windows 10

<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## How to Test the Changes:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

This test requires the PR mentioned above:

1. .go c 31749
2. Talking to Susurrus it doesn't display any gossip menu options
3. .add 23843
4. Now the gossip option displays as "I am ready to be flown down to the Exodar"
5. After clicking on the option you receive "Buffeting winds of susurrus" and start flying down to the Exodar
6. When arriving to the destination the **Buffeting Winds of Susurrus** should be removed


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
