### PR TITLE
fix(DB/creature_loot_template): Fix Broken Tooth loot table

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1618709045226609356.sql
+++ b/data/sql/updates/pending_db_world/rev_1618709045226609356.sql
@@ -12,7 +12,6 @@ FROM `creature_loot_template`
 WHERE ENTRY = 2850
   AND Item NOT IN (1688, 4580, 8146);
 
-
 # Update chance for Long Soft Tail
 UPDATE `creature_loot_template` SET Chance = 19 WHERE Entry = 2850 AND Item = 1688;
 

--- a/data/sql/updates/pending_db_world/rev_1618709045226609356.sql
+++ b/data/sql/updates/pending_db_world/rev_1618709045226609356.sql
@@ -6,42 +6,6 @@ DELETE
 FROM `creature_loot_template`
 WHERE Comment LIKE '%Broken Tooth - (ReferenceTable%';
 
-DELETE
-FROM `reference_loot_template`
-WHERE reference_loot_template.Entry IN
-      (24016,
-       24036,
-       24037,
-       24038,
-       24039,
-       24040,
-       24041,
-       24042,
-       24047,
-       24048,
-       24049,
-       24050,
-       24051,
-       24052,
-       24053,
-       24054,
-       24055,
-       24056,
-       24057,
-       24058,
-       24059,
-       24060,
-       24061,
-       24062,
-       24063,
-       24064,
-       24065,
-       24066,
-       24067,
-       24068,
-       24069,
-       24078);
-
 # Delete the junk Broken Tooth currently drops like Melon Juice
 DELETE
 FROM `creature_loot_template`

--- a/data/sql/updates/pending_db_world/rev_1618709045226609356.sql
+++ b/data/sql/updates/pending_db_world/rev_1618709045226609356.sql
@@ -1,0 +1,116 @@
+INSERT INTO `version_db_world` (`sql_rev`)
+VALUES ('1618709045226609356');
+
+# Delete current loot reference loot templates for Broken Tooth
+DELETE
+FROM `creature_loot_template`
+WHERE Comment LIKE '%Broken Tooth - (ReferenceTable%';
+
+DELETE
+FROM `reference_loot_template`
+WHERE reference_loot_template.Entry IN
+      (24016,
+       24036,
+       24037,
+       24038,
+       24039,
+       24040,
+       24041,
+       24042,
+       24047,
+       24048,
+       24049,
+       24050,
+       24051,
+       24052,
+       24053,
+       24054,
+       24055,
+       24056,
+       24057,
+       24058,
+       24059,
+       24060,
+       24061,
+       24062,
+       24063,
+       24064,
+       24065,
+       24066,
+       24067,
+       24068,
+       24069,
+       24078);
+
+# Delete the junk Broken Tooth currently drops like Melon Juice
+DELETE
+FROM `creature_loot_template`
+WHERE ENTRY = 2850
+  AND Item NOT IN (1688, 4580, 8146);
+
+
+# Update chance for Long Soft Tail
+UPDATE `creature_loot_template` SET Chance = 19 WHERE Entry = 2850 AND Item = 1688;
+
+# Update chance for Sabertooth Fang
+UPDATE `creature_loot_template` SET Chance = 11 WHERE Entry = 2850 AND Item = 4580;
+
+# Add Thick Leather to Broken Tooth loot table
+INSERT INTO `creature_loot_template`
+VALUES (2850, 4304, 0, 3, 0, 1, 0, 1, 1, 'Broken Tooth - Thick Leather');
+
+# Add a guaranteed green to drop
+INSERT INTO creature_loot_template
+VALUES (2850, 7493, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Captain''s Bracers'),
+       (2850, 7492, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Captain''s Cloak'),
+       (2850, 9885, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Huntsman''s Boots'),
+       (2850, 7461, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Knight''s Bracers'),
+       (2850, 7483, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Ranger Cloak'),
+       (2850, 7474, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Regal Cloak'),
+       (2850, 7476, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Regal Sash'),
+       (2850, 7441, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sentinel Cap'),
+       (2850, 7448, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sentinel Girdle'),
+       (2850, 9879, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sorcerer Bracelets'),
+       (2850, 9876, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sorcerer Slippers'),
+       (2850, 7435, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Twilight Mantle'),
+       (2850, 7430, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Twilight Robe'),
+       (2850, 9848, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Conjurer''s Gloves'),
+       (2850, 9850, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Conjurer''s Mantle'),
+       (2850, 9890, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Huntsman''s Cape'),
+       (2850, 7459, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Knight''s Pauldrons'),
+       (2850, 9864, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Renegade Boots'),
+       (2850, 9871, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Renegade Leggings'),
+       (2850, 9875, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sorcerer Sash'),
+       (2850, 9856, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Archer''s Boots'),
+       (2850, 9852, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Conjurer''s Robe'),
+       (2850, 7447, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sentinel Bracers'),
+       (2850, 9877, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sorcerer Cloak'),
+       (2850, 7434, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Twilight Boots'),
+       (2850, 9849, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Conjurer''s Hood'),
+       (2850, 9844, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Conjurer''s Vest'),
+       (2850, 9886, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Huntsman''s Bands'),
+       (2850, 7454, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Knight''s Breastplate'),
+       (2850, 9870, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Renegade Circlet'),
+       (2850, 7438, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Twilight Belt'),
+       (2850, 7433, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Twilight Gloves'),
+       (2850, 7431, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Twilight Pants'),
+       (2850, 7455, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Knight''s Legguards'),
+       (2850, 7443, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sentinel Gloves'),
+       (2850, 9862, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Archer''s Trousers'),
+       (2850, 7462, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Knight''s Girdle'),
+       (2850, 9872, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Renegade Pauldrons'),
+       (2850, 9880, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sorcerer Gloves'),
+       (2850, 7437, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Twilight Cuffs'),
+       (2850, 9851, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Conjurer''s Breeches'),
+       (2850, 7458, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Knight''s Boots'),
+       (2850, 7444, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sentinel Boots'),
+       (2850, 7432, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Twilight Cowl'),
+       (2850, 9863, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Archer''s Shoulderpads'),
+       (2850, 7457, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Knight''s Gauntlets'),
+       (2850, 9866, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Renegade Chestguard'),
+       (2850, 9896, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Jazeraint Bracers'),
+       (2850, 7446, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sentinel Cloak'),
+       (2850, 7445, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sentinel Shoulders');
+
+
+

--- a/data/sql/updates/pending_db_world/rev_1618709045226609356.sql
+++ b/data/sql/updates/pending_db_world/rev_1618709045226609356.sql
@@ -111,6 +111,3 @@ VALUES (2850, 7493, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Captain''s Bracers'),
        (2850, 9896, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Jazeraint Bracers'),
        (2850, 7446, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sentinel Cloak'),
        (2850, 7445, 0, 0, 0, 1, 1, 1, 1, 'Broken Tooth - Sentinel Shoulders');
-
-
-


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.
 Please fill this template and do not forget to have a look at our Pull Request tutorial: https://www.azerothcore.org/wiki/How-to-create-a-PR
-->


## Changes Proposed:
- Update the loot table of Broken Tooth to be more consistent with Wowhead


## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5336
<!-- If the issue does not exist, please describe it and how to reproduce it. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->


## SOURCE:
<!-- If this pull request IS linked with in-game content, please include any evidence/documentation/video or further proof in order to guarantee that the proposed changes described above are the correct ones.
 - If it is described in a guide/post or Wowhead comment, please include the link.
 - Can you link a video that confirms it?
 - Please share the source which states how it should work.
 - If this pull request IS NOT linked with in-game content, please leave this field as N/A
-->


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux/Mac/Windows? Describe any other tests performed -->
- Spawn a bunch of Broken Tooth, kill them and verify the loot is as expected.


## How to Test the Changes:
<!-- We need to confirm the changes are going to be working, so please describe in general and for non-developers how to test the changes:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console?
 - Describe any other steps
-->

1. `.npc add 2850`
2. Target it and do `.damage 10000`
3. Loot it and verify that the loot table is as in https://classic.wowhead.com/npc=2850/broken-tooth#drops;0-3+17-21+1

## Known Issues and TODO List:
<!-- This is a TODO list with checkboxes to tick -->
- [ ] There is a slight discrepancy in chances for different green items to be dropped according to Wowhead, but the current PR makes them all equally possible to drop. This is a simplification of the statistics in Wowhead. It is done this way because I believe it is not that easy to assign different chances to subgroups of items. 
- [ ] 


## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
