### PR TITLE
fix(DB/creature_loot_template): Increase drop chance for Diabolical Plans

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1623303655379442308.sql
+++ b/data/sql/updates/pending_db_world/rev_1623303655379442308.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1623303655379442308');
+
+-- Unify and increase drop chance for Diabolical Plans to 8% (was 1.2% .. 3%)
+UPDATE `creature_loot_template` SET `Chance`=8 WHERE `Item` IN (23777, 23797);


### PR DESCRIPTION
## Changes Proposed:
- Increase and unify drop chance for **Diabolical Plans (23777, 23797)** to `8%`
- The drop chance varied between `1.2%` and `3%` (for no specific reason) and resulted in roughly a `65%` chance to not get this quest starter item while doing **Destroy the Legion**. With this change the overall chance of not getting the followup quest is reduced to roughly `20%` when only killing the required number of demons.


## Issues Addressed:
- Closes #6295
- Closes https://github.com/chromiecraft/chromiecraft/issues/829


## SOURCE:
- https://www.wowhead.com/item=23797/diabolical-plans#comments:id=1125955
The drop rates are actually higher than listed on WoWhead because the quest item will not drop for people who have already completed the quest or are currently on it.
- https://github.com/chromiecraft/chromiecraft/issues/829#issuecomment-858293543
I kinda like the idea that the chance of getting the item while doing the quest should be roughly `80%` which means the individual drop chances should be adjusted to `8%` for all 3 demons and both quest starter items.


## Tests Performed:
- SQL statement executed 
- Tested in game


## How to Test the Changes:
```SQL
SELECT `Entry`, `Item`, `Chance`, `Comment` FROM `creature_loot_template` WHERE `Item` IN (23777, 23797);
+-------+-------+--------+-------------------------------------+
| Entry | Item  | Chance | Comment                             |
+-------+-------+--------+-------------------------------------+
|  6073 | 23777 |      8 | Searing Infernal - Diabolical Plans |
|  6073 | 23797 |      8 | Searing Infernal - Diabolical Plans |
|  6115 | 23777 |      8 | Roaming Felguard - Diabolical Plans |
|  6115 | 23797 |      8 | Roaming Felguard - Diabolical Plans |
| 11697 | 23777 |      8 | Mannoroc Lasher - Diabolical Plans  |
| 11697 | 23797 |      8 | Mannoroc Lasher - Diabolical Plans  |
+-------+-------+--------+-------------------------------------+
6 rows in set (0.000 sec)
```
or
- Go to Felfire Hill in Ashenvale
- Kill some demons
- Observe the increased drop chance (> 80% when killing 20 demons total)


## Known Issues and TODO List:


## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
