### PR TITLE
fix(Core/Quest): Update all quests when item is optained/removed

### DIFF
--- a/src/server/game/Entities/Player/PlayerQuest.cpp
+++ b/src/server/game/Entities/Player/PlayerQuest.cpp
@@ -1780,7 +1780,6 @@ void Player::ItemAddedQuestCheck(uint32 entry, uint32 count)
                     CompleteQuest(questid);
                 else
                     AdditionalSavingAddMask(ADDITIONAL_SAVING_INVENTORY_AND_GOLD | ADDITIONAL_SAVING_QUEST_STATUS);
-                return;
             }
         }
     }
@@ -1822,7 +1821,6 @@ void Player::ItemRemovedQuestCheck(uint32 entry, uint32 count)
                     m_QuestStatusSave[questid] = true;
                     IncompleteQuest(questid);
                 }
-                return;
             }
         }
     }


### PR DESCRIPTION
Co-Authored-By: Gildor <521036+Jildor@users.noreply.github.com>
Co-Authored-By: Wyrserth <43747507+Wyrserth@users.noreply.github.com>
* cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/fece5bdbf39ba3fb99c2b99dd00580ffdc68c5a2)
* cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/91f214cd220e3f23ff713853f991ffc7d323173a)

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- When you obtain or removed an item that is required for multiple quests we should update all and not return after the first object  

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- None

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. You can test this by taking quests 2583 && 2585 
2. Go out into the world and collect the required amount
3. See that you can turn in the quests and that they both update in the quest log

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
