### PR TITLE
fix(DB/creature_loot): Remove Frost Oil drops from 3 NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1630927565231100667.sql
+++ b/data/sql/updates/pending_db_world/rev_1630927565231100667.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1630927565231100667');
+
+-- Remove Frost Oil from Vilebranch Witch Doctor, Tar Creeper, and Deadwood Gardener
+DELETE FROM `creature_loot_template` WHERE `Entry` IN (2640, 6527, 7154) AND `Item` = 3829;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Deletes Frost Oil (ID 3829) from the drop tables of 3 NPCs - Vilebranch Witch Doctor 2640, Tar Creeper 6527, and Deadwood Gardener 7154. The origins of this item are a bit unclear, whether it's alchemist-only or if one mob in Silithus also drops it (see the original ticket for a fuller discussion of the matter) but either way, these 3 NPCs should not drop it.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7744
- Closes https://github.com/chromiecraft/chromiecraft/issues/1637

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://classic.wowhead.com/quest=713/coolant-heads-prevail#comments
https://wowpedia.fandom.com/wiki/Frost_Oil?oldid=2030887 
Also https://tbc.wowhead.com/item=3829/frost-oil#dropped-by which shows data that is probably contaminated (imo) but does show these NPCs do not drop it.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQl, no errors/warnings, 3 rows deleted as expected.
- Ran SQL in original ticket, now finding no results.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run this query:
```SQL
SELECT ct.entry, ct.name, clt.Chance
FROM `creature_template` ct
JOIN `creature_loot_template` clt ON ct.lootid = clt.Entry
WHERE clt.Item = 3829
```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
