### PR TITLE
fix(DB/quest): Removed the quest Sartheril's Haven(9395) from the quest chain

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1628103343468216300.sql
+++ b/data/sql/updates/pending_db_world/rev_1628103343468216300.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628103343468216300');
+
+-- Removed the quest Sartheril's Haven(9395) from the quest chain starting at The Wayward Apprentice [9254]
+UPDATE `quest_template_addon` SET `PrevQuestID` = 0 WHERE (`ID` = 9395);
+


### PR DESCRIPTION
This quest  it's been added to the end of Magistrix Landra Dawnstrider's other quest chain, that starts with [The Wayward Apprentice](https://tbc.wowhead.com/quest=9254/the-wayward-apprentice) ->[ Corrupted Soil ](https://tbc.wowhead.com/quest=8487/corrupted-soil)-> [Unexpected Results](https://tbc.wowhead.com/quest=8488/unexpected-results) -> [Research Notes](https://tbc.wowhead.com/quest=9255/research-notes). Research Notes is tagged in the DB as the pre-req for Saltheril's Haven whereas Wowhead shows it as a separate and unrelated quest.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Deleted the quest Sartheril's Haven(9395) from the chain quest starting at The Wayward Apprentice [9254]

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6880
- Closes https://github.com/chromiecraft/chromiecraft/issues/1155

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- .go c 56869 (Magistrix Landra Dawnstrider)
- Note which quests are available.
- .q add 9255 (Research Notes)
- Hand in quest to Magistrix
- Sartheril's Haven quest is now available.

Changes after deleting  Sartheril's Haven(9395) from the quest chain, where you can see it without needing another quest

![6880](https://user-images.githubusercontent.com/87535580/128240348-f49ddc31-1c5c-452d-8a23-64e0996ea592.jpg)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 56869 (Magistrix Landra Dawnstrider)
2. Note which quests are available.
3. .q add 9255 (Research Notes)
4. Hand in quest to Magistrix
5. Sartheril's Haven quest is now available.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- On wowhead they put this quests  The Wayward Apprentice [9254] ,Corrupted Soil [8487] ,Unexpected Results [8488] and Research Notes [9255] on 2 differents qquest chains. 
- First  being Unexpected Results [8488] and Research Notes [9255]
- The second being  The Wayward Apprentice [9254] ,Corrupted Soil [8487]
- I dont know if the data is wrong or not, just pointing it out.


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
