### PR TITLE
fix(Core/EventScripts): Credit nearby group members when using the SC…

### DIFF
--- a/src/server/game/Scripting/MapScripts.cpp
+++ b/src/server/game/Scripting/MapScripts.cpp
@@ -566,7 +566,7 @@ void Map::ScriptsProcess()
                     // quest id and flags checked at script loading
                     if ((worldObject->GetTypeId() != TYPEID_UNIT || ((Unit*)worldObject)->IsAlive()) &&
                             (step.script->QuestExplored.Distance == 0 || worldObject->IsWithinDistInMap(player, float(step.script->QuestExplored.Distance))))
-                        player->AreaExploredOrEventHappens(step.script->QuestExplored.QuestID);
+                        player->GroupEventHappens(step.script->QuestExplored.QuestID, worldObject);
                     else
                         player->FailQuest(step.script->QuestExplored.QuestID);
 


### PR DESCRIPTION
…RIPT_COMMAND_QUEST_EXPLORED event_scripts command

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Credit nearby group members when using the SCRIPT_COMMAND_QUEST_EXPLORED event_scripts command

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Updates https://github.com/azerothcore/azerothcore-wotlk/issues/8254

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
- Tested Shy-Rotam quest credit in-game

## How to Test the Changes:
```
.q add 5056
.additem [Sacred Frostsaber Meat]
.go o 99884 - ports you to the rock
```
Use the meat on the rock and observe.

-  There's only 4 rows using this command, so should be safe enough.

```sql
SELECT * FROM event_scripts WHERE command = 7;
```

## Known Issues and TODO List:
- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
