### PR TITLE
fix(DB/Loot): Create new skinning entries, assigns to various 10-15 NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1628329351520849428.sql
+++ b/data/sql/updates/pending_db_world/rev_1628329351520849428.sql
@@ -1,0 +1,18 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628329351520849428');
+
+-- Create new skinning table for 100015 for lvl 10-15 NPCs
+DELETE from `skinning_loot_template` WHERE `Entry` = 100015;
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(100015, 2318, 0, 60, 0, 1, 1, 1, 2, '10-15 drops - Light Leather'),
+(100015, 2934, 0, 35, 0, 1, 1, 1, 1, '10-15 drops - Ruined Leather Scraps'),
+(100015,  783, 0,  5, 0, 1, 1, 1, 1, '10-15 drops - Light Hide');
+
+-- Add level-appropriate skinning drops to various 10-16 mobs
+UPDATE `creature_template` SET `skinloot` = 100015 WHERE `entry` IN (157, 454, 833, 1130, 1186, 1188, 1191, 1271, 1693, 1766, 1769, 1770, 1778, 1779, 1782, 1797, 1892, 1893, 1896, 1924, 1961, 1972, 2069, 2163, 2164, 2185, 2321, 2322, 2974, 3056, 3058, 3231, 3234, 3241, 3242, 3243, 3244, 3246, 3248, 3254, 3255, 3415, 3425, 3461, 3531, 4127, 4316, 5865, 12431, 12432, 16348, 16354, 17347, 17525, 17556);
+
+-- Remove skinning loot from lvl 1 Parasitic Serpent and Vagash
+UPDATE `creature_template` SET `skinloot` = 0 WHERE `entry` IN (1388, 14884);
+
+-- Update Snort the Heckler to better table
+UPDATE `creature_template` SET `skinloot` = 100004 WHERE `entry` = 5829;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Adds 3 entries to `skinning_loot_template` to create a new group of drops for level 10-15 creates. This table is as follows:

| Item ID | Item Name | Drop % |
|------|------|-----|
| 2318 | Light Leather| 60% |
| 2934 | Ruined Leather Scraps | 35% |
| 783 | Light Hide | 5% |

This table is derived from studying the loot tables of 58 creatures in the relevant level range. Of course I checked the `skinning_loot_template` table for entries that would fit this distribution first before making a new table, but I couldn't find one that matched with sufficient precision, or one that didn't also contain other leather items that were incorrect. (like medium leather/hides, deviate scales, etc.) And it seems to me that 55 creature templates is a large enough group that making a table to fit their drops exactly isn't too wasteful.

- Adds this table as the skinning loot for 55 creatures from levels 10 to 16. This is to replace table 100003, which contains level 50-60 leather.
- Deletes the skinning tables for 2 NPCs which were found to have skinning loot when they shouldn't. These were a lvl 1 raid mob from Zul'Gurub, [Parasitic Serpent](https://tbc.wowhead.com/npc=14884/parasitic-serpent ) and a lvl 11 yeti, [Vagash](https://tbc.wowhead.com/npc=1388/vagash), who doesn't have a skinning loot table.
- Changed the skinning loot for lvl 17 [Snort the Heckler](https://tbc.wowhead.com/npc=5829/snort-the-heckler#skinning) to skinning template 100004, which matches his drops more closely. (100004 = light hide 5%, light leather 72%, medium leather 20%, medium hide 3%. WH drops for Snort:  light hide 3%, light leather 78%, medium leather 18%, medium hide 1.5%)

Went through and checked the 58 mobs identified as dropping lvl 50-60 skins, and checked on TBC Wowhead for how closely they matched the 60-35-5 leather distribution in 100015. I'm rating drops as 'correct' if they match to within 5%.

| ID | Name | Level | Comments |
|---|-------|--------|-------------|
| 14884 | Parasitic Serpent            |        1 | no skinning table, removed |
| 17556 | Death Ravager                |       10 | missing 1% drop of rugged, 0.5% drop heavy hide - probably contaminated data |
| 17525 | Bloodmyst Hatchling          |       11 | correct |
|  1271 | Old Icebeard                 |       11 | light leather 10% higher, scraps 17% lower, light hide 7% higher |
|  1388 | Vagash                       |       11 | no skinning table, removed |
|  3058 | Arra'chea                    |       11 | correct |
|  1769 | Moonrage Whitescalp          |       11 | correct |
|  1961 | Mangeclaw                    |       11 | 17% higher light hide, 17% lower scraps |
|  2974 | Kodo Matriarch               |       12 | correct |
|  3415 | Savannah Huntress            |       12 | correct |
|  3244 | Greater Plainstrider         |       12 | correct |
|  3231 | Corrupted Dreadmaw Crocolisk |       12 | correct |
|  3056 | Ghost Howl                   |       12 | correct |
|  2163 | Thistle Bear                 |       12 | correct |
|   833 | Coyote Packleader            |       12 | correct |
|  1130 | Bjarn                        |       12 | correct |
|  1778 | Ferocious Grizzled Bear      |       12 | correct |
|  1186 | Elder Black Bear             |       12 | correct |
|  1770 | Moonrage Darkrunner          |       12 | correct |
|  1766 | Mottled Worg                 |       12 | correct |
|  3243 | Savannah Highmane            |       13 | correct |
|   454 | Young Goretusk               |       13 | correct |
| 17347 | Grizzled Brown Bear          |       13 | correct |
| 12431 | Gorefang                     |       13 | correct |
|  5865 | Dishu                        |       13 | correct |
|  4316 | Kolkar Packhound             |       13 | correct |
|  3254 | Sunscale Lashtail            |       13 | correct |
|  3246 | Fleeting Plainstrider        |       13 | correct |
|  1779 | Moonrage Glutton             |       13 | correct |
|  1797 | Giant Grizzled Bear          |       13 | correct |
|  2321 | Foreststrider Fledgling      |       13 | correct |
|  2164 | Rabid Thistle Bear           |       13 | correct |
|  1782 | Moonrage Darksoul            |       14 | correct |
|  1892 | Moonrage Watcher             |       14 | correct |
| 16348 | Ghostclaw Lynx               |       14 | correct |
|  3242 | Zhevra Runner                |       14 | correct |
|  1188 | Grizzled Black Bear          |       14 | correct |
|  2185 | Darkshore Thresher           |       14 | correct |
| 12432 | Old Vicejaw                  |       14 | correct |
|  3425 | Savannah Prowler             |       15 | correct |
| 16354 | Vampiric Mistbat             |       15 | correct |
|  1893 | Moonrage Sentry              |       15 | light leather 7% high, scraps 5% low, hide 2% low |
|  1896 | Moonrage Elder               |       15 | correct |
|  1972 | Grimson the Pale             |       15 | correct |
|  3531 | Moonrage Tailor              |       15 | light leather 7% low, scraps 7% high |
|   157 | Goretusk                     |       15 | correct |
|  2069 | Moonstalker                  |       15 | correct |
|  3255 | Sunscale Screecher           |       15 | correct |
|  3234 | Lost Barrens Kodo            |       15 | correct |
|  1191 | Mangy Mountain Boar          |       15 | correct |
|  1693 | Loch Crocolisk               |       15 | correct |
|  3461 | Oasis Snapjaw                |       16 | correct |
|  4127 | Hecklefang Hyena             |       16 | correct |
|  1924 | Moonrage Bloodhowler         |       16 | correct |
|  3248 | Barrens Giraffe              |       16 | correct |
|  3241 | Savannah Patriarch           |       16 | correct |
|  2322 | Foreststrider                |       16 | correct |
|  5829 | Snort the Heckler            |       17 | drops medium leather/hide - swap to 100004 |

So overall, apart from two named NPCs and some Moonrages, this table matches Wowhead data pretty closely.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7253
- Closes https://github.com/chromiecraft/chromiecraft/issues/1347

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Thick leather - "This item can be obtained through the Skinning profession on level 40-50 mobs."
https://wowpedia.fandom.com/wiki/Thick_Leather?oldid=2256833

Thick hide - "Obtained with the Skinning skill on level 40-60 skinnable animals" - https://wowpedia.fandom.com/wiki/Thick_Hide?oldid=1763966

"Rugged Leather is the last stage of non-Outland leather skinned directly from normal monsters(lvl 55-60)."
https://wowpedia.fandom.com/wiki/Rugged_Leather?oldid=2335617

Rugged Hide - "The hide is skinned from 50-60 mobs."
https://wowpedia.fandom.com/wiki/Rugged_Hide?direction=next&oldid=2993980 - Cata source

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL step by step, no warnings/errors, correct number of lines changed
- Tested in-game:

![WoWScrnShot_080721_190909](https://user-images.githubusercontent.com/81782124/128596621-a9067acb-6083-44d9-8bf4-7112f8745365.jpg)
![WoWScrnShot_080721_190922](https://user-images.githubusercontent.com/81782124/128596624-d9ad61f3-230a-4e5d-960c-8a66068b85ed.jpg)
![WoWScrnShot_080721_190939](https://user-images.githubusercontent.com/81782124/128596625-b51df626-f550-45c9-b932-9c7635ddaa23.jpg)
![WoWScrnShot_080721_190947](https://user-images.githubusercontent.com/81782124/128596628-0f254ae9-ce14-4194-8ac5-cc664cf14aa7.jpg)
![WoWScrnShot_080721_191003](https://user-images.githubusercontent.com/81782124/128596629-34066bdf-079e-4665-bdb9-d76426ec6e3f.jpg)
![WoWScrnShot_080721_191018](https://user-images.githubusercontent.com/81782124/128596631-76233e07-90c4-40d2-b0b3-b4ac8503a5da.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. You can check to ensure the incorrect table 100003 is not being used by any creatures under lvl 40 with this query:
```SQL
SELECT ct.entry, ct.name, ct.maxlevel
FROM `creature_template` ct
WHERE ct.skinloot = 100003 AND ct.maxlevel <= 40
ORDER BY ct.maxlevel
```
2. Check any of the NPCs listed above versus the drops on Wowhead and you should find the new table 100015 matches skinning loot drops fairly closely in almost all cases.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
