### PR TITLE
fix(Core/Commands): Partially fix an issue with mails sent from conso…

### DIFF
--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -2680,8 +2680,10 @@ public:
         std::string subject = msgSubject;
         std::string text    = msgText;
 
-        // from console show not existed sender
-        MailSender sender(MAIL_NORMAL, handler->GetSession() ? handler->GetSession()->GetPlayer()->GetGUID().GetCounter() : 0, MAIL_STATIONERY_GM);
+        ObjectGuid::LowType senderGuid;
+        // If the message is sent from console, set it as sent by the target itself, like the other Customer Support mails.
+        senderGuid = handler->GetSession() ? handler->GetSession()->GetPlayer()->GetGUID().GetCounter() : targetGuid.GetCounter();
+        MailSender sender(MAIL_NORMAL, senderGuid, MAIL_STATIONERY_GM);
 
         //- TODO: Fix poor design
         CharacterDatabaseTransaction trans = CharacterDatabase.BeginTransaction();
@@ -2778,8 +2780,10 @@ public:
             }
         }
 
-        // from console show not existed sender
-        MailSender sender(MAIL_NORMAL, handler->GetSession() ? handler->GetSession()->GetPlayer()->GetGUID().GetCounter() : 0, MAIL_STATIONERY_GM);
+        ObjectGuid::LowType senderGuid;
+        // If the message is sent from console, set it as sent by the target itself, like the other Customer Support mails.
+        senderGuid = handler->GetSession() ? handler->GetSession()->GetPlayer()->GetGUID().GetCounter() : receiverGuid.GetCounter();
+        MailSender sender(MAIL_NORMAL, senderGuid, MAIL_STATIONERY_GM);
 
         // fill mail
         MailDraft draft(subject, text);


### PR DESCRIPTION
…le never showing up the 'Customer Support' sender in-game

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Assign the target (receiver) as sender when mails are sent from console, so they properly display the "Customer Support" sender-tag in-game (same as with any other CS mail, like item recovery and such, that also use receiver as sender).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
It's the same thing done by other support mail deliveries, so I don't see a reason why we shouldn't also do it here
https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Entities/Player/Player.cpp#L11610

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds successfully on Win11.
- Tested sending mails from console, works (but check the notes bellow on how to test it)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .send items / .send mail from console, twice (once to load the mail list, the other to actually show the notice).
2. Proper notification from "Customer Support" will show

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

We have issues loading the mail packets that handle the notifications. 

The call that handles the notifications loads all of the character mails as well, clearing the cache that is then repopulated from database - in this line: https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Handlers/MailHandler.cpp#L780

But by the time the iteration happens (to send the unread mails data), the mail cache isn't populated yet. https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Handlers/MailHandler.cpp#L790

So the first part of the packet, that tells there are unread mails, is sent, but the actual information isn't.

I'll submit another PR to address this, as I feel like it escapes the scope of this issue even if it's related to it somehow.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
