### PR TITLE
fix(DB/Spell): Glodrak Huntsniper should not spaw with his mug throwi…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1632482613720296800.sql
+++ b/data/sql/updates/pending_db_world/rev_1632482613720296800.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1632482613720296800');
+
+DELETE FROM `spell_script_names` WHERE `spell_id`=43714;
+INSERT INTO `spell_script_names` VALUES
+(43714,'spell_brewfest_relay_race_force_cast');

--- a/src/server/scripts/Events/brewfest.cpp
+++ b/src/server/scripts/Events/brewfest.cpp
@@ -1758,6 +1758,46 @@ public:
     }
 };
 
+class spell_brewfest_relay_race_force_cast : public SpellScriptLoader
+{
+public:
+    spell_brewfest_relay_race_force_cast() : SpellScriptLoader("spell_brewfest_relay_race_force_cast") {}
+
+    class spell_brewfest_relay_race_force_cast_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_brewfest_relay_race_force_cast_SpellScript);
+
+        SpellCastResult CheckItem()
+        {
+            if (Unit* target = GetExplTargetUnit())
+            {
+                if (SpellInfo const* triggeredSpellInfo = sSpellMgr->GetSpellInfo(GetSpellInfo()->Effects[EFFECT_0].TriggerSpell))
+                {
+                    if (Player* player = target->ToPlayer())
+                    {
+                        if (player->HasItemCount(triggeredSpellInfo->Reagent[0]))
+                        {
+                            return SPELL_CAST_OK;
+                        }
+                    }
+                }
+            }
+
+            return SPELL_FAILED_DONT_REPORT;
+        }
+
+        void Register() override
+        {
+            OnCheckCast += SpellCheckCastFn(spell_brewfest_relay_race_force_cast_SpellScript::CheckItem);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_brewfest_relay_race_force_cast_SpellScript();
+    }
+};
+
 void AddSC_event_brewfest_scripts()
 {
     // Npcs
@@ -1783,6 +1823,7 @@ void AddSC_event_brewfest_scripts()
     new spell_brewfest_unfill_keg();
     new spell_brewfest_toss_mug();
     new spell_brewfest_add_mug();
+    new spell_brewfest_relay_race_force_cast();
 
     // beer effect
     new npc_brew_bubble();


### PR DESCRIPTION
…ng spell if player does not have Portable Brewfest Keg.

Fixes #7913

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #7913

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. `.event start 24`
2. go to horde brewfest area outside Orgrimmar as horde or alliance
3. no throwing mug animation anymore

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
