### PR TITLE
fix(Scripts/Spells): Move script for the spell Summon Shy-Rotam to core scripts

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1633798793231677400.sql
+++ b/data/sql/updates/pending_db_world/rev_1633798793231677400.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1633798793231677400');
+
+DELETE FROM `event_scripts` WHERE `id` = 4975 AND `command` = 10;
+
+DELETE FROM `spell_script_names` WHERE `spell_id` = 16796 AND `ScriptName` = 'spell_q5056_summon_shy_rotam';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(16796, 'spell_q5056_summon_shy_rotam');

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -3077,6 +3077,42 @@ public:
     }
 };
 
+enum QuestShyRotam
+{
+    NPC_SHY_ROTAM = 10737,
+};
+
+// 16796 - Summon Shy-Rotam
+class spell_q5056_summon_shy_rotam : public SpellScriptLoader
+{
+public:
+    spell_q5056_summon_shy_rotam() : SpellScriptLoader("spell_q5056_summon_shy_rotam") {}
+
+    class spell_q5056_summon_shy_rotam_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_q5056_summon_shy_rotam_SpellScript);
+
+        void HandleFinish()
+        {
+            Position shyRotamSpawnPosition = Position(8072.38f, -3833.81f, 690.03f, 4.56f);
+            if (Creature* summon = GetCaster()->SummonCreature(NPC_SHY_ROTAM, shyRotamSpawnPosition, TEMPSUMMON_TIMED_DESPAWN, 15 * MINUTE * IN_MILLISECONDS))
+            {
+                summon->AI()->AttackStart(GetCaster());
+            }
+        }
+
+        void Register() override
+        {
+            AfterCast += SpellCastFn(spell_q5056_summon_shy_rotam_SpellScript::HandleFinish);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_q5056_summon_shy_rotam_SpellScript();
+    };
+};
+
 void AddSC_quest_spell_scripts()
 {
     // Ours
@@ -3148,4 +3184,5 @@ void AddSC_quest_spell_scripts()
     new spell_q12619_emblazon_runeblade_effect();
     new spell_q12919_gymers_grab();
     new spell_q12919_gymers_throw();
+    new spell_q5056_summon_shy_rotam();
 }


### PR DESCRIPTION
* Move creature summon script to core spell scripts from event_scripts
* Fixes it not engaging player when summoned

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Move creature summon script to core spell scripts from event_scripts
- Fixes it not engaging player when summoned

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8254
- Closes https://github.com/chromiecraft/chromiecraft/issues/1960

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.q add 5056
.additem [Sacred Frostsaber Meat]
.go o 99884 - ports you to the rock
Use the meat on the rock and observe.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Merge this https://github.com/azerothcore/azerothcore-wotlk/pull/8378 before (not entirely necessary, but it'll be better)
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
