### PR TITLE
fix(DB/GO): Repositioning of a Small Thorium Vein

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630089240125826910.sql
+++ b/data/sql/updates/pending_db_world/rev_1630089240125826910.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630089240125826910');
+
+-- Decreases the respawntime for Garrick Padfoot to 90 s
+UPDATE `creature` SET `spawntimesecs` = 90 WHERE `id` = 103 AND `guid` IN (80247);

--- a/data/sql/updates/pending_db_world/rev_1630089240125826910.sql
+++ b/data/sql/updates/pending_db_world/rev_1630089240125826910.sql
@@ -1,4 +1,0 @@
-INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630089240125826910');
-
--- Decreases the respawntime for Garrick Padfoot to 90 s
-UPDATE `creature` SET `spawntimesecs` = 90 WHERE `id` = 103 AND `guid` IN (80247);

--- a/data/sql/updates/pending_db_world/rev_1630139869353251128.sql
+++ b/data/sql/updates/pending_db_world/rev_1630139869353251128.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630139869353251128');
+
+-- Slightly changes the position of a Small Thorium Vein so it can be mined
+UPDATE `gameobject` SET `position_x` = -7275, `position_y` = -788, `position_z` = 299.15 WHERE `id` = 324 AND `guid` = 154;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Slightly changes the position of a Small Thorium Vein (guid = 154), so that is not in the rock and can be mined

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7574
- Closes https://github.com/chromiecraft/chromiecraft/issues/1554

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors
- checked in-game
- looks good and can be mined now


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go gobject 154`
2. check that it is there
3. if not spawned, check with the coordinates of the object with `.gobject near` or check the db

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
