### PR TITLE
fix(DB/loot): Fix messed up Noblegarden loot

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622106798992540218.sql
+++ b/data/sql/updates/pending_db_world/rev_1622106798992540218.sql
@@ -3,6 +3,7 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622106798992540218');
 -- Noblegarden items:
 -- 6833: White Tuxedo Shirt
 -- 6835: Black Tuxedo Pants
+-- 7806: Lollipop
 -- 7807: Candy Bar
 -- 7808: Chocolate Square
 -- 7809: Easter Dress
@@ -13,14 +14,16 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622106798992540218');
 -- 2020: Bloodfeather Wind Witch
 -- 3197: Burning Blade Fanatic
 -- 3448: Tonga Runetotem
-DELETE FROM `creature_loot_template` WHERE `entry` IN (423, 2020, 3197, 3448) AND `item` IN (6833, 6835, 7807, 7808, 7809, 19028);
-INSERT INTO `creature_loot_template` VALUES (
-    (16112, 7807, 0, 24, 0, 1, 0, 1, 1, 'Korfax, Champion of the Light - Candy Bar'),
-    (2389, 7807, 0, 21, 0, 1, 0, 1, 1, 'Zarise - Candy Bar'),
-    (15500, 7807, 0, 8, 0, 1, 0, 1, 1, 'Keyl Swiftclaw - Candy Bar'),
-    (16134, 7806, 0, 40, 0, 1, 0, 1, 1, 'Rimblat Earthshatter - Lollipop'),
-    (16133, 7806, 0, 38, 0, 1, 0, 1, 1, 'Mataus the Wrathcaster - Lollipop'),
-    (15500, 7806, 0, 16, 0, 1, 0, 1, 1, 'Keyl Swiftclaw - Lollipop'),
-    (2302, 7806, 0, 13, 0, 1, 0, 1, 1, 'Aethalas - Lollipop'),
-    (1573, 7806, 0, 5, 0, 1, 0, 1, 1, 'Gryth Thurden - Lollipop')
-);
+DELETE FROM `creature_loot_template` WHERE `entry` IN (423, 2020, 3197, 3448) AND `item` IN (6833, 6835, 7806, 7807, 7808, 7809, 19028);
+INSERT INTO `creature_loot_template` VALUES
+(16112, 7807, 0, 24, 0, 1, 0, 1, 1, 'Korfax, Champion of the Light - Candy Bar'),
+(2389, 7807, 0, 21, 0, 1, 0, 1, 1, 'Zarise - Candy Bar'),
+(15500, 7807, 0, 8, 0, 1, 0, 1, 1, 'Keyl Swiftclaw - Candy Bar'),
+(16134, 7806, 0, 40, 0, 1, 0, 1, 1, 'Rimblat Earthshatter - Lollipop'),
+(16133, 7806, 0, 38, 0, 1, 0, 1, 1, 'Mataus the Wrathcaster - Lollipop'),
+(15500, 7806, 0, 16, 0, 1, 0, 1, 1, 'Keyl Swiftclaw - Lollipop'),
+(2302, 7806, 0, 13, 0, 1, 0, 1, 1, 'Aethalas - Lollipop'),
+(1573, 7806, 0, 5, 0, 1, 0, 1, 1, 'Gryth Thurden - Lollipop');
+
+-- Add missing lootids
+UPDATE `creature_template` SET `lootid` = `entry` WHERE `entry` IN (16112, 2389, 15500, 16134, 16133, 2302, 1573);

--- a/data/sql/updates/pending_db_world/rev_1622106798992540218.sql
+++ b/data/sql/updates/pending_db_world/rev_1622106798992540218.sql
@@ -1,0 +1,26 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622106798992540218');
+
+-- Noblegarden items:
+-- 6833: White Tuxedo Shirt
+-- 6835: Black Tuxedo Pants
+-- 7807: Candy Bar
+-- 7808: Chocolate Square
+-- 7809: Easter Dress
+-- 19028: Elegant Dress
+
+-- Creatures who drop Noblegarden items:
+-- 423: Redridge Mongrel 
+-- 2020: Bloodfeather Wind Witch
+-- 3197: Burning Blade Fanatic
+-- 3448: Tonga Runetotem
+DELETE FROM `creature_loot_template` WHERE `entry` IN (423, 2020, 3197, 3448) AND `item` IN (6833, 6835, 7807, 7808, 7809, 19028);
+INSERT INTO `creature_loot_template` VALUES (
+    (16112, 7807, 0, 24, 0, 1, 0, 1, 1, 'Korfax, Champion of the Light - Candy Bar'),
+    (2389, 7807, 0, 21, 0, 1, 0, 1, 1, 'Zarise - Candy Bar'),
+    (15500, 7807, 0, 8, 0, 1, 0, 1, 1, 'Keyl Swiftclaw - Candy Bar'),
+    (16134, 7806, 0, 40, 0, 1, 0, 1, 1, 'Rimblat Earthshatter - Lollipop'),
+    (16133, 7806, 0, 38, 0, 1, 0, 1, 1, 'Mataus the Wrathcaster - Lollipop'),
+    (15500, 7806, 0, 16, 0, 1, 0, 1, 1, 'Keyl Swiftclaw - Lollipop'),
+    (2302, 7806, 0, 13, 0, 1, 0, 1, 1, 'Aethalas - Lollipop'),
+    (1573, 7806, 0, 5, 0, 1, 0, 1, 1, 'Gryth Thurden - Lollipop')
+);


### PR DESCRIPTION
Here's a list of all Noblegarden-related items that I could find:
```sql
SELECT `entry`, `name` FROM `item_template` WHERE `entry` IN (6833, 6835, 7806, 7807, 7808, 7809, 19028);
```

```
+-------+--------------------+
| entry | name               |
+-------+--------------------+
|  6833 | White Tuxedo Shirt |
|  6835 | Black Tuxedo Pants |
|  7806 | Lollipop           |
|  7807 | Candy Bar          |
|  7808 | Chocolate Square   |
|  7809 | Easter Dress       |
| 19028 | Elegant Dress      |
+-------+--------------------+
```

These items are normally available from Brightly Colored Eggs. No creatures should drop these items, with the exception of Candy Bar and Lollipop which are dropped by a select few named NPCs.

None of these items are included in reference tables so no intervention needed there.

I'm adjusting the creature loot tables to match the loot info gathered from wowhead classic. 

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6029
- Closes https://github.com/chromiecraft/chromiecraft/issues/692

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://classic.wowhead.com/guides/wow-classic-noblegarden-holiday-egg-spawns-rewards
https://classic.wowhead.com/item=6833/white-tuxedo-shirt
https://classic.wowhead.com/item=6835/black-tuxedo-pants
https://classic.wowhead.com/item=7806/lollipop
https://classic.wowhead.com/item=7807/candy-bar
https://classic.wowhead.com/item=7808/chocolate-square
https://classic.wowhead.com/item=7809/easter-dress
https://classic.wowhead.com/item=19028/elegant-dress

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested with the following query:
```sql
SELECT ct.name as `creature_name`, it.name as `item_name`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, clt.MaxCount, Comment 
FROM
    `creature_loot_template` clt 
    JOIN `creature_template` ct ON ct.lootid = clt.entry
    JOIN `item_template` it ON clt.item = it.entry
WHERE `item` IN (6833, 6835, 7806, 7807, 7808, 7809, 19028);

```
Results are as expected:
```
+-------------------------------+-----------+-----------+--------+---------------+----------+---------+----------+----------+-------------------------------------------+
| creature_name                 | item_name | Reference | Chance | QuestRequired | LootMode | GroupId | MinCount | MaxCount | Comment                                   |
+-------------------------------+-----------+-----------+--------+---------------+----------+---------+----------+----------+-------------------------------------------+
| Gryth Thurden                 | Lollipop  |         0 |      5 |             0 |        1 |       0 |        1 |        1 | Gryth Thurden - Lollipop                  |
| Aethalas                      | Lollipop  |         0 |     13 |             0 |        1 |       0 |        1 |        1 | Aethalas - Lollipop                       |
| Zarise                        | Candy Bar |         0 |     21 |             0 |        1 |       0 |        1 |        1 | Zarise - Candy Bar                        |
| Keyl Swiftclaw                | Lollipop  |         0 |     16 |             0 |        1 |       0 |        1 |        1 | Keyl Swiftclaw - Lollipop                 |
| Keyl Swiftclaw                | Candy Bar |         0 |      8 |             0 |        1 |       0 |        1 |        1 | Keyl Swiftclaw - Candy Bar                |
| Korfax, Champion of the Light | Candy Bar |         0 |     24 |             0 |        1 |       0 |        1 |        1 | Korfax, Champion of the Light - Candy Bar |
| Mataus the Wrathcaster        | Lollipop  |         0 |     38 |             0 |        1 |       0 |        1 |        1 | Mataus the Wrathcaster - Lollipop         |
| Rimblat Earthshatter          | Lollipop  |         0 |     40 |             0 |        1 |       0 |        1 |        1 | Rimblat Earthshatter - Lollipop           |
+-------------------------------+-----------+-----------+--------+---------------+----------+---------+----------+----------+-------------------------------------------+
```


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run the query above
2. Make sure the results are identical to wowhead classic info

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
