### PR TITLE
fix(DB/creature_addon): Remove path info from Blackwater Deckhand

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1620616751102617000.sql
+++ b/data/sql/updates/pending_db_world/rev_1620616751102617000.sql
@@ -2,7 +2,6 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1620616751102617000');
 
 -- Remove path
 UPDATE `creature_addon` SET `path_id`=0 WHERE `guid`=11198;
-
 -- Make npc walk around
 UPDATE `creature` SET `MovementType`=1 WHERE `guid`=11198;
 

--- a/data/sql/updates/pending_db_world/rev_1620616751102617000.sql
+++ b/data/sql/updates/pending_db_world/rev_1620616751102617000.sql
@@ -1,4 +1,8 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1620616751102617000');
 
+-- Remove path
 UPDATE `creature_addon` SET `path_id`=0 WHERE `guid`=11198;
+
+-- Make npc walk around
+UPDATE `creature` SET `MovementType`=1 WHERE `guid`=11198;
 

--- a/data/sql/updates/pending_db_world/rev_1620616751102617000.sql
+++ b/data/sql/updates/pending_db_world/rev_1620616751102617000.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1620616751102617000');
+
+UPDATE `creature_addon` SET `path_id`=0 WHERE `guid`=11198;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
The path 111980 is from an NPC in a camp in Swamp of Sorrows but is currently unknown who is the owner.

This path is no active in TC 3.3.5a branch and it was removed in Cataclysm
https://github.com/TrinityCore/TrinityCore/blob/f759809d9d4364bc1d988e4390d3d5a33d5469e9/sql/old/4.3.4/TDB5_to_TDB6_updates/world/130_reguiding.sql#L1

## Changes Proposed:
-  Remove path info from Blackwater Deckhand

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5757


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
