### PR TITLE
fix(Core/Pets): Eye of Kilrogg should not put its owner in combat wit…

### DIFF
--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -137,9 +137,13 @@ void HostileReference::addThreat(float modThreat)
 
     if (isValid() && modThreat >= 0.0f)
     {
-        Unit* victimOwner = getTarget()->GetCharmerOrOwner();
-        if (victimOwner && victimOwner->IsAlive())
-            GetSource()->addThreat(victimOwner, 0.0f);     // create a threat to the owner of a pet, if the pet attacks
+        Unit* target = getTarget();
+        if (target->GetEntry() != NPC_EYE_OF_KILROGG) // Excluded Eye of Kilrogg
+        {
+            Unit* victimOwner = target->GetCharmerOrOwner();
+            if (victimOwner && victimOwner->IsAlive())
+                GetSource()->addThreat(victimOwner, 0.0f); // create a threat to the owner of a pet, if the pet attacks
+        }
     }
 }
 

--- a/src/server/game/Entities/Pet/PetDefines.h
+++ b/src/server/game/Entities/Pet/PetDefines.h
@@ -97,6 +97,7 @@ enum NPCEntries
     NPC_SUCCUBUS                = 1863,
     NPC_DOOMGUARD               = 11859,
     NPC_FELGUARD                = 17252,
+    NPC_EYE_OF_KILROGG          = 4277,
 
     // Mage
     NPC_WATER_ELEMENTAL_TEMP    = 510,


### PR DESCRIPTION
…h current victim.

Fixed #6627

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Exclude Eye of Kilrogg from transferring threat to charmer.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6627
- Closes https://github.com/chromiecraft/chromiecraft/issues/869

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Cast Eye of Kilrogg while out of aggro range of a mob
2. Aggro the mob with the Eye
3. Watch the mob make one attack and not  change target to the warlock.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
