### PR TITLE
fix(DB/SmartAI): fix Screecher Spirit despawn target

### DIFF
--- a/data/sql/updates/rev_1630698323562531323.sql
+++ b/data/sql/updates/rev_1630698323562531323.sql
@@ -1,0 +1,5 @@
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 8612;
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 8612) AND (`source_type` = 0) AND (`id` IN (3));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(8612, 0, 3, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 11, 5307, 3, 0, 0, 0, 0, 0, 0, 'On Reset - Despawn Target');

--- a/data/sql/updates/rev_1630698323562531323.sql
+++ b/data/sql/updates/rev_1630698323562531323.sql
@@ -1,5 +1,6 @@
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 8612;
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630698323562531323');
 
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 8612;
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 8612) AND (`source_type` = 0) AND (`id` IN (3));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (8612, 0, 3, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 11, 5307, 3, 0, 0, 0, 0, 0, 0, 'On Reset - Despawn Target');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

sup. this mf -> Screecher Spirit which has entry of 8612 got himself a SmartAI to despawn rogue vale screecher (entry = 5308). i just added new row in its SmartAI script to depsawn vale screecher too (entry = 5307)

idk if for this action (FORCE_DESPAWN) there's a way to specify multiple targets. i didn't find it

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6879
- Closes https://github.com/chromiecraft/chromiecraft/issues/1154

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested locally and seems all gucci for my ass


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .q add 3520
2. .go c 51207 and kill the Screecher.
3. Use the quest item on its corpse
4. the mf should disappear when the spirit spawn

word.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
