### PR TITLE
fix(Core/ObjectGuid): prevent creating copies when looping objects

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -265,7 +265,7 @@ void PetAI::UpdateAI(uint32 diff)
                 // No enemy, check friendly
                 if (!spellUsed)
                 {
-                    for (ObjectGuid const guid : m_AllySet)
+                    for (ObjectGuid const& guid : m_AllySet)
                     {
                         Unit* ally = ObjectAccessor::GetUnit(*me, guid);
 

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -328,7 +328,7 @@ inline void Battleground::_ProcessResurrect(uint32 diff)
             for (std::map<ObjectGuid, GuidVector>::iterator itr = m_ReviveQueue.begin(); itr != m_ReviveQueue.end(); ++itr)
             {
                 Creature* sh = nullptr;
-                for (ObjectGuid const guid : itr->second)
+                for (ObjectGuid const& guid : itr->second)
                 {
                     Player* player = ObjectAccessor::FindPlayer(guid);
                     if (!player)
@@ -360,7 +360,7 @@ inline void Battleground::_ProcessResurrect(uint32 diff)
     }
     else if (m_LastResurrectTime > 500)    // Resurrect players only half a second later, to see spirit heal effect on NPC
     {
-        for (ObjectGuid const guid : m_ResurrectQueue)
+        for (ObjectGuid const& guid : m_ResurrectQueue)
         {
             Player* player = ObjectAccessor::FindPlayer(guid);
             if (!player)
@@ -1479,7 +1479,7 @@ void Battleground::RelocateDeadPlayers(ObjectGuid queueIndex)
     if (!ghostList.empty())
     {
         GraveyardStruct const* closestGrave = nullptr;
-        for (ObjectGuid const guid : ghostList)
+        for (ObjectGuid const& guid : ghostList)
         {
             Player* player = ObjectAccessor::FindPlayer(guid);
             if (!player)

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
@@ -897,7 +897,7 @@ void BattlegroundSA::CaptureGraveyard(BG_SA_Graveyards i, Player* Source)
     if (!ghost_list.empty())
     {
         GraveyardStruct const* ClosestGrave = nullptr;
-        for (ObjectGuid const guid : ghost_list)
+        for (ObjectGuid const& guid : ghost_list)
         {
             Player* player = ObjectAccessor::FindPlayer(guid);
             if (!player)

--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -1129,7 +1129,7 @@ namespace lfg
 
                 if (!deletedGroupsToErase.empty())
                 {
-                    for (ObjectGuid const toErase : deletedGroupsToErase)
+                    for (ObjectGuid const& toErase : deletedGroupsToErase)
                     {
                         deletedGroups.erase(toErase);
                     }
@@ -1137,7 +1137,7 @@ namespace lfg
 
                 if (!deletedGroups.empty())
                 {
-                    for (ObjectGuid const deletedGroup : deletedGroups)
+                    for (ObjectGuid const& deletedGroup : deletedGroups)
                     {
                         ++deletedCounter;
                         buffer_deleted << deletedGroup;

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -212,7 +212,7 @@ void GameObject::ClearRitualList()
     if (!animSpell || m_unique_users.empty())
         return;
 
-    for (ObjectGuid const guid : m_unique_users)
+    for (ObjectGuid const& guid : m_unique_users)
     {
         if (Player* channeler = ObjectAccessor::GetPlayer(*this, guid))
             if (Spell* spell = channeler->GetCurrentSpell(CURRENT_CHANNELED_SPELL))

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -843,7 +843,7 @@ public:
     void AddToSkillupList(ObjectGuid playerGuid) { m_SkillupList.push_back(playerGuid); }
     [[nodiscard]] bool IsInSkillupList(ObjectGuid playerGuid) const
     {
-        for (ObjectGuid const guid : m_SkillupList)
+        for (ObjectGuid const& guid : m_SkillupList)
             if (guid == playerGuid)
                 return true;
 

--- a/src/server/game/Entities/Object/Updates/UpdateData.cpp
+++ b/src/server/game/Entities/Object/Updates/UpdateData.cpp
@@ -104,7 +104,7 @@ bool UpdateData::BuildPacket(WorldPacket* packet)
         buf << (uint8) UPDATETYPE_OUT_OF_RANGE_OBJECTS;
         buf << (uint32) m_outOfRangeGUIDs.size();
 
-        for (ObjectGuid const guid : m_outOfRangeGUIDs)
+        for (ObjectGuid const& guid : m_outOfRangeGUIDs)
         {
             buf << guid.WriteAsPacked();
         }

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -784,7 +784,7 @@ void PoolMgr::LoadFromDB()
 
             // Now check for circular reference
             // All pool_ids are in pool_template
-            for (auto const it : mPoolTemplate)
+            for (auto const& it : mPoolTemplate)
             {
                 std::set<uint32> checkedPools;
                 for (SearchMap::iterator poolItr = mPoolSearchMap.find(it.first); poolItr != mPoolSearchMap.end(); poolItr = mPoolSearchMap.find(poolItr->second))

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
@@ -169,7 +169,7 @@ public:
                 case DATA_RAZORGORE_THE_UNTAMED:
                     if (state == DONE)
                     {
-                        for (ObjectGuid const guid : EggList)
+                        for (ObjectGuid const& guid : EggList)
                             if (GameObject* egg = instance->GetGameObject(guid))
                                 egg->SetPhaseMask(2, true);
                     }

--- a/src/server/scripts/EasternKingdoms/SunkenTemple/instance_sunken_temple.cpp
+++ b/src/server/scripts/EasternKingdoms/SunkenTemple/instance_sunken_temple.cpp
@@ -96,7 +96,7 @@ public:
                     }
                     break;
                 case DATA_ERANIKUS_FIGHT:
-                    for (ObjectGuid const guid : _dragonkinList)
+                    for (ObjectGuid const& guid : _dragonkinList)
                     {
                         if (Creature* creature = instance->GetCreature(guid))
                             if (instance->IsGridLoaded(creature->GetPositionX(), creature->GetPositionY()))

--- a/src/server/scripts/EasternKingdoms/zone_undercity.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_undercity.cpp
@@ -1086,7 +1086,7 @@ public:
                     }
                 }
 
-                for (ObjectGuid const guid : allianceGuardsGUID)
+                for (ObjectGuid const& guid : allianceGuardsGUID)
                     if (Creature* temp = ObjectAccessor::GetCreature(*me, guid))
                         temp->DespawnOrUnsummon();
 
@@ -2415,7 +2415,7 @@ public:
                     SaurfangGUID.Clear();
                 }
 
-                for (ObjectGuid const guid : hordeGuardsGUID)
+                for (ObjectGuid const& guid : hordeGuardsGUID)
                     if (Creature* temp = ObjectAccessor::GetCreature(*me, guid))
                         temp->DespawnOrUnsummon();
 

--- a/src/server/scripts/Events/hallows_end.cpp
+++ b/src/server/scripts/Events/hallows_end.cpp
@@ -699,7 +699,7 @@ public:
                             if (counter > 12)
                             {
                                 bool failed = false;
-                                for (ObjectGuid const guid : unitList)
+                                for (ObjectGuid const& guid : unitList)
                                     if (Unit* c = ObjectAccessor::GetUnit(*me, guid))
                                         if (c->HasAuraType(SPELL_AURA_PERIODIC_DUMMY))
                                         {
@@ -753,7 +753,7 @@ public:
         Unit* getTrigger()
         {
             std::list<Unit*> tmpList;
-            for (ObjectGuid const guid : unitList)
+            for (ObjectGuid const& guid : unitList)
                 if (Unit* c = ObjectAccessor::GetUnit(*me, guid))
                     if (!c->HasAuraType(SPELL_AURA_PERIODIC_DUMMY))
                         tmpList.push_back(c);
@@ -772,7 +772,7 @@ public:
             {
                 me->MonsterYell("Fire consumes! You've tried and failed. Let there be no doubt, justice prevailed!", LANG_UNIVERSAL, 0);
                 me->PlayDirectSound(11967);
-                for (ObjectGuid const guid : unitList)
+                for (ObjectGuid const& guid : unitList)
                     if (Unit* c = ObjectAccessor::GetUnit(*me, guid))
                         c->RemoveAllAuras();
 

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/instance_hyjal.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/instance_hyjal.cpp
@@ -220,7 +220,7 @@ public:
                     {
                         if (!m_uiAncientGemGUID.empty())
                         {
-                            for (ObjectGuid const guid : m_uiAncientGemGUID)
+                            for (ObjectGuid const& guid : m_uiAncientGemGUID)
                             {
                                 //don't know how long it expected
                                 DoRespawnGameObject(guid, DAY);

--- a/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/instance_old_hillsbrad.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/instance_old_hillsbrad.cpp
@@ -183,7 +183,7 @@ public:
                         instance->LoadGrid(instancePositions[0].GetPositionX(), instancePositions[0].GetPositionY());
                         instance->LoadGrid(instancePositions[1].GetPositionX(), instancePositions[1].GetPositionY());
 
-                        for (ObjectGuid const guid : _prisonersSet)
+                        for (ObjectGuid const& guid : _prisonersSet)
                             if (Creature* orc = instance->GetCreature(guid))
                             {
                                 uint8 index = orc->GetDistance(instancePositions[0]) < 80.0f ? 0 : 1;
@@ -193,7 +193,7 @@ public:
                                 orc->SetStandState(UNIT_STAND_STATE_STAND);
                             }
 
-                        for (ObjectGuid const guid : _initalFlamesSet)
+                        for (ObjectGuid const& guid : _initalFlamesSet)
                             if (GameObject* gobject = instance->GetGameObject(guid))
                             {
                                 gobject->SetRespawnTime(0);
@@ -215,14 +215,14 @@ public:
                                         player->KilledMonsterCredit(NPC_LODGE_QUEST_TRIGGER);
                         }
 
-                        for (ObjectGuid const guid : _finalFlamesSet)
+                        for (ObjectGuid const& guid : _finalFlamesSet)
                             if (GameObject* gobject = instance->GetGameObject(guid))
                             {
                                 gobject->SetRespawnTime(0);
                                 gobject->UpdateObjectVisibility(true);
                             }
 
-                        for (ObjectGuid const guid : _prisonersSet)
+                        for (ObjectGuid const& guid : _prisonersSet)
                             if (Creature* orc = instance->GetCreature(guid))
                                 if (roll_chance_i(25))
                                     orc->HandleEmoteCommand(EMOTE_ONESHOT_CHEER);

--- a/src/server/scripts/Kalimdor/CavernsOfTime/TheBlackMorass/instance_the_black_morass.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/TheBlackMorass/instance_the_black_morass.cpp
@@ -60,7 +60,7 @@ public:
             }
 
             GuidSet eCopy = encounterNPCs;
-            for (ObjectGuid const guid : eCopy)
+            for (ObjectGuid const& guid : eCopy)
                 if (Creature* creature = instance->GetCreature(guid))
                     creature->DespawnOrUnsummon();
         }
@@ -184,7 +184,7 @@ public:
 
                                 // Xinef: delete all spawns
                                 GuidSet eCopy = encounterNPCs;
-                                for (ObjectGuid guid : eCopy)
+                                for (ObjectGuid const& guid : eCopy)
                                     if (Creature* creature = instance->GetCreature(guid))
                                         creature->DespawnOrUnsummon();
                             }
@@ -227,7 +227,7 @@ public:
         void SummonPortalKeeper()
         {
             Creature* rift = nullptr;
-            for (ObjectGuid const guid : encounterNPCs)
+            for (ObjectGuid const& guid : encounterNPCs)
                 if (Creature* summon = instance->GetCreature(guid))
                     if (summon->GetEntry() == NPC_TIME_RIFT)
                     {

--- a/src/server/scripts/Kalimdor/OnyxiasLair/instance_onyxias_lair.cpp
+++ b/src/server/scripts/Kalimdor/OnyxiasLair/instance_onyxias_lair.cpp
@@ -79,7 +79,7 @@ public:
                     bDeepBreath = true;
                     if( uiData == NOT_STARTED )
                     {
-                        for (ObjectGuid guid : minions)
+                        for (ObjectGuid const& guid : minions)
                             if (Creature* c = instance->GetCreature(guid))
                                 c->DespawnOrUnsummon();
                         minions.clear();

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ayamiss.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ayamiss.cpp
@@ -187,7 +187,7 @@ public:
                         events.ScheduleEvent(EVENT_PARALYZE, 15000);
                         break;
                     case EVENT_SWARMER_ATTACK:
-                        for (ObjectGuid guid : _swarmers)
+                        for (ObjectGuid const& guid : _swarmers)
                             if (Creature* swarmer = me->GetMap()->GetCreature(guid))
                                 if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM))
                                     swarmer->AI()->AttackStart(target);

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
@@ -63,7 +63,7 @@ public:
         {
             BossAI::EnterEvadeMode();
 
-            for (ObjectGuid guid : Eggs)
+            for (ObjectGuid const& guid : Eggs)
                 if (Creature* egg = me->GetMap()->GetCreature(guid))
                     egg->Respawn();
 

--- a/src/server/scripts/Northrend/AzjolNerub/ahnkahet/boss_herald_volazj.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/ahnkahet/boss_herald_volazj.cpp
@@ -200,7 +200,7 @@ public:
             }
 
             uint16 phase = 1;
-            for (ObjectGuid guid : summons)
+            for (ObjectGuid const& guid : summons)
             {
                 if (Creature* summon = ObjectAccessor::GetCreature(*me, guid))
                     phase |= summon->GetPhaseMask();

--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
@@ -420,7 +420,7 @@ public:
                 summons.RemoveNotExisting();
                 if (!summons.empty())
                 {
-                    for (ObjectGuid const summonGuid : summons)
+                    for (ObjectGuid const& summonGuid : summons)
                     {
                         Creature* summon = ObjectAccessor::GetCreature(*me, summonGuid);
                         if (summon && summon->GetEntry() == NPC_FIRE_CYCLONE)
@@ -556,7 +556,7 @@ public:
                         uint8 iter = 0;
                         if (!summons.empty())
                         {
-                            for (ObjectGuid const summonGuid : summons)
+                            for (ObjectGuid const& summonGuid : summons)
                             {
                                 Creature* summon = ObjectAccessor::GetCreature(*me, summonGuid);
                                 if (summon && summon->GetEntry() == NPC_FIRE_CYCLONE && iter == rand)
@@ -636,7 +636,7 @@ public:
                 return;
             }
 
-            for (ObjectGuid const guid : summons)
+            for (ObjectGuid const& guid : summons)
             {
                 Creature* tsunami = ObjectAccessor::GetCreature(*me, guid);
                 if (!tsunami || tsunami->GetEntry() != NPC_FLAME_TSUNAMI)
@@ -1129,7 +1129,7 @@ public:
                 {
                     summons.RemoveNotExisting();
                     summons.DespawnEntry(NPC_TWILIGHT_WHELP);
-                    for (ObjectGuid const summonGuid : summons)
+                    for (ObjectGuid const& summonGuid : summons)
                     {
                         Creature const* summon = ObjectAccessor::GetCreature(*me, summonGuid);
                         if (!summon || !summon->IsAlive() || summon->GetEntry() != NPC_TWILIGHT_EGG)

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/instance_trial_of_the_champion.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/instance_trial_of_the_champion.cpp
@@ -279,7 +279,7 @@ public:
                 case INSTANCE_PROGRESS_CHAMPION_GROUP_DIED_3:
                     // revert to INSTANCE_PROGRESS_INITIAL
                     {
-                        for (ObjectGuid const guid : VehicleList)
+                        for (ObjectGuid const& guid : VehicleList)
                             if (Creature* veh = instance->GetCreature(guid))
                             {
                                 veh->DespawnOrUnsummon();
@@ -567,7 +567,7 @@ public:
                             {
                                 Counter = 0;
                                 InstanceProgress = INSTANCE_PROGRESS_CHAMPIONS_UNMOUNTED;
-                                for (ObjectGuid const guid : VehicleList)
+                                for (ObjectGuid const& guid : VehicleList)
                                     if (Creature* veh = instance->GetCreature(guid))
                                         veh->DespawnOrUnsummon();
                                 events.ScheduleEvent(EVENT_GRAND_CHAMPIONS_MOVE_SIDE, 0);

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
@@ -200,7 +200,7 @@ public:
             if( !IsHeroic() )
                 events.RescheduleEvent(EVENT_RESPAWN_SPHERE, 4000);
 
-            for (ObjectGuid guid : summons)
+            for (ObjectGuid const& guid : summons)
                 if (pInstance)
                     if (Creature* c = pInstance->instance->GetCreature(guid))
                     {

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
@@ -73,7 +73,7 @@ public:
 
                 // move corpses
                 const ObjectGuid npcs[4] = { NPC_IcehowlGUID, NPC_JaraxxusGUID, NPC_LightbaneGUID, NPC_DarkbaneGUID };
-                for (const ObjectGuid i : npcs)
+                for (ObjectGuid const& i : npcs)
                 {
                     if (Creature* c = instance->GetCreature(i))
                     {
@@ -402,7 +402,7 @@ public:
                             InstanceProgress = INSTANCE_PROGRESS_FACTION_CHAMPIONS_DEAD;
                             events.RescheduleEvent(EVENT_SCENE_FACTION_CHAMPIONS_DEAD, 2500);
 
-                            for (ObjectGuid guid : NPC_ChampionGUIDs)
+                            for (ObjectGuid const& guid : NPC_ChampionGUIDs)
                                 if (Creature* c = instance->GetCreature(guid))
                                     c->DespawnOrUnsummon(15000);
                             NPC_ChampionGUIDs.clear();
@@ -455,7 +455,7 @@ public:
                     {
                         EncounterStatus = IN_PROGRESS;
                         AchievementTimer = 0;
-                        for (ObjectGuid guid : NPC_ChampionGUIDs)
+                        for (ObjectGuid const& guid : NPC_ChampionGUIDs)
                             if (Creature* c = instance->GetCreature(guid))
                                 if (!c->IsInCombat())
                                     if (Unit* target = c->SelectNearestTarget(200.0f))
@@ -1093,7 +1093,7 @@ public:
                     }
                 case EVENT_CHAMPIONS_ATTACK:
                     {
-                        for (ObjectGuid guid : NPC_ChampionGUIDs)
+                        for (ObjectGuid const& guid : NPC_ChampionGUIDs)
                             if (Creature* c = instance->GetCreature(guid))
                             {
                                 c->SetReactState(REACT_AGGRESSIVE);
@@ -1493,7 +1493,7 @@ public:
                 case INSTANCE_PROGRESS_JARAXXUS_DEAD:
                     if( Creature* c = instance->GetCreature(NPC_BarrettGUID) )
                         c->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
-                    for (ObjectGuid guid : NPC_ChampionGUIDs)
+                    for (ObjectGuid const& guid : NPC_ChampionGUIDs)
                         if (Creature* c = instance->GetCreature(guid))
                             c->DespawnOrUnsummon();
                     NPC_ChampionGUIDs.clear();

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/pit_of_saron.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/pit_of_saron.cpp
@@ -958,7 +958,7 @@ public:
 
                 TSSpawnPos.GetAngle(&TSMidPos);
 
-                for (ObjectGuid guid : summons)
+                for (ObjectGuid const& guid : summons)
                     if (Creature* c = pInstance->instance->GetCreature(guid))
                     {
                         float hx, hy, hz, ho;
@@ -974,7 +974,7 @@ public:
                 if (pInstance)
                     if (Creature* c = pInstance->instance->GetCreature(pInstance->GetGuidData(DATA_SINDRAGOSA_GUID)))
                     {
-                        for (ObjectGuid guid : summons)
+                        for (ObjectGuid const& guid : summons)
                             if (Creature* s = pInstance->instance->GetCreature(guid))
                                 if (s->IsAlive())
                                     Unit::Kill(c, s);
@@ -1026,7 +1026,7 @@ public:
                     me->SetFacingTo(5.26f);
                     me->SetOrientation(5.26f);
                     me->SetHomePosition(*me);
-                    for (ObjectGuid guid : summons)
+                    for (ObjectGuid const& guid : summons)
                         if (Creature* c = pInstance->instance->GetCreature(guid))
                         {
                             c->SetFacingTo(5.26f);
@@ -1056,7 +1056,7 @@ public:
                             float offset = frand(0.0f, 10.0f);
                             c->GetMotionMaster()->MovePoint(0, 1047.0f + offset, 118.0f + offset, 628.2f);
                             c->SetHomePosition(*me);
-                            for (ObjectGuid guid : summons)
+                            for (ObjectGuid const& guid : summons)
                                 if (Creature* s = pInstance->instance->GetCreature(guid))
                                 {
                                     if (s->GetEntry() == NPC_FALLEN_WARRIOR)

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
@@ -369,7 +369,7 @@ public:
                                     {
                                         // shouldn't be casted on any victim of summoned mobs
                                         bool valid = true;
-                                        for (ObjectGuid const guid : summons)
+                                        for (ObjectGuid const& guid : summons)
                                             if (Creature* c = ObjectAccessor::GetCreature(*me, guid))
                                                 if (c->IsAlive() && c->GetVictim() && c->GetVictim()->GetGUID() == plr->GetGUID())
                                                 {

--- a/src/server/scripts/Northrend/Naxxramas/boss_sapphiron.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_sapphiron.cpp
@@ -191,7 +191,7 @@ public:
 
         bool IsValidExplosionTarget(WorldObject* target)
         {
-            for (ObjectGuid const guid : blockList)
+            for (ObjectGuid const& guid : blockList)
             {
                 if (target->GetGUID() == guid)
                     return false;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
@@ -291,7 +291,7 @@ public:
                             events.RepeatEvent(30000);
                         else
                         {
-                            for (ObjectGuid guid : summons)
+                            for (ObjectGuid const& guid : summons)
                                 if (Creature* sv = ObjectAccessor::GetCreature(*me, guid))
                                 {
                                     sv->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -2321,7 +2321,7 @@ public:
 
         void RemoveAll()
         {
-            for (ObjectGuid guid : FlameList)
+            for (ObjectGuid const& guid : FlameList)
                 if (Creature* c = ObjectAccessor::GetCreature(*me, guid))
                     c->DespawnOrUnsummon();
             FlameList.clear();

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -1219,7 +1219,7 @@ void instance_ulduar::instance_ulduar_InstanceMapScript::SpawnLeviathanEncounter
 {
     if (!_leviathanVehicles.empty())
     {
-        for (ObjectGuid guid : _leviathanVehicles)
+        for (ObjectGuid const& guid : _leviathanVehicles)
             if (Creature* cr = instance->GetCreature(guid))
                 if (Vehicle* veh = cr->GetVehicleKit())
                     veh->Dismiss();

--- a/src/server/scripts/Northrend/VioletHold/boss_ichoron.cpp
+++ b/src/server/scripts/Northrend/VioletHold/boss_ichoron.cpp
@@ -209,7 +209,7 @@ public:
                         bool bIsWaterElementsAlive = false;
                         if (!globules.empty())
                         {
-                            for (ObjectGuid const guid : globules)
+                            for (ObjectGuid const& guid : globules)
                                 if (Creature* pTemp = ObjectAccessor::GetCreature(*me, guid))
                                     if (pTemp->IsAlive())
                                     {

--- a/src/server/scripts/Northrend/VioletHold/boss_xevozz.cpp
+++ b/src/server/scripts/Northrend/VioletHold/boss_xevozz.cpp
@@ -124,7 +124,7 @@ public:
                     {
                         bool found = false;
                         if (pInstance)
-                            for (ObjectGuid guid : spheres)
+                            for (ObjectGuid const& guid : spheres)
                                 if (Creature* c = pInstance->instance->GetCreature(guid))
                                     if (me->GetDistance(c) < 3.0f)
                                     {

--- a/src/server/scripts/Northrend/VioletHold/instance_violet_hold.cpp
+++ b/src/server/scripts/Northrend/VioletHold/instance_violet_hold.cpp
@@ -434,7 +434,7 @@ public:
                         DoUpdateWorldState(WORLD_STATE_VH_PRISON_STATE, (uint32)GateHealth);
                         DoUpdateWorldState(WORLD_STATE_VH_WAVE_COUNT, (uint32)WaveCount);
 
-                        for (ObjectGuid guid : GO_ActivationCrystalGUID)
+                        for (ObjectGuid const& guid : GO_ActivationCrystalGUID)
                             if (GameObject* go = instance->GetGameObject(guid))
                             {
                                 HandleGameObject(ObjectGuid::Empty, false, go); // not used yet
@@ -528,7 +528,7 @@ public:
             CLEANED = true;
 
             // reset defense crystals
-            for (ObjectGuid guid : GO_ActivationCrystalGUID)
+            for (ObjectGuid const& guid : GO_ActivationCrystalGUID)
                 if (GameObject* go = instance->GetGameObject(guid))
                 {
                     HandleGameObject(ObjectGuid::Empty, false, go); // not used yet
@@ -555,7 +555,7 @@ public:
             NPC_PortalGUID.Clear();
 
             // remove trash
-            for (ObjectGuid guid : trashMobs)
+            for (ObjectGuid const& guid : trashMobs)
                 if (Creature* c = instance->GetCreature(guid))
                     c->DespawnOrUnsummon();
 

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -171,7 +171,7 @@ public:
         void CheckSummons()
         {
             bool allow = true;
-            for (ObjectGuid guid : summons)
+            for (ObjectGuid const& guid : summons)
                 if (Creature* cr = ObjectAccessor::GetCreature(*me, guid))
                     if (cr->IsAlive())
                         allow = false;

--- a/src/server/scripts/Northrend/zone_sholazar_basin.cpp
+++ b/src/server/scripts/Northrend/zone_sholazar_basin.cpp
@@ -176,7 +176,7 @@ public:
                 if (action == ACTION_BIND_MINIONS)
                     me->CastSpell(me, SPELL_ARTRUIS_BINDING, true);
 
-                for (ObjectGuid const guid : summons)
+                for (ObjectGuid const& guid : summons)
                 {
                     Creature* minion = ObjectAccessor::GetCreature(*me, guid);
                     if (minion && minion->IsAlive())

--- a/src/server/scripts/Outland/BlackTemple/instance_black_temple.cpp
+++ b/src/server/scripts/Outland/BlackTemple/instance_black_temple.cpp
@@ -187,7 +187,7 @@ public:
 
             if (type == DATA_SHADE_OF_AKAMA && state == DONE)
             {
-                for (ObjectGuid const guid : ashtongueGUIDs)
+                for (ObjectGuid const& guid : ashtongueGUIDs)
                     if (Creature* ashtongue = instance->GetCreature(guid))
                         ashtongue->setFaction(FACTION_ASHTONGUE);
             }
@@ -293,7 +293,7 @@ public:
 
         void HandleEffectRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
         {
-            for (ObjectGuid const guid : _turtleSet)
+            for (ObjectGuid const& guid : _turtleSet)
                 if (Creature* turtle = ObjectAccessor::GetCreature(*GetUnitOwner(), guid))
                 {
                     turtle->TauntFadeOut(GetUnitOwner());

--- a/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/instance_blood_furnace.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/instance_blood_furnace.cpp
@@ -218,7 +218,7 @@ public:
 
         void ResetPrisoners(GuidSet prisoners)
         {
-            for (ObjectGuid guid : prisoners)
+            for (ObjectGuid const& guid : prisoners)
                 if (Creature* prisoner = instance->GetCreature(guid))
                     ResetPrisoner(prisoner);
         }
@@ -300,7 +300,7 @@ public:
 
         void ActivatePrisoners(GuidSet prisoners)
         {
-            for (ObjectGuid guid : prisoners)
+            for (ObjectGuid const& guid : prisoners)
                 if (Creature* prisoner = instance->GetCreature(guid))
                 {
                     prisoner->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC | UNIT_FLAG_NON_ATTACKABLE);

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/instance_magtheridons_lair.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/instance_magtheridons_lair.cpp
@@ -118,7 +118,7 @@ public:
             {
                 if (state == IN_PROGRESS)
                 {
-                    for (ObjectGuid const guid : _wardersSet)
+                    for (ObjectGuid const& guid : _wardersSet)
                         if (Creature* warder = instance->GetCreature(guid))
                             if (warder->IsAlive())
                             {
@@ -128,7 +128,7 @@ public:
                 }
                 else
                 {
-                    for (ObjectGuid const guid : _cubesSet)
+                    for (ObjectGuid const& guid : _cubesSet)
                         if (GameObject* cube = instance->GetGameObject(guid))
                             cube->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
 
@@ -149,12 +149,12 @@ public:
                             magtheridon->SetInCombatWithZone();
                     break;
                 case DATA_ACTIVATE_CUBES:
-                    for (ObjectGuid const guid : _cubesSet)
+                    for (ObjectGuid const& guid : _cubesSet)
                         if (GameObject* cube = instance->GetGameObject(guid))
                             cube->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
                     break;
                 case DATA_COLLAPSE:
-                    for (ObjectGuid const guid : _columnSet)
+                    for (ObjectGuid const& guid : _columnSet)
                         if (GameObject* column = instance->GetGameObject(guid))
                             column->SetGoState(GOState(data));
                     break;

--- a/src/server/scripts/Outland/TempestKeep/botanica/instance_the_botanica.cpp
+++ b/src/server/scripts/Outland/TempestKeep/botanica/instance_the_botanica.cpp
@@ -105,7 +105,7 @@ public:
 
         void HandleEffectRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
         {
-            for (ObjectGuid const guid : _falconSet)
+            for (ObjectGuid const& guid : _falconSet)
                 if (Creature* falcon = ObjectAccessor::GetCreature(*GetUnitOwner(), guid))
                 {
                     falcon->TauntFadeOut(GetUnitOwner());

--- a/src/server/scripts/Outland/zone_netherstorm.cpp
+++ b/src/server/scripts/Outland/zone_netherstorm.cpp
@@ -1097,7 +1097,7 @@ public:
         {
             if (!summons.empty())
             {
-                for (ObjectGuid guid : summons)
+                for (ObjectGuid const& guid : summons)
                     if (Creature* cr = ObjectAccessor::GetCreature(*me, guid))
                     {
                         float x, y, z, o;

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -983,7 +983,7 @@ public:
                     {
                         if (!Patients.empty())
                         {
-                            for (ObjectGuid const guid : Patients)
+                            for (ObjectGuid const& guid : Patients)
                             {
                                 if (Creature* patient = ObjectAccessor::GetCreature(*me, guid))
                                     patient->setDeathState(JUST_DIED);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Avoid copying objects when looping through `ObjectGuid` arrays
-  Fixed many warnings like:
```
 warning: loop variable 'guid' of type 'const ObjectGuid' creates a copy from type 'const ObjectGuid' [-Wrange-loop-analysis]
```

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game by doing some random stuff such as killing a couple of creatures, buying items, using potions, etc...

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- Just compile the core, run it, access the game and play a bit with it

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
