### PR TITLE
feat(Core/Hooks): Added new hooks on talents reset

### DIFF
--- a/doc/changelog/pendings/changes_1629207725397189314.md
+++ b/doc/changelog/pendings/changes_1629207725397189314.md
@@ -1,0 +1,5 @@
+### Added
+
+- Added `OnAfterTalentsReset` hook that is fired after a Players talents have been reset.
+
+This should be considered the "after" while `OnTalentsReset` is the "before".

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2468,9 +2468,8 @@ void Player::GiveLevel(uint8 level)
 void Player::InitTalentForLevel()
 {
     uint32 talentPointsForLevel = CalculateTalentsPoints();
-    uint8 level = getLevel();
 
-    sScriptMgr->OnBeforeInitTalentForLevel(this, level, talentPointsForLevel);
+    sScriptMgr->OnBeforeInitTalentForLevel(this, talentPointsForLevel);
 
     // xinef: more talent points that we have are used, reset
     if (m_usedTalentCount > talentPointsForLevel)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2468,8 +2468,9 @@ void Player::GiveLevel(uint8 level)
 void Player::InitTalentForLevel()
 {
     uint32 talentPointsForLevel = CalculateTalentsPoints();
+    uint8 level = getLevel();
 
-    sScriptMgr->OnBeforeInitTalentForLevel(this, talentPointsForLevel);
+    sScriptMgr->OnBeforeInitTalentForLevel(this, level, talentPointsForLevel);
 
     // xinef: more talent points that we have are used, reset
     if (m_usedTalentCount > talentPointsForLevel)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -12648,18 +12648,24 @@ void Player::StoreLootItem(uint8 lootSlot, Loot* loot)
 
 uint32 Player::CalculateTalentsPoints() const
 {
+    uint32 talentPointsForLevel = 0;
     uint32 base_talent = getLevel() < 10 ? 0 : getLevel() - 9;
 
     if (getClass() != CLASS_DEATH_KNIGHT || GetMapId() != 609)
-        return uint32(base_talent * sWorld->getRate(RATE_TALENT));
-
-    uint32 talentPointsForLevel = getLevel() < 56 ? 0 : getLevel() - 55;
-    talentPointsForLevel += m_questRewardTalentCount;
-
-    if (talentPointsForLevel > base_talent)
+    {
         talentPointsForLevel = base_talent;
+    }
+    else
+    {
+        talentPointsForLevel = getLevel() < 56 ? 0 : getLevel() - 55;
+        talentPointsForLevel += m_questRewardTalentCount;
+
+        if (talentPointsForLevel > base_talent)
+            talentPointsForLevel = base_talent;
+    }
 
     talentPointsForLevel += m_extraBonusTalentCount;
+
     return uint32(talentPointsForLevel * sWorld->getRate(RATE_TALENT));
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -12652,19 +12652,22 @@ void Player::StoreLootItem(uint8 lootSlot, Loot* loot)
 
 uint32 Player::CalculateTalentsPoints() const
 {
+    uint8 currentLevel = getLevel();
     uint32 talentPointsForLevel = 0;
-    uint32 base_talent = getLevel() < 10 ? 0 : getLevel() - 9;
+    uint32 baseTalents = currentLevel < 10 ? 0 : currentLevel - 9;
 
     if (getClass() != CLASS_DEATH_KNIGHT || GetMapId() != 609)
     {
-        talentPointsForLevel = base_talent;
+        talentPointsForLevel = baseTalents;
     }
     else
     {
-        talentPointsForLevel = getLevel() < 56 ? 0 : getLevel() - 55;
+        talentPointsForLevel = currentLevel < 56 ? 0 : currentLevel - 55;
         talentPointsForLevel += m_questRewardTalentCount;
-        if (talentPointsForLevel > base_talent)
-            talentPointsForLevel = base_talent;
+        if (talentPointsForLevel > baseTalents)
+        {
+            talentPointsForLevel = baseTalents;
+        }
     }
 
     talentPointsForLevel += m_extraBonusTalentCount;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -3685,6 +3685,8 @@ bool Player::resetTalents(bool noResetCost)
         m_resetTalentsTime = time(nullptr);
     }
 
+    sScriptMgr->OnAfterTalentsReset(this);
+
     return true;
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2469,6 +2469,8 @@ void Player::InitTalentForLevel()
 {
     uint32 talentPointsForLevel = CalculateTalentsPoints();
 
+    sScriptMgr->OnBeforeInitTalentForLevel(this, talentPointsForLevel);
+
     // xinef: more talent points that we have are used, reset
     if (m_usedTalentCount > talentPointsForLevel)
         resetTalents(true);
@@ -12659,7 +12661,6 @@ uint32 Player::CalculateTalentsPoints() const
     {
         talentPointsForLevel = getLevel() < 56 ? 0 : getLevel() - 55;
         talentPointsForLevel += m_questRewardTalentCount;
-
         if (talentPointsForLevel > base_talent)
             talentPointsForLevel = base_talent;
     }

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -2093,9 +2093,9 @@ void ScriptMgr::OnAfterUpdateAttackPowerAndDamage(Player* player, float& level, 
     FOREACH_SCRIPT(PlayerScript)->OnAfterUpdateAttackPowerAndDamage(player, level, base_attPower, attPowerMod, attPowerMultiplier, ranged);
 }
 
-void ScriptMgr::OnBeforeInitTalentForLevel(Player* player, uint8& level, uint32& talentPointsForLevel)
+void ScriptMgr::OnBeforeInitTalentForLevel(Player* player, uint32& talentPointsForLevel)
 {
-    FOREACH_SCRIPT(PlayerScript)->OnBeforeInitTalentForLevel(player, level, talentPointsForLevel);
+    FOREACH_SCRIPT(PlayerScript)->OnBeforeInitTalentForLevel(player, talentPointsForLevel);
 }
 
 void ScriptMgr::OnAfterArenaRatingCalculation(Battleground* const bg, int32& winnerMatchmakerChange, int32& loserMatchmakerChange, int32& winnerChange, int32& loserChange)

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -2098,7 +2098,7 @@ void ScriptMgr::OnAfterUpdateAttackPowerAndDamage(Player* player, float& level, 
     FOREACH_SCRIPT(PlayerScript)->OnAfterUpdateAttackPowerAndDamage(player, level, base_attPower, attPowerMod, attPowerMultiplier, ranged);
 }
 
-void ScriptMgr::OnBeforeInitTalentForLevel(Player* player, uint8& level, uint32& talentPointsForLevel)
+void ScriptMgr::OnBeforeInitTalentForLevel(Player* player, uint32& talentPointsForLevel)
 {
     FOREACH_SCRIPT(PlayerScript)->OnBeforeInitTalentForLevel(player, talentPointsForLevel);
 }

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1395,6 +1395,11 @@ void ScriptMgr::OnPlayerTalentsReset(Player* player, bool noCost)
     FOREACH_SCRIPT(PlayerScript)->OnTalentsReset(player, noCost);
 }
 
+void ScriptMgr::OnAfterTalentsReset(Player* player)
+{
+    FOREACH_SCRIPT(PlayerScript)->OnAfterTalentsReset(player);
+}
+
 void ScriptMgr::OnPlayerMoneyChanged(Player* player, int32& amount)
 {
 #ifdef ELUNA

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -2098,7 +2098,7 @@ void ScriptMgr::OnAfterUpdateAttackPowerAndDamage(Player* player, float& level, 
     FOREACH_SCRIPT(PlayerScript)->OnAfterUpdateAttackPowerAndDamage(player, level, base_attPower, attPowerMod, attPowerMultiplier, ranged);
 }
 
-void ScriptMgr::OnBeforeInitTalentForLevel(Player* player, uint32& talentPointsForLevel)
+void ScriptMgr::OnBeforeInitTalentForLevel(Player* player, uint8& level, uint32& talentPointsForLevel)
 {
     FOREACH_SCRIPT(PlayerScript)->OnBeforeInitTalentForLevel(player, talentPointsForLevel);
 }

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -915,7 +915,7 @@ public:
     virtual void OnBeforeUpdateAttackPowerAndDamage(Player* /*player*/, float& /*level*/, float& /*val2*/, bool /*ranged*/) { }
     virtual void OnAfterUpdateAttackPowerAndDamage(Player* /*player*/, float& /*level*/, float& /*base_attPower*/, float& /*attPowerMod*/, float& /*attPowerMultiplier*/, bool /*ranged*/) { }
 
-    virtual void OnBeforeInitTalentForLevel(Player* /*player*/, uint8& /*level*/, uint32& /*talentPointsForLevel*/) { }
+    virtual void OnBeforeInitTalentForLevel(Player* /*player*/, uint32& /*talentPointsForLevel*/) { }
 
     virtual void OnFirstLogin(Player* /*player*/) { }
 
@@ -1665,7 +1665,7 @@ public: /* PlayerScript */
     void OnAfterUpdateMaxHealth(Player* player, float& value);
     void OnBeforeUpdateAttackPowerAndDamage(Player* player, float& level, float& val2, bool ranged);
     void OnAfterUpdateAttackPowerAndDamage(Player* player, float& level, float& base_attPower, float& attPowerMod, float& attPowerMultiplier, bool ranged);
-    void OnBeforeInitTalentForLevel(Player* player, uint8& level, uint32& talentPointsForLevel);
+    void OnBeforeInitTalentForLevel(Player* player, uint32& talentPointsForLevel);
     void OnFirstLogin(Player* player);
     void OnPlayerCompleteQuest(Player* player, Quest const* quest);
     void OnBattlegroundDesertion(Player* player, BattlegroundDesertionType const desertionType);

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -908,7 +908,7 @@ public:
     virtual void OnBeforeUpdateAttackPowerAndDamage(Player* /*player*/, float& /*level*/, float& /*val2*/, bool /*ranged*/) { }
     virtual void OnAfterUpdateAttackPowerAndDamage(Player* /*player*/, float& /*level*/, float& /*base_attPower*/, float& /*attPowerMod*/, float& /*attPowerMultiplier*/, bool /*ranged*/) { }
 
-    virtual void OnBeforeInitTalentForLevel(Player* /*player*/, uint8& /*level*/, uint32& /*talentPointsForLevel*/) { }
+    virtual void OnBeforeInitTalentForLevel(Player* /*player*/, uint32& /*talentPointsForLevel*/) { }
 
     virtual void OnFirstLogin(Player* /*player*/) { }
 
@@ -1657,7 +1657,7 @@ public: /* PlayerScript */
     void OnAfterUpdateMaxHealth(Player* player, float& value);
     void OnBeforeUpdateAttackPowerAndDamage(Player* player, float& level, float& val2, bool ranged);
     void OnAfterUpdateAttackPowerAndDamage(Player* player, float& level, float& base_attPower, float& attPowerMod, float& attPowerMultiplier, bool ranged);
-    void OnBeforeInitTalentForLevel(Player* player, uint8& level, uint32& talentPointsForLevel);
+    void OnBeforeInitTalentForLevel(Player* player, uint32& talentPointsForLevel);
     void OnFirstLogin(Player* player);
     void OnPlayerCompleteQuest(Player* player, Quest const* quest);
     void OnBattlegroundDesertion(Player* player, BattlegroundDesertionType const desertionType);

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -915,7 +915,7 @@ public:
     virtual void OnBeforeUpdateAttackPowerAndDamage(Player* /*player*/, float& /*level*/, float& /*val2*/, bool /*ranged*/) { }
     virtual void OnAfterUpdateAttackPowerAndDamage(Player* /*player*/, float& /*level*/, float& /*base_attPower*/, float& /*attPowerMod*/, float& /*attPowerMultiplier*/, bool /*ranged*/) { }
 
-    virtual void OnBeforeInitTalentForLevel(Player* /*player*/, uint32& /*talentPointsForLevel*/) { }
+    virtual void OnBeforeInitTalentForLevel(Player* /*player*/, uint8& /*level*/, uint32& /*talentPointsForLevel*/) { }
 
     virtual void OnFirstLogin(Player* /*player*/) { }
 
@@ -1665,7 +1665,7 @@ public: /* PlayerScript */
     void OnAfterUpdateMaxHealth(Player* player, float& value);
     void OnBeforeUpdateAttackPowerAndDamage(Player* player, float& level, float& val2, bool ranged);
     void OnAfterUpdateAttackPowerAndDamage(Player* player, float& level, float& base_attPower, float& attPowerMod, float& attPowerMultiplier, bool ranged);
-    void OnBeforeInitTalentForLevel(Player* player, uint32& talentPointsForLevel);
+    void OnBeforeInitTalentForLevel(Player* player, uint8& level, uint32& talentPointsForLevel);
     void OnFirstLogin(Player* player);
     void OnPlayerCompleteQuest(Player* player, Quest const* quest);
     void OnBattlegroundDesertion(Player* player, BattlegroundDesertionType const desertionType);

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -729,6 +729,13 @@ public:
     // Called when a player's talent points are reset (right before the reset is done)
     virtual void OnTalentsReset(Player* /*player*/, bool /*noCost*/) { }
 
+    /**
+     * @brief Fired after resetting a players talents has completed.
+     *
+     * @param player The player whos talents were reset.
+     */
+    virtual void OnAfterTalentsReset(Player* /*player*/) { }
+
     // Called for player::update
     virtual void OnBeforeUpdate(Player* /*player*/, uint32 /*p_time*/) { }
     virtual void OnUpdate(Player* /*player*/, uint32 /*p_time*/) { }
@@ -1596,6 +1603,7 @@ public: /* PlayerScript */
     void OnPlayerLevelChanged(Player* player, uint8 oldLevel);
     void OnPlayerFreeTalentPointsChanged(Player* player, uint32 newPoints);
     void OnPlayerTalentsReset(Player* player, bool noCost);
+    void OnAfterTalentsReset(Player* player);
     void OnPlayerMoneyChanged(Player* player, int32& amount);
     void OnGivePlayerXP(Player* player, uint32& amount, Unit* victim);
     void OnPlayerReputationChange(Player* player, uint32 factionID, int32& standing, bool incremental);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Adds a hook within `InitTalentForLevel`. The actual hook already existed however wasn't fired.
-  Adds an `OnAfterTalentsReset` hook that fires once a players talent points have been successfully removed. There is an existing `OnPlayerTalentsReset` which is essentially the "before" and this is the "after". I have not renamed this hook to the logical `OnBeforePlayerTalentsReset` as I figured it could be breaking since that touches Eluna too. Maybe worth another PR with a clear point in the changelog?
- Pulled in the fix from attached issue as I also needed this for my module.

## Issues Addressed:
- Closes #4327

## Tests Performed:
- Docker build
- Custom player script in module that grants them 5 talent points every 15 levels so that at 60 they have 71. (See Below)

```c++
void OverrideTalents::OnBeforeInitTalentForLevel(Player* player, uint8& /*level*/ uint32& talentPointsForLevel)
{
    sLog->outError("Adjusting Talents for %s", player->GetName());

    uint8 level = player->getLevel();
    uint32 base_talents = level < 10 ? 0 : level - 9;
    uint32 extra_talents = 0;

    if (level >= 15)
        extra_talents += 5;

    if (level >= 30)
        extra_talents += 5;

    if (level >= 45)
        extra_talents += 5;

    if (level >= 60)
        extra_talents += 5;

    talentPointsForLevel = base_talents + extra_talents;
}

void OverrideTalents::OnAfterTalentsReset(Player* player)
{
    sLog->outError("Talents were reset for %s", player->GetName());

    player->InitTalentForLevel();
}
```


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
