### PR TITLE
fix(Core/Items): Destroy invalid own guild/arena charter if already j…

### DIFF
--- a/src/server/game/Petitions/PetitionMgr.cpp
+++ b/src/server/game/Petitions/PetitionMgr.cpp
@@ -100,10 +100,6 @@ void PetitionMgr::RemovePetitionByOwnerAndType(ObjectGuid ownerGuid, uint8 type)
     {
         if (itr->second.ownerGuid == ownerGuid && (!type || type == itr->second.petitionType))
         {
-            // remove signatures
-            SignatureStore.erase(itr->first);
-            PetitionStore.erase(itr++);
-
             // Remove invalid charter item
             if (type == itr->second.petitionType)
             {
@@ -115,6 +111,10 @@ void PetitionMgr::RemovePetitionByOwnerAndType(ObjectGuid ownerGuid, uint8 type)
                     }
                 }
             }
+
+            // remove signatures
+            SignatureStore.erase(itr->first);
+            PetitionStore.erase(itr++);
         }
         else
             ++itr;

--- a/src/server/game/Petitions/PetitionMgr.cpp
+++ b/src/server/game/Petitions/PetitionMgr.cpp
@@ -5,6 +5,7 @@
 #include "DatabaseEnv.h"
 #include "Log.h"
 #include "PetitionMgr.h"
+#include "Player.h"
 #include "QueryResult.h"
 #include "Timer.h"
 
@@ -102,6 +103,18 @@ void PetitionMgr::RemovePetitionByOwnerAndType(ObjectGuid ownerGuid, uint8 type)
             // remove signatures
             SignatureStore.erase(itr->first);
             PetitionStore.erase(itr++);
+
+            // Remove invalid charter item
+            if (type == itr->second.petitionType)
+            {
+                if (Player* owner = ObjectAccessor::FindConnectedPlayer(ownerGuid))
+                {
+                    if (Item* item = owner->GetItemByGuid(itr->first))
+                    {
+                        owner->DestroyItem(item->GetBagSlot(), item->GetSlot(), true);
+                    }
+                }
+            }
         }
         else
             ++itr;


### PR DESCRIPTION
…oined to other guild/arena team.

Fixed #6642

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Players should destroy own arena team/guild charter if already joined to other arena team/guild.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6642

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Create guild charter and get 1 signature
2. Join a guild
3. Leave the guild
4. Observe there is no longer charter item in your inventory.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
