### PR TITLE
fix(DB/Loot): Bloated Slippery Eel should be lootable only with quest.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630405222505942000.sql
+++ b/data/sql/updates/pending_db_world/rev_1630405222505942000.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630405222505942000');
+
+UPDATE `gameobject_loot_template` SET `QuestRequired`=1 WHERE `item`=45328;
+UPDATE `reference_loot_template` SET `QuestRequired`=1 WHERE `item`=45328;


### PR DESCRIPTION
Fixes #6633

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6633
- Closes https://github.com/chromiecraft/chromiecraft/issues/1030

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. go to dalaran sewers
2. train fishing
3. `.set 356 450`
4. .additem 19970, 19971, 7996, 50287, 6553 5, 38802
5. `.cast 59645` (Hungry Tuskarr) This should out level fishing for all of 3.3.5 (600 is max for MOP)
6. Turn off auto loot and fish.
7. You will always get loot.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
