### PR TITLE
fix(DB/Loot): changed sum RLT fo Blackrom Champion

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1632423232437840216.sql
+++ b/data/sql/updates/pending_db_world/rev_1632423232437840216.sql
@@ -1,0 +1,37 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1632423232437840216');
+
+DELETE FROM `reference_loot_template` WHERE (`Entry` = 44011);
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(44011, 935, 0, 0, 0, 1, 1, 1, 1, 'Night Watch Shortsword'),
+(44011, 12975, 0, 0, 0, 1, 1, 1, 1, 'Prospector Axe'),
+(44011, 12976, 0, 0, 0, 1, 1, 1, 1, 'Ironpatch Blade'),
+(44011, 12978, 0, 0, 0, 1, 1, 1, 1, 'Stormbringer Belt'),
+(44011, 12979, 0, 0, 0, 1, 1, 1, 1, 'Firebane Cloak'),
+(44011, 12982, 0, 0, 0, 1, 1, 1, 1, 'Silver-linked Footguards'),
+(44011, 12983, 0, 0, 0, 1, 1, 1, 1, 'Rakzur Club'),
+(44011, 12984, 0, 0, 0, 1, 1, 1, 1, 'Skycaller'),
+(44011, 13136, 0, 0, 0, 1, 1, 1, 1, 'Lil Timmy\'s Peashooter');
+
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 435) AND (`Item` IN (24061)) AND (`Reference` IN (24061));
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 435) AND (`Item` IN (44011)) AND (`Reference` IN (44011));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(435, 44011, 44011, 0.5, 0, 1, 1, 1, 1, 'Blackrock Champion - (ReferenceTable)');
+
+
+DELETE FROM `reference_loot_template` WHERE (`Entry` = 44012);
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(44012, 720, 0, 0, 0, 1, 1, 1, 1, 'Brawler Gloves'),
+(44012, 3203, 0, 0, 0, 1, 1, 1, 1, 'Dense Triangle Mace'),
+(44012, 13005, 0, 0, 0, 1, 1, 1, 1, 'Amy\'s Blanket'),
+(44012, 13031, 0, 0, 0, 1, 1, 1, 1, 'Orb of Mistmantle'),
+(44012, 13057, 0, 0, 0, 1, 1, 1, 1, 'Bloodpike'),
+(44012, 13097, 0, 0, 0, 1, 1, 1, 1, 'Thunderbrow Ring'),
+(44012, 13099, 0, 0, 0, 1, 1, 1, 1, 'Moccasins of the White Hare'),
+(44012, 13131, 0, 0, 0, 1, 1, 1, 1, 'Sparkleshell Mantle');
+
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 435) AND (`Item` IN (24069, 24069));
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 435) AND (`Item` IN (44012, 44012));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(435, 44012, 44012, 0.5, 0, 1, 1, 1, 1, 'Blackrock Champion - (ReferenceTable)');

--- a/data/sql/updates/pending_db_world/rev_1632423232437840216.sql
+++ b/data/sql/updates/pending_db_world/rev_1632423232437840216.sql
@@ -35,3 +35,4 @@ DELETE FROM `creature_loot_template` WHERE (`Entry` = 435) AND (`Item` IN (24069
 DELETE FROM `creature_loot_template` WHERE (`Entry` = 435) AND (`Item` IN (44012, 44012));
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (435, 44012, 44012, 0.5, 0, 1, 1, 1, 1, 'Blackrock Champion - (ReferenceTable)');
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

whas good

we got 2 new bitches in RLT table u dig. just copied the original ones, removed the items references in the original issue and assigned em to the creature loot and we should be chillin now.

i inserted 2 new RLT cuz of groupid (wanted at first to just put items str8 into mob loot but that wouldn't be lit)

gang gang

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6252
- Closes https://github.com/chromiecraft/chromiecraft/issues/790

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

didnt kill lotta mf but to the ones i killed in never got them items removed dropped. should be ok imo


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  Go to Redridge Mountains
2.  Go to Render's Rock
3.  Kill Blackrock Champions and loot them
4.  Observe

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
