### PR TITLE
fix(DB/Loot): Correct Blackwater Cutlass drops

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1625375927776772391.sql
+++ b/data/sql/updates/pending_db_world/rev_1625375927776772391.sql
@@ -1,0 +1,16 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1625375927776772391');
+
+-- Delete Blackwater Cutlass from RLT 24078
+DELETE FROM `reference_loot_template` WHERE `Entry` = 24078 AND `Item` = 1951;
+
+-- Blackwater Cutlass added to Defias Pirate loot table with 6% drop rate
+DELETE FROM `creature_loot_template` WHERE `Entry` = 657 AND `Item` = 1951;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(657, 1951, 0, 6, 0, 1, 1, 1, 1, 'Blackwater Cutlass');
+
+-- Blackwater Cutlass added to Defias Squallshaper loot table with 6% drop rate
+DELETE FROM `creature_loot_template` WHERE `Entry` = 1732 AND `Item` = 1951;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(1732, 1951, 0, 6, 0, 1, 1, 1, 1, 'Blackwater Cutlass')
+
+

--- a/data/sql/updates/pending_db_world/rev_1625375927776772391.sql
+++ b/data/sql/updates/pending_db_world/rev_1625375927776772391.sql
@@ -11,6 +11,6 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 -- Blackwater Cutlass added to Defias Squallshaper loot table with 6% drop rate
 DELETE FROM `creature_loot_template` WHERE `Entry` = 1732 AND `Item` = 1951;
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(1732, 1951, 0, 6, 0, 1, 1, 1, 1, 'Blackwater Cutlass')
+(1732, 1951, 0, 6, 0, 1, 1, 1, 1, 'Blackwater Cutlass');
 
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Delete Blackwater Cutlass from general RLT 24078.
- Add Blackwater Cutlass to Defias Pirate and Squallshaper drop tables with 6% drop rate and GroupId of 1. 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6605
- Closes https://github.com/chromiecraft/chromiecraft/issues/1015

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/item=1951/blackwater-cutlass

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings.
- Checked in-game, Deadmines Pirates/Squallshapers now occasionally drop the sword.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check RLT 24078 - it should not contain the sword.
2. Check loot tables for Pirates and Squallshapers - they should have the sword with 6% drop rate and a GroupId of 1.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
