### PR TITLE
fix(DB/Creature): set movementType to 2 for Rageclaw

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1617634980911314885.sql
+++ b/data/sql/updates/pending_db_world/rev_1617634980911314885.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1617634980911314885');
+
+DELETE FROM `creature` WHERE (`id` = 7318) AND (`guid` IN (46818));
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(46818, 7318, 1, 0, 0, 1, 1, 6231, 1, 9843.19, 1496.22, 1257.25, 2.34654, 300, 0, 0, 186, 191, 2, 0, 0, 0, '', 0);
+


### PR DESCRIPTION
the waypoint were there, the only missing thing was the movementType in the creature table

## Changes Proposed:
-  set movementType to 2 for Rageclaw in creature table

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5153
- Closes https://github.com/chromiecraft/chromiecraft/issues/345

## Tests Performed:
- tested in-game

## How to Test the Changes:
.go cr id 7318


## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
