### PR TITLE
fix(DB/gameobject): Fix Andorhal sign location

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1621496626209255481.sql
+++ b/data/sql/updates/pending_db_world/rev_1621496626209255481.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1621496626209255481');
+
+UPDATE `gameobject` 
+SET `position_x` = 455.827, `position_y` = -628.813, `position_z` = 167
+WHERE `guid` = 30079;


### PR DESCRIPTION
Andorhal sign (id: 30079) was floating in midair next to a signpost, but
its orientation was correct. It has been attached to the signpost, below
the sign pointing to Strahnbrad.

![WoWScrnShot_052021_095133](https://user-images.githubusercontent.com/39011611/118941792-62254a80-b952-11eb-83c7-384168563ee2.jpg)

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Place floating Andorhal sign below the Strahnbrad sign on the nearby signpost

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5945
- Closes https://github.com/chromiecraft/chromiecraft/issues/674

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `go o 30079`
2. Make sure the signpost looks ok

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
