### PR TITLE
docs: replacing Bountysource with PayPal donation

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: salt.bountysource.com/checkout/amount?team=azerothcore
+custom: https://www.paypal.com/donate/?hosted_button_id=L69ANPSR8BJDU

--- a/.github/README.md
+++ b/.github/README.md
@@ -94,7 +94,8 @@ Check the **CONTRIBUTING** section below.
 
 ### Financially :moneybag:
 
-You can support the project by financing the resolution of issues [using Bountysource](http://www.azerothcore.org/wiki/Bountysource "Bountysource explained in our wiki").
+You can support the AzerothCore by [donating](https://www.paypal.com/donate/?hosted_button_id=L69ANPSR8BJDU).
+The money will be used to pay freelance developers for more open-source fixes.
 
 ### Advertising
 


### PR DESCRIPTION
Due to serious issues with Bountysource (which we can't control) such as developers not receiving the money they claimed, Bountysource support not answering our emails,  etc... we will be considering the possibility of completely opting out from Bountysource. It looks like other communities are experiencing the same issue: https://github.com/bountysource/core/issues/1539

Meanwhile, we are placing our "donate" links to point to the PayPal of our legal non-profit organisation (Drassil). With the money collected, we will keep paying freelance developers for their open-source contributions using different means (such as GitHub Sponsor, PayPal, etc...).

If you want to donate to AzerothCore, from now on please use: https://www.paypal.com/donate/?hosted_button_id=L69ANPSR8BJDU
100% of the money will be invested to improve our project.