### PR TITLE
fix(DB/Quest): Changed allowed races on Fire Hardened Mail

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1629981420936961816.sql
+++ b/data/sql/updates/pending_db_world/rev_1629981420936961816.sql
@@ -1,11 +1,11 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629981420936961816');
 
--- Change the allowed race to this quest
+-- Change the allowed race to this quest (Flags: Human 1, Dwarf 4, Night elf 8, Gnome 64, Draenei 1024)
 
 -- Only human Grimand Elmore (1700)
-UPDATE `quest_template` SET `AllowableRaces` = 1 WHERE (`ID` = 1700);
+UPDATE `quest_template` SET `AllowableRaces` = `AllowableRaces`&~(4|8|64|1024) WHERE (`ID` = 1700);
 -- Only dwarfs and gnomes Klockmort Spannerspan (1704)
-UPDATE `quest_template` SET `AllowableRaces` = 68 WHERE (`ID` = 1704);
+UPDATE `quest_template` SET `AllowableRaces` = `AllowableRaces`&~(1|8|1024) WHERE (`ID` = 1704);
 -- Only night elves Mathiel (1703)
-UPDATE `quest_template` SET `AllowableRaces` = 8 WHERE (`ID` = 1703);
+UPDATE `quest_template` SET `AllowableRaces` = `AllowableRaces`&~(1|4|64|1024) WHERE (`ID` = 1703);
 

--- a/data/sql/updates/pending_db_world/rev_1629981420936961816.sql
+++ b/data/sql/updates/pending_db_world/rev_1629981420936961816.sql
@@ -1,0 +1,11 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1629981420936961816');
+
+-- Change the allowed race to this quest
+
+-- Only human Grimand Elmore (1700)
+UPDATE `quest_template` SET `AllowableRaces` = 1 WHERE (`ID` = 1700);
+-- Only dwarfs and gnomes Klockmort Spannerspan (1704)
+UPDATE `quest_template` SET `AllowableRaces` = 68 WHERE (`ID` = 1704);
+-- Only night elves Mathiel (1703)
+UPDATE `quest_template` SET `AllowableRaces` = 8 WHERE (`ID` = 1703);
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Changed allowed races on Fire Hardened Mail. Follow up quest should be race-specific.

## Changes Proposed:
- Changed the allowed races from alliance only to race specific
- Grimand Elmore (1700) is now human only
- Klockmort Spannerspan (1704) is not dwarf/gnome only
- Mathiel (1703) is now night elf only

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7549
- Closes https://github.com/chromiecraft/chromiecraft/issues/1529

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

https://tbc.wowhead.com/quest=1701/fire-hardened-mail

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- Be warrior lvl 20 (.levelup 19 on yourself)
- .quest add 1702 (required for this to pop up)
- .go c id  5413  Pick the quest fire-hardened-mail from furen-longbeard
- .quest complete 1701 ( fire-hardened-mail )
- Now we should have the 3 quest available, without race filter
- Apply the sql
- Check again. Now depending of race shoudl appear the right one

TEST

Before

![7549 before](https://user-images.githubusercontent.com/87535580/130965416-9f3c5291-1c35-4854-bd44-76c9e555c81a.jpg)

After

Human

![7549 after human](https://user-images.githubusercontent.com/87535580/130965443-5e01613b-4884-42ee-aa40-46371d480447.jpg)

Dwarf

![7549 after dwarf](https://user-images.githubusercontent.com/87535580/130965485-829668b8-d302-4991-9bfc-f71369307678.jpg)

Elf

![7549 after elf](https://user-images.githubusercontent.com/87535580/130965513-029e22be-aa6d-483d-992d-49e0209acc03.jpg)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- Be warrior lvl 20 (.levelup 19 on yourself)
- .quest add 1702 (required for this to pop up)
- .go c id  5413  Pick the quest fire-hardened-mail from furen-longbeard
- .quest complete 1701 ( fire-hardened-mail )
- Now we should have the 3 quest available, without race filter
- Apply the sql
- Check again. Now depending of race shoudl appear the right one


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
