### PR TITLE
Paladin Seal of Righteousness

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -24077,13 +24077,34 @@ void Player::learnSkillRewardedSpells(uint32 skill_id, uint32 skill_value)
             removeSpell(pAbility->Spell, GetActiveSpec(), true);
         }
         // need learn
-        else if (!IsInWorld())
-        {
-            addSpell(pAbility->Spell, true, true, true, false);
-        }
         else
         {
-            learnSpell(pAbility->Spell);
+            //used to avoid double Seal of Righteousness on paladins, it's the only player spell which has both spell and forward spell in auto learn
+            if (pAbility->AcquireMethod == SKILL_LINE_ABILITY_LEARNED_ON_SKILL_LEARN && pAbility->SupercededBySpell)
+            {
+                bool skipCurrent = false;
+                auto bounds = sSpellMgr->GetSkillLineAbilityMapBounds(pAbility->SupercededBySpell);
+                for (auto itr = bounds.first; itr != bounds.second; ++itr)
+                {
+                    if (itr->second->AcquireMethod == SKILL_LINE_ABILITY_LEARNED_ON_SKILL_LEARN && skill_value >= itr->second->MinSkillLineRank)
+                    {
+                        skipCurrent = true;
+                        break;
+                    }
+                }
+                if (skipCurrent)
+                {
+                    continue;
+                }
+            }
+            if (!IsInWorld())
+            {
+                addSpell(pAbility->Spell, true, true, true, false);
+            }
+            else
+            {
+                learnSpell(pAbility->Spell);
+            }
         }
     }
 }


### PR DESCRIPTION
fix 2 Seal of Righteousness spells on paladins

## Changes Proposed:
https://github.com/TrinityCore/TrinityCore/issues/14239
https://github.com/azerothcore/azerothcore-wotlk/pull/6015
https://github.com/TrinityCore/TrinityCore/commit/08fdac340c8af7d7426870d3ec51ab88c5dd77db

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
