### PR TITLE
fix(DB/Skinning_loot): Remove Chimaera Leather

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629290838385347720.sql
+++ b/data/sql/updates/pending_db_world/rev_1629290838385347720.sql
@@ -1,0 +1,56 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629290838385347720');
+
+-- Delete Chimaera Leather
+DELETE FROM `skinning_loot_template` WHERE `item` = 15423 AND `entry` IN (7447, 7448, 7449, 8763, 8764, 10807, 11497);
+
+-- Update Fledgling Chillwind
+DELETE FROM `skinning_loot_template` WHERE (`Entry` = 7447) AND (`Item` IN (4304, 8169, 8170, 8171));
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(7447, 4304, 0, 37.199, 0, 1, 1, 1, 1, 'Fledgling Chillwind - Thick Leather'),
+(7447, 8169, 0, 3.869, 0, 1, 1, 1, 1, 'Fledgling Chillwind - Thick Hide'),
+(7447, 8170, 0, 52.755, 0, 1, 1, 1, 1, 'Fledgling Chillwind - Rugged Leather'),
+(7447, 8171, 0, 6.177, 0, 1, 1, 1, 1, 'Fledgling Chillwind - Rugged Hide');
+
+-- Update Chillwind Chimaera
+DELETE FROM `skinning_loot_template` WHERE (`Entry` = 7448) AND (`Item` IN (4304, 8170, 8171));
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(7448, 4304, 0, 10.456, 0, 1, 1, 1, 1, 'Chillwind Chimaera - Thick Leather'),
+(7448, 8170, 0, 81.050, 0, 1, 1, 1, 1, 'Chillwind Chimaera - Rugged Leather'),
+(7448, 8171, 0, 8.494, 0, 1, 1, 1, 1, 'Chillwind Chimaera - Rugged Hide');
+
+-- Update Chillwind Ravager
+DELETE FROM `skinning_loot_template` WHERE (`Entry` = 7449) AND (`Item` IN (4304, 8170, 8171));
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(7449, 4304, 0, 7.990, 0, 1, 1, 1, 1, 'Chillwind Ravager - Thick Leather'),
+(7449, 8170, 0, 83.502, 0, 1, 1, 1, 1, 'Chillwind Ravager - Rugged Leather'),
+(7449, 8171, 0, 8.508, 0, 1, 1, 1, 1, 'Chillwind Ravager - Rugged Hide');
+
+-- Update Mistwing Rogue
+DELETE FROM `skinning_loot_template` WHERE (`Entry` = 8763) AND (`Item` IN (4304, 8169, 8170, 8171));
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(8763, 4304, 0, 41.811, 0, 1, 1, 1, 1, 'Mistwing Rogue - Thick Leather'),
+(8763, 8169, 0, 4.529, 0, 1, 1, 1, 1, 'Mistwing Rogue - Thick Hide'),
+(8763, 8170, 0, 48.782, 0, 1, 1, 1, 1, 'Mistwing Rogue - Rugged Leather'),
+(8763, 8171, 0, 4.878, 0, 1, 1, 1, 1, 'Mistwing Rogue - Rugged Hide');
+
+-- Update Mistwing Ravager
+DELETE FROM `skinning_loot_template` WHERE (`Entry` = 8764) AND (`Item` IN (4304, 8169, 8170, 8171));
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(8764, 4304, 0, 37.879, 0, 1, 1, 1, 1, 'Mistwing Ravager - Thick Leather'),
+(8764, 8169, 0, 4.243, 0, 1, 1, 1, 1, 'Mistwing Ravager - Thick Hide'),
+(8764, 8170, 0, 53.636, 0, 1, 1, 1, 1, 'Mistwing Ravager - Rugged Leather'),
+(8764, 8171, 0, 4.242, 0, 1, 1, 1, 1, 'Mistwing Ravager - Rugged Hide');
+
+-- Update Brumeran
+DELETE FROM `skinning_loot_template` WHERE (`Entry` = 10807) AND (`Item` IN (4304, 8170, 8171));
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(10807, 4304, 0, 7.628, 0, 1, 1, 1, 1, 'Brumeran - Thick Leather'),
+(10807, 8170, 0, 83.050, 0, 1, 1, 1, 1, 'Brumeran - Rugged Leather'),
+(10807, 8171, 0, 9.322, 0, 1, 1, 1, 1, 'Brumeran - Rugged Hide');
+
+-- Update The Razza
+DELETE FROM `skinning_loot_template` WHERE (`Entry` = 11497) AND (`Item` IN (4304, 8170, 8171));
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(11497, 4304, 0, 5.413, 0, 1, 0, 1, 1, 'The Razza - Thick Leather'),
+(11497, 8170, 0, 82.823, 0, 1, 0, 1, 1, 'The Razza - Rugged Leather'),
+(11497, 8171, 0, 11.764, 0, 1, 0, 1, 1, 'The Razza - Rugged Hide');


### PR DESCRIPTION
Removes Chimaera Leather from `skinning_loot_template` (this item was removed from Skinning Loot in Patch 3.1.0). Furthermore, this PR increases the Skinning Loot chance for all remaining Skinning Loot (Thick Leather, Thick Hide (if present), Rugged Leather & Rugged Hide) to add up to 100 %, so that there is no chance of no Skinning Loot after removing Chimaera Leather.

The increase was calculated by multiplying with the following factor: 100/(100 - [%chance of Chimaera Leather]).
We don't have any blizzlike data for the exact chances without Chimaera Leather after Patch 3.1.0, so this is the best I can do.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes Chimaera Leather from `skinning_loot_template`
-  Increases the chance for Thick Leather, Thick Hide (if present), Rugged Leather & Rugged Hide appropriately (sum =100 % -> always skinning loot)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7377)
- Closes https://github.com/chromiecraft/chromiecraft/issues/1426)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran the SQL, no errors
- Checked the db, no more Chimaera Leather and updated Skinning Loot chances
- no in-game tests so far

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to any guid of the following creatures:
![grafik](https://user-images.githubusercontent.com/68868567/129902825-36a622e0-dce7-4248-8a89-a8b47a0d8078.png)
2. Kill the creature
3. Loot the creature
4. Skin the creature
5. Repeat multiple times and for all creatures
6. See that you don't get any Chimaera Leather
7. See that you always get Skinning Loot (never empty)
8. Additionally, check the db with the changes

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
