### PR TITLE
fix(format): Acessmodifieroffset & line breaks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
-﻿---
+---
+AccessModifierOffset: '-4'
 AlignConsecutiveMacros: 'true'
 AlignConsecutiveAssignments: 'true'
 AlignConsecutiveDeclarations: 'true'
@@ -14,7 +15,9 @@ AllowShortLoopsOnASingleLine: 'true'
 BinPackArguments: 'true'
 BinPackParameters: 'true'
 BreakBeforeBraces: Allman
+ColumnLimit: '500'
 IndentWidth: '4'
+PointerAlignment: Left
 SpaceAfterCStyleCast: 'true'
 SpaceBeforeCpp11BracedList: 'true'
 SpaceBeforeParens: ControlStatements
@@ -24,11 +27,7 @@ SpacesInAngles: 'false'
 SpacesInCStyleCastParentheses: 'false'
 SpacesInContainerLiterals: 'false'
 SpacesInParentheses: 'false'
-Standard: Latest
 TabWidth: '0'
 UseTab: Never
-PointerAlignment: Left
-ColumnLimit: 0
-
 
 ...


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changes the AccessModifiersOffset to -4 
-  Changes the ColumnLimit to 500

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6995

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

![New formatting](https://camo.githubusercontent.com/30df460eaa3908a8cd94da18e594199eeb3af924f7fabedca50b6647d0b07bdc/68747470733a2f2f692e696d6775722e636f6d2f687369476233772e706e67)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- None yet.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Format a file with clang-format
2. (Optional) Test if it compiles

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
