### PR TITLE
fix(Core/Player): Players are allowed to continue melee attacking on …

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21093,12 +21093,6 @@ void Player::SendAutoRepeatCancel(Unit* target)
     WorldPacket data(SMSG_CANCEL_AUTO_REPEAT, target->GetPackGUID().size());
     data << target->GetPackGUID();                  // may be it's target guid
     SendMessageToSet(&data, true);
-
-    // To properly cancel autoshot done by client
-    if (!HasUnitState(UNIT_STATE_MELEE_ATTACKING))
-    {
-        SendAttackSwingCancelAttack();
-    }
 }
 
 void Player::SendExplorationExperience(uint32 Area, uint32 Experience)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21096,7 +21096,9 @@ void Player::SendAutoRepeatCancel(Unit* target)
 
     // To properly cancel autoshot done by client
     if (!HasUnitState(UNIT_STATE_MELEE_ATTACKING))
+    {
         SendAttackSwingCancelAttack();
+    }
 }
 
 void Player::SendExplorationExperience(uint32 Area, uint32 Experience)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21095,7 +21095,8 @@ void Player::SendAutoRepeatCancel(Unit* target)
     SendMessageToSet(&data, true);
 
     // To properly cancel autoshot done by client
-    SendAttackSwingCancelAttack();
+    if (!HasUnitState(UNIT_STATE_MELEE_ATTACKING))
+        SendAttackSwingCancelAttack();
 }
 
 void Player::SendExplorationExperience(uint32 Area, uint32 Experience)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3375,10 +3375,11 @@ void Unit::_UpdateAutoRepeatSpell()
     static uint32 const HUNTER_AUTOSHOOT = 75;
 
     // Check "realtime" interrupts
-    if ((GetTypeId() == TYPEID_PLAYER && ToPlayer()->isMoving() && spellProto->Id != HUNTER_AUTOSHOOT) ||
-        IsNonMeleeSpellCast(false, false, true, spellProto->Id == HUNTER_AUTOSHOOT))
+    if ((GetTypeId() == TYPEID_PLAYER && ToPlayer()->isMoving() && spellProto->Id != HUNTER_AUTOSHOOT) || IsNonMeleeSpellCast(false, false, true, spellProto->Id == HUNTER_AUTOSHOOT))
     {
-        InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
+        // cancel wand shoot
+        if (spellProto->Id != HUNTER_AUTOSHOOT)
+            InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
         m_AutoRepeatFirstCast = true;
         return;
     }


### PR DESCRIPTION
…autoshoot cancel.

Fixed #6248.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Player that is already melee attacking target should not send  `SMSG_CANCEL_COMBAT` packet on autoshoot cancel.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6248.
- Closes #5734
- Closes chromiecraft/chromiecraft#795

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
