### PR TITLE
fix(DB/Creature): Removed skinloot and skinning_loot_template for Spirestone Mystic

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629293337424377430.sql
+++ b/data/sql/updates/pending_db_world/rev_1629293337424377430.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629293337424377430');
+
+UPDATE `creature_template` SET `skinloot` = 0 WHERE `entry` = 9198;
+DELETE FROM `skinning_loot_template` WHERE `entry` = 9198;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removed `skinloot` entry from Spirestone Mystic which is a humanoid NPC (ogre)
- Removed `skinning_loot_template` for this NPC as well


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- Humanoids can't be skinned.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- Applied PR and tested skinning on a dead NPC


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Apply this PR
2. .npc add 9198 and kill him
3. Try to skin Spirestone Mystic

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.