### PR TITLE
fix:(Core\Instance):Gothik souls travel to dead zone

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
@@ -381,11 +381,15 @@ public:
                     break;
                 case SPELL_INFORM_LIVING_KNIGHT:
                     if (Creature* target = me->SummonCreature(NPC_DEAD_KNIGHT, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
+					{
                         me->CastSpell(target, SPELL_INFORM_DEAD_KNIGHT, true);
+					}
                     break;
                 case SPELL_INFORM_LIVING_RIDER:
                     if (Creature* target = me->SummonCreature(NPC_DEAD_RIDER, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
+					{
                         me->CastSpell(target, SPELL_INFORM_DEAD_RIDER, true);
+					}
                     me->SummonCreature(NPC_DEAD_HORSE, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation());
                     break;
             }

--- a/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
@@ -386,7 +386,7 @@ public:
                     if (Creature* target = me->SummonCreature(NPC_DEAD_KNIGHT, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
                         {
                         me->CastSpell(target, SPELL_INFORM_DEAD_KNIGHT, true);
-                        }
+                    }
                     break;
                     }
                 case SPELL_INFORM_LIVING_RIDER:

--- a/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
@@ -376,9 +376,9 @@ public:
                 case SPELL_INFORM_LIVING_TRAINEE:
                     {
                     if (Creature* target = me->SummonCreature(NPC_DEAD_TRAINEE, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
-                        {
+                    {
                         me->CastSpell(target, SPELL_INFORM_DEAD_TRAINEE, true);
-                        }
+                    }
                     break;
                     }
                 case SPELL_INFORM_LIVING_KNIGHT:

--- a/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
@@ -374,24 +374,30 @@ public:
             switch (spellInfo->Id)
             {
                 case SPELL_INFORM_LIVING_TRAINEE:
-                    if(Creature* target = me->SummonCreature(NPC_DEAD_TRAINEE, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
                     {
+                    if (Creature* target = me->SummonCreature(NPC_DEAD_TRAINEE, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
+                        {
                         me->CastSpell(target, SPELL_INFORM_DEAD_TRAINEE, true);
+                        }
+                    break;
                     }
-                    break;
                 case SPELL_INFORM_LIVING_KNIGHT:
+                    {
                     if (Creature* target = me->SummonCreature(NPC_DEAD_KNIGHT, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
-					{
+                        {
                         me->CastSpell(target, SPELL_INFORM_DEAD_KNIGHT, true);
-					}
+                        }
                     break;
+                    }
                 case SPELL_INFORM_LIVING_RIDER:
+                    {
                     if (Creature* target = me->SummonCreature(NPC_DEAD_RIDER, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
-					{
+                        {
                         me->CastSpell(target, SPELL_INFORM_DEAD_RIDER, true);
-					}
+                        }
                     me->SummonCreature(NPC_DEAD_HORSE, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation());
                     break;
+                    }
             }
             me->HandleEmoteCommand(EMOTE_ONESHOT_SPELL_CAST);
         }

--- a/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
@@ -375,7 +375,9 @@ public:
             {
                 case SPELL_INFORM_LIVING_TRAINEE:
                     if(Creature* target = me->SummonCreature(NPC_DEAD_TRAINEE, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
+                    {
                         me->CastSpell(target, SPELL_INFORM_DEAD_TRAINEE, true);
+                    }
                     break;
                 case SPELL_INFORM_LIVING_KNIGHT:
                     if (Creature* target = me->SummonCreature(NPC_DEAD_KNIGHT, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))

--- a/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
@@ -397,7 +397,7 @@ public:
                     }
                     me->SummonCreature(NPC_DEAD_HORSE, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation());
                     break;
-                    }
+                }
             }
             me->HandleEmoteCommand(EMOTE_ONESHOT_SPELL_CAST);
         }

--- a/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
@@ -384,7 +384,7 @@ public:
                 case SPELL_INFORM_LIVING_KNIGHT:
                     {
                     if (Creature* target = me->SummonCreature(NPC_DEAD_KNIGHT, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
-                        {
+                    {
                         me->CastSpell(target, SPELL_INFORM_DEAD_KNIGHT, true);
                     }
                     break;

--- a/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
@@ -374,13 +374,16 @@ public:
             switch (spellInfo->Id)
             {
                 case SPELL_INFORM_LIVING_TRAINEE:
-                    me->SummonCreature(NPC_DEAD_TRAINEE, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation());
+                    if(Creature* target = me->SummonCreature(NPC_DEAD_TRAINEE, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
+                        me->CastSpell(target, SPELL_INFORM_DEAD_TRAINEE, true);
                     break;
                 case SPELL_INFORM_LIVING_KNIGHT:
-                    me->SummonCreature(NPC_DEAD_KNIGHT, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation());
+                    if (Creature* target = me->SummonCreature(NPC_DEAD_KNIGHT, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
+                        me->CastSpell(target, SPELL_INFORM_DEAD_KNIGHT, true);
                     break;
                 case SPELL_INFORM_LIVING_RIDER:
-                    me->SummonCreature(NPC_DEAD_RIDER, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation());
+                    if (Creature* target = me->SummonCreature(NPC_DEAD_RIDER, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
+                        me->CastSpell(target, SPELL_INFORM_DEAD_RIDER, true);
                     me->SummonCreature(NPC_DEAD_HORSE, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation());
                     break;
             }

--- a/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
@@ -392,9 +392,9 @@ public:
                 case SPELL_INFORM_LIVING_RIDER:
                     {
                     if (Creature* target = me->SummonCreature(NPC_DEAD_RIDER, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation()))
-                        {
+                    {
                         me->CastSpell(target, SPELL_INFORM_DEAD_RIDER, true);
-                        }
+                    }
                     me->SummonCreature(NPC_DEAD_HORSE, PosSummonDead[pos].GetPositionX(), PosSummonDead[pos].GetPositionY(), PosSummonDead[pos].GetPositionZ(), PosSummonDead[pos].GetOrientation());
                     break;
                     }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4273

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .go c id 16060 and engage Gothik, killed minions and their souls won't "travel" to dead zone
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 16060 and engage Gothik, kill his minions and their souls now "travel" to dead zone
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
