### PR TITLE
fix(Script/Spell): fly/ground mounts triggered by zone and riding skill

### DIFF
--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -4562,16 +4562,10 @@ public:
                 target->RemoveAurasByType(SPELL_AURA_MOUNTED, ObjectGuid::Empty, GetHitAura());
 
                 // Triggered spell id dependent on riding skill and zone
-                bool canFly = false;
-                uint32 map = GetVirtualMapForMapAndZone(target->GetMapId(), target->GetZoneId());
-                if (map == 530 || (map == 571 && target->HasSpell(SPELL_COLD_WEATHER_FLYING)))
-                    canFly = true;
-
-                AreaTableEntry const* area = sAreaTableStore.LookupEntry(target->GetAreaId());
-                // Xinef: add battlefield check
-                Battlefield* Bf = sBattlefieldMgr->GetBattlefieldToZoneId(target->GetZoneId());
-                if (!area || (canFly && ((area->flags & AREA_FLAG_NO_FLY_ZONE) || (Bf && !Bf->CanFlyIn()))))
-                    canFly = false;
+                SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(_mount150);
+                uint32 zoneid, areaid;
+                target->GetZoneAndAreaId(zoneid, areaid);
+                bool const canFly = spellInfo && (spellInfo->CheckLocation(target->GetMapId(), zoneid, areaid, target) == SPELL_CAST_OK);
 
                 uint32 mount = 0;
                 switch (target->GetBaseSkillValue(SKILL_RIDING))


### PR DESCRIPTION
Co-Authored-By: Ariel Silva <ariel-@users.noreply.github.com>

- cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/0bb1c03fbf3d2253d18873600cfb10d2f54825c6)

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Improve logic for spell_gen_mount

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6634

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds, tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check that you can fly Invincible in Outlands & Northrend
2. Check that you cannot fly inside of BGs or Arenas

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.