### PR TITLE
fix(Core/Loot): Properly handle referenced group loot templates.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
+++ b/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
@@ -1,4 +1,14 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629826555036082700');
 
 ALTER TABLE `creature_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
+ALTER TABLE `disenchant_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
+ALTER TABLE `fishing_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
+ALTER TABLE `gameobject_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
+ALTER TABLE `item_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
+ALTER TABLE `mail_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
+ALTER TABLE `milling_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
+ALTER TABLE `pickpocketing_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
 ALTER TABLE `prospecting_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
+ALTER TABLE `reference_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
+ALTER TABLE `skinning_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
+ALTER TABLE `spell_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;

--- a/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
+++ b/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629826555036082700');
+
+SET @THORIUM_ORE = 10620; 
+UPDATE `prospecting_loot_template` SET `GroupId`=1 WHERE ENTRY = @THORIUM_ORE

--- a/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
+++ b/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
@@ -1,3 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629826555036082700');
 
 ALTER TABLE `creature_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
+ALTER TABLE `prospecting_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;

--- a/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
+++ b/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
@@ -1,4 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629826555036082700');
 
-SET @THORIUM_ORE = 10620; 
-UPDATE `prospecting_loot_template` SET `GroupId`=1 WHERE ENTRY = @THORIUM_ORE;
+SET @THORIUM_ORE := 10620; 
+UPDATE `prospecting_loot_template` SET `GroupId`=1 WHERE `entry` = @THORIUM_ORE;

--- a/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
+++ b/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
@@ -1,4 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629826555036082700');
 
 SET @THORIUM_ORE = 10620; 
-UPDATE `prospecting_loot_template` SET `GroupId`=1 WHERE ENTRY = @THORIUM_ORE
+UPDATE `prospecting_loot_template` SET `GroupId`=1 WHERE ENTRY = @THORIUM_ORE;

--- a/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
+++ b/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
@@ -1,4 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629826555036082700');
 
+ALTER TABLE `creature_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
+
 SET @THORIUM_ORE := 10620; 
 UPDATE `prospecting_loot_template` SET `GroupId`=1 WHERE `entry` = @THORIUM_ORE;
+UPDATE `prospecting_loot_template` SET `Reference`=-13001 WHERE `entry` = @THORIUM_ORE AND `item`=1;

--- a/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
+++ b/data/sql/updates/pending_db_world/rev_1629826555036082700.sql
@@ -1,7 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629826555036082700');
 
 ALTER TABLE `creature_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;
-
-SET @THORIUM_ORE := 10620; 
-UPDATE `prospecting_loot_template` SET `GroupId`=1 WHERE `entry` = @THORIUM_ORE;
-UPDATE `prospecting_loot_template` SET `Reference`=-13001 WHERE `entry` = @THORIUM_ORE AND `item`=1;

--- a/data/sql/updates/pending_db_world/rev_1630094503763134300.sql
+++ b/data/sql/updates/pending_db_world/rev_1630094503763134300.sql
@@ -1,3 +1,0 @@
-INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630094503763134300');
-
-ALTER TABLE `creature_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;

--- a/data/sql/updates/pending_db_world/rev_1630094503763134300.sql
+++ b/data/sql/updates/pending_db_world/rev_1630094503763134300.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630094503763134300');
+
+ALTER TABLE `creature_loot_template` CHANGE `Reference` `Reference` MEDIUMINT DEFAULT 0 NOT NULL;

--- a/data/sql/updates/pending_db_world/rev_1630484852047598500.sql
+++ b/data/sql/updates/pending_db_world/rev_1630484852047598500.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630484852047598500');
+
+SET @THORIUM_ORE := 10620; 
+UPDATE `prospecting_loot_template` SET `GroupId`=1 WHERE `entry` = @THORIUM_ORE;
+UPDATE `prospecting_loot_template` SET `Reference`=-13001 WHERE `entry` = @THORIUM_ORE AND `item`=1;

--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -51,20 +51,23 @@ struct LootGroupInvalidSelector : public Acore::unary_function<LootStoreItem*, b
         if (!(item->lootmode & _lootMode))
             return true;
 
-        ItemTemplate const* _proto = sObjectMgr->GetItemTemplate(item->itemid);
-        if (!_proto)
-            return true;
+        if (!item->reference)
+        {
+            ItemTemplate const* _proto = sObjectMgr->GetItemTemplate(item->itemid);
+            if (!_proto)
+                return true;
 
-        uint8 foundDuplicates = 0;
-        for (std::vector<LootItem>::const_iterator itr = _loot.items.begin(); itr != _loot.items.end(); ++itr)
-            if (itr->itemid == item->itemid)
-            {
-                ++foundDuplicates;
-                if (_proto->InventoryType == 0 && foundDuplicates == 3 && _proto->ItemId != 47242 /*Trophy of the Crusade*/)      // Non-equippable items are limited to 3 drops
-                    return true;
-                else if (_proto->InventoryType != 0 && foundDuplicates == 1) // Equippable item are limited to 1 drop
-                    return true;
-            }
+            uint8 foundDuplicates = 0;
+            for (std::vector<LootItem>::const_iterator itr = _loot.items.begin(); itr != _loot.items.end(); ++itr)
+                if (itr->itemid == item->itemid)
+                {
+                    ++foundDuplicates;
+                    if (_proto->InventoryType == 0 && foundDuplicates == 3 && _proto->ItemId != 47242 /*Trophy of the Crusade*/) // Non-equippable items are limited to 3 drops
+                        return true;
+                    else if (_proto->InventoryType != 0 && foundDuplicates == 1) // Equippable item are limited to 1 drop
+                        return true;
+                }
+        }
 
         return false;
     }
@@ -80,9 +83,9 @@ public:
     LootGroup() { }
     ~LootGroup();
 
-    void AddEntry(LootStoreItem* item);                 // Adds an entry to the group (at loading stage)
-    bool HasQuestDrop() const;                          // True if group includes at least 1 quest drop entry
-    bool HasQuestDropForPlayer(Player const* player) const;
+    void AddEntry(LootStoreItem* item);                     // Adds an entry to the group (at loading stage)
+    bool HasQuestDrop(LootTemplateMap const& store) const;  // True if group includes at least 1 quest drop entry
+    bool HasQuestDropForPlayer(Player const* player, LootTemplateMap const& store) const;
     // The same for active quests of the player
     void Process(Loot& loot, Player const* player, LootStore const& lootstore, uint16 lootMode) const;    // Rolls an item from the group (if any) and adds the item to the loot
     float RawTotalChance() const;                       // Overall chance for the group (without equal chanced items)
@@ -1226,29 +1229,101 @@ LootStoreItem const* LootTemplate::LootGroup::Roll(Loot& loot, Player const* pla
 }
 
 // True if group includes at least 1 quest drop entry
-bool LootTemplate::LootGroup::HasQuestDrop() const
+bool LootTemplate::LootGroup::HasQuestDrop(LootTemplateMap const& store) const
 {
     for (LootStoreItemList::const_iterator i = ExplicitlyChanced.begin(); i != ExplicitlyChanced.end(); ++i)
-        if ((*i)->needs_quest)
+    {
+        LootStoreItem* item = *i;
+        if (item->reference > 0) // References
+        {
+            LootTemplateMap::const_iterator Referenced = store.find(item->reference);
+            if (Referenced == store.end())
+            {
+                continue; // Error message [should be] already printed at loading stage
+            }
+
+            if (Referenced->second->HasQuestDrop(store, item->groupid))
+            {
+                return true;
+            }
+        }
+        else if (item->needs_quest)
+        {
             return true;
+        }
+    }
 
     for (LootStoreItemList::const_iterator i = EqualChanced.begin(); i != EqualChanced.end(); ++i)
-        if ((*i)->needs_quest)
+    {
+        LootStoreItem* item = *i;
+        if (item->reference > 0) // References
+        {
+            LootTemplateMap::const_iterator Referenced = store.find(item->reference);
+            if (Referenced == store.end())
+            {
+                continue; // Error message [should be] already printed at loading stage
+            }
+
+            if (Referenced->second->HasQuestDrop(store, item->groupid))
+            {
+                return true;
+            }
+        }
+        else if (item->needs_quest)
+        {
             return true;
+        }
+    }
 
     return false;
 }
 
 // True if group includes at least 1 quest drop entry for active quests of the player
-bool LootTemplate::LootGroup::HasQuestDropForPlayer(Player const* player) const
+bool LootTemplate::LootGroup::HasQuestDropForPlayer(Player const* player, LootTemplateMap const& store) const
 {
     for (LootStoreItemList::const_iterator i = ExplicitlyChanced.begin(); i != ExplicitlyChanced.end(); ++i)
-        if (player->HasQuestForItem((*i)->itemid))
-            return true;
+    {
+        LootStoreItem* item = *i;
+        if (item->reference > 0)                        // References processing
+        {
+            LootTemplateMap::const_iterator Referenced = store.find(item->reference);
+            if (Referenced == store.end())
+            {
+                continue;                                   // Error message already printed at loading stage
+            }
+
+            if (Referenced->second->HasQuestDropForPlayer(store, player, item->groupid))
+            {
+                return true;
+            }
+        }
+        else if (player->HasQuestForItem(item->itemid))
+        {
+            return true;                                    // active quest drop found
+        }
+    }
 
     for (LootStoreItemList::const_iterator i = EqualChanced.begin(); i != EqualChanced.end(); ++i)
-        if (player->HasQuestForItem((*i)->itemid))
-            return true;
+    {
+        LootStoreItem* item = *i;
+        if (item->reference > 0)                        // References processing
+        {
+            LootTemplateMap::const_iterator Referenced = store.find(item->reference);
+            if (Referenced == store.end())
+            {
+                continue;                                   // Error message already printed at loading stage
+            }
+
+            if (Referenced->second->HasQuestDropForPlayer(store, player, item->groupid))
+            {
+                return true;
+            }
+        }
+        else if (player->HasQuestForItem(item->itemid))
+        {
+            return true;                                    // active quest drop found
+        }
+    }
 
     return false;
 }
@@ -1266,7 +1341,26 @@ void LootTemplate::LootGroup::CopyConditions(ConditionList /*conditions*/)
 void LootTemplate::LootGroup::Process(Loot& loot, Player const* player, LootStore const& store, uint16 lootMode) const
 {
     if (LootStoreItem const* item = Roll(loot, player, store, lootMode))
-        loot.AddItem(*item);
+    {
+        bool rate = store.IsRatesAllowed();
+
+        if (item->reference > 0) // References processing
+        {
+            if (LootTemplate const* Referenced = LootTemplates_Reference.GetLootFor(item->reference))
+            {
+                uint32 maxcount = uint32(float(item->maxcount) * sWorld->getRate(RATE_DROP_ITEM_REFERENCED_AMOUNT));
+                sScriptMgr->OnAfterRefCount(player, loot, rate, lootMode, const_cast<LootStoreItem*>(item), maxcount, store);
+                for (uint32 loop = 0; loop < maxcount; ++loop) // Ref multiplicator
+                    Referenced->Process(loot, store, lootMode, player, item->groupid);
+            }
+        }
+        else
+        {
+            // Plain entries (not a reference, not grouped)
+            sScriptMgr->OnBeforeDropAddItem(player, loot, rate, lootMode, const_cast<LootStoreItem*>(item), store);
+            loot.AddItem(*item); // Chance is already checked, just add
+        }
+    }
 }
 
 // Overall chance for the group without equal chanced items
@@ -1353,16 +1447,21 @@ LootTemplate::~LootTemplate()
 // Adds an entry to the group (at loading stage)
 void LootTemplate::AddEntry(LootStoreItem* item)
 {
-    if (item->groupid > 0 && item->reference == 0)            // Group
+    if (item->groupid > 0)  // Group
     {
         if (item->groupid >= Groups.size())
-            Groups.resize(item->groupid, nullptr);               // Adds new group the the loot template if needed
-        if (!Groups[item->groupid - 1])
-            Groups[item->groupid - 1] = new LootGroup();
+        {
+            Groups.resize(item->groupid, nullptr);  // Adds new group the the loot template if needed
+        }
 
-        Groups[item->groupid - 1]->AddEntry(item);            // Adds new entry to the group
+        if (!Groups[item->groupid - 1])
+        {
+            Groups[item->groupid - 1] = new LootGroup();
+        }
+
+        Groups[item->groupid - 1]->AddEntry(item);  // Adds new entry to the group
     }
-    else                                                      // Non-grouped entries and references are stored together
+    else                                            // Non-grouped entries
         Entries.push_back(item);
 }
 
@@ -1543,7 +1642,7 @@ bool LootTemplate::HasQuestDrop(LootTemplateMap const& store, uint8 groupId) con
         if (!Groups[groupId - 1])
             return false;
 
-        return Groups[groupId - 1]->HasQuestDrop();
+        return Groups[groupId - 1]->HasQuestDrop(store);
     }
 
     for (LootStoreItemList::const_iterator i = Entries.begin(); i != Entries.end(); ++i)
@@ -1554,6 +1653,7 @@ bool LootTemplate::HasQuestDrop(LootTemplateMap const& store, uint8 groupId) con
             LootTemplateMap::const_iterator Referenced = store.find(item->reference);
             if (Referenced == store.end())
                 continue;                                   // Error message [should be] already printed at loading stage
+
             if (Referenced->second->HasQuestDrop(store, item->groupid))
                 return true;
         }
@@ -1563,9 +1663,15 @@ bool LootTemplate::HasQuestDrop(LootTemplateMap const& store, uint8 groupId) con
 
     // Now processing groups
     for (LootGroups::const_iterator i = Groups.begin(); i != Groups.end(); ++i)
+    {
         if (LootGroup* group = *i)
-            if (group->HasQuestDrop())
+        {
+            if (group->HasQuestDrop(store))
+            {
                 return true;
+            }
+        }
+    }
 
     return false;
 }
@@ -1581,7 +1687,7 @@ bool LootTemplate::HasQuestDropForPlayer(LootTemplateMap const& store, Player co
         if (!Groups[groupId - 1])
             return false;
 
-        return Groups[groupId - 1]->HasQuestDropForPlayer(player);
+        return Groups[groupId - 1]->HasQuestDropForPlayer(player, store);
     }
 
     // Checking non-grouped entries
@@ -1602,9 +1708,15 @@ bool LootTemplate::HasQuestDropForPlayer(LootTemplateMap const& store, Player co
 
     // Now checking groups
     for (LootGroups::const_iterator i = Groups.begin(); i != Groups.end(); ++i)
+    {
         if (LootGroup* group = *i)
-            if (group->HasQuestDropForPlayer(player))
+        {
+            if (group->HasQuestDropForPlayer(player, store))
+            {
                 return true;
+            }
+        }
+    }
 
     return false;
 }

--- a/src/server/game/Loot/LootMgr.h
+++ b/src/server/game/Loot/LootMgr.h
@@ -117,7 +117,7 @@ struct Loot;
 struct LootStoreItem
 {
     uint32  itemid;                                         // id of the item
-    uint32  reference;                                      // referenced TemplateleId
+    int32   reference;                                      // referenced TemplateleId
     float   chance;                                         // chance to drop for both quest and non-quest items, chance to be used for refs
     bool    needs_quest : 1;                                // quest drop (quest is required for item to drop)
     uint16  lootmode;
@@ -128,7 +128,7 @@ struct LootStoreItem
 
     // Constructor
     // displayid is filled in IsValid() which must be called after
-    LootStoreItem(uint32 _itemid, uint32 _reference, float _chance, bool _needs_quest, uint16 _lootmode, uint8 _groupid, int32 _mincount, uint8 _maxcount)
+    LootStoreItem(uint32 _itemid, int32 _reference, float _chance, bool _needs_quest, uint16 _lootmode, uint8 _groupid, int32 _mincount, uint8 _maxcount)
         : itemid(_itemid), reference(_reference), chance(_chance), needs_quest(_needs_quest),
           lootmode(_lootmode), groupid(_groupid), mincount(_mincount), maxcount(_maxcount)
     {}
@@ -362,7 +362,7 @@ struct Loot
     void RemoveLooter(ObjectGuid GUID) { PlayersLooting.erase(GUID); }
 
     void generateMoneyLoot(uint32 minAmount, uint32 maxAmount);
-    bool FillLoot(uint32 lootId, LootStore const& store, Player* lootOwner, bool personal, bool noEmptyError = false, uint16 lootMode = LOOT_MODE_DEFAULT);
+    bool FillLoot(uint32 lootId, LootStore const& store, Player* lootOwner, bool personal, bool noEmptyError = false, uint16 lootMode = LOOT_MODE_DEFAULT, WorldObject* lootSource = nullptr);
 
     // Inserts the item into the loot (called by LootTemplate processors)
     void AddItem(LootStoreItem const& item);
@@ -372,12 +372,12 @@ struct Loot
     bool hasItemForAll() const;
     bool hasItemFor(Player* player) const;
     [[nodiscard]] bool hasOverThresholdItem() const;
-    void FillNotNormalLootFor(Player* player, bool presentAtLooting);
+    void FillNotNormalLootFor(Player* player);
 
 private:
     QuestItemList* FillFFALoot(Player* player);
     QuestItemList* FillQuestLoot(Player* player);
-    QuestItemList* FillNonQuestNonFFAConditionalLoot(Player* player, bool presentAtLooting);
+    QuestItemList* FillNonQuestNonFFAConditionalLoot(Player* player);
 
     typedef GuidSet PlayersLootingSet;
     PlayersLootingSet PlayersLooting;


### PR DESCRIPTION
Fixed #5781

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5781
- closes https://github.com/chromiecraft/chromiecraft/issues/600
- Might close other tickets about empty loot tables using references.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame with prospecting.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. `.additem 10620 300`
2. `.learn 31252`
3. set your prospecting to a number key and start tapping

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
