### PR TITLE
fix(DB/Loot): Remove Arathi PVP food/bandages from open world NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1626007477539439387.sql
+++ b/data/sql/updates/pending_db_world/rev_1626007477539439387.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1626007477539439387');
+
+-- Delete Arathi PVP supplies from Warpwood Stomper, Desert Rumbler, Vekniss Soldier
+DELETE FROM `creature_loot_template` WHERE `entry` IN (11465, 11746, 15229) AND `item` IN (20062, 20066);
+
+-- Delete loot table for Field Marshal Oslight 
+UPDATE `creature_template` SET `lootid` = 0 WHERE `entry` = 14983;
+DELETE FROM `creature_loot_template` WHERE `entry` = 14983;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Deletes Arathi Basin Enriched Ration (ID 20062) and Arathi Basin Runecloth Bandage (ID 20066) from the loot tables of:
   - Warpwood Stomper (ID 11465)
   - Desert Rumbler (ID 11746)
   - Vekniss Soldier (ID 15229)
- Deletes the entire loot table of Field Marshal Oslight (ID 14983). This sounds drastic, but Wowhead shows he shouldn't drop anything at all. (At the moment he drops 9 items, including 6 different types of Arathi PVP supplies.) This brings Oslight into line with other nearby PVP NPCs like Sir Maximus Adams and Samuel Hawke, who also have no drops. (Apparently incorrectly in Hawke's case according to WH, but that's another issue.)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6882
- Closes https://github.com/chromiecraft/chromiecraft/issues/1157

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Links showing that these items should only ever drop from Arathor Advanced Care Package or Defiler's Advanced Care Package:
https://tbc.wowhead.com/item=20062/arathi-basin-enriched-ration
https://tbc.wowhead.com/item=20066/arathi-basin-runecloth-bandage

Oslight's drop table or lack thereof:
https://tbc.wowhead.com/npc=14983/field-marshal-oslight

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warning, correct number of rows modified.
- Checked in game (went and ganked the Field Marshal, no problems found.)
- Tested with following query searching for all Arathi PVP supplies:
```
SELECT ct.entry, ct.name, clt.chance
FROM `creature_template` ct
JOIN `creature_loot_template` clt ON ct.lootid = clt.entry
JOIN `item_template` it ON clt.item = it.entry
WHERE it.entry IN (20062, 20063, 20064, 20065, 20066, 20067);
```
Returned no results as expected.
```
Empty set (0.09 sec)
```
## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. SQL above would be a good start, the usual open world drop rate for these is currently 0.02% so testing in open world might take a while.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
