### PR TITLE
fix(Core/Graveyards): Rework the graveyard selection logic to allow l…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1632245299092353800.sql
+++ b/data/sql/updates/pending_db_world/rev_1632245299092353800.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1632245299092353800');
+
+DELETE FROM `graveyard_zone` WHERE `ID` = 101 AND `GhostZone` = 135;
+INSERT INTO `graveyard_zone` (`ID`, `GhostZone`, `Faction`, `Comment`) VALUES
+(101, 135, 469, 'Frostmane Hold, Kharanos GY - Dun Morogh');


### PR DESCRIPTION
…inking graveyards to areas, not just zones

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Rework the graveyard selection logic to allow linking graveyards to areas as well, not only zones.
- Fully compatible with the entirety of the previously linked entries - if no linked graveyard is found to the player's current area, it'll just fallback to checking for zone as it would before.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/5199

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
There's apparently some faulty logic in the graveyard selection code we have.

For example, it's worth noting that while the wiki mentions the entries from graveyard_zone are linked following the values from **AreaTable.dbc**, the code only looks up the player Zone, and searches for links according to that.

I searched about this for a bit and ended up finding this https://github.com/TrinityCore/TrinityCore/commit/9c220e8f55eaa8cfc93ed26ea7318430e5c6749b where TC allowed areas to be linked to graveyards in the early 6.x branch, but that code was never backported to 3.3.5.

While I'm unsure why that never happened, it seems clear to me that graveyards should optimally be linked by area and not simply by zone as it's done currently, which causes strange results like seen in the issue #5199, where it just abritrary chooses the closest graveyard regardless of it being "acessible" or not.

Furthermore, the video from classic TBC presented in that issue (https://youtu.be/wyaBOODuwqs) shows that there's clearly more to it than just a mere distance calculation, seeing how the player was sent to Kharanos and not to Coldridge Valley, as happens currently.


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds successfully in Win11.
- Killed myself inside caves, inside instances, works fines.
- KIlled myself in Frostmane Hold and got ported to Kharanos.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .tele frostmane hold
2. .die self
3. Release

## Known Issues and TODO List:

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
