### PR TITLE
fix(DB/gameobject): Add missing Azshara fish nodes

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622719475133710519.sql
+++ b/data/sql/updates/pending_db_world/rev_1622719475133710519.sql
@@ -1,0 +1,42 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622719475133710519');
+
+-- unused GUIDs
+SET @GOB1 := 64811;
+SET @GOB2 := 64827;
+SET @GOB3 := 64837;
+SET @GOB4 := 64839;
+SET @GOB5 := 64843;
+SET @GOB6 := 64859;
+SET @POOL1:= 364;
+SET @POOL2 := 387;
+
+DELETE FROM `gameobject` WHERE `id` = 180753 AND `guid` IN (@GOB1, @GOB2, @GOB3, @GOB4, @GOB5, @GOB6);
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `position_x`, `position_y`, `spawntimesecs`, `animprogress`) VALUES
+(64811, 180753, 1, 3638.1101, -6042.0297, 3600, 100),
+(64827, 180753, 1, 3993.8320, -6058.8184, 3600, 100),
+(64837, 180753, 1, 3966.5193, -6337.3110, 3600, 100),
+(64839, 180753, 1, 3551.7053, -7292.4677, 3600, 100),
+(64843, 180753, 1, 2892.4980, -7080.7880, 3600, 100),
+(64859, 180753, 1, 3025.6696, -6657.1953, 3600, 100);
+
+DELETE FROM `pool_template` WHERE `entry` = @POOL1;
+INSERT INTO `pool_template` (`entry`, `max_limit`, `description`) VALUES
+(@POOL1, 4, 'Azshara - Patch of Elemental Water');
+
+DELETE FROM `pool_gameobject` WHERE `guid` IN (@GOB1, @GOB2, @GOB3, @GOB4, @GOB5, @GOB6);
+INSERT INTO `pool_gameobject` (`guid`, `pool_entry`, `chance`, `description`) VALUES
+(64811, @POOL1, 0, '1 - Patch of Elemental Water'),
+(64827, @POOL1, 0, '2 - Patch of Elemental Water'),
+(64837, @POOL1, 0, '3 - Patch of Elemental Water'),
+(64839, @POOL1, 0, '4 - Patch of Elemental Water'),
+(64843, @POOL1, 0, '5 - Patch of Elemental Water'),
+(64859, @POOL1, 0, '6 - Patch of Elemental Water');
+
+DELETE FROM `pool_template` WHERE `entry` = @POOL2;
+INSERT INTO `pool_template` (`entry`, `max_limit`, `description`) VALUES
+(@POOL2, 1, 'Azshara - Various Fishing Nodes');
+
+DELETE FROM `pool_gameobject` WHERE `guid` IN (@GOB1, 48232);
+INSERT INTO `pool_gameobject` (`guid`, `pool_entry`, `chance`, `description`) VALUES
+(64811, @POOL2, 0, '1 - Patch of Elemental Water'),
+(48232, @POOL2, 0, '2 - Floating Wreckage');


### PR DESCRIPTION
Azshara was missing several Patch of Elemental Water fishing nodes. I've added 6 of these nodes to locations specified on [this classic wowhead page](https://classic.wowhead.com/item=7080/essence-of-water). The page says there are 11 fishing nodes, but some of them are overlapping and there are only 6 unique locations.

Initially I hand picked the new locations based on the map they've provided. Afterwards I discovered that one of the comments has screenshots of the exact node locations, so I adjusted my coords to be mimic those locations as accurately as I could.

A commenter claims that they've seen as many as 4 of these nodes consecutively active, so I put them all into a pool with a max limit of 4. The already existing fishing nodes in Azshara were not pooled (with the exception of 2 which were overlapping). The addition of new nodes did not cause any overlaps.

I've tested the new nodes without pooling and I could fish from all of them, so they're all accessible.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Add 6 Patch of Elemental Water fishing nodes in Azshara zone
- Pool these 6 nodes so only 4 are active at a time

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6165
- Closes chromiecraft/chromiecraft#751

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://classic.wowhead.com/item=7080/essence-of-water#comments

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game. All new fishing nodes are accessible and the pooling seems to work correctly

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Visit each new fishing node (`.go o ...`)
2. Verify that they're accessible and only 4 nodes are active at a time

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
