### PR TITLE
fix(DB\GameObject):Blood of Heroes respawn time, position and data corrections

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1634231663747169200.sql
+++ b/data/sql/updates/pending_db_world/rev_1634231663747169200.sql
@@ -1,15 +1,3 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1634231663747169200');
 
-UPDATE `gameobject` SET `spawntimesecs`=7200 WHERE `guid` IN (45513,45515,45854,45869,45935,45937);
-UPDATE `gameobject` SET `position_z`=47.4206 WHERE `guid`=5281;
-UPDATE `gameobject` SET `position_z`=65.9905 WHERE `guid`=5276;
--- Correct object data to match the original
-UPDATE `gameobject_template` SET `displayId`=4211 WHERE `entry`=176214;
-UPDATE `gameobject_template` SET `type`=3 WHERE `entry`=176214;
-UPDATE `gameobject_template` SET `Data1`=13622 WHERE `entry`=176214;
-UPDATE `gameobject_template` SET `Data0`=43 WHERE `entry`=176214;
-UPDATE `gameobject_template` SET `Data3`=1 WHERE `entry`=176214;
-UPDATE `gameobject_template` SET `Data4`=0, `Data9`=0 WHERE `entry`=176214;
-UPDATE `gameobject_template_addon` SET `faction`=0 WHERE `entry`=176214;
--- Duplicates
-DELETE FROM `gameobject` WHERE `guid` IN (45512,45514,45853,45868,45934,45936);
+UPDATE `gameobject` SET `id`=176213 WHERE `id`=176214;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8507
- Closes https://github.com/chromiecraft/chromiecraft/issues/2089

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- SELECT * FROM gameobject WHERE id IN (176213,176214); and see that there are duplicate spawns
- same query, respawn time is not the same to all objects
- guids 5281 and 5276 are underground


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. SELECT * FROM gameobject WHERE id IN (176213,176214); no more duplicates
2. same query, respawn time is the same and adjusted gameobject_template data to match the original
3. guids 5281 and 5276 are above ground

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
