### PR TITLE
fix(Core): fix instance portal not resurrecting when corpse is not spawned

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5484,6 +5484,18 @@ Corpse* Player::CreateCorpse()
     return corpse;
 }
 
+void Player::RemoveCorpse()
+{
+    if (GetCorpse())
+    {
+        GetCorpse()->RemoveFromWorld();
+    }
+
+    SQLTransaction trans = CharacterDatabase.BeginTransaction();
+    Corpse::DeleteFromDB(GetGUID(), trans);
+    CharacterDatabase.CommitTransaction(trans);
+}
+
 void Player::SpawnCorpseBones(bool triggerSave /*= true*/)
 {
     _corpseLocation.WorldRelocate();

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2030,6 +2030,7 @@ public:
     [[nodiscard]] Corpse* GetCorpse() const;
     void SpawnCorpseBones(bool triggerSave = true);
     Corpse* CreateCorpse();
+    void RemoveCorpse();
     void KillPlayer();
     static void OfflineResurrect(ObjectGuid const guid, SQLTransaction& trans);
     bool HasCorpse() const { return _corpseLocation.GetMapId() != MAPID_INVALID; }

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -190,6 +190,17 @@ void WorldSession::HandleMoveWorldportAck()
         }
     }
 
+    if (!corpse && mEntry->IsDungeon())
+    {
+        // resurrect character upon entering instance when the corpse is not available anymore
+        if (GetPlayer()->GetCorpseLocation().GetMapId() == mEntry->MapID)
+        {
+            GetPlayer()->ResurrectPlayer(0.5f, false);
+            GetPlayer()->RemoveCorpse();
+        }
+    }
+
+
     bool allowMount = !mEntry->IsDungeon() || mEntry->IsBattlegroundOrArena();
     if (mInstance)
     {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Resurrect players upon entering instance portals even if their corpse is not spawned in the world

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5896
- Closes https://github.com/chromiecraft/chromiecraft/issues/577

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Applied C++ fix and tested on Windows 10 clients and server


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Log in with 5 characters
2. Queue the 5 characters in random dungeon finder
3. When everyone is in the instance, have one of the players die (don't release spirit)
4. Close the game for the character that died with alt+f4
5. Wait until the dead character appears offline
6. Votekick the dead character
7. Log back in on the dead character
8. As a ghost, run to the instance portal and enter it
9. Verify that you are spawned inside the instance alive

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
