### PR TITLE
fix(DB/gameobject): Out of place Bruiseweed nodes

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1621155608885533484.sql
+++ b/data/sql/updates/pending_db_world/rev_1621155608885533484.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1621155608885533484');
+
+DELETE FROM `gameobject` WHERE `guid` IN (2944, 3069);


### PR DESCRIPTION
Bruiseweed nodes (id: 2944, 3069) are located inside buildings.
This is wrong. I chose to remove the nodes instead of relocating them
nearby, because the Bruiseweed density in this area already way higher
than on live classic.

17 Bruiseweeds in a 100 radius from a point midway between the two affected buildings:
![WoWScrnShot_051621_105123](https://user-images.githubusercontent.com/39011611/118392179-7dcddf80-b638-11eb-83cc-5ad701dff299.jpg)
(everything except Bruiseweeds are filtered out)

Only 11 Bruiseweeds in the vicinity according to wowhead classic:
![2021-05-16_11:17:14:7463](https://user-images.githubusercontent.com/39011611/118392145-45c69c80-b638-11eb-8cda-f8e937965b2d.png)

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove Bruiseweed nodes (id: 2944, 3069)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5884 
- Closes https://github.com/chromiecraft/chromiecraft/issues/589

## SOURCE:
https://classic.wowhead.com/object=1622/bruiseweed

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested on 8168f9a

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go o 2944` shouldn't work
2. `.go o 3069` shouldn't work

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
