### PR TITLE
fix(DB/Creature): Delete skinning table from lvl 1 Serpentbloom Snake

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1628521621840404043.sql
+++ b/data/sql/updates/pending_db_world/rev_1628521621840404043.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628521621840404043');
+
+-- Delete skinning table 100008 from lvl 1 Serpentbloom Snake
+UPDATE `creature_template` SET `skinloot` = 0 WHERE `entry` = 3680;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Deletes skinning table 100008 from lvl 1 Serpentbloom Snake (ID 3680). This NPC is too low level to be skinnable, and definitely shouldn't be dropping medium leather or red whelp scales, which it currently does. 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7270
- Closes https://github.com/chromiecraft/chromiecraft/issues/1365

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/npc=3680/serpentbloom-snake

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, 1 row changed as expected.
- Checked in-game, was unable to skin snake corpses:

![WoWScrnShot_081021_004642](https://user-images.githubusercontent.com/81782124/128730532-7ce2183b-8a98-44d0-aa1f-81f4831af177.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- Be Horde
- .quest add 962
- .go o 13264 through to 13277
- pick herb, kill snake
- check for skinnability.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
