### PR TITLE
fix(DB/smart_scripts): Fix Aku'mai Servant spell targeting

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1628777209086733059.sql
+++ b/data/sql/updates/pending_db_world/rev_1628777209086733059.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1628777209086733059');
+
+-- Make Aku'mai Servant cast Frostbolt Volley on victims and not itself
+UPDATE `smart_scripts` SET `target_type` = 2 WHERE `source_type` = 0 AND `id` = 0 AND `entryorguid` = 4978;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Aku'mai Servants in BFD (ID 4978) were not casting Frostbolt Volley properly. Checking smart_scripts showed the target selection was 1 (self) not 2 (victim.) This PR corrects that. The confusion probably came from Frost Nova which they also cast, where the spell target is correctly set to 1.

Also note the Frostbolt Volley spell they use is https://wowgaming.altervista.org/aowow/?spell=15043. However, Wowpedia and Wowhead both say they use https://wowgaming.altervista.org/aowow/?spell=8398. However, I have left this alone for now, as the 8398 version does double the damage and I don't want to cause balance issues when someone presumably had good reason to set it this way.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7313
- Closes https://github.com/chromiecraft/chromiecraft/issues/1382

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowpedia.fandom.com/wiki/Aku'mai_Servant?oldid=2298127
https://classic.wowhead.com/npc=4978/akumai-servant#abilities;mode:normal

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, 1 row changed as expected.
- Tested in-game, and they are now happily shooting frostbolts:

![WoWScrnShot_081221_231747](https://user-images.githubusercontent.com/81782124/129213029-0818a2f2-2926-4d1c-b930-fa59706fca89.jpg)
![WoWScrnShot_081221_232019](https://user-images.githubusercontent.com/81782124/129213041-021516a5-b34c-4805-80b9-e1cd96acc66c.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 27424 will port you to the Twilight Lord. Kill him and light the braziers.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
