### PR TITLE
fix(Scripts/Event): Always the nearest baker should throw Complimenta…

### DIFF
--- a/src/server/scripts/Events/brewfest.cpp
+++ b/src/server/scripts/Events/brewfest.cpp
@@ -1675,7 +1675,6 @@ public:
 
         void HandleScriptEffect(SpellEffIndex /*effIndex*/)
         {
-            Creature* cr = nullptr;
             Unit* caster = GetCaster();
             if (!caster)
                 return;
@@ -1683,23 +1682,49 @@ public:
             if (!GetHitUnit() || GetHitUnit()->GetGUID() != caster->GetGUID())
                 return;
 
+            std::vector<Creature*> bakers;
             if (caster->GetMapId() == 1) // Kalimdor
             {
-                if ((cr = caster->FindNearestCreature(NPC_NORMAL_VOODOO, 40.0f)))
-                    cr->CastSpell(caster, SPELL_THROW_MUG_TO_PLAYER, true);
-                else if ((cr = caster->FindNearestCreature(NPC_NORMAL_DROHN, 40.0f)))
-                    cr->CastSpell(caster, SPELL_THROW_MUG_TO_PLAYER, true);
-                else if ((cr = caster->FindNearestCreature(NPC_NORMAL_GORDOK, 40.0f)))
-                    cr->CastSpell(caster, SPELL_THROW_MUG_TO_PLAYER, true);
+                if (Creature* creature = caster->FindNearestCreature(NPC_NORMAL_VOODOO, 40.0f))
+                {
+                    bakers.push_back(creature);
+                }
+
+                if (Creature* creature = caster->FindNearestCreature(NPC_NORMAL_DROHN, 40.0f))
+                {
+                    bakers.push_back(creature);
+                }
+
+                if (Creature* creature = caster->FindNearestCreature(NPC_NORMAL_GORDOK, 40.0f))
+                {
+                    bakers.push_back(creature);
+                }
             }
             else // EK
             {
-                if ((cr = caster->FindNearestCreature(NPC_NORMAL_THUNDERBREW, 40.0f)))
-                    cr->CastSpell(caster, SPELL_THROW_MUG_TO_PLAYER, true);
-                else if ((cr = caster->FindNearestCreature(NPC_NORMAL_BARLEYBREW, 40.0f)))
-                    cr->CastSpell(caster, SPELL_THROW_MUG_TO_PLAYER, true);
-                else if ((cr = caster->FindNearestCreature(NPC_NORMAL_GORDOK, 40.0f)))
-                    cr->CastSpell(caster, SPELL_THROW_MUG_TO_PLAYER, true);
+                if (Creature* creature = caster->FindNearestCreature(NPC_NORMAL_THUNDERBREW, 40.0f))
+                {
+                    bakers.push_back(creature);
+                }
+
+                if (Creature* creature = caster->FindNearestCreature(NPC_NORMAL_BARLEYBREW, 40.0f))
+                {
+                    bakers.push_back(creature);
+                }
+
+                if (Creature* creature = caster->FindNearestCreature(NPC_NORMAL_GORDOK, 40.0f))
+                {
+                    bakers.push_back(creature);
+                }
+            }
+
+            if (!bakers.empty())
+            {
+                std::sort(bakers.begin(), bakers.end(), Acore::ObjectDistanceOrderPred(caster));
+                if (Creature* creature = *bakers.begin())
+                {
+                    creature->CastSpell(caster, SPELL_THROW_MUG_TO_PLAYER, true);
+                }
             }
         }
 


### PR DESCRIPTION
…ry Brewfest Sampler back.

Fixes #8027

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #8027

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Be horde
2. `.event start 24` (unless you're doing this between Sep 20- Oct 6)
3. `.go c 88944`
4. Grab a complimentary mug off the table
5. Run around the area periodically drinking and tossing the mug
6. Pay attention to who is throwing you a new mug.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
