### PR TITLE
fix(DB/gameobject): Fix respawn timers for "Refugee's Quandary" items

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1631329691460885909.sql
+++ b/data/sql/updates/pending_db_world/rev_1631329691460885909.sql
@@ -1,0 +1,11 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1631329691460885909');
+
+-- Set Felix's Box respawn to 10 seconds
+UPDATE `gameobject` SET `spawntimesecs` = 10 WHERE `id` = 148499 AND `guid`= 1380;
+
+-- Set Felix's Chest respawn to 10 seconds
+UPDATE `gameobject` SET `spawntimesecs` = 10 WHERE `id` = 178084 AND `guid`= 1386;
+
+-- Set Felix's Bucket of Bolts respawn to 10 seconds
+UPDATE `gameobject` SET `spawntimesecs` = 10 WHERE `id` = 178085 AND `guid`= 1394;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Changes the respawn timer for 3 quest items used in ["A Refugee's Quandary"](https://www.wowhead.com/quest=3361/a-refugees-quandary). These items are:
- [Felix's Chest](https://www.wowhead.com/item=16313/felixs-chest) (16313)
- [Felix's Bucket of Bolts](https://www.wowhead.com/item=16314/felixs-bucket-of-bolts)(16314)
- [Felix's Box](https://www.wowhead.com/item=10438/felixs-box) (10438)

The respawn for all of these is changed from 180 secs/3 mins to 10 seconds.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7817
- Closes https://github.com/chromiecraft/chromiecraft/issues/1689

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://youtu.be/3xH2zHN4J7c?t=86 - someone grabs item before the person recording, so we get to see the full respawn time. This was shot on Wow Classic.
https://youtu.be/3xH2zHN4J7c?t=135 - same video, but for the next item.
"The thing with all three items is that whenever a player grabs one of them, they disappear for a couple of seconds." - https://www.gosunoob.com/wow-classic/refugees-quandary-felixs-box-chest-bucket-of-bolts-location/

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, correct number of rows affected.
- Checked in game, looted all 3 items and verified they respawned in expected time:

![WoWScrnShot_091121_125124](https://user-images.githubusercontent.com/81782124/132934622-4eb73fdc-ce5a-4a60-bb3b-c55ee5ac0848.jpg)
![WoWScrnShot_091121_125141](https://user-images.githubusercontent.com/81782124/132934628-b4f88893-1902-4354-8f16-dd88236bed4f.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check Keira.
2. Alternatively, check in game - .q add 3361, then .go o 1380 / 1386 / 1394 - loot items and observe.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
