### PR TITLE
fix(DB/creature_loot_template): Revelosh items drop

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1620435208642994700.sql
+++ b/data/sql/updates/pending_db_world/rev_1620435208642994700.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1620435208642994700');
+
+-- es.classic.wowhead.com/npc=6910/revelosh
+UPDATE `creature_loot_template` SET `Chance`=41 WHERE `Entry`=6910 AND `Item`=7741;
+UPDATE `creature_loot_template` SET `Chance`=23 WHERE `Entry`=6910 AND `Item` IN (9387,9389);
+UPDATE `creature_loot_template` SET `Chance`=21 WHERE `Entry`=6910 AND `Item` IN (9390,9388);
+UPDATE `creature_loot_template` SET `Chance`=13 WHERE `Entry`=6910 AND `Item`=4306;
+UPDATE `creature_loot_template` SET `Chance`=2 WHERE `Entry`=6910 AND `Item`=3771;
+


### PR DESCRIPTION
### Changes proposed:
- Adjust Ravelosh's loot with the classic loot table

### Source:
- https://classic.wowhead.com/npc=6910/revelosh

### Test performed:
- Tested in-game

### Issues addressed:
- Closes #5707
- Closes https://github.com/chromiecraft/chromiecraft/issues/559