### PR TITLE
fix(DB/Creature): move creature spawn

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1618169871194421039.sql
+++ b/data/sql/updates/pending_db_world/rev_1618169871194421039.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1618169871194421039');
+
+DELETE FROM `creature` WHERE (`id` = 9164) AND (`guid` IN (24506));
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(24506, 9164, 1, 0, 0, 1, 1, 8512, 0, -7306.250977, -375.499695, -268.558746, 0.703892, 300, 5, 0, 3293, 0, 1, 0, 0, 0, '', 0);


### PR DESCRIPTION
## Changes Proposed:
-  move spawn out from the tree

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5241
- Closes https://github.com/chromiecraft/chromiecraft/issues/404 
<!-- If the issue does not exist, please describe it and how to reproduce it. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

## Tests Performed:
- tested in-game


## How to Test the Changes:
.go cr 24506


## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
