### PR TITLE
fix(scripts/DB): Implement "Marked immortal guardian"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1616977871251124200.sql
+++ b/data/sql/updates/pending_db_world/rev_1616977871251124200.sql
@@ -4,7 +4,7 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1616977871251124200');
 UPDATE `creature_template` SET `ScriptName`='boss_yoggsaron_immortal_guardian' WHERE `entry`=36064;
 -- Match "Immortal Guardian" values with "Marked immortal guardian"
 UPDATE `creature_template` SET `speed_walk`=1.6, `speed_run`=1.71429, `DamageModifier`=7.5, `mechanic_immune_mask`=617299839, `flags_extra`=1073741824 WHERE `entry` IN (36064, 36067);
-UPDATE `creature_template` SET `DamageModifier`=8 WHERE `entry` IN (33989, 36067);
+UPDATE `creature_template` SET `DamageModifier`=8 WHERE `entry` IN (33989, 36067); -- 25mode
 -- Add script into DB
 DELETE FROM `spell_script_names` WHERE  `spell_id`=64465 AND `ScriptName`='spell_yogg_saron_shadow_beacon';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (64465, 'spell_yogg_saron_shadow_beacon');

--- a/data/sql/updates/pending_db_world/rev_1616977871251124200.sql
+++ b/data/sql/updates/pending_db_world/rev_1616977871251124200.sql
@@ -11,6 +11,6 @@ INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (64465, 'spel
 -- Add/rework conditions for effect 'Titanic Storm'
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry`=64172;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`SourceId`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionTarget`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`NegativeCondition`,`ErrorType`,`ErrorTextId`,`ScriptName`,`Comment`) VALUES
-(13,1,64172,0,0,31,0,3,33988,0,0,0,0,'','Titanic Storm'),
-(13,1,64172,0,1,31,0,3,36064,0,0,0,0,'','Titanic Storm');
+(13,1,64172,0,0,31,0,3,33988,0,0,0,0,'','Titanic Storm on Immortal Guardian'),
+(13,1,64172,0,1,31,0,3,36064,0,0,0,0,'','Titanic Storm on Marked Immortal Guardian');
 

--- a/data/sql/updates/pending_db_world/rev_1616977871251124200.sql
+++ b/data/sql/updates/pending_db_world/rev_1616977871251124200.sql
@@ -1,7 +1,11 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1616977871251124200');
 
--- Add IA
+-- Add IA for 'Marked immortal guardian'
 UPDATE `creature_template` SET `ScriptName`='boss_yoggsaron_immortal_guardian' WHERE `entry`=36064;
 -- Match "Immortal Guardian" values with "Marked immortal guardian"
 UPDATE `creature_template` SET `speed_walk`=1.6, `speed_run`=1.71429, `DamageModifier`=7.5, `mechanic_immune_mask`=617299839, `flags_extra`=1073741824 WHERE `entry` IN (36064, 36067);
+UPDATE `creature_template` SET `DamageModifier`=8 WHERE `entry` IN (33989, 36067);
+-- Add script into DB
+DELETE FROM `spell_script_names` WHERE  `spell_id`=64465 AND `ScriptName`='spell_yogg_saron_shadow_beacon';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (64465, 'spell_yogg_saron_shadow_beacon');
 

--- a/data/sql/updates/pending_db_world/rev_1616977871251124200.sql
+++ b/data/sql/updates/pending_db_world/rev_1616977871251124200.sql
@@ -8,4 +8,9 @@ UPDATE `creature_template` SET `DamageModifier`=8 WHERE `entry` IN (33989, 36067
 -- Add script into DB
 DELETE FROM `spell_script_names` WHERE  `spell_id`=64465 AND `ScriptName`='spell_yogg_saron_shadow_beacon';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (64465, 'spell_yogg_saron_shadow_beacon');
+-- Add/rework conditions for effect 'Titanic Storm'
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry`=64172;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`SourceId`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionTarget`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`NegativeCondition`,`ErrorType`,`ErrorTextId`,`ScriptName`,`Comment`) VALUES
+(13,1,64172,0,0,31,0,3,33988,0,0,0,0,'','Titanic Storm'),
+(13,1,64172,0,1,31,0,3,36064,0,0,0,0,'','Titanic Storm');
 

--- a/data/sql/updates/pending_db_world/rev_1616977871251124200.sql
+++ b/data/sql/updates/pending_db_world/rev_1616977871251124200.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1616977871251124200');
+
+-- Add IA
+UPDATE `creature_template` SET `ScriptName`='boss_yoggsaron_immortal_guardian' WHERE `entry`=36064;
+-- Match "Immortal Guardian" values with "Marked immortal guardian"
+UPDATE `creature_template` SET `speed_walk`=1.6, `speed_run`=1.71429, `DamageModifier`=7.5, `mechanic_immune_mask`=617299839, `flags_extra`=1073741824 WHERE `entry` IN (36064, 36067);
+

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -2401,6 +2401,44 @@ public:
     }
 };
 
+class spell_yogg_saron_shadow_beacon : public SpellScriptLoader
+{
+    public:
+        spell_yogg_saron_shadow_beacon() : SpellScriptLoader("spell_yogg_saron_shadow_beacon") { }
+
+        class spell_yogg_saron_shadow_beacon_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_yogg_saron_shadow_beacon_AuraScript);
+
+            void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+            {
+                if (Creature* target = GetTarget()->ToCreature())
+                {
+                    target->SetEntry(NPC_MARKED_IMMORTAL_GUARDIAN);
+                }
+            }
+
+            void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+            {
+                if (Creature* target = GetTarget()->ToCreature())
+                {
+                    target->SetEntry(NPC_IMMORTAL_GUARDIAN);
+                }
+            }
+
+            void Register() override
+            {
+                AfterEffectApply += AuraEffectApplyFn(spell_yogg_saron_shadow_beacon_AuraScript::OnApply, EFFECT_0, SPELL_AURA_PERIODIC_TRIGGER_SPELL, AURA_EFFECT_HANDLE_REAL);
+                AfterEffectRemove += AuraEffectRemoveFn(spell_yogg_saron_shadow_beacon_AuraScript::OnRemove, EFFECT_0, SPELL_AURA_PERIODIC_TRIGGER_SPELL, AURA_EFFECT_HANDLE_REAL);
+            }
+        };
+
+        AuraScript* GetAuraScript() const override
+        {
+            return new spell_yogg_saron_shadow_beacon_AuraScript();
+        }
+};
+
 class spell_yogg_saron_destabilization_matrix : public SpellScriptLoader
 {
 public:
@@ -2996,6 +3034,7 @@ void AddSC_boss_yoggsaron()
     // SPELLS
     new spell_yogg_saron_malady_of_the_mind();
     new spell_yogg_saron_brain_link();
+    new spell_yogg_saron_shadow_beacon();
     new spell_yogg_saron_destabilization_matrix();
     new spell_yogg_saron_titanic_storm();
     new spell_yogg_saron_lunatic_gaze();

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -181,6 +181,7 @@ enum NPCsGOs
     NPC_LAUGHING_SKULL                  = 33990,
 
     NPC_IMMORTAL_GUARDIAN               = 33988,
+    NPC_MARKED_IMMORTAL_GUARDIAN        = 36064,
 
     // CHAMBER ILLUSION
     NPC_CONSORT_FIRST                   = 33716,


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template and do not forget to have a look at our Pull Request tutorial: https://www.azerothcore.org/wiki/How-to-create-a-PR
-->


## Changes Proposed:
-  Implement the [NPC](https://www.wowhead.com/npc=36064/marked-immortal-guardian) into the world at the [Yogg-Saron](https://www.wowhead.com/npc=33288/yogg-saron)'s encounter (Ulduar)
-  Create spell script for [Shadow beacon](https://www.wowhead.com/spell=64465/shadow-beacon)


## Issues Addressed:
- The NPC nor the mechanic for his existence are used in AC
<!-- If the issue does not exist, please describe it and how to reproduce it. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## SOURCE:
<!-- If this pull request IS linked with in-game content, please include any evidence/documentation/video or further proof in order to guarantee that the proposed changes described above are the correct ones.
 - If it is described in a guide/post or Wowhead comment, please include the link.
 - Can you link a video that confirms it?
 - Please share the source which states how it should work.
 - If this pull request IS NOT linked with in-game content, please leave this field as N/A
-->

![image](https://user-images.githubusercontent.com/61223313/112778244-51ff8780-9001-11eb-8fe5-b4ae9d856ee9.png)
Link: https://wowwiki-archive.fandom.com/wiki/Immortal_Guardian


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux/Mac/Windows? Describe any other tests performed -->
- Built:
SQL = /* Affected rows: 4  Found rows: 0  Warnings: 0  Duration for 5 queries: 0.000 sec. */
Core = ========== Build: 1 succeeded, 0 failed, 15 up-to-date, 2 skipped ==========
- Tested in-game as shown below:

### Before "Shadow beacon" application on the target
![image](https://user-images.githubusercontent.com/61223313/112781987-2da7a900-9009-11eb-811c-b34cd9d375c9.png)

### After "Shadow beacon" application on the target
![image](https://user-images.githubusercontent.com/61223313/112782018-42843c80-9009-11eb-94c2-1a2672fa0492.png)


## How to Test the Changes:
<!-- We need to confirm the changes are going to be working, so please describe in general and for non-developers how to test the changes:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console?
 - Describe any other steps
-->
Check guardians at Yogg-Saron's encounter when they are buffed with "Shadow beacon"

## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- N/A


## Target Branch(es):
- [x] Master


## NOTE: 
<!-- You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->

A [Marked immortal guardian](https://www.wowhead.com/npc=36064/marked-immortal-guardian) is exactly the same as an [Immortal guardian](https://www.wowhead.com/npc=33988/immortal-guardian), only name changes due to spell mechanic.

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
