### PR TITLE
fix(DB/creature_template): Disciple of Naralax walking speed

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1617177621821036427.sql
+++ b/data/sql/updates/pending_db_world/rev_1617177621821036427.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1617177621821036427');
+
+-- Disciple of Naralex
+UPDATE `creature_template` SET `speed_walk`=0.8 WHERE `entry`=3678;


### PR DESCRIPTION

<!-- First of all, THANK YOU for your contribution.
 Please fill this template and do not forget to have a look at our Pull Request tutorial: https://www.azerothcore.org/wiki/How-to-create-a-PR
-->


## Changes Proposed:
-  He should walk much slower (from 1.4 to 0.8)
- The number 0.8 was selected as a "seems about right" number. Anything from 0.7-0.9 is probably fine.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5011
- Closes https://github.com/chromiecraft/chromiecraft/issues/297
<!-- If the issue does not exist, please describe it and how to reproduce it. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## SOURCE:
<!-- If this pull request IS linked with in-game content, please include any evidence/documentation/video or further proof in order to guarantee that the proposed changes described above are the correct ones.
 - If it is described in a guide/post or Wowhead comment, please include the link.
 - Can you link a video that confirms it?
 - Please share the source which states how it should work.
 - If this pull request IS NOT linked with in-game content, please leave this field as N/A
-->
- https://youtu.be/xeW3Nl9akYA?t=1721 - from Classic, but he's slow as molasses going uphill on a cold day

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux/Mac/Windows? Describe any other tests performed -->
- Applied SQL
- Did the quest. He walks slowly... but when testing, I found out there's more wrong... The issue is here:  https://github.com/azerothcore/azerothcore-wotlk/issues/4953. This does not invalidate this PR, but there's more to fix afterwards...


## How to Test the Changes:
<!-- We need to confirm the changes are going to be working, so please describe in general and for non-developers how to test the changes:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console?
 - Describe any other steps
-->

In order to start the event which makes Disciple of Naralex start walking, you must kill the 4 Leaders of the Fang
They can be found here:
.go creature 27380
.go creature 27366
.go creature 87107
.go creature 38148

Once they are dead go to the Disciple of Naralex:
.go creature 18675

Talk to him and select the gossip option "Let the event begin!"
He will begin to walk away.

## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 


## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
