### PR TITLE
fix(DB/Creature): Fix various motionless rare spawns - 30-30 bracket

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1624891276964449853.sql
+++ b/data/sql/updates/pending_db_world/rev_1624891276964449853.sql
@@ -1,0 +1,23 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1624891276964449853');
+
+-- Accursed Slitherblade 14229, GUID 51846 - MovementType to 1, wander dist to 20
+UPDATE `creature_template` SET `movementId` = 1 WHERE `entry` = 14229;
+DELETE FROM `creature` WHERE `id` = 14229 AND `guid` = 51846;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(51846, 14229, 1, 0, 0, 1, 1, 0, 0, -117.75, 2337.5, -24.0244, 6.12535, 9900, 20, 0, 1342, 0, 1, 0, 0, 0, '', 0);
+
+-- Giggler - 14228, GUID 51847 - MovementType to 1, wander dist to 5
+UPDATE `creature_template` SET `MovementType` = 1 WHERE `entry` = 14228;
+DELETE FROM `creature` WHERE `id` = 14228 AND `guid` = 51847;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(51847, 14228, 1, 0, 0, 1, 1, 0, 0, -414.566, 1477.82, 90.7611, 4.68571, 9900, 5, 0, 1279, 0, 1, 0, 0, 0, '', 0);
+
+-- Normalize Giggler speed (was 2.12)
+UPDATE `creature_template` SET `speed_walk` = 1 WHERE `entry` = 14228;
+
+-- Crusty - 18241, GUID 27825 -  MovementType to 1, wander dist to 20
+UPDATE `creature_template` SET `MovementType` = 1 WHERE `entry` = 18241;
+DELETE FROM `creature` WHERE `id` = 18241 AND `guid` = 27825;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(27825, 18241, 1, 0, 0, 1, 1, 17625, 0, -100.613, 2832.51, -40.6645, 3.98299, 21600, 20, 0, 955, 0, 1, 0, 0, 0, '', 0);
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Rare spawn Accursed Slitherblade (ID 14229, GUID 51846) - MovementType to 1, wander dist to 20
- Rare spawn Giggler - (ID 14228, GUID 51847) - MovementType to 1, wander dist to 5
- Also normalize Giggler's speed to 1. (was 2.12)
- Rare spawn Crusty - (ID 18241, GUID 27825) -  MovementType to 1, wander dist to 20

I've tried to match wander_distance to local mobs of the same kind. Accursed Slitherblade was matched to Slitherblade Nagas, Giggler was matched to Bonepaw Hyenas, and Crusty was matched to Enraged Reef Crawlers.

Also noted Giggler's speed was inconsistent with that shown in source, so adjusted to usual hyena speed.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Partially addresses https://github.com/azerothcore/azerothcore-wotlk/issues/6548

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Acc Slither - https://www.youtube.com/watch?v=MyFZNA4DuWk
Giggler - https://www.youtube.com/watch?v=JctIw5Cnkjc
Crusty - https://tbc.wowhead.com/npc=18241/crusty#comments

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQl, no error or warnings noted.
- Checked these mobs in game, they are now all wandering correctly.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to provided GUIDs and observe.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
