### PR TITLE
fix(DB/Quest): When Smokey sings, I get violent

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1633602145949999800.sql
+++ b/data/sql/updates/pending_db_world/rev_1633602145949999800.sql
@@ -36,3 +36,6 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 -- Remove the SAI that grants quest credit from the compound, it's handled by the NPC instead.
 DELETE FROM `smart_scripts` WHERE `entryorguid`  = 177672 AND `source_type` = 1;
 UPDATE `gameobject_template` SET `AIName` = '' WHERE `entry` = 177672;
+
+-- Set respawn timer for the Mark of Detonation GO to 3 minutes.
+UPDATE `gameobject` SET `spawntimesecs` = 180 WHERE `id` = 177668;


### PR DESCRIPTION
- Port conditions/SAI from TC
- Explosion effect works, gameobjects despawn

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Port conditions/SAI from TC
- Explosion effect works, gameobjects despawn  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8297
- Closes https://github.com/chromiecraft/chromiecraft/issues/1992

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
TrinityCore

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. go gob 45698
2. quest add 6041
3.Use item provided near the marks

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] CRITICAL - Gameobjects never respawn, SAI needs to be updated (https://github.com/azerothcore/azerothcore-wotlk/pull/8340)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
