### PR TITLE
fix(DB/quest_poi): Wrong map marker position - The Princial Source (A)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1615882800304292617.sql
+++ b/data/sql/updates/pending_db_world/rev_1615882800304292617.sql
@@ -1,0 +1,2 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1615882800304292617');
+UPDATE `quest_poi_points` SET `X`=6882, `Y`=-653 WHERE `QuestID`=6122 AND `Idx1`=1 AND `Idx2`=0;


### PR DESCRIPTION
## Changes Proposed:
-  Change map marker coordinates for quest [The Principal Source](https://wotlkdb.com/?quest=6122) from (7218, -386) to (6882, -653). 

## Issues Addressed:
- Closes #4867
- Closes https://github.com/chromiecraft/chromiecraft/issues/212

## Tests Performed:
- cmake, make on Linux without errors
- db_assembler.sh without errors
- checked DB using mysql command prompt
-  checked in game

## How to Test the Changes:
- Roll an Alliance Druid
- `.quest add 6122`
- `.tele Auberdine`
- `.go xyz 6882 -653`
- Draw the sample (success)

## Known Issues and TODO List:

## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
