### PR TITLE
fix(DB/Loot): Delete Pure Un'goro Sample from Firegut Brute drops

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1628079063977567436.sql
+++ b/data/sql/updates/pending_db_world/rev_1628079063977567436.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628079063977567436');
+
+-- Deletes Pure Un'goro Sample from Firegut Brute
+DELETE FROM `creature_loot_template` WHERE `Entry` = 7035 AND `Item` = 12236;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Deletes item Pure Un'goro Sample (ID 12236) from NPC Firegut Brute (ID 7035). 

This is because the item should not drop from any world NPCs, as it is generated as part of [this quest](https://tbc.wowhead.com/quest=4294/and-a-batch-of-ooze) instead.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7226
- Closes https://github.com/chromiecraft/chromiecraft/issues/1336

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/item=12236/pure-ungoro-sample shows no drops from world NPCs - instead the item is generated as part of a quest.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings.
- Checked all other drop tables/RLTs, no other NPCs dropping the item found.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. View the Firegut Brute's drop table in Keira and verify item 12236 is not present.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
