### PR TITLE
fix:(DB\Smart_scripts):Blazing Invader should not despawn

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1632568180601547400.sql
+++ b/data/sql/updates/pending_db_world/rev_1632568180601547400.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1632568180601547400');
+
+UPDATE ``smart_scripts` SET `action_param3`='990000' WHERE  `entryorguid`=179666 AND `source_type`=1 AND `id`=0 AND `link`=0;
+
+DELETE FROM `smart_scripts` WHERE `entryorguid`=14460;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(14460, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 89, 11, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Blazing Invader - Is Summoned - Random Move'),
+(14460, 0, 1, 0, 0, 0, 100, 0, 0, 11000, 10000, 16000, 0, 11, 23113, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Blazing Invader - In Combat - Cast Blast Wave');

--- a/data/sql/updates/pending_db_world/rev_1632568180601547400.sql
+++ b/data/sql/updates/pending_db_world/rev_1632568180601547400.sql
@@ -1,6 +1,6 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1632568180601547400');
 
-UPDATE `smart_scripts` SET `action_param3`='990000' WHERE  `entryorguid`=179666 AND `source_type`=1 AND `id`=0 AND `link`=0;
+UPDATE `smart_scripts` SET `action_param3`=990000 WHERE  `entryorguid`=179666 AND `source_type`=1 AND `id`=0 AND `link`=0;
 
 DELETE FROM `smart_scripts` WHERE `entryorguid`=14460;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1632568180601547400.sql
+++ b/data/sql/updates/pending_db_world/rev_1632568180601547400.sql
@@ -1,6 +1,6 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1632568180601547400');
 
-UPDATE ``smart_scripts` SET `action_param3`='990000' WHERE  `entryorguid`=179666 AND `source_type`=1 AND `id`=0 AND `link`=0;
+UPDATE `smart_scripts` SET `action_param3`='990000' WHERE  `entryorguid`=179666 AND `source_type`=1 AND `id`=0 AND `link`=0;
 
 DELETE FROM `smart_scripts` WHERE `entryorguid`=14460;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7369
- Closes https://github.com/chromiecraft/chromiecraft/issues/1440

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .go c id 14460 and look for the portal, it despawned either after 500ms (when out of combat) either 2 mins after spawned.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 14460 and look for the portal, stay near portal and look at elementals, they won't despawn anymore
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
