### PR TITLE
fix(DB/SAI): "Attack on the Tower" Quest - Incorrect NPC Spawn Behaviour

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1626358725875698500.sql
+++ b/data/sql/updates/pending_db_world/rev_1626358725875698500.sql
@@ -1,0 +1,14 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1626358725875698500');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 2569;
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 2569) AND (`source_type` = 0) AND (`id` IN (2));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2569, 0, 2, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 49, 100, 0, 0, 0, 0, 0, 21, 30, 0, 0, 0, 0, 0, 0, 0, 'Boulderfist Mauler - Just Summoned - Attack Start');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 2570;
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 2570) AND (`source_type` = 0) AND (`id` IN (4));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2570, 0, 4, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 21, 30, 0, 0, 0, 0, 0, 0, 0, 'Boulderfist Shaman - Just Summoned - Attack Start');
+

--- a/data/sql/updates/pending_db_world/rev_1626358725875698500.sql
+++ b/data/sql/updates/pending_db_world/rev_1626358725875698500.sql
@@ -1,14 +1,9 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1626358725875698500');
 
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 2569;
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (2569, 2570);
 
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 2569) AND (`source_type` = 0) AND (`id` IN (2));
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(2569, 0, 2, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 49, 100, 0, 0, 0, 0, 0, 21, 30, 0, 0, 0, 0, 0, 0, 0, 'Boulderfist Mauler - Just Summoned - Attack Start');
-
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 2570;
-
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 2570) AND (`source_type` = 0) AND (`id` IN (4));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2569, 0, 2, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 49, 100, 0, 0, 0, 0, 0, 21, 30, 0, 0, 0, 0, 0, 0, 0, 'Boulderfist Mauler - Just Summoned - Attack Start'),
 (2570, 0, 4, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 21, 30, 0, 0, 0, 0, 0, 0, 0, 'Boulderfist Shaman - Just Summoned - Attack Start');
-

--- a/data/sql/updates/pending_db_world/rev_1626358725875698500.sql
+++ b/data/sql/updates/pending_db_world/rev_1626358725875698500.sql
@@ -7,3 +7,4 @@ DELETE FROM `smart_scripts` WHERE (`entryorguid` = 2570) AND (`source_type` = 0)
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (2569, 0, 2, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 49, 100, 0, 0, 0, 0, 0, 21, 30, 0, 0, 0, 0, 0, 0, 0, 'Boulderfist Mauler - Just Summoned - Attack Start'),
 (2570, 0, 4, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 21, 30, 0, 0, 0, 0, 0, 0, 0, 'Boulderfist Shaman - Just Summoned - Attack Start');
+


### PR DESCRIPTION
## Changes Proposed:
-  Mobs now run to the player and attack

## Issues Addressed:
- Closes #6944
- Closes chromiecraft/chromiecraft#1187

## SOURCE:
- Trelane's Footlocker (2717) - 16611 - https://www.youtube.com/watch?v=oFdLPHn4w7E&t=731s
- Trelane's Lockbox (2718) - 16610 - https://youtu.be/oFdLPHn4w7E?t=951
- Trelane's Chest (2716) - 16617 - https://youtu.be/oFdLPHn4w7E?t=2166

## Tests Performed:
- Tested on local server

## How to Test the Changes:
1. .q add 696
2. .go o 16611 - loot and observe
3. .go o 16610 - loot and observe
4. .go o 16617 - loot and observe

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
