### PR TITLE
fix(DB/creature): Remove Civilian flag from Emerald Dragon Whelp

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1633308203494634065.sql
+++ b/data/sql/updates/pending_db_world/rev_1633308203494634065.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1633308203494634065');
+
+-- Remove Civilian flag from summoned Emerald Dragon Whelp
+UPDATE `creature_template` SET `flags_extra`=`flags_extra`&~(2) WHERE `entry` = 8776;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Removes the Civilian flag from [Emerald Dragon Whelp](https://tbc.wowhead.com/npc=8776/emerald-dragon-whelp), a summoned pet spawned by [Dragon's Call](https://tbc.wowhead.com/item=10847/dragons-call). The pet is supposed to assist you in battle, but is currently passive because of the flag.

Also note that this is a summoned creature only, there are no other open-world spawns affected by this change.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8244
- Closes https://github.com/chromiecraft/chromiecraft/issues/1933

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowpedia.fandom.com/wiki/Dragon's_Call?oldid=2175104
https://tbc.wowhead.com/npc=8776/emerald-dragon-whelp#comments

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, 1 row changed as expected.
- Tested in-game. Summoned whelp now correctly attacks targets:

![WoWScrnShot_100421_105553](https://user-images.githubusercontent.com/81782124/135779562-b695bd48-596a-4e88-adf2-76d0fb3f2532.jpg)
![WoWScrnShot_100421_105817](https://user-images.githubusercontent.com/81782124/135779575-6eaf9f51-0071-41e3-8fd7-cd06915c307c.jpg)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .additem [dragon's call]
2. Hit things until it procs. I did try just using the summon spell directly, but the dragon summoned directly behaved differently to that summoned by the sword proc for some reason.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
