### PR TITLE
fix(Core/Spells): Removed hack fix for sword specialization proc.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9029,25 +9029,7 @@ bool Unit::HandleProcTriggerSpell(Unit* victim, uint32 damage, AuraEffect* trigg
             break;
     }
 
-    // Sword Specialization
-    if (auraSpellInfo->SpellFamilyName == SPELLFAMILY_GENERIC)
-    {
-        if (auraSpellInfo->SpellIconID == 1462 && procSpell)
-        {
-            if (Player* plr = ToPlayer())
-            {
-                if (!victim || plr->HasSpellCooldown(16459))
-                    return false;
-
-                plr->AddSpellCooldown(16459, 0, cooldown);
-
-                if (plr->IsWithinMeleeRange(victim))
-                    plr->AttackerStateUpdate(victim);
-                return true;
-            }
-        }
-    }
-    else if (auraSpellInfo->SpellFamilyName == SPELLFAMILY_DEATHKNIGHT)
+    if (auraSpellInfo->SpellFamilyName == SPELLFAMILY_DEATHKNIGHT)
     {
         // Xinef: keep this order, Aura 70656 has SpellIconID 85!
         // Item - Death Knight T10 Melee 4P Bonus


### PR DESCRIPTION
Fixed #6935

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removed hack fix for sword specialization proc that blocked Hack and Slash proc off from special abilities.
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6935
- Closes https://github.com/chromiecraft/chromiecraft/issues/1169

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. start auto attacking Targetdummy
2. keep document of procc rates

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
