### PR TITLE
fix(Core/Chat): Fix muteTime for players that were muted when offline.

### DIFF
--- a/src/server/game/Maps/MapUpdater.cpp
+++ b/src/server/game/Maps/MapUpdater.cpp
@@ -67,6 +67,7 @@ MapUpdater::~MapUpdater()
 
 void MapUpdater::activate(size_t num_threads)
 {
+    _workerThreads.reserve(num_threads);
     for (size_t i = 0; i < num_threads; ++i)
     {
         _workerThreads.push_back(std::thread(&MapUpdater::WorkerThread, this));
@@ -83,7 +84,10 @@ void MapUpdater::deactivate()
 
     for (auto& thread : _workerThreads)
     {
-        thread.join();
+        if (thread.joinable())
+        {
+            thread.join();
+        }
     }
 }
 

--- a/src/server/game/Maps/MapUpdater.cpp
+++ b/src/server/game/Maps/MapUpdater.cpp
@@ -67,7 +67,6 @@ MapUpdater::~MapUpdater()
 
 void MapUpdater::activate(size_t num_threads)
 {
-    _workerThreads.reserve(num_threads);
     for (size_t i = 0; i < num_threads; ++i)
     {
         _workerThreads.push_back(std::thread(&MapUpdater::WorkerThread, this));
@@ -84,10 +83,7 @@ void MapUpdater::deactivate()
 
     for (auto& thread : _workerThreads)
     {
-        if (thread.joinable())
-        {
-            thread.join();
-        }
+        thread.join();
     }
 }
 

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -540,6 +540,17 @@ void WorldSocket::HandleAuthSessionCallback(std::shared_ptr<AuthSession> authSes
         }
     }
 
+    //! Negative mutetime indicates amount of minutes to be muted effective on next login - which is now.
+    if (account.MuteTime < 0)
+    {
+        account.MuteTime = time(nullptr) + llabs(account.MuteTime);
+
+        auto* stmt = LoginDatabase.GetPreparedStatement(LOGIN_UPD_MUTE_TIME_LOGIN);
+        stmt->setInt64(0, account.MuteTime);
+        stmt->setUInt32(1, account.Id);
+        LoginDatabase.Execute(stmt);
+    }
+
     if (account.IsBanned)
     {
         SendAuthResponseError(AUTH_BANNED);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Update WorldSocket.cpp

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7350

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Muted an offline player then logged on the offline player and he was properly muted.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Mute an offline player
2. Login with the offline player
3. Try speaking

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
