### PR TITLE
fix(DB/Spells): spell "57874 Twilight Shift" should be negative + target only players

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1617254287410662400.sql
+++ b/data/sql/updates/pending_db_world/rev_1617254287410662400.sql
@@ -1,7 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1617254287410662400');
 
-SET @SPELL_ATTR0_CU_NEGATIVE_EFF0                 := 0x00001000;
-SET @SPELL_ATTR0_CU_NEGATIVE_EFF1                 := 0x00002000;
+SET @SPELL_ATTR0_CU_NEGATIVE_EFF0 := 4096,
+	@SPELL_ATTR0_CU_NEGATIVE_EFF1 := 8192;
 
 DELETE FROM `spell_custom_attr` WHERE `spell_id`=57874;
 INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1617254287410662400.sql
+++ b/data/sql/updates/pending_db_world/rev_1617254287410662400.sql
@@ -1,0 +1,12 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1617254287410662400');
+
+SET @SPELL_ATTR0_CU_NEGATIVE_EFF0                 := 0x00001000;
+SET @SPELL_ATTR0_CU_NEGATIVE_EFF1                 := 0x00002000;
+
+DELETE FROM `spell_custom_attr` WHERE `spell_id`=57874;
+INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES
+(57874, @SPELL_ATTR0_CU_NEGATIVE_EFF0|@SPELL_ATTR0_CU_NEGATIVE_EFF1);
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=17 AND `SourceGroup`=0 AND `SourceEntry`=57874 AND `SourceId`=0 AND `ElseGroup`=0 AND `ConditionTypeOrReference`=31 AND `ConditionTarget`=1 AND `ConditionValue1`=4 AND `ConditionValue2`=0 AND `ConditionValue3`=0;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(17, 0, 57874, 0, 0, 31, 1, 4, 0, 0, 0, 0, 0, '', 'Twilight Shift spell should be applied only on player');


### PR DESCRIPTION
This spell is applied when players in Obsidian Sanctum enters to twilight portal.
By default this spell is applied by player himself, at initial point its counted as positive spell and any damage increase spells which player gets - it increases damage on that aura.

Also this aura shouldn;t be applied on npcs (only on players).

<!-- First of all, THANK YOU for your contribution.
 Please fill this template and do not forget to have a look at our Pull Request tutorial: https://www.azerothcore.org/wiki/How-to-create-a-PR
-->


## Changes Proposed:
-  Marked aura effects as negative
-  Added condition to allow casting this aura only on players.


## Issues Addressed:
- Closes 
<!-- If the issue does not exist, please describe it and how to reproduce it. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## SOURCE:
<!-- If this pull request IS linked with in-game content, please include any evidence/documentation/video or further proof in order to guarantee that the proposed changes described above are the correct ones.
 - If it is described in a guide/post or Wowhead comment, please include the link.
 - Can you link a video that confirms it?
 - Please share the source which states how it should work.
 - If this pull request IS NOT linked with in-game content, please leave this field as N/A
-->


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux/Mac/Windows? Describe any other tests performed -->
- Entered to twilight portal and used damage increase spells (tested mainly on warrior, with death wish)
- 


## How to Test the Changes:
<!-- We need to confirm the changes are going to be working, so please describe in general and for non-developers how to test the changes:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console?
 - Describe any other steps
-->

To test these change, well, its enough to enter to twilight portal in Obsidian Sanctum and try to use some damage increase buffs (berserk, enrage, death wish).

## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- [x] None


## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
