### PR TITLE
fix(DB/Quest) Smolderwing from TrinityCore

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1620835284341181100.sql
+++ b/data/sql/updates/pending_db_world/rev_1620835284341181100.sql
@@ -1,0 +1,31 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1620835284341181100');
+
+UPDATE `creature_template` SET `AIName`="SmartAI" WHERE `entry`=23789;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=23789 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(23789,0,0,0,63,0,100,0,0,0,0,0,80,23789*100+00,2,0,0,0,0,1,0,0,0,0,0,0,0,"Smolderwing - On Just Created - Run Script"),
+(23789,0,1,0,34,0,100,0,0,1,0,0,80,23789*100+01,2,0,0,0,0,1,0,0,0,0,0,0,0,"Smolderwing - On Reached Point 1 - Run Script");
+
+
+DELETE FROM `smart_scripts` WHERE `entryorguid`=2378900 AND `source_type`=9;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(2378900,9,0,0,0,0,100,0,0,0,0,0,18,770,0,0,0,0,0,1,0,0,0,0,0,0,0,"On Script - Set Flags Not Attackable & Immune To Players & Immune To NPC's"),
+(2378900,9,1,0,0,0,100,0,2000,2000,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,0,"On Script - Say Line 0"),
+(2378900,9,2,0,0,0,100,0,5000,5000,0,0,1,1,0,0,0,0,0,1,0,0,0,0,0,0,0,"On Script - Say Line 1"),
+(2378900,9,3,0,0,0,100,0,3000,3000,0,0,69,1,0,0,0,0,0,20,186335,100,0,0,0,0,0,"On Script - Move To Closest Gameobject 'Stonemaul Banner'");
+
+
+DELETE FROM `smart_scripts` WHERE `entryorguid`=2378901 AND `source_type`=9;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(2378901,9,0,0,0,0,100,0,0,0,0,0,11,42433,0,0,0,0,0,1,0,0,0,0,0,0,0,"On Script - Cast 'Smolderwing Fire Breath'"),
+(2378901,9,1,0,0,0,100,0,3000,3000,0,0,19,770,0,0,0,0,0,1,0,0,0,0,0,0,0,"On Script - Remove Flags Not Attackable & Immune To Players & Immune To NPC's"),
+(2378901,9,2,0,0,0,100,0,0,0,0,0,49,0,0,0,0,0,0,21,20,0,0,0,0,0,0,"On Script - Start Attacking");
+
+DELETE FROM `creature_text` WHERE `creatureid`=23789;
+INSERT INTO `creature_text` (`creatureid`, `groupid`, `id`, `text`, `type`, `language`, `probability`, `emote`, `duration`, `sound`, `BroadcastTextId`, `comment`) VALUES 
+(23789, 0, 0, 'Pitiful mortal, Onyxia answers to no one!', 14, 0, 100, 0, 0, 0, 22285, 'Smolderwing'),
+(23789, 1, 0, 'Your pathetic challenge has not gone unnoticed. I shall enjoy toying with you before you die.', 14, 0, 100, 0, 0, 0, 22286, 'Smolderwing');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=17 AND `SourceGroup`=0 AND `SourceEntry`=42425;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`SourceId`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionTarget`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`NegativeCondition`,`ErrorType`,`ErrorTextId`,`ScriptName`,`Comment`) VALUES
+(17,0,42425,0,0,29,0,23789,200,0,1,0,0,"","Cannot cast Plant Stonemaul Banner if Smolderwing is in range");


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  He should now yell when banner is placed


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5808

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Original fix -> https://github.com/TrinityCore/TrinityCore/issues/18444
Thanks to @Rushor !
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
On windows 10 local server


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .quest add 11162
2. .additem [stonemaul banner]
3. .go c 31463 takes you to a mob right outside the Onyxia Lair entrance
4. Plant the banner in front and see Smolderwing spawn

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
I don't know about the flying over that the bug report mentions seperately. That might need me to take a 2nd look at it.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
