### PR TITLE
fix(DB/quest): Fix Defiling Uther's Tomb visuals & quest objective

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1633627685425341900.sql
+++ b/data/sql/updates/pending_db_world/rev_1633627685425341900.sql
@@ -17,14 +17,14 @@ UPDATE `conditions` SET `ConditionValue1`=3, `ConditionValue2`=17066  WHERE `Sou
 
 DELETE FROM `conditions` WHERE `SourceEntry` IN (30098) AND `SourceTypeOrReferenceId`=17;
 DELETE FROM `conditions` WHERE `SourceEntry` IN (30098) AND `SourceTypeOrReferenceId`=13;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId, SourceGroup, SourceEntry, SourceId, ElseGroup, ConditionTypeOrReference, ConditionTarget`, `ConditionValue1, ConditionValue2, ConditionValue3, NegativeCondition, ErrorType, ErrorTextId, ScriptName, COMMENT`) VALUES
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `COMMENT`) VALUES
 (13, 2, 30098, 0, 0, 31, 0, 3, 17253, 0, 0, 0, 0, "", ""),
 (13, 2, 30098, 0, 0, 29, 0, 17233, 20, 0, 1, 0, 0, "", ""),
 (13, 1, 30098, 0, 0, 31, 0, 5, 182483, 0, 0, 0, 0, "", ""),
 (13, 4, 30098, 0, 0, 31, 0, 5, 181653, 0, 0, 0, 0, "", "");
 
 DELETE FROM `conditions` WHERE `SourceEntry` IN (17233) AND `SourceTypeOrReferenceId`=22;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId, SourceGroup, SourceEntry, SourceId, ElseGroup, ConditionTypeOrReference, ConditionTarget`, `ConditionValue1, ConditionValue2, ConditionValue3, NegativeCondition, ErrorType, ErrorTextId, ScriptName, COMMENT`) VALUES
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `COMMENT`) VALUES
 (22, 1, 17233, 0, 0, 6, 0, 67, 0, 0, 1, 0, 0, "", "");
 
 UPDATE `event_scripts` SET `datalong2`=55000 WHERE `id`=10561;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fix beam when item used 
-  Fix texts
-  Fix quest objective not being rewarded

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/1955
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8249

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://github.com/TrinityCore/TrinityCore/commit/18222b8d5053a04c9c1665de9562d87ebccddef3

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Checked ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.q a 9444`
2. `.go c id 1854`
3. Equip the quest item, use it and check RP & quest is rewarded

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
