### PR TITLE
fix(DB/creature): Added movement to Mok'rash (1493)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1627818799536182900.sql
+++ b/data/sql/updates/pending_db_world/rev_1627818799536182900.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1627818799536182900');
+
+-- Added movement to Mok'rash (1493)
+UPDATE `creature` SET  `MovementType` = 1, `wander_distance`= 5 WHERE (`id` = 1493) AND (`guid` IN (1672));
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added movement type 1 and wander of 5 to Mok'rash (1493)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6226
- Closes https://github.com/chromiecraft/chromiecraft/issues/778

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .go c id 1493
- Check if he moves


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  .go c id 1493
2. Check if he moves

https://user-images.githubusercontent.com/87535580/127769955-51e37c04-0397-4f66-8ae3-1a41c6ca9b50.mp4

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
