### PR TITLE
fix(DB/Quest): "Plundering the Plunderers" has incorrect quest completion text

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1626545461944168600.sql
+++ b/data/sql/updates/pending_db_world/rev_1626545461944168600.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1626545461944168600');
+
+-- We change the quest reward to use the name and gender of our character.
+UPDATE `quest_offer_reward` SET `RewardText` = 'Incredible! Improbable! Simply amazing! You\'ve got talent, $N. Either that or you\'re the luckiest $gman:woman; alive!$b$bHere\'s your cut of the action. I\'m sure you would make better use of this stuff than I could.$b$b' WHERE (`ID` = 2381);
+
+


### PR DESCRIPTION
The quest reward gossip had text with a setted name and gender. Its changed to use the name and character now

Closes AzerothCore issue #6976

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changing in the database the text of the quest using $N to take the name and $gman:woman; to change between man and woman.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6976
- Closes https://github.com/chromiecraft/chromiecraft/issues/1219

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Picture of the new text

![image](https://user-images.githubusercontent.com/87535580/126046187-60ba76fb-3bb6-41c1-bf92-6ec8dbc83b56.png)

With man named World

![image](https://user-images.githubusercontent.com/87535580/126046290-a3258a12-106f-467a-a8a1-a8bdfab11dd6.png)



## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  .go c id 7161
- .quest add 2381 to add the quest
- .quest complete 2381 to complete it
-  I talked with the goblin and saw the he used my name and gender on the text.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c  id 7161
2. .quest add 2381 to add the quest
3. .quest complete 2381 to complete it
4. Talk with the goblin and see if the text use the name and gender of the character.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
