### PR TITLE
Fix(Core) Remove hard-coded texts from npc Innkeeper

### DIFF
--- a/src/server/scripts/World/npc_innkeeper.cpp
+++ b/src/server/scripts/World/npc_innkeeper.cpp
@@ -12,7 +12,8 @@ enum eTrickOrTreatSpells
     SPELL_TREAT                 = 24715,
     SPELL_TRICKED_OR_TREATED    = 24755,
     HALLOWEEN_EVENTID           = 12,
-    GOSSIP_MENU                 = 9733
+    GOSSIP_MENU                 = 9733,
+    GOSSIP_MENU_EVENT           = 342
 };
 
 class npc_innkeeper : public CreatureScript
@@ -24,7 +25,7 @@ public:
     {
         if (IsEventActive(HALLOWEEN_EVENTID) && !player->HasAura(SPELL_TRICKED_OR_TREATED))
         {
-            AddGossipItemFor(player, 342, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + HALLOWEEN_EVENTID);
+            AddGossipItemFor(player, GOSSIP_MENU_EVENT, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + HALLOWEEN_EVENTID);
         }
 
         if (creature->IsQuestGiver())

--- a/src/server/scripts/World/npc_innkeeper.cpp
+++ b/src/server/scripts/World/npc_innkeeper.cpp
@@ -12,6 +12,7 @@ enum eTrickOrTreatSpells
     SPELL_TREAT                 = 24715,
     SPELL_TRICKED_OR_TREATED    = 24755,
     HALLOWEEN_EVENTID           = 12,
+    GOSSIP_MENU                 = 9733
 };
 
 class npc_innkeeper : public CreatureScript
@@ -22,16 +23,24 @@ public:
     bool OnGossipHello(Player* player, Creature* creature) override
     {
         if (IsEventActive(HALLOWEEN_EVENTID) && !player->HasAura(SPELL_TRICKED_OR_TREATED))
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Trick or Treat!", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + HALLOWEEN_EVENTID);
+        {
+            AddGossipItemFor(player, 342, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + HALLOWEEN_EVENTID);
+        }
 
         if (creature->IsQuestGiver())
+        {
             player->PrepareQuestMenu(creature->GetGUID());
+        }
 
         if (creature->IsVendor())
-            AddGossipItemFor(player, GOSSIP_ICON_VENDOR, GOSSIP_TEXT_BROWSE_GOODS, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_TRADE);
+        {
+            AddGossipItemFor(player, GOSSIP_MENU, 2, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_TRADE);
+        }
 
         if (creature->IsInnkeeper())
-            AddGossipItemFor(player, GOSSIP_ICON_INTERACT_1, "Make this inn my home.", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INN);
+        {
+            AddGossipItemFor(player, GOSSIP_MENU, 1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INN);
+        }
 
         player->TalkedToCreature(creature->GetEntry(), creature->GetGUID());
         SendGossipMenuFor(player, player->GetGossipTextId(creature), creature->GetGUID());


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Use the texts in the database which are already translated.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- https://github.com/azerothcore/azerothcore-wotlk/issues/5809

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- After applying the script, the texts appeared in Spanish (since it is the game client I use) but it should be able to be translated in several languages.

![WoWScrnShot_051221_124555](https://user-images.githubusercontent.com/2810187/118010069-0c82e980-b325-11eb-849b-014257a88b65.jpg)

![WoWScrnShot_051221_145658](https://user-images.githubusercontent.com/2810187/118022167-6dfd8500-b332-11eb-9aaa-d7766d79136b.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- However, it can be tested without the event. It is preferable to activate it: `event start 12`
- If it is an alliance: `.go c 110585`
- If horde: `.go c 97714`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [x] The menu to be shown in the Halloween event is yet to be defined correctly, since there were many options to use and I don't know which one is the right one.
- [x] I am not sure if I should add a GOSSIP_MENU_OPTION or if it is not necessary. The menu, I assumed it had to be added, but the options, I don't know if they are necessary.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
