### PR TITLE
fix(Scripts/Ulduar): Hodir boss fight issue

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -239,11 +239,11 @@ public:
                 pInstance->SetData(TYPE_HODIR, NOT_STARTED);
             }
 
-            if (GameObject* go = me->FindNearestGameObject(GO_HODIR_FRONTDOOR, 300.0f))
+            if (GameObject* go = me->FindNearestGameObject(GO_HODIR_FRONTDOOR, 900.0f))
             {
                 go->SetGoState(GO_STATE_ACTIVE);
             }
-
+            
             if (pInstance && pInstance->GetData(TYPE_HODIR) != DONE)
             {
                 pInstance->SetData(TYPE_SPAWN_HODIR_CACHE, 0);
@@ -252,6 +252,7 @@ public:
             // Reset helpers
             if (!summons.size())
                 SpawnHelpers();
+            
         }
 
         void EnterCombat(Unit*  /*pWho*/) override
@@ -375,8 +376,9 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
-            if (!IsInRoom(&ENTRANCE_DOOR, Axis::AXIS_Y, false) || !IsInRoom(&EXIT_DOOR, Axis::AXIS_Y, true))
+            if (me->GetPositionY() <= ENTRANCE_DOOR.GetPositionY() || me->GetPositionY() >= EXIT_DOOR.GetPositionY())
             {
+                boss_hodirAI::EnterEvadeMode();
                 return;
             }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -252,7 +252,6 @@ public:
             // Reset helpers
             if (!summons.size())
                 SpawnHelpers();
-            
         }
 
         void EnterCombat(Unit*  /*pWho*/) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -243,7 +243,7 @@ public:
             {
                 go->SetGoState(GO_STATE_ACTIVE);
             }
-            
+
             if (pInstance && pInstance->GetData(TYPE_HODIR) != DONE)
             {
                 pInstance->SetData(TYPE_SPAWN_HODIR_CACHE, 0);


### PR DESCRIPTION
-Prior to this change the Hodir encounter could not be started due to constant Reset(); spam -

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changed IsInRoom call to standard Y axis comparison.
-  Added EvadeMode when Hodir leaves the room.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5859

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested changes in-game.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Hodir.
2. Attack.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- No other issues on this ticket.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
