### PR TITLE
 fix (DB/Creature): Add roaming Quel'dorei

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630421521637477310.sql
+++ b/data/sql/updates/pending_db_world/rev_1630421521637477310.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630421521637477310');
+
+-- Adds movements for Quel`dorei Ghost
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5 WHERE `id` = 16325 AND `guid` IN (82177, 82178, 82180, 82183, 82184, 82185, 82186, 82187, 82189, 82190, 82193, 82198, 82200, 82205, 82208, 82241, 82254);
+
+-- Adds movements for Quel`dorei Wraith
+UPDATE `creature` SET `MovementType` = 1, `wander_distance` = 5 WHERE `id` = 16326 AND `guid` IN (82175, 82179, 82181, 82182, 82188, 82191, 82194, 82195, 82196, 82197, 82199, 82207, 82210, 82253);


### PR DESCRIPTION


<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added roaming to Quel'Dorei Wraith and Ghost

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7486
- Closes https://github.com/chromiecraft/chromiecraft/issues/1492

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://youtu.be/RaNFK9upvM0?t=117

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  Ran SQL, 31 Affected rows, 0 errors
![image](https://user-images.githubusercontent.com/44707108/131526200-cc6bed2a-58e4-4cd3-a02f-79292a249135.png)

- SQL query
```
Quel'dorei Wraith
+-------+--------------+-----------------+
| guid  | MovementType | wander_distance |
+-------+--------------+-----------------+
| 82165 |            1 |               5 |
| 82175 |            1 |               5 |
| 82176 |            1 |               5 |
| 82179 |            1 |               5 |
| 82181 |            1 |               5 |
| 82182 |            1 |               5 |
| 82188 |            1 |               5 |
| 82191 |            1 |               5 |
| 82194 |            1 |               5 |
| 82195 |            1 |               5 |
| 82196 |            1 |               5 |
| 82197 |            1 |               5 |
| 82199 |            1 |               5 |
| 82201 |            1 |               5 |
| 82202 |            1 |               5 |
| 82204 |            1 |               5 |
| 82207 |            1 |               5 |
| 82209 |            1 |               5 |
| 82210 |            1 |               5 |
| 82242 |            1 |               5 |
| 82253 |            1 |               5 |
+-------+--------------+-----------------+
21 rows in set (0.00 sec)
```

```
Quel'dorei Ghost
+-------+--------------+-----------------+
| guid  | MovementType | wander_distance |
+-------+--------------+-----------------+
| 82164 |            1 |               5 |
| 82177 |            1 |               5 |
| 82178 |            1 |               5 |
| 82180 |            1 |               5 |
| 82183 |            1 |               5 |
| 82184 |            1 |               5 |
| 82185 |            1 |               5 |
| 82186 |            1 |               5 |
| 82187 |            1 |               5 |
| 82189 |            1 |               5 |
| 82190 |            1 |               5 |
| 82193 |            1 |               5 |
| 82198 |            1 |               5 |
| 82200 |            1 |               5 |
| 82203 |            1 |               5 |
| 82205 |            1 |               5 |
| 82208 |            1 |               5 |
| 82211 |            1 |               5 |
| 82241 |            1 |               5 |
| 82254 |            1 |               5 |
+-------+--------------+-----------------+
20 rows in set (0.00 sec)
```


- Check in-game

https://streamable.com/1ad2sf

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 82177 or .go c 82175
2. observe


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
