### PR TITLE
fix(Core/AI): fixed possible "self interrupts" in BossAI::ExecuteEvent calls

### DIFF
--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -622,15 +622,25 @@ void BossAI::SummonedCreatureDespawnAll()
 void BossAI::UpdateAI(uint32 diff)
 {
     if (!UpdateVictim())
+    {
         return;
+    }
 
     events.Update(diff);
 
     if (me->HasUnitState(UNIT_STATE_CASTING))
+    {
         return;
+    }
 
-    while (uint32 eventId = events.ExecuteEvent())
+    while (uint32 const eventId = events.ExecuteEvent())
+    {
         ExecuteEvent(eventId);
+        if (me->HasUnitState(UNIT_STATE_CASTING))
+        {
+            return;
+        }
+    }
 
     DoMeleeAttackIfReady();
 }


### PR DESCRIPTION
This PR fixed possible issue where for example, we get 2 events, at first event unit started to channel some spell but at same event loop, at same time there another event is about to get triggered which maybe is also about to trigger another spell. Result for this is clear - one of spells will not get executed or both casts will get interrupted.
This PR fully addresses possible "self interrupt" case. Instead of having two spells dodging between themselves - next event spell will get delayed once unit state gets changed (casting finished). 
Instant spells doesn;t have any impact for this.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  adds additional casting state check in BossAI::UpdateAI after ExecuteEvent.
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Made custom creature script which has two identical channeled spells cast events and examined if they gets casted properly.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

This mainly can be tested by C++ developers, choose any boss script, select two or more events which triggers channeled spells and set identical event timers.


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
