### PR TITLE
fix(DB/creature_loot): Remove Dark Iron Ore from various NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1634216213882872003.sql
+++ b/data/sql/updates/pending_db_world/rev_1634216213882872003.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1634216213882872003');
+
+-- Remove Dark Iron Ore from various NPCs
+DELETE FROM `creature_loot_template` WHERE `Entry` NOT IN (8905, 8906, 8907, 8908, 8923, 9502) AND `Item` = 11370;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Removes Dark Iron Ore as a drop from 11 NPCs. The TBC Wowhead data for this is a corrupted mess with 6 of the listed 12 having invalid drops in any case, but the other 6 look good, and they all drop it on AC with normal rates. The other 11 NPCs that drop it on AC are not listed, have weird droprates, and aren't in the right place, so removing it from them.

Note the NOT in the query here is intentional.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8511
- Closes https://github.com/chromiecraft/chromiecraft/issues/1787

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/item=11370/dark-iron-ore
https://web.archive.org/web/20110613144351/http://www.wowhead.com/item=11370

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings. Note that although 11 NPCs are affected, you only get 9 rows changed - this is because 3 of the NPCs, Anvilrage Overseers, Wardens and Guardsman, all share the same drop table.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Run tthe query below. Remianing 6 should match the 6 with standard drops listed in sources above:
```SQL
SELECT ct.name, clt.chance, ct.maxlevel, it.ItemLevel
FROM `creature_template` ct
JOIN `creature_loot_template` clt ON ct.lootid = clt.entry
JOIN `item_template` it ON clt.item = it.entry
WHERE it.entry = 11370;
```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
