### PR TITLE
fix(DB/Loot): Shredder Operating Manual pages now drop for Horde only

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624655873326823800.sql
+++ b/data/sql/updates/pending_db_world/rev_1624655873326823800.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624655873326823800');
+
+UPDATE `item_template` SET `FlagsExtra` = 1 WHERE `entry` BETWEEN 16645 AND 16656;


### PR DESCRIPTION
## Changes Proposed:
-  Shredder Operating Manual pages(Character GUID: 32947) now drop for Horde only

## Issues Addressed:
- Closes issue #6572

## CO-AUTHOR(S)
- necropola

## Tests Performed:
-


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. ``` .go creature 32947 ```
2. Kill monsters on Alliance character
3. Kill monster on Horde character

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
