### PR TITLE
fix(DB/Creature): Fix Deepstrider Searcher resets when attacked underwater

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1626777621665410700.sql
+++ b/data/sql/updates/pending_db_world/rev_1626777621665410700.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1626777621665410700');
+
+UPDATE `creature_template` SET `InhabitType` = 3 WHERE (`entry` = 4687);
+


### PR DESCRIPTION
Deepstrider Searcher had only a inhabit type of ground, i added water to it

Closes AzerothCore issue#7016

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added water to inhabitType

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7016

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  .go c id 4687
- attack it underwater
- He should attack you

TEST

https://streamable.com/aa9m9r

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  .go c id 4687
2. attack it underwater
3. He should attack you


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
