### PR TITLE
fix(DB/creature_summon_groups): Adjust creature despawn in BFD / Fire Of Aku'Mai

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624669484085082860.sql
+++ b/data/sql/updates/pending_db_world/rev_1624669484085082860.sql
@@ -1,4 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624669484085082860');
 
 -- Despawn the summoned creatures/corpses 5 minutes after being killed instead of 1 minute after not being in combat.
-UPDATE  `creature_summon_groups` SET `summonType`=6, `summonTime`=300000 WHERE `summonerId` IN (21118, 21119, 21120, 21121);
+UPDATE `creature_summon_groups` SET `summonType`=6, `summonTime`=300000 WHERE `summonerId` IN (21118, 21119, 21120, 21121);

--- a/data/sql/updates/pending_db_world/rev_1624669484085082860.sql
+++ b/data/sql/updates/pending_db_world/rev_1624669484085082860.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624669484085082860');
+
+-- Despawn the summoned creatures/corpses 5 minutes after being killed instead of 1 minute after not being in combat.
+UPDATE  `creature_summon_groups` SET `summonType`=6, `summonTime`=300000 WHERE `summonerId` IN (21118, 21119, 21120, 21121);


### PR DESCRIPTION
## Changes Proposed:
- Change `summonType` from `TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT` to ` TEMPSUMMON_CORPSE_TIMED_DESPAWN ` 
- Change `summonTime` (despawn timer) from 1 minute (out of combat) to 5 minutes (dead)
- Groups may now wipe at the **Fire Of Aku'Mai** event and come back to finish it


## Issues Addressed:
- Closes #5213
- Closes https://github.com/chromiecraft/chromiecraft/issues/220


## SOURCE:
Plenty. Check the addressed issues including comments.


## Tests Performed:
- SQL statement successfully executed
- Tested in game


## How to Test the Changes:
On a GM account
- `.tele Blackfathom`
- enter
- `.go creature id 4832`
- Light all fires
- Observe that the summoned creatures do not despawn (after 1 minute). Stay as long as you like, leave the instance and come back, ... they are still there. 
- Kill all summoned creatures
- Observe that the door opens
- Observe that the corpses depawn after 5 minutes


## Known Issues and TODO List:


## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
