### PR TITLE
fix(DB/Gameobject): moves stranglekelps to the shore

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1631368907971857000.sql
+++ b/data/sql/updates/pending_db_world/rev_1631368907971857000.sql
@@ -1,0 +1,14 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1631368907971857000');
+
+SET @ID = 2045;
+
+# Sets position of stranglekelp to positions gathered from Wowhead
+UPDATE `gameobject` SET `position_x` = -860.287476, `position_y` = -3811.75, `position_z` = 2.997894 WHERE `id` = @ID AND `guid` = 8231;
+UPDATE `gameobject` SET `position_x` = -988.582275, `position_y` = -3831.728271, `position_z` = -22.586107 WHERE `id` = @ID AND `guid` = 8382;
+UPDATE `gameobject` SET `position_x` = -981.448547, `position_y` = -3812.717285, `position_z` = -20.767349 WHERE `id` = @ID AND `guid` = 8383;
+UPDATE `gameobject` SET `position_x` = -995.412476, `position_y` = -3720.549805, `position_z` = 3.327584 WHERE `id` = @ID AND `guid` = 8384;
+UPDATE `gameobject` SET `position_x` = -1191.343872, `position_y` = -3811.750000, `position_z` = 4.271667 WHERE `id` = @ID AND `guid` = 8425;
+UPDATE `gameobject` SET `position_x` = -1326.468872, `position_y` = -4034.682617, `position_z` = 7.943251 WHERE `id` = @ID AND `guid` = 8426;
+UPDATE `gameobject` SET `position_x` = -1921.018921, `position_y` = -3750.950195, `position_z` = -0.358390 WHERE `id` = @ID AND `guid` = 8452;
+UPDATE `gameobject` SET `position_x` = -1981.825073, `position_y` = -3750.950195, `position_z` = 1.099884 WHERE `id` = @ID AND `guid` = 8466;
+UPDATE `gameobject` SET `position_x` = -2393.956543, `position_y` = -3781.350098, `position_z` = 0.065314 WHERE `id` = @ID AND `guid` = 8570;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Moves multiple stranglekelp to the shore

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5794
- Closes https://github.com/chromiecraft/chromiecraft/issues/608

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
New positions gathered from [wowhead](https://tbc.wowhead.com/item=3820/stranglekelp#map)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Checked whether the new positions are to close, by .gobject near 20
- Also performed below test

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Perform SQL query
     * Should change one row per query
2. Check that each stranglekelp spawns in/near water

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
