### PR TITLE
fix(DB/gameobject): Unreachable Copper vein

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1623196877899764500.sql
+++ b/data/sql/updates/pending_db_world/rev_1623196877899764500.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1623196877899764500');
+
+-- Update unreachable copper vein
+UPDATE `gameobject`
+SET `position_x`=-9144, `position_y`=-2078, `position_z`=125, `orientation`=3.369
+WHERE `guid`=5149 AND `id`=1731;


### PR DESCRIPTION
## Changes Proposed:
- copper vein with the guid 5149 is now moved on top of the cliff so that players can reach it 


## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6270
- Closes https://github.com/chromiecraft/chromiecraft/issues/807

## Tests Performed:
- SQL Script executed without errors
- Checked the changes ingame

New location
![grafik](https://user-images.githubusercontent.com/10009755/121273827-6a293800-c8c9-11eb-8cdd-feffad1963b3.png)

Old location
![grafik](https://user-images.githubusercontent.com/10009755/121273900-9644b900-c8c9-11eb-8fae-51a75d53722a.png)

## How to Test the Changes:
To see the new location:
`.go gobject 5149`

You can check the old location around this coords:
`.go xyz -9165 -2091 90`


## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
