### PR TITLE
fix(Core/GameEvents): Attempt to fix holiday game events endind to ea…

### DIFF
--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1767,6 +1767,8 @@ void GameEventMgr::SetHolidayEventTime(GameEventData& event)
         stageOffset += holiday->Duration[i] * HOUR;
     }
 
+    event.length += stageOffset / MINUTE;
+
     switch (holiday->CalendarFilterType)
     {
         case -1: // Yearly


### PR DESCRIPTION
…rly. Author:  sirikfoll

Fixes #6345

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Ported from https://github.com/TrinityCore/TrinityCore/issues/25550#issuecomment-881110808
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6345
- Closes https://github.com/chromiecraft/chromiecraft/issues/858

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Change server clock to some time after 12:01 AM on the 11th and before 11:59 PM on the 12th, when the DMF should be going, and start the server. Then visit Goldshire in Elwynn Forest (the DMF is a bit south of it) and note it's not there.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
