### PR TITLE
fix(DB/SAI): Remove despawn event from Lorgus Jett

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1623254092348182246.sql
+++ b/data/sql/updates/pending_db_world/rev_1623254092348182246.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1623254092348182246');
+
+-- Delete despawn event from SmartAI of Lorgus Jett
+DELETE FROM `smart_scripts` WHERE `entryorguid`=12902 AND `id`=0;


### PR DESCRIPTION
## Changes Proposed:
Remove despawn event (`id=0`) from `smart_scripts` for **Lorgus Jett**  (`entryorguid=12902`)


## Issues Addressed:
- Closes #6286
- Closes https://github.com/chromiecraft/chromiecraft/issues/823


## SOURCE:
- https://wowpedia.fandom.com/wiki/Lorgus_Jett?oldid=2297733
- https://wowgaming.altervista.org/aowow/?quest=6565


## Tests Performed:
- SQL statement successfully executed
- Tested in game


## How to Test the Changes:
- `.tele Blackfathom Deeps`
- `.instance unbind all`
- enter instance
- `.go creature id 12902` 
- observe that **Lorgus Jett** has not be depawned
- repeat until convinced that the fix works


## Known Issues and TODO List:


## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
