### PR TITLE
fix(DB/loot): Adjust SM mobs' loot tables

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1621426406097836315.sql
+++ b/data/sql/updates/pending_db_world/rev_1621426406097836315.sql
@@ -1,0 +1,14 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1621426406097836315');
+
+SET @REF_TIGERSTRIKE_MANTLE := 24053;
+
+DELETE FROM `creature_loot_template` 
+WHERE `Reference` = @REF_TIGERSTRIKE_MANTLE AND `entry` IN (4287, 4291, 4296, 4299, 4306, 4540);
+
+-- 4287 - Scarlet Gallant
+-- 4291 - Scarlet Diviner
+-- 4296 - Scarlet Adept
+-- 4299 - Scarlet Chaplain
+-- 4306 - Scarlet Torturer
+-- 4540 - Scarlet Monk
+

--- a/data/sql/updates/pending_db_world/rev_1621426406097836315.sql
+++ b/data/sql/updates/pending_db_world/rev_1621426406097836315.sql
@@ -11,4 +11,3 @@ WHERE `Reference` = @REF_TIGERSTRIKE_MANTLE AND `entry` IN (4287, 4291, 4296, 42
 -- 4299 - Scarlet Chaplain
 -- 4306 - Scarlet Torturer
 -- 4540 - Scarlet Monk
-

--- a/data/sql/updates/pending_db_world/rev_1621426406097836315.sql
+++ b/data/sql/updates/pending_db_world/rev_1621426406097836315.sql
@@ -2,12 +2,11 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1621426406097836315');
 
 SET @REF_TIGERSTRIKE_MANTLE := 24053;
 
-DELETE FROM `creature_loot_template` 
-WHERE `Reference` = @REF_TIGERSTRIKE_MANTLE AND `entry` IN (4287, 4291, 4296, 4299, 4306, 4540);
-
 -- 4287 - Scarlet Gallant
 -- 4291 - Scarlet Diviner
 -- 4296 - Scarlet Adept
 -- 4299 - Scarlet Chaplain
 -- 4306 - Scarlet Torturer
 -- 4540 - Scarlet Monk
+DELETE FROM `creature_loot_template` 
+WHERE `Reference` = @REF_TIGERSTRIKE_MANTLE AND `entry` IN (4287, 4291, 4296, 4299, 4306, 4540);


### PR DESCRIPTION
Some Scarlet Monastery mobs were dropping items they were not supposed
to. Reference table 24053 consists of these items. Refs to this table
from the affected creatures were removed.

```
SELECT * from `reference_loot_table` WHERE `entry` = 24053;

+-------+-------+-----------+--------+---------------+----------+---------+----------+----------+----------------------+
| Entry | Item  | Reference | Chance | QuestRequired | LootMode | GroupId | MinCount | MaxCount | Comment              |
+-------+-------+-----------+--------+---------------+----------+---------+----------+----------+----------------------+
| 24053 |  2277 |         0 |      0 |             0 |        1 |       1 |        1 |        1 | Necromancer Leggings |
| 24053 |  2565 |         0 |      0 |             0 |        1 |       1 |        1 |        1 | Rod of Molten Fire   |
| 24053 |  9395 |         0 |      0 |             0 |        1 |       1 |        1 |        1 | Gloves of Old        |
| 24053 | 13033 |         0 |      0 |             0 |        1 |       1 |        1 |        1 | Zealot Blade         |
| 24053 | 13045 |         0 |      0 |             0 |        1 |       1 |        1 |        1 | Viscous Hammer       |
| 24053 | 13063 |         0 |      0 |             0 |        1 |       1 |        1 |        1 | Starfaller           |
| 24053 | 13084 |         0 |      0 |             0 |        1 |       1 |        1 |        1 | Kaleidoscope Chain   |
| 24053 | 13108 |         0 |      0 |             0 |        1 |       1 |        1 |        1 | Tigerstrike Mantle   |
| 24053 | 13124 |         0 |      0 |             0 |        1 |       1 |        1 |        1 | Ravasaur Scale Boots |
| 24053 | 13137 |         0 |      0 |             0 |        1 |       1 |        1 |        1 | Ironweaver           |
+-------+-------+-----------+--------+---------------+----------+---------+----------+----------+----------------------+
```

I checked each and every item in this table. According to classic wowhead, 
none of them are obtainable from Scarlet Monastery mobs. Since these are 
all Rare (blue) items, I then checked all six affected SM mobs' loot tables to 
see if there were any missing Rare drops, and there weren't. 

There were *slight* inaccuracies, eg. Warchief Kilt (id: 7760) drops from a
different subset of SM mobs than what's listed on wowhead, however you encounter
these mobs in the same dungeon anyway so I don't think it's a huge deal.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove ref to reference table 24503 from the affected creatures

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5892 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://classic.wowhead.com/npc=4287/scarlet-gallant
https://classic.wowhead.com/npc=4291/scarlet-diviner
https://classic.wowhead.com/npc=4296/scarlet-adept
https://classic.wowhead.com/npc=4299/scarlet-chaplain
https://classic.wowhead.com/npc=4306/scarlet-torturer
https://classic.wowhead.com/npc=4540/scarlet-monk

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Testing this in-game is not really feasible. I made sure the DB update applies without problems and I double checked the loot tables to make sure I did not mess up something.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Look at the loot tables I suppose

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
