### PR TITLE
fix(DB/quest_request_items): quest completion text for Crew Under Fire & closes #7029

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1627727878498349900.sql
+++ b/data/sql/updates/pending_db_world/rev_1627727878498349900.sql
@@ -1,0 +1,2 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1627727878498349900');
+UPDATE `quest_request_items` SET `CompletionText` = 'This is going to be a tough battle...' WHERE (`ID` = 3382);


### PR DESCRIPTION
Fixes quest text in issue #7029

Fixed quest text for quest in Azshara called Crew Under Fire



<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Adjust quest text from incorrect quest to correct quest
-  

 'This is going to be a tough battle...' 


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #7029

https://github.com/azerothcore/azerothcore-wotlk/issues/7029

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

Sources in issue report

https://classic.wowhead.com/quest=3382/a-crew-under-fire

https://vanillawowdb.com/?quest=3564

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 

No tests, SQL fix only.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Azshara
2. Start quest Crew Under Fire
3. Observe progress text mid quest by talking to questgiver

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
