### PR TITLE
fix(DB/item_template): Flag all "Shredder Operating Manual" pages for HORDE_ONLY

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624657033501888850.sql
+++ b/data/sql/updates/pending_db_world/rev_1624657033501888850.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624657033501888850');
+
+-- Flag all "Shredder Operating Manual - Page %" items for HORDE_ONLY
+UPDATE `item_template` SET `FlagsExtra`=1 WHERE `entry` BETWEEN 16645 AND 16656;


### PR DESCRIPTION
## Changes Proposed:
Flag all **Shredder Operating Manual - Page %** items for `HORDE_ONLY` so that they no longer drop for Alliance characters.


## Issues Addressed:
- Closes #6572
- Closes https://github.com/chromiecraft/chromiecraft/issues/1001


## SOURCE:
From https://wowpedia.fandom.com/wiki/Shredder_Operating_Manual_-_Page_1:
>Patch 1.8.0 (2005-10-10): Shredder Operating Manual pages will no longer drop for the Alliance.


## Tests Performed:
- SQL statement executed
- Tested in game


## How to Test the Changes:
- Run the following SQL statement to verify that the fix was applied
```SQL
SELECT `entry`, `name`, `FlagsExtra` FROM `item_template` WHERE `name` LIKE 'Shredder Operating Manual - Page %' ORDER BY `entry`;
+-------+-------------------------------------+------------+
| entry | name                                | FlagsExtra |
+-------+-------------------------------------+------------+
| 16645 | Shredder Operating Manual - Page 1  |          1 |
| 16646 | Shredder Operating Manual - Page 2  |          1 |
| 16647 | Shredder Operating Manual - Page 3  |          1 |
| 16648 | Shredder Operating Manual - Page 4  |          1 |
| 16649 | Shredder Operating Manual - Page 5  |          1 |
| 16650 | Shredder Operating Manual - Page 6  |          1 |
| 16651 | Shredder Operating Manual - Page 7  |          1 |
| 16652 | Shredder Operating Manual - Page 8  |          1 |
| 16653 | Shredder Operating Manual - Page 9  |          1 |
| 16654 | Shredder Operating Manual - Page 10 |          1 |
| 16655 | Shredder Operating Manual - Page 11 |          1 |
| 16656 | Shredder Operating Manual - Page 12 |          1 |
+-------+-------------------------------------+------------+
12 rows in set (0.000 sec)
```
- On an Alliance character go to **Felfire Hill** in **Ashenvale** and kill loads of demons
- Observe that the pages no longer drop
- When you are doing this on a local AC server compiled with `EXTRA_LOGS` enabled and `Logger.Loot=5` in `worldserver.conf` a debug message added with PR #5774 is generated everytime such a page was suppressed from loot, e. g. ` Skipping ++unlootedCount for unlootable item: 16648`
- Do the same on a Horde character and observe that you are still getting the pages


## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
