### PR TITLE
fix(DB/loot): remove shadowcat hide from skinning loot

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629326440508086998.sql
+++ b/data/sql/updates/pending_db_world/rev_1629326440508086998.sql
@@ -16,7 +16,5 @@ UPDATE `skinning_loot_template` SET `Chance` = 72.8 WHERE `Entry` = 1713 AND `It
 UPDATE `skinning_loot_template` SET `Chance` = 3.3 WHERE `Entry` = 1713 AND `Item` = 4235;
 UPDATE `skinning_loot_template` SET `Chance` = 23.9 WHERE `Entry` = 1713 AND `Item` = 4304;
 
--- Adjust skinning drop rates for Yor <UNUSED>
-UPDATE `skinning_loot_template` SET `Chance` = 72 WHERE `Entry` = 10237 AND `Item` = 4234;
-UPDATE `skinning_loot_template` SET `Chance` = 4.7 WHERE `Entry` = 10237 AND `Item` = 4235;
-UPDATE `skinning_loot_template` SET `Chance` = 23.3 WHERE `Entry` = 10237 AND `Item` = 4304;
+UPDATE `creature_template` SET `skinloot` = 0 WHERE (`entry` = 10237);
+DELETE FROM `skinning_loot_template` WHERE `Entry` = 10237;

--- a/data/sql/updates/pending_db_world/rev_1629326440508086998.sql
+++ b/data/sql/updates/pending_db_world/rev_1629326440508086998.sql
@@ -1,2 +1,22 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629326440508086998');
 DELETE FROM `skinning_loot_template` WHERE `Entry` IN (684, 768, 1713, 10237) AND (`Item` IN (7428));
+
+-- Adjust skinning drop rates for Shadowmaw Panther
+UPDATE `skinning_loot_template` SET `Chance` = 73.4 WHERE `Entry` = 684 AND `Item` = 4234;
+UPDATE `skinning_loot_template` SET `Chance` = 3.3 WHERE `Entry` = 684 AND `Item` = 4235;
+UPDATE `skinning_loot_template` SET `Chance` = 23.3 WHERE `Entry` = 684 AND `Item` = 4304;
+
+-- Adjust skinning drop rates for Shadow Panther
+UPDATE `skinning_loot_template` SET `Chance` = 72.7 WHERE `Entry` = 768 AND `Item` = 4234;
+UPDATE `skinning_loot_template` SET `Chance` = 4.2 WHERE `Entry` = 768 AND `Item` = 4235;
+UPDATE `skinning_loot_template` SET `Chance` = 23.1 WHERE `Entry` = 768 AND `Item` = 4304;
+
+-- Adjust skinning drop rates for Elder Shadowmaw Panther
+UPDATE `skinning_loot_template` SET `Chance` = 72.8 WHERE `Entry` = 1713 AND `Item` = 4234;
+UPDATE `skinning_loot_template` SET `Chance` = 3.3 WHERE `Entry` = 1713 AND `Item` = 4235;
+UPDATE `skinning_loot_template` SET `Chance` = 23.9 WHERE `Entry` = 1713 AND `Item` = 4304;
+
+-- Adjust skinning drop rates for Yor <UNUSED>
+UPDATE `skinning_loot_template` SET `Chance` = 72 WHERE `Entry` = 10237 AND `Item` = 4234;
+UPDATE `skinning_loot_template` SET `Chance` = 4.7 WHERE `Entry` = 10237 AND `Item` = 4235;
+UPDATE `skinning_loot_template` SET `Chance` = 23.3 WHERE `Entry` = 10237 AND `Item` = 4304;

--- a/data/sql/updates/pending_db_world/rev_1629326440508086998.sql
+++ b/data/sql/updates/pending_db_world/rev_1629326440508086998.sql
@@ -1,0 +1,2 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629326440508086998');
+DELETE FROM `skinning_loot_template` WHERE `Entry` IN (684, 768, 1713, 10237) AND (`Item` IN (7428));


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  removed shadowcat hide entries listed in https://github.com/azerothcore/azerothcore-wotlk/issues/7341

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7341

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- None


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Skin the mobs listed in https://github.com/azerothcore/azerothcore-wotlk/issues/7341 and see if shadowcat hide drops

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
No.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
