### PR TITLE
fix(DB/loot): Fix Staff of Horrors drops

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1621659447273280925.sql
+++ b/data/sql/updates/pending_db_world/rev_1621659447273280925.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1621659447273280925');
+
+DELETE FROM `reference_loot_template` WHERE `Entry` = 24062 AND `Item` = 880;
+
+DELETE FROM `creature_loot_template` WHERE `Entry` = 202 AND `Item` = 880;
+
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(202, 880, 0, 1.6, 0, 1, 0, 1, 1, "Skeletal Horror - Staff of Horrors");
+


### PR DESCRIPTION
The Staff of Horrors should only be dropped by Skeletal Horrors with a ~1.6% drop rate. At the moment it is contained in a reference table that is shared by several hundred NPCs instead, and is not directly dropped at all.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove Staff of Horrors from reference_loot_table 24062.
-  Add it to Skeletal Horrors drop table with 1.6% drop rate.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5987

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://classic.wowhead.com/item=880/staff-of-horrors
I have chosen to use the Wowhead drop rate over that of WOTLKDB because Wowhead's data is more likely to be accurate.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Checked modified tables in Keira

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Check Skeletal Horror (entry 202) loot table
2. Check Staff (880) doesn't drop anywhere else
3. Check Staff is not contained in any reference tables.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
