### PR TITLE
fix(DB/creature): Add movement to static Withered Green Keepers

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629435906739087287.sql
+++ b/data/sql/updates/pending_db_world/rev_1629435906739087287.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629435906739087287');
+
+-- Add movement to Withered Green Keepers
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5 WHERE `id` = 15637 AND `guid` IN (55527, 55528, 55529, 55532, 55533, 55534, 55535, 55569, 55570);
+
+-- Shift one spawn slightly to avoid overlapping
+UPDATE `creature` SET `position_x` = 8258, `position_y` = -6136.1, `position_z` = 34.2 WHERE `id` = 15637 AND `guid` = 55534;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Adds movement to a group of 9 Withered Green Keepers (ID 15637) in Eversong Woods. Wander distance is derived from other moving spawns of the same type.
- Moves one of the spawns (55534) slightly to avoid overlapping with spawn 55533.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7463
- Closes https://github.com/chromiecraft/chromiecraft/issues/1471

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Consistency with others of the same type.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, correct number of rows changed.
- Checked in-game - trees are now moving correctly, and new spawn position worked:

Blue square is 55533, red cross is 55534. They used to be on top of each other.
![WoWScrnShot_082021_143431](https://user-images.githubusercontent.com/81782124/130182546-543f8e4f-7925-4b84-8c3a-67e97f5488f0.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Visit any of the provided GUIDs  (55527, 55528, 55529, 55532, 55533, 55534, 55535, 55569, 55570) and verify movement.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

Noticed while testing this that Old Whitebark nearby is also static, which is probably incorrect.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
