### PR TITLE
fix(DB/Spell): Set proc cooldown of Taste of Blood to 5.5 sec.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1627655074869500200.sql
+++ b/data/sql/updates/pending_db_world/rev_1627655074869500200.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1627655074869500200');
+
+UPDATE `spell_proc_event` SET `cooldown`=5500 WHERE `entry`=-56636;


### PR DESCRIPTION
Fixed #6542

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  There is some time desynchro between aura duration and proc cooldown - that's why Taste for Blood sometimes does not proc from Rend. The problem might be something general. I modified cooldown to ensure that TfB will always proc. There is not threat about early proc - Rend ticks every 3 sec, so TfB will always proc every 2nd tick of Rend.
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6542
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6542

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. get a warrior, level it it up to have at least 18 talent points
2. spend your points in arms tree and get 3/3 taste of blood
3. get glyph of rending
4. use rend on a target dummy.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
