### PR TITLE
fix(CORE/Loot): make Loot::AddItem() honor LootItem::AllowedForPlayer()

### DIFF
--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -500,6 +500,7 @@ void Loot::AddItem(LootStoreItem const& item)
 
         if (!canSeeItemInLootWindow)
         {
+            LOG_DEBUG("loot", "Skipping ++unlootedCount for unlootable item: %u", item.itemid);
             continue;
         }
 

--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -474,6 +474,35 @@ void Loot::AddItem(LootStoreItem const& item)
         lootItems.push_back(generatedLoot);
         count -= proto->GetMaxStackSize();
 
+        // In some cases, a dropped item should be visible/lootable only for some players in group
+        bool canSeeItemInLootWindow = false;
+        if (auto player = ObjectAccessor::FindPlayer(lootOwnerGUID))
+        {
+            if (auto group = player->GetGroup())
+            {
+                for (auto itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+                {
+                    if (auto member = itr->GetSource())
+                    {
+                        if (generatedLoot.AllowedForPlayer(member))
+                        {
+                            canSeeItemInLootWindow = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            else if (generatedLoot.AllowedForPlayer(player))
+            {
+                canSeeItemInLootWindow = true;
+            }
+        }
+
+        if (!canSeeItemInLootWindow)
+        {
+            continue;
+        }
+
         // non-conditional one-player only items are counted here,
         // free for all items are counted in FillFFALoot(),
         // non-ffa conditionals are counted in FillNonQuestNonFFAConditionalLoot()
@@ -488,6 +517,8 @@ bool Loot::FillLoot(uint32 lootId, LootStore const& store, Player* lootOwner, bo
     // Must be provided
     if (!lootOwner)
         return false;
+
+    lootOwnerGUID = lootOwner->GetGUID();
 
     LootTemplate const* tab = store.GetLootFor(lootId);
 

--- a/src/server/game/Loot/LootMgr.h
+++ b/src/server/game/Loot/LootMgr.h
@@ -309,6 +309,7 @@ struct Loot
     uint32 gold;
     uint8 unlootedCount{0};
     ObjectGuid roundRobinPlayer;        // GUID of the player having the Round-Robin ownership for the loot. If 0, round robin owner has released.
+    ObjectGuid lootOwnerGUID;
     LootType loot_type{LOOT_NONE};      // required for achievement system
 
     // GUID of container that holds this loot (item_instance.entry), set for items that can be looted


### PR DESCRIPTION
Patch ported from TC
Original Author:  @Wyrserth 

## Changes Proposed:
(copied from TC PR)
> Currently Loot::AddItem() will increase unlootedCount without checking LootItem::AllowedForPlayer's result first. This means that items that cannot be looted by any player can be added to the loot. Because nobody can loot them, they're never removed and the creature will show an empty loot window and can't be skinned as a result.

> However, in some cases the dropped item is not visible by some players (because they're not allowed to loot it) but should start a roll if any other player in party/raid can loot it. This case is also fixed in this PR. 

This appllies 100% to our issue with Fishing Trunks staying in the inventory when it contains an invisible **Weather-Beaten Journal**.

## Issues Addressed:
- Closes #5372
- Closes https://github.com/chromiecraft/chromiecraft/issues/444

## SOURCE:
- **TC PR:** [Core/Loot: make Loot::AddItem() honor LootItem::AllowedForPlayer()](https://github.com/TrinityCore/TrinityCore/pull/23408)
- **TC Commit:** [Core/Loot: make Loot::AddItem() honor LootItem::AllowedForPlayer() so that items that cannot be looted don't prevent skinning.](https://github.com/TrinityCore/TrinityCore/commit/a1b2aa97fcb64be82050af037cec955ce361ccad#diff-a736cdc931cfd00b9cc8e640f94c74cfbcfecfee0c8d7b986a624749a0129bdc)
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
- Build successfull
- Tested in game


## How to Test the Changes:
- `.setskill 356 100 150` (Learn Fishing 100)
- `.learn 43308` (Learn to Find Fish)
- `.additem 20708 10`
- `.additem 21113 10`
- `.additem 21150 10`
- `.additem 21128 10`
- Loot and observe that the trunks can now always be fully looted and are removed from the inventory. The **Weather-Beaten Journal** is still suppressed from being shown in the loot (player is not allowed to see a BoP recipe he already knows), but this no longer prevents the trunk from becoming **empty** (`unlootedCount == 0`).

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
