### PR TITLE
fix(DB/Creature): prevent scarlet friar floor fall

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629418018641557053.sql
+++ b/data/sql/updates/pending_db_world/rev_1629418018641557053.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629418018641557053');
+
+# Update Scarlet Friar preventing evade / floor falling
+UPDATE `creature` SET `position_z` = 81 WHERE (`id` = 1538) AND (`guid` IN (44770));


### PR DESCRIPTION
## Changes Proposed:
-  Scarlet Friar z position increased slightly

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/1472

## Tests Performed:
- Untested


## How to Test the Changes:
1. Tirisfal Glades position 2169.060059 -520.564026 81.734024 
2. Kill Scarlet Friar
3. Wait for spawn
4. Attack
5. Mob should no longer evade or fall through floor

## Known Issues and TODO List:
- n/a

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.


👋 My first contribution. Still figuring out GM commands, keira, and how everything works in general. Let me know if theres something dumb I'm missing!