### PR TITLE
fix(DB/game_event_gameobject): link to brewfest 2 gameobjects

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1619469854375537568.sql
+++ b/data/sql/updates/pending_db_world/rev_1619469854375537568.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1619469854375537568');
+
+DELETE FROM `game_event_gameobject` WHERE `guid` IN (59183, 59184);
+INSERT INTO `game_event_gameobject` (`eventEntry`, `guid`) VALUES
+(24, 59183),
+(24, 59184);


### PR DESCRIPTION
## Changes Proposed:
-  link to brewfest the 2 gameobjects in SilvermoonCity


## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5422
- Closes https://github.com/chromiecraft/chromiecraft/issues/459


## Tests Performed:
- tested in-game


## How to Test the Changes:
.go obj 59183
.event start 24
.event stop 24
you will see the gameobject appearing and disappearing, repeat the same with gameobject 59184


## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
