### PR TITLE
fix(Core/World): -Wrange-loop-analysis warning

### DIFF
--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1490,8 +1490,10 @@ void World::SetInitialWorldSettings()
     sIPLocation->Load();
 
     std::vector<uint32> mapIds;
-    for (auto const& map : sMapStore)
+    for (auto const map : sMapStore)
+    {
         mapIds.emplace_back(map->MapID);
+    }
 
     vmmgr2->InitializeThreadUnsafe(mapIds);
 


### PR DESCRIPTION
Fixes the following warning:

```
azerothcore-wotlk/src/server/game/World/World.cpp:1493:22: warning: loop variable 'map' is always a copy because the range of type 'DBCStorage<MapEntry>' does not return a reference [-Wrange-loop-analysis]
    for (auto const& map : sMapStore)
                     ^
azerothcore-wotlk/src/server/game/World/World.cpp:1493:10: note: use non-reference type 'const MapEntry *'
    for (auto const& map : sMapStore)
         ^~~~~~~~~~~~~~~~~
```

According to [this answer](https://stackoverflow.com/a/50066414/3497671):

>  That means in every iteration you have an object that is being created and destroyed, which could be costly, and is not obvious as you are using a reference. The warning wants you to use a non reference type to make it obvious that you are not actually working with the element from the range but instead a copy/proxy of it.

## Tests performed:

- Tested in-game by doing some random stuff such as killing a couple of creatures, buying items, using potions, etc...