### PR TITLE
fix(DB/Creature): Correct Dread Swoop spawn point

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1625485014381956791.sql
+++ b/data/sql/updates/pending_db_world/rev_1625485014381956791.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1625485014381956791');
+
+-- Relocate Dread Swoop
+DELETE FROM `creature` WHERE `id` = 4692 AND `guid` = 27980;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(27980, 4692, 1, 0, 0, 1, 1, 1192, 0, 52.892, 1563.021, 124.512, 3.459, 300, 3, 0, 1163, 0, 1, 0, 0, 0, '', 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Moves Dread Swoop GUID 27980's spawn point to above ground, and adds random movement.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6743
- Closes https://github.com/chromiecraft/chromiecraft/issues/1099

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Mobs should not spawn underground.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings.
- Checked in game, swoop is now enjoying a nice view and guarding its own copper node. (Also, what's a copper node doing in Desolace?)

![WoWScrnShot_070521_210548](https://user-images.githubusercontent.com/81782124/124466292-a91db100-ddd5-11eb-9d98-ba0263cb23a8.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 27980
2. If you land on the small hill and a bird starts attacking you, it worked. If you fall into the endless void, it didn't.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
