### PR TITLE
fix(DB/Graveyard): add ghostZone for zone 1537

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1619891302194258700.sql
+++ b/data/sql/updates/pending_db_world/rev_1619891302194258700.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1619891302194258700');
+DELETE FROM `graveyard_zone` WHERE `ID`=852 AND `GhostZone`=1537;
+INSERT INTO `graveyard_zone` (`ID`, `GhostZone`, `Faction`, `Comment`) VALUES
+(852, 1537, 469, 'Ironforge');

--- a/data/sql/updates/pending_db_world/rev_1619891302194258700.sql
+++ b/data/sql/updates/pending_db_world/rev_1619891302194258700.sql
@@ -1,4 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1619891302194258700');
 DELETE FROM `graveyard_zone` WHERE `ID`=852 AND `GhostZone`=1537;
 INSERT INTO `graveyard_zone` (`ID`, `GhostZone`, `Faction`, `Comment`) VALUES
-(852, 1537, 469, 'Ironforge');
+(852, 1537, 469, 'Dun Morogh, Gates of Ironforge - Ironforge');

--- a/data/sql/updates/pending_db_world/rev_1619893844216235100.sql
+++ b/data/sql/updates/pending_db_world/rev_1619893844216235100.sql
@@ -1,2 +1,0 @@
-INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1619893844216235100');
-DELETE FROM `creature_loot_template` WHERE  `Entry`=3928 AND `Item`=5519;

--- a/data/sql/updates/pending_db_world/rev_1619893844216235100.sql
+++ b/data/sql/updates/pending_db_world/rev_1619893844216235100.sql
@@ -1,0 +1,2 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1619893844216235100');
+DELETE FROM `creature_loot_template` WHERE  `Entry`=3928 AND `Item`=5519;


### PR DESCRIPTION
## Changes Proposed:
-  Add graveyard for zone 1537 (ironforge)


## Issues Addressed:
- Closes [5579](https://github.com/azerothcore/azerothcore-wotlk/issues/5579)
- Issue wasn't just in lava, but all of Ironforge as well.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux/Mac/Windows? Describe any other tests performed -->
- Teleports player to correct graveyard in Ironforge.
![WoWScrnShot_050121_125757](https://user-images.githubusercontent.com/25990459/116790983-ffd8d880-aa7c-11eb-9070-65f9dcc65db3.jpg)
![WoWScrnShot_050121_125802](https://user-images.githubusercontent.com/25990459/116790984-01a29c00-aa7d-11eb-803c-a6d91ba18ad6.jpg)




## How to Test the Changes:
- .tele ironforge
- select yourself and .die
- release spirit

## Target Branch(es):
- [x] Master


<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
