### PR TITLE
fix(DB/quest_poi): Waters of Xavian (1944) and Laughing Sisters (1945)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624198243312398771.sql
+++ b/data/sql/updates/pending_db_world/rev_1624198243312398771.sql
@@ -1,0 +1,19 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624198243312398771');
+
+-- Mark existing POI as quest turn in for Waters of Xavian (1944)
+UPDATE `quest_poi` SET `ObjectiveIndex`=-1 WHERE `QuestID`=1944 AND `id`=0;
+
+-- Add POI for the quest objective of Waters of Xavian (1944)
+DELETE FROM `quest_poi` WHERE `QuestId`=1944 AND `id`=1;
+INSERT INTO `quest_poi` (`QuestId`, `id`, `ObjectiveIndex`, `MapId`, `WorldMapAreaId`, `Floor`, `Priority`, `Flags`, `VerifiedBuild`) VALUES (1944,1,4,1,43,0,0,1,0);
+DELETE FROM `quest_poi_points` WHERE `QuestId`=1944 AND `Idx1`=1;
+INSERT INTO `quest_poi_points` (`QuestId`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (1944, 1, 0, 3079, -2701, 0);
+
+-- Add POIs for the quest objective of Laughing Sisters (1945)
+DELETE FROM `quest_poi` WHERE `QuestId`=1945 AND `id`=1;
+INSERT INTO `quest_poi` (`QuestId`, `id`, `ObjectiveIndex`, `MapId`, `WorldMapAreaId`, `Floor`, `Priority`, `Flags`, `VerifiedBuild`) VALUES (1945,1,4,1,43,0,0,1,0);
+DELETE FROM `quest_poi_points` WHERE `QuestId`=1945 AND `Idx1`=1;
+INSERT INTO `quest_poi_points` (`QuestId`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES
+(1945, 1, 0, 2797, -1812, 0),
+(1945, 1, 1, 2524, -1801, 0),
+(1945, 1, 2, 2519, -1618, 0);

--- a/data/sql/updates/pending_db_world/rev_1624198243312398771.sql
+++ b/data/sql/updates/pending_db_world/rev_1624198243312398771.sql
@@ -1,17 +1,14 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624198243312398771');
 
--- Mark existing POI as quest turn in for Waters of Xavian (1944)
-UPDATE `quest_poi` SET `ObjectiveIndex`=-1 WHERE `QuestID`=1944 AND `id`=0;
-
 -- Add POI for the quest objective of Waters of Xavian (1944)
 DELETE FROM `quest_poi` WHERE `QuestId`=1944 AND `id`=1;
-INSERT INTO `quest_poi` (`QuestId`, `id`, `ObjectiveIndex`, `MapId`, `WorldMapAreaId`, `Floor`, `Priority`, `Flags`, `VerifiedBuild`) VALUES (1944,1,4,1,43,0,0,1,0);
+INSERT INTO `quest_poi` (`QuestId`, `id`, `ObjectiveIndex`, `MapId`, `WorldMapAreaId`, `Floor`, `Priority`, `Flags`, `VerifiedBuild`) VALUES (1944, 1, 4, 1, 43, 0, 0, 1, 0);
 DELETE FROM `quest_poi_points` WHERE `QuestId`=1944 AND `Idx1`=1;
 INSERT INTO `quest_poi_points` (`QuestId`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES (1944, 1, 0, 3079, -2701, 0);
 
 -- Add POIs for the quest objective of Laughing Sisters (1945)
 DELETE FROM `quest_poi` WHERE `QuestId`=1945 AND `id`=1;
-INSERT INTO `quest_poi` (`QuestId`, `id`, `ObjectiveIndex`, `MapId`, `WorldMapAreaId`, `Floor`, `Priority`, `Flags`, `VerifiedBuild`) VALUES (1945,1,4,1,43,0,0,1,0);
+INSERT INTO `quest_poi` (`QuestId`, `id`, `ObjectiveIndex`, `MapId`, `WorldMapAreaId`, `Floor`, `Priority`, `Flags`, `VerifiedBuild`) VALUES (1945, 1, 4, 1, 43, 0, 0, 1, 0);
 DELETE FROM `quest_poi_points` WHERE `QuestId`=1945 AND `Idx1`=1;
 INSERT INTO `quest_poi_points` (`QuestId`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES
 (1945, 1, 0, 2797, -1812, 0),


### PR DESCRIPTION
## Changes Proposed:
- Add missing POI for quest objective of **Waters of Xavian (1944)**
- Add missing POIs for quest objective of **Laughing Sisters (1945)**


## Issues Addressed:
- Closes #6456
- Closes https://github.com/chromiecraft/chromiecraft/issues/924


## SOURCE:
Quest objectives should have proper POIs as shown in https://github.com/azerothcore/azerothcore-wotlk/issues/6456#issuecomment-864560108


## Tests Performed:
- SQL statements executed 
- Tested in game


## How to Test the Changes:
- `.quest add 1944`
- Observe that the quest objective at the **Xavian Waterfall (Ashenvale)**  is now properly marked on the map 
- `.quest add 1945`
- Observe that the quest objective at **Raynewood Retreat (Ashenvale)**  is now properly marked on the map 

 
## Known Issues and TODO List:


## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
