### PR TITLE
fix(DB/Quest): Remove deprecated Arathi Basin quests

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624714294954952856.sql
+++ b/data/sql/updates/pending_db_world/rev_1624714294954952856.sql
@@ -1,7 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624714294954952856');
 
-DELETE FROM `creature_queststarter` WHERE `quest` IN (8154, 8155, 8156, 8080, 8297. 8162, 8161, 8160, 8123, 8299);
-DELETE FROM `creature_questender` WHERE `quest` IN (8154, 8155, 8156, 8080, 8297. 8162, 8161, 8160, 8123, 8299);
+DELETE FROM `creature_queststarter` WHERE `quest` IN (8154, 8155, 8156, 8080, 8297, 8162, 8161, 8160, 8123, 8299);
+DELETE FROM `creature_questender` WHERE `quest` IN (8154, 8155, 8156, 8080, 8297, 8162, 8161, 8160, 8123, 8299);
 
 DELETE FROM `disables` WHERE `entry` IN (8154, 8155, 8156, 8080, 8297, 8162, 8161, 8160, 8123, 8299);
 INSERT INTO `disables` (sourceType, entry, flags, comment) VALUES 

--- a/data/sql/updates/pending_db_world/rev_1624714294954952856.sql
+++ b/data/sql/updates/pending_db_world/rev_1624714294954952856.sql
@@ -1,0 +1,17 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624714294954952856');
+
+DELETE FROM `creature_queststarter` WHERE `quest` IN (8154, 8155, 8156, 8080, 8297. 8162, 8161, 8160, 8123, 8299);
+DELETE FROM `creature_questender` WHERE `quest` IN (8154, 8155, 8156, 8080, 8297. 8162, 8161, 8160, 8123, 8299);
+
+DELETE FROM `disables` WHERE `entry` IN (8154, 8155, 8156, 8080, 8297, 8162, 8161, 8160, 8123, 8299);
+INSERT INTO `disables` (sourceType, entry, flags, comment) VALUES 
+(1, 8154, 0, 'Deprecated quest: Arathi Basin Resources!'),
+(1, 8155, 0, 'Deprecated quest: Arathi Basin Resources!'),
+(1, 8156, 0, 'Deprecated quest: Arathi Basin Resources!'),
+(1, 8080, 0, 'Deprecated quest: Arathi Basin Resources!'),
+(1, 8297, 0, 'Deprecated quest: Arathi Basin Resources!'),
+(1, 8160, 0, 'Deprecated quest: Cut Arathor Supply Lines'),
+(1, 8161, 0, 'Deprecated quest: Cut Arathor Supply Lines'),
+(1, 8162, 0, 'Deprecated quest: Cut Arathor Supply Lines'),
+(1, 8123, 0, 'Deprecated quest: Cut Arathor Supply Lines'),
+(1, 8299, 0, 'Deprecated quest: Cut Arathor Supply Lines');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Attempts to disable 10 Arathi Basin quests that were deprecated in path 2.4. They are:
- Alliance: 8154, 8155, 8156, 8080, 8297 - [Arathi Basin Resources!](https://wowpedia.fandom.com/wiki/Arathi_Basin_Resources!_(level_20))
- Horde: 8160, 8161, 8162, 8123, 8299 - [Cut Arathor Supply Lines](https://wowpedia.fandom.com/wiki/Cut_Arathor_Supply_Lines_(level_20))

It does this by removing the quests from the `creature_queststarter` and `creature_questender` tables and inserting the quests into `disables`. If anything else needs to be done to disable these quests, let me know.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6503
- Closes https://github.com/chromiecraft/chromiecraft/issues/958

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- https://wowpedia.fandom.com/wiki/Arathi_Basin_Resources!_(level_20)
- https://wowpedia.fandom.com/wiki/Cut_Arathor_Supply_Lines_(level_20)
- wowwiki link (check under letter "A"): https://wowwiki-archive.fandom.com/wiki/Category:Removed_in_patch_2.4.0

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors.
- Checked quest givers in game. Both now show empty dialog pages, no quests available, and no longer show a yellow exclamation mark over their heads.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Hammerfall and/or Refuge Pointe and talk to Deathstalker Mortis or Sergeant Maclear.
2. Note lack of quests offered.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
