### PR TITLE
fix(DB/loot): Fix Shiver Blade drop

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1621414710329639831.sql
+++ b/data/sql/updates/pending_db_world/rev_1621414710329639831.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1621414710329639831');
+
+SET @SHIVER_BLADE := 5182;
+SET @GESHARAHAN := 3398;
+
+DELETE FROM `reference_loot_template` where `Item` = @SHIVER_BLADE;
+
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(@GESHARAHAN, @SHIVER_BLADE, 0, 72.12, 0, 1, 0, 1, 1, "Gesharahan - Shiver Blade");

--- a/data/sql/updates/pending_db_world/rev_1621414710329639831.sql
+++ b/data/sql/updates/pending_db_world/rev_1621414710329639831.sql
@@ -5,5 +5,6 @@ SET @GESHARAHAN := 3398;
 
 DELETE FROM `reference_loot_template` where `Item` = @SHIVER_BLADE;
 
+DELETE FROM `creature_loot_template` WHERE `Entry` = @GESHARAHAN AND `Item` = @SHIVER_BLADE;
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (@GESHARAHAN, @SHIVER_BLADE, 0, 72.12, 0, 1, 0, 1, 1, "Gesharahan - Shiver Blade");


### PR DESCRIPTION
Only Gesharahan (id: 3398) should be able to drop Shiver Blade (id: 5182), with a ~72% drop chance.

Currently no gameobjects or creatures drop Shiver Blade directly. It's only included in a reference table:

```
SELECT * FROM `creature_loot_template` WHERE `Item` = 5182;
Empty set (0.080 sec)

SELECT * FROM `gameobject_loot_template` WHERE `Item` = 5182;
Empty set (0.018 sec)
```
```
SELECT * FROM `reference_loot_template` WHERE `Item` = 5182;
+-------+------+-----------+--------+---------------+----------+---------+----------+----------+--------------+
| Entry | Item | Reference | Chance | QuestRequired | LootMode | GroupId | MinCount | MaxCount | Comment      |
+-------+------+-----------+--------+---------------+----------+---------+----------+----------+--------------+
| 24060 | 5182 |         0 |      0 |             0 |        1 |       1 |        1 |        1 | Shiver Blade |
+-------+------+-----------+--------+---------------+----------+---------+----------+----------+--------------+
```

Since Gesharahan is the only creature who's supposed to drop the Shiver Blade, I have removed the item from the reference table and added it to Gesharahan's loot table directly, with the drop chance taken from wowhead. The item is now only obtainable from Gesharahan.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Remove Shiver Blade from the reference table that includes it
- Add Shiver Blade to Gesharahan's loot table directly

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5943
- Closes https://github.com/chromiecraft/chromiecraft/issues/672

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://classic.wowhead.com/item=5182/shiver-blade

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Made sure the new loot table lines up with what's expected

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Look up new loot table for Gesharahan
2. Look up where Shiver Blade drops from

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
