### PR TITLE
fix(DB/Loot): Remove two lvl 75 plans from Galak Windchaser drops

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1628079878307473993.sql
+++ b/data/sql/updates/pending_db_world/rev_1628079878307473993.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628079878307473993');
+
+-- Delete lvl 75 plans from Galak Windchaser
+DELETE FROM `creature_loot_template` WHERE `Entry` = 4096 AND `Item` IN (30302, 30322);
+

--- a/data/sql/updates/pending_db_world/rev_1628079878307473993.sql
+++ b/data/sql/updates/pending_db_world/rev_1628079878307473993.sql
@@ -2,4 +2,5 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628079878307473993');
 
 -- Delete lvl 75 plans from Galak Windchaser
 DELETE FROM `creature_loot_template` WHERE `Entry` = 4096 AND `Item` IN (30302, 30322);
-
+-- Deletes drop condition skill requirement
+DELETE FROM `conditions` WHERE `SourceGroup` = 4096 AND `SourceEntry` IN (30302, 30322);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Deletes lvl 75 items "Plans: Red Belt of Battle" and "Pattern: Belt of Deep Shadow" from Galak Windchaser drop table. The Windchaser is a lvl 25 NPC and should not be dropping lvl 75 plans.
- UPDATE: also deletes two entries pertaining to this NPC and these two items from the conditions table.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7223
- Closes https://github.com/chromiecraft/chromiecraft/issues/1335

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/item=30322/plans-red-belt-of-battle
https://tbc.wowhead.com/item=30302/pattern-belt-of-deep-shadow
https://tbc.wowhead.com/npc=4096/galak-windchaser#drops

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. View Galak Windchaser drop table in Keira and verify the two items are no longer present.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
