### PR TITLE
fix(Script/Spells): Anti-Magic Zone amount calc

### DIFF
--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -1198,7 +1198,7 @@ public:
             amount = talentSpell->Effects[EFFECT_0].CalcValue(owner);
             if (Player* player = owner->ToPlayer())
             {
-                amount += int32(2 * owner->GetTotalAttackPowerValue(BASE_ATTACK));
+                amount += int32(2 * player->GetTotalAttackPowerValue(BASE_ATTACK));
             }
         }
 

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -1185,14 +1185,21 @@ public:
             return ValidateSpellInfo({ SPELL_DK_ANTI_MAGIC_SHELL_TALENT });
         }
 
-        void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& canBeRecalculated)
+        void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
         {
             SpellInfo const* talentSpell = sSpellMgr->AssertSpellInfo(SPELL_DK_ANTI_MAGIC_SHELL_TALENT);
-            amount = talentSpell->Effects[EFFECT_0].CalcValue(GetCaster());
-            if (Unit* totem = GetCaster())
-                if (Unit* owner = totem->ToTotem()->GetSummoner())
-                    amount += int32(2 * owner->GetTotalAttackPowerValue(BASE_ATTACK));
-            canBeRecalculated = false;
+            
+            Unit* owner = GetCaster()->GetOwner();
+            if (!owner)
+            {
+                return;
+            }
+
+            amount = talentSpell->Effects[EFFECT_0].CalcValue(owner);
+            if (Player* player = owner->ToPlayer())
+            {
+                amount += int32(2 * owner->GetTotalAttackPowerValue(BASE_ATTACK));
+            }
         }
 
         void Absorb(AuraEffect* /*aurEff*/, DamageInfo& dmgInfo, uint32& absorbAmount)

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -1188,7 +1188,7 @@ public:
         void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
         {
             SpellInfo const* talentSpell = sSpellMgr->AssertSpellInfo(SPELL_DK_ANTI_MAGIC_SHELL_TALENT);
-            
+
             Unit* owner = GetCaster()->GetOwner();
             if (!owner)
             {


### PR DESCRIPTION
* cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/bea682f95c374d914f47925448fff6b8c9d3fcb4)

Co-Authored-By: Lucas Nascimento <keader.android@gmail.com>

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
* Spell is casted by a trigger, not a player, so script need get owner instead caster

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- None


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. See that the CalculateAmount is properly calculated

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
