### PR TITLE
(Core/Fix) Segment fault error fix

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -2210,7 +2210,7 @@ void ObjectMgr::LoadGameobjects()
         data.rotation.z     = fields[9].GetFloat();
         data.rotation.w     = fields[10].GetFloat();
         data.spawntimesecs  = fields[11].GetInt32();
-        data.ScriptId       = GetScriptId(fields[19].GetString());
+        data.ScriptId       = GetScriptId(fields[18].GetString());
         if (!data.ScriptId)
             data.ScriptId = gInfo->ScriptId;
 


### PR DESCRIPTION
This solves issue https://github.com/azerothcore/azerothcore-wotlk/issues/8819

This is related to my previous PR https://github.com/azerothcore/azerothcore-wotlk/pull/8715 .
I had a wrong field id number being 19 when it should be 18 by error. I apologize.

## Changes Proposed:
Change incorrect field from 19 to 18.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8819

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
Segment fault issue should be resolved. I apologize for the typo.


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
