### PR TITLE
DB/Graveyards: Corrected graveyard for alliance in Shadowfang Keep.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1626810503477176700.sql
+++ b/data/sql/updates/pending_db_world/rev_1626810503477176700.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1626810503477176700');
+
+UPDATE `graveyard_zone` SET `Faction`=67 WHERE `Id`=97 AND `GhostZone`=209;
+UPDATE `graveyard_zone` SET `Faction`=469 WHERE `Id`=149 AND `GhostZone`=209;
+
+DELETE FROM `graveyard_zone` WHERE `ID`=1256 AND `GhostZone`=209;
+INSERT INTO `graveyard_zone` VALUES
+(1256,209,0,'Silverpine Forest, South GY - Silverpine Forest');


### PR DESCRIPTION
Fixed #5520.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Corrected and added new graveyard for alliance players in Shadowfang Keep instance.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5520
- Closes https://github.com/chromiecraft/chromiecraft/issues/479

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.Travel to SFK (not through dungeon finder), enter the instance and logout (or die.)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
