### PR TITLE
fix(DB/loot): Remove Webbed Creature drops

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622644136275319906.sql
+++ b/data/sql/updates/pending_db_world/rev_1622644136275319906.sql
@@ -1,3 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622644136275319906');
 
+UPDATE `creature_template` SET `lootid` = 0 WHERE `entry` = 17680;
 DELETE FROM `creature_loot_template` WHERE `Entry` = 17680;

--- a/data/sql/updates/pending_db_world/rev_1622644136275319906.sql
+++ b/data/sql/updates/pending_db_world/rev_1622644136275319906.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622644136275319906');
+
+DELETE FROM `creature_loot_template` WHERE `Entry` = 17680;


### PR DESCRIPTION
Webbed Creature (id: 17680) is not supposed to drop any items. Currently they drop Coarse Stone with 2/3 probability.


<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove all drops from Webbed Creature

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6123
- Closes chromiecraft/chromiecraft#732

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Made sure the loot table was empty after applying the sql

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. run ```SELECT * FROM `creature_loot_template` WHERE `Entry` = 17680;```
2. Result should be the empty set

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
