### PR TITLE
fix(Scripts/SpellHunter): prevent crash in spell_hun_readiness

### DIFF
--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -798,8 +798,12 @@ public:
                 ++next;
 
                 SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(itr->first);
-                if (spellInfo->SpellFamilyName == SPELLFAMILY_HUNTER && spellInfo->Id != SPELL_HUNTER_READINESS && spellInfo->Id != SPELL_HUNTER_BESTIAL_WRATH &&
-                    spellInfo->Id != SPELL_DRAENEI_GIFT_OF_THE_NAARU && spellInfo->GetRecoveryTime() > 0)
+                if (spellInfo
+                && spellInfo->SpellFamilyName == SPELLFAMILY_HUNTER
+                && spellInfo->Id != SPELL_HUNTER_READINESS
+                && spellInfo->Id != SPELL_HUNTER_BESTIAL_WRATH
+                && spellInfo->Id != SPELL_DRAENEI_GIFT_OF_THE_NAARU
+                && spellInfo->GetRecoveryTime() > 0)
                 {
                     caster->RemoveSpellCooldown(spellInfo->Id, itr->second.needSendToClient);
                 }


### PR DESCRIPTION
- Checks for `spellInfo` before accessing `spellInfo->xxx`
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8846