### PR TITLE
fix(DB/object): Fixed skull piles despawning on quest Speaking with Nezzliok

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1627896958983750100.sql
+++ b/data/sql/updates/pending_db_world/rev_1627896958983750100.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1627896958983750100');
+
+-- Change the spawn to 1 second so the item wont dissapear
+UPDATE `gameobject` SET `spawntimesecs` = 1 WHERE `guid` IN (9986, 10135, 10030);
+

--- a/data/sql/updates/pending_db_world/rev_1627896958983750100.sql
+++ b/data/sql/updates/pending_db_world/rev_1627896958983750100.sql
@@ -1,5 +1,13 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1627896958983750100');
 
--- Change the spawn to 1 second so the item wont dissapear
+-- Change the spawn to 1 second from 15 minutes
 UPDATE `gameobject` SET `spawntimesecs` = 1 WHERE `guid` IN (9986, 10135, 10030);
+UPDATE `gameobject_template` SET `size` = 1 WHERE `entry` IN (2891, 2892, 2893);
+
+ -- Add 3 piles of bones generic so when they despawn is not noticed
+DELETE FROM `gameobject` WHERE (`id` = 177604) AND (`guid` IN (100507, 100508, 100509));
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(100507, 177604, 0, 0, 0, 1, 1,-12544.0, -723.063, 40.4432, 3.14159, 0, 0, 0, 0, 0, 0, 0, '', 0), -- Balia'mah Trophy Skulls
+(100508, 177604, 0, 0, 0, 1, 1,-12705.1, -472.833, 30.2692, 3.14159, 0, 0, 0, 0, 0, 0, 0, '', 0), -- Ziata'jai Trophy Skulls
+(100509, 177604, 0, 0, 0, 1, 1,-12850.8, -819.736, 54.8824, 3.14159, 0, 0, 0, 0, 0, 0, 0, '', 0); -- Zul'Mamwe Trophy Skulls
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Reduced the spawn of the skull piles from 900 seconds to 1 so they wont dissapear

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7199
- Closes https://github.com/chromiecraft/chromiecraft/issues/1324

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-Be Horde
-.quest add 585
-.go object 9986
-.gm off
-Pick up the skull.
-The pile only dissapears for a brief moment
-Repeat for objects 10135, and 10030


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Be Horde
2. quest add 585
3. .go object 9986
4.  gm off
5. Pick up the skull.
6. The pile only dissapears for a brief moment
7. Repeat for objects 10135, and 10030

**Test redone with the generic pile of bones inside the quest piles**


https://user-images.githubusercontent.com/87535580/128197230-e79bd5a7-bd20-485e-97d9-cd7fb6f911eb.mp4

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
