### PR TITLE
fix(DB/Quest): Remove respawn timers from "Broken Alliances" pillars

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1625410362418489198.sql
+++ b/data/sql/updates/pending_db_world/rev_1625410362418489198.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1625410362418489198');
+
+UPDATE `gameobject` SET `spawntimesecs` = 0 WHERE `id` = 2842 AND `guid` = 10643;
+UPDATE `gameobject` SET `spawntimesecs` = 0 WHERE `id` = 2848 AND `guid` = 10644;
+UPDATE `gameobject` SET `spawntimesecs` = 0 WHERE `id` = 2858 AND `guid` = 10830;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
The Horde quest "Broken Alliances" 2/2 (ID 793) and the Alliance quest "Tremors of the Earth" 2/2 (ID 717) both require the player to click on three pillars in the Badlands. This PR changes the respawn timers of the Pillars of Diamond (ID 2842, GUID 10643), Opal (ID 2848, GUID 10644) and Amethyst (ID 2858, GUID 10830) to 0 seconds to match observed retail behaviour. They were previously 2 seconds/2 hours/2 hours respectively. 

This ensures that more than one person can complete this quest every two hours.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6719
- Closes https://github.com/chromiecraft/chromiecraft/issues/1081

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://youtu.be/tX7AS0eM2J4?t=4
https://youtu.be/o7feaCOmsWg?t=120
https://youtu.be/x6xQeumYLCU?t=633

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings.
- Ran the relevant quest again and checked pillars. They no longer disappear, but remain in place:

https://user-images.githubusercontent.com/81782124/124389976-b761c380-dd28-11eb-8450-3b9ca24918c1.mp4

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .quest add 793
2. .go o 10643 - interact with pillar.
3. .go o 10644 - interact with pillar.
4. .go o 10830 - interact with pillar.
5. Note that they have not faded out or vanished for two hours.

Alternatively, check in Keira. 

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A. 

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
