### PR TITLE
fix(DB) Untranslated texts for The Battle for Undercity

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624668958042794600.sql
+++ b/data/sql/updates/pending_db_world/rev_1624668958042794600.sql
@@ -1,10 +1,11 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624668958042794600');
+
 DELETE FROM `gossip_menu_option_locale` WHERE `MenuID` = 10189 AND OptionID = 0 AND `Locale` IN ('esES','esMX');
 INSERT INTO `gossip_menu_option_locale` (`MenuID`, `OptionID`, `Locale`, `OptionText`, `BoxText`) VALUES
 (10189,0,'esES','Lady Valiente, estoy listo para ir a Orgrimmar. Abre el portal.',''),
 (10189,0,'esMX','Lady Valiente, estoy listo para ir a Orgrimmar. Abre el portal.','');
 
-DELETE FROM `creature_text_locale` WHERE `CreatureID` IN (32364, 32346) AND GroupID IN (0, 1, 2, 3 ,4) AND `Locale` IN ('esES','esMX');
+DELETE FROM `creature_text_locale` WHERE `CreatureID` = 32346 AND GroupID IN (0, 1, 2, 3 ,4) AND `Locale` IN ('esES','esMX');
 INSERT INTO `creature_text_locale` (`CreatureID`, `GroupID`, `ID`, `Locale`, `Text`) VALUES
 (32364,0,0,'esES','Thrall, ¿qué ha ocurrido? El Rey se prepara para la guerra...'),
 (32364,1,0,'esES','Haré llegar esta información al Rey Wrynn, Thrall, pero...'),
@@ -26,10 +27,10 @@ INSERT INTO `creature_text_locale` (`CreatureID`, `GroupID`, `ID`, `Locale`, `Te
 
 DELETE FROM `quest_request_items_locale` WHERE `ID` IN (13347, 13242) AND `locale` IN ('esES','esMX');
 INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(13347,'esES','<El rey Wrynn se seca una lágrima>.$B$B<El Rey asiente.>$B$BEsto es culpa mía.',18019),
 (13242,'esES','<La cara de Colmillosaurio se desfigura.>$B$BMi corazón... mi fuerza...',18019),
-(13347,'esMX','<El rey Wrynn se seca una lágrima>.$B$B<El Rey asiente.>$B$BEsto es culpa mía.',18019),
-(13242,'esMX','<La cara de Colmillosaurio se desfigura.>$B$BMi corazón... mi fuerza...',18019);
+(13242,'esMX','<La cara de Colmillosaurio se desfigura.>$B$BMi corazón... mi fuerza...',18019),
+(13347,'esES','<El rey Wrynn se seca una lágrima>.$B$B<El Rey asiente.>$B$BEsto es culpa mía.',18019),
+(13347,'esMX','<El rey Wrynn se seca una lágrima>.$B$B<El Rey asiente.>$B$BEsto es culpa mía.',18019);
 
 DELETE FROM `quest_offer_reward_locale` WHERE `ID` IN (13347, 13369, 13370, 13371, 13377, 13242, 13257, 13266, 13267) AND `locale` IN ('esES','esMX');
 INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1624668958042794600.sql
+++ b/data/sql/updates/pending_db_world/rev_1624668958042794600.sql
@@ -1,0 +1,53 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624668958042794600');
+DELETE FROM `gossip_menu_option_locale` WHERE `MenuID` = 10189 AND OptionID = 0 AND `Locale` IN ('esES','esMX');
+INSERT INTO `gossip_menu_option_locale` (`MenuID`, `OptionID`, `Locale`, `OptionText`, `BoxText`) VALUES
+(10189,0,'esES','Lady Valiente, estoy listo para ir a Orgrimmar. Abre el portal.',''),
+(10189,0,'esMX','Lady Valiente, estoy listo para ir a Orgrimmar. Abre el portal.','');
+
+DELETE FROM `creature_text_locale` WHERE `CreatureID` IN (32364, 32346) AND GroupID IN (0, 1, 2, 3 ,4) AND `Locale` IN ('esES','esMX');
+INSERT INTO `creature_text_locale` (`CreatureID`, `GroupID`, `ID`, `Locale`, `Text`) VALUES
+(32364,0,0,'esES','Thrall, ¿qué ha ocurrido? El Rey se prepara para la guerra...'),
+(32364,1,0,'esES','Haré llegar esta información al Rey Wrynn, Thrall, pero...'),
+(32364,2,0,'esES','Bolvar era como un hermano para él. En ausencia del Rey, Bolvar mantenía unida a la Alianza. Proporcionó fuerza a nuestro pueblo en los momentos más oscuros. Cuidó de Anduin, como si fuera su propio hijo.'),
+(32364,3,0,'esES','Temo que la ira lo consuma, Thrall. Espero que la razón prevalezca, pero debemos prepararnos para lo peor... para la guerra.'),
+(32364,4,0,'esES','Adiós, Jefe de Guerra. Rezo para que la próxima vez que nos encontremos sea como aliados.'),
+(32364,0,0,'esMX','Thrall, ¿qué ha ocurrido? El Rey se prepara para la guerra...'),
+(32364,1,0,'esMX','Haré llegar esta información al Rey Wrynn, Thrall, pero...'),
+(32364,2,0,'esMX','Bolvar era como un hermano para él. En ausencia del Rey, Bolvar mantenía unida a la Alianza. Proporcionó fuerza a nuestro pueblo en los momentos más oscuros. Cuidó de Anduin, como si fuera su propio hijo.'),
+(32364,3,0,'esMX','Temo que la ira lo consuma, Thrall. Espero que la razón prevalezca, pero debemos prepararnos para lo peor... para la guerra.'),
+(32364,4,0,'esMX','Adiós, Jefe de Guerra. Rezo para que la próxima vez que nos encontremos sea como aliados.');
+
+DELETE FROM `creature_text_locale` WHERE `CreatureID` IN (32364, 32346) AND GroupID IN (0, 1) AND `Locale` IN ('esES','esMX');
+INSERT INTO `creature_text_locale` (`CreatureID`, `GroupID`, `ID`, `Locale`, `Text`) VALUES
+(32346,0,0,'esES','No hagas nada que pueda provocar a la horda. $N. El Jefe de Guerra confía en nuestra buena fe.'),
+(32346,1,0,'esES','Vamos.'),
+(32346,0,0,'esMX','No hagas nada que pueda provocar a la horda. $N. El Jefe de Guerra confía en nuestra buena fe.'),
+(32346,1,0,'esMX','Vamos.');
+
+DELETE FROM `quest_request_items_locale` WHERE `ID` IN (13347, 13242) AND `locale` IN ('esES','esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(13347,'esES','<El rey Wrynn se seca una lágrima>.$B$B<El Rey asiente.>$B$BEsto es culpa mía.',18019),
+(13242,'esES','<La cara de Colmillosaurio se desfigura.>$B$BMi corazón... mi fuerza...',18019),
+(13347,'esMX','<El rey Wrynn se seca una lágrima>.$B$B<El Rey asiente.>$B$BEsto es culpa mía.',18019),
+(13242,'esMX','<La cara de Colmillosaurio se desfigura.>$B$BMi corazón... mi fuerza...',18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID` IN (13347, 13369, 13370, 13371, 13377, 13242, 13257, 13266, 13267) AND `locale` IN ('esES','esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(13347,'esES','La Reina de Dragones tiene razón $N. No todo está perdido. Habrá una fuerza que renazca de las cenizas y yo purgaré el mal de la Horda de este mundo. Las muertes de nuestros hermanos y hermanas no habrán sido en vano.',18019),
+(13369,'esES','La Horda no quiere guerra $R. Escúchame bien...',18019),
+(13370,'esES','¿Han perdido Entrañas? Entonces el momento de golpearles es ahora. Nos encargaremos de Putress nosotros mismos y retomaremos las Ruinas de Lordaeron para la Alianza!',18019),
+(13371,'esES','¿Y tú quién se supone que eres? Varian dijo que mandaría héroes.',18019),
+(13377,'esES','Durante mucho tiempo la horda ha sido libre. Hemos permitido que sus territorios prosperaran y, en pago por nuestra generosidad, han planeado y tramado nuestra caída.$B$B¿Paz? No tiene sentido... No nos ha llevado a ninguna parte. Hemos perdido a algunos de nuestros mejores héroes por la "paz". Veamos qué nos trae la batalla...$B$BVuelve a Rasganorte, $N. Conquístalo para tu rey: ¡POR LA ALIANZA!',18019),
+(13242,'esES','<Colmillosaurio mira al cielo>.$B$BAl igual que Brox, mi hijo murió siendo un héroe. No guardes luto por él $N. ¡No existe mejor final para un orco! ¡No existe mayor honor! Ahora mismo, mi corazón está henchido de orgullo.$B$BGracias por devolvernos la armadura de batalla. La pondremos sobre su pira en las Tierras Ancestrales de Nagrand.$B$BTenemos que concentrarnos en los temas más urgentes.',18019),
+(13257,'esES','El señor demoníaco, Varimathras, y el boticario jefe renegado, Putress, son los responsables de esta traición.$B$B<Thrall asiente.>$B$BSí, el mismo Putress que ha descubierto la cura para el reciente brote de Plaga.$B$BAquellos que no se aliaron con su régimen han sido ejecutados o desterrados. Sylvanas casi murió en el golpe.$B$BLa horda ha perdido entrañas. Orgrimmar acogerá a los refugiados Renegados hasta que se resuelva la crisis. Por ahora, estamos bajo ley marcial.',18019),
+(13266,'esES','Te pondré al día rápidamente, $N.$B$BEntrañas está en guerra. Los boticarios de Putress y los demonios de Varimathras han asediado la ciudad. Han tomado una posición defensiva en el interior y usan el maldito añublo contra nuestras tropas.',18019),
+(13267,'esES','El mañana está lleno de incertidumbre. Los días en los que la Alianza y Horda luchaban juntos contra un enemigo común se han ido. Una nueva batalla amanece, $N, una batalla en la que no habrá ganador.$B$BPero debemos seguir avanzando hacia Corona de Hielo. No tenemos elección. Nuestra salvación está en manos de héroes como tú, $N. El futuro de la Horda, y del mundo, depende de tí.$B$BVolvamos a Orgrimmar, Debes volver a Rasganorte de inmediato.',18019),
+(13347,'esMX','La Reina de Dragones tiene razón $N. No todo está perdido. Habrá una fuerza que renazca de las cenizas y yo purgaré el mal de la Horda de este mundo. Las muertes de nuestros hermanos y hermanas no habrán sido en vano.',18019),
+(13369,'esMX','La Horda no quiere guerra $R. Escúchame bien...',18019),
+(13370,'esMX','¿Han perdido Entrañas? Entonces el momento de golpearles es ahora. Nos encargaremos de Putress nosotros mismos y retomaremos las Ruinas de Lordaeron para la Alianza!',18019),
+(13371,'esMX','¿Y tú quién se supone que eres? Varian dijo que mandaría héroes.',18019),
+(13377,'esMX','Durante mucho tiempo la horda ha sido libre. Hemos permitido que sus territorios prosperaran y, en pago por nuestra generosidad, han planeado y tramado nuestra caída.$B$B¿Paz? No tiene sentido... No nos ha llevado a ninguna parte. Hemos perdido a algunos de nuestros mejores héroes por la "paz". Veamos qué nos trae la batalla...$B$BVuelve a Rasganorte, $N. Conquístalo para tu rey: ¡POR LA ALIANZA!',18019),
+(13242,'esMX','<Colmillosaurio mira al cielo>.$B$BAl igual que Brox, mi hijo murió siendo un héroe. No guardes luto por él $N. ¡No existe mejor final para un orco! ¡No existe mayor honor! Ahora mismo, mi corazón está henchido de orgullo.$B$BGracias por devolvernos la armadura de batalla. La pondremos sobre su pira en las Tierras Ancestrales de Nagrand.$B$BTenemos que concentrarnos en los temas más urgentes.',18019),
+(13257,'esMX','El señor demoníaco, Varimathras, y el boticario jefe renegado, Putress, son los responsables de esta traición.$B$B<Thrall asiente.>$B$BSí, el mismo Putress que ha descubierto la cura para el reciente brote de Plaga.$B$BAquellos que no se aliaron con su régimen han sido ejecutados o desterrados. Sylvanas casi murió en el golpe.$B$BLa horda ha perdido entrañas. Orgrimmar acogerá a los refugiados Renegados hasta que se resuelva la crisis. Por ahora, estamos bajo ley marcial.',18019),
+(13266,'esMX','Te pondré al día rápidamente, $N.$B$BEntrañas está en guerra. Los boticarios de Putress y los demonios de Varimathras han asediado la ciudad. Han tomado una posición defensiva en el interior y usan el maldito añublo contra nuestras tropas.',18019),
+(13267,'esMX','El mañana está lleno de incertidumbre. Los días en los que la Alianza y Horda luchaban juntos contra un enemigo común se han ido. Una nueva batalla amanece, $N, una batalla en la que no habrá ganador.$B$BPero debemos seguir avanzando hacia Corona de Hielo. No tenemos elección. Nuestra salvación está en manos de héroes como tú, $N. El futuro de la Horda, y del mundo, depende de tí.$B$BVolvamos a Orgrimmar, Debes volver a Rasganorte de inmediato.',18019);

--- a/data/sql/updates/pending_db_world/rev_1624668958042794600.sql
+++ b/data/sql/updates/pending_db_world/rev_1624668958042794600.sql
@@ -5,7 +5,7 @@ INSERT INTO `gossip_menu_option_locale` (`MenuID`, `OptionID`, `Locale`, `Option
 (10189,0,'esES','Lady Valiente, estoy listo para ir a Orgrimmar. Abre el portal.',''),
 (10189,0,'esMX','Lady Valiente, estoy listo para ir a Orgrimmar. Abre el portal.','');
 
-DELETE FROM `creature_text_locale` WHERE `CreatureID` = 32346 AND GroupID IN (0, 1, 2, 3 ,4) AND `Locale` IN ('esES','esMX');
+DELETE FROM `creature_text_locale` WHERE `CreatureID` = 32346 AND `GroupID` IN (0, 1, 2, 3 ,4) AND `Locale` IN ('esES','esMX');
 INSERT INTO `creature_text_locale` (`CreatureID`, `GroupID`, `ID`, `Locale`, `Text`) VALUES
 (32364,0,0,'esES','Thrall, ¿qué ha ocurrido? El Rey se prepara para la guerra...'),
 (32364,1,0,'esES','Haré llegar esta información al Rey Wrynn, Thrall, pero...'),

--- a/data/sql/updates/pending_db_world/rev_1624668958042794600.sql
+++ b/data/sql/updates/pending_db_world/rev_1624668958042794600.sql
@@ -5,7 +5,7 @@ INSERT INTO `gossip_menu_option_locale` (`MenuID`, `OptionID`, `Locale`, `Option
 (10189,0,'esES','Lady Valiente, estoy listo para ir a Orgrimmar. Abre el portal.',''),
 (10189,0,'esMX','Lady Valiente, estoy listo para ir a Orgrimmar. Abre el portal.','');
 
-DELETE FROM `creature_text_locale` WHERE `CreatureID` = 32346 AND `GroupID` IN (0, 1, 2, 3 ,4) AND `Locale` IN ('esES','esMX');
+DELETE FROM `creature_text_locale` WHERE `CreatureID` = 32364 AND `GroupID` IN (0, 1, 2, 3 ,4) AND `Locale` IN ('esES','esMX');
 INSERT INTO `creature_text_locale` (`CreatureID`, `GroupID`, `ID`, `Locale`, `Text`) VALUES
 (32364,0,0,'esES','Thrall, ¿qué ha ocurrido? El Rey se prepara para la guerra...'),
 (32364,1,0,'esES','Haré llegar esta información al Rey Wrynn, Thrall, pero...'),

--- a/data/sql/updates/pending_db_world/rev_1624668958042794600.sql
+++ b/data/sql/updates/pending_db_world/rev_1624668958042794600.sql
@@ -17,7 +17,7 @@ INSERT INTO `creature_text_locale` (`CreatureID`, `GroupID`, `ID`, `Locale`, `Te
 (32364,3,0,'esMX','Temo que la ira lo consuma, Thrall. Espero que la razón prevalezca, pero debemos prepararnos para lo peor... para la guerra.'),
 (32364,4,0,'esMX','Adiós, Jefe de Guerra. Rezo para que la próxima vez que nos encontremos sea como aliados.');
 
-DELETE FROM `creature_text_locale` WHERE `CreatureID` IN (32364, 32346) AND GroupID IN (0, 1) AND `Locale` IN ('esES','esMX');
+DELETE FROM `creature_text_locale` WHERE `CreatureID` = 32346 AND GroupID IN (0, 1) AND `Locale` IN ('esES','esMX');
 INSERT INTO `creature_text_locale` (`CreatureID`, `GroupID`, `ID`, `Locale`, `Text`) VALUES
 (32346,0,0,'esES','No hagas nada que pueda provocar a la horda. $N. El Jefe de Guerra confía en nuestra buena fe.'),
 (32346,1,0,'esES','Vamos.'),


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Creates the missing `gossip_menu_option_locale`, `creature_text_locale`, `quest_request_items_locale` and `quest_offer_reward_locale` to spanish.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- File and statements executed on my database several times to verify failures.
- Changes seen in-game with both alliance and horde.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- Inserting the sql in your acore_world database.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
