### PR TITLE
fix(DB/Creature): Olm the Wise (rare) missing movement pattern

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1626780409112630500.sql
+++ b/data/sql/updates/pending_db_world/rev_1626780409112630500.sql
@@ -1,9 +1,10 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1626780409112630500');
 
--- Added 2 more spwn points and movement on them
-DELETE FROM `creature` WHERE (`id` = 14343);
+-- Added movement to the default spawn point he had
+UPDATE `creature` SET `wander_distance` = 20, `MovementType` = 1 WHERE (`id` = 14343) AND (`guid` = 51897);
+
+-- Added 2 more spawn points and movement on them
 INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
-(51897, 14343, 1, 0, 0, 1, 1, 0, 0, 5875.65, -1242.83, 403.304, 5.35714, 9900, 20, 0, 3082, 0, 1, 0, 0, 0, '', 0),
 (301303, 14343, 1, 0, 0, 1, 1, 0, 0, 6091.22, -1485.77, 438.13, 0.18, 9900, 20, 0, 1, 0, 1, 0, 0, 0, '', 0),
 (301304, 14343, 1, 0, 0, 1, 1, 0, 0, 6307.9, -1637.18, 474.611, 0, 9900, 20, 0, 1, 0, 1, 0, 0, 0, '', 0);
 

--- a/data/sql/updates/pending_db_world/rev_1626780409112630500.sql
+++ b/data/sql/updates/pending_db_world/rev_1626780409112630500.sql
@@ -4,6 +4,7 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1626780409112630500');
 UPDATE `creature` SET `wander_distance` = 20, `MovementType` = 1 WHERE (`id` = 14343) AND (`guid` = 51897);
 
 -- Added 2 more spawn points and movement on them
+DELETE FROM `creature` WHERE (`id` = 14343) AND (`guid` IN (301303, 301304));
 INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
 (301303, 14343, 1, 0, 0, 1, 1, 0, 0, 6091.22, -1485.77, 438.13, 0.18, 9900, 20, 0, 1, 0, 1, 0, 0, 0, '', 0),
 (301304, 14343, 1, 0, 0, 1, 1, 0, 0, 6307.9, -1637.18, 474.611, 0, 9900, 20, 0, 1, 0, 1, 0, 0, 0, '', 0);

--- a/data/sql/updates/pending_db_world/rev_1626780409112630500.sql
+++ b/data/sql/updates/pending_db_world/rev_1626780409112630500.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1626780409112630500');
+
+-- Added 2 more spwn points and movement on them
+DELETE FROM `creature` WHERE (`id` = 14343);
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(51897, 14343, 1, 0, 0, 1, 1, 0, 0, 5875.65, -1242.83, 403.304, 5.35714, 9900, 20, 0, 3082, 0, 1, 0, 0, 0, '', 0),
+(301303, 14343, 1, 0, 0, 1, 1, 0, 0, 6091.22, -1485.77, 438.13, 0.18, 9900, 20, 0, 1, 0, 1, 0, 0, 0, '', 0),
+(301304, 14343, 1, 0, 0, 1, 1, 0, 0, 6307.9, -1637.18, 474.611, 0, 9900, 20, 0, 1, 0, 1, 0, 0, 0, '', 0);
+


### PR DESCRIPTION
I added some new spawn points and added movements to all of them

Closes AzerothCore issue#7012

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added 2 new spawn points 
-  Added movement to the creature on all of them

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7012
- Closes https://github.com/chromiecraft/chromiecraft/issues/1224

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/npc=14343/olm-the-wise

https://www.youtube.com/watch?v=evs3q3xk_fs
https://youtu.be/WEg1X9Cs6eg?t=9
https://youtu.be/dkk3VDeS-LU?t=2

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .go c id 14343
- Observe if it moves around the spawn point

Video test

https://streamable.com/7fwttv


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 14343
2. Observe if it moves around the spawn point

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- Tried to give it the faction of Cenarion circle as the source
-  " Alliance hunters might be puzzled by the fact Olm the Wise is clearly rated "Tameable" via Beast Lore, yet if they try to tame him they get an "invalid target" message. The reason is because Olm has faction with Cenarion Circle. "
- When i added him the faction i couldnt see it, so i dont know if can be possible or not, just to add.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
