### PR TITLE
fix(DB): Adjust Blackhoof Cage behaviour

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1621246170226501700.sql
+++ b/data/sql/updates/pending_db_world/rev_1621246170226501700.sql
@@ -1,0 +1,11 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1621246170226501700');
+
+-- These cages shouldn't really despawn
+UPDATE `gameobject` SET `spawntimesecs` = 0 WHERE (`id` = 186287);
+
+-- Prevent players from using keys while there's no prisoner inside
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 18628700) AND (`source_type` = 9) AND (`id` IN (2,3,4));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+(18628700, 9, 2, 0, 0, 0, 100, 0, 300000, 300000, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Blackhoof Cage - Script - Reset Go'),
+(18628700, 9, 3, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 104, 48, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Blackhoof Cage - Script - Set Flag'),
+(18628700, 9, 4, 0, 0, 0, 100, 0, 64500, 64500, 0, 0, 0, 104, 32, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Blackhoof Cage - Script - Set Flag');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Prevent Blackhoof Cages (ID 186287)  from despawning
- Make the cages not selectable after they close, while there's no Theramore Prisoner alive inside (roughly 60 seconds)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5790
- Closes https://github.com/chromiecraft/chromiecraft/issues/602

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The cage should not despawn, but reset and wait for another prisoner spawn (or spawn same time/before the prisoner)

https://www.wowhead.com/quest=11145/deprecated-prisoners-of-the-grimtotems

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game. Windows 10 - enGB client.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go go 11719`
2. `.add [Grimtotem Key]`
3. Open one of the cages and observe

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
