### PR TITLE
feat(CI): deprecated clang7 in Ubuntu 18.04 and switch to clang10

### DIFF
--- a/.github/workflows/core_build.yml
+++ b/.github/workflows/core_build.yml
@@ -30,7 +30,7 @@ jobs:
             modules: without
             extra_logs: false
           - os: ubuntu-18.04
-            compiler: clang7
+            compiler: clang10
             modules: without
             extra_logs: false
           - os: ubuntu-18.04


### PR DESCRIPTION
## Changes Proposed:
-  
-  