### PR TITLE
fix(Core/Spells): Do not remove stances when teleported from instance…

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1586,7 +1586,10 @@ void Player::ProcessDelayedOperations()
         if (m_entryPointData.mountSpell)
         {
             // xinef: remove shapeshift auras
-            RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
+            if (IsInDisallowedMountForm())
+            {
+                RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
+            }
             AddAura(m_entryPointData.mountSpell, this);
             m_entryPointData.mountSpell = 0;
         }


### PR DESCRIPTION
…/bg out.

Fixed #7402

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Do not remove stances when teleported from instance/bg out

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #7402
- Closes https://github.com/chromiecraft/chromiecraft/issues/1424

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Be a warrior, Be in a stance. Be mounted.
2. Enter a RDF.
3. Exit the RDF.
4. You'll be mounted still and have your stance.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
