### PR TITLE
fix(DB/Fishing): Add seasonal fish, Raw Summer Bass/Winter Squid. Sou…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1633019690709542500.sql
+++ b/data/sql/updates/pending_db_world/rev_1633019690709542500.sql
@@ -1,0 +1,17 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1633019690709542500');
+
+DELETE FROM `reference_loot_template` WHERE `Entry` IN (11009,11105) AND `Item`=13755;
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(11009, 13755, 0, 15, 0, 1, 1, 1, 1, ""),
+(11105, 13755, 0, 20, 0, 1, 1, 1, 1, "");
+
+DELETE FROM `game_event` WHERE `eventEntry`=78;
+INSERT INTO `game_event` (`eventEntry`,`start_time`,`end_time`,`occurence`,`length`,`holiday`,`description`,`world_event`, announce) VALUES
+(78, '2019-03-20 07:00:00', '2030-12-31 07:00:00',525600,262800,0, 'Summer seasonal fish',0,2);
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=10 AND `SourceGroup` IN (11009,11105) AND `SourceEntry` IN (13755,13756);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(10, 11009, 13756, 0, 0, 12, 0, 78, 0, 0, 0, 0, 0, "", "Raw Summer Bass during Summer seasonal fish only"),
+(10, 11105, 13756, 0, 0, 12, 0, 78, 0, 0, 0, 0, 0, "", "Raw Summer Bass during Summer seasonal fish only"),
+(10, 11009, 13755, 0, 0, 12, 0, 78, 0, 0, 1, 0, 0, "", "Winter Squid only when Summer seasonal fish is off"),
+(10, 11105, 13755, 0, 0, 12, 0, 78, 0, 0, 1, 0, 0, "", "Winter Squid only when Summer seasonal fish is off");


### PR DESCRIPTION
…rce: TrinityCore.

Fixes #8033

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #8033
- Closes https://github.com/chromiecraft/chromiecraft/issues/1817

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Learn Fishing
`.setskill 356 450 450`

Buy Fishing spell from Marcia Chase
`.go cr 102399`
`.mod money 485600`

Get a Fishing Rod
`.additem 43651`

Go to Bay of Storms in Azshara
`.tele bayofstorms`

Start fishing

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
