### PR TITLE
fix(DB/Reputation): Correct Caliph/Wastewander Gadgetzan reps

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1628001727322964286.sql
+++ b/data/sql/updates/pending_db_world/rev_1628001727322964286.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628001727322964286');
+
+-- Caliph Scorpidsting - Gadgetzan kill rep to 15
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 15, `MaxStanding1` = 4 WHERE `creature_id` = 7847;
+
+-- Wastewander Assassin, Bandit, Rogue, Scofflaw, Shadow Mage, Thief - Gadgetzan kill rep to 5
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 5 WHERE `creature_id` IN (5623, 5618, 5615, 7805, 5617, 5616);
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changes the Gadgetzan reputation gain from killing Caliph Scorpidsting from 25 to 15, and stops rep gain from killing him at Honoured instead of Revered.
-  Changes the Gadgetzan reputation gain from killing Wastewander Assassin, Bandit, Rogue, Scofflaw, Shadow Mage, and Thief from 10 to 5.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7207
- Closes https://github.com/chromiecraft/chromiecraft/issues/1321

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- Caliph: https://tbc.wowhead.com/npc=7847/caliph-scorpidsting
- Wastewanders: https://tbc.wowhead.com/npc=5618/wastewander-bandit

See the [original AC issue](https://github.com/azerothcore/azerothcore-wotlk/issues/7207) for more discussion on sources. Most of them contradict each other in at least one way, so I've gone with Wowhead as the most modern source. The others all agreed on the 5 rep being the correct value, but not when it should stop being added.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, expected number of rows changed.
- Tested in-game:

Gadget rep at neutral, killing Wastewanders gives 5 rep and 2.5 to allied cities:, and killing Caliph gives 15 rep:
![WoWScrnShot_080421_000820](https://user-images.githubusercontent.com/81782124/128037500-761e944a-743c-4f03-b51e-23ce962c57b5.jpg)

Once I hit Friendly, Wastewander rep gain for Gadget stops, although allied cities continues:
![WoWScrnShot_080421_000850](https://user-images.githubusercontent.com/81782124/128037557-6d9bd6ef-6874-4196-ad0f-6829fdf87a49.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .modify reputation 369 2950 - sets Gadget rep to Neutral, just below Friendly
2. Gank some Wastewanders - .go c 23286 will port you to Caliph, and he's surrounded by lots of others.
3. When you reach Friendly with Gadgetzan, rep gains from killing Wastewanders should stop.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
