### PR TITLE
fix(CORE/AI): Added a condition to force casters into melee combat

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -772,7 +772,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                             SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(e.action.cast.spell);
                             int32 currentPower = me->GetPower(GetCasterPowerType());
 
-                            if ((spellInfo && (currentPower < spellInfo->CalcPowerCost(me, spellInfo->GetSchoolMask()))) || me->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SILENCED))
+                            if ((spellInfo && (currentPower < spellInfo->CalcPowerCost(me, spellInfo->GetSchoolMask()) || me->IsSpellProhibited(spellInfo->GetSchoolMask()))) || me->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SILENCED))
                             {
                                 SetCasterActualDist(0);
                                 CAST_AI(SmartAI, me->AI())->SetForcedCombatMove(0);


### PR DESCRIPTION
## Changes Proposed:
-  SAI creatures change to melee combat if the current spell is prohibited


## Issues Addressed:
- Closes #4468 
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4091

## Tests Performed:
- Tested on Defias Rogue Wizard and NPCs inside Hellfire Ramparts

## How to Test the Changes:
 - .go xyz -9224 -1006 71
 - Stand at a distance from a Defias Rogue Wizard
 - Interrupt it with Counterspell (.cast 2139)
 - NPC will now change to melee attacks until the Counterspell's effect ends


## Target Branch(es):
- [x] Master
 

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
