### PR TITLE
fix(DB/GameObject-Spawn): Solid Chest respawn time for gameobject 100068,16946

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1617988329167837335.sql
+++ b/data/sql/updates/pending_db_world/rev_1617988329167837335.sql
@@ -1,15 +1,16 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1617988329167837335');
 
--- Create pooling, 11650 is the latest+1 entry in `pool_template`
-DELETE FROM `pool_template` WHERE `entry` IN (11650);
+-- Create pooling, 11651 is the latest+2 entry in `pool_template`
+DELETE FROM `pool_template` WHERE `entry` IN (11651);
 INSERT INTO `pool_template` (`entry`,`max_limit`,`description`) VALUES
-(11650,1,"Solid Chests, Northfold Manor");
+(11651,1,"Solid Chests, Northfold Manor");
 
 -- Add gameobjects to pools
 DELETE FROM `pool_gameobject` WHERE `guid` IN (16946,100068);
 INSERT INTO `pool_gameobject` (`guid`,`pool_entry`,`chance`,`description`) VALUES
-(16946,11650,0,"Solid Chests, Northfold Manor, node 1"),
-(100068,11650,0,"Solid Chests, Northfold Manor, node 2");
+(16946,11651,0,"Solid Chests, Northfold Manor, node 1"),
+(100068,11651,0,"Solid Chests, Northfold Manor, node 2");
 
 -- Set spawn time to 15 minutes
 UPDATE `gameobject` SET `spawntimesecs`=900 WHERE `guid` IN (16946,100068);
+

--- a/data/sql/updates/pending_db_world/rev_1617988329167837335.sql
+++ b/data/sql/updates/pending_db_world/rev_1617988329167837335.sql
@@ -1,0 +1,15 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1617988329167837335');
+
+-- Create pooling, 11650 is the latest+1 entry in `pool_template`
+DELETE FROM `pool_template` WHERE `entry` IN (11650);
+INSERT INTO `pool_template` (`entry`,`max_limit`,`description`) VALUES
+(11650,1,"Solid Chests, Northfold Manor");
+
+-- Add gameobjects to pools
+DELETE FROM `pool_gameobject` WHERE `guid` IN (16946,100068);
+INSERT INTO `pool_gameobject` (`guid`,`pool_entry`,`chance`,`description`) VALUES
+(16946,11650,0,"Solid Chests, Northfold Manor, node 1"),
+(100068,11650,0,"Solid Chests, Northfold Manor, node 2");
+
+-- Set spawn time to 15 minutes
+UPDATE `gameobject` SET `spawntimesecs`=900 WHERE `guid` IN (16946,100068);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template and do not forget to have a look at our Pull Request tutorial: https://www.azerothcore.org/wiki/How-to-create-a-PR
-->


## Changes Proposed:
-  Add two chests (guids `(16946,100068)`) in Northfold Manor into a gamepool, sharing respawn of 15 minutes, with 1 max limit


## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5211
<!-- If the issue does not exist, please describe it and how to reproduce it. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## SOURCE:
<!-- If this pull request IS linked with in-game content, please include any evidence/documentation/video or further proof in order to guarantee that the proposed changes described above are the correct ones.
 - If it is described in a guide/post or Wowhead comment, please include the link.
 - Can you link a video that confirms it?
 - Please share the source which states how it should work.
 - If this pull request IS NOT linked with in-game content, please leave this field as N/A
-->


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux/Mac/Windows? Describe any other tests performed -->
- Verify the issue is reproducible in the latest master
- Rebuilt using docker on Linux host
- Tested locally to verify no chest in `.go object 100067` in two minutes.


## How to Test the Changes:
<!-- We need to confirm the changes are going to be working, so please describe in general and for non-developers how to test the changes:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console?
 - Describe any other steps
-->

- Verify the issue is reproducible in the latest master
- Apply the SQL update file.
- Reload the world `.reload all`
- Verify that there is only one chest spawned across two locations (`.go object 100067`, `.go object 16946`)
- Loot the chest
- Wait 15 minutes (when I was testing it I updated the spawn time to something more feasible for testing)
- Verify that there is only one chest spawned across two locations (`.go object 100067`, `.go object 16946`)


## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- [ ]
- [ ] 


## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
