### PR TITLE
fix(Core/Chat): add missing eluna chat api

### DIFF
--- a/src/server/game/Chat/ChatCommands/ChatCommand.cpp
+++ b/src/server/game/Chat/ChatCommands/ChatCommand.cpp
@@ -21,12 +21,15 @@
 #include "DBCStores.h"
 #include "DatabaseEnv.h"
 #include "Log.h"
-#include "Map.h"
 #include "Player.h"
 #include "ScriptMgr.h"
 #include "StringFormat.h"
 #include "Tokenize.h"
 #include "WorldSession.h"
+
+#ifdef ELUNA
+#include "LuaEngine.h"
+#endif
 
 using ChatSubCommandMap = std::map<std::string_view, Acore::Impl::ChatCommands::ChatCommandNode, StringCompareLessI_T>;
 
@@ -333,11 +336,25 @@ namespace Acore::Impl::ChatCommands
         }
         else if (!handler.HasSentErrorMessage())
         { /* invocation failed, we should show usage */
+#ifdef ELUNA
+            if (!sEluna->OnCommand(handler.IsConsole() ? nullptr : handler.GetSession()->GetPlayer(), std::string(cmdStr).c_str()))
+            {
+                return true;
+            }
+#endif
+
             cmd->SendCommandHelp(handler);
             handler.SetSentErrorMessage(true);
         }
         return true;
     }
+
+#ifdef ELUNA
+    if (!sEluna->OnCommand(handler.IsConsole() ? nullptr : handler.GetSession()->GetPlayer(), std::string(cmdStr).c_str()))
+    {
+        return true;
+    }
+#endif
 
     return false;
 }


### PR DESCRIPTION
## Changes Proposed:
- Add missing eluna api for chat command

## Issues Addressed:
- Closes https://github.com/azerothcore/mod-eluna-lua-engine/issues/66

## Source:
https://github.com/ElunaLuaEngine/ElunaTrinityWotlk/blob/2e5c65693fcd9aafa3ef3f95595f12df016d9e25/src/server/game/Chat/ChatCommands/ChatCommand.cpp#L304

https://github.com/ElunaLuaEngine/ElunaTrinityWotlk/blob/2e5c65693fcd9aafa3ef3f95595f12df016d9e25/src/server/game/Chat/ChatCommands/ChatCommand.cpp#L314

### Tested by @NemoPRM:
![image](https://user-images.githubusercontent.com/18329778/139483928-6c8c86ab-b9ab-4011-b928-eccee8fc37ec.png)
![image](https://user-images.githubusercontent.com/18329778/139483989-51ae790e-8b6c-475e-97e9-51ff4c09c812.png)
