### PR TITLE
fix(CORE/UNIT) Fix criticals not working against sitting players.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1630,7 +1630,7 @@ public:
     void HandleEmoteCommand(uint32 anim_id);
     void AttackerStateUpdate (Unit* victim, WeaponAttackType attType = BASE_ATTACK, bool extra = false);
 
-    void CalculateMeleeDamage(Unit* victim, uint32 damage, CalcDamageInfo* damageInfo, WeaponAttackType attackType = BASE_ATTACK);
+    void CalculateMeleeDamage(Unit* victim, uint32 damage, CalcDamageInfo* damageInfo, WeaponAttackType attackType = BASE_ATTACK, const bool sittingVictim = false);
     void DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss);
     void HandleProcExtraAttackFor(Unit* victim);
 


### PR DESCRIPTION
**Description:**
The issue is that we set the enemy player into the stand state when we put them into combat.
As a result, when we check to see if they are in the sit state later, its always false.
So the only way you were getting a critical was with the base crit chance.

With this fix if an enemy player is sitting. And you swing at them you will always crit.
This also removes the chance to miss or dodge when sitting down, which I believe is blizzlike, and saves me from passing around a ton of parameters, or having to cache the state inside of the class.

https://github.com/azerothcore/azerothcore-wotlk/issues/5635

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Cache the sit state of the enemy player at the start of the attack state sequence.
- Pass the cached sit state into the CalculateMeleeDamage function later on.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 
- https://github.com/azerothcore/azerothcore-wotlk/issues/5635

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds without errors


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create 2 Accounts
2. Create 2 Nightelves 
3. Run outside starting zone
4. Duel eachother
5. Have 1 player sit 
6. Auto attack sitting player

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
An argument could be made about whether it should be possible to miss an attack on sitting player.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
