### PR TITLE
fix(DB/gameobject_loot): Delete incorrect items from Alterac Granite …

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630118063882922979.sql
+++ b/data/sql/updates/pending_db_world/rev_1630118063882922979.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630118063882922979');
+
+-- Delete all items except Alterac Granite from Alterac Granite spawns
+DELETE FROM `gameobject_loot_template` WHERE `Entry` = 2145 AND `Item` <> 4521;
+


### PR DESCRIPTION
…loot

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Deletes 115 items from game object Alterac Granite (ID 2714) loot table. These items were weapons, armour, cloth, and other quest items, and were not correct for this game object. The only item now remaining is item Alterac Granite (ID 4521) with a 100% drop rate.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7596
- Closes https://github.com/chromiecraft/chromiecraft/issues/1563

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/object=2714/alterac-granite

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnins, 115 rows deleted as expected.
- Tested in-game. Granite now drops granite only, no other items found while completing quest:

![WoWScrnShot_082821_122812](https://user-images.githubusercontent.com/81782124/131204341-27a495ed-5013-4f75-a924-3b5a2eddb62f.jpg)
![WoWScrnShot_082821_122842](https://user-images.githubusercontent.com/81782124/131204346-7bd06596-3a16-4e2a-afe6-e0a59e69cf53.jpg)
![WoWScrnShot_082821_122857](https://user-images.githubusercontent.com/81782124/131204348-0ab1182c-0eaf-43a0-ae8a-3516d061a322.jpg)
![WoWScrnShot_082821_122940](https://user-images.githubusercontent.com/81782124/131204349-edcd357e-0c3e-4121-8492-abb9a6e55062.jpg)
![WoWScrnShot_082821_123003](https://user-images.githubusercontent.com/81782124/131204350-c5db7fbd-5cb2-4594-8c71-778b4b0a89ab.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Have a character with at least level 25
2. .quest add 689
3. .go o 20781
4. Interact with object 'Alterac Granite'
5. Pay attention to items offered in the loot
6. 
Or more directly, view 2145 in the gameobject_loot_template table.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
