### PR TITLE
fix(DB/Loot): Delete 'Recipe: Savory Deviate Delight' from RLT 24701

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1627805665809266322.sql
+++ b/data/sql/updates/pending_db_world/rev_1627805665809266322.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1627805665809266322');
+
+-- Delete 'Recipe: Savory Deviate Delight' from RLT 24701
+DELETE FROM `reference_loot_template` WHERE `Entry` = 24701 AND `Item` = 6661;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Deletes 'Recipe: Savory Deviate Delight' (ID 6661) from RLT 24701

The Recipe is supposed to be a Barrens-exclusive drop, and thus it is a direct drop from the loot tables of 110 creatures from the Barrens. However, the problem comes from the fact that the Recipe is also contained in reference_loot_template (RLT) 24701. This RLT is only directly used by 1 creature (Murloc Warrior, ID 171) but is itself contained by 3 other RLTS, 24730, 24731, and 24732. These 3 RLTs are used by a total of 122 various random low level NPCs, all of which are from the Eastern Kingdoms. In other words, it is not a valid drop for any of them.

Checking via SQL confirms this. Creature field `map` is 0 for Eastern Kingdoms and 1 for Kalimdor. If we search for creatures who use these RLTs in Kalimdor, we get an empty set.
```
mysql> SELECT distinct ct.entry, ct.name
    -> FROM `creature_template` ct
    -> JOIN `creature_loot_template` clt ON ct.lootid = clt.entry
    -> JOIN `creature` c ON c.id = ct.entry
    -> WHERE clt.Reference IN (24701, 24730, 24731, 24732)
    -> AND c.map = 1;
Empty set (1.93 sec)
```
Thus, it is safe to remove the Recipe from this RLT as all the creatures using this RLT are in the wrong map.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7158
- Closes https://github.com/chromiecraft/chromiecraft/issues/1301

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Drop list from Wowhead here. Notice only Barrens mobs are listed:
https://tbc.wowhead.com/item=6661/recipe-savory-deviate-delight#dropped-by

"This recipe has a small chance to drop from any mob in the Northern Barrens or Southern Barrens." - https://wowpedia.fandom.com/wiki/Recipe:_Savory_Deviate_Delight

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- ran SQL, no errors/warnings, 1 row affected as expected.
- checked RLT in Keira, Recipe was missing.
- Ran recursive SQL check for item (query is [here](https://www.azerothcore.org/wiki/useful-sql#recursively-find-an-item-by-name)) and the only creatures still dropping the item are in the Barrens.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check RLT 24701 in Keira.
2. Run [this query](https://www.azerothcore.org/wiki/useful-sql#recursively-find-an-item-by-name) with "Recipe: Savory Deviate Delight" as item name and confirm only remaining creatures dropping it are in the Barrens.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
