### PR TITLE
fix(DB/creature_loot): Remove Plans: Corruption from various NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1634130719161646149.sql
+++ b/data/sql/updates/pending_db_world/rev_1634130719161646149.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1634130719161646149');
+
+-- Delete Plans: Corruption from various NPCs
+DELETE FROM `creature_loot_template` WHERE `Entry` IN (10398, 10399, 10400, 10406, 10407, 10408, 10409, 10412, 10413, 10463, 10464) AND `Item` = 12830;
+
+-- Delete Plans: Corruption from RLT 24709
+DELETE FROM `reference_loot_template` WHERE `Entry` = 24709 AND `Item` = 12830;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Deletes [Plans: Corruption](https://tbc.wowhead.com/item=12830/plans-corruption) from the drop tables of 11 NPCs.
- Removes the same item from RLT 24709, which is indirectly used by [Red Dragonspawn](https://tbc.wowhead.com/npc=1045/red-dragonspawn) by way of RLT 24739. This NPC shouldn't have access to the item either.

This removal is because the item is not supposed to be a world drop, but is instead contained inside an item [Blacksmithing Plans](https://tbc.wowhead.com/object=176327/blacksmithing-plans) in Strath, and should only be available from it. Also checked the plans and they do drop the item correctly.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8479
- Closes https://github.com/chromiecraft/chromiecraft/issues/1860

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/item=12830/plans-corruption
https://wowpedia.fandom.com/wiki/Plans:_Corruption?oldid=2227987

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, correct number of lines changed.
- checked with SQL queries below.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Run queries below, they should both return no results.
```SQL
SELECT ct.name, clt.chance, ct.maxlevel, it.ItemLevel
FROM `creature_template` ct
JOIN `creature_loot_template` clt ON ct.lootid = clt.entry
JOIN `item_template` it ON clt.item = it.entry
WHERE it.entry = 12830;
```

```SQL
SELECT rlt.entry, it.name
FROM `reference_loot_template` rlt
JOIN `item_template` it ON rlt.Item = it.entry
WHERE rlt.item = 12830;
```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
