### PR TITLE
fix(DB/Creature): Change respawn timer and added movement to The Husk

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630158070330132264.sql
+++ b/data/sql/updates/pending_db_world/rev_1630158070330132264.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630158070330132264');
+
+-- Added movement for The Husk
+DELETE FROM `creature` WHERE (`id` = 1851) AND (`guid` IN (53933));
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(53933, 1851, 0, 0, 0, 1, 1, 0, 0, 2325.76, -2255.95, 47.0159, 1.90398, 72000, 5, 0, 4370, 0, 1, 0, 0, 0, '', 0);
+
+-- Set The Husk respawn to 32 hours
+UPDATE `creature` SET `spawntimesecs` = 115200 WHERE `id` = 1851 AND `guid` = 53933;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change respawn from 20 hours to 32 hours
-  Add random movement for The Husk

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7558
- Closes https://github.com/chromiecraft/chromiecraft/issues/1540

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/npc=1851/the-husk
https://youtu.be/wxcbnYbk_uY?t=121
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Run SQL via Heidisql, 4 affected rows, no error.
![image](https://user-images.githubusercontent.com/44707108/131221087-4fd92c08-63e8-4cb0-a99f-33bbbd9617e1.png)
- Check via in-game

https://user-images.githubusercontent.com/44707108/131220449-f5717733-039a-4e81-8d50-08bf12ffd37e.mp4

- Tested on local server / Win 10 64Bit

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 53933
2. Observe movement
3. Check databases using keira3


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
