### PR TITLE
fix(DB/Loot): Limit maximum Darkclaw Lobster catches

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1625291253501808914.sql
+++ b/data/sql/updates/pending_db_world/rev_1625291253501808914.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1625291253501808914');
+
+DELETE FROM `reference_loot_template` WHERE `Entry` = 11105 AND `Item` = 13888;
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(11105, 13888, 0, 0, 0, 1, 1, 1, 1, 'Darkclaw Lobster');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Limit maximum number of Darkclaw Lobsters caught in one fishing cast from 2 to 1.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6681
- Closes https://github.com/chromiecraft/chromiecraft/issues/1048

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/azshara#fishing

TBC comments don't mention multiple drops at all. However, the vast majority of fish are caught one at a time.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings.
- Tested in game,now behaving as expected.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Look at RLT 11105 in Keira

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
