### PR TITLE
fix(DB/creature_loot): Removes Sayge's Fortunes from all NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1636026426526412472.sql
+++ b/data/sql/updates/pending_db_world/rev_1636026426526412472.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1636026426526412472');
+
+-- Removes Sayge's Fortunes from all NPCs
+DELETE FROM `creature_loot_template` WHERE `Comment` LIKE '%Sayge\'s Fortune%' AND `Item` IN (19229, 19237, 19238, 19239, 19240, 19241, 19242, 19243, 19244, 19245, 19246, 19247, 19248, 19249, 19250, 19251, 19252, 19253, 19254, 19255, 19256, 19266, 19423, 19424, 19443, 19451, 19452, 19453, 19454);
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
There are 29 Sayge's Fortune cards dropping from 51 various NPCs, which should only drop from [Darkmoon Faire Fortune](https://tbc.wowhead.com/item=19422/darkmoon-faire-fortune). This removes the fortunes from the NPC drop tables. The items are still dropped from the DMF Fortune item as they should be.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8943
- Closes https://github.com/chromiecraft/chromiecraft/issues/2259

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://tbc.wowhead.com/item=19229/sayges-fortune-1#contained-in-item
https://tbc.wowhead.com/item=19422/darkmoon-faire-fortune#contains
https://wowpedia.fandom.com/wiki/Sayge's_Fortunes?oldid=2385001

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran SQL, no errors/warnings. Only 50 rows changed instead of 51, turns out that Lieutenant Lewis ID 13147 and Lieutenant Lewis (1) ID 22703 share the same drop table, so this is fine. 

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Use this query. It should now return no results:
```SQL
SELECT ct.entry, ct.name, it.entry, it.name
FROM `creature_template` ct
JOIN `creature_loot_template` clt ON ct.lootid = clt.entry
JOIN `item_template` it ON clt.item = it.entry
WHERE it.entry IN (
	SELECT it.entry
	FROM `item_template` it
	WHERE it.name LIKE '%Sayge\'s Fortune%')
```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
