### PR TITLE
fix(DB/gameobject_loot): Correct Rich Thorium Vein drops

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630148697901793648.sql
+++ b/data/sql/updates/pending_db_world/rev_1630148697901793648.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630148697901793648');
+
+-- Minimum of 3 Thorium Ore drops from Rich Thorium Vein
+UPDATE `gameobject_loot_template` SET `MinCount` = 3 WHERE `Item` = 10620 AND `Entry` = 12883;
+-- Minimum of 4 Dense Stone drops from Rich Thorium Vein
+UPDATE `gameobject_loot_template` SET `MinCount` = 4 WHERE `Item` = 12365 AND `Entry` = 12883;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Changes the minimum amount of Rich Thorium (ID 10620) mined from Rich Thorium Veins and Ooze Covered Thorium Veins from 1 to 3. This results in 3-5 units mined.
- Changes the minimum amount of Dense Stone (ID 12365) mined from Rich Thorium Veins and Ooze Covered Thorium Veins from 1 to 4. This results in a 50% chance of 4-7 units mined.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7578
- Closes https://github.com/chromiecraft/chromiecraft/issues/1485

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowpedia.fandom.com/wiki/Thorium_Ore
https://wotlkdb.com/?object=175404
https://wotlk.evowow.com/?object=175404

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, 2 rows changed as expected.
- Tested in-game. All nodes mined conformed to new minimum drops.

![WoWScrnShot_082821_204200](https://user-images.githubusercontent.com/81782124/131216128-6089dc9b-d514-4805-b1b6-e6754cebb881.jpg)
![WoWScrnShot_082821_204139](https://user-images.githubusercontent.com/81782124/131216127-c9506db5-8fc7-4463-a967-f65349045aee.jpg)
![WoWScrnShot_082821_204127](https://user-images.githubusercontent.com/81782124/131216122-09779b80-7956-4238-9405-2d52aed53f51.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .set 185 255/300
2. .additem 2901
3. .go object 39945
4. Mine and count how much ore you get
5. Repeat with other nodes in the area
6. Or look in the DB.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
