### PR TITLE
fix(DB/Gameobjects): Remove Classic Naxxramas Portal

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629208615028131900.sql
+++ b/data/sql/updates/pending_db_world/rev_1629208615028131900.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629208615028131900');
+
+DELETE FROM `gameobject` WHERE `guid` = 45739 AND `id` = 181476;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes the singular spawn of the Naxxramas portal in Plaguewood.

I've left the `gameobject_template` as it can be used by custom content.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/1238
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7401

## SOURCE:
I don't have a source besides just straight up game knowledge. The portal was removed when Naxx moved. 

## Tests Performed:
- No start up errors / warnings
- Tested in game


## How to Test the Changes:
1. `.go zonexy 35.8 21 139`

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
