### PR TITLE
fix(Core/Unit): Remove wrong CombatStop() and keep Threat when charming

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9759,7 +9759,7 @@ bool Unit::AttackStop()
     m_attacking = nullptr;
 
     // Clear our target
-    SetTarget();
+    SetTarget(ObjectGuid::Empty);
 
     ClearUnitState(UNIT_STATE_MELEE_ATTACKING);
 
@@ -17588,17 +17588,6 @@ bool Unit::SetCharmedBy(Unit* charmer, CharmType type, AuraApplication const* au
     else if (GetTypeId() == TYPEID_PLAYER)
         RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
 
-    _charmThreatInfo.clear();
-
-    // Xinef: move invalid threat / hostile references to offline lists
-    ThreatContainer::StorageType threatList = getThreatMgr().getThreatList();
-    for (ThreatContainer::StorageType::const_iterator itr = threatList.begin(); itr != threatList.end(); ++itr)
-        if (Unit* target = (*itr)->getTarget())
-            _charmThreatInfo[target->GetGUID()] = (*itr)->getThreat() - (*itr)->getTempThreatModifier();
-
-    CombatStop();
-    DeleteThreatList();
-
     if (Creature* creature = ToCreature())
         creature->RefreshSwimmingFlag();
 
@@ -17640,10 +17629,7 @@ void Unit::RemoveCharmedBy(Unit* charmer)
         RestoreFaction();
 
     CastStop();
-
-    CombatStop();
-    getHostileRefMgr().deleteReferences();
-    DeleteThreatList();
+    AttackStop();
 
     // xinef: update speed after charming
     UpdateSpeed(MOVE_RUN, false);


### PR DESCRIPTION
* partial cherry-pick from commit (https://github.com/TrinityCore/TrinityCore/commit/fa3a62ae4e890dc526f2f0474e3469ccddb15edf)

## Changes Proposed:
-  When we set charmed by SetCharmedBy() we don't want to clear threatlist as it is still relevant for when you exit charm
-  We don't want to call CombatStop() in SetCharmedBy() as it removes combat for a split-seconds causing exploits.
- in RemoveCharmedBy() we don't want to call CombatStop() as it will remove combat for a split-second. We use AttackStop() instead.

Using CombatStop() here causes exploits where your potions go on cooldown when you enter/exit charm as you exit combat for a short time.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Get 3 accounts
2. Start Lady Deathwhisper
3. Use a potion
4. See that the potion of the MC:d character goes on cooldown immediately as you get mc:d

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
