### PR TITLE
fix(DB): The Demon seed conditions

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624286776168757800.sql
+++ b/data/sql/updates/pending_db_world/rev_1624286776168757800.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624286776168757800');
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 926) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 924) AND (`ConditionValue2` = 8) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(19, 0, 926, 0, 0, 47, 0, 924, 8, 0, 0, 0, 0, '', "Quest \'Flawed Power Stone\' should be available if \'The Demon Seed\' is incomplete");


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Missing condition on quest `Flawed Power Stone` that was able to be picked up if players finished quest `The Demon Seed`

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes not reported bug

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://youtu.be/1S-cTwn-EHo?t=581
You can see that the stones on the table next to the quest giver aren't able to be taken no longer

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .q a 924
2. .go c id 3521
3. Quest `Flawed Power Stones` are able to be taken
4. .q c 924
5. Quest `Flawed Power Stones` are no longer able to be taken

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
Complete

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
