### PR TITLE
fix(DB/creature_loot): Removes invalid Firebloom drops from various NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1634042303141509213.sql
+++ b/data/sql/updates/pending_db_world/rev_1634042303141509213.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1634042303141509213');
+
+-- Removes invalid Firebloom drops from various NPCs
+DELETE FROM `creature_loot_template` WHERE `item` = 4625 AND `entry` NOT IN (1812, 1851, 5481, 5485, 5490, 5881, 6509, 6510, 6511, 6512, 6517, 6518, 
+6519, 6527, 7100, 7101, 7139, 7584, 8384, 11462, 12219, 12220, 12223, 12224, 13022, 13141, 13142);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes invalid Firebloom drops from various NPCs

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8424
- Closes https://github.com/chromiecraft/chromiecraft/issues/1852

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

See issue please

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors
- checked db afterwards, now only 27 NPCs are dropping Firebloom


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. 125 rows affected
2. Check:
```
SELECT ct.entry, ct.name, clt.chance, ct.maxlevel, it.ItemLevel
FROM `creature_template` ct
JOIN `creature_loot_template` clt ON ct.lootid = clt.entry
JOIN `item_template` it ON clt.item = it.entry
WHERE it.entry = 4625;
```
3. see that 27 mobs are left, that drop Firebloom

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
