### PR TITLE
(Script/Core Logging): Remove Unnecessary Logging. D.R.Y. Cosmetic.

### DIFF
--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -1548,8 +1548,6 @@ public:
         if (!playerTarget)
             playerTarget = player;
 
-        LOG_DEBUG("misc", handler->GetAcoreString(LANG_ADDITEM), itemId, count);
-
         ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(itemId);
         if (!itemTemplate)
         {
@@ -1645,8 +1643,6 @@ public:
         Player* playerTarget = handler->getSelectedPlayer();
         if (!playerTarget)
             playerTarget = player;
-
-        LOG_DEBUG("misc", handler->GetAcoreString(LANG_ADDITEMSET), itemSetId);
 
         bool found = false;
         ItemTemplateContainer const* its = sObjectMgr->GetItemTemplateStore();


### PR DESCRIPTION
It is already logged in the gm logs. **D**on't**R**epeat**Y**ourself.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Remove Two Unnecessary Loggers
These logs could only be triggered by gm level accounts only and never the player.
Pointless having these two here where they will be repeated and taking up space.

## Issues Addressed:
Code Reduction

## SOURCE:
This is a screen shot of the logs after the pr is applied. Their is zero need to have these two as they are logged in the gm logs already.
![image](https://user-images.githubusercontent.com/16887899/138881038-51872631-e10c-47c4-8ec6-2858a4512a95.png)


## Tests Performed:
Builds and Compiles with no issues.


## How to Test the Changes:
1. Do a .additem or .additemset of any item.
2. Check Gm log file
3. Notice it is logged there after this pr. 

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
