### PR TITLE
fix(DB/Creature): Fix various static NPCs in Darkshore/Tanaris

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1625925059779148449.sql
+++ b/data/sql/updates/pending_db_world/rev_1625925059779148449.sql
@@ -10,3 +10,6 @@ UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5  WHERE `id` = 21
 UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 10 WHERE `id` = 7015 AND `guid` = 51899;
 -- Lord Sinslayer
 UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE `id` = 7017 AND `guid` = 37089;
+
+-- Correct speeds for Kregg and Licillin
+UPDATE `creature_template` SET `speed_walk` = 1 WHERE `entry`IN (8203, 2191);

--- a/data/sql/updates/pending_db_world/rev_1625925059779148449.sql
+++ b/data/sql/updates/pending_db_world/rev_1625925059779148449.sql
@@ -1,0 +1,12 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1625925059779148449');
+
+-- Kregg Keelhaul
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 10 WHERE `id` = 8203 AND `guid` = 51834;
+-- Licillin
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 10 WHERE `id` = 2191 AND `guid` = 52009;
+-- Carnivous the Breaker
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5  WHERE `id` = 2186 AND `guid` = 51900;
+-- Flagglemurk the Cruel
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 10 WHERE `id` = 7015 AND `guid` = 51899;
+-- Lord Sinslayer
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE `id` = 7017 AND `guid` = 37089;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Adds movement and wander distances to:
- Kregg Keelhaul - ID 8203- matched to SouthSea Freebooter. Also setting his speed_walk to 1 as it was too high (checked with @Efymer 's web app [here ](https://azerothcore-speedchecker.web.app) to verify correct speed was 1, not 1.68.)
- Licillin ID 2191 - matched to Vile Sprite - also setting speed_walk from 1.83 to 1.
- Carnivous the Breaker ID 2186  - matched to Blackwood Windtalker, speed was fine.
- Flagglemurk the Cruel ID 7015 - no nearby murlocs, matched to Tide Crawler, speed was fine.
- Lord Sinslayer ID 7017 - matched to Stormscale Waverider, speed was fine.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes  https://github.com/azerothcore/azerothcore-wotlk/issues/6815
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6826

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- Kregg - https://www.youtube.com/watch?v=tlVlehGsilM
- Licillin - https://www.youtube.com/watch?v=3ig-AfSgz58
- Carnivous the Breaker - https://www.youtube.com/watch?v=Qy6CrNpwT2I
- Flagglemurk the Cruel ID - https://youtu.be/L7DVNi0JDhQ?t=193
- Lord Sinslayer - https://youtu.be/ba2bpQP9OKM?t=80

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, expected number of rows modified.
- Checked in game, hence speed updates because some of them were moving a bit too well.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Visit GUIDs provided, or check in Keira.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
