### PR TITLE
fix(Core/Conf): worldserver.conf.dist duplicate entry for Logger.mmaps

### DIFF
--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3597,7 +3597,6 @@ Logger.scripts.hotswap=4,Console Server
 Logger.server=4,Console Server
 Logger.sql.sql=2,Console DBErrors
 Logger.sql=4,Console Server
-Logger.mmaps=4,Server
 
 #Logger.achievement=4,Console Server
 #Logger.addon=4,Console Server


### PR DESCRIPTION
Duplicate entry for Logger.mmaps=4,Server

![asd](https://user-images.githubusercontent.com/86543222/124372756-caa65d80-dc5a-11eb-9bce-47f9d60c5be0.jpg)

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove duplicate entry in worldserver.conf.dist
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Launch the server with new worldserver.conf.dist and do not log the duplicate entry error.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. The server log the duplicate entry error inmediatly after launch.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
