### PR TITLE
fix(DB/Loot): Removes underlevelled RLT 24078 from various NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624779042193682155.sql
+++ b/data/sql/updates/pending_db_world/rev_1624779042193682155.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624779042193682155');
+
+-- Deletes underlevelled (lvl 18-19) RLT 24078 from lvl 28 Nightbane Dark Runner (ID 205), lvl 28 Dark Strand Voidcaller (ID 2337), lvl 31 Athrikus Narassin (ID 3660), lvl 50 Jadefire Rogue (ID 7106), lvl 54 Scarshield Spellbinder (ID 9098)
+DELETE FROM `creature_loot_template` WHERE `Entry` IN (205, 2337, 3660, 7106, 9098) AND `Reference` = 24078;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Deletes underlevelled (lvl 18-19) RLT 24078 from:
  -  lvl 28 Nightbane Dark Runner (ID 205)
  - lvl 28 Dark Strand Voidcaller (ID 2337)
  - lvl 31 Athrikus Narassin (ID 3660)
  - lvl 50 Jadefire Rogue (ID 7106)
  - lvl 54 Scarshield Spellbinder (ID 9098)

RLT 20478 has an average item level of 18.5 - it's made up of lvl 18-19 gear. A query finding all mobs with RLT 24078 in their loot tables who are 5+ level higher than that gives this list:

```
+-------+------------------------+----------+
| entry | name                   | minlevel |
+-------+------------------------+----------+
|   205 | Nightbane Dark Runner  |       28 |
|  2337 | Dark Strand Voidcaller |       28 |
|  3660 | Athrikus Narassin      |       31 |
|  7106 | Jadefire Rogue         |       50 |
|  9098 | Scarshield Spellbinder |       54 |
+-------+------------------------+----------+
5 rows in set (24.92 sec)
```

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6596

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

Checking TBC WH shows no sighs of lvl 18-19 drops for these creatures:
https://tbc.wowhead.com/npc=205/nightbane-dark-runner#drops;0+2+16-20+1
https://tbc.wowhead.com/npc=2337/dark-strand-voidcaller#drops;0+2+16-20+1
https://tbc.wowhead.com/npc=3660/athrikus-narassin#drops;0+2+16-20+1
https://tbc.wowhead.com/npc=7106/jadefire-rogue#drops;0+2+16-20+1
https://tbc.wowhead.com/npc=9098/scarshield-spellbinder#drops;mode:normal;0+2+16-20+1

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no issues.
- Checked tables in Keira, RLT removed.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

 ```
SELECT distinct ct.entry, ct.name, ct.minlevel 
FROM `creature_template` ct 
JOIN `creature_loot_template` clt ON ct.lootid = clt.entry 
JOIN `reference_loot_template` rlt ON clt.reference = rlt.entry 
WHERE rlt.entry = 24078 and ct.minlevel > 24;
``` 
should return an empty set.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
