### PR TITLE
fix(Core/Spells): Levitate cannot be casted on mounted targets.

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6123,7 +6123,9 @@ SpellCastResult Spell::CheckCast(bool strict)
             case SPELL_AURA_HOVER:
                 {
                     if ((m_spellInfo->AuraInterruptFlags & AURA_INTERRUPT_FLAG_MOUNT) != 0 && m_targets.GetUnitTarget() && m_targets.GetUnitTarget()->IsMounted())
+                    {
                         return SPELL_FAILED_NOT_ON_MOUNTED;
+                    }
                     break;
                 }
             default:

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6120,6 +6120,12 @@ SpellCastResult Spell::CheckCast(bool strict)
 
                     break;
                 }
+            case SPELL_AURA_HOVER:
+                {
+                    if ((m_spellInfo->AuraInterruptFlags & AURA_INTERRUPT_FLAG_MOUNT) != 0 && m_targets.GetUnitTarget() && m_targets.GetUnitTarget()->IsMounted())
+                        return SPELL_FAILED_NOT_ON_MOUNTED;
+                    break;
+                }
             default:
                 break;
         }


### PR DESCRIPTION
Fixed #7090

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Display spell error if cast levitate on mounted target.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #7090
- Closes https://github.com/chromiecraft/chromiecraft/issues/1271

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. While playing a character of any class, summon a mount.
2. Using a Priest character, find the mounted character.
3. Cast levitate on the mounted character.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
