### PR TITLE
fix(DB/Gameobject): Bruiseweed spawn at entrance of the building

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1633732567546468906.sql
+++ b/data/sql/updates/pending_db_world/rev_1633732567546468906.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1633732567546468906');
+
+#fix herb at entrance of the building #8355
+DELETE FROM `gameobject` WHERE (`id` = 1622) AND (`guid` IN (3764));
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(3764, 1622, 0, 0, 0, 1, 1, -2644.78, -2362.86, 97.341, 2.909, 0, 0, 0, 0, 60, 100, 1, '', 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  fix spawn point

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #8355

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- sql applied

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go gobject 3764
2. spawn is now in good place

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
