### PR TITLE
fix(DB/Quest): make quest "a new plague" for Horde

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1617403339704819681.sql
+++ b/data/sql/updates/pending_db_world/rev_1617403339704819681.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1617403339704819681');
+
+UPDATE `quest_template` SET `AllowableRaces` = 690 WHERE `ID` IN (367, 368, 369, 492);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template and do not forget to have a look at our Pull Request tutorial: https://www.azerothcore.org/wiki/How-to-create-a-PR
-->


## Changes Proposed:
-  make the quests "A new plague" available for all hordes


## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5109
- Closes https://github.com/chromiecraft/chromiecraft/issues/326


## SOURCE:
WoWhead https://classic.wowhead.com/quest=369/a-new-plague (and wowgaming/AoWoW, so TC DB)

## Tests Performed:
didn't test

## How to Test the Changes:
try to take the quests with an horde that is not undead


## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
