### PR TITLE
fix(DB/loot): Remove overlevelled items

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622117565567403115.sql
+++ b/data/sql/updates/pending_db_world/rev_1622117565567403115.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622117565567403115');
+
+-- Remove Shriveled Heart from Farmer Ray
+DELETE FROM `creature_loot_template` WHERE `Entry` = 232 AND `Item` = 9243;
+-- Remove Sunroc Mask from Sawtooth Crocolisk
+DELETE FROM `creature_loot_template` WHERE `Entry` = 1082 AND `Item` = 24737;
+-- Remove Sunroc Gloves from Sawtooth Snapper
+DELETE FROM `creature_loot_template` WHERE `Entry` = 1087 AND `Item` = 24736;


### PR DESCRIPTION
Removes three overlevelled items from NPCs. Checked  and all three items are well outside the standard level range, and should not be dropped by these NPCs.

I did consider modifying the Sawtooth drops to be reference table IDs instead of just deleting them, as the numbers are in the right range and it looked as if that's what they were originally supposed to be. However, checking those reference IDs, they contained various recipes that were as much as 10 levels higher than the Sawtooths, so were not level appropriate. So instead I am simply deleting them.

Partially addresses https://github.com/azerothcore/azerothcore-wotlk/issues/6000

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Remove Shriveled Heart (iLvl 45) from Farmer Ray (lvl 23)
- Remove Sunroc Mask (iLvl 96) from Sawtooth Crocolisk (lvl 39)
- Remove Sunroc Gloves (iLvl 96) from Sawtooth Snapper(lvl 42)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- https://github.com/azerothcore/azerothcore-wotlk/issues/6000

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Loot tables shown here for all 3 creatures do not contain these items.
- https://tbc.wowhead.com/npc=232/farmer-ray
- https://tbc.wowhead.com/npc=1082/sawtooth-crocolisk
- https://tbc.wowhead.com/npc=1087/sawtooth-snapper

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL commands, nothing caught fire.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Check above-named NPCs in Keira, view their loot tables and observe absence of items.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- Rather a lot of both over- and under-levelled loot drops remain.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
