### PR TITLE
fix(DB/Creature) Bellygrub not wandering

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624818270368841200.sql
+++ b/data/sql/updates/pending_db_world/rev_1624818270368841200.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624818270368841200');
+
+UPDATE `acore_world`.`creature` SET `wander_distance` = 5, `MovementType` = 1 WHERE `guid` = 10105;

--- a/data/sql/updates/pending_db_world/rev_1624818270368841200.sql
+++ b/data/sql/updates/pending_db_world/rev_1624818270368841200.sql
@@ -1,3 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624818270368841200');
 
-UPDATE `acore_world`.`creature` SET `wander_distance` = 5, `MovementType` = 1 WHERE `guid` = 10105;
+UPDATE `creature` SET `wander_distance` = 5, `MovementType` = 1 WHERE `guid` = 10105;

--- a/data/sql/updates/pending_db_world/rev_1624818270368841200.sql
+++ b/data/sql/updates/pending_db_world/rev_1624818270368841200.sql
@@ -1,3 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624818270368841200');
 
 UPDATE `creature` SET `wander_distance` = 5, `MovementType` = 1 WHERE `guid` = 10105;
+


### PR DESCRIPTION
## Changes Proposed:
-  Bellygrub now wandering

## Issues Addressed:
- Closes #6275

## SOURCE:
He should be wandering like in this video: https://www.youtube.com/watch?v=KKlibkOYRm0

## Tests Performed:
- Tested on local server

## How to Test the Changes:
1. ```go creature 10105```
2. Observe

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
