### PR TITLE
fix(DB/gameobject_loot_template): Silver Piffeny Band should not be lootable from chests

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1620033619588576561.sql
+++ b/data/sql/updates/pending_db_world/rev_1620033619588576561.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1620033619588576561');
+
+DELETE FROM `gameobject_loot_template` WHERE `item`=7338; -- Mood Ring
+DELETE FROM `gameobject_loot_template` WHERE `item`=7339; -- Miniscule Diamond Ring
+DELETE FROM `gameobject_loot_template` WHERE `item`=7341; -- Cubic Zirconia Ring
+DELETE FROM `gameobject_loot_template` WHERE `item`=7342; -- Silver Piffeny Band
+


### PR DESCRIPTION
## Changes Proposed:
- Remove Silver Piffeny Band (7342) from chest (gameobject) loot
- Also remove Mood Ring (7338), Miniscule Diamond Ring (7339) and Cubic Zirconia Ring (7341)


## Issues Addressed:
- Closes #5607
- Closes https://github.com/chromiecraft/chromiecraft/issues/527


## SOURCE:
- https://wotlkdb.com/?item=7338#sold-by-npc
- https://wotlkdb.com/?item=7339#sold-by-npc
- https://wotlkdb.com/?item=7341#sold-by-npc
- https://wotlkdb.com/?item=7342#sold-by-npc
- https://wowpedia.fandom.com/wiki/Mood_Ring?oldid=2467657
- https://wowpedia.fandom.com/wiki/Miniscule_Diamond_Ring?oldid=2467448
- https://wowpedia.fandom.com/wiki/Cubic_Zirconia_Ring?oldid=2453741
- https://wowpedia.fandom.com/wiki/Silver_Piffeny_Band?oldid=2515822


## Tests Performed:
- SQL statement executed


## How to Test the Changes:
- Execute the SQL statements mentioned in  the bug report


## Known Issues and TODO List:


## Target Branch(es):
- [x] Master

 
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
