### PR TITLE
fix(Core): Code warnings clean-up 

### DIFF
--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -1211,6 +1211,11 @@ struct BfWGGameObjectBuilding
 
     void Init(GameObject* gobj, uint32 type, uint32 worldstate, uint8 damageText, uint8 destroyText)
     {
+        if (!gobj)
+        {
+            return;
+        }
+
         // GameObject associated to object
         m_Build = gobj->GetGUID();
 


### PR DESCRIPTION
- Enums when passed into uint32 functions produce warnings
- Mixed enums with const std::array for readability and type safety

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->

<!-- WRITE A RELEVANT TITLE -->
In preparation for Wintergrasp fixes. I've added a temporary solution to one of the many underlying problems on the core, passing enum values (which are int) into functions that receive uint32 numbers due to the ease of use of defining names to numbers such as this:

``` c++
enum npc_spells
{
    SPELL_FIREBALL = 1234,
    SPELL_TELEPORT = 5678
}
```
## Changes Proposed:
- Mixed enums with const array for readability and type safety


## Issues Addressed:
- Doesn't close any specific issue
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## Tests Performed:
- Compiled on Windows 10
- Doesn't need any other test since no logic was changed, just types sent to functions

<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->


## How to Test the Changes:
<!-- We need to confirm the changes first, so try to make the work easy for testers (who are not necessarily coders), please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->
Compile the core without errors


## Target Branch(es):
- [x] Master


<!-- NOTE: You do not need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
