### PR TITLE
feat(bash): Improved support for gperftools

### DIFF
--- a/apps/docker/Dockerfile
+++ b/apps/docker/Dockerfile
@@ -28,7 +28,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # since it's not cacheable by docker
 RUN apt-get update && apt-get install -y gdb gdbserver git dos2unix lsb-core sudo curl unzip \
   make cmake clang libmysqlclient-dev libace-dev \
-  build-essential libtool cmake-data openssl libgoogle-perftools-dev \
+  build-essential libtool cmake-data openssl libgoogle-perftools-dev google-perftools \
   libssl-dev libmysql++-dev libreadline6-dev zlib1g-dev libbz2-dev mysql-client \
   libncurses5-dev ccache \
   && rm -rf /var/lib/apt/lists/*
@@ -106,7 +106,8 @@ RUN addgroup --gid $GROUP_ID acore && \
     echo 'acore ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers
 
 # install the required dependencies to run the server
-RUN apt-get update && apt-get install -y dos2unix gdb gdbserver net-tools tzdata libmysqlclient-dev libace-dev mysql-client curl unzip && rm -rf /var/lib/apt/lists/* ;
+RUN apt-get update && apt-get install -y dos2unix gdb gdbserver google-perftools libgoogle-perftools-dev net-tools \
+    tzdata libmysqlclient-dev libace-dev mysql-client curl unzip && rm -rf /var/lib/apt/lists/* ;
 
 # change timezone in container
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata

--- a/apps/docker/docker-cmd.ts
+++ b/apps/docker/docker-cmd.ts
@@ -108,7 +108,10 @@ shellCommandFactory(
 shellCommandFactory(
   "dev:shell [args...]",
   "Open an interactive shell within the dev server",
-  ["docker-compose run --rm ac-dev-server bash"],
+  [
+    "docker-compose up -d ac-dev-server",
+    "docker-compose exec ac-dev-server bash",
+  ],
   env,
 );
 

--- a/apps/installer/includes/os_configs/ubuntu.sh
+++ b/apps/installer/includes/os_configs/ubuntu.sh
@@ -8,7 +8,7 @@ UBUNTU_VERSION=$(lsb_release -sr);
 sudo apt-get update -y
 
 # shared deps
-sudo apt-get -y install make cmake clang curl unzip libmysqlclient-dev libace-dev ccache
+sudo apt-get -y install make cmake clang curl unzip libmysqlclient-dev libace-dev ccache google-perftools
 
 if [[ $CONTINUOUS_INTEGRATION || $DOCKER ]]; then
   sudo apt-get -y install build-essential libtool cmake-data openssl libgoogle-perftools-dev \

--- a/bin/acore-restarter
+++ b/bin/acore-restarter
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-CUR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-source "$CUR_PATH/../apps/startup-scripts/simple-restarter"

--- a/conf/dist/config.sh
+++ b/conf/dist/config.sh
@@ -105,7 +105,7 @@ export CCACHE_DIR=${CCACHE_DIR:-"$AC_PATH_VAR/ccache"}
 #  3. run the worldserver with the "./acore.sh run-worldserver"
 #  4. run "killall -12 worldserver"  This command will start the monitoring process. Run "killall -12 worldserver" again to stop the process when you want
 #  5. At this time you will have the .prof file ready in the folder configured below.
-#  Run "pprof --callgrind <path/of/worldserver/bin> /path/of/prof/file" This will generate a callgrind file that can be read with
+#  Run "google-pprof --callgrind <path/of/worldserver/bin> </path/of/prof/file>" This will generate a callgrind file that can be read with
 #  QCacheGrind, KCacheGrind and any other compatible tools
 #
 ##############################################

--- a/conf/dist/config.sh
+++ b/conf/dist/config.sh
@@ -88,6 +88,47 @@ CCUSTOMOPTIONS=${CCUSTOMOPTIONS:-''}
 AC_CCACHE=${AC_CCACHE:-false}
 export CCACHE_DIR=${CCACHE_DIR:-"$AC_PATH_VAR/ccache"}
 
+##############################################
+#
+#  GOOGLE PERF TOOLS
+#
+#  Repository: https://github.com/gperftools/gperftools#readme
+#  Documentation: https://gperftools.github.io/gperftools/
+#
+# Install (Ubuntu):
+#  sudo apt-get install google-perftools libgoogle-perftools-dev
+# Note: dependencies above are already installed in docker
+#
+# Usage:
+#  1. To enable the gperftools you need to compile with the -DWITH_PERFTOOLS=ON compiler flag. You can use CCUSTOMOPTIONS above to set it for the dashboard compiler
+#  2. Configure the variable below accordingly to your needs
+#  3. run the worldserver with the "./acore run-worldserver"
+#  4. run "killall -12 worldserver"  This command will start the monitoring process. Run "killall -12 worldserver" again to stop the process when you want
+#  5. At this time you will have the .prof file ready in the folder configured below.
+#  Run "pprof --callgrind <path/of/worldserver/bin> /path/of/prof/file" This will generate a callgrind file that can be read with
+#  QCacheGrind, KCacheGrind and any other compatible tools
+#
+##############################################
+
+# files used by gperftools to store monitored information
+export CPUPROFILE=${CPUPROFILE:-"$BINPATH/logs/worldserver-cpu.prof"}
+# heap profile is disabled by default. Uncomment this line to enable it
+# export HEAPPROFILE=${HEAPPROFILE:-"$BINPATH/logs/worldserver-heap.prof"}
+
+# signal to send to the kill command to start/stop the profiling process. kill -12
+export CPUPROFILESIGNAL=${CPUPROFILESIGNAL:-12}
+
+# How many interrupts/second the cpu-profiler samples.
+#export CPUPROFILE_FREQUENCY=${CPUPROFILESIGNAL:-100}
+
+# If set to any value (including 0 or the empty string), use ITIMER_REAL instead of ITIMER_PROF to gather profiles.
+# In general, ITIMER_REAL is not as accurate as ITIMER_PROF, and also interacts badly with use of alarm(),
+# so prefer ITIMER_PROF unless you have a reason prefer ITIMER_REAL.
+#export CPUPROFILE_REALTIME=${CPUPROFILE_REALTIME}
+
+# Other values for HEAPCHECK: minimal, normal (equivalent to "1"), strict, draconian
+#export HEAPCHECK=${HEAPCHECK:-normal}
+
 
 ##############################################
 #

--- a/conf/dist/config.sh
+++ b/conf/dist/config.sh
@@ -102,7 +102,7 @@ export CCACHE_DIR=${CCACHE_DIR:-"$AC_PATH_VAR/ccache"}
 # Usage:
 #  1. To enable the gperftools you need to compile with the -DWITH_PERFTOOLS=ON compiler flag. You can use CCUSTOMOPTIONS above to set it for the dashboard compiler
 #  2. Configure the variable below accordingly to your needs
-#  3. run the worldserver with the "./acore run-worldserver"
+#  3. run the worldserver with the "./acore.sh run-worldserver"
 #  4. run "killall -12 worldserver"  This command will start the monitoring process. Run "killall -12 worldserver" again to stop the process when you want
 #  5. At this time you will have the .prof file ready in the folder configured below.
 #  Run "pprof --callgrind <path/of/worldserver/bin> /path/of/prof/file" This will generate a callgrind file that can be read with


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

Added more support to the gperftools (integrated in AzerothCore since 2016)

This is a powerful tool from google that allows you to get monitoring information to profile the CPU and the memory
Also useful to spot memory leaks

Screenshot with AzerothCore:
![image](https://user-images.githubusercontent.com/147092/117697104-615a1f00-b1c2-11eb-8599-f5893a04de0c.png)


Video demo:

Soon available

## How to test:

 GOOGLE PERF TOOLS

  Repository: https://github.com/gperftools/gperftools#readme
  Documentation: https://gperftools.github.io/gperftools/

 Install (Ubuntu):
  sudo apt-get install google-perftools libgoogle-perftools-dev
 Note: dependencies above are already installed in docker

 Usage:
  1. To enable the gperftools you need to compile with the -DWITH_PERFTOOLS=ON compiler flag. You can use CUSTOMOPTIONS above to set it for the dashboard compiler
  2. Configure the variable below accordingly to your needs
  3. run the worldserver with the "./acore.sh run-worldserver"
  4. run "killall -12 worldserver"  This command will start the monitoring process. Run "killall -12 worldserver" again to stop the process when you want
  5. At this time you will have the .prof file ready in the folder configured below.
  Run "google-pprof--callgrind <path/of/worldserver/bin> </path/of/prof/file>" This will generate a callgrind file that can be read with
  QCacheGrind, KCacheGrind or any other compatible tools