### PR TITLE
fix(DB/Creature): Adds a spawn point and movement to Sister Riven

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1632680088118540400.sql
+++ b/data/sql/updates/pending_db_world/rev_1632680088118540400.sql
@@ -1,0 +1,11 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1632680088118540400');
+
+DELETE FROM `creature` WHERE (`id` = 5930);
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(16400, 5930, 1, 406, 465, 1, 1, 10875, 0, 684.793, 1458.34, -12.6599, 0.93, 43200, 10, 0, 2196, 1512, 1, 0, 0, 0, '', 0),
+(29213, 5930, 1, 406, 465, 1, 1, 10875, 0, 657.605, 1796.68, -13.2473, 3.28, 43200, 20, 0, 2196, 1512, 1, 0, 0, 0, '', 0);
+
+DELETE FROM `pool_creature` WHERE `guid` IN (16400, 29213);
+INSERT INTO `pool_creature` (`guid`, `pool_entry`, `chance`, `description`) VALUES
+(16400, 359, 0, 'Sister Riven Spawn 1'),
+(29213, 359, 0, 'Sister Riven Spawn 2');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Adds a spawn point and movement to Sister Riven
- The issue lists 3 spawn points, but 2 of them are near the same place, so didn't add that.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #7967

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Done as described below


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run SQL
     * First query should delete 1 row
     * Second query should insert 2 rows
     * Third query should delete 0 rows
     * Fourth query should insert 2 rows
2. ``` .go c 16400 ``` & ``` .go c 29213 ``` 
    * Check that only one of them spawns
    * Check that they move

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
