### PR TITLE
fix(DB/translation):some keys Chinese translation

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630059418158443255.sql
+++ b/data/sql/updates/pending_db_world/rev_1630059418158443255.sql
@@ -1,0 +1,17 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630059418158443255');
+
+-- add `Rusty Prison Key`(id 43650) Chinese translation
+DELETE from `item_template_locale` where `ID` = 43650 AND `locale` = 'zhCN';
+INSERT INTO `item_template_locale` (`ID`,`locale`, `Name`, `Description`) VALUES ('43650','zhCN', '生锈的监狱钥匙', '看起来像一把打开水下宝箱的钥匙。。。'); 
+
+-- add `Shadowforge Key`(id 11000) Chinese translation
+DELETE from `item_template_locale` where `ID` = 11000 AND `locale` = 'zhCN';
+INSERT INTO `item_template_locale` (`ID`,`locale`, `Name`, `Description`) VALUES ('11000','zhCN', '暗炉钥匙', '通往黑石深渊的钥匙。。。'); 
+
+-- add `Heroic Key to the Focusing Iris`(id 44581) Chinese translation
+DELETE from `item_template_locale` where `ID` = 44581 AND `locale` = 'zhCN';
+INSERT INTO `item_template_locale` (`ID`, `locale`, `Name`, `Description`, `VerifiedBuild`) VALUES ('44581', 'zhCN', '英雄聚焦之虹的钥匙', '', '15050'); 
+
+-- add `Key to the Focusing Iris`(id 44582) Chinese translation
+DELETE from `item_template_locale` where `ID` = 44582 AND `locale` = 'zhCN';
+INSERT INTO `item_template_locale` (`ID`, `locale`, `Name`, `Description`, `VerifiedBuild`) VALUES ('44582', 'zhCN', '聚焦之虹的钥匙', '', '15050'); 


### PR DESCRIPTION
- add `Rusty Prison Key`(id 43650) Chinese translation
- add `Shadowforge Key`(id 11000) Chinese translation
- add `Heroic Key to the Focusing Iris`(id 44581) Chinese translation
- add `Key to the Focusing Iris`(id 44582) Chinese translation

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- no issue 

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## How to Test AzerothCore PRs
 
No testing required


http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
