### PR TITLE
fix(DB/creature_formations): Adjust Boss Tho'grun's group

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1620425644910599900.sql
+++ b/data/sql/updates/pending_db_world/rev_1620425644910599900.sql
@@ -1,0 +1,16 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1620425644910599900');
+
+-- Delete WP path info for minions
+DELETE FROM `creature_addon` WHERE `guid` IN (6973, 6975, 6974 ,6989 ,7210);
+
+-- Create group
+SET @leader:=7209;
+DELETE FROM `creature_formations` WHERE `leaderGUID`=@leader;
+INSERT INTO `creature_formations` (`leaderGUID`, `memberGUID`, `dist`, `angle`, `groupAI`, `point_1`, `point_2`) VALUES 
+(@leader, @leader, 5, 0, 2, 0, 0), -- core
+(@leader, 6973, 8, 90, 2, 0, 0),
+(@leader, 6975, 14, 140, 2, 0, 0),
+(@leader, 6974, 16, 210, 2, 0, 0),
+(@leader, 6989, 12, 260, 2, 0, 0),
+(@leader, 7210, 10, 320, 2, 0, 0);
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Delete path info for minions (only boss need to have one)
- Create formation group using Tho'grun as core leader

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5698
- Closes https://github.com/chromiecraft/chromiecraft/issues/564 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.youtube.com/watch?v=efOrXMZriLU

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested

![image](https://user-images.githubusercontent.com/61223313/117514655-a0356e00-af51-11eb-8bd3-7f0c5a5260b0.png)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
