### PR TITLE
fix(Quest): Fixed npcs and factions for Argent Dawn Commission quests

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1633441032592746463.sql
+++ b/data/sql/updates/pending_db_world/rev_1633441032592746463.sql
@@ -1,0 +1,32 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1633441032592746463');
+
+-- Change the allowed races for Argent Dawn Commission quests and their starting and ending npcs.
+
+-- FLAGS
+-- Alliance 1 Human , 4 Dwarf, 8 Night Elf, 64 Gnome ,1024	Draenei
+-- Horde  2 Orc , 16 Undead, 32 Tauren, 128 Troll, 512 Blood Elf
+
+-- Alliance only(5401)
+UPDATE `quest_template` SET `AllowableRaces` = `AllowableRaces`|1|4|8|64|1024 WHERE (`ID` = 5401);
+
+-- Horde only(5405)
+UPDATE `quest_template` SET `AllowableRaces` = `AllowableRaces`|2|16|32|128|512 WHERE (`ID` = 5405);
+
+-- Changed from Argent Officer Pureheart to Argent Officer Garush.
+DELETE FROM `creature_queststarter` WHERE (`quest` = 5405) AND (`id` IN (10857, 10839));
+INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES
+(10839, 5405);
+
+DELETE FROM `creature_questender` WHERE (`quest` = 5405) AND (`id` IN (10857, 10839));
+INSERT INTO `creature_questender` (`id`, `quest`) VALUES
+(10839, 5405);
+
+-- Changed from Argent Officer Garush to Duke Nicholas Zverenhoff  For the neutral quest(5503)
+DELETE FROM `creature_queststarter` WHERE (`quest` = 5503) AND (`id` IN (10839, 11039));
+INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES
+(11039, 5503);
+
+DELETE FROM `creature_questender` WHERE (`quest` = 5503) AND (`id` IN (10839, 11039));
+INSERT INTO `creature_questender` (`id`, `quest`) VALUES
+(11039, 5503);
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changed the faction needed for the alliance only (5401) and horde only(5405) quests
-  Fixed the NPC for the quests horde only from Argent Officer Pureheart to Argent Officer Garush.
- Fixed the NPC for the neutral quest(5503) from Argent Officer Garush to Duke Nicholas Zverenhoff 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8253
- Closes https://github.com/chromiecraft/chromiecraft/issues/1959

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://classic.wowhead.com/quest=5503/argent-dawn-commission
https://classic.wowhead.com/quest=5401/argent-dawn-commission
https://classic.wowhead.com/quest=5405/argent-dawn-commission


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

As Horde: 
- .go c id 10839 and check that you can take it. (Horde only)
- .go c id 10840 and check that you can NOT take it (Alliance only)
- .go c id 11039 and check that you can take it (All factions)

As alliance
- .go c id 10839 and check that you can NOT take it. (Horde only)
- .go c id 10840 and check that you can take it (Alliance only)
- .go c id 11039 and check that you can take it (All factions)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Same as ## Tests Performed:

Test images

HORDE

Horde quest
![argen dawn horde](https://user-images.githubusercontent.com/87535580/136035136-7a3ea99d-0e81-4922-a0cc-227fd4be3f22.jpg)

Alliance quest
![argen dawn alliance](https://user-images.githubusercontent.com/87535580/136035177-9e28b225-b3aa-4f8c-919e-dabdbb84a708.jpg)

Neutral quest
![argen dawn neutral](https://user-images.githubusercontent.com/87535580/136035195-fc86c681-a4bc-4e48-a97d-74073a77daed.jpg)

ALLIANCE

Horde quest
![alliance dawn horde](https://user-images.githubusercontent.com/87535580/136035247-1c2d8d3d-d2f9-4d73-8ca9-dd37a00b0011.jpg)

Alliance quest
![alliance dawn alliance](https://user-images.githubusercontent.com/87535580/136035270-f1806597-1668-4ea3-bbe3-5adabe2f4f4c.jpg)

Neutral quest
![alliance dawn neutral](https://user-images.githubusercontent.com/87535580/136035324-4ee74ad8-4372-43a5-9893-10dcad8529b0.jpg)


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
