### PR TITLE
fix(DB/creature_formations): hezrul bodyguards path and formations

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1619636650124390405.sql
+++ b/data/sql/updates/pending_db_world/rev_1619636650124390405.sql
@@ -1,0 +1,15 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1619636650124390405');
+
+DELETE FROM `waypoint_data` WHERE `id` IN (139910, 139920);
+DELETE FROM `creature_addon` WHERE (`guid` IN (13991, 13992));
+
+DELETE FROM `creature` WHERE (`id` = 3397) AND (`guid` IN (13991, 13992));
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(13991, 3397, 1, 0, 0, 1, 1, 9447, 1, -1168.06, -2040.54, 92.2584, 0.481264, 275, 0, 1, 235, 295, 0, 0, 0, 0, '', 0),
+(13992, 3397, 1, 0, 0, 1, 1, 9447, 1, -1168.91, -2043.24, 92.2584, 0.481511, 275, 0, 1, 235, 295, 0, 0, 0, 0, '', 0);
+
+DELETE FROM `creature_formations` WHERE `leaderGUID`=13990;
+INSERT INTO `creature_formations` (`leaderGUID`,`memberGUID`,`dist`,`angle`,`groupAI`,`point_1`,`point_2`) VALUES
+(13990,13990,0,0,515,0,0),
+(13990,13991,3,80,515,0,0),
+(13990,13992,3,280,515,0,0);


### PR DESCRIPTION
## Changes Proposed:
- deleted the waypoint path of the Hezrul's companions and used the creature_formations

## Issues Addressed:
-  Close https://github.com/chromiecraft/chromiecraft/issues/472
-  Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4398

## Tests Performed:
- tested in-game 

## How to Test the Changes:
.go cr 13991
try to attack Hezrul from a far distance and see if the bodyguards attack you

## Target Branch(es):
- [x] Master


<!-- NOTES: 
 - You do not need to squash your commits, on merge, we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy-to-read history).
 - If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba -->



<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
