### PR TITLE
fix(DB/Creature): Spawntimer fix GUID 36519

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630423020825292612.sql
+++ b/data/sql/updates/pending_db_world/rev_1630423020825292612.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630423020825292612');
+
+UPDATE `acore_world`.`creature` SET `spawntimesecs`='37800' WHERE `guid`=36519;

--- a/data/sql/updates/pending_db_world/rev_1630423020825292612.sql
+++ b/data/sql/updates/pending_db_world/rev_1630423020825292612.sql
@@ -1,3 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630423020825292612');
 
-UPDATE `acore_world`.`creature` SET `spawntimesecs`='37800' WHERE `guid`=36519;
+UPDATE `creature` SET `spawntimesecs` = 37800 WHERE `guid` = 36519 and `id`= 6651;

--- a/data/sql/updates/pending_db_world/rev_1630423020825292612.sql
+++ b/data/sql/updates/pending_db_world/rev_1630423020825292612.sql
@@ -1,3 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630423020825292612');
 
-UPDATE `creature` SET `spawntimesecs` = 37800 WHERE `guid` = 36519 and `id`= 6651;
+UPDATE `creature` SET `spawntimesecs` = 37800 WHERE `guid` = 36519 AND `id`= 6651;


### PR DESCRIPTION
Fixed the spawntimer of Gatekeeper Rageroar (GUID: 36519) to 37800 according to Blizzlike documentation. This translates to 10.5 hours.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fixing spawntimer of Gatekeeper Rageroar by matching the Blizzlike configuration of 10.5-16 hours 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7500
- Closes https://github.com/chromiecraft/chromiecraft/issues/1500

## SOURCE:


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game by verifying the spawntimer using `.npcinfo` on Gatekeeper Rageroar

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go creature 36519
2. .npcinfo when selected
3. check spawntimer of 37800 seconds

See screenshots for actual time.

**Alive**
![Gatekeeper_Rageroar_Alive](https://user-images.githubusercontent.com/89851300/131575552-39cecde8-2ef9-4ae1-b5f5-0e494f91f0bb.PNG)
**Dead**
![Gatekeeper_Rageroar_Dead](https://user-images.githubusercontent.com/89851300/131575555-c42ae7eb-1361-4d44-a830-e79453d7ac9c.PNG)


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
