### PR TITLE
fix(DB/smart_scripts): Add Voidwalker summons to Apothecary Falthis

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1631537204810734698.sql
+++ b/data/sql/updates/pending_db_world/rev_1631537204810734698.sql
@@ -6,5 +6,5 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (3735, 0, 2, 0, 1, 0, 100, 1, 100, 1000, 0, 0, 0, 11, 12746, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Apothecary Falthis - Out of Combat - Cast \'Summon Voidwalker\' (No Repeat)');
 
 -- Moves Apothecary Falthis slightly to correct position
-UPDATE `creature` SET `position_x` = 3845.8,  `position_y` = -217.3, `position_z` = 4.25, `orientation` = 1.67 WHERE `id` = 3735 AND `guid` = 32913;
+UPDATE `creature` SET `position_x` = 3845.6,  `position_y` = -213.6, `position_z` = 4.8, `orientation` = 1.67 WHERE `id` = 3735 AND `guid` = 32913;
 

--- a/data/sql/updates/pending_db_world/rev_1631537204810734698.sql
+++ b/data/sql/updates/pending_db_world/rev_1631537204810734698.sql
@@ -1,0 +1,10 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1631537204810734698');
+
+-- Adds voidwalker summon to Apothecary Falthis
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 3735 AND `source_type` = 0 AND `id` = 2;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(3735, 0, 2, 0, 1, 0, 100, 1, 100, 1000, 0, 0, 0, 11, 12746, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Apothecary Falthis - Out of Combat - Cast \'Summon Voidwalker\' (No Repeat)');
+
+-- Moves Apothecary Falthis slightly to correct position
+UPDATE `creature` SET `position_x` = 3845.8,  `position_y` = -217.3, `position_z` = 4.25, `orientation` = 1.67 WHERE `id` = 3735 AND `guid` = 32913;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Adds missing Voidwalker summons to [Apothecary Falthis](https://tbc.wowhead.com/npc=3735/apothecary-falthis). Video and Wowhead both support him having this ability.
- Also shifted his spawn slightly to match observed spawn point in Wrath-era video listed in sources below. I was much more hesitant about this bit because of the concerns about using footage from a private server. (Were there private servers in 2010? In German?) But checking some of his other videos does show signs of other people (flying taxis in the distance, people helping in fights) so the risk doesn't seem that high. The new spawn point also averages the two points shown on TBC Wowhead, instead of being slightly off for one and way off for the other as it is currently.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7844
- No corresponding CC report to close.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/npc=3735/apothecary-falthis#abilities
https://tbc.wowhead.com/spell=12746/summon-voidwalker#used-by-npc

https://vanillawowdb.com/?npc=3735#comments
https://wowwiki-archive.fandom.com/wiki/Apothecary_Falthis

https://www.youtube.com/watch?v=GnxD_UowrrY video from 2010, not sure if retail but it shows spawn as it is on wowhead, and has voidwalker

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, correct number of rows changed.
- Checked in game:

![WoWScrnShot_091321_224216](https://user-images.githubusercontent.com/81782124/133090285-d5dcad01-0f35-40a9-9e7a-157c242bbad3.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 32913
2. Observe no voidwalker.
3. Observe position.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
