### PR TITLE
fix(DB/Spawns): duplicate nodes

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1618169172923159272.sql
+++ b/data/sql/updates/pending_db_world/rev_1618169172923159272.sql
@@ -2,7 +2,7 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1618169172923159272');
 
 DELETE FROM `gameobject` WHERE (`id` = 2040) AND (`guid` IN (32880)); -- mithril vein duplicate
 DELETE FROM `gameobject` WHERE (`id` = 3726) AND (`guid` IN (13596)); -- earthroot duplicate
-DELETE FROM `gameobject` WHERE (`id` = 175404) AND (`guid` IN (17507)); -- rich thorium veins duplicate
+DELETE FROM `gameobject` WHERE (`id` = 175404) AND (`guid` IN (17506, 17507)); -- rich thorium veins duplicate
 
 -- fix spawn small thorium vein
 DELETE FROM `gameobject` WHERE (`id` = 324) AND (`guid` IN (317));

--- a/data/sql/updates/pending_db_world/rev_1618169172923159272.sql
+++ b/data/sql/updates/pending_db_world/rev_1618169172923159272.sql
@@ -1,0 +1,12 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1618169172923159272');
+
+DELETE FROM `gameobject` WHERE (`id` = 2040) AND (`guid` IN (32880)); -- mithril vein duplicate
+DELETE FROM `gameobject` WHERE (`id` = 3726) AND (`guid` IN (13596)); -- earthroot duplicate
+DELETE FROM `gameobject` WHERE (`id` = 175404) AND (`guid` IN (17507)); -- rich thorium veins duplicate
+
+-- fix spawn small thorium vein
+DELETE FROM `gameobject` WHERE (`id` = 324) AND (`guid` IN (317));
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(317, 324, 1, 0, 0, 1, 1, -7213.251465, -2300.464355, -262.501099, 3.603, 0, 0, -0.973506, 0.228663, 2700, 100, 1, '', 0);
+
+DELETE FROM `gameobject` WHERE (`id` = 324) AND (`guid` IN (374)); -- small thorium vein cluster (removed 1 on 3)


### PR DESCRIPTION
## Changes Proposed:
-  removed duplicates nodes
-  moved one small thorium vein in the right position

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/401
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5242
- Closes https://github.com/chromiecraft/chromiecraft/issues/393
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5233
- Closes https://github.com/chromiecraft/chromiecraft/issues/398
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5234

## Tests Performed:
- tested in-game


## How to Test the Changes:
Now you will not see the duplicates listed in the issues


## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
