### PR TITLE
[DB/SQL]: Fix wrong skilllineability_dbc structure

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629670488191888600.sql
+++ b/data/sql/updates/pending_db_world/rev_1629670488191888600.sql
@@ -1,0 +1,12 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629670488191888600');
+
+ALTER TABLE `skilllineability_dbc`
+    CHANGE `MinSkillLineRank` `ExcludeRace` INT NOT NULL DEFAULT 0,
+    CHANGE `SupercededBySpell` `ExcludeClass` INT NOT NULL DEFAULT 0,
+    CHANGE `AcquireMethod` `MinSkillLineRank` INT NOT NULL DEFAULT 0,
+    CHANGE `TrivialSkillLineRankHigh` `SupercededBySpell` INT NOT NULL DEFAULT 0,
+    CHANGE `TrivialSkillLineRankLow` `AcquireMethod` INT NOT NULL DEFAULT 0, 
+    CHANGE `CharacterPoints_1` `TrivialSkillLineRankHigh` INT NOT NULL DEFAULT 0,
+    CHANGE `CharacterPoints_2` `TrivialSkillLineRankLow` INT NOT NULL DEFAULT 0,
+    CHANGE `TradeSkillCategoryID` `CharacterPoints_1` INT NOT NULL DEFAULT 0,
+    ADD COLUMN `CharacterPoints_2` INT NOT NULL DEFAULT 0 AFTER `CharacterPoints_1`;

--- a/src/server/shared/DataStores/DBCDatabaseLoader.cpp
+++ b/src/server/shared/DataStores/DBCDatabaseLoader.cpp
@@ -93,6 +93,7 @@ char* DBCDatabaseLoader::Load(uint32& records, char**& indexTable)
                     break;
                 case FT_SORT:
                 case FT_NA:
+                case FT_NA_BYTE:
                     break;
                 default:
                     ASSERT(false, "Unsupported data type '%c' in table '%s'", *dbcFormat, _sqlTableName);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fix wrong skilllineability_dbc structure
-  Add a check for the unused FT_NA_BYTE

You'll also need the new skilllineability_dbc data

[skilllineability_dbc.zip](https://github.com/azerothcore/azerothcore-wotlk/files/7028256/skilllineability_dbc.zip)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4312

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran the worldserver


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
