### PR TITLE
fix(DB/creature): Kurdros and Granistad movement

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622559179437510182.sql
+++ b/data/sql/updates/pending_db_world/rev_1622559179437510182.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622559179437510182');
+
+SET @KURDROS := 16025;
+SET @GRANISTAD := 16027;
+UPDATE `creature` SET `wander_distance` = 5, `MovementType` = 1 WHERE `guid` IN (@KURDROS, @GRANISTAD);


### PR DESCRIPTION
Kurdros and Granistad NPCs are now wandering randomly in a small radius like they're supposed to.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Adjust Kurdros (16025) and Granistad (16027) movement type and wander radius.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6156
- Closes chromiecraft/chromiecraft#749

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Video footage from classic: (watch the beginning)
https://www.youtube.com/watch?v=sQuox81DZYA

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go c 16025`
2. Make sure both griffins fly around randomly

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
