### PR TITLE
fix(DB/creature): Fix some raptors not moving

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622733528401617288.sql
+++ b/data/sql/updates/pending_db_world/rev_1622733528401617288.sql
@@ -1,0 +1,12 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622733528401617288');
+
+UPDATE `creature` SET `wander_distance` = 5, `MovementType` = 1
+WHERE `guid` IN (
+    SELECT c.guid 
+    FROM 
+	`creature` c 
+	JOIN `creature_template` ct ON c.id = ct.entry
+    WHERE c.wander_distance = 0 
+    AND c.MovementType = 0 
+    AND (ct.name LIKE "%Razormaw%" OR ct.name LIKE "%Bloodfen%" OR ct.name = "Goreclaw the Ravenous")
+);

--- a/data/sql/updates/pending_db_world/rev_1622733528401617288.sql
+++ b/data/sql/updates/pending_db_world/rev_1622733528401617288.sql
@@ -1,12 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622733528401617288');
 
 UPDATE `creature` SET `wander_distance` = 5, `MovementType` = 1
-WHERE `guid` IN (
-    SELECT c.guid 
-    FROM 
-	`creature` c 
-	JOIN `creature_template` ct ON c.id = ct.entry
-    WHERE c.wander_distance = 0 
-    AND c.MovementType = 0 
-    AND (ct.name LIKE "%Razormaw%" OR ct.name LIKE "%Bloodfen%" OR ct.name = "Goreclaw the Ravenous")
-);
+WHERE `guid` IN (9720, 9761, 9981, 10226, 31701, 31706, 31708, 31710);


### PR DESCRIPTION
Some creatures were not patrolling or wandering around as they're supposed to. 

Initially I only looked at mobs whose names contain the word "Razormaw", but during this I encountered other mobs having the same issue, so I extended my query to cover them as well. One of them is a unique (Goreclaw the Ravenous), but there's nothing that suggests that he should be standing still.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Give the affected creatures random movement with a radius of 5

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5823
- Closes https://github.com/chromiecraft/chromiecraft/issues/627

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
For the common creatures: none
For the unique creature: https://www.wowhead.com/npc=23873/goreclaw-the-ravenous#comments

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Teleport to the mentioned creatures `.go c ...`
2. Make sure they're moving

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
