### PR TITLE
Core/Movement: Fixed weird pathing by clearing old path.

### DIFF
--- a/src/server/game/Movement/MovementGenerators/PathGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/PathGenerator.h
@@ -111,6 +111,12 @@ class PathGenerator
             return len;
         }
 
+        void Clear()
+        {
+            _polyLength = 0;
+            _pathPoints.clear();
+        }
+
     private:
         dtPolyRef _pathPolyRefs[MAX_PATH_LENGTH];   // array of detour polygon references
         uint32 _polyLength;                         // number of polygons in the path
@@ -138,12 +144,6 @@ class PathGenerator
         void SetEndPosition(G3D::Vector3 const& point) { _actualEndPosition = point; _endPosition = point; }
         void SetActualEndPosition(G3D::Vector3 const& point) { _actualEndPosition = point; }
         void NormalizePath();
-
-        void Clear()
-        {
-            _polyLength = 0;
-            _pathPoints.clear();
-        }
 
         bool InRange(G3D::Vector3 const& p1, G3D::Vector3 const& p2, float r, float h) const;
         float Dist3DSqr(G3D::Vector3 const& p1, G3D::Vector3 const& p2) const;

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -131,6 +131,8 @@ bool ChaseMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
 
     if (!i_path || moveToward != _movingTowards)
         i_path = std::make_unique<PathGenerator>(owner);
+    else
+        i_path->Clear();
 
     float x, y, z;
     bool shortenPath;


### PR DESCRIPTION
Fixed #5220.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Clear out path generator if not initializing the new one in `TargetedMovementGenerator`. We need to do this, because later in `PathGenerator` calculations we still have old points if something went wrong.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5220.
- Closes https://github.com/chromiecraft/chromiecraft/issues/369

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame in Stromgarde Keep.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Description [here](https://github.com/azerothcore/azerothcore-wotlk/issues/5220)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
