### PR TITLE
fix(Core/Movement): Make sure pet always follows its master.

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -174,7 +174,7 @@ bool ChaseMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
     }
 
     owner->AddUnitState(UNIT_STATE_CHASE_MOVE);
-    i_recalculateTravel = true;
+    i_recalculateTravel = false;
 
     Movement::MoveSplineInit init(owner);
     init.MovebyPath(i_path->GetPath());
@@ -347,7 +347,7 @@ bool FollowMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
 
     owner->AddUnitState(UNIT_STATE_FOLLOW_MOVE);
 
-    i_recalculateTravel = true;
+    i_recalculateTravel = false;
 
     init.MovebyPath(i_path->GetPath());
     init.SetFacing(target->GetOrientation());

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -334,8 +334,10 @@ bool FollowMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
 
     target->GetNearPoint(owner, x, y, z, _range, 0.f, target->ToAbsoluteAngle(tAngle));
 
+    Movement::MoveSplineInit init(owner);
+
     bool success = i_path->CalculatePath(x, y, z, forceDest);
-    if (!success || i_path->GetPathType() & PATHFIND_NOPATH)
+    if ((!success || i_path->GetPathType() & PATHFIND_NOPATH) && !followingMaster) // Exclude pets - must always follow its master
     {
         owner->StopMoving();
         return true;
@@ -345,7 +347,6 @@ bool FollowMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
 
     i_recalculateTravel = true;
 
-    Movement::MoveSplineInit init(owner);
     init.MovebyPath(i_path->GetPath());
     init.SetFacing(target->GetOrientation());
     init.SetWalk(target->IsWalking());

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -157,7 +157,7 @@ bool ChaseMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
     {
         if (cOwner)
             cOwner->SetCannotReachTarget(true);
-        owner->StopMoving();
+        i_recalculateTravel = false;
         return true;
     }
 
@@ -337,9 +337,11 @@ bool FollowMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
     Movement::MoveSplineInit init(owner);
 
     bool success = i_path->CalculatePath(x, y, z, forceDest);
-    if ((!success || i_path->GetPathType() & PATHFIND_NOPATH) && !followingMaster) // Exclude pets - must always follow its master
+    if (!success || i_path->GetPathType() & PATHFIND_NOPATH)
     {
-        owner->StopMoving();
+        if (cOwner)
+            cOwner->SetCannotReachTarget(true);
+        i_recalculateTravel = false;
         return true;
     }
 

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -334,8 +334,6 @@ bool FollowMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
 
     target->GetNearPoint(owner, x, y, z, _range, 0.f, target->ToAbsoluteAngle(tAngle));
 
-    Movement::MoveSplineInit init(owner);
-
     bool success = i_path->CalculatePath(x, y, z, forceDest);
     if (!success || i_path->GetPathType() & PATHFIND_NOPATH)
     {
@@ -349,6 +347,7 @@ bool FollowMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
 
     i_recalculateTravel = false;
 
+    Movement::MoveSplineInit init(owner);
     init.MovebyPath(i_path->GetPath());
     init.SetFacing(target->GetOrientation());
     init.SetWalk(target->IsWalking());

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -152,12 +152,13 @@ bool ChaseMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
     if (owner->IsHovering())
         owner->UpdateAllowedPositionZ(x, y, z);
 
+    i_recalculateTravel = true;
+
     bool success = i_path->CalculatePath(x, y, z, forceDest);
     if (!success || i_path->GetPathType() & PATHFIND_NOPATH)
     {
         if (cOwner)
             cOwner->SetCannotReachTarget(true);
-        i_recalculateTravel = true;
         return true;
     }
 
@@ -174,7 +175,6 @@ bool ChaseMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
     }
 
     owner->AddUnitState(UNIT_STATE_CHASE_MOVE);
-    i_recalculateTravel = false;
 
     Movement::MoveSplineInit init(owner);
     init.MovebyPath(i_path->GetPath());
@@ -334,18 +334,17 @@ bool FollowMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
 
     target->GetNearPoint(owner, x, y, z, _range, 0.f, target->ToAbsoluteAngle(tAngle));
 
+    i_recalculateTravel = true;
+
     bool success = i_path->CalculatePath(x, y, z, forceDest);
     if (!success || i_path->GetPathType() & PATHFIND_NOPATH)
     {
         if (cOwner)
             cOwner->SetCannotReachTarget(true);
-        i_recalculateTravel = true;
         return true;
     }
 
     owner->AddUnitState(UNIT_STATE_FOLLOW_MOVE);
-
-    i_recalculateTravel = false;
 
     Movement::MoveSplineInit init(owner);
     init.MovebyPath(i_path->GetPath());

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -157,7 +157,7 @@ bool ChaseMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
     {
         if (cOwner)
             cOwner->SetCannotReachTarget(true);
-        i_recalculateTravel = false;
+        i_recalculateTravel = true;
         return true;
     }
 
@@ -341,7 +341,7 @@ bool FollowMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
     {
         if (cOwner)
             cOwner->SetCannotReachTarget(true);
-        i_recalculateTravel = false;
+        i_recalculateTravel = true;
         return true;
     }
 


### PR DESCRIPTION
Fixed #4603.

<!-- First of all, THANK YOU for your contribution.
 Please fill this template and do not forget to have a look at our Pull Request tutorial: https://www.azerothcore.org/wiki/How-to-create-a-PR
-->


## Changes Proposed:
-  Added code that enables pets to always follow its master.


## Issues Addressed:
- Closes #4603
<!-- If the issue does not exist, please describe it and how to reproduce it. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux/Mac/Windows? Describe any other tests performed -->
- Tested ingame on Warsong Gulch with warlock's Imp


## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
