### PR TITLE
fix(DB/creature): respawn timer for Timmy the Cruel

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629279891518261056.sql
+++ b/data/sql/updates/pending_db_world/rev_1629279891518261056.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629279891518261056');
+
+UPDATE `creature` SET `spawntimesecs` = 86400 WHERE `guid` = 247227;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fixed respawn timer for Timmy the Cruel - Stratholme Boss in Scarlet Side. Respawn timer was 300 seconds.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
This is a dungeon boss, 86400 seconds is a standard respawn timer for them.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .go c 247227
- Killed the boss, boss no longer spawns after 5 minutes.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go c 247227`
2. Kill all Scarlet mobs around to spawn the boss
3. Kill the boss
4. Wait for 5 minutes


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
