### PR TITLE
fix(DB/disenchant_loot): DE loot for Dusty Mail Boots

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1634048043586591327.sql
+++ b/data/sql/updates/pending_db_world/rev_1634048043586591327.sql
@@ -1,6 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1634048043586591327');
 
 -- Fixes disenchanting loot for Dusty Mail Boots
-DELETE FROM `disenchant_loot_template` WHERE (`Entry` = 7) AND (`Item` IN (11137, 11174, 11177));
-INSERT INTO `disenchant_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(7, 11177, 0, 100, 0, 1, 1, 1, 1, 'Small Radiant Shard');
+UPDATE `item_template` SET `DisenchantID` = 45 WHERE `entry` = 19509;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  changes DE loot for Dusty Mail Boots to 100 % small radiant shard (it's a blue item since patch 3.3.0)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8152
- Closes https://github.com/chromiecraft/chromiecraft/issues/1885

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

See issue please

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors
- checked db
- also checked in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.additem 19509`
2. DE
3. See that you always get a Small Radiant Shard

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
