### PR TITLE
fix(DB/smart_ai): Prevent Vylestem Vine to be used multiple times

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1625515191527869300.sql
+++ b/data/sql/updates/pending_db_world/rev_1625515191527869300.sql
@@ -1,0 +1,10 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1625515191527869300');
+
+UPDATE `gameobject_template` SET `AIName` = 'SmartGameObjectAI' WHERE `entry` = 178908;
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 1 AND `entryorguid` = 178908);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(178908, 1, 0, 0, 8, 0, 100, 0, 21885, 0, 0, 0, 0, 12, 13696, 4, 30000, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 'Vylestem Vine - On Spellhit \'Heal Vylestem Vine\' - Summon Creature \'Noxxious Scion\''),
+(178908, 1, 1, 0, 8, 0, 100, 0, 21885, 0, 0, 0, 0, 12, 13696, 4, 30000, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Vylestem Vine - On Spellhit \'Heal Vylestem Vine\' - Summon Creature \'Noxxious Scion\''),
+(178908, 1, 2, 0, 8, 0, 100, 0, 21885, 0, 0, 0, 0, 12, 13696, 4, 30000, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Vylestem Vine - On Spellhit \'Heal Vylestem Vine\' - Summon Creature \'Noxxious Scion\''),
+(178908, 1, 3, 0, 8, 0, 100, 0, 21885, 0, 0, 0, 0, 99, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Vylestem Vine - On Spellhit \'Heal Vylestem Vine\' - Set Lootstate Deactivated');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Despawn Vylestem Vine in order to not be abused, also added 3 summoned creatures in total 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6752
- Closes https://github.com/chromiecraft/chromiecraft/issues/1101

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- https://www.youtube.com/watch?v=um3d4wdd4Ag&t=111s

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Object can only be used once, 3 creatures spawn.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. `.q a 7041`
2. Fill in the Orange Pool outside the Maraudon instance
3. Try to use the filled object inside Orange Maraudon Instance, you will only be able to do it once, with 3 creatures spawned

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
