### PR TITLE
fix(DB/Creature): Fixed some murlocs spawns

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629313785965120137.sql
+++ b/data/sql/updates/pending_db_world/rev_1629313785965120137.sql
@@ -1,13 +1,13 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629313785965120137');
 
 -- Add movement to Marsh Inkspewer
-UPDATE `creature` SET wander_distance = 5, `MovementType` = 1 WHERE (`id` = 750) AND (`guid` IN (42643, 43629, 42837, 43610));
+UPDATE `creature` SET `wander_distance` = 5, `MovementType` = 1 WHERE (`id` = 750) AND (`guid` IN (42643, 43629, 42837, 43610));
 
 -- Add movement to Marsh Murloc
-UPDATE `creature` SET wander_distance = 5, `MovementType` = 1 WHERE (`id` = 747) AND (`guid` IN (43612, 43607));
+UPDATE `creature` SET `wander_distance` = 5, `MovementType` = 1 WHERE (`id` = 747) AND (`guid` IN (43612, 43607));
 
 -- Add movement to Jarquia
-UPDATE `creature` SET wander_distance = 5, `MovementType` = 1 WHERE (`id` = 9916) AND (`guid` = 43774);
+UPDATE `creature` SET `wander_distance` = 5, `MovementType` = 1 WHERE (`id` = 9916) AND (`guid` = 43774);
 
 -- Remove movement to prevent clipping
-UPDATE `creature` SET wander_distance = 0, `MovementType` = 0 WHERE (`id` = 752) AND (`guid` = 43658);
+UPDATE `creature` SET `wander_distance` = 0, `MovementType` = 0 WHERE (`id` = 752) AND (`guid` = 43658);

--- a/data/sql/updates/pending_db_world/rev_1629313785965120137.sql
+++ b/data/sql/updates/pending_db_world/rev_1629313785965120137.sql
@@ -1,0 +1,13 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629313785965120137');
+
+-- Add movement to Marsh Inkspewer
+UPDATE `creature` SET wander_distance = 5, `MovementType` = 1 WHERE (`id` = 750) AND (`guid` IN (42643, 43629, 42837, 43610));
+
+-- Add movement to Marsh Murloc
+UPDATE `creature` SET wander_distance = 5, `MovementType` = 1 WHERE (`id` = 747) AND (`guid` IN (43612, 43607));
+
+-- Add movement to Jarquia
+UPDATE `creature` SET wander_distance = 5, `MovementType` = 1 WHERE (`id` = 9916) AND (`guid` = 43774);
+
+-- Remove movement to prevent clipping
+UPDATE `creature` SET wander_distance = 0, `MovementType` = 0 WHERE (`id` = 752) AND (`guid` = 43658);


### PR DESCRIPTION
Changed the movement to some murlocs.
The (Optional) Move guid 43610 a bit to the side, he is much too close to the tower.
New position could be: x = -11051.1 y = -4121.6 z = 0.85 i checked and he is just in that spot, so all good.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added movement to some mutlocs, removed movement from 1 to prevent clipping

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7409
- Closes https://github.com/chromiecraft/chromiecraft/issues/1454

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .go c 42643. 43629, 42837, 43610, 43612, 43607,  43774 and check the movement
- .go c 43658 and check that he is NOT moving


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 42643. 43629, 42837, 43610, 43612, 43607,  43774 and check the movement
2. .go c 43658 and check that he is NOT moving

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
