### PR TITLE
fix(DB/Loot): Remove Dark Iron Ale Mug from Whit Wantmal

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1625490612430815354.sql
+++ b/data/sql/updates/pending_db_world/rev_1625490612430815354.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1625490612430815354');
+
+-- Remove Whit Wantmal's loot table
+UPDATE `creature_template` SET `lootid` = 0 WHERE `entry` = 275;
+DELETE FROM `creature_loot_template` WHERE `Entry` = 275;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Removes the Dark Iron Ale Mug (item ID 11325) from Whit Wantmal's (ID 275) loot table. As that was the only item he dropped, and Wowhead confirms that he isn't supposed to actually drop anything at all, deleted his loot template and set his lootID to 0.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6737
- Closes https://github.com/chromiecraft/chromiecraft/issues/1088

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/npc=275/whit-wantmal
https://tbc.wowhead.com/item=11325/dark-iron-ale-mug

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings.
- Then checked in game, ganked Whit and he dropped nothing.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 4196
2. Tell him how much you disliked "Leaves of Grass" in school and then gank him.
3. you should be unable to loot as he drops nothing.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
