### PR TITLE
fix(DB/Loot): Correct various bag item lists

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1625577114142882549.sql
+++ b/data/sql/updates/pending_db_world/rev_1625577114142882549.sql
@@ -8,5 +8,5 @@ UPDATE `item_loot_template` SET `Chance` = 100 WHERE `Entry` = 11568 AND `Item` 
 -- Delete Threshadon Meat/Preserved Pheromone from Hoard of the Black Dragonflight
 DELETE FROM `item_loot_template` WHERE `Entry` = 10569 AND `Item` IN (11569, 11570);
 
--- Delete Threshadon Meat/Preserved Pheromone from A Small Pouch
+-- Delete Threshadon Meat/Preserved Pheromone from A Small Pack
 DELETE FROM `item_loot_template` WHERE `Entry` = 11107 AND `Item` IN (11569, 11570);

--- a/data/sql/updates/pending_db_world/rev_1625577114142882549.sql
+++ b/data/sql/updates/pending_db_world/rev_1625577114142882549.sql
@@ -1,0 +1,12 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1625577114142882549');
+
+-- Delete various incorrect items from Torwa's Pouch
+DELETE FROM `item_loot_template` WHERE `Entry` = 11568 AND `Item` IN (2450, 3820, 8838, 11018, 16204);
+-- Make Preserved Pheromone Mixture drop with 100% chance
+UPDATE `item_loot_template` SET `Chance` = 100 WHERE `Entry` = 11568 AND `Item` = 11570;
+
+-- Delete Threshadon Meat/Preserved Pheromone from Hoard of the Black Dragonflight
+DELETE FROM `item_loot_template` WHERE `Entry` = 10569 AND `Item` IN (11569, 11570);
+
+-- Delete Threshadon Meat/Preserved Pheromone from A Small Pouch
+DELETE FROM `item_loot_template` WHERE `Entry` = 11107 AND `Item` IN (11569, 11570);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Deletes Illusion Dust, Sungrass, Stranglekelp, Briarthorn, and Un'Goro Soil from Torwa's Pouch (ID 11568). this pouch should only contain two quest items.
- Deletes Preserved Threshadon Meat (ID 11569) and Preserved Pheromone Mixture (ID 11570) from Hoard of the Black Dragonflight (ID 10569). WH shows this bag should not contain these items.
- Deletes Preserved Threshadon Meat (ID 11569) and Preserved Pheromone Mixture (ID 11570) from A Small Pack (ID 11107). WH shows this bag should not cvontain these items.
- Changes drop rate of Preserved Pheromone Mixture from Torwa's Pouch from 99.6% to 100%.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6763
- Closes https://github.com/chromiecraft/chromiecraft/issues/1107

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/item=11568/torwas-pouch
https://tbc.wowhead.com/item=11569/preserved-threshadon-meat
https://tbc.wowhead.com/item=11570/preserved-pheromone-mixture
https://tbc.wowhead.com/item=10569/hoard-of-the-black-dragonflight
https://tbc.wowhead.com/item=11107/a-small-pack

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, correct number of rows affected.
- Checked Keira, bag contents were now as expected.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check the three affected bags in Keira to ensure the deleted items are gone from all three and the Pheremones have 100% drop rate.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
