### PR TITLE
fix(Core/Spell): Make use of SPELL_ATTR6_DONT_CONSUME_PROC_CHARGES

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -2075,7 +2075,7 @@ void Aura::PrepareProcToTrigger(AuraApplication* aurApp, ProcEventInfo& eventInf
         return;
 
     // take one charge, aura expiration will be handled in Aura::TriggerProcOnEvent (if needed)
-    if (IsUsingCharges())
+    if (IsUsingCharges() && (!eventInfo.GetSpellInfo() || !eventInfo.GetSpellInfo()->HasAttribute(SPELL_ATTR6_DONT_CONSUME_PROC_CHARGES)))
     {
         --m_procCharges;
         SetNeedClientUpdateForTargets();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template and do not forget to have a look at our Pull Request tutorial: https://www.azerothcore.org/wiki/How-to-create-a-PR
-->
cp from tc

## Changes Proposed:
-  Don't remove proc charges from spells with SPELL_ATTR6_DONT_CONSUME_PROC_CHARGES

<details>
<summary>Spells with the attribute</summary>

dbc_spell
---
```sql
SELECT `id`, `name_lang_1`, `attributesEx6`
FROM `dbc_spell` 
WHERE `attributesEx6` & @flag = @flag
```
| id | name_lang_1 | attributesEx6 | 
| ---: | --- | ---: | 
| 698 | Ritual of Summoning | 32 | 
| 1464 | Slam | 32 | 
| 8820 | Slam | 32 | 
| 11604 | Slam | 32 | 
| 11605 | Slam | 32 | 
| 25241 | Slam | 32 | 
| 25242 | Slam | 32 | 
| 46584 | Raise Dead | 32 | 
| 47474 | Slam | 32 | 
| 47475 | Slam | 32 | 
| 47632 | Death Coil | 32 | 
| 47633 | Death Coil | 32 | 
| 53352 | Explosive Shot | 32 | 
| 53353 | Chimera Shot - Serpent | 33 | 
| 53769 | Death Coil | 32 | 
| 60856 | TF-Xplosive Rocket Turret | 32 | 
| 61999 | Raise Ally | 32 | 
| 62735 | Ritual of Summoning Test | 32 | 

</details>

## Issues Addressed:
- ref https://github.com/azerothcore/azerothcore-wotlk/issues/4306
<!-- If the issue does not exist, please describe it and how to reproduce it. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux/Mac/Windows? Describe any other tests performed -->
- None

## How to Test the Changes:
<!-- We need to confirm the changes are going to be working, so please describe in general and for non-developers how to test the changes:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console?
 - Describe any other steps
-->
The logic is here... but
1. Use the spells above, they shouldn't consume proc charges

## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
