### PR TITLE
fix(DB/Creature): Remove mount visual from Forsaken Thugs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1634394523910362900.sql
+++ b/data/sql/updates/pending_db_world/rev_1634394523910362900.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1634394523910362900');
+
+ -- Forsaken Thug
+UPDATE `creature_template_addon` SET `mount` = 0, `bytes2` = 4097 WHERE `entry` = 3734;
+UPDATE `creature_addon` SET `mount` = 0 WHERE `guid` IN (32905, 32906, 32907, 32908, 32909, 32910);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove mount visual from Forsaken Thugs.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8545
- Closes https://github.com/chromiecraft/chromiecraft/issues/2108

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Retail, none of the spawns shows up mounted

![Skärmbild 2021-10-16 114654](https://user-images.githubusercontent.com/47818697/137591848-48b513fc-feed-49fa-85a3-ceb14d49ecc4.jpg)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
Tested in-game.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- go creature 3734
- Check if it's mounted

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
