### PR TITLE
fix(Core): Remove RDF cooldown after completion

### DIFF
--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -2069,6 +2069,12 @@ namespace lfg
                 continue;
             }
 
+            // Remove Dungeon Finder Cooldown if still exists
+            if (player->HasAura(LFG_SPELL_DUNGEON_COOLDOWN))
+            {
+                player->RemoveAurasDueToSpell(LFG_SPELL_DUNGEON_COOLDOWN);
+            }
+
             // Xinef: Update achievements, set correct amount of randomly grouped players
             if (dungeon->difficulty == DUNGEON_DIFFICULTY_HEROIC)
                 if (uint8 count = GetRandomPlayersCount(player->GetGUID()))


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template and do not forget to have a look at our Pull Request tutorial: https://www.azerothcore.org/wiki/How-to-create-a-PR
-->


## Changes Proposed:
- After finishing random dungeon, RDF cooldown is removed from players


## Issues Addressed:
- Closes #5001
- Closes chromiecraft/chromiecraft#294
<!-- If the issue does not exist, please describe it and how to reproduce it. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## SOURCE:
<!-- If this pull request IS linked with in-game content, please include any evidence/documentation/video or further proof in order to guarantee that the proposed changes described above are the correct ones.
 - If it is described in a guide/post or Wowhead comment, please include the link.
 - Can you link a video that confirms it?
 - Please share the source which states how it should work.
 - If this pull request IS NOT linked with in-game content, please leave this field as N/A
-->


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux/Mac/Windows? Describe any other tests performed -->
- Tested in-game


## How to Test the Changes:
<!-- We need to confirm the changes are going to be working, so please describe in general and for non-developers how to test the changes:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console?
 - Describe any other steps
-->
- Log in with 5 players
- From group using RDF 
- Finished dungeon before cooldown (15min)
- Disband group
- Check if players are able to queue RDF again

## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 


## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
