### PR TITLE
fix(Core/Quests): Send SMSG_QUESTUPDATE_COMPLETE packet on quest comp…

### DIFF
--- a/src/server/game/Entities/Player/PlayerQuest.cpp
+++ b/src/server/game/Entities/Player/PlayerQuest.cpp
@@ -1719,9 +1719,7 @@ void Player::AreaExploredOrEventHappens(uint32 questId)
                 q_status->Explored = true;
                 m_QuestStatusSave[questId] = true;
 
-                // xinef: if we cannot complete quest send exploration succeded
-                if (!CanCompleteQuest(questId, q_status))
-                    SendQuestComplete(questId);
+                SendQuestComplete(questId);
             }
         }
         if (CanCompleteQuest(questId, q_status))


### PR DESCRIPTION
…letion.

Fixed #6652

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removed wrong code about sending SMSG_QUESTUPDATE_COMPLETE on quest completion.
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6652

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. `.q a 5727`
2. Talk to Neeru Fireblade and see that on quest completion, there will be a yellow message about quest completion status

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
