### PR TITLE
fix(DB/loot): Clean up refs to ref table 24060

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622103568572292814.sql
+++ b/data/sql/updates/pending_db_world/rev_1622103568572292814.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622103568572292814');
+
+-- 118: Prowler
+-- 3660: Athrikus Narassin
+-- 8386: Horizon Scout Crewman
+-- 10495: Diseased Ghoul
+-- 11562: Drysnap Crawler
+-- 11563: Drysnap Pincer
+DELETE FROM `creature_loot_template` WHERE `reference` = 24060 AND `entry` IN (118, 3660, 8386, 10495, 11562, 11563);


### PR DESCRIPTION
Some loot tables mistakenly include reference table 24060, which (mostly) contains equipable items with an average itemlevel of 20.36:

```sql
SELECT AVG(itemlevel) FROM `item_template` it JOIN `reference_loot_template` rlt ON it.entry = rlt.item WHERE rlt.entry = 24060;
```
```
+----------------+
| AVG(itemlevel) |
+----------------+
|        20.3649 |
+----------------+
```

List of creatures where the deviation between this number and the given creature's avg level is higher than 10:

```sql
SET @AVG = (SELECT AVG(itemlevel) FROM `item_template` it JOIN `reference_loot_template` rlt ON it.entry = rlt.item WHERE rlt.entry = 24060);

SELECT ct.entry, ct.name, ROUND(ABS(@AVG - (ct.minlevel + ct.maxlevel) / 2), 2) AS delta
FROM 
    `creature_loot_template` clt 
    JOIN `creature_template` ct ON clt.entry = ct.lootid 
WHERE clt.reference = 24060 AND ABS(@AVG - (ct.minlevel + ct.maxlevel) / 2) > 10
ORDER BY delta;
```
```
+-------+-----------------------+-------+
| entry | name                  | delta |
+-------+-----------------------+-------+
|  3660 | Athrikus Narassin     | 10.64 |
|   118 | Prowler               | 10.86 |
| 11562 | Drysnap Crawler       | 13.14 |
| 11563 | Drysnap Pincer        | 14.14 |
|  8386 | Horizon Scout Crewman | 21.64 |
| 10495 | Diseased Ghoul        | 38.14 |
+-------+-----------------------+-------+
```

None of these creatures should drop items from ref table 24060 according to wowhead classic. 

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Remove entries that point to ref table 24060 from the listed creatures' loot tables

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6042
- Closes https://github.com/chromiecraft/chromiecraft/issues/697

## SOURCE:
https://classic.wowhead.com/npc=3660/athrikus-narassin#drops;0+2+1+16-20
https://classic.wowhead.com/npc=118/prowler#drops;0-2+16-20+1
https://classic.wowhead.com/npc=11563/drysnap-pincer#drops;0+2+16-20+1
https://classic.wowhead.com/npc=11562/drysnap-crawler#drops;0+2+16-20+1
https://classic.wowhead.com/npc=8386/horizon-scout-crewman
https://classic.wowhead.com/npc=10495/diseased-ghoul#drops;mode:normal;0+2+1+16-20

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Made sure the right entries were removed


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run the 2nd query described above. The result should be an empty set.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
