### PR TITLE
fix(DB/creature): Changed the spell Chill to Chilled for Chillwind Ravager

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1628065925391917900.sql
+++ b/data/sql/updates/pending_db_world/rev_1628065925391917900.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628065925391917900');
+
+-- Changed the spell Chill(28547) to Chilled(15850) for Chillwind Ravager(7449)
+UPDATE `smart_scripts` SET `action_param1` = 15850, `comment` = 'Chillwind Ravager - In Combat - Cast \'Chilled\'' WHERE (`entryorguid` = 7449) AND (`source_type` = 0) AND (`id` IN (0));
+


### PR DESCRIPTION
According to multiple data sources, the Chillwind Ravager casts [Chill](https://wowgaming.altervista.org/aowow/?spell=28547). This is an error, as that amout of damage would oneshot a level 60, and I think someone realized this at some point because the spell on AC has been altered to do no damage. AC has the mob casting that spell. It has the same animation and thumbnail as the Blizzard spell, and players can easily just move out of it, but again it causes no damage.
We changed it to [Chilled](https://classic.wowhead.com/spell=15850/chilled) 

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changed the spell Chill (28547) to Chilled (15850)
-  Updated comment

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7224
- Closes https://github.com/chromiecraft/chromiecraft/issues/1338

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .go Creature 41331
- Attack it and wait for the spell. Check it, should be Chilled


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go Creature 41331
2. Attack it and wait for the spell. Check it, should be Chilled

![Captura de pantalla 2021-08-04 103555](https://user-images.githubusercontent.com/87535580/128150249-0af356a1-7b4a-41e0-9dc2-d7306b202804.jpg)

![image](https://user-images.githubusercontent.com/87535580/128150269-cce68ea9-fa67-4970-a6ce-cf8c584af359.png)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
