### PR TITLE
fix(DB/Loot): Remove underlevel RLT 24074 from Rocs/Hyenas

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1625916764471568068.sql
+++ b/data/sql/updates/pending_db_world/rev_1625916764471568068.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1625916764471568068');
+
+-- Deletes lvl (min:10/avg:10.68/max:11) RLT 24074 from lvl 44 Blisterpaw Hyena (ID 5426), lvl 43 Fire Roc (ID 5429)
+DELETE FROM `creature_loot_template` WHERE `Entry` IN (5426, 5429) AND `Reference` = 24074;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Deletes lvl (min:10/avg:10.68/max:11) RLT 24074 from lvl 44 Blisterpaw Hyena (ID 5426), lvl 43 Fire Roc (ID 5429)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6863
- Closes https://github.com/chromiecraft/chromiecraft/issues/1145

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/npc=5429/fire-roc#drops
https://tbc.wowhead.com/npc=5426/blisterpaw-hyena#drops

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, correct number of rows affected.
- Checked in Keira.
- Verified with [ac-whcomp](https://github.com/Azcobu/ac-whcomp) that these items were not listed in Wowheads drop tables for these NPCs.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Checked DB, ensure that RLT 24074 is no longer listed for IDs 5426 and 5429.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
