### PR TITLE
fix(Core/Entities): contested guards attacking after bg/recent pvp

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -16525,8 +16525,22 @@ void Unit::SetContestedPvP(Player* attackedPlayer)
 {
     Player* player = GetCharmerOrOwnerPlayerOrPlayerItself();
 
-    if (!player || (attackedPlayer && (attackedPlayer == player || (player->duel && player->duel->opponent == attackedPlayer))))
+    if (!player || (attackedPlayer && (attackedPlayer == player || (player->duel && player->duel->opponent == attackedPlayer)) || player->InBattleground()))
         return;
+
+    // check if there any any guards that should give a fuck about the contested flag on player
+
+    std::list<Unit*>                                                                targets;
+    Acore::NearestVisibleDetectableContestedGuardUnitCheck                          u_check(this);
+    Acore::UnitListSearcher<Acore::NearestVisibleDetectableContestedGuardUnitCheck> searcher(this, targets, u_check);
+    Cell::VisitAllObjects(this, searcher, MAX_AGGRO_RADIUS);
+
+    // return if there are no contested guards found
+
+    if (!targets.size())
+    {
+        return;
+    }
 
     player->SetContestedPvPTimer(30000);
     if (!player->HasUnitState(UNIT_STATE_ATTACK_PLAYER))

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -1103,6 +1103,26 @@ namespace Acore
         NearestHostileUnitInAttackDistanceCheck(NearestHostileUnitInAttackDistanceCheck const&);
     };
 
+    class NearestVisibleDetectableContestedGuardUnitCheck
+    {
+    public:
+        explicit NearestVisibleDetectableContestedGuardUnitCheck(Unit const* unit) : me(unit) {}
+        bool operator()(Unit* u)
+        {
+            if (!u->CanSeeOrDetect(me, true, true, false))
+                return false;
+
+            if (!u->IsContestedGuard())
+                return false;
+
+            return true;
+        }
+
+    private:
+        Unit const* me;
+        NearestVisibleDetectableContestedGuardUnitCheck(NearestVisibleDetectableContestedGuardUnitCheck const&);
+    };
+
     class AnyAssistCreatureInRangeCheck
     {
     public:


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
aye, so always setting PLAYER_FLAGS_CONTESTED_PVP flag when player go in pvp was fucking us cover cuz this is the flag that announce to the contested guards to whoop our ass which imo shouldn't be set always but only when needed like the issue states

what i did was to not set the contest pvp timer if player in bg (extend maybe in arenas?) or there are no contested guards that can see or detect me nearby (not sure about this part maybe better smth else?).

i used MAX_AGGRO_RADIUS for the search of nearby units but idk if that's correct tbh. maybe i should put some greater constant u dig. im taking suggestions cuz idk if in retail there is a fixed radius for this bih

word

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7497

## SOURCE:
look issue referenced

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested both world pvp and bg


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. open two client and log in two different chars
3. with one account the other (or enter bg and leave)
4. .go c 76
5. booty bay goblins shouldn't be after ur ass

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
