### PR TITLE
feat(Core/Script): allow ValidateSpellInfo to work with any container type

### DIFF
--- a/src/server/game/Spells/SpellScript.cpp
+++ b/src/server/game/Spells/SpellScript.cpp
@@ -14,26 +14,21 @@ bool _SpellScript::_Validate(SpellInfo const* entry)
 {
     if (!Validate(entry))
     {
-        LOG_ERROR("server", "_SpellScript::_Validate: Spell `%u` did not pass Validate() function of script `%s` - script will not be added to the spell", entry->Id, m_scriptName->c_str());
+        LOG_ERROR("scripts.spells", "_SpellScript::_Validate: Spell `%u` did not pass Validate() function of script `%s` - script will not be added to the spell", entry->Id, m_scriptName->c_str());
         return false;
     }
     return true;
 }
 
-bool _SpellScript::_ValidateSpellInfo(uint32 const* begin, uint32 const* end)
+bool _SpellScript::_ValidateSpellInfo(uint32 spellId)
 {
-    bool allValid = true;
-    while (begin != end)
+    if (!sSpellMgr->GetSpellInfo(spellId))
     {
-        if (!sSpellMgr->GetSpellInfo(*begin))
-        {
-            LOG_ERROR("server", "_SpellScript::_ValidateSpellInfo: Spell %u does not exist.", *begin);
-            allValid = false;
-        }
-
-        ++begin;
+        LOG_ERROR("scripts.spells", "_SpellScript::ValidateSpellInfo: Spell %u does not exist.", spellId);
+        return false;
     }
-    return allValid;
+
+    return true;
 }
 
 void _SpellScript::_Register()

--- a/src/server/game/Spells/SpellScript.h
+++ b/src/server/game/Spells/SpellScript.h
@@ -123,7 +123,23 @@ public:
     }
 
 private:
-    static bool _ValidateSpellInfo(uint32 const* begin, uint32 const* end);
+    template<typename Iterator>
+    static bool _ValidateSpellInfo(Iterator begin, Iterator end)
+    {
+        bool allValid = true;
+        while (begin != end)
+        {
+            if (!_ValidateSpellInfo(*begin))
+            {
+                allValid = false;
+            }
+
+            ++begin;
+        }
+        return allValid;
+    }
+
+    static bool _ValidateSpellInfo(uint32 spellId);
 };
 
 // SpellScript interface - enum used for runtime checks of script function calls


### PR DESCRIPTION

* Cherry-pick https://github.com/TrinityCore/TrinityCore/commit/f2f0aeb562dfc1a78b04d13a14e3c37a58367619

Co-Authored-By: Shauren <shauren.trinity@gmail.com>

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Allow spell script ValidateSpellInfo to work with any container type

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Does not break current Validation

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
