### PR TITLE
Hackfix skill range check

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -8041,6 +8041,11 @@ SkillRangeType GetSkillRangeType(SkillRaceClassInfoEntry const* rcEntry)
             return SKILL_RANGE_MONO;
         case SKILL_CATEGORY_LANGUAGES:
             return SKILL_RANGE_LANGUAGE;
+        case SKILL_CATEGORY_SECONDARY:
+        case SKILL_CATEGORY_PROFESSION:
+            // not set skills for professions and racial abilities
+            if (IsProfessionOrRidingSkill(rcEntry->SkillID))
+                return SKILL_RANGE_RANK;
     }
 
     return SKILL_RANGE_LEVEL;


### PR DESCRIPTION
Hackfix for not getting profession and riding skill range right, leading to incorrect adjustment of max skill level of those skills in case of login/levelup

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Quick fix for checking correctly whether a skill is a profession or a riding skill.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- #6563 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Built with CMake on a Windows 10, tested in game by creating characters, leveling them up and logging in and out to check for changes.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create a character
2. Learn a profession/riding skill
3. Log out and log in again into the character, the max value for the skill shouldn't change.
4.  Level up your character, the max value for the skill shouldn't change again

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] To find out why professions and riding skills are not being catched by the command `sSkillTiersStore.LookupEntry(rcEntry->SkillTierID)` a few lines prior to the proposed changes in ObjectMgr.cpp, and address this issue.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
