### PR TITLE
fix(Core/Creatures): Creatures' guardian should not despawn on summon…

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10394,11 +10394,6 @@ void Unit::RemoveAllControlled(bool onDeath /*= false*/)
 
     if (showErrors)
     {
-        if (GetPetGUID())
-        {
-            LOG_FATAL("entities.unit", "Unit %u is not able to release its pet %s", GetEntry(), GetPetGUID().ToString().c_str());
-        }
-
         if (GetMinionGUID())
         {
             LOG_FATAL("entities.unit", "Unit %u is not able to release its minion %s", GetEntry(), GetMinionGUID().ToString().c_str());
@@ -10504,6 +10499,7 @@ void Unit::RemoveCharmAuras()
 
 void Unit::UnsummonAllTotems(bool onDeath /*= false*/)
 {
+    bool showErrors = true;
     for (uint8 i = 0; i < MAX_SUMMON_SLOT; ++i)
     {
         if (!m_SummonSlot[i])
@@ -10519,7 +10515,19 @@ void Unit::UnsummonAllTotems(bool onDeath /*= false*/)
                 {
                     OldTotem->ToTempSummon()->UnSummon();
                 }
+                else
+                {
+                    showErrors = false;
+                }
             }
+        }
+    }
+
+    if (showErrors)
+    {
+        if (GetPetGUID())
+        {
+            LOG_FATAL("entities.unit", "Unit %u is not able to release its pet %s", GetEntry(), GetPetGUID().ToString().c_str());
         }
     }
 }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10366,6 +10366,7 @@ void Unit::RemoveAllControlled(bool onDeath /*= false*/)
     if (GetTypeId() == TYPEID_PLAYER)
         ToPlayer()->StopCastingCharm();
 
+    bool showErrors = true;
     while (!m_Controlled.empty())
     {
         Unit* target = *m_Controlled.begin();
@@ -10380,6 +10381,10 @@ void Unit::RemoveAllControlled(bool onDeath /*= false*/)
             {
                 target->ToTempSummon()->UnSummon();
             }
+            else
+            {
+                showErrors = false;
+            }
         }
         else
         {
@@ -10387,19 +10392,22 @@ void Unit::RemoveAllControlled(bool onDeath /*= false*/)
         }
     }
 
-    if (GetPetGUID())
+    if (showErrors)
     {
-        LOG_FATAL("entities.unit", "Unit %u is not able to release its pet %s", GetEntry(), GetPetGUID().ToString().c_str());
-    }
+        if (GetPetGUID())
+        {
+            LOG_FATAL("entities.unit", "Unit %u is not able to release its pet %s", GetEntry(), GetPetGUID().ToString().c_str());
+        }
 
-    if (GetMinionGUID())
-    {
-        LOG_FATAL("entities.unit", "Unit %u is not able to release its minion %s", GetEntry(), GetMinionGUID().ToString().c_str());
-    }
+        if (GetMinionGUID())
+        {
+            LOG_FATAL("entities.unit", "Unit %u is not able to release its minion %s", GetEntry(), GetMinionGUID().ToString().c_str());
+        }
 
-    if (GetCharmGUID())
-    {
-        LOG_FATAL("entities.unit", "Unit %u is not able to release its charm %s", GetEntry(), GetCharmGUID().ToString().c_str());
+        if (GetCharmGUID())
+        {
+            LOG_FATAL("entities.unit", "Unit %u is not able to release its charm %s", GetEntry(), GetCharmGUID().ToString().c_str());
+        }
     }
 }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10494,16 +10494,25 @@ void Unit::RemoveCharmAuras()
     RemoveAurasByType(SPELL_AURA_AOE_CHARM);
 }
 
-void Unit::UnsummonAllTotems()
+void Unit::UnsummonAllTotems(bool onDeath /*= false*/)
 {
     for (uint8 i = 0; i < MAX_SUMMON_SLOT; ++i)
     {
         if (!m_SummonSlot[i])
+        {
             continue;
+        }
 
         if (Creature* OldTotem = GetMap()->GetCreature(m_SummonSlot[i]))
+        {
             if (OldTotem->IsSummon())
-                OldTotem->ToTempSummon()->UnSummon();
+            {
+                if (!(onDeath && !IsPlayer() && OldTotem->IsGuardian()))
+                {
+                    OldTotem->ToTempSummon()->UnSummon();
+                }
+            }
+        }
     }
 }
 
@@ -13589,7 +13598,7 @@ void Unit::setDeathState(DeathState s, bool despawn)
         if (IsNonMeleeSpellCast(false))
             InterruptNonMeleeSpells(false);
 
-        UnsummonAllTotems();
+        UnsummonAllTotems(true);
         RemoveAllControlled(true);
         RemoveAllAurasOnDeath();
     }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10366,7 +10366,6 @@ void Unit::RemoveAllControlled(bool onDeath /*= false*/)
     if (GetTypeId() == TYPEID_PLAYER)
         ToPlayer()->StopCastingCharm();
 
-    bool showErrors = true;
     while (!m_Controlled.empty())
     {
         Unit* target = *m_Controlled.begin();
@@ -10381,27 +10380,10 @@ void Unit::RemoveAllControlled(bool onDeath /*= false*/)
             {
                 target->ToTempSummon()->UnSummon();
             }
-            else
-            {
-                showErrors = false;
-            }
         }
         else
         {
             LOG_ERROR("entities.unit", "Unit %u is trying to release unit %u which is neither charmed nor owned by it", GetEntry(), target->GetEntry());
-        }
-    }
-
-    if (showErrors)
-    {
-        if (GetMinionGUID())
-        {
-            LOG_FATAL("entities.unit", "Unit %u is not able to release its minion %s", GetEntry(), GetMinionGUID().ToString().c_str());
-        }
-
-        if (GetCharmGUID())
-        {
-            LOG_FATAL("entities.unit", "Unit %u is not able to release its charm %s", GetEntry(), GetCharmGUID().ToString().c_str());
         }
     }
 }
@@ -10499,7 +10481,6 @@ void Unit::RemoveCharmAuras()
 
 void Unit::UnsummonAllTotems(bool onDeath /*= false*/)
 {
-    bool showErrors = true;
     for (uint8 i = 0; i < MAX_SUMMON_SLOT; ++i)
     {
         if (!m_SummonSlot[i])
@@ -10520,14 +10501,6 @@ void Unit::UnsummonAllTotems(bool onDeath /*= false*/)
                     showErrors = false;
                 }
             }
-        }
-    }
-
-    if (showErrors)
-    {
-        if (GetPetGUID())
-        {
-            LOG_FATAL("entities.unit", "Unit %u is not able to release its pet %s", GetEntry(), GetPetGUID().ToString().c_str());
         }
     }
 }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10496,10 +10496,6 @@ void Unit::UnsummonAllTotems(bool onDeath /*= false*/)
                 {
                     OldTotem->ToTempSummon()->UnSummon();
                 }
-                else
-                {
-                    showErrors = false;
-                }
             }
         }
     }

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2244,7 +2244,7 @@ public:
     void ModifyAuraState(AuraStateType flag, bool apply);
     uint32 BuildAuraStateUpdateForTarget(Unit* target) const;
     bool HasAuraState(AuraStateType flag, SpellInfo const* spellProto = nullptr, Unit const* Caster = nullptr) const;
-    void UnsummonAllTotems();
+    void UnsummonAllTotems(bool onDeath = false);
     Unit* GetMagicHitRedirectTarget(Unit* victim, SpellInfo const* spellInfo);
     Unit* GetMeleeHitRedirectTarget(Unit* victim, SpellInfo const* spellInfo = nullptr);
 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1918,7 +1918,7 @@ public:
 
     ControlSet m_Controlled;
     [[nodiscard]] Unit* GetFirstControlled() const;
-    void RemoveAllControlled();
+    void RemoveAllControlled(bool onDeath = false);
 
     [[nodiscard]] bool IsCharmed() const { return GetCharmerGUID(); }
     [[nodiscard]] bool isPossessed() const { return HasUnitState(UNIT_STATE_POSSESSED); }


### PR DESCRIPTION
…er's death.

Fixes #6211

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6211
- Closes https://github.com/chromiecraft/chromiecraft/issues/767

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Go to Barrens, near 55 ; 26, and find a Razormane Hunter.
2. Kill the Razormane Hunter while not killing the Wolf.
3. See the Razormane Wolf is alive as the Hunter dies.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
