### PR TITLE
fix(DB/Creature): fix gordunni/forest walker movement

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629752061588917431.sql
+++ b/data/sql/updates/pending_db_world/rev_1629752061588917431.sql
@@ -3,16 +3,8 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629752061588917431');
 UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE (`guid` IN (50173, 50175, 50176, 50177, 50179, 50180, 50194, 50195, 50196, 50198, 50203, 50205, 50206, 50215, 50216, 50217, 50218, 50222, 50227, 50230, 50235, 50244, 50250, 50251, 50252, 50253, 50254, 50291, 50297, 50307, 50313, 50314, 50317, 50319));
 UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 15 WHERE (`guid` IN (50800, 50268, 50269, 50270, 50294));
 UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 6  WHERE (`guid` IN (50314, 91739, 91738));
-
 UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 2  WHERE (`guid` IN (91746,91747,91722, 91744, 91731, 91740, 91741, 91742, 91748, 91745 ));
-
 UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE (`guid` IN (91720,91721));
-
-
 UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 4  WHERE (`guid` IN (91719 ,91721, 91728 ));
 
 UPDATE `creature_template` SET `MovementType` = 1 WHERE (`entry` IN (5229,5231,5232,5234,5236,5237,5238,5239,5240,5241,22143,22144,22148,23022));
-
-
-
-

--- a/data/sql/updates/pending_db_world/rev_1629752061588917431.sql
+++ b/data/sql/updates/pending_db_world/rev_1629752061588917431.sql
@@ -1,0 +1,16 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629752061588917431');
+
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE (`guid` IN (50173, 50175, 50176, 50177, 50179, 50180, 50194, 50195, 50196, 50198, 50203, 50205, 50206, 50215, 50216, 50217, 50218, 50222, 50227, 50230, 50235, 50244, 50250, 50251, 50252, 50253, 50254, 50291, 50297, 50307, 50313, 50314, 50317, 50319));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 15 WHERE (`guid` IN (50800, 50268, 50269, 50270, 50294));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 6  WHERE (`guid` IN (50314, 91739, 91738));
+
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 2  WHERE (`guid` IN (91746,91747,91722, 91744, 91731, 91740, 91741, 91742, 91748, 91745 ));
+
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE (`guid` IN (91720,91721));
+
+
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 4  WHERE (`guid` IN (91719 ,91721, 91728 ));
+
+
+
+

--- a/data/sql/updates/pending_db_world/rev_1629752061588917431.sql
+++ b/data/sql/updates/pending_db_world/rev_1629752061588917431.sql
@@ -1,10 +1,22 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629752061588917431');
 
-UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE (`guid` IN (50173, 50175, 50176, 50177, 50179, 50180, 50194, 50195, 50196, 50198, 50203, 50205, 50206, 50215, 50216, 50217, 50218, 50222, 50227, 50230, 50235, 50244, 50250, 50251, 50252, 50253, 50254, 50291, 50297, 50307, 50313, 50314, 50317, 50319));
-UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 15 WHERE (`guid` IN (50800, 50268, 50269, 50270, 50294));
-UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 6  WHERE (`guid` IN (50314, 91739, 91738));
-UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 2  WHERE (`guid` IN (91746,91747,91722, 91744, 91731, 91740, 91741, 91742, 91748, 91745 ));
-UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE (`guid` IN (91720,91721));
-UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 4  WHERE (`guid` IN (91719 ,91721, 91728 ));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE `id` = 5229 AND (`guid` IN (50173, 50175, 50176, 50177, 50179, 50180));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE `id` = 5232 AND (`guid` IN (50194, 50195, 50196, 50198, 50203, 50205, 50206, 50215, 50216, 50217, 50218));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE `id` = 5234 AND (`guid` IN (50222, 50227, 50230));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE `id` = 5236 AND (`guid` IN (50235, 50244));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE `id` = 5237 AND (`guid` IN (50250, 50251, 50252, 50253, 50254));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE `id` = 5240 AND (`guid` IN (50291, 50297));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE `id` = 5241 AND (`guid` IN (50307, 50313, 50317, 50319));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 15 WHERE `id` = 5238 AND (`guid` IN (50268, 50269, 50270));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 15 WHERE `id` = 5240 AND (`guid` IN (50294));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 15 WHERE `id` = 7584 AND (`guid` IN (50800));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE `id` = 5241 AND (`guid` IN (50314));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 6  WHERE `id` = 23022 AND (`guid` IN (91738));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 6  WHERE `id` = 22148 AND (`guid` IN (91739));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 2  WHERE `id` = 22143 AND (`guid` IN (91722, 91744,91746, 91747));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 2  WHERE `id` = 22144 AND (`guid` IN (91731, 91740, 91741, 91742, 91748));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 2  WHERE `id` = 22148 AND (`guid` IN (91745));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE `id` = 22143 AND (`guid` IN (91720,91721));
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 4  WHERE `id` = 22144 AND (`guid` IN (91719 ,91728));
 
 UPDATE `creature_template` SET `MovementType` = 1 WHERE (`entry` IN (5229,5231,5232,5234,5236,5237,5238,5239,5240,5241,22143,22144,22148,23022));

--- a/data/sql/updates/pending_db_world/rev_1629752061588917431.sql
+++ b/data/sql/updates/pending_db_world/rev_1629752061588917431.sql
@@ -11,6 +11,8 @@ UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 3  WHERE (`guid` I
 
 UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 4  WHERE (`guid` IN (91719 ,91721, 91728 ));
 
+UPDATE `creature_template` SET `MovementType` = 1 WHERE (`entry` IN (5229,5231,5232,5234,5236,5237,5238,5239,5240,5241,22143,22144,22148,23022));
+
 
 
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

since we dont be havin no solid source i just checked more or less erry guid for the radius to wander. i left some to 0 cuz imo they be guards and issa right that they stay in the place and not stroll around

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6959
- Closes https://github.com/chromiecraft/chromiecraft/issues/1210

## SOURCE:
none really, only thang we know is that they gotta be wandering

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested locally, all good.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. just go in the guids provided in the commit file and check mobs wandering

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
