### PR TITLE
fix(DB/smart_scripts): The Plains Vision speed

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622735574123785029.sql
+++ b/data/sql/updates/pending_db_world/rev_1622735574123785029.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622735574123785029');
+
+UPDATE `smart_scripts` SET `action_param1` = 0 WHERE `entryorguid` = 2983 AND `source_type` = 0 AND `id` = 0 AND `link` = 0;


### PR DESCRIPTION
During the Rite of Vision quest (id: 772), The Plains Vision creature
(entry: 2983) guides the player to a location. The creature moves too
fast and outruns the player, making it impossible to follow all the way.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Adjust The Plains Vision movement from running to walking

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5982
- Closes https://github.com/chromiecraft/chromiecraft/issues/680

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.youtube.com/watch?v=BYy_-uytlrg

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.quest add 772`
2. `.go o 20436`
3. Use quest item and follow the ghost wolf

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
