### PR TITLE
feat(DB/Version): Add date on update

### DIFF
--- a/apps/db_pendings/import.sh
+++ b/apps/db_pendings/import.sh
@@ -43,7 +43,6 @@ function import() {
             newVer=$dateToday"_"$cnt
 
             startTransaction="START TRANSACTION;";
-            updHeader="ALTER TABLE version_db_"$db" CHANGE COLUMN "$oldVer" "$newVer" bit;";
             endTransaction="COMMIT;";
 
             newFile="$updPath/"$dateToday"_"$cnt".sql"
@@ -65,14 +64,13 @@ function import() {
                 echo "DELIMITER //"  >> "$newFile";
                 echo "CREATE PROCEDURE updateDb ()" >> "$newFile";
                 echo "proc:BEGIN DECLARE OK VARCHAR(100) DEFAULT 'FALSE';" >> "$newFile";
-                echo "SELECT COUNT(*) INTO @COLEXISTS"  >> "$newFile";
-                echo "FROM information_schema.COLUMNS" >> "$newFile";
-                echo "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'version_db_"$db"' AND COLUMN_NAME = '"$oldVer"';" >> "$newFile";
-                echo "IF @COLEXISTS = 0 THEN LEAVE proc; END IF;" >> "$newFile";
+                echo "SELECT date INTO @COLEXISTS" >> "$newFile";
+                echo "FROM version_db_"$db  >> "$newFile";
+                echo "ORDER BY date DESC LIMIT 1;"  >> "$newFile";
+                echo "IF @COLEXISTS <> '"$oldVer"' THEN LEAVE proc; END IF;" >> "$newFile";
             fi
 
             echo "$startTransaction" >> "$newFile";
-            echo "$updHeader" >> "$newFile";
 
             if [[ $isRev -eq 1 ]]; then
                 echo "SELECT sql_rev INTO OK FROM version_db_"$db" WHERE sql_rev = '$rev'; IF OK <> 'FALSE' THEN LEAVE proc; END IF;" >> "$newFile";
@@ -89,6 +87,8 @@ function import() {
             echo "--" >> "$newFile";
             echo "-- END UPDATING QUERIES" >> "$newFile";
             echo "--" >> "$newFile";
+
+            echo "UPDATE version_db_"$db" SET date = '"$newVer"' WHERE sql_rev = '"$rev"';" >> "$newFile";
 
             echo "$endTransaction" >> "$newFile";
 

--- a/data/sql/updates/pending_db_auth/rev_1621715473238990700.sql
+++ b/data/sql/updates/pending_db_auth/rev_1621715473238990700.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_auth` (`sql_rev`) VALUES ('1621715473238990700');
+
+ALTER TABLE `version_db_auth`
+	ADD COLUMN `date` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8mb4_0900_ai_ci' AFTER `required_rev`;

--- a/data/sql/updates/pending_db_auth/rev_1621715473238990700.sql
+++ b/data/sql/updates/pending_db_auth/rev_1621715473238990700.sql
@@ -1,4 +1,4 @@
 INSERT INTO `version_db_auth` (`sql_rev`) VALUES ('1621715473238990700');
 
 ALTER TABLE `version_db_auth`
-	ADD COLUMN `date` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8mb4_0900_ai_ci' AFTER `required_rev`;
+	ADD COLUMN `date` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci' AFTER `required_rev`;

--- a/data/sql/updates/pending_db_characters/rev_1621715444570678000.sql
+++ b/data/sql/updates/pending_db_characters/rev_1621715444570678000.sql
@@ -1,4 +1,4 @@
 INSERT INTO `version_db_characters` (`sql_rev`) VALUES ('1621715444570678000');
 
 ALTER TABLE `version_db_characters`
-	ADD COLUMN `date` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8mb4_0900_ai_ci' AFTER `required_rev`;
+	ADD COLUMN `date` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci' AFTER `required_rev`;

--- a/data/sql/updates/pending_db_characters/rev_1621715444570678000.sql
+++ b/data/sql/updates/pending_db_characters/rev_1621715444570678000.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_characters` (`sql_rev`) VALUES ('1621715444570678000');
+
+ALTER TABLE `version_db_characters`
+	ADD COLUMN `date` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8mb4_0900_ai_ci' AFTER `required_rev`;

--- a/data/sql/updates/pending_db_world/rev_1621709841145351300.sql
+++ b/data/sql/updates/pending_db_world/rev_1621709841145351300.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1621709841145351300');
+
+ALTER TABLE `version_db_world`
+	ADD COLUMN `date` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8mb4_0900_ai_ci' AFTER `required_rev`;

--- a/data/sql/updates/pending_db_world/rev_1621709841145351300.sql
+++ b/data/sql/updates/pending_db_world/rev_1621709841145351300.sql
@@ -1,4 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1621709841145351300');
 
 ALTER TABLE `version_db_world`
-	ADD COLUMN `date` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8mb4_0900_ai_ci' AFTER `required_rev`;
+	ADD COLUMN `date` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci' AFTER `required_rev`;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  This is good and can open for opportunities where we can output current DB version with commands ingame etc.
- Introduce date column
-  Don't update and check column name
- Start to check latest date column instead
- insert date when importing DB

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. run import.sh and db_assambler

## Known Issues and TODO List:

WHEN MERGED!!!!

We need to MANUALLY DELETE THIS FOR THE DB FILES:

```sql
SELECT date INTO @COLEXISTS
FROM version_db_db
ORDER BY date DESC LIMIT 1;
IF @COLEXISTS <> '"$oldVer"' THEN LEAVE proc; END IF;
```

when the CI has run the script for ONLY THESE FILES IN THE PR. Otherwise importing with db_assambler will break.

It works as it should after that and we don't need to touch it again.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested locally with import.sh and db_assambler.sh 

| # | C |
| :- | :- | 
| 1 | File that imported these changes (The ones you find in this PR) |
| 2 | A new file generated and imported after these changes |

WORLD:
![image](https://user-images.githubusercontent.com/24550914/119240401-8437ec00-bb4f-11eb-9724-d1f1f16c8321.png)

CHARACTERS:
![image](https://user-images.githubusercontent.com/24550914/119240429-c19c7980-bb4f-11eb-8d60-91f8455126b9.png)

AUTH:
![image](https://user-images.githubusercontent.com/24550914/119240437-ce20d200-bb4f-11eb-8c27-40e46cdcdf9c.png)