### PR TITLE
fix(DB/SAI): Remove SMARTCAST_COMBAT_MOVE from Jadenir Oracles/Tree W…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1634490332525494100.sql
+++ b/data/sql/updates/pending_db_world/rev_1634490332525494100.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1634490332525494100');
+
+UPDATE `smart_scripts` SET `action_param2` = 0 WHERE `entryorguid` IN (5319, 5317) AND `source_type` = 0 AND `id` IN (0, 1);
+


### PR DESCRIPTION
…ardens spell cast SAI

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove the cast flag that prevents them from moving
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8576
- Closes https://github.com/chromiecraft/chromiecraft/issues/2126

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Go to Northern Feralas - .go c 51237 gets you to the right area.
Engage a Tree Warder or an Oracle by itself
As a spellcaster, or a ranged class, engage and observe that the Tree Warder and Oracle will not engage you in melee, and will instead just stand still and if a tree warder, cast entangle.
Bug seen.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
