### PR TITLE
fix(DB/Gameobject): Adjust Tin Vein position in Westfall

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630416137992915266.sql
+++ b/data/sql/updates/pending_db_world/rev_1630416137992915266.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630416137992915266');
+
+-- Move Tin Vein 63486 slightly so it is accessible to players
+UPDATE `gameobject` SET `position_x` = -10483.46, `position_y` = 1969.77, `position_z` =  12.065  WHERE `id` = 1732 AND `guid` = 63486;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Moves Tin Vein ID 1732 GUID 63486 slightly so it is accessible to players. Previously it was stuck inside a cave wall.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7659
- Closes https://github.com/chromiecraft/chromiecraft/issues/1564

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
This is not controversial.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, 1 row affected as expected.
- Checked in-game, node is now accessible:

![WoWScrnShot_083121_230659](https://user-images.githubusercontent.com/81782124/131513936-a32dbaec-4c85-48ce-b6f5-30112d09b615.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go o 63486 and observe.

Note that as this node is pooled, it may not spawn. I ended up temporarily deleting it from the `pool_gameobject` table just to eventually get it to appear (```DELETE FROM `pool_gameobject` WHERE `guid` = 63486;```) - not exactly elegant, but it did make the node spawn at last. The change to the node pool is of course not part of this PR.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
