### PR TITLE
fix(DB/loot): Delete more overlevelled items from world NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1622966158177775526.sql
+++ b/data/sql/updates/pending_db_world/rev_1622966158177775526.sql
@@ -1,0 +1,35 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1622966158177775526');
+
+-- Removes lvl 27 Cuirboulli Boots from lvl 21 Blackfathom Tide Priestess
+DELETE FROM `creature_loot_template` WHERE `Entry` = 4802 AND `Item` = 2143;
+
+-- Removes lvl 27 Cuirboulli Boots from lvl 21 Blackfathom Oracle
+DELETE FROM `creature_loot_template` WHERE `Entry` = 4803 AND `Item` = 2143;
+
+-- Removes lvl 65 Idol of Brutality from lvl 59 Hive'Zora Tunneler
+DELETE FROM `creature_loot_template` WHERE `Entry` = 11726 AND `Item` = 23198;
+
+-- Removes lvl 65 Idol of Brutality from lvl 60 Twilight Stonecaller
+DELETE FROM `creature_loot_template` WHERE `Entry` = 11882 AND `Item` = 23198;
+
+-- Removes lvl 17 Stonesplinter Rags from lvl 12 Stonesplinter Scout
+DELETE FROM `creature_loot_template` WHERE `Entry` = 1162 AND `Item` = 5109;
+
+-- Removes lvl 17 Stonesplinter Rags from lvl 12 Stonesplinter Trogg
+DELETE FROM `creature_loot_template` WHERE `Entry` = 1161 AND `Item` = 5109;
+
+-- Removes lvl 23 Scouting Spaulders from lvl 18 Foreman Thistlenettle
+DELETE FROM `creature_loot_template` WHERE `Entry` = 626 AND `Item` = 6588;
+
+-- Removes lvl 65 Idol of Brutality from lvl 60 Scourge Champion
+DELETE FROM `creature_loot_template` WHERE `Entry` = 8529 AND `Item` = 23198;
+
+-- Removes lvl 65 Idol of Brutality from lvl 60 Hive'Zora Hive Sister
+DELETE FROM `creature_loot_template` WHERE `Entry` = 11729 AND `Item` = 23198;
+
+-- Removes lvl 65 Idol of Brutality from lvl 60 Hive'Regal Ambusher
+DELETE FROM `creature_loot_template` WHERE `Entry` = 11730 AND `Item` = 23198;
+
+-- Removes lvl 65 Idol of Brutality from lvl 60 Hive'Regal Spitfire
+DELETE FROM `creature_loot_template` WHERE `Entry` = 11732 AND `Item` = 23198;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Removes lvl 27 Cuirboulli Boots from lvl 21 Blackfathom Tide Priestess
- Removes lvl 27 Cuirboulli Boots from lvl 21 Blackfathom Oracle
- Removes lvl 65 Idol of Brutality from lvl 59 Hive'Zora Tunneler
- Removes lvl 65 Idol of Brutality from lvl 60 Twilight Stonecaller
- Removes lvl 17 Stonesplinter Rags from lvl 12 Stonesplinter Scout
- Removes lvl 17 Stonesplinter Rags from lvl 12 Stonesplinter Trogg
- Removes lvl 23 Scouting Spaulders from lvl 18 Foreman Thistlenettle
- Removes lvl 65 Idol of Brutality from lvl 60 Scourge Champion
- Removes lvl 65 Idol of Brutality from lvl 60 Hive'Zora Hive Sister
- Removes lvl 65 Idol of Brutality from lvl 60 Hive'Regal Ambusher
- Removes lvl 65 Idol of Brutality from lvl 60 Hive'Regal Spitfire

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Partially addresses https://github.com/azerothcore/azerothcore-wotlk/issues/6000

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Checked TBC Wowhead vs these creatures to ensure items were not part of typical loot tables.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL command without errors.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Re-run listed SQL commands with SELECT instead of DELETE, result should be empty set.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
More items still to go.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
