### PR TITLE
fix(CORE/Spells): Warrior's slam and execute spells miss bug

### DIFF
--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -76,6 +76,30 @@ enum SpellRangeFlag
     SPELL_RANGE_RANGED              = 2,     //hunter range and ranged weapon
 };
 
+enum SpellIdForClient
+{
+    WARRIOR_SLAM_RANK_1 = 1464,
+    WARRIOR_SLAM_RANK_2 = 8820,
+    WARRIOR_SLAM_RANK_3 = 11604,
+    WARRIOR_SLAM_RANK_4 = 11605,
+    WARRIOR_SLAM_RANK_5 = 25241,
+    WARRIOR_SLAM_RANK_6 = 25242,
+    WARRIOR_SLAM_RANK_7 = 47474,
+    WARRIOR_SLAM_RANK_8 = 47475,
+    WARRIOR_SLAM_CLIENT = 50783,
+
+    WARRIOR_EXECUTE_RANK_1 = 5308,
+    WARRIOR_EXECUTE_RANK_2 = 20658,
+    WARRIOR_EXECUTE_RANK_3 = 20660,
+    WARRIOR_EXECUTE_RANK_4 = 20661,
+    WARRIOR_EXECUTE_RANK_5 = 20662,
+    WARRIOR_EXECUTE_RANK_6 = 25234,
+    WARRIOR_EXECUTE_RANK_7 = 25236,
+    WARRIOR_EXECUTE_RANK_8 = 47470,
+    WARRIOR_EXECUTE_RANK_9 = 47471,
+    WARRIOR_EXECUTE_CLIENT = 20647
+};
+
 struct SpellDestination
 {
     SpellDestination();
@@ -537,6 +561,9 @@ public:
 
     void SetSpellValue(SpellValueMod mod, int32 value);
     SpellValue const* GetSpellValue() { return m_spellValue; }
+
+    uint32 GetTranslatedSpellIdForClientCombaLog();
+    bool   CheckIfMissedSpellNeedToBeSent();
 
     // xinef: moved to public
     void LoadScripts();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
aye whas good. this shit is not even a complete fix cuz there's still one problem but i still finna try a PR on this cuz at least the most annoying bug was resolved i think.

so the problem is this: when u execute or slam the server doesn't cast only 1 spell but two. example: if u cast rank 1 slam (id = 1464) the program finna call a script inside ```Spell::CallScriptEffectHandlers``` that is located in ```src/scripts/Spells/spell_warrior.cpp``` that is gonna execute ANOTHER slam spell (id = 50783, don't ask me where this comes from prolly something in dbc?) that is the actual spell that gon send the dmg back to the client.

**note** that both these spells can miss (block,parry,miss,reflect) so u with one cast u got double chance to fail (lmao). 

the problem with this is that if u cast slam, the sever is going to execute spell with id = 1464 and if it miss it gon send back the client a ```SMSG_SPELL_GO``` packet with inside the miss condition **and** the spell id which for some reason won't show up into the combat log or floating combat text either. matter of fact if u change, in the packet, that spell id with 50783 the miss will show up in the log. it seems like it doesn't recognize 1464  as a spell id or some shit.

so that's the first problem. 

the other problem is that if errythang went gucci the first time with spell id = 1464 when the program will execute the final spell with id = 50783 going through spell scripts the spell can still fail cuz ```targetInfo.missCondition``` is calculated every time u call a spell. if it doesn't then errythang is lit and we get dmg packet ```SMSG_SPELLNONMELEEDAMAGELOG``` back in the client otherwise **NOTHING** will be sent back to the client bc the ```SMSG_SPELL_GO``` is sent only once when spell id = 1464.

to fix this shit i did a dirty ass trick and introduced a call to ```Unit::SendSpellMiss``` to let the client know the attack went shit. this fixed both combat log + floating combat text.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- https://github.com/azerothcore/azerothcore-wotlk/issues/7428

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
None, cuz it common sense

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tried locally and apart from one problem still present i didnt find anythang else. would be good tho if  some other tester could provide feedback as well.

![1](https://user-images.githubusercontent.com/88903576/130256759-62f37106-f653-44fb-83f1-4c757fc8b046.PNG)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. pick up a war (i did lvl 49) nothing but a 2h sword
2. spawn high lvl training dummy
3. slam it
4. to test execute pick a low lvl mob and have fun

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

the elephant in the room that remains to fuck with is the particle effect. this shit is popped when the ```SMSG_SPELL_GO``` packet is received by the client and so basically (in the clase of slam) when spell id =1464 and the cast can succeed so in the client we gon see the particle effect but the next cast can still fail so we can still get like a miss in the combat log.

to fix this latter issue i think we gotta redo how the spell works or dome some spellscript-fu shit to workaround this shit. ideally we would only need to call the spell once no matter what and not call-chaining this shit that create only confusion. 

also forgot to mention: this problem affect a shit ton of other abilities. right now i only worried bout the spells in the mentioned in the issue but ideally a lot of spells got this double-chance-to-fail type of stuff.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
