### PR TITLE
fix(DB/creature_loot_template): Remove the Scarlet Key from creature loot tables

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1620842884434937800.sql
+++ b/data/sql/updates/pending_db_world/rev_1620842884434937800.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1620842884434937800');
+
+DELETE FROM `creature_loot_template` WHERE `Item` = 7146;

--- a/data/sql/updates/pending_db_world/rev_1620842884434937800.sql
+++ b/data/sql/updates/pending_db_world/rev_1620842884434937800.sql
@@ -1,3 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1620842884434937800');
 
-DELETE FROM `creature_loot_template` WHERE `Item` = 7146;
+DELETE FROM `creature_loot_template` WHERE `Item` = 7146 AND `Entry` IN (4291,4299,4540);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove The Scarlet Key (ID 7146) from Scarlet Diviner, Scarlet Chaplain and Scarlet Monk loot tables (IDs 4291,4299,4540 respectively)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5806
- Closes https://github.com/chromiecraft/chromiecraft/issues/618

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
"You get the key from a chest after finishing the Library wing in SM." (https://classic.wowhead.com/item=7146/the-scarlet-key#comments:id=52)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game. Windows 10 - enGB client.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go c id 4299`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
