### PR TITLE
fix(Core/Player): Learn runeforging & lockpicking

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -4108,7 +4108,9 @@ bool Player::_addSpell(uint32 spellId, uint8 addSpecMask, bool temporary, bool l
                 continue;
             }
 
-            if (_spell_idx->second->AcquireMethod == SKILL_LINE_ABILITY_LEARNED_ON_SKILL_LEARN && !HasSkill(pSkill->id))
+            // @todo confirm if rogues start wth lockpicking skill at level 1 but only recieve the spell to use it at level 16
+            // Added for runeforging, it is confirmed via sniff that this happens when death knights learn the spell, not on character creation.
+            if ((_spell_idx->second->AcquireMethod == SKILL_LINE_ABILITY_LEARNED_ON_SKILL_LEARN && !HasSkill(pSkill->id)) || ((pSkill->id == SKILL_LOCKPICKING || pSkill->id == SKILL_RUNEFORGING) && _spell_idx->second->TrivialSkillLineRankHigh == 0))
             {
                 LearnDefaultSkill(pSkill->id, 0);
             }


### PR DESCRIPTION
* cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/b1ac631f68d122558c25c4da7eedef75b4c2b7b6)

Co-Authored-By: r00ty-tc <173349+r00ty-tc@users.noreply.github.com>

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Learn skill runeforging when the spell is learned
- Do same for lockpicking to avoid issues (half of the lockpicking stuff was already imported, missing this stuff see https://github.com/TrinityCore/TrinityCore/commit/dcba0106d64bd598e70cc65be8e28f6ee279dcfd)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6611
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6604

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
![image](https://user-images.githubusercontent.com/24550914/123545557-e55b6c80-d758-11eb-9d20-0f3b862e2da0.png)
![image](https://user-images.githubusercontent.com/24550914/123546556-57ce4b80-d75d-11eb-8eaf-d038478ea37c.png)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Do the DK questline
2. When you finish the quest to get runeforging, see that you learn the Spell and the Skill "Runeforging"
1. Have a rogue at lvl 16
2. Learn lockpicking at trainer
<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
