### PR TITLE
fix(DB/quest_template_addon): Set honored requirement for "Favor Amongst the Brotherhood" quests

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630055966364700300.sql
+++ b/data/sql/updates/pending_db_world/rev_1630055966364700300.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630055966364700300');
+
+-- Set Honored rep requirement for the following quests:
+-- 6645 - [Favor Amongst the Brotherhood, Core Leather]
+-- 6646 - [Favor Amongst the Brotherhood, Blood of the Mountain]
+-- 6642 - [Favor Amongst the Brotherhood, Dark Iron Ore]
+-- 6643 - [Favor Amongst the Brotherhood, Fiery Core]
+-- 6644 - [Favor Amongst the Brotherhood, Lava Core]
+UPDATE `quest_template_addon` SET `RequiredMinRepValue` = 9000 WHERE `ID` IN ('6645', '6646', '6642', '6643', '6644');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Set Honored rep requirement in order to access to this quests.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7581

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Checked ingame before/after having the rep.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. `.go c id 12944`
2. Check that you cannot access the quests.
3. `.modify reputation 59 9000`
4. Check that you can access the quests.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
