### PR TITLE
fix(DB/Quest) Adds Alchemy requirement to "Badlands Reagent Run II" (H)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1625406775061855034.sql
+++ b/data/sql/updates/pending_db_world/rev_1625406775061855034.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1625406775061855034');
+
+UPDATE `quest_template_addon` SET `RequiredSkillPoints` = 210 WHERE `ID` = 2203;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Adds 210 Alchemy as a requirement to the Horde quest "Badlands Reagent Run II" (ID 2203). This brings it into line with the Alliance version of the same quest.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6718
- Closes https://github.com/chromiecraft/chromiecraft/issues/1080

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
"This quest requires an Alchemy skill of 210 to pick it up. " - https://tbc.wowhead.com/quest=2203/badlands-reagent-run-ii#comments:id=2781389

"Requires a minimum 210 Alchemy to be able to be offered this quest." - https://classic.wowhead.com/quest=2501/badlands-reagent-run-ii#comments:id=3159614

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings.
- Tested in game:

Character with no Alchemy - not offered quest:
![WoWScrnShot_070421_232620](https://user-images.githubusercontent.com/81782124/124388577-a8781280-dd22-11eb-835c-09ea211c9135.jpg)

Character with 209 Alchemy - not offered quest:
![WoWScrnShot_070421_232947](https://user-images.githubusercontent.com/81782124/124388493-5df69600-dd22-11eb-8bda-fef049149a73.jpg)

Character with 210 Alchemy is offered quest (also levelled down to 45 so the quest marker would be visible.)
![WoWScrnShot_070421_234434](https://user-images.githubusercontent.com/81782124/124388506-71096600-dd22-11eb-9f57-f242bba67e23.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 6859 - teleports you to questgiver.
2. .quest add 2202 (adds the prereq quest.)
3. .additem [Magenta Fungus Cap] 12
4. Hand in.
5. check for offer of "Badlands Reagent Run II" 
6. .setskill 171 210 to set Alchemy to required level.
7. check for quest offer again.

Or just look in Keira for quest 2203 and look at the quest_template_addon table under Addon Requirements.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
