### PR TITLE
Fix(Core/Script): Molten Core: Garr

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1620389620746734790.sql
+++ b/data/sql/updates/pending_db_world/rev_1620389620746734790.sql
@@ -5,3 +5,9 @@ DELETE FROM `creature_text` WHERE `CreatureID`=12057 AND `GroupID`=0 AND `ID`=0;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
 (12057, 0, 0, '%s forces one of his Firesworn minions to erupt!', 41, 0, 100, 0, 0, 0, 8254, 0, 'Garr EMOTE_MASS_ERRUPTION');
 
+-- Garr
+-- Firesworn
+-- add them immolate and thrash auras 
+UPDATE `creature_template_addon` SET `auras`='8876 15733' WHERE `entry`=12099;
+
+

--- a/data/sql/updates/pending_db_world/rev_1620389620746734790.sql
+++ b/data/sql/updates/pending_db_world/rev_1620389620746734790.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1620389620746734790');
+
+-- Garr texts
+DELETE FROM `creature_text` WHERE `CreatureID`=12057 AND `GroupID`=0 AND `ID`=0;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(12057, 0, 0, '%s forces one of his Firesworn minions to erupt!', 41, 0, 100, 0, 0, 0, 8254, 0, 'Garr EMOTE_MASS_ERRUPTION');
+

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_garr.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_garr.cpp
@@ -71,7 +71,7 @@ public:
             me->GetCreatureListWithEntryInGrid(fireworns, NPC_FIRESWORN, 240.0f);
             if (!fireworns.empty())
             {
-                for (Creature* fireworn : fireworns)
+                for (auto fireworn : fireworns)
                 {
                     if (fireworn && fireworn->isDead())
                     {

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_garr.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_garr.cpp
@@ -179,7 +179,7 @@ public:
     {
         npc_fireswornAI(Creature* creature) : ScriptedAI(creature),
                                               instance(creature->GetInstanceScript()),
-                                              aniexityTimer(10000),
+                                              anxietyTimer(10000),
                                               canErrupt(true)
         {
         }
@@ -221,7 +221,7 @@ public:
                 return;
             }
 
-            if (aniexityTimer <= diff)
+            if (anxietyTimer <= diff)
             {
                 if (!me->HasAura(SPELL_SEPARATION_ANXIETY))
                 {
@@ -234,18 +234,18 @@ public:
                     }
                 }
 
-                aniexityTimer = 250;
+                anxietyTimer = 250;
             }
             else
             {
-                aniexityTimer -= diff;
+                anxietyTimer -= diff;
             }
 
             DoMeleeAttackIfReady();
         }
     private:
         InstanceScript const* instance;
-        uint32 aniexityTimer;
+        uint32 anxietyTimer;
         bool canErrupt;
     };
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_garr.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_garr.cpp
@@ -11,76 +11,157 @@ SDComment: Adds NYI
 SDCategory: Molten Core
 EndScriptData */
 
+#include "Containers.h"
 #include "molten_core.h"
-#include "ObjectMgr.h"
+#include "ObjectAccessor.h"
 #include "ScriptedCreature.h"
 #include "ScriptMgr.h"
+#include "SpellInfo.h"
+
+enum Texts
+{
+    EMOTE_MASS_ERRUPTION        = 0,
+};
 
 enum Spells
 {
     // Garr
-    SPELL_ANTIMAGIC_PULSE   = 19492,
-    SPELL_MAGMA_SHACKLES    = 19496,
-    SPELL_ENRAGE            = 19516,
+    SPELL_ANTIMAGIC_PULSE       = 19492,
+    SPELL_MAGMA_SHACKLES        = 19496,
+    SPELL_ENRAGE                = 19516,
 
-    // Adds
-    SPELL_ERUPTION          = 19497,
-    SPELL_IMMOLATE          = 20294,
+    // Fireworn
+    SPELL_THRASH                = 8876,
+    SPELL_IMMOLATE              = 15733,
+    SPELL_SEPARATION_ANXIETY    = 23492,
+    SPELL_ERUPTION              = 19497,
+    SPELL_MASSIVE_ERUPTION      = 20483,
+    SPELL_ERUPTION_TRIGGER      = 20482,    // Removes banish auras and applied immunity to banish
 };
 
 enum Events
 {
     EVENT_ANTIMAGIC_PULSE    = 1,
-    EVENT_MAGMA_SHACKLES     = 2,
+    EVENT_MAGMA_SHACKLES,
+};
+
+enum Creatures
+{
+    NPC_FIRESWORN            = 12099,
 };
 
 class boss_garr : public CreatureScript
 {
 public:
-    boss_garr() : CreatureScript("boss_garr") { }
+    boss_garr() : CreatureScript("boss_garr")
+    {
+    }
 
     struct boss_garrAI : public BossAI
     {
-        boss_garrAI(Creature* creature) : BossAI(creature, BOSS_GARR)
+        boss_garrAI(Creature* creature) : BossAI(creature, BOSS_GARR),
+                                          massEruptionTimer(600000)
         {
         }
 
-        void EnterCombat(Unit* victim) override
+        void Reset() override
         {
-            BossAI::EnterCombat(victim);
+            _Reset();
+            massEruptionTimer = 600000;
+
+            std::list<Creature*> fireworns;
+            me->GetCreatureListWithEntryInGrid(fireworns, NPC_FIRESWORN, 240.0f);
+            if (!fireworns.empty())
+            {
+                for (Creature* fireworn : fireworns)
+                {
+                    if (fireworn && fireworn->isDead())
+                    {
+                        fireworn->Respawn(true);
+                    }
+                }
+            }
+        }
+
+        void JustDied(Unit* /*killer*/) override
+        {
+            _JustDied();
+            std::list<Creature*> fireworns;
+            me->GetCreatureListWithEntryInGrid(fireworns, NPC_FIRESWORN, 240.0f);
+            if (!fireworns.empty())
+            {
+                for (Creature* fireworn : fireworns)
+                {
+                    if (fireworn)
+                    {
+                        fireworn->DespawnOrUnsummon();
+                    }
+                }
+            }
+        }
+
+        void EnterCombat(Unit* /*attacker*/) override
+        {
+            _EnterCombat();
             events.ScheduleEvent(EVENT_ANTIMAGIC_PULSE, 15000);
             events.ScheduleEvent(EVENT_MAGMA_SHACKLES, 10000);
+            massEruptionTimer = 600000;
         }
 
         void UpdateAI(uint32 diff) override
         {
             if (!UpdateVictim())
+            {
                 return;
+            }
+
+            if (massEruptionTimer <= diff)
+            {
+                Talk(EMOTE_MASS_ERRUPTION, me);
+                DoCastAOE(SPELL_ERUPTION_TRIGGER, true);
+                massEruptionTimer = 20000;
+            }
+            else
+            {
+                massEruptionTimer -= diff;
+            }
 
             events.Update(diff);
 
             if (me->HasUnitState(UNIT_STATE_CASTING))
+            {
                 return;
+            }
 
-            while (uint32 eventId = events.ExecuteEvent())
+            while (uint32 const eventId = events.ExecuteEvent())
             {
                 switch (eventId)
                 {
                     case EVENT_ANTIMAGIC_PULSE:
-                        DoCast(me, SPELL_ANTIMAGIC_PULSE);
-                        events.ScheduleEvent(EVENT_ANTIMAGIC_PULSE, 20000);
+                    {
+                        DoCastSelf(SPELL_ANTIMAGIC_PULSE);
+                        events.RepeatEvent(20000);
                         break;
+                    }
                     case EVENT_MAGMA_SHACKLES:
-                        DoCast(me, SPELL_MAGMA_SHACKLES);
-                        events.ScheduleEvent(EVENT_MAGMA_SHACKLES, 15000);
+                    {
+                        DoCastSelf(SPELL_MAGMA_SHACKLES);
+                        events.RepeatEvent(15000);
                         break;
-                    default:
-                        break;
+                    }
+                }
+
+                if (me->HasUnitState(UNIT_STATE_CASTING))
+                {
+                    return;
                 }
             }
 
             DoMeleeAttackIfReady();
         }
+
+    private:
+        uint32 massEruptionTimer;
     };
 
     CreatureAI* GetAI(Creature* creature) const override
@@ -92,47 +173,84 @@ public:
 class npc_firesworn : public CreatureScript
 {
 public:
-    npc_firesworn() : CreatureScript("npc_firesworn") { }
+    npc_firesworn() : CreatureScript("npc_firesworn")
+    {
+    }
 
     struct npc_fireswornAI : public ScriptedAI
     {
-        npc_fireswornAI(Creature* creature) : ScriptedAI(creature) { }
-
-        uint32 immolateTimer;
-
-        void Reset() override
+        npc_fireswornAI(Creature* creature) : ScriptedAI(creature),
+                                              instance(creature->GetInstanceScript()),
+                                              aniexityTimer(10000),
+                                              canErrupt(true)
         {
-            immolateTimer = 4000;                              //These times are probably wrong
         }
 
-        void DamageTaken(Unit*, uint32& damage, DamageEffectType, SpellSchoolMask) override
+        void EnterCombat(Unit* /*attacker*/) override
         {
-            uint32 const health10pct = me->CountPctFromMaxHealth(10);
-            uint32 health = me->GetHealth();
-            if (int32(health) - int32(damage) < int32(health10pct))
+            DoCastSelf(SPELL_THRASH);
+            DoCastSelf(SPELL_IMMOLATE);
+        }
+
+        void DamageTaken(Unit* attacker, uint32& damage, DamageEffectType /*dmgType*/, SpellSchoolMask /*school*/) override
+        {
+            if (canErrupt && damage >= me->GetHealth() && attacker->GetGUID() != me->GetGUID())
             {
-                damage = 0;
-                DoCastVictim(SPELL_ERUPTION);
-                me->DespawnOrUnsummon();
+                DoCastAOE(SPELL_ERUPTION, true);
+                Unit::Kill(attacker, me);
+            }
+        }
+
+        void JustDied(Unit* /*killer*/) override
+        {
+            if (Creature* garr = ObjectAccessor::GetCreature(*me, instance->GetGuidData(BOSS_GARR)))
+            {
+                garr->CastSpell(garr, SPELL_ENRAGE, true);
+            }
+        }
+
+        void SpellHit(Unit* /*caster*/, SpellInfo const* pSpell) override
+        {
+            if (pSpell->Id == SPELL_ERUPTION_TRIGGER)
+            {
+                canErrupt = false;
+                DoCastAOE(SPELL_MASSIVE_ERUPTION);
             }
         }
 
         void UpdateAI(uint32 diff) override
         {
             if (!UpdateVictim())
-                return;
-
-            if (immolateTimer <= diff)
             {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
-                    DoCast(target, SPELL_IMMOLATE);
-                immolateTimer = urand(5000, 10000);
+                return;
+            }
+
+            if (aniexityTimer <= diff)
+            {
+                if (!me->HasAura(SPELL_SEPARATION_ANXIETY))
+                {
+                    if (Creature const* garr = ObjectAccessor::GetCreature(*me, instance->GetGuidData(BOSS_GARR)))
+                    {
+                        if (me->GetDistance2d(garr) > 45.0f)
+                        {
+                            DoCastSelf(SPELL_SEPARATION_ANXIETY);
+                        }
+                    }
+                }
+
+                aniexityTimer = 250;
             }
             else
-                immolateTimer -= diff;
+            {
+                aniexityTimer -= diff;
+            }
 
             DoMeleeAttackIfReady();
         }
+    private:
+        InstanceScript const* instance;
+        uint32 aniexityTimer;
+        bool canErrupt;
     };
 
     CreatureAI* GetAI(Creature* creature) const override

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_garr.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_garr.cpp
@@ -31,8 +31,6 @@ enum Spells
     SPELL_ENRAGE                = 19516,
 
     // Fireworn
-    SPELL_THRASH                = 8876,
-    SPELL_IMMOLATE              = 15733,
     SPELL_SEPARATION_ANXIETY    = 23492,
     SPELL_ERUPTION              = 19497,
     SPELL_MASSIVE_ERUPTION      = 20483,
@@ -188,8 +186,6 @@ public:
 
         void EnterCombat(Unit* /*attacker*/) override
         {
-            DoCastSelf(SPELL_THRASH);
-            DoCastSelf(SPELL_IMMOLATE);
         }
 
         void DamageTaken(Unit* attacker, uint32& damage, DamageEffectType /*dmgType*/, SpellSchoolMask /*school*/) override

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/molten_core.h
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/molten_core.h
@@ -37,7 +37,7 @@ enum Actions
 Position const RagnarosTelePos   = {829.159f, -815.773f, -228.972f, 5.30500f};
 Position const RagnarosSummonPos = {838.510f, -829.840f, -232.000f, 2.00000f};
 
-enum Creatures
+enum MCCreatures
 {
     NPC_LUCIFRON                    = 12118,
     NPC_MAGMADAR                    = 11982,


### PR DESCRIPTION
Co-Author: @sanctum32 (Code)
Co-Author: @T1ti (Research)
Co-Author: @Hacki95 (Coordination)

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Correct Garr's timers
- Add the missing mechanics to Garrs adds

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5803 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Applied patch
- Fought Garr


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Apply patch
2. .tele moltencore
3. Fight Garr

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- Seperation anxiety
- Move some spells to DB

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
