### PR TITLE
feat(Core): deprecate clang-9 and older

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -38,9 +38,7 @@ Versions of CLang:
 | 12              | :white_check_mark: |
 | 11              | :white_check_mark: |
 | 10              | :white_check_mark: |
-| 9               | :white_check_mark: |
-| 7               | :white_check_mark: |
-| 6 and lower     | :red_circle:       |
+| 9 and lower     | :red_circle:       |
 
 Versions of GCC:
 

--- a/.github/workflows/core_build.yml
+++ b/.github/workflows/core_build.yml
@@ -24,21 +24,13 @@ jobs:
           - os: ubuntu-20.04
             compiler: clang12
             modules: without
-            extra_logs: false
-          - os: ubuntu-20.04
-            compiler: clang11
-            modules: without
             extra_logs: true
           - os: ubuntu-20.04
             compiler: clang11
             modules: without
             extra_logs: false
-          - os: ubuntu-20.04
-            compiler: clang8
-            modules: without
-            extra_logs: false
           - os: ubuntu-18.04
-            compiler: clang7
+            compiler: clang10
             modules: without
             extra_logs: false
           - os: ubuntu-18.04

--- a/apps/ci/ci-conf.sh
+++ b/apps/ci/ci-conf.sh
@@ -47,24 +47,6 @@ case $COMPILER in
     echo "CCOMPILERCXX=\"clang++\"" >> ./conf/config.sh
     ;;
 
-  "clang7" )
-    time sudo apt-get install -y clang-7
-    echo "CCOMPILERC=\"clang-7\"" >> ./conf/config.sh
-    echo "CCOMPILERCXX=\"clang++-7\"" >> ./conf/config.sh
-    ;;
-
-  "clang8" )
-    time sudo apt-get install -y clang-8
-    echo "CCOMPILERC=\"clang-8\"" >> ./conf/config.sh
-    echo "CCOMPILERCXX=\"clang++-8\"" >> ./conf/config.sh
-    ;;
-
-  "clang9" )
-    time sudo apt-get install -y clang-9
-    echo "CCOMPILERC=\"clang-9\"" >> ./conf/config.sh
-    echo "CCOMPILERCXX=\"clang++-9\"" >> ./conf/config.sh
-    ;;
-
   "clang10" )
     time sudo apt-get install -y clang-10
     echo "CCOMPILERC=\"clang-10\"" >> ./conf/config.sh

--- a/apps/ci/ci-install.sh
+++ b/apps/ci/ci-install.sh
@@ -52,24 +52,6 @@ case $COMPILER in
     echo "CCOMPILERCXX=\"clang++\"" >> ./conf/config.sh
     ;;
 
-  "clang7" )
-    time sudo apt-get install -y clang-7
-    echo "CCOMPILERC=\"clang-7\"" >> ./conf/config.sh
-    echo "CCOMPILERCXX=\"clang++-7\"" >> ./conf/config.sh
-    ;;
-
-  "clang8" )
-    time sudo apt-get install -y clang-8
-    echo "CCOMPILERC=\"clang-8\"" >> ./conf/config.sh
-    echo "CCOMPILERCXX=\"clang++-8\"" >> ./conf/config.sh
-    ;;
-
-  "clang9" )
-    time sudo apt-get install -y clang-9
-    echo "CCOMPILERC=\"clang-9\"" >> ./conf/config.sh
-    echo "CCOMPILERCXX=\"clang++-9\"" >> ./conf/config.sh
-    ;;
-
   "clang10" )
     time sudo apt-get install -y clang-10
     echo "CCOMPILERC=\"clang-10\"" >> ./conf/config.sh

--- a/src/cmake/compiler/clang/settings.cmake
+++ b/src/cmake/compiler/clang/settings.cmake
@@ -14,7 +14,7 @@ target_compile_definitions(acore-compile-option-interface
   INTERFACE
     -D_BUILD_DIRECTIVE="${CMAKE_BUILD_TYPE}")
 
-set(CLANG_EXPECTED_VERSION 7.0.0)
+set(CLANG_EXPECTED_VERSION 10.0.0)
 
 if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS CLANG_EXPECTED_VERSION)
   message(FATAL_ERROR "Clang: AzerothCore requires version ${CLANG_EXPECTED_VERSION} to build but found ${CMAKE_CXX_COMPILER_VERSION}")


### PR DESCRIPTION
- From now on, the minimum required clang version will be 10
- Also removed some builds to save runs