### PR TITLE
fix(DB/item_template): Remove Horde-only flag from Pattern: Raptor Hide Harness

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1615843852881240992.sql
+++ b/data/sql/updates/pending_db_world/rev_1615843852881240992.sql
@@ -1,0 +1,2 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1615843852881240992');
+UPDATE `item_template` SET `FlagsExtra`=0 WHERE `entry`=13287;


### PR DESCRIPTION
## Changes Proposed:
- Allow [Pattern: Raptor Hide Harness](https://wotlkdb.com/?item=13287) to be learned by Alliance character when transfered via trade, mail or AH   

## Issues Addressed:
- Closes #4854
- Closes https://github.com/chromiecraft/chromiecraft/issues/204

## Tests Performed:
- cmake, make on Linux without errors
- db_assembler.sh without errors
- checked DB using mysql command prompt
- learned pattern on Alliance character 

## How to Test the Changes:
- Get Alliance character to LW skill >= 165 
- Run .additem 13287
- Learn the pattern

## Known Issues and TODO List:

## Target Branch(es):
- [x] Master
 
## How to Test AzerothCore PRs
 When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
