### PR TITLE
fix(DB/Quest): Fixed  Brood of Onyxia (1172) eggs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1627894869122476600.sql
+++ b/data/sql/updates/pending_db_world/rev_1627894869122476600.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1627894869122476600');
+
+-- Make the Egg of Onyxia (20359) dissapear after atacking for the quest Brood of Onyxia (1172)
+UPDATE `gameobject_template` SET `Data3` = 1 WHERE (`entry` = 20359);
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added the flag so they dissapear now after attacking them for the quest Brood of Onyxia (1172)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6832
- Closes https://github.com/chromiecraft/chromiecraft/issues/1135

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .quest add 1172
- .go go 13656
- Attack the egg and see them explode and dissapear

Video proof

https://streamable.com/hrcehq

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .quest add 1172
2.  .go go 13656
3.  Attack the egg and see them explode and dissapear

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
