### PR TITLE
fix(DB/creature_loot): Removes Black Metal War Axe from RLT

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1634045250480483175.sql
+++ b/data/sql/updates/pending_db_world/rev_1634045250480483175.sql
@@ -1,7 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1634045250480483175');
 
 -- Deletes Black Metal War Axe from the RLT 24068
-DELETE FROM `reference_loot_template` WHERE `Entry` = 24068 AND `item` = 2015;
+DELETE FROM `reference_loot_template` WHERE `Entry` = 24068 AND `Item` = 2015;
 
 -- Adds Black Metal War Axe to Brain Eaters directly
 DELETE FROM `creature_loot_template` WHERE `Entry` = 570 AND `Item` = 2015;
@@ -9,4 +9,4 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (570, 2015, 0, 0.9, 0, 1, 0, 1, 1, '');
 
 -- Reduces the drop chance of Nightcrawler to not exceed 100 % overall loot chance for Brain Eaters
-UPDATE `creature_loot_template` SET `Chance` = 32.28 WHERE `Entry` = 570 AND `item` = 6530;
+UPDATE `creature_loot_template` SET `Chance` = 32.28 WHERE `Entry` = 570 AND `Item` = 6530;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Removes Black Metal War Axe from RLT 24068
- Adds the Black Metal War Axe directly to Brain Eaters, as only they should drop it
- Adjusts the drop chance for Nightcrawler, to not exceed 100%

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8423
- Closes https://github.com/chromiecraft/chromiecraft/issues/1881

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

See issue please

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors
- checked db afterwards


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run:
```
SELECT * FROM `creature_loot_template` WHERE `item` = 2015
```
2. See that now ONLY Brain Eaters drops the item
3. Run:
```
SELECT SUM(`Chance`) FROM `creature_loot_template` WHERE `entry` = 570 AND `QuestRequired` = 0 AND `GroupID` = 0;
```
4. See that the overall loot chance for Brain Eaters (excluding group loots) is 100%

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
