### PR TITLE
fix(DB/quest_template_addon): Min. rep honored for "Favor Amongst the Brotherhood"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630056132119470340.sql
+++ b/data/sql/updates/pending_db_world/rev_1630056132119470340.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630056132119470340');
+
+-- Sets the minimum reputation needed to Honored (9000 rep) for the quests: Favor Amongst the Brotherhood, Blood of the Mountain, Favor Amongst the Brotherhood, Core Leather, Favor Amongst the Brotherhood, Dark Iron Ore, Favor Amongst the Brotherhood, Fiery Core, Favor Amongst the Brotherhood, Lava Core
+UPDATE `quest_template_addon` SET RequiredMinRepValue = 9000 WHERE `ID` IN (6642, 6643, 6644, 6645, 6646);


### PR DESCRIPTION

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Sets the required rep to honored (9000 rep) for all five of the "Favor Amongst the Brotherhood" quests

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7581

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors
- Checked db, looks good
- Checked in-game, quests are only available with at least honored rep with the Thorium Brotherhood


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go c 47779` 
2. he shouldn't have quests available if you are only neutral or friendly with the Thorium Brotherhood
3. `.modify reputation 59 9000` set your reputation to honored and see, that the five quests are now available

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
