### PR TITLE
fix(Core/Tools) Compile fix std::filesystem

### DIFF
--- a/src/tools/map_extractor/CMakeLists.txt
+++ b/src/tools/map_extractor/CMakeLists.txt
@@ -25,7 +25,8 @@ target_include_directories(mapextractor
 target_link_libraries(mapextractor
   PUBLIC
     common
-    mpq)
+    mpq
+    stdc++fs)
 
 CollectIncludeDirectories(
   ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
Whenever a C++ compilation error says the <filesystem> header is not found it is because GNU libstdc++ prior to 9.1 and LLVM libc++ prior to 9.0 have not implemented std::filesystem yet and requires linking -lc++fs.

https://en.cppreference.com/w/cpp/filesystem

## Changes Proposed:
-  Makes it possible to use filesystem header on "old" linux distributions


## Issues Addressed:
- [Fixes this](https://github.com/azerothcore/azerothcore-wotlk/commit/0a8a7ef1494b1dcc43bdf5134f7c4836acc66f4e#r46240059)


## Tests Performed:
- Debian 10
- clang 7.0
- gcc 8.3


## How to Test the Changes:
 - Compile with -DTOOLS=1


## Target Branch(es):
- [x] Master
