### PR TITLE
fix(DB/spell): Fix Hex of Ravenclaw Removal spell

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622632251168886593.sql
+++ b/data/sql/updates/pending_db_world/rev_1622632251168886593.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622632251168886593');
+
+UPDATE `spell_dbc` SET `Effect_1` = 164, `ImplicitTargetA_1`= 0, `EffectTriggerSpell_1` = 7655 WHERE `ID` = 8320;

--- a/data/sql/updates/pending_db_world/rev_1622632251168886593.sql
+++ b/data/sql/updates/pending_db_world/rev_1622632251168886593.sql
@@ -1,3 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622632251168886593');
 
-UPDATE `spell_dbc` SET `Effect_1` = 164, `ImplicitTargetA_1`= 0, `EffectTriggerSpell_1` = 7655 WHERE `ID` = 8320;
+UPDATE `spell_dbc` SET `Effect_1` = 164, `ImplicitTargetA_1`= 0, `EffectTriggerSpell_1` = 7656 WHERE `ID` = 8320;


### PR DESCRIPTION
Drinking Bethor's Potion (spell id: 7669) triggered the Hex of Ravenclaw
Removal (spell id: 8320), which was supposed to remove the Hex of
Ravenclaw debuff from the caster (spell id: 7656), but it didn't.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Adjust Hex of Ravenclaw Removal (spell id: 8320) to actually do what its name suggests

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5906
- Closes chromiecraft/chromiecraft#661

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://classic.wowhead.com/item=3251/bethors-potion#comments

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

https://user-images.githubusercontent.com/39011611/120484747-a9302880-c3b3-11eb-8206-cc8f79720f80.mp4

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.additem 3251`
2. `.go c 18277`
3. Wait until he casts Hex of Ravenclaw
4. Drink potion and make sure it cancels the Hex of Ravenclaw aura on you

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
