### PR TITLE
fix(DB\Loot):Cuergo's Hidden Treasure synced drop rate to an item and added additional item

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1633781441009417000.sql
+++ b/data/sql/updates/pending_db_world/rev_1633781441009417000.sql
@@ -1,8 +1,0 @@
-INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1633781441009417000');
-
--- Target: Felstone Field
-UPDATE `quest_template` SET `RewardFactionOverride2`='50000' WHERE `ID`=5229;
--- Dead Man's Plea
-UPDATE `quest_template` SET `RewardFactionOverride1`='100000' WHERE `ID`=8945;
--- Above and Beyond
-UPDATE `quest_template` SET `RewardFactionOverride1`='100000' WHERE  `ID`=5263;

--- a/data/sql/updates/pending_db_world/rev_1633781700837048300.sql
+++ b/data/sql/updates/pending_db_world/rev_1633781700837048300.sql
@@ -1,8 +1,0 @@
-INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1633781700837048300');
-
--- Target: Felstone Field
-UPDATE `quest_template` SET `RewardFactionOverride2`=50000 WHERE `ID`=5229;
--- Dead Man's Plea
-UPDATE `quest_template` SET `RewardFactionOverride1`=100000 WHERE `ID`=8945;
--- Above and Beyond
-UPDATE `quest_template` SET `RewardFactionOverride1`=100000 WHERE  `ID`=5263;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8408
- Closes https://github.com/chromiecraft/chromiecraft/issues/1996

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Added the item multiple times, Cuergo's Gold will drop 100% and Cuergo's Gold with Worm won't at all since its not in database.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Add the item multiple times and notice that Cuergo's Gold won't drop 100% and Cuergo's Gold with Worm is present in loot table.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
