### PR TITLE
fix(DB/Creature): Fix Quartermaster Zigris loot table

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629205101934861200.sql
+++ b/data/sql/updates/pending_db_world/rev_1629205101934861200.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629205101934861200');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 9736) AND (`Item` IN (12835, 13252, 13253, 16716));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(9736, 12835, 0, 13, 0, 1, 0, 1, 1, 'Quartermaster Zigris - Plans: Annihilator'),
+(9736, 13252, 0, 19, 0, 1, 1, 1, 1, 'Quartermaster Zigris - Cloudrunner Girdle'),
+(9736, 13253, 0, 18, 0, 1, 1, 1, 1, 'Quartermaster Zigris - Hands of Power'),
+(9736, 16716, 0, 1.1, 0, 1, 1, 1, 1, 'Quartermaster Zigris - Wildheart Belt');

--- a/data/sql/updates/pending_db_world/rev_1629205101934861200.sql
+++ b/data/sql/updates/pending_db_world/rev_1629205101934861200.sql
@@ -3,6 +3,6 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629205101934861200');
 DELETE FROM `creature_loot_template` WHERE (`Entry` = 9736) AND (`Item` IN (12835, 13252, 13253, 16716));
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (9736, 12835, 0, 13, 0, 1, 0, 1, 1, 'Quartermaster Zigris - Plans: Annihilator'),
-(9736, 13252, 0, 19, 0, 1, 1, 1, 1, 'Quartermaster Zigris - Cloudrunner Girdle'),
-(9736, 13253, 0, 18, 0, 1, 1, 1, 1, 'Quartermaster Zigris - Hands of Power'),
-(9736, 16716, 0, 1.1, 0, 1, 1, 1, 1, 'Quartermaster Zigris - Wildheart Belt');
+(9736, 13252, 0, 20, 0, 1, 1, 1, 1, 'Quartermaster Zigris - Cloudrunner Girdle'),
+(9736, 13253, 0, 19, 0, 1, 1, 1, 1, 'Quartermaster Zigris - Hands of Power'),
+(9736, 16716, 0, 1.3, 0, 1, 1, 1, 1, 'Quartermaster Zigris - Wildheart Belt');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add the missing [Wildheart Belt](https://tbc.wowhead.com/item=16716/wildheart-belt) item to the loot table
-  Change rates to items based on [this](https://tbc.wowhead.com/npc=9736/quartermaster-zigris)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes partially https://github.com/azerothcore/azerothcore-wotlk/issues/7366

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/npc=9736/quartermaster-zigris

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Runned the SQL query and tried some runs on the boss but i ain't that lucky to get a 1.3% drop :(


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run the SQL query
2. Kill the boss

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
