### PR TITLE
fix(DB): Webbed Creature missing flags

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624283834038071800.sql
+++ b/data/sql/updates/pending_db_world/rev_1624283834038071800.sql
@@ -1,3 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624283834038071800');
 
-UPDATE `creature_template` SET `unit_flags` = 131076, `flags_extra` = 8388866 WHERE (`entry` = 17680);
+UPDATE `creature_template` SET `unit_flags` = `unit_flags`|4|131072, `flags_extra` = `flags_extra`|2|256|8388608 WHERE (`entry` = 17680);

--- a/data/sql/updates/pending_db_world/rev_1624283834038071800.sql
+++ b/data/sql/updates/pending_db_world/rev_1624283834038071800.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624283834038071800');
+
+UPDATE `creature_template` SET `unit_flags` = 131076, `flags_extra` = 8388866 WHERE (`entry` = 17680);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added flags to creature

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6478

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game
![Screenshot_1](https://user-images.githubusercontent.com/54484196/122775098-b26d3080-d2a1-11eb-98ac-7d92dd59d420.png)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 17680
2. They are immune to taunt
3. They are immobile
4. They don't attack
5. They can't dodge attacks

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
