### PR TITLE
fix(DB): Moved Briarthorn node outside of terrain

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1627581490592719000.sql
+++ b/data/sql/updates/pending_db_world/rev_1627581490592719000.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1627581490592719000');
+
+-- Moved the node outside of the tree
+UPDATE `gameobject` SET `position_x` = 6629.067 , `position_y` = -7382.726, `position_z` = 54.81 WHERE (`id` = 1621) AND (`guid` = 65024);
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changed the coords of the node, so now it will spawn outside of the tree

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7142
- Closes https://github.com/chromiecraft/chromiecraft/issues/1298

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .go go 65024
- Check the new spawn


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go go 65024
2. Check the new spawn

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
