### PR TITLE
fix(DB/Conditions): Fix conditions for Larion's Bloodpetal Zapper rep…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1633980818495484300.sql
+++ b/data/sql/updates/pending_db_world/rev_1633980818495484300.sql
@@ -1,5 +1,9 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1633980818495484300');
 
+DELETE FROM `gossip_menu` WHERE `MenuID` = 5631 AND `TextID` = 6742;
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES
+(5631, 6742);
+
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` = 5630;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (15, 5630, 0, 0, 0, 8, 0, 4148, 0, 0, 0, 0, 0, '', 'Show gossip option if quest \'Bloodpetal Zapper\' is rewarded'),


### PR DESCRIPTION
…lacement gossip and script so item is granted

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fix the conditions so the gossip only shows if players have quest 4148 (Bloodpetal Zapper) rewarded and don't have the Bloodpetal Zapper item in their inventory (TC Port)
-  Implement missing gossip text that is displayed after selecting the gossip option (TC Port)
- Actually scripted it so the item is granted once the gossip is selected

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/2060
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8433

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. go creature 9118
2. Check if he still offers the gossip without quest 4148 rewarded
3. quest reward 4148
4. check if he offers you the gossip, and if selecting it gives you the item (you mustn't already have the item in your inventory)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
