### PR TITLE
fix(DB/Graveyard) Move Ally GY when dying in Thunder Bluff

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624718377760938108.sql
+++ b/data/sql/updates/pending_db_world/rev_1624718377760938108.sql
@@ -6,4 +6,4 @@ DELETE FROM `graveyard_zone` WHERE `ID`= 249 AND `GhostZone`= 1638;
 -- Adds Bloodhoof Village as Ally GY when dying in Thunder Bluff
 DELETE FROM `graveyard_zone` WHERE `ID`= 89 AND `GhostZone`= 1638;
 INSERT INTO `graveyard_zone` (`ID`, `GhostZone`, `Faction`, `Comment`) VALUES
-(89, 1638, 469, 'Mulgore, Bloodhoof Village GY - Mulgore');
+(1435, 1638, 469, 'Mulgore, Bloodhoof Village GY - Mulgore');

--- a/data/sql/updates/pending_db_world/rev_1624718377760938108.sql
+++ b/data/sql/updates/pending_db_world/rev_1624718377760938108.sql
@@ -4,6 +4,6 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624718377760938108');
 DELETE FROM `graveyard_zone` WHERE `ID`= 249 AND `GhostZone`= 1638;
 
 -- Adds Bloodhoof Village as Ally GY when dying in Thunder Bluff
-DELETE FROM `graveyard_zone` WHERE `ID`= 89 AND `GhostZone`= 1638;
+DELETE FROM `graveyard_zone` WHERE `ID`= 1435 AND `GhostZone`= 1638;
 INSERT INTO `graveyard_zone` (`ID`, `GhostZone`, `Faction`, `Comment`) VALUES
 (1435, 1638, 469, 'Mulgore, Bloodhoof Village GY - Mulgore');

--- a/data/sql/updates/pending_db_world/rev_1624718377760938108.sql
+++ b/data/sql/updates/pending_db_world/rev_1624718377760938108.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624718377760938108');
+
+-- Deletes Ratchet as Ally GY when dying in Thunder Bluff
+DELETE FROM `graveyard_zone` WHERE `ID`= 249 AND `GhostZone`= 1638;
+
+-- Adds Bloodhoof Village as Ally GY when dying in Thunder Bluff
+DELETE FROM `graveyard_zone` WHERE `ID`= 89 AND `GhostZone`= 1638;
+INSERT INTO `graveyard_zone` (`ID`, `GhostZone`, `Faction`, `Comment`) VALUES
+(89, 1638, 469, 'Mulgore, Bloodhoof Village GY - Mulgore');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- When an Ally player dies in Thunder Bluff, they currently respawn in Ratchet, which is quite a long way away. This PR moves their respawn point to what I believe is the correct GY, which is the GY SE of Bloodhoof Village in Mulgore. This is where Allies who die in the rest of Mulgore go, so it's consistent. There is an argument to be made that they should respawn in Bloodhoof itself, however.

As a tauren player, was tempted to have Ally players who died in TB forced to run back from say, Outlands, but have nobly refrained.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6499
- Closes https://github.com/chromiecraft/chromiecraft/issues/954

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Only source I could find was https://us.forums.blizzard.com/en/wow/t/beta-graveyard-hopping/221094/3, which is patch 1.6 and thus rather out of date. It mentions Allies respawning in Bloodhoof, but since that is vague and inconsistent with current Mulgore GY for Allies, I'm choosing consistency over this fairly shaky source.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors.
- Tested by dying with an Ally character, found they resurrected in the chosen spot.
- Also tried with a Horde character to make sure nothing was wrong, and they resurrected in a GY much closer to TB, which is correct behaviour.

Location of the chosen GY:
![WoWScrnShot_062721_002138](https://user-images.githubusercontent.com/81782124/123516997-0fbc1400-d6de-11eb-9264-d8682a6b1893.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Die as an Ally in TB, see where you respawn.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
