### PR TITLE
fix(DB/Creature) Remove Civilian flag from Nazzivus Summoners

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624689676324157623.sql
+++ b/data/sql/updates/pending_db_world/rev_1624689676324157623.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624689676324157623');
+
+-- Removes Civilian flag from Nazzivus Summoners
+UPDATE `creature_template` SET `flags_extra` = `flags_extra`&~(2) WHERE `entry` = 17524;
+
+-- Set MovementType to 1 for spawn 86538 to match all other Nazzivus Summoners
+DELETE FROM `creature` WHERE `id` = 17524 AND `guid` = 86538;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(86538, 17524, 530, 0, 0, 1, 1, 0, 1, -2481.5, -11259.1, 31.07, 5.3, 534, 0, 0, 273, 0, 1, 0, 0, 0, '', 0);

--- a/data/sql/updates/pending_db_world/rev_1624689676324157623.sql
+++ b/data/sql/updates/pending_db_world/rev_1624689676324157623.sql
@@ -6,4 +6,4 @@ UPDATE `creature_template` SET `flags_extra` = `flags_extra`&~(2) WHERE `entry` 
 -- Set MovementType to 1 for spawn 86538 to match all other Nazzivus Summoners
 DELETE FROM `creature` WHERE `id` = 17524 AND `guid` = 86538;
 INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
-(86538, 17524, 530, 0, 0, 1, 1, 0, 1, -2481.5, -11259.1, 31.07, 5.3, 534, 0, 0, 273, 0, 1, 0, 0, 0, '', 0);
+(86538, 17524, 530, 0, 0, 1, 1, 0, 1, -2481.5, -11259.1, 31.07, 5.3, 534, 5, 0, 273, 0, 1, 0, 0, 0, '', 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes the Civilian flag from the flags_extra field of Nazzivus Summoners (ID 17524) so they will now attack players.
-  Also set one individual spawn (86538) to have a MovementType of 1 (random wandering) instead of 0 (standing still) to match all the others in the area.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6538
- Closes https://github.com/chromiecraft/chromiecraft/issues/962

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Common sense.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors.
- Checked in-game, NPCs are now properly aggressive and attack when you go near them.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 86538, it should attack you instead of ignoring you.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
