### PR TITLE
fix(DB:Creature) Removes Spider Meat from Deviate Creepers/Lurkers

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624770439358526029.sql
+++ b/data/sql/updates/pending_db_world/rev_1624770439358526029.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624770439358526029');
+
+-- Remove Crisp Spider Meat from Deviate Lurker and Deviate Creeper
+DELETE FROM `creature_loot_template` WHERE `Entry` IN (3632, 3641) AND `Item` = 1081;
+
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Delete Crisp Spider Meat (ID 1081) from Deviate Lurkers and Deviate Creepers (both non-spiders.)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6602
- Closes https://github.com/chromiecraft/chromiecraft/issues/1014

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowpedia.fandom.com/wiki/Crisp_Spider_Meat
https://tbc.wowhead.com/npc=3641/deviate-lurker
https://tbc.wowhead.com/npc=3632/deviate-creeper

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors.
- Checked creature's drop tables in Keira.
- Ran original query looking for spider meat, two Deviates now both missing.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check creature's drop tables in Keira.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
