### PR TITLE
fix(DB/Loot): Remove NPC drop tables from BRD Arena Team

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630816536518638817.sql
+++ b/data/sql/updates/pending_db_world/rev_1630816536518638817.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630816536518638817');
+
+-- Delete Arena Spoils items from arena team loot tables
+DELETE FROM `creature_loot_template` WHERE `Entry` IN (16049, 16050, 16051, 16052, 16055, 16058, 16095);
+
+-- Clear loot tables for arena team
+UPDATE `creature_template` SET `lootid` = 0 WHERE `Entry` IN (16049, 16050, 16051, 16052, 16055, 16058, 16095);
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Deletes the drop tables for Theldren's 7 Arena Team NPCs in BRD. They are:

| entry | name | 
| ---: | --- | 
| 16049 | Lefty | 
| 16050 | Rotfang | 
| 16051 | Snokh Blackspine | 
| 16052 | Malgen Longspear | 
| 16055 | Va'jashni | 
| 16058 | Volida | 
| 16095 | Gnashjaw | 

These NPCs were collectively dropping 4 items ([Ironweave Mantle](https://tbc.wowhead.com/item=22305/ironweave-mantle), [Shroud of Arcane Mastery](https://tbc.wowhead.com/item=22330/shroud-of-arcane-mastery), [Malgen's Long Bow](https://tbc.wowhead.com/item=22318/malgens-long-bow), [Lefty's Brass Knuckle](https://tbc.wowhead.com/item=22317/leftys-brass-knuckle)) which should only be dropped from the [Arena Spoils](https://tbc.wowhead.com/object=181074/arena-spoils) item. Checking their tables showed they dropped nothing else, and checking them on Wowhead also shows they should not drop any other items. So I'm removing the items from the `creature_loot_templates` for all of them, and then setting their lootIDs to 0.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7727
- Closes https://github.com/chromiecraft/chromiecraft/issues/1628

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

TBC and Live Wowhead do not show any drops for any of them, with the sole exception of Volida. However, since the drop she shows is a single item with a listed count of ??, this is probably contaminated data from another private server.

Source for the 4 Arena Spoils items only dropping from the item:
"This item can be found inside the Arena Spoils in Blackrock Depths. Upon killing Theldren in BRD, the Arena Spoils chest will spawn. This weapon is one of the possible rewards from that chest."
https://wowpedia.fandom.com/wiki/Malgen's_Long_Bow?oldid=2110488

"Ironweave Mantle spawn in the Arena Spoils from Ring of Law in Blackrock Depths after using the [Banner of Provocation] for the Theldren fight."
https://wowpedia.fandom.com/wiki/Ironweave_Mantle?oldid=2034886 - note that Wowhead does show this dropping from Volida, but has ?? as the drop count, so this seems more likely to be data contamination from another private server to me.

"Upon killing Theldren in BRD, the Arena Spoils chest will spawn. This weapon is one of the possible rewards from that chest. "
https://wowpedia.fandom.com/wiki/Lefty's_Brass_Knuckle?oldid=2110487

"This item can be found inside the Arena Spoils in Blackrock Depths."
https://wowpedia.fandom.com/wiki/Shroud_of_Arcane_Mastery?oldid=2248006

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings. 19 rows affected by first line, 7 affected by second, both as expected.

```SQL
SELECT ct.entry, ct.name, it.name, clt.chance
FROM `creature_template` ct
JOIN `creature_loot_template` clt ON ct.lootid = clt.Entry
JOIN `item_template` it ON clt.Item = it.entry
WHERE clt.item IN (22317, 22318, 22330, 22305)
```
Shows no further drops of these items.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check SQL above, or creature's individual drop tables, which should all be 0.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
