### PR TITLE
fix(DB/creature): Son of Arugal movement

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622617341739892363.sql
+++ b/data/sql/updates/pending_db_world/rev_1622617341739892363.sql
@@ -1,4 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622617341739892363');
 
 UPDATE `creature` SET `wander_distance` = 10, `MovementType` = 1 WHERE `guid` = 18424 AND `id` = 2529;
-

--- a/data/sql/updates/pending_db_world/rev_1622617341739892363.sql
+++ b/data/sql/updates/pending_db_world/rev_1622617341739892363.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622617341739892363');
+
+UPDATE `creature` SET `wander_distance` = 10, `MovementType` = 1 WHERE `guid` = 18424;

--- a/data/sql/updates/pending_db_world/rev_1622617341739892363.sql
+++ b/data/sql/updates/pending_db_world/rev_1622617341739892363.sql
@@ -1,3 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622617341739892363');
 
-UPDATE `creature` SET `wander_distance` = 10, `MovementType` = 1 WHERE `guid` = 18424;
+UPDATE `creature` SET `wander_distance` = 10, `MovementType` = 1 WHERE `guid` = 18424 AND `id` = 2529;
+


### PR DESCRIPTION
Son of Arugal (id: 18424) was standing still. The only "source" I have found claims that he doesn't have a set path, so I made him wander around instead.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Give Son of Arugal (18424) random movement

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6084

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://vanillawowdb.com/?npc=2529 - only the one on the top has a path, 18424 is the bottom one

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `go c 18424`
2. Watch him wander around

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
