### PR TITLE
chore(deps/acelite): Remove VERSION

### DIFF
--- a/deps/acelite/VERSION
+++ b/deps/acelite/VERSION
@@ -1,8 +1,0 @@
-This is ACE version 6.3.2, released Thu May 07 10:14:44 CEST 2015
-
-If you have any problems with or questions about ACE, please send
-e-mail to the ACE mailing list (ace-bugs@list.isis.vanderbilt.edu),
-using the form found in the file PROBLEM-REPORT-FORM. In order
-to post to the list you must subscribe to it.
-
-See http://www.dre.vanderbilt.edu/~schmidt/ACE-mail.html


### PR DESCRIPTION
VERSION was deprecated when acelite was bumped to newer version 7 months ago, and now we have VERSION.txt

deleting VERSION might fix Windows CI build... Hopefully... 

ace... ace... ace... 💩