### PR TITLE
fix(DB): The Missing Diplomat Part 11 Fix

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1617170212396609300.sql
+++ b/data/sql/updates/pending_db_world/rev_1617170212396609300.sql
@@ -1,0 +1,21 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1617170212396609300');
+/* Slim is walking just barely too far to target and send data back to Mikhail on a failed quest*/
+
+-- -------------------------------- Missing Diplomat Part 11 Failed Quest Recovery Fix -----------------------------------------------
+
+-- Tapoke "Slim" Jahn
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 4962 AND `id` IN (6,11,12);
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 496200 AND `id` = 8;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES 
+(4962,0,6,0,40,0,100,0,7,4962,0,0,0,45,1,1,0,0,0,0,10,9432,4963,1,0,0,0,0,0,"Tapoke \"Slim\" Jahn - On Waypoint 7 Reached - Set Data to Mikhail"),
+(4962,0,11,0,38,0,100,0,1,1,0,0,0,48,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,"Tapoke \"Slim\" Jahn - On Data Set - Set Active On"),
+(4962,0,12,0,11,0,100,0,0,0,0,0,0,48,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,"Tapoke \"Slim\" Jahn - On Respawn - Set Active Off"),
+
+(496200,9,8,0,0,0,100,0,1000,1000,0,0,0,45,1,1,0,0,0,0,10,9432,4963,1,0,0,0,0,0,"Tapoke \"Slim\" Jahn - On Script - Set Data to Mikhail");
+
+-- Mikhail
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 4963 AND `id` = 6;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 496300 AND `id` = 2;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(4963,0,6,0,19,0,100,0,1249,0,0,0,0,48,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,"Mikhail - On Quest 'The Missing Diplomat (Part 11)' Taken - Set Active On"),
+(496300,9,2,0,0,0,100,0,0,0,0,0,0,48,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,"Mikhail - On Script - Set Active Off");

--- a/data/sql/updates/pending_db_world/rev_1617170212396609300.sql
+++ b/data/sql/updates/pending_db_world/rev_1617170212396609300.sql
@@ -4,8 +4,8 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1617170212396609300');
 -- -------------------------------- Missing Diplomat Part 11 Failed Quest Recovery Fix -----------------------------------------------
 
 -- Tapoke "Slim" Jahn
-DELETE FROM `smart_scripts` WHERE `entryorguid` = 4962 AND `id` IN (6,11,12);
-DELETE FROM `smart_scripts` WHERE `entryorguid` = 496200 AND `id` = 8;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 4962 AND `source_type` = 0 AND `id` IN (6,11,12);
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 496200 AND `source_type` = 9 AND `id` = 8;
 INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES 
 (4962,0,6,0,40,0,100,0,7,4962,0,0,0,45,1,1,0,0,0,0,10,9432,4963,1,0,0,0,0,0,"Tapoke \"Slim\" Jahn - On Waypoint 7 Reached - Set Data to Mikhail"),
 (4962,0,11,0,38,0,100,0,1,1,0,0,0,48,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,"Tapoke \"Slim\" Jahn - On Data Set - Set Active On"),
@@ -14,8 +14,8 @@ INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type
 (496200,9,8,0,0,0,100,0,1000,1000,0,0,0,45,1,1,0,0,0,0,10,9432,4963,1,0,0,0,0,0,"Tapoke \"Slim\" Jahn - On Script - Set Data to Mikhail");
 
 -- Mikhail
-DELETE FROM `smart_scripts` WHERE `entryorguid` = 4963 AND `id` = 6;
-DELETE FROM `smart_scripts` WHERE `entryorguid` = 496300 AND `id` = 2;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 4963 AND `source_type` = 0 AND `id` = 6;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 496300 AND `source_type` = 9 AND `id` = 2;
 INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
 (4963,0,6,0,19,0,100,0,1249,0,0,0,0,48,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,"Mikhail - On Quest 'The Missing Diplomat (Part 11)' Taken - Set Active On"),
 (496300,9,2,0,0,0,100,0,0,0,0,0,0,48,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,"Mikhail - On Script - Set Active Off");


### PR DESCRIPTION




<!-- First of all, THANK YOU for your contribution.
 Please fill this template and do not forget to have a look at our Pull Request tutorial: https://www.azerothcore.org/wiki/How-to-create-a-PR
-->


## Changes Proposed:
-  Make both Mikhail and Slim Active for the duration of event
-  Use hashmap targeting to overcome targeting distance limitations


## Issues Addressed:
- Slim is walking just barely too far to target and send data back to Mikhail on a failed quest so Mikhail never returns to Quest Giver status without a GM respawning Mikhail
- Closes #4871
<!-- If the issue does not exist, please describe it and how to reproduce it. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## SOURCE:
<!-- If this pull request IS linked with in-game content, please include any evidence/documentation/video or further proof in order to guarantee that the proposed changes described above are the correct ones.
 - If it is described in a guide/post or Wowhead comment, please include the link.
 - Can you link a video that confirms it?
 - Please share the source which states how it should work.
 - If this pull request IS NOT linked with in-game content, please leave this field as N/A
-->


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux/Mac/Windows? Describe any other tests performed -->
- I did the how to test changes section instructions.  
- 


## How to Test the Changes:
<!-- We need to confirm the changes are going to be working, so please describe in general and for non-developers how to test the changes:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console?
 - Describe any other steps
--> 
- .add quest 1248
- Complete quest at Mikhail (.quest remove 1249, 1250 before if you already did quests)
- Accept Subdue Slim quest 1249
- Just stand there and wait for a quest fail
- Wait at least 10 seconds more then abandon failed quest.
- Mikhail should allow you to accept the Subdue Slim quest
- Also test by following Slim to his final waypoint when he despawns 
- wait 10 seconds and return to Mikhail and abandon failed quest
- Mikhail should offer the quest again.
- Also test abandoning quest after curbstomping Slim and waiting 10 seconds or so to see if he respawns and mikhail returns to normal.


## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 


## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
