### PR TITLE
fix(Scripts/VoA): Toravon Orbs Bug

### DIFF
--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_toravon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_toravon.cpp
@@ -104,6 +104,7 @@ public:
                 pInstance->SetData(EVENT_TORAVON, DONE);
                 pInstance->DoRemoveAurasDueToSpellOnPlayers(SPELL_WHITEOUT);
             }
+            summons.DespawnAll();
         }
 
         void JustSummoned(Creature* cr) override


### PR DESCRIPTION
Toravon The Ice Watchter in Archavon when dead the Orbs not despawn

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add the despawn of the Orbs on Toravon Icewatcher when he dies

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- https://github.com/azerothcore/azerothcore-wotlk/issues/5494



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 38433
2. Wait until boss spawns "Frozen Orb"
3. Kill the boss
4. Look how now the Orb disappeared correctly :D
