### PR TITLE
fix(DB/Loot): Remove Alterac Valley BG items from open world

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1625295995097462808.sql
+++ b/data/sql/updates/pending_db_world/rev_1625295995097462808.sql
@@ -3,9 +3,6 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1625295995097462808');
 -- Warmaster Laggond
 DELETE FROM `creature_loot_template` WHERE `Entry` = 13840 AND `Item` IN (17422, 17423, 17503, 17504);
 
--- Sergeant Durgen Stormpike
-DELETE FROM `creature_loot_template` WHERE `Entry` = 13777 AND `Item` = 17306;
-
 -- Corporal Teeka Bloodsnarl
 DELETE FROM `creature_loot_template` WHERE `Entry` = 13776 AND `Item` IN (17422, 17423, 17502, 17503);
 
@@ -14,9 +11,6 @@ DELETE FROM `creature_loot_template` WHERE `Entry` = 14285 AND `Item` IN (17422,
 
 -- Lieutenant Haggerdin 
 DELETE FROM `creature_loot_template` WHERE `Entry` = 13841 AND `Item` IN (17306, 17327, 17328, 17422);
-
--- Prospector Stonehewer
-DELETE FROM `creature_loot_template` WHERE `Entry` = 13816 AND `Item` IN (17306, 17326, 17327, 17422, 18206, 18225, 18231);
 
 -- Stormpike Mountaineer
 DELETE FROM `creature_loot_template` WHERE `Entry` = 12047 AND `Item` IN (17306, 17326, 17327, 17328, 17422, 17423, 17502, 17503, 17504, 18143, 18144, 18145, 18146, 18147, 18206, 18207, 18225, 18231, 18233);

--- a/data/sql/updates/pending_db_world/rev_1625295995097462808.sql
+++ b/data/sql/updates/pending_db_world/rev_1625295995097462808.sql
@@ -1,0 +1,22 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1625295995097462808');
+
+-- Warmaster Laggond
+DELETE FROM `creature_loot_template` WHERE `Entry` = 13840 AND `Item` IN (17422, 17423, 17503, 17504);
+
+-- Sergeant Durgen Stormpike
+DELETE FROM `creature_loot_template` WHERE `Entry` = 13777 AND `Item` = 17306;
+
+-- Corporal Teeka Bloodsnarl
+DELETE FROM `creature_loot_template` WHERE `Entry` = 13776 AND `Item` IN (17422, 17423, 17502, 17503);
+
+-- Frostwolf Battleguard 
+DELETE FROM `creature_loot_template` WHERE `Entry` = 14285 AND `Item` IN (17422, 17423, 17503);
+
+-- Lieutenant Haggerdin 
+DELETE FROM `creature_loot_template` WHERE `Entry` = 13841 AND `Item` IN (17306, 17327, 17328, 17422);
+
+-- Prospector Stonehewer
+DELETE FROM `creature_loot_template` WHERE `Entry` = 13816 AND `Item` IN (17306, 17326, 17327, 17422, 18206, 18225, 18231);
+
+-- Stormpike Mountaineer
+DELETE FROM `creature_loot_template` WHERE `Entry` = 12047 AND `Item` IN (17306, 17326, 17327, 17328, 17422, 17423, 17502, 17503, 17504, 18143, 18144, 18145, 18146, 18147, 18206, 18207, 18225, 18231, 18233);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Deletes various Alterac Valley battleground-only items from the loot tables of open world mobs. To ensure no mobs inside the BG itself were affected, the query I used to find NPCs specifically checked that the mobs targeted spawn in maps 0 or 1, which is the open world. (or at least the bits of it accessible right now.)

These items are:
- Armor Scraps (17422)

Faction Lord Summons:
- Storm Crystal 17423
- Stormpike Soldier's Blood 17306

Horde:
- Stormpike Soldier's Flesh 17326
- Stormpike Lieutenant's Flesh 17327
- Stormpike Commander's Flesh 17328

Ally:
- Frostwolf Soldier's Medal 17502
- Frostwolf Lieutenant's Medal 17503
- Frostwolf Commander's Medal 17504

There are other AV items such as Coldtooth Supplies (5893, 6982), Irondeep Supplies (5892, 6985), Frostwolf Banner 17850 and Stormpike Banner 17849, but they don't seem to be dropping from any open world mobs.

There is yet another class of deprecated grey item drops - joke items such as Worn Running Shoes 18225 and Tear Stained Handkerchief 18233, and body parts from an old classic AV quest such as Orc Tooth, Dwarf Spine, Human Bone Chip, etc. Those have been removed where I saw them, but apart from Stormpike Mountaineers, which bizarrely had all of them at once, they don't seem to be in open world drops either except in one or two cases which are addressed here.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6678
- Closes https://github.com/chromiecraft/chromiecraft/issues/1050

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
TBC Wowhead shows these items should only drop in AV.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings.
- Tested in open world, NPCs now dropping expected items only.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Use this query:
```
SELECT ct.name, clt.chance
FROM `creature_template` ct
JOIN `creature_loot_template` clt ON ct.lootid = clt.entry
JOIN `item_template` it ON it.entry = clt.item
JOIN `creature` c ON c.id = ct.entry
WHERE c.map IN (0,1) AND clt.item IN (17422, 17423, 17306, 17326, 17327, 17328, 17849, 17502, 17503, 17504, 17850, 5893, 6982, 5892, 6985)
```
It should return an empty set.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
