### PR TITLE
Add Emote Reactions to Guards Part 2

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1633110270390665427.sql
+++ b/data/sql/updates/pending_db_world/rev_1633110270390665427.sql
@@ -1,0 +1,11 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1633110270390665427');
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (5595) AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(5595,0,1,0,22,0,100,0,101,5000,5000,0,80,6800,0,0,0,0,0,1,0,0,0,0,0,0,0,"Ironforge Guard - On Received Emote 'Wave' - Run Script"),
+(5595,0,2,0,22,0,100,0,78,5000,5000,0,80,6801,0,0,0,0,0,1,0,0,0,0,0,0,0,"Ironforge Guard - On Received Emote 'Salute' - Run Script"),
+(5595,0,3,0,22,0,100,0,58,5000,5000,0,80,6802,0,0,0,0,0,1,0,0,0,0,0,0,0,"Ironforge Guard - On Received Emote 'Kiss' - Run Script"),
+(5595,0,4,0,22,0,100,0,84,5000,5000,0,80,6803,0,0,0,0,0,1,0,0,0,0,0,0,0,"Ironforge Guard - On Received Emote 'Shy' - Run Script"),
+(5595,0,5,0,22,0,100,0,77,5000,5000,0,80,6804,0,0,0,0,0,1,0,0,0,0,0,0,0,"Ironforge Guard - On Received Emote 'Rude' - Run Script"),
+(5595,0,7,0,22,0,100,0,17,5000,5000,0,80,6802,0,0,0,0,0,1,0,0,0,0,0,0,0,"Ironforge Guard - On Received Emote 'Bow' - Run Script");
+UPDATE `creature_template` SET `AIName`='SmartAI' WHERE  `entry`=5595;


### PR DESCRIPTION
## Changes Proposed:
-  Add Emote Reactions to Guards Part 2 (Ironforge Guards)
- 
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Got close to a Ironforge Guard and did any emote specified in the commit
(wave, salute, kiss, bow, shy, rude)



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- Get close to a Ironforge Guard and do any emote specified in the commit
(wave, salute, kiss, bow, shy, rude)

## Known Issues and TODO List:

Give more Guards emotions