### PR TITLE
fix(DB/Quest): improved No Fly Zone

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1625841824336043500.sql
+++ b/data/sql/updates/pending_db_world/rev_1625841824336043500.sql
@@ -26,5 +26,4 @@ INSERT IGNORE INTO `spell_dbc` VALUES
 -- Radius 5 Yards
 -- I tested it with Knock Back (350), which is a very far distance. Therefore, I reduced it to 200
 -- https://www.wowhead.com/spell=54469/plague-strike
-UPDATE `spell_dbc` SET `EffectRadiusIndex_1`='8', `EffectRadiusIndex_2`='8', `EffectRadiusIndex_3`='8' WHERE  `ID`=54469;
-UPDATE `spell_dbc` SET `EffectMiscValue_3` = 200 WHERE (`ID` = 54469);
+UPDATE `spell_dbc` SET `EffectRadiusIndex_1`=8, `EffectRadiusIndex_2`=8, `EffectRadiusIndex_3`=8, `EffectMiscValue_3` = 200 WHERE  `ID`=54469;

--- a/data/sql/updates/pending_db_world/rev_1625841824336043500.sql
+++ b/data/sql/updates/pending_db_world/rev_1625841824336043500.sql
@@ -1,0 +1,30 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1625841824336043500');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 29414;
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 29414);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(29414, 0, 0, 1, 25, 0, 100, 256, 0, 0, 0, 0, 0, 60, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Bone Gryphon - On Reset - Set Fly On'),
+(29414, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 207, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Bone Gryphon - On Reset - Set hover 0'),
+(29414, 0, 2, 0, 28, 0, 100, 0, 0, 0, 0, 0, 0, 11, 45472, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Bone Gryphon - On Passenger Removed - Cast \'Parachute\''),
+(29414, 0, 3, 0, 1, 0, 100, 1, 300, 300, 0, 0, 0, 11, 54476, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Bone Gryphon - Out of Combat - Cast \'Blood Presence\' (No Repeat)');
+
+-- no use, spell removed
+DELETE FROM `npc_spellclick_spells` WHERE  `npc_entry`=29414 AND `spell_id`=18277;
+
+-- fix Radius: 3 yards
+-- https://www.wowhead.com/spell=18277/call-bone-gryphon
+DELETE FROM `spell_script_names` WHERE `spell_id`=18277 AND `ScriptName`='spell_onslaught_or_call_bone_gryphon';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (18277, 'spell_onslaught_or_call_bone_gryphon');
+
+-- only aura fly
+UPDATE `creature_template_addon` SET `auras` = '54422' WHERE (`entry` = 29414);
+
+INSERT IGNORE INTO `spell_dbc` VALUES
+(54469, 0, 3, 0, 16, 131584, 0, 262144, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 80, 80, 29, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 121, 6, 98, 1, 1, 1, 0, 0, 0, 1999, 549, 149, 0, 0, 0, 18, 18, 18, 16, 16, 16, 0, 0, 0, 0, 3, 0, 0, 3000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 127, 350, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11965, 0, 2719, 0, 50, 'Plague Strike', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 16712190, '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 16712188, 'A vicious strike that deals talon damage plus $s1 modified by attack power and plagues the target, dealing $o2 Shadow damage over $d.  Only useful versus Onslaught Gryphon Riders.', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 16712190, 'Deals $o2 Shadow damage over $d.', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 16712190, 0, 133, 1500, 0, 0, 0, 0, 0, 0, 2, 2, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 32, 1102, 0, 0, 0, 0, 0, 0, 0);
+
+-- Radius 5 Yards
+-- I tested it with Knock Back (350), which is a very far distance. Therefore, I reduced it to 200
+-- https://www.wowhead.com/spell=54469/plague-strike
+UPDATE `spell_dbc` SET `EffectRadiusIndex_1`='8', `EffectRadiusIndex_2`='8', `EffectRadiusIndex_3`='8' WHERE  `ID`=54469;
+UPDATE `spell_dbc` SET `EffectMiscValue_3` = 200 WHERE (`ID` = 54469);

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -1412,6 +1412,36 @@ public:
     }
 };
 
+class spell_onslaught_or_call_bone_gryphon : public SpellScriptLoader
+{
+public:
+    spell_onslaught_or_call_bone_gryphon() : SpellScriptLoader("spell_onslaught_or_call_bone_gryphon") { }
+
+    class spell_onslaught_or_call_bone_gryphon_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_onslaught_or_call_bone_gryphon_SpellScript);
+
+        void ChangeSummonPos(SpellEffIndex /*effIndex*/)
+        {
+            WorldLocation summonPos = *GetExplTargetDest();
+            Position offset = { 0.0f, 0.0f, 3.0f, 0.0f };
+            summonPos.RelocateOffset(offset);
+            SetExplTargetDest(summonPos);
+            GetHitDest()->RelocateOffset(offset);
+        }
+
+        void Register() override
+        {
+            OnEffectHit += SpellEffectFn(spell_onslaught_or_call_bone_gryphon_SpellScript::ChangeSummonPos, EFFECT_0, SPELL_EFFECT_SUMMON);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_onslaught_or_call_bone_gryphon_SpellScript();
+    }
+};
+
 // Theirs
 /*######
 ## npc_guardian_pavilion
@@ -2098,6 +2128,7 @@ void AddSC_icecrown()
     new spell_fight_fire_bomber();
     new spell_anti_air_rocket_bomber();
     new npc_infra_green_bomber_generic();
+    new spell_onslaught_or_call_bone_gryphon();
 
     // Theirs
     new npc_guardian_pavilion();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Quest: No Fly Zone  available through the website [here](https://www.wowhead.com/quest=12815/no-fly-zone)

## Changes Proposed:
-  Fix: Raidus 3yards
-  Fix: removed the Blood Presence aura. Correct function added smart_scripts Cast (11)
-  Fix: Gravity and Hover
-  Fix: Plague Strike ability of the npc Bone Gryphon

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  was performed windows 7 64bits. Not a single error was found and it is Functional


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. quest add 12815
2. tele icecrown
3. go to the zone indicated by the map and test

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
