### PR TITLE
fix(DB/Creature): Added new spawn to Masophet the Black and more

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630335615911208914.sql
+++ b/data/sql/updates/pending_db_world/rev_1630335615911208914.sql
@@ -6,7 +6,7 @@ UPDATE `creature_template` SET `InhabitType` = 4 WHERE (`entry` = 10415);
 -- Added one spawn points to Masophet the Black (16249) in the left Ziggurat
 DELETE FROM `creature` WHERE (`id` = 16249) AND (`guid` IN (152293));
 INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
-(152293, 16249, 530, 0, 0, 1, 1, 0, 1, 6311.317, -6250.117, 86.2826, 2, 300, 0, 0, 486, 1202, 0, 0, 0, 0, '', 0);
+(152293, 16249, 530, 0, 0, 1, 1, 0, 1, 6311.317, -6250.117, 80.81, 2, 300, 0, 0, 486, 1202, 0, 0, 0, 0, '', 0);
 
 -- Add the new spawn to the same spawn pool so he can only be spawned once at a time
 DELETE FROM `pool_template` WHERE `entry` = 373;

--- a/data/sql/updates/pending_db_world/rev_1630335615911208914.sql
+++ b/data/sql/updates/pending_db_world/rev_1630335615911208914.sql
@@ -1,0 +1,26 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630335615911208914');
+
+-- Fixed the Ash'ari Crystal (10415) dropping into the ground
+UPDATE `creature_template` SET `InhabitType` = 4 WHERE (`entry` = 10415);
+
+-- Added one spawn points to Masophet the Black (16249) in the left Ziggurat
+DELETE FROM `creature` WHERE (`id` = 16249) AND (`guid` IN (152293));
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(152293, 16249, 530, 0, 0, 1, 1, 0, 1, 6311.317, -6250.117, 86.2826, 2, 300, 0, 0, 486, 1202, 0, 0, 0, 0, '', 0);
+
+-- Add the new spawn to the same spawn pool so he can only be spawned once at a time
+DELETE FROM `pool_template` WHERE `entry` = 373;
+INSERT INTO `pool_template` (`entry`, `max_limit`, `description`)  VALUES (373, 1, "Masophet the Black Spawns");
+
+DELETE FROM `pool_creature` WHERE `guid` IN (82907, 152293);
+INSERT INTO `pool_creature` (`guid`, `pool_entry`, `chance`, `description`) VALUES 
+(82907, 373, 0, "Masophet the Black Spawn 1"),
+(152293, 373, 0, "Masophet the Black Spawn 2");
+
+-- Add the 3 Deatholme Necromancer missing there
+DELETE FROM `creature` WHERE (`id` = 16317) AND (`guid` IN (152294, 152295, 152296));
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(152294, 16317, 530, 0, 0, 1, 1, 0, 1, 6306.93, -6257.11, 77.81, 1.20, 300, 0, 0, 377, 408, 0, 0, 0, 0, '', 0),
+(152295, 16317, 530, 0, 0, 1, 1, 0, 1, 6301.00, -6240.72, 77.81, 5.49, 300, 0, 0, 377, 408, 0, 0, 0, 0, '', 0),
+(152296, 16317, 530, 0, 0, 1, 1, 0, 1, 6315.15, -6236.77, 77.81, 4.35, 300, 0, 0, 377, 408, 0, 0, 0, 0, '', 0);
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
While i was working on it i realized that some crystals were dropping from the sky.
The item falling its a Ash'ari Crystal (10415).
https://wotlk-twinhead.twinstar.cz/?npc=10415
I changed their habitat so its air only and they stay on it. Please if they should go to the ground at some point tell me so we can see the better fix.
Also i added for Masophet the Black a new spawn with 3 new Deatholme Necromancer ready to defend him from some heroes.

## Changes Proposed:
-  Changed habitat for  Ash'ari Crystal (10415) to only air
- Added new spawn to Masophet the Black
- Added 3 new spawns to Deatholme Necromancer inside the same ziggurat

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7614
- Closes https://github.com/chromiecraft/chromiecraft/issues/1571

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/npc=16249/masophet-the-black#comments

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .go c 152293
- Check the new spawn and check that there are 3 new necromancers there
- Check that no crystal is dropping into your head

Pictures

New crystals

![ziggurats floating](https://user-images.githubusercontent.com/87535580/131360748-43068373-c975-482b-9755-76b0c15f1d08.jpg)

New spawns

![new spawn masophet](https://user-images.githubusercontent.com/87535580/131360801-ec35ed15-f358-4c02-be10-1751c18d3241.JPG)

![3 new spawns  Deatholme Necromancer](https://user-images.githubusercontent.com/87535580/131360810-30a85a5b-d5dc-49b8-b62f-2e81e1cc48c9.JPG)

Videos of the dropings

https://user-images.githubusercontent.com/87535580/131360877-ce90aa28-49bb-4c1c-9818-6f5f5890489d.mp4


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 152293
2. Check the new spawn and check that there are 3 new necromancers there
3.  Check that no crystal is dropping into your head

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
