### PR TITLE
fix(DB/Gameobject): Moves a Goldthorn herb to the ground

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1632681445196667900.sql
+++ b/data/sql/updates/pending_db_world/rev_1632681445196667900.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1632681445196667900');
+
+DELETE FROM `gameobject` WHERE (`id` = 2046) AND (`guid` IN (8699));
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(8699, 2046, 0, 0, 0, 1, 1, -807.73, -3595.466797, 76.099289, 2.67, 0, 0, 0, 0, 60, 100, 1, '', 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Moves a Goldthorn herb to the ground, see new position below:
![image](https://user-images.githubusercontent.com/53914190/134820043-e81ddd01-51d2-4646-badf-b11ad214bfbe.png)
This position comes from [wowhead](https://tbc.wowhead.com/object=2046/goldthorn)
![image](https://user-images.githubusercontent.com/53914190/134820077-67c7c560-3bdd-4009-9dcf-e04da9e097c0.png)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5934
- Closes https://github.com/chromiecraft/chromiecraft/issues/667

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Done as described below


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run SQL — Should both change 1 row
2. ``` .go o 8699 ``` — See that it spawns on the ground 
    * As it is in a pool, it might not spawn. Check in that case with ``` .gobject near 1 ```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
