### PR TITLE
Fix(DB): Gelkis/Magram reputations

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1631634961417748000.sql
+++ b/data/sql/updates/pending_db_world/rev_1631634961417748000.sql
@@ -1,0 +1,19 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1631634961417748000');
+-- sets for all, generic 20/100 and maxrep
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 20, `MaxStanding1` = 5, `MaxStanding2` = 7, `RewOnKillRepValue2` = -100 WHERE (`RewOnKillRepFaction1` = 92 AND `RewOnKillRepFaction2` = 93);
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 20, `MaxStanding1` = 5, `MaxStanding2` = 7, `RewOnKillRepValue2` = -100 WHERE (`RewOnKillRepFaction1` = 93 AND `RewOnKillRepFaction2` = 92);
+
+
+-- Warug bodyguard
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 5, `RewOnKillRepValue2` = -25 WHERE (`creature_id` = 6068);
+
+
+
+-- khan shaka doesn't exist in current DB
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE (`entry` = 5602);
+DELETE FROM `creature_onkill_reputation` WHERE (`creature_id` = 5602);
+INSERT INTO `creature_onkill_reputation` (`creature_id`, `RewOnKillRepFaction1`, `RewOnKillRepFaction2`, `MaxStanding1`, `IsTeamAward1`, `RewOnKillRepValue1`, `MaxStanding2`, `IsTeamAward2`, `RewOnKillRepValue2`, `TeamDependent`) VALUES
+(5602, 93, 92, 5, 0, 25, 7, 0, -125, 0);
+
+-- khan jehn
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 25, `RewOnKillRepValue2` = -125 WHERE (`creature_id` = 5601);

--- a/data/sql/updates/pending_db_world/rev_1631634961417748000.sql
+++ b/data/sql/updates/pending_db_world/rev_1631634961417748000.sql
@@ -1,13 +1,11 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1631634961417748000');
+
 -- sets for all, generic 20/100 and maxrep
 UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 20, `MaxStanding1` = 5, `MaxStanding2` = 7, `RewOnKillRepValue2` = -100 WHERE (`RewOnKillRepFaction1` = 92 AND `RewOnKillRepFaction2` = 93);
 UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 20, `MaxStanding1` = 5, `MaxStanding2` = 7, `RewOnKillRepValue2` = -100 WHERE (`RewOnKillRepFaction1` = 93 AND `RewOnKillRepFaction2` = 92);
 
-
 -- Warug bodyguard
 UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 5, `RewOnKillRepValue2` = -25 WHERE (`creature_id` = 6068);
-
-
 
 -- khan shaka doesn't exist in current DB
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE (`entry` = 5602);


### PR DESCRIPTION
Reputation gains were too high (x5). No decrease after honored.
Some mobs (Warug bodyguard, Khan shaka, Khan Jehn) had wrong reputation.

Closes AzerothCore 7339 and 6526
ChromieCraft 1406

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Reduce reputation gain for Gelkis and Magram 
-  Add variable reputations for the different mobs based on data from commits
-  Increase "MaxStanding" to make the loss of reputation possible beyond honored. Increase MaxStanding to make revered possible.
- Added SmartAI to Khan Shaka but not used, I think he should have some scripts based on wowhead, he should be the opposite of Jehn which has defensive abilities, wowhead says he has offensive abilities.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7339
- closes https://github.com/chromiecraft/chromiecraft/issues/1406
- closes https://github.com/azerothcore/azerothcore-wotlk/issues/6526

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://github.com/azerothcore/azerothcore-wotlk/issues/6526 provided the following sources:
https://wowpedia.fandom.com/wiki/Gelkis_clan
https://classic.wowhead.com/faction=92/gelkis-clan-centaur#npcs;0-4+10

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Imported the changes in heidiSQL and test around on mobs to make the how-to test, without being very thorough.



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .teleport desolace
2. .modify reputation 92 21000 to get revered gelkis
3. .go -2410.729980 2412.80 75.421700 to get to Khan Shaka. Killing him should grant +25 Magram and -125 Gelkis (gain only if Magram less than revered)
4. .go -1957.279052 1260.353149 91.637878 to get to Khan Jehn, +25 Gelkis, -125 Magram
5. .go -1584.412231 864.234070 110.168549 to get to Warug bodyguard. Should be +5 Gelkis, -25 Magram
6. Kill any other Gelkis/Magram to confirm 20/100 and revered limit.



## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
