### PR TITLE
 fix(DB/Loot): Change blood red key drop rate

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630085433143335851.sql
+++ b/data/sql/updates/pending_db_world/rev_1630085433143335851.sql
@@ -10,9 +10,9 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (14522, 13140, 0, 3.7, 0, 1, 0, 1, 1, 'Ur\'dan - Blood Red Key');
 -- Jaednar Darkweaver drop rate
 UPDATE `creature_loot_template` SET `Chance`= 5.6 WHERE `Entry`=7118  AND `Item`=@ITEM;
--- Jaednar Enforcer drop rate
+-- Jaednar Warlock drop rate
 UPDATE `creature_loot_template` SET `Chance`= 5.7 WHERE `Entry`=7120  AND `Item`=@ITEM;
---  Jaednar Warlock drop rate
+-- Jaednar Enforcer drop rate
 UPDATE `creature_loot_template` SET `Chance`= 6.2 WHERE `Entry`=7114  AND `Item`=@ITEM;
 -- Ulathek drop rate
 UPDATE `creature_loot_template` SET `Chance`= 4 WHERE `Entry`=14523 AND `Item`=@ITEM;

--- a/data/sql/updates/pending_db_world/rev_1630085433143335851.sql
+++ b/data/sql/updates/pending_db_world/rev_1630085433143335851.sql
@@ -1,33 +1,20 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630085433143335851');
 
--- Add lootid for Ur'dan
+SET @ITEM := 13140;
 
-DELETE FROM `creature_template` WHERE (`entry` = 14522);
-INSERT INTO `creature_template` (`entry`, `difficulty_entry_1`, `difficulty_entry_2`, `difficulty_entry_3`, `KillCredit1`, `KillCredit2`, `modelid1`, `modelid2`, `modelid3`, `modelid4`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `scale`, `rank`, `dmgschool`, `DamageModifier`, `BaseAttackTime`, `RangeAttackTime`, `BaseVariance`, `RangeVariance`, `unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`, `family`, `trainer_type`, `trainer_spell`, `trainer_class`, `trainer_race`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `PetSpellDataId`, `VehicleId`, `mingold`, `maxgold`, `AIName`, `MovementType`, `InhabitType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `RacialLeader`, `movementId`, `RegenHealth`, `mechanic_immune_mask`, `spell_school_immune_mask`, `flags_extra`, `ScriptName`, `VerifiedBuild`) VALUES
-(14522, 0, 0, 0, 0, 0, 14564, 0, 0, 0, 'Ur\'dan', NULL, NULL, 0, 54, 54, 0, 1434, 129, 1, 1.14286, 1, 0, 0, 1, 2000, 2000, 1, 1, 2, 32768, 2048, 0, 0, 0, 0, 0, 0, 7, 0, 14522, 0, 0, 0, 0, 100, 136, '', 0, 3, 1, 1.3, 1, 1, 0, 0, 1, 0, 0, 0, '', 12340);
-
--- Change drop rate
-
-DELETE FROM `creature_loot_template` WHERE (`Entry` = 7118) AND (`Item` IN (13140));
-INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(7118, 13140, 0, 5.6, 0, 1, 0, 1, 1, 'Jaedenar Darkweaver - Blood Red Key');
-
-DELETE FROM `creature_loot_template` WHERE (`Entry` = 7120) AND (`Item` IN (13140));
-INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(7120, 13140, 0, 5.7, 0, 1, 0, 1, 1, 'Jaedenar Warlock - Blood Red Key');
-
-DELETE FROM `creature_loot_template` WHERE (`Entry` = 7114) AND (`Item` IN (13140));
-INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(7114, 13140, 0, 6.2, 0, 1, 0, 1, 1, 'Jaedenar Enforcer - Blood Red Key');
-
-DELETE FROM `creature_loot_template` WHERE (`Entry` = 14523) AND (`Item` IN (13140));
-INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(14523, 13140, 0, 4, 0, 1, 0, 1, 1, 'Ulathek - Blood Red Key');
- 
-DELETE FROM `creature_loot_template` WHERE (`Entry` = 14522) AND (`Item` IN (13140));
+-- Add Ur'dan to loot table
+UPDATE `creature_template` SET `lootid`= 14522 WHERE `entry` = 14522;
+-- Ur'dan drop rate
+DELETE FROM `creature_loot_template` WHERE `Entry` = 14522 AND `Item`= 13140;
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (14522, 13140, 0, 3.7, 0, 1, 0, 1, 1, 'Ur\'dan - Blood Red Key');
-
-DELETE FROM `creature_loot_template` WHERE (`Entry` = 9862) AND (`Item` IN (13140));
-INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(9862, 13140, 0, 3.1, 0, 1, 0, 1, 1, 'Jaedenar Legionnaire - Blood Red Key');
+-- Jaednar Darkweaver drop rate
+UPDATE `creature_loot_template` SET `Chance`= 5.6 WHERE `Entry`=7118  AND `Item`=@ITEM;
+-- Jaednar Enforcer drop rate
+UPDATE `creature_loot_template` SET `Chance`= 5.7 WHERE `Entry`=7120  AND `Item`=@ITEM;
+--  Jaednar Warlock drop rate
+UPDATE `creature_loot_template` SET `Chance`= 6.2 WHERE `Entry`=7114  AND `Item`=@ITEM;
+-- Ulathek drop rate
+UPDATE `creature_loot_template` SET `Chance`= 4 WHERE `Entry`=14523 AND `Item`=@ITEM;
+-- Jaedenar Legionaire drop rate
+UPDATE `creature_loot_template` SET `Chance`=3.1 WHERE `Entry`=9862  AND `Item`=@ITEM;

--- a/data/sql/updates/pending_db_world/rev_1630085433143335851.sql
+++ b/data/sql/updates/pending_db_world/rev_1630085433143335851.sql
@@ -1,0 +1,33 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630085433143335851');
+
+-- Add lootid for Ur'dan
+
+DELETE FROM `creature_template` WHERE (`entry` = 14522);
+INSERT INTO `creature_template` (`entry`, `difficulty_entry_1`, `difficulty_entry_2`, `difficulty_entry_3`, `KillCredit1`, `KillCredit2`, `modelid1`, `modelid2`, `modelid3`, `modelid4`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `scale`, `rank`, `dmgschool`, `DamageModifier`, `BaseAttackTime`, `RangeAttackTime`, `BaseVariance`, `RangeVariance`, `unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`, `family`, `trainer_type`, `trainer_spell`, `trainer_class`, `trainer_race`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `PetSpellDataId`, `VehicleId`, `mingold`, `maxgold`, `AIName`, `MovementType`, `InhabitType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `RacialLeader`, `movementId`, `RegenHealth`, `mechanic_immune_mask`, `spell_school_immune_mask`, `flags_extra`, `ScriptName`, `VerifiedBuild`) VALUES
+(14522, 0, 0, 0, 0, 0, 14564, 0, 0, 0, 'Ur\'dan', NULL, NULL, 0, 54, 54, 0, 1434, 129, 1, 1.14286, 1, 0, 0, 1, 2000, 2000, 1, 1, 2, 32768, 2048, 0, 0, 0, 0, 0, 0, 7, 0, 14522, 0, 0, 0, 0, 100, 136, '', 0, 3, 1, 1.3, 1, 1, 0, 0, 1, 0, 0, 0, '', 12340);
+
+-- Change drop rate
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 7118) AND (`Item` IN (13140));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(7118, 13140, 0, 5.6, 0, 1, 0, 1, 1, 'Jaedenar Darkweaver - Blood Red Key');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 7120) AND (`Item` IN (13140));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(7120, 13140, 0, 5.7, 0, 1, 0, 1, 1, 'Jaedenar Warlock - Blood Red Key');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 7114) AND (`Item` IN (13140));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(7114, 13140, 0, 6.2, 0, 1, 0, 1, 1, 'Jaedenar Enforcer - Blood Red Key');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 14523) AND (`Item` IN (13140));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(14523, 13140, 0, 4, 0, 1, 0, 1, 1, 'Ulathek - Blood Red Key');
+ 
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 14522) AND (`Item` IN (13140));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(14522, 13140, 0, 3.7, 0, 1, 0, 1, 1, 'Ur\'dan - Blood Red Key');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 9862) AND (`Item` IN (13140));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(9862, 13140, 0, 3.1, 0, 1, 0, 1, 1, 'Jaedenar Legionnaire - Blood Red Key');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Drop rate of the Blood Red Key is different from the drop rate on TBC Wowhead.
Added missing lootid for Dur'an since Keira3 can't open creature loot template without lootid value

## Changes Proposed:
-  Changes drop rate for Blood Red Key

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7498
- Closes 
https://github.com/chromiecraft/chromiecraft/issues/1498

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/item=13140/blood-red-key

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Apply SQL via HeidiSQL, no error
  
![image](https://user-images.githubusercontent.com/44707108/131208071-b87efb97-abf2-41c4-ac1d-2ab6fa7c4a17.png)

- Check via SQL Statement
 
  BEFORE

```
mysql> SELECT ct.name, clt.chance
    -> FROM `creature_template` ct
    -> LEFT JOIN `creature_loot_template` clt ON ct.lootid = clt.entry
    -> JOIN `item_template` it ON clt.item = it.entry
    -> WHERE it.entry = 13140
    -> ORDER BY clt.chance DESC LIMIT 5;
+----------------------+--------+
| name                 | chance |
+----------------------+--------+
| Jaedenar Darkweaver  | 3.6381 |
| Jaedenar Warlock     | 3.4858 |
| Jaedenar Enforcer    | 3.4631 |
| Ulathek              | 3.0488 |
| Jaedenar Legionnaire | 2.6372 |
+----------------------+--------+
5 rows in set (0.32 sec)
```


AFTER

```
mysql> SELECT ct.name, clt.chance
    -> FROM `creature_template` ct
    -> LEFT JOIN `creature_loot_template` clt ON ct.lootid = clt.entry
    -> JOIN `item_template` it ON clt.item = it.entry
    -> WHERE it.entry = 13140
    -> ORDER BY clt.chance DESC LIMIT 10;
+----------------------+--------+
| name                 | chance |
+----------------------+--------+
| Jaedenar Enforcer    |    6.2 |
| Jaedenar Warlock     |    5.7 |
| Jaedenar Darkweaver  |    5.6 |
| Ulathek              |      4 |
| Ur'dan               |    3.7 |
| Jaedenar Legionnaire |    3.1 |
+----------------------+--------+
6 rows in set (0.15 sec)
```

- Tested on local server / Win 10 64 Bit

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Ur'dan
![WoWScrnShot_082821_124238](https://user-images.githubusercontent.com/44707108/131207840-73de93d5-fdec-404e-bb1e-14d765ad6d11.jpg)

2. Jaedenar Legionnaire
![WoWScrnShot_082821_124253](https://user-images.githubusercontent.com/44707108/131207845-c8c94f3b-bb5b-49f6-8b14-b1e3249e8e57.jpg)

3. Jaedenar Darkweaver
![WoWScrnShot_082821_124327](https://user-images.githubusercontent.com/44707108/131207847-e050473f-56e4-4bc4-a0d5-f29cda81d9ed.jpg)

4. Jaedenar Warlock  
![WoWScrnShot_082821_124334](https://user-images.githubusercontent.com/44707108/131207848-5f2a618b-24e8-418f-b903-dee0645fe855.jpg)

5. Jaedenar Enforcer
![WoWScrnShot_082821_124449](https://user-images.githubusercontent.com/44707108/131207849-ca4f6997-3027-4707-8a49-415646428c94.jpg)

6. Ulathek
![WoWScrnShot_082821_125821](https://user-images.githubusercontent.com/44707108/131208031-56e421d7-2ff3-4b18-97cd-5e6e93d2673f.jpg)


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
