### PR TITLE
fix(Spell): Victory Rush spammable ability

### DIFF
--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -106,6 +106,7 @@ public:
         {
             if (Unit* player = GetCaster())
             {
+                player->ModifyAuraState(AURA_STATE_WARRIOR_VICTORY_RUSH, false);
                 if (Unit* victim = GetHitUnit())
                 {
                     if (victim->isDead())


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove aura state for victory rush on hit confirmed

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6657
- Closes https://github.com/chromiecraft/chromiecraft/issues/1039

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested on windows 10: https://youtu.be/XB8FhYbQa3s

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Kill an enemy with Victory Rush
2. Cast the next Victory Rush
3. Can't cast it again like on the linked issue

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
