### PR TITLE
fix(DB/creature_loot): Removes invalid Goldthorn drops from NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1634737924283682006.sql
+++ b/data/sql/updates/pending_db_world/rev_1634737924283682006.sql
@@ -2,4 +2,3 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1634737924283682006');
 
 -- Deletes Goldthorn from 370 NPCs not listed below
 DELETE FROM `creature_loot_template` WHERE `item` = 3821 AND `entry` NOT IN (1081, 1812, 5354, 5481, 5485, 5490, 6509, 6510, 6511, 6512, 6517, 6518, 6519, 6527, 7100, 7101, 7139, 7584, 8384, 11462, 12219, 12220, 12223, 12224, 13022, 13141, 13142);
-


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Remves invalid [Goldthorn](https://tbc.wowhead.com/item=3821/goldthorn) drops from 370 NPCs. Wowhead shows it's exclusively from various plant elementals, but on AC it's dropped by lots of unrelated NPCs, usually with a 0.02% rate.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8647
- Closes https://github.com/chromiecraft/chromiecraft/issues/1854

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/item=3821/goldthorn

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings, 370 rows changed as expected.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

This checks for all NPCs dropping goldthorn who are not listed on WH. It should now return no results.
```SQL
SELECT ct.entry, ct.name, clt.chance, ct.maxlevel, it.ItemLevel
FROM `creature_template` ct
JOIN `creature_loot_template` clt ON ct.lootid = clt.entry
JOIN `item_template` it ON clt.item = it.entry
WHERE it.entry = 3821
AND ct.entry NOT IN (1081, 1812, 5354, 5481, 5485, 5490, 6509, 6510, 6511, 6512, 6517, 6518, 6519, 
6527, 7100, 7101, 7139, 7584, 8384, 11462, 12219, 12220, 12223, 12224, 13022, 13141, 13142)
```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
