### PR TITLE
fix(Scripts/Spells): Unlit Torches cannot be used too far away from t…

### DIFF
--- a/src/server/scripts/Events/midsummer.cpp
+++ b/src/server/scripts/Events/midsummer.cpp
@@ -389,15 +389,23 @@ public:
         bool handled;
         bool Load() override { handled = false; return true; }
 
+        SpellCastResult CheckCast()
+        {
+            GetCaster()->GetCreaturesWithEntryInRange(_crList, 100.0f, NPC_TORCH_TARGET);
+            if (_crList.empty())
+            {
+                return SPELL_FAILED_NOT_HERE;
+            }
+
+            return SPELL_CAST_OK;
+        }
+
         void ThrowNextTorch(Unit* caster)
         {
-            std::list<Creature*> crList;
-            caster->GetCreaturesWithEntryInRange(crList, 100.0f, NPC_TORCH_TARGET);
-
-            uint8 rand = urand(0, crList.size() - 1);
+            uint8 rand = urand(0, _crList.size() - 1);
             Position pos;
             pos.Relocate(0.0f, 0.0f, 0.0f);
-            for (std::list<Creature*>::const_iterator itr = crList.begin(); itr != crList.end(); ++itr, --rand)
+            for (std::list<Creature*>::const_iterator itr = _crList.begin(); itr != _crList.end(); ++itr, --rand)
             {
                 if (caster->GetDistance(*itr) < 5)
                 {
@@ -473,8 +481,14 @@ public:
         {
             AfterCast += SpellCastFn(spell_midsummer_fling_torch_SpellScript::HandleFinish);
             if (m_scriptSpellId == 45671)
+            {
+                OnCheckCast += SpellCheckCastFn(spell_midsummer_fling_torch_SpellScript::CheckCast);
                 OnEffectHitTarget += SpellEffectFn(spell_midsummer_fling_torch_SpellScript::HandleScript, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+            }
         }
+
+    private:
+        std::list<Creature*> _crList;
     };
 
     SpellScript* GetSpellScript() const override


### PR DESCRIPTION
…he bonfire.

Fixes #6551

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6551
- Closes https://github.com/chromiecraft/chromiecraft/issues/930

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Get Midsummer daily Catch More Torches (or Torch Catching)
2. go somewhere like Tirisfal Glades (60, 59). Or some other distance far from the bonfire (more than 100y)
3. Use Unlit Torches on yourself

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
