### PR TITLE
fix(DB/gameobject): Adjust Barrel location

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622640898688425404.sql
+++ b/data/sql/updates/pending_db_world/rev_1622640898688425404.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622640898688425404');
+
+UPDATE `gameobject` SET `position_z` = 5.4598 WHERE `guid` = 14890 AND `id` = 3659;


### PR DESCRIPTION
Melon Juice Barrel (id: 14890) was floating in the air.
Its z coordinate has been adjusted. 

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Adjust z coordinate of gameobject id 14890

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6157
- Closes chromiecraft/chromiecraft#744

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
None

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

![WoWScrnShot_060221_153800](https://user-images.githubusercontent.com/39011611/120490826-05497b80-c3b9-11eb-90f3-0e6e734149d8.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go o 14890`
2. Make sure the barrel is not midair

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
