### PR TITLE
fix(DB/Creature): Some Nethergarde Foremans missing patrol pattern

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622849161495010100.sql
+++ b/data/sql/updates/pending_db_world/rev_1622849161495010100.sql
@@ -1,3 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622849161495010100');
 
-UPDATE `creature` SET `wander_distance` = 5 WHERE `guid` IN (3713, 3863, 3878);
+UPDATE `creature` SET `wander_distance` = 5, `MovementType` = 1 WHERE `guid` IN (3713, 3863, 3878);

--- a/data/sql/updates/pending_db_world/rev_1622849161495010100.sql
+++ b/data/sql/updates/pending_db_world/rev_1622849161495010100.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622849161495010100');
+
+UPDATE `creature` SET `wander_distance` = 5 WHERE `guid` IN (3713, 3863, 3878);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added missing wander distance to match other npcs of this type.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6189 
- Closes chromiecraft/chromiecraft#759

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran ```SELECT * FROM `acore_world`.`creature` WHERE `id` = 5998;``` and ensure all wander_distance values are set to 5 and MovementType is set to 1
- Teleported to the 3 affected npcs to ensure they were now wandering.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run ```SELECT * FROM `acore_world`.`creature` WHERE `id` = 5998;``` and ensure all wander_distance values are set to 5 and MovementType is set to 1
2. use ```go creature 3713``` ```go creature 3863``` ```go creature 3878```to check that each npc is now wandering.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
