### PR TITLE
fix(Core/Spells): Do not attack focus target while charging.

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5082,7 +5082,7 @@ void Spell::EffectCharge(SpellEffIndex /*effIndex*/)
         }
 
         // not all charge effects used in negative spells
-        if (!m_spellInfo->IsPositive() && m_caster->GetTypeId() == TYPEID_PLAYER)
+        if (!m_spellInfo->IsPositive() && m_caster->GetTypeId() == TYPEID_PLAYER && m_caster->GetTarget() == unitTarget->GetGUID())
             m_caster->Attack(unitTarget, true);
     }
 }


### PR DESCRIPTION
Fixed #6721.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  If player charges, they should attack only their current target.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6721
- Closes https://github.com/chromiecraft/chromiecraft/issues/1078

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. create a warrior, learn charge/intercept
2. go to the dummies select one dummy as your main target and the other one as your focus target by simply typing /focus
3. use this macro while targeting your main target, it will charge the focus target and melee swing at it without changing targets
`/cast [@Focus] Charge`
or
`/cast [@Focus] Intercept`

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
