### PR TITLE
fix(DB/pool_template): Fix Black Lotus in Burning Steppes

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1617172919168716426.sql
+++ b/data/sql/updates/pending_db_world/rev_1617172919168716426.sql
@@ -1,0 +1,42 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1617172919168716426');
+
+-- Remove a double spawn of Black Lotus
+DELETE FROM `gameobject` WHERE `guid`=65289 AND `id`=176589;
+
+-- One spawn per zone only
+SET
+@POOL            = '11653',
+@POOLSIZE        = '1',
+@POOLDESC        = 'Black Lotus - Burning Steppes',
+@RESPAWN         = '3600',
+@GUID            = '20263,20266,20268,20272,20275,20279,20280,20282,20284,20288,20289,20293,20294,20295,20297,20305,20307,33420,65290';
+
+-- Create pool(s)
+DELETE FROM `pool_template` WHERE `entry`=@POOL;
+INSERT INTO `pool_template` (`entry`,`max_limit`,`description`) VALUES (@POOL,@POOLSIZE,@POOLDESC);
+
+-- Add gameobjects to pools
+DELETE FROM `pool_gameobject` WHERE FIND_IN_SET (`guid`,@GUID);
+INSERT INTO `pool_gameobject` (`guid`,`pool_entry`,`chance`,`description`) VALUES
+(20263,@POOL,0,@POOLDESC),
+(20266,@POOL,0,@POOLDESC),
+(20268,@POOL,0,@POOLDESC),
+(20272,@POOL,0,@POOLDESC),
+(20275,@POOL,0,@POOLDESC),
+(20279,@POOL,0,@POOLDESC),
+(20280,@POOL,0,@POOLDESC),
+(20282,@POOL,0,@POOLDESC),
+(20284,@POOL,0,@POOLDESC),
+(20288,@POOL,0,@POOLDESC),
+(20289,@POOL,0,@POOLDESC),
+(20293,@POOL,0,@POOLDESC),
+(20294,@POOL,0,@POOLDESC),
+(20295,@POOL,0,@POOLDESC),
+(20297,@POOL,0,@POOLDESC),
+(20305,@POOL,0,@POOLDESC),
+(20307,@POOL,0,@POOLDESC),
+(33420,@POOL,0,@POOLDESC),
+(65290,@POOL,0,@POOLDESC);
+
+-- Respawn rates of gameobjects
+UPDATE `gameobject` SET `spawntimesecs`=@RESPAWN WHERE FIND_IN_SET (`guid`,@GUID);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template and do not forget to have a look at our Pull Request tutorial: https://www.azerothcore.org/wiki/How-to-create-a-PR
-->


## Changes Proposed:
-  Remove a double spawn and pool the rest,  so it's 1 Black Lotus per zone per hour (and not 20 every 3 minutes)


## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5037
- Closes https://github.com/chromiecraft/chromiecraft/issues/309
<!-- If the issue does not exist, please describe it and how to reproduce it. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## SOURCE:
<!-- If this pull request IS linked with in-game content, please include any evidence/documentation/video or further proof in order to guarantee that the proposed changes described above are the correct ones.
 - If it is described in a guide/post or Wowhead comment, please include the link.
 - Can you link a video that confirms it?
 - Please share the source which states how it should work.
 - If this pull request IS NOT linked with in-game content, please leave this field as N/A
-->
- https://classicguides.org/black-lotus-farming-guide/ (comments say 1 per zone per hour)
- Notice that Blizzard has later changed this for more - it will be trivial to adjust this later if needed, using the created pool

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux/Mac/Windows? Describe any other tests performed -->
- Applied SQL
- Visited locations

Before the PR:
![lotus_bs_before](https://user-images.githubusercontent.com/541438/113107008-ae31f980-9203-11eb-9e27-4b35654a1bd8.png)
(You only see 19 marks on the map, since 1 is a double spawn. So that's 20 spawns in total).

After the PR test 1:
![black_lotus_after1](https://user-images.githubusercontent.com/541438/113108870-bdb24200-9205-11eb-8c1f-eaeb2989f997.png)

and test 2:
![blacklotus_bs_after2](https://user-images.githubusercontent.com/541438/113108893-c440b980-9205-11eb-8d85-caa91e577201.png)

So it looks fine to me.

## How to Test the Changes:
<!-- We need to confirm the changes are going to be working, so please describe in general and for non-developers how to test the changes:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console?
 - Describe any other steps
-->
- `.go object <guid>`, check the list with numbers
- Only 1 should be available at a time, once picked, it should respawn in 1 hour


## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 


## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
