### PR TITLE
fix(Core/Visibility): Notifies AI of nearby creatures immediately if forced update object visibility is called.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -18348,14 +18348,9 @@ void Unit::UpdateObjectVisibility(bool forced, bool /*fromUpdate*/)
     else
     {
         WorldObject::UpdateObjectVisibility(true);
-
-        // pussywizard: generally this is not needed here, delayed notifier will handle this, call only for pets
-        if ((IsGuardian() || IsPet()) && GetOwnerGUID().IsPlayer())
-        {
-            Acore::AIRelocationNotifier notifier(*this);
-            float radius = 60.0f;
-            Cell::VisitAllObjects(this, notifier, radius);
-        }
+        Acore::AIRelocationNotifier notifier(*this);
+        float radius = 60.0f;
+        Cell::VisitAllObjects(this, notifier, radius);
     }
 }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Notifies AI of nearby creatures immediately if forced update object visibility is called.
-  Removed wrong code. Forced mean forced. Comment `generally this is not needed here, delayed notifier will handle this, call only for pets` is totally wrong, because delayed notifier is called only for non-forced update.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #7126
- Closes https://github.com/chromiecraft/chromiecraft/issues/1264
- Might closes other tickets about creatures not attacking on player's revive/teleport etc

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Teleport to any Hillsbrad Miner NPC (GUID 15931) (coords: 27.0, 57.8)
2. Let him kill you
3. Go behind him as a spirit
4. Resurrect & wait

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
