### PR TITLE
fix(DB/Gameobject): Remove Shipment of Iron respawn timer

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1631433270459665577.sql
+++ b/data/sql/updates/pending_db_world/rev_1631433270459665577.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1631433270459665577');
+
+-- Remove respawn timer from Shipment of Iron
+UPDATE `gameobject` SET `spawntimesecs` = 0 WHERE `id` = 1736 AND `guid` = 20778;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Removes the respawn timer from [quest](https://tbc.wowhead.com/quest=529/battle-of-hillsbrad) object [Shipment of Iron](https://tbc.wowhead.com/item=3564/shipment-of-iron) ID 1736. It was previously set to 5 minutes. This is to bring it in line with observed behaviour on Classic servers. 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7831
- Closes https://github.com/chromiecraft/chromiecraft/issues/1703

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
YouTube:
[Youtube Clip 1](https://youtu.be/kq_xTYj_XBw?t=128) 2:07
[Youtube Clip 2](https://youtu.be/MJ8g6jNHB3k?t=252) 4:12

Both of these appear to be shot on retail servers. I did find other clips showing the crate vanishing when clicked, but they were either self-identified as being on private servers (Wow-Mania in this case), or were made by people who seemed very likely to be on private servers from circumstantial evidence (i.e. no other players ever seen, no world chat activity) like Bue.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, 1 row changed as expected.
- Checked in-game, crate no longer despawns.

![WoWScrnShot_091221_174209](https://user-images.githubusercontent.com/81782124/132979137-943aa774-fa05-4044-a6c9-8192d8ae0a82.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .q add 529
2. .go o 20778
3. Gather item and observe spawn timer

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
