### PR TITLE
fix(DB/loot): Remove Mana Agate drop from Vultros

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1623193677054313100.sql
+++ b/data/sql/updates/pending_db_world/rev_1623193677054313100.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1623193677054313100');
+
+-- Remove Conjured Mana Agate drop from Vultros
+DELETE FROM `creature_loot_template` WHERE `entry` = 462 AND `item` = 5514;


### PR DESCRIPTION
## Changes Proposed:
- Removed Conjured Mana Agate from the drop table because it is a conjured mage item and should not drop anywhere

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6249
- Closes https://github.com/chromiecraft/chromiecraft/issues/791

## Tests Performed:
- After running the sql script the drop is no longer in the database
![grafik](https://user-images.githubusercontent.com/10009755/121270189-82955480-c8c1-11eb-899b-ea71fbd507c4.png)


## How to Test the Changes:
1. Execute the sql script
2. Make sure that the query SELECT entry FROM \`creature_loot_template\`  WHERE \`item\`=5514; does not return entry 462 (id of Vultros)

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
