### PR TITLE
fix(Core): revert Boost minimum version change

### DIFF
--- a/deps/boost/CMakeLists.txt
+++ b/deps/boost/CMakeLists.txt
@@ -28,8 +28,12 @@ endif()
 
 include (CheckCXXSourceCompiles)
 
-# C++20 requires Boost 1.74 to build
-set(BOOST_REQUIRED_VERSION 1.74)
+if (WIN32)
+  # On windows the requirements are higher according to the wiki.
+  set(BOOST_REQUIRED_VERSION 1.70)
+else()
+  set(BOOST_REQUIRED_VERSION 1.67)
+endif()
 
 find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED system filesystem program_options iostreams regex)
 


### PR DESCRIPTION
- This was broken the Docker build
- This was causing some issues to some users, as in several systems such as Debian and Ubuntu the default Boost version is not 1.74 yet and can be cumbersome to migrate

However, this is just a temporary revert. We'll need to require Boost 1.74+ in future. But I guess it's better to wait for now.