### PR TITLE
Scripts/MoltenCore: Fixed golemagg minions evade due range behavior

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_golemagg.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_golemagg.cpp
@@ -178,10 +178,10 @@ public:
             // Should have no impact from unit state
             if (rangeCheckTimer <= diff)
             {
-                Creature const* golemagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_GEDDON));
+                Creature const* golemagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_GOLEMAGG));
                 if (golemagg && me->GetDistance(golemagg) > 100.0f)
                 {
-                    instance->DoAction(ACTION_RESET_MAGMADAR_ENCOUNTER);
+                    instance->DoAction(ACTION_RESET_GOLEMAGG_ENCOUNTER);
                     return;
                 }
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/instance_molten_core.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/instance_molten_core.cpp
@@ -324,7 +324,7 @@ public:
 
         void DoAction(int32 action) override
         {
-            if (action == ACTION_RESET_MAGMADAR_ENCOUNTER)
+            if (action == ACTION_RESET_GOLEMAGG_ENCOUNTER)
             {
                 if (Creature* golemagg = instance->GetCreature(_golemaggGUID))
                 {

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/molten_core.h
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/molten_core.h
@@ -44,7 +44,7 @@ enum MCActions
 {
     ACTION_START_RAGNAROS_INTRO         = -1,
     ACTION_FINISH_RAGNAROS_INTRO        = -2,
-    ACTION_RESET_MAGMADAR_ENCOUNTER     = -3,   // Used when ragers are pulled far away
+    ACTION_RESET_GOLEMAGG_ENCOUNTER     = -3,   // Used when ragers are pulled far away
     ACTION_PREPARE_MAJORDOMO_RAGNA      = -4,
 };
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Basically when you pull out golemagg "Core Ragers" far away, boss and ragers should evade. This PR corrects my stupid mistakes in previous PR which been merged into master.

## Changes Proposed:
- PR fixes my mistake in previous molten core PR and makes core ragers to evade if pulled too far away
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested at Golemagg encounter
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Well, i will tell tricky way how to test it...
1. Cast spell "23775 Stun Forever" on boss (you must learn this spell)
2. Pull out Core Ragers away, about 100 yards or more.
3. Whole encounter should reset

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
