### PR TITLE
fix(DB/Gameobject_loot): Remove Rethban/Underlight ores from non-zone…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630334062369804993.sql
+++ b/data/sql/updates/pending_db_world/rev_1630334062369804993.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630334062369804993');
+
+-- Remove Rethban and Underlight ores from non-specific area drops
+DELETE FROM `gameobject_loot_template` WHERE `Entry` IN (1502, 1503) AND `Item` IN (2798, 22634);
+
+-- Change Tirisfal outlier node to standard non-Redridge copper node 
+UPDATE `gameobject` SET `id` = 1731 WHERE `id` = 2055 AND `guid` = 5483;
+


### PR DESCRIPTION
… ores

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Deletes Rethban ore (ID 2798) and Underlight ore (ID 22634) from gameobject_loot_templates 1502 and 1503. These were used by various copper and tin ore nodes that spawned all over the map. As the two unique ores are only supposed to be mined in Redridge and Ghostlands respectively, this was causing incorrect drops. The two unique ores are still contained in some other object types with much smaller numbers of spawns that are concentrated in the correct areas.
- Also changes a copper node in Tirisfal from entry 2055 (Redridge variety that does contain Rethban) to 1731 (normal type that doesn't.) This is because the rest of the spawns of type 2055 were correctly in Redridge, just this one was outside it.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7637
- Closes https://github.com/chromiecraft/chromiecraft/issues/1583

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/item=2798/rethban-ore#comments
https://wowpedia.fandom.com/wiki/Underlight_Ore
https://tbc.wowhead.com/item=22634/underlight-ore

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, correct number of rows changed.
- Checked in game, following tests described below:
1. Check copper ID 1731 - .go o 4649 - verify no Rethban or Underlight

![WoWScrnShot_083121_004145](https://user-images.githubusercontent.com/81782124/131361712-2c9e0a7a-fd6d-4905-9c50-b1033c62533b.jpg)

2. Check tin ID 103711 - .go o 13059 - verify no Rethban or Underlight

![WoWScrnShot_083121_004103](https://user-images.githubusercontent.com/81782124/131361650-1f201d01-913e-46dc-a903-0a1407851297.jpg)

3. Check tin ID 1732 - .go o 5485 - verify no Rethban or Underlight

![WoWScrnShot_083121_003110](https://user-images.githubusercontent.com/81782124/131361799-69e7d6a2-6013-4360-a172-cd8594a36bbb.jpg)

4. .quest add 347 - gives Rethban Ore quest - https://tbc.wowhead.com/quest=347/rethban-ore
5. Check tin ID 2054 - .go o 5511 - verify you're in Redridge and Rethban drops

![WoWScrnShot_083121_003412](https://user-images.githubusercontent.com/81782124/131361847-abb2e8b7-c167-4d21-9440-4e05d6f95633.jpg)

6. Check copper ID 2055 - .go o 4669 - verify you're in Redridge and Rethban drops

![WoWScrnShot_083121_003533](https://user-images.githubusercontent.com/81782124/131361881-25ff718d-73d0-4ad0-8619-d0f5936515cd.jpg)

7. .quest add 9207 - gives Underlight Ore Samples quest - https://tbc.wowhead.com/quest=9207/underlight-ore-samples
8. Check copper ID 181248 - .go o 64800 - verify you're in Underlight Mine in Ghostlands and Underlight ore drops

![WoWScrnShot_083121_003834](https://user-images.githubusercontent.com/81782124/131361929-fbb71b40-6d35-41fc-be02-5ca0f519b459.jpg)

9. Check tin ID 181249 - .go o 64801 - verify you're in Underlight Mine in Ghostlands and Underlight ore drops

![WoWScrnShot_083121_003947](https://user-images.githubusercontent.com/81782124/131361939-260a3f43-f5d7-449f-88f9-b88b509c98c3.jpg)

10. Check copper node 5483 is of type 1731 now, and only drops copper even with the Rethban quest active:

![WoWScrnShot_083121_004454](https://user-images.githubusercontent.com/81782124/131362309-b8278204-62ff-43e3-9458-1016879707b8.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check copper ID 1731 - .go o 4649 - verify no Rethban or Underlight
2. Check tin ID 103711 - .go o 13059 - verify no Rethban or Underlight
3. Check tin ID 1732 - .go o 5485 - verify no Rethban or Underlight
4. .quest add 347 - gives Rethban Ore quest - https://tbc.wowhead.com/quest=347/rethban-ore
5. Check tin ID 2054 - .go o 5511 - verify you're in Redridge and Rethban drops
6. Check copper ID 2055 - .go o 4669 - verify you're in Redridge and Rethban drops
7. .quest add 9207 - gives Underlight Ore Samples quest - https://tbc.wowhead.com/quest=9207/underlight-ore-samples
8. Check copper ID 181248 - .go o 64800 - verify you're in Underlight Mine in Ghostlands and Underlight ore drops
9. Check tin ID 181249 - .go o 64801 - verify you're in Underlight Mine in Ghostlands and Underlight ore drops
10. Check copper node 5483 is of type 1731 now, and only drops copper even with the Rethban quest active:

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
