### PR TITLE
fix(Core/Unit): Prevent Unit emote when entering combat

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12924,6 +12924,7 @@ void Unit::CombatStart(Unit* target, bool initialAggro)
 
         SetInCombatWith(target);
         target->SetInCombatWith(this);
+        target->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
 
         // Xinef: If pet started combat - put owner in combat
         if (Unit* owner = GetOwner())


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added `EMOTE_ONESHOT_NONE` to `m_uint32Values` when a unit enters combat.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5515

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://youtu.be/vVRB_1s38QA?t=116

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- Tested without the changes: mobs continue the emote animation when fleeing.
- Tested in game on linux/docker setup from windows client.
- Tested with the changes: mobs don't play the emote animation when fleeing
![2021-05-24 20-04-36](https://user-images.githubusercontent.com/10816895/119386639-7e1d4900-bcd0-11eb-94a6-c389d0b156c4.gif)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Rebuild against the change in this branch.
2. Go to Azurelode Mine in Hillsbrad Foothills.
3. Clear nearby mobs.
4. Lower HP of the Hillsbrad Miner to the point where they flee.
5. Watch the fleeing animation.
6. The Hillsbrad Miner shouldn't be playing the mining animation.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
