### PR TITLE
feat(Core/Group): Add support enter queue at diff group

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1859,7 +1859,7 @@ GroupJoinBattlegroundResult Group::CanJoinBattlegroundQueue(Battleground const* 
             return ERR_BATTLEGROUND_JOIN_FAILED;
 
         // don't allow cross-faction groups to join queue
-        if (member->GetTeamId() != teamId)
+        if (member->GetTeamId() != teamId && sWorld->getBoolConfig(CONFIG_ALLOW_TWO_SIDE_INTERACTION_GROUP))
             return ERR_BATTLEGROUND_JOIN_TIMED_OUT;
 
         // don't let join rated matches if the arena team id doesn't match

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1859,7 +1859,7 @@ GroupJoinBattlegroundResult Group::CanJoinBattlegroundQueue(Battleground const* 
             return ERR_BATTLEGROUND_JOIN_FAILED;
 
         // don't allow cross-faction groups to join queue
-        if (member->GetTeamId() != teamId && sWorld->getBoolConfig(CONFIG_ALLOW_TWO_SIDE_INTERACTION_GROUP))
+        if (member->GetTeamId() != teamId && !sWorld->getBoolConfig(CONFIG_ALLOW_TWO_SIDE_INTERACTION_GROUP))
             return ERR_BATTLEGROUND_JOIN_TIMED_OUT;
 
         // don't let join rated matches if the arena team id doesn't match


### PR DESCRIPTION
## Changes Proposed:
- Add support enter queue at diff group

## Issues Addressed:
- Part #5315

## Tests Performed:
![image](https://user-images.githubusercontent.com/18329778/122671967-5946c380-d1f3-11eb-888d-bca07b723af9.png)
![image](https://user-images.githubusercontent.com/18329778/122672008-8eebac80-d1f3-11eb-985f-1dd62581b0f2.png)


## How to Test the Changes:
- Just enter queue with diff faction in one group

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
