### PR TITLE
[Core/Misc]: Restore playercreateinfo_item item deletion functionality.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629485842027723200.sql
+++ b/data/sql/updates/pending_db_world/rev_1629485842027723200.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629485842027723200');
+
+ALTER TABLE `playercreateinfo_item`
+    CHANGE `amount` `amount` TINYINT(4) SIGNED NOT NULL DEFAULT 1;
+
+INSERT INTO `playercreateinfo_item` (`race`, `class`, `itemid`, `amount`, `Note`) VALUES (0, 6, 40582, -1, "[PH] Scrouge Hearthstone");

--- a/data/sql/updates/pending_db_world/rev_1629485842027723200.sql
+++ b/data/sql/updates/pending_db_world/rev_1629485842027723200.sql
@@ -1,7 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629485842027723200');
 
 ALTER TABLE `playercreateinfo_item`
-    CHANGE `amount` `amount` INT(11) SIGNED NOT NULL DEFAULT 1;
+    CHANGE `amount` `amount` INT SIGNED NOT NULL DEFAULT 1;
 
 DELETE FROM `playercreateinfo_item` WHERE `itemid` = 40582;
 INSERT INTO `playercreateinfo_item` (`race`, `class`, `itemid`, `amount`, `Note`) VALUES (0, 6, 40582, -1, "[TDB PH] - unsused Scourgestone");

--- a/data/sql/updates/pending_db_world/rev_1629485842027723200.sql
+++ b/data/sql/updates/pending_db_world/rev_1629485842027723200.sql
@@ -3,4 +3,4 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629485842027723200');
 ALTER TABLE `playercreateinfo_item`
     CHANGE `amount` `amount` TINYINT(4) SIGNED NOT NULL DEFAULT 1;
 
-INSERT INTO `playercreateinfo_item` (`race`, `class`, `itemid`, `amount`, `Note`) VALUES (0, 6, 40582, -1, "[PH] Scrouge Hearthstone");
+INSERT INTO `playercreateinfo_item` (`race`, `class`, `itemid`, `amount`, `Note`) VALUES (0, 6, 40582, -1, "[TDB PH] - unsused Scourgestone");

--- a/data/sql/updates/pending_db_world/rev_1629485842027723200.sql
+++ b/data/sql/updates/pending_db_world/rev_1629485842027723200.sql
@@ -1,6 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629485842027723200');
 
 ALTER TABLE `playercreateinfo_item`
-    CHANGE `amount` `amount` TINYINT(4) SIGNED NOT NULL DEFAULT 1;
+    CHANGE `amount` `amount` INT(11) SIGNED NOT NULL DEFAULT 1;
 
+DELETE FROM `playercreateinfo_item` WHERE `itemid` = 40582;
 INSERT INTO `playercreateinfo_item` (`race`, `class`, `itemid`, `amount`, `Note`) VALUES (0, 6, 40582, -1, "[TDB PH] - unsused Scourgestone");

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -3458,7 +3458,7 @@ void ObjectMgr::LoadPlayerInfo()
                     continue;
                 }
 
-                int32 amount   = fields[3].GetUInt16();
+                int32 amount = fields[3].GetInt8();
 
                 if (!amount)
                 {

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -3458,7 +3458,7 @@ void ObjectMgr::LoadPlayerInfo()
                     continue;
                 }
 
-                int32 amount = fields[3].GetInt8();
+                int32 amount = fields[3].GetInt32();
 
                 if (!amount)
                 {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Partially revert https://github.com/azerothcore/azerothcore-wotlk/pull/3122

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5919

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested using the method below


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create a fresh DK character.
2. Open your bags
3. Look if you have the item ```[TDB PH] - unsused Scourgestone```
4. If you don't see the item in your inventory then the PR did it's job

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
