### PR TITLE
fix(DB/Gameobject): Add new spawns to Slagtree's Lost Tools

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629808025047678029.sql
+++ b/data/sql/updates/pending_db_world/rev_1629808025047678029.sql
@@ -1,0 +1,22 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629808025047678029');
+
+-- Add the new spawns for the item Slagtree's Lost Tools
+DELETE FROM `gameobject` WHERE (`id` = 179908) AND `guid` IN (46420, 100510, 100511, 100512, 100513);
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(46420, 179908, 0, 0, 0, 1, 1, 374.858, -3784.89, 169.835, 2.96706, 0, 0, 0.996195, 0.087156, 2, 100, 1, '', 0), -- Skull rock
+(100510, 179908, 0, 0, 0, 1, 1, 323.533, -4133.47, 119.93, 0, 0, 0, 0.996195, 0.087156, 2, 100, 1, '', 0), -- Base down below
+(100511, 179908, 0, 0, 0, 1, 1, 217.35,-4318.79, 117.73, 0, 0, 0, 0.996195, 0.087156, 2, 100, 1, '', 0), -- 2 Base below
+(100512, 179908, 0, 0, 0, 1, 1, 108.72, -4365.943, 120.63, 0, 0, 0, 0.996195, 0.087156, 2, 100, 1, '', 0), -- Lowest base
+(100513, 179908, 0, 0, 0, 1, 1, 456.74, -3628.453, 120.03, 0, 0, 0, 0.996195, 0.087156, 2, 100, 1, '', 0); -- Top base
+
+-- Add the new spawns to the same spawn pool so the item Slagtree's Lost Tools is spawned once at a time
+DELETE FROM `pool_template` WHERE `entry` = 371;
+INSERT INTO `pool_template` (`entry`, `max_limit`, `description`)  VALUES (371, 1, "Slagtree's Lost Tools Spawns");
+
+DELETE FROM `pool_gameobject` WHERE `guid` IN (46420, 100510, 100511, 100512, 100513);
+INSERT INTO `pool_gameobject` (`guid`, `pool_entry`, `chance`, `description`) VALUES 
+(46420, 371, 0, "Slagtree's Lost Tools Spawn 1"),
+(100510, 371, 0, "Slagtree's Lost Tools Spawn 2"),
+(100511, 371, 0, "Slagtree's Lost Tools Spawn 3"),
+(100512, 371, 0, "Slagtree's Lost Tools Spawn 4"),
+(100513, 371, 0, "Slagtree's Lost Tools Spawn 5");


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added 4 new spawns to Slagtree's Lost Tools quest item

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6915
- Closes https://github.com/chromiecraft/chromiecraft/issues/1175

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/item=19033/slagtrees-lost-tools#comments
Comments from wowhead for classic realms.

https://www.wowhead.com/object=179908/slagtrees-lost-tools#comments
Comment from 2009 for patch 3.2 where the location still differs from the single spawn on AzerothCore.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .go go 46420 or 100510, 100511, 100512,100513 and queck the spawn
- Should only be 1 present

Test image of one of the new spawns

![image](https://user-images.githubusercontent.com/87535580/130617385-30ee40d7-8953-4818-ae07-6e01554fd3f8.png)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go go 46420 or 100510, 100511, 100512,100513 and queck the spawn
2. Should only be 1 present

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- Looks like the Point of interest is setted on the base the deepest below the map. I dont know if on 3.3.5 were area quests, but maybe another issue should be opened and add the new spawns as possible areas for the item

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
