### PR TITLE
fix(DB/Creature): Fixed the spawns of two Heavy War Golem (5854)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1627735957987999500.sql
+++ b/data/sql/updates/pending_db_world/rev_1627735957987999500.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1627735957987999500');
+
+-- Change the spawn points of Heavy War Golem (5854) so they spawn in the bridge
+UPDATE `creature` SET `position_x` = -6681.53, `position_y` = -1352.86, `position_z` = 210.77  WHERE (`id` = 5854) AND (`guid` = 5608);
+UPDATE `creature` SET `position_x` = -6663.55, `position_y` = -1317.16, `position_z` = 208.48  WHERE (`id` = 5854) AND (`guid` = 5687);
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changed the coords of 2 spawn points (guid 5608 and guid 5687)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/881
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6393

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .go c 5608 
- .go c 5687
- Check if the position is good

Test

![image](https://user-images.githubusercontent.com/87535580/127740604-241c0664-ad25-4c93-9bde-32ed1457d811.png)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 5608 
2. .go c 5687
3. Check if the position is good

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
