### PR TITLE
fix(DB/Spells): Shadow Weaving can proc from periodic spells.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1628018690377094600.sql
+++ b/data/sql/updates/pending_db_world/rev_1628018690377094600.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628018690377094600');
+
+UPDATE `spell_proc_event` SET `procFlags`=`procFlags`|0x00040000 WHERE `entry` IN (15257,15331,15332);


### PR DESCRIPTION
Fixed #6689

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Updated `spell_proc_event` so Shadow Weaving can proc from DOTs.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6689
- Closes https://github.com/chromiecraft/chromiecraft/issues/1049

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Priest with 3/3 Shadow weaving in shadow talent tree
2. Spam Devouring plaque on mobs
3.Shadow weaving proc from DOTs

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
