### PR TITLE
fix(DB/Quest): "Sturdy Rope" Quest Item Despawns Any Low Health NPC, Including Dungeon/Raid Bosses

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1628543691784458000.sql
+++ b/data/sql/updates/pending_db_world/rev_1628543691784458000.sql
@@ -1,7 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628543691784458000');
 
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceGroup` = 0) AND (`SourceEntry` = 42325) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 1) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 4351) AND (`ConditionValue3` = 0);
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceGroup` = 0) AND (`SourceEntry` = 42325) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 1) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 4352) AND (`ConditionValue3` = 0);
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceGroup` = 0) AND (`SourceEntry` = 42325) AND (`SourceId` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 1) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 4351) AND (`ConditionValue3` = 0);
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceGroup` = 0) AND (`SourceEntry` = 42325) AND (`SourceId` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 1) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 4352) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(17, 0, 42325, 0, 0, 31, 1, 3, 4351, 0, 0, 0, 0, '', 'Casting a spell only on a Bloodfen Raptor '),
-(17, 0, 42325, 0, 0, 31, 1, 3, 4352, 0, 0, 0, 0, '', 'Casting a spell only on a Bloodfen Screecher');
+(17, 0, 42325, 0, 1, 31, 1, 3, 4351, 0, 0, 0, 0, '', 'Casting a spell only on a Bloodfen Raptor '),
+(17, 0, 42325, 0, 2, 31, 1, 3, 4352, 0, 0, 0, 0, '', 'Casting a spell only on a Bloodfen Screecher');

--- a/data/sql/updates/pending_db_world/rev_1628543691784458000.sql
+++ b/data/sql/updates/pending_db_world/rev_1628543691784458000.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628543691784458000');
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceGroup` = 0) AND (`SourceEntry` = 42325) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 1) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 4351) AND (`ConditionValue3` = 0);
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceGroup` = 0) AND (`SourceEntry` = 42325) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 1) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 4352) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(17, 0, 42325, 0, 0, 31, 1, 3, 4351, 0, 0, 0, 0, '', 'Casting a spell only on a Bloodfen Raptor '),
+(17, 0, 42325, 0, 0, 31, 1, 3, 4352, 0, 0, 0, 0, '', 'Casting a spell only on a Bloodfen Screecher');


### PR DESCRIPTION
## Changes Proposed:
- Added conditions for using the spell

## Issues Addressed:
- Closes #7267
- Closes chromiecraft/chromiecraft#1361

## Tests Performed:
- Tested on local server

## How to Test the Changes:
1. Take the quest [Raptor Captor](https://wowgaming.altervista.org/aowow/?quest=11146)
2. Attack any mob until it's low on health (~10%/20%)
3. Use the quest item [Sturdy Rope](https://wotlkdb.com/?item=33069) on any NPC
4. Use the quest item [Sturdy Rope](https://wotlkdb.com/?item=33069) on Bloodfen Raptor or Bloodfen Screecher

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
