### PR TITLE
fix(Core/Formations): fixed mistake in radians calculation (for formation angle calculation)

### DIFF
--- a/src/server/game/Entities/Creature/CreatureGroups.cpp
+++ b/src/server/game/Entities/Creature/CreatureGroups.cpp
@@ -101,7 +101,7 @@ void FormationMgr::LoadCreatureFormations()
         group_member.leaderGUID            = fields[0].GetUInt32();
         ObjectGuid::LowType const memberGUID = fields[1].GetUInt32();
         float const follow_dist             = fields[2].GetFloat();
-        float const follow_angle            = fields[3].GetFloat() * static_cast<float>(M_PI) / 180;
+        float const follow_angle            = fields[3].GetFloat() * (static_cast<float>(M_PI) / 180);
         group_member.groupAI               = fields[4].GetUInt16();
         group_member.point_1               = fields[5].GetUInt16();
         group_member.point_2               = fields[6].GetUInt16();
@@ -124,7 +124,7 @@ void FormationMgr::LoadCreatureFormations()
             else
             {
                 group_member.follow_dist       = follow_dist;
-                group_member.follow_angle      = follow_angle * static_cast<float>(M_PI) / 180;
+                group_member.follow_angle      = follow_angle;
             }
         }
         else


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fixed formation angle calculation
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Checked Garr (Molten Core) minions formation and Lower Spire adds (Icecrown Citadel)
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Go to creature 56609 (Garr, Molten Core) and observe motion

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
