### PR TITLE
fix(DB/Spells): Malown's Slam should proc Surge of Strenght

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1633368419901196100.sql
+++ b/data/sql/updates/pending_db_world/rev_1633368419901196100.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1633368419901196100');
+
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 17500;
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES
+(17500, 17499, 0, 'Malown\'s Slam - trigger Surge of Strenght');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Link 17499 (Surge of Strenght) to Malown's Slam (17500)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8265

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Spellworks indicates that this is the aura to be applied once the spell is cast.
![Skärmbild 2021-10-04 143326](https://user-images.githubusercontent.com/47818697/135897502-539cc111-7bf8-48f3-b823-32f0e209d2e6.jpg)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.add item 13393
2. go hit dummy or mobs
3. see when the target gets stunned, you obtain the strength buff

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
