### PR TITLE
fix(Scripts/Spells): Linken's boomerang

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1633027575141830731.sql
+++ b/data/sql/updates/pending_db_world/rev_1633027575141830731.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1633027575141830731');
+
+DELETE FROM `spell_script_names` WHERE `spell_id` = 15712 AND `ScriptName` = "spell_item_linken_boomerang";
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (15712, "spell_item_linken_boomerang");

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -4385,6 +4385,69 @@ public:
     }
 };
 
+
+
+enum LinkenBoomerang
+{
+    SPELL_DISARM = 15752,
+    SPELL_STUN   = 15753
+};
+
+class spell_item_linken_boomerang : public SpellScriptLoader
+{
+public:
+    spell_item_linken_boomerang() : SpellScriptLoader("spell_item_linken_boomerang") {}
+
+    class spell_item_linken_boomerang_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_item_linken_boomerang_SpellScript)
+
+            void OnEffectHitTargetDisarm(SpellEffIndex effIndex)
+        {
+            PreventHitDefaultEffect(effIndex);
+        }
+
+        void OnEffectHitTargetStun(SpellEffIndex effIndex)
+        {
+            PreventHitDefaultEffect(effIndex);
+        }
+
+        void OnEffectLaunchTargetDisarm(SpellEffIndex effIndex)
+        {
+            PreventHitDefaultEffect(effIndex);
+
+            if (roll_chance_i(3)) // 3% from wiki n shit
+            {
+                GetCaster()->CastSpell(GetHitUnit(), SPELL_DISARM, true);
+            }
+        }
+
+        void OnEffectLaunchTargetStun(SpellEffIndex effIndex)
+        {
+            PreventHitDefaultEffect(effIndex);
+
+            if (roll_chance_i(3)) // 3% from wiki n shit
+            {
+                GetCaster()->CastSpell(GetHitUnit(), SPELL_STUN, true);
+            }
+        }
+
+        void Register() override
+        {
+            OnEffectLaunchTarget += SpellEffectFn(spell_item_linken_boomerang_SpellScript::OnEffectLaunchTargetDisarm, EFFECT_1, SPELL_EFFECT_TRIGGER_SPELL);
+            OnEffectLaunchTarget += SpellEffectFn(spell_item_linken_boomerang_SpellScript::OnEffectLaunchTargetStun, EFFECT_2, SPELL_EFFECT_TRIGGER_SPELL);
+
+            OnEffectHitTarget += SpellEffectFn(spell_item_linken_boomerang_SpellScript::OnEffectHitTargetDisarm, EFFECT_1, SPELL_EFFECT_TRIGGER_SPELL);
+            OnEffectHitTarget += SpellEffectFn(spell_item_linken_boomerang_SpellScript::OnEffectHitTargetStun, EFFECT_2, SPELL_EFFECT_TRIGGER_SPELL);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_item_linken_boomerang_SpellScript();
+    }
+};
+
 void AddSC_item_spell_scripts()
 {
     // Ours
@@ -4494,4 +4557,5 @@ void AddSC_item_spell_scripts()
     new spell_item_greatmothers_soulcatcher();
     new spell_item_eggnog();
     new spell_item_goblin_bomb();
+    new spell_item_linken_boomerang();
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

spells script to fix this bih

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7816
- https://github.com/chromiecraft/chromiecraft/issues/1695

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
wiki says so

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .additem 11905
2. keep spammin that bih and u gon hardly see now (3% chance) that it finna stun or disarm wor


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
