### PR TITLE
[Quest Bug] - Giant Softshell Clam Unlootable

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1632611085790498000.sql
+++ b/data/sql/updates/pending_db_world/rev_1632611085790498000.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1632611085790498000');
+
+UPDATE `gameobject_template` SET `Data8` = 6142 WHERE (`entry` = 177784);


### PR DESCRIPTION
## Changes Proposed:
-  Update Giant Softshell Clam (177784) with correct questID (6142)

## Issues Addressed:
- Closes #7908

## Tests Performed:
- Successfully loot clam

![clamlootable](https://user-images.githubusercontent.com/6396416/134788622-803e7214-824a-40f7-915a-e7b3a0c43071.jpg)

## How to Test the Changes:

1. .quest add 6142
2. .go o 31973
3. Loot big clam

## Known Issues and TODO List:

- NA

