### PR TITLE
feat(Modules): Load modules configs before Log initialization to prop…

### DIFF
--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -347,7 +347,6 @@ bool ConfigMgr::LoadModulesConfigs()
         return true;
 
     // Start loading module configs
-    std::vector<std::string /*config variant*/> moduleConfigFiles;
     std::string const& moduleConfigPath = GetConfigPath() + "modules/";
     bool isExistDefaultConfig = true;
     bool isExistDistConfig = true;
@@ -368,25 +367,25 @@ bool ConfigMgr::LoadModulesConfigs()
             isExistDefaultConfig = false;
 
         if (isExistDefaultConfig && isExistDistConfig)
-            moduleConfigFiles.emplace_back(defaultFileName);
+            _moduleConfigFiles.emplace_back(defaultFileName);
         else if (!isExistDefaultConfig && isExistDistConfig)
-            moduleConfigFiles.emplace_back(distFileName);
+            _moduleConfigFiles.emplace_back(distFileName);
     }
 
     // If module configs not exist - no load
-    if (moduleConfigFiles.empty())
-        return false;
+    return !_moduleConfigFiles.empty();
+}
 
+void ConfigMgr::PrintLoadedModulesConfigs()
+{
     // Print modules configurations
     LOG_INFO("server", " ");
     LOG_INFO("server", "Using modules configuration:");
 
-    for (auto const& itr : moduleConfigFiles)
+    for (auto const& itr : _moduleConfigFiles)
         LOG_INFO("server", "> %s", itr.c_str());
 
     LOG_INFO("server", " ");
-
-    return true;
 }
 
 /*

--- a/src/common/Configuration/Config.h
+++ b/src/common/Configuration/Config.h
@@ -58,6 +58,8 @@ public:
     bool isDryRun() { return dryRun; }
     void setDryRun(bool mode) { dryRun = mode; }
 
+    void PrintLoadedModulesConfigs();
+
 private:
     /// Method used only for loading main configuration files (authserver.conf and worldserver.conf)
     bool LoadInitial(std::string const& file);
@@ -67,6 +69,8 @@ private:
     T GetValueDefault(std::string const& name, T const& def, bool showLogs = true) const;
 
     bool dryRun = false;
+
+    std::vector<std::string /*config variant*/> _moduleConfigFiles;
 };
 
 class ConfigException : public std::length_error

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -122,6 +122,9 @@ extern int main(int argc, char** argv)
     if (!sConfigMgr->LoadAppConfigs())
         return 1;
 
+    // Loading modules configs
+    sConfigMgr->LoadModulesConfigs();
+
     sLog->RegisterAppender<AppenderDB>();
     sLog->Initialize();
 

--- a/src/server/worldserver/Master.cpp
+++ b/src/server/worldserver/Master.cpp
@@ -139,7 +139,7 @@ int Master::Run()
     LoadRealmInfo();
 
     // Loading modules configs
-    sConfigMgr->LoadModulesConfigs();
+    sConfigMgr->PrintLoadedModulesConfigs();
 
     ///- Initialize the World
     sSecretMgr->Initialize();


### PR DESCRIPTION
…erly load modules appenders and loggers.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Modules configs should be loaded right after worldserver config to properly handle appenders and loggers came from modules.
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame with anticheat module: https://github.com/azerothcore/mod-anticheat/pull/32#

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
