### PR TITLE
Bug Trio not respawning properly on reset fix.

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_bug_trio.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_bug_trio.cpp
@@ -61,9 +61,9 @@ public:
         return GetInstanceAI<boss_kriAI>(creature);
     }
 
-    struct boss_kriAI : public ScriptedAI
+    struct boss_kriAI : public boss_bug_trioAI
     {
-        boss_kriAI(Creature* creature) : ScriptedAI(creature)
+        boss_kriAI(Creature* creature) : boss_bug_trioAI(creature)
         {
             instance = creature->GetInstanceScript();
         }
@@ -158,9 +158,9 @@ public:
         return GetInstanceAI<boss_vemAI>(creature);
     }
 
-    struct boss_vemAI : public ScriptedAI
+    struct boss_vemAI : public boss_bug_trioAI
     {
-        boss_vemAI(Creature* creature) : ScriptedAI(creature)
+        boss_vemAI(Creature* creature) : boss_bug_trioAI(creature)
         {
             instance = creature->GetInstanceScript();
         }
@@ -251,9 +251,9 @@ public:
         return GetInstanceAI<boss_yaujAI>(creature);
     }
 
-    struct boss_yaujAI : public ScriptedAI
+    struct boss_yaujAI : public boss_bug_trioAI
     {
-        boss_yaujAI(Creature* creature) : ScriptedAI(creature)
+        boss_yaujAI(Creature* creature) : boss_bug_trioAI(creature)
         {
             instance = creature->GetInstanceScript();
         }

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_bug_trio.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_bug_trio.cpp
@@ -85,7 +85,6 @@ public:
 
             VemDead = false;
             Death = false;
-            
             RespawnTrio();
         }
 
@@ -180,7 +179,6 @@ public:
             Enrage_Timer = 120000;
 
             Enraged = false;
-            
             RespawnTrio();
         }
 
@@ -273,7 +271,6 @@ public:
             Check_Timer = 2000;
 
             VemDead = false;
-            
             RespawnTrio();
         }
 

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_bug_trio.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_bug_trio.cpp
@@ -29,6 +29,28 @@ enum Spells
     SPELL_FEAR         = 19408
 };
 
+struct boss_bug_trioAI : public ScriptedAI
+{
+public:
+    boss_bug_trioAI(Creature* creature) : ScriptedAI(creature) { instance = me->GetInstanceScript(); }
+
+    void RespawnTrio()
+    {
+        if (Creature* vem = ObjectAccessor::GetCreature(*me, instance->GetData64(DATA_VEM)))
+            if (!vem->IsAlive())
+                vem->Respawn();
+        if (Creature* kri = ObjectAccessor::GetCreature(*me, instance->GetData64(DATA_KRI)))
+            if (!kri->IsAlive())
+                kri->Respawn();
+        if (Creature* yauj = ObjectAccessor::GetCreature(*me, instance->GetData64(DATA_YAUJ)))
+            if (!yauj->IsAlive())
+                yauj->Respawn();
+    }
+
+private:
+    InstanceScript* instance;
+};
+
 class boss_kri : public CreatureScript
 {
 public:
@@ -63,6 +85,8 @@ public:
 
             VemDead = false;
             Death = false;
+            
+            RespawnTrio();
         }
 
         void EnterCombat(Unit* /*who*/) override
@@ -156,6 +180,8 @@ public:
             Enrage_Timer = 120000;
 
             Enraged = false;
+            
+            RespawnTrio();
         }
 
         void JustDied(Unit* /*killer*/) override
@@ -247,6 +273,8 @@ public:
             Check_Timer = 2000;
 
             VemDead = false;
+            
+            RespawnTrio();
         }
 
         void JustDied(Unit* /*killer*/) override

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/instance_temple_of_ahnqiraj.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/instance_temple_of_ahnqiraj.cpp
@@ -36,6 +36,7 @@ public:
         uint64 SkeramGUID;
         uint64 VemGUID;
         uint64 KriGUID;
+        uint64 YaujGUID;
         uint64 VeklorGUID;
         uint64 VeknilashGUID;
         uint64 ViscidusGUID;
@@ -53,6 +54,7 @@ public:
             SkeramGUID = 0;
             VemGUID = 0;
             KriGUID = 0;
+            YaujGUID = 0;
             VeklorGUID = 0;
             VeknilashGUID = 0;
             ViscidusGUID = 0;
@@ -71,6 +73,9 @@ public:
                     break;
                 case NPC_VEM:
                     VemGUID = creature->GetGUID();
+                    break;
+                case NPC_YAUJ:
+                    YaujGUID = creature->GetGUID();
                     break;
                 case NPC_KRI:
                     KriGUID = creature->GetGUID();
@@ -131,6 +136,8 @@ public:
                     return VemGUID;
                 case DATA_KRI:
                     return KriGUID;
+                case DATA_YAUJ:
+                    return YaujGUID;
                 case DATA_VEKLOR:
                     return VeklorGUID;
                 case DATA_VEKNILASH:

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/temple_of_ahnqiraj.h
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/temple_of_ahnqiraj.h
@@ -22,7 +22,8 @@ enum DataTypes
     DATA_VEKNILASH_DEATH    = 11,
     DATA_BUG_TRIO_DEATH     = 14,
     DATA_CTHUN_PHASE        = 20,
-    DATA_VISCIDUS           = 21
+    DATA_VISCIDUS           = 21,
+    DATA_YAUJ               = 22
 };
 
 enum Creatures
@@ -44,6 +45,7 @@ enum Creatures
     NPC_SKERAM              = 15263,
     NPC_VEM                 = 15544,
     NPC_KRI                 = 15511,
+    NPC_YAUJ                = 15543,
     NPC_VEKLOR              = 15276,
     NPC_VEKNILASH           = 15275
 };


### PR DESCRIPTION
Fix to Bug Trio in AQ40 not properly resetting the encounter.

## Changes Proposed:
An addition to the bug trio and AQ40 instance script/header.


## Issues Addressed:
The issue is not currently listed.  In AQ40, if you engage the Bug Trio fight and wipe after killing only 1 or 2 of the bugs, the dead bug bosses will not respawn.  This means the next time you engage them, only the bugs that were not killed will be present for the fight.


## Tests Performed:
I have build this code and engaged the bosses many times on my server and it worked every single time.  However, I do also have many other custom edits to this boss code and I started with the rewritten boss script from an open issue that changed the script over to the event map system instead of the timer system.  I also only did this testing on a Windows 10 system.


## How to Test the Changes:
- Go into AQ40 on a GM account
- Engage Bug Trio and use .die or .damage to kill 1 or 2 of the bug bosses
- Kill yourself while at least 1 of the bug bosses is still alive
- Go back into AQ40 and you will see that the bug bosses that you killed will have respawned

## Target Branch(es):
- [x] Master
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
