### PR TITLE
fix(Script/Mandorik): enrage on reset and on subsequent pulls.

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
@@ -112,7 +112,7 @@ public:
             }
 
             killCount = 0;
-            me->RemoveAura(SPELL_FRENZY);
+            me->RemoveAurasDueToSpell(SPELL_FRENZY);
             me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC);
             summons.DespawnAll();
             instance->SetBossState(DATA_OHGAN, NOT_STARTED);

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
@@ -105,14 +105,17 @@ public:
         {
             if (me->GetPositionZ() > 140.0f)
             {
-                killCount = 0;
                 events.ScheduleEvent(EVENT_CHECK_START, 1000);
                 if (Creature* speaker = ObjectAccessor::GetCreature(*me, instance->GetGuidData(NPC_VILEBRANCH_SPEAKER)))
                     if (!speaker->IsAlive())
                         speaker->Respawn(true);
             }
+
+            killCount = 0;
+            me->RemoveAura(SPELL_FRENZY);
             me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC);
             summons.DespawnAll();
+            instance->SetBossState(DATA_OHGAN, NOT_STARTED);
             me->Mount(MODEL_OHGAN_MOUNT);
         }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added checks to remove frenzy aura within Reset()
-  Correctly set Ohgans boss state to NOT_STARTED when Mandokir's Reset() is called.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes part of: https://github.com/azerothcore/azerothcore-wotlk/issues/834 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested on Windows10 64-bit in-game following the steps outline below.
- Tested additional bug where if you had killed Ohgan then reset the fight, Ohgans data remained as DONE and mandokir
   would immediately enrage on subsequent pulls.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Pull Mandokir and .damage or .die Ohgan, see Mandokir enrage.
2. Reset the fight by turning GM on or dying. Observe that enrage is removed on reset.
3. Additionally, observe that mandokir does not enrage if you have killed ohgan before him, and then re-pulled him.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [This PR is complete, however it does not resolve all the issues outlined in the linked issue #834 ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
