### PR TITLE
fix(Core/Shared/DB): transactions not being recommitted on dead-lock error

### DIFF
--- a/src/server/database/Database/MySQLConnection.cpp
+++ b/src/server/database/Database/MySQLConnection.cpp
@@ -355,11 +355,11 @@ void MySQLConnection::CommitTransaction()
     Execute("COMMIT");
 }
 
-bool MySQLConnection::ExecuteTransaction(SQLTransaction& transaction)
+int MySQLConnection::ExecuteTransaction(SQLTransaction& transaction)
 {
     std::list<SQLElementData> const& queries = transaction->m_queries;
     if (queries.empty())
-        return false;
+        return -1;
 
     BeginTransaction();
 
@@ -376,8 +376,9 @@ bool MySQLConnection::ExecuteTransaction(SQLTransaction& transaction)
                 if (!Execute(stmt))
                 {
                     LOG_INFO("sql.driver", "[Warning] Transaction aborted. %u queries not executed.", (uint32)queries.size());
+                    int errorCode = GetLastError();
                     RollbackTransaction();
-                    return false;
+                    return errorCode;
                 }
             }
             break;
@@ -388,8 +389,9 @@ bool MySQLConnection::ExecuteTransaction(SQLTransaction& transaction)
                 if (!Execute(sql))
                 {
                     LOG_INFO("sql.driver", "[Warning] Transaction aborted. %u queries not executed.", (uint32)queries.size());
+                    int errorCode = GetLastError();
                     RollbackTransaction();
-                    return false;
+                    return errorCode;
                 }
             }
             break;
@@ -402,7 +404,7 @@ bool MySQLConnection::ExecuteTransaction(SQLTransaction& transaction)
     // and not while iterating over every element.
 
     CommitTransaction();
-    return true;
+    return 0;
 }
 
 MySQLPreparedStatement* MySQLConnection::GetPreparedStatement(uint32 index)

--- a/src/server/database/Database/MySQLConnection.h
+++ b/src/server/database/Database/MySQLConnection.h
@@ -78,7 +78,7 @@ public:
     void BeginTransaction();
     void RollbackTransaction();
     void CommitTransaction();
-    bool ExecuteTransaction(SQLTransaction& transaction);
+    int ExecuteTransaction(SQLTransaction& transaction);
 
     operator bool () const { return m_Mysql != nullptr; }
     void Ping() { mysql_ping(m_Mysql); }

--- a/src/server/database/Database/Transaction.cpp
+++ b/src/server/database/Database/Transaction.cpp
@@ -7,6 +7,8 @@
 #include "DatabaseEnv.h"
 #include "Transaction.h"
 
+#include <mysqld_error.h>
+
 //- Append a raw ad-hoc query to the transaction
 void Transaction::Append(const char* sql)
 {
@@ -63,14 +65,15 @@ void Transaction::Cleanup()
 
 bool TransactionTask::Execute()
 {
-    if (m_conn->ExecuteTransaction(m_trans))
+    int errorCode = m_conn->ExecuteTransaction(m_trans);
+    if (!errorCode)
         return true;
 
-    if (m_conn->GetLastError() == 1213)
+    if (errorCode == ER_LOCK_DEADLOCK)
     {
         uint8 loopBreaker = 5;  // Handle MySQL Errno 1213 without extending deadlock to the core itself
         for (uint8 i = 0; i < loopBreaker; ++i)
-            if (m_conn->ExecuteTransaction(m_trans))
+            if (!m_conn->ExecuteTransaction(m_trans))
                 return true;
     }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Fix transactions not being recommitted on dead-lock error (error code 1213) because of calling http://dev.mysql.com/doc/refman/5.0/en/mysql-errno.html after sending the ROLLBACK command. This way the returned error code was related to the ROLLBACK command, not the failed transaction.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Updates #3679.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  Not tested 

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Follow #3679.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
