### PR TITLE
fix(DB/Creature) bugged Pridewing Soarer

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1615597737321479109.sql
+++ b/data/sql/updates/pending_db_world/rev_1615597737321479109.sql
@@ -1,0 +1,17 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1615597737321479109');
+
+-- Fixing template for Pridewing Soarer
+DELETE FROM `creature_template` WHERE (`entry` = 6141);
+INSERT INTO `creature_template` (`entry`, `difficulty_entry_1`, `difficulty_entry_2`, `difficulty_entry_3`, `KillCredit1`, `KillCredit2`, `modelid1`, `modelid2`, `modelid3`, `modelid4`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `scale`, `rank`, `mindmg`, `maxdmg`, `dmgschool`, `attackpower`, `DamageModifier`, `BaseAttackTime`, `RangeAttackTime`, `unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`, `family`, `trainer_type`, `trainer_spell`, `trainer_class`, `trainer_race`, `minrangedmg`, `maxrangedmg`, `rangedattackpower`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `resistance1`, `resistance2`, `resistance3`, `resistance4`, `resistance5`, `resistance6`, `spell1`, `spell2`, `spell3`, `spell4`, `spell5`, `spell6`, `spell7`, `spell8`, `PetSpellDataId`, `VehicleId`, `mingold`, `maxgold`, `AIName`, `MovementType`, `InhabitType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `RacialLeader`, `movementId`, `RegenHealth`, `mechanic_immune_mask`, `spell_school_immune_mask`, `flags_extra`, `ScriptName`, `VerifiedBuild`) VALUES
+(6141, 0, 0, 0, 0, 0, 2155, 0, 0, 0, 'Pridewing Soarer', NULL, NULL, 0, 22, 22, 0, 16, 0, 1, 1.14286, 1, 0, 32, 42, 0, 78, 1, 2000, 2000, 1, 0, 2048, 0, 0, 0, 0, 0, 0, 21, 32, 4, 1, 0, 0, 0, 100006, 0, 0, 0, 0, 0, 0, 744, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', 1, 1, 1, 1.02, 1, 1, 0, 144, 1, 0, 0, 2, '', 12340);
+
+-- Fixing spawn places for Pridewing Soarer
+DELETE FROM `creature` WHERE (`id` = 6141);
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(32317, 6141, 1, 0, 0, 1, 1, 2155, 0, 1392.03, 920.975, 149.868, 5.91921, 300, 0, 0, 574, 0, 0, 0, 0, 0, '', 0),
+(32316, 6141, 1, 0, 0, 1, 1, 2155, 0, 1644.5, 907.431, 124.021, 0.897669, 300, 0, 0, 574, 0, 0, 0, 0, 0, '', 0);
+
+-- Quest item loot added for Pridewing Soarer
+DELETE FROM `creature_questitem` WHERE (`CreatureEntry` = 6141);
+INSERT INTO `creature_questitem` (`CreatureEntry`, `Idx`, `ItemId`, `VerifiedBuild`) VALUES
+(6141, 0, 5808, 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->

## Changes Proposed:
-  Fix non hitable mobs Pridewing Soarer in Stonetalon Mountains


## Issues Addressed:
- Closes #4801
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## Tests Performed:
- Aplied SQL
- Mobs can be mark and kill, they are skinnable and drop only quest item (https://classicdb.ch/?npc=6141#drop)
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## How to Test the Changes:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
- Go to Stonetalon Mountains
1st mob 47.60 46.63
2nd mob 47.78 38.90
Can be killed, skinned and drop quest item for quest Pridewings of Stonetalon


## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
