### PR TITLE
fix(DB/creature_loot_template): Add Azure Whelpling on Blue Dragonspawn

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1631038913388302500.sql
+++ b/data/sql/updates/pending_db_world/rev_1631038913388302500.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1631038913388302500');
+
+DELETE FROM `creature_loot_template` WHERE `Entry`=193 AND `Item`=34535;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
+(193, 34535, 0, 0.1, 0, 1, 0, 1, 1, 'Blue Dragonspawn - Azure Whelpling');
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add missing item to loot table

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #7761
- Closes https://github.com/chromiecraft/chromiecraft/issues/1645

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
[Wiki](https://vanilla-wow-archive.fandom.com/wiki/Azure_Whelpling)
```
Azure Whelpling drops from Blue Dragonspawn, Blue Scalebane, Draconic Magelord and Draconic Mageweaver in Azshara.
This drop possibility was added in Patch 2.3.
```
[TBC Wowhead](https://tbc.wowhead.com/item=34535/azure-whelpling)
```
By Nexuslord on 2008/04/12 (Patch 2.4.1) 
I believe Blue Dragonspawns have a increased drop chance believe it or not.
I have gotten 2 whelps from them. One for myself and one for my friend.
Took me 154 kills to get two whelps from them. But I was still killing the dragons that were all over the place.
```
```
By Rholm on 2007/11/15 (Patch 2.3.0)
I got mine from a Blue Dragonspawn. All the dragonkins around Lake Mennar in south Azshara can drop it (around 36,72).
Good luck everyone, it's a cute pet.
```

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
