### PR TITLE
fix(DB/creature): Greymist murlocs movement

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622621882267236728.sql
+++ b/data/sql/updates/pending_db_world/rev_1622621882267236728.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622621882267236728');
+
+-- These murlocs aren't guarding anything so they should wander around
+UPDATE `creature` SET `wander_distance` = 5, `MovementType` = 1 WHERE `guid` IN (37854, 37951, 37955, 37967, 37974) AND `id` BETWEEN 2201 AND 2208;
+
+-- Murloc 37990 should face the bonfire he's standing next to
+UPDATE `creature` SET `orientation` = 5.9828 WHERE `guid` = 37990 AND `id` BETWEEN 2201 AND 2208;


### PR DESCRIPTION
Some Greymist murlocs were standing still instead of wandering around as they're supposed to.

I checked all Greymist murlocs (template id 2201 - 2208) and made them move around randomly, except if they were obviously meant to stand still (guarding something).

I also flipped murloc 37990 around because he wasn't facing the bonfire he's standing next to, unlike his homies.

Closes #6020

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Make some stationary murlocs wander around instead
- Adjust murloc 37990 orientation 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6020

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
None

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go c 37974`, make sure they're moving around
2. `.go c 37990`, make sure he's facing the bonfire

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
