### PR TITLE
fix(DB/Loot): 'Deadwood Headdress Feather' Drop rates Inaccurate

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1626317015822404300.sql
+++ b/data/sql/updates/pending_db_world/rev_1626317015822404300.sql
@@ -1,0 +1,37 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1626317015822404300');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 7158) AND (`Item` IN (21377));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(7158, 21377, 0, 49, 0, 1, 0, 1, 1, 'Deadwood Shaman - Deadwood Headdress Feather');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 7157) AND (`Item` IN (21377));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(7157, 21377, 0, 48, 0, 1, 0, 1, 1, 'Deadwood Avenger - Deadwood Headdress Feather');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 7156) AND (`Item` IN (21377));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(7156, 21377, 0, 49, 0, 1, 0, 1, 1, 'Deadwood Den Watcher - Deadwood Headdress Feather');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 7155) AND (`Item` IN (21377));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(7155, 21377, 0, 27, 0, 1, 0, 1, 1, 'Deadwood Pathfinder - Deadwood Headdress Feather');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 7154) AND (`Item` IN (21377));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(7154, 21377, 0, 28, 0, 1, 0, 1, 1, 'Deadwood Gardener - Deadwood Headdress Feather');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 7153) AND (`Item` IN (21377));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(7153, 21377, 0, 30, 0, 1, 0, 1, 1, 'Deadwood Warrior - Deadwood Headdress Feather');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 9464) AND (`Item` IN (21377));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(9464, 21377, 0, 28, 0, 1, 0, 1, 1, 'Overlord Ror - Deadwood Headdress Feather');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 14342) AND (`Item` IN (21377));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(14342, 21377, 0, 17, 0, 1, 0, 1, 1, 'Ragepaw - Deadwood Headdress Feather');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 9462) AND (`Item` IN (21377));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(9462, 21377, 0, 39, 0, 1, 0, 1, 1, 'Chieftain Bloodmaw - Deadwood Headdress Feather');


### PR DESCRIPTION
## Changes Proposed:
- Changed the drop rates for  'Deadwood Headdress Feather'

## Issues Addressed:
- Closes #6937
- Closes chromiecraft/chromiecraft#1179

## SOURCE:
- https://tbc.wowhead.com/item=21377/deadwood-headdress-feather

## Tests Performed:
- Tested on local server

## How to Test the Changes:
1. Directly kill NPCs from the list and check the item drop rate
2. Look in Keira3 or in DB

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
