### PR TITLE
fix(DB/creature_loot): Reduce Alanna's Embrace drop rate

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1633177696846115469.sql
+++ b/data/sql/updates/pending_db_world/rev_1633177696846115469.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1633177696846115469');
+
+-- Change Alanna's Embrace drop chance from Ras Frostwhisper to 0.36% (x2 = 0.72% total)
+UPDATE `reference_loot_template` SET `Chance` = 0.36 WHERE `Entry` = 35030 AND `Item` = 13314;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Reduces the drop rate of [Alanna's Embrace](https://tbc.wowhead.com/item=13314/alannas-embrace) from a total of 4% (from 2 rolls at 2% each) to 0.72% (2 rolls at 0.36% each.) (It's x 2 because the RLT in question is rolled twice.) This brings it into line with data from Wowhead/Wowpedia. The RLT affected is only used by Ras Frostwhisper, so no other NPCs are affected.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8214
- Closes https://github.com/chromiecraft/chromiecraft/issues/1918

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/item=13314/alannas-embrace
https://wowpedia.fandom.com/wiki/Alanna's_Embrace?oldid=2021557

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, 1 row affected.
- Checked in Keira

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check in Keira, the drop rate is too low to sensibly test in game.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
