### PR TITLE
fix(DB/Creature): Removed spell Trash from Mosh'Ogg Brute (1142)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1628101702822210800.sql
+++ b/data/sql/updates/pending_db_world/rev_1628101702822210800.sql
@@ -1,6 +1,6 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628101702822210800');
 
 -- Removed script where Mosh'Ogg Brute (1142) used Trash. Because it was the only entry it was changed to AggressorAI
-UPDATE `creature_template` SET `AIName` = 'AggressorAI' WHERE (`entry` = 1142);
+UPDATE `creature_template` SET `AIName` = '' WHERE (`entry` = 1142);
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 1142) AND (`source_type` = 0) AND (`id` IN (0));
 

--- a/data/sql/updates/pending_db_world/rev_1628101702822210800.sql
+++ b/data/sql/updates/pending_db_world/rev_1628101702822210800.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628101702822210800');
+
+-- Removed script where Mosh'Ogg Brute (1142) used Trash. Because it was the only entry it was changed to AggressorAI
+UPDATE `creature_template` SET `AIName` = 'AggressorAI' WHERE (`entry` = 1142);
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 1142) AND (`source_type` = 0) AND (`id` IN (0));
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removed the script that made them use Trash
-  Because it was the only script i changed it to AggresorAI, that said: Creature attacks when entering aggro radius; uses only melee attacks.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6916
- Closes https://github.com/chromiecraft/chromiecraft/issues/1178

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .go c id 1142
- Test the damage, they should only auto atack

![image](https://user-images.githubusercontent.com/87535580/128235500-0d7dea40-f779-43ee-b3cb-b4ef660ac7fe.png)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  .go c id 1142
2. Test the damage, they should only auto atack


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
