### PR TITLE
fix(DB/Creature): Corrects spawn times of various Westfall rare mobs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1636045459174422908.sql
+++ b/data/sql/updates/pending_db_world/rev_1636045459174422908.sql
@@ -1,0 +1,16 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1636045459174422908');
+
+# Sets spawntime of Sergeant Brashclaw to 2.5 hours
+UPDATE `creature` SET `spawntimesecs` = 9000 WHERE `id` = 506;
+
+# Sets spawntime of Slark to 2 hours
+UPDATE `creature` SET `spawntimesecs` = 7200 WHERE `id` = 519;
+
+# Sets spawntime of Brack to 2.5 hours
+UPDATE `creature` SET `spawntimesecs` = 9000 WHERE `id` = 520;
+
+# Sets spawntime of Foe Reaper 4000 to 5 hours
+UPDATE `creature` SET `spawntimesecs` = 18000 WHERE `id` = 573;
+
+# Sets spawntime of Master Digger to 2 hours
+UPDATE `creature` SET `spawntimesecs` = 7200 WHERE `id` = 1424;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Sets spawn timers in accordance to the addressed issue.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #7588
- Closes https://github.com/chromiecraft/chromiecraft/issues/1558

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
See linked issue

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- As below


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run query - Each row should change respectively 1, 1, 1, 41 and 1 rows 
2. Check that each mob have the correct spawn time
     * ID 506 should have 9000 seconds
     * ID 519 should have 10800 seconds
     * ID 520 should have 9000 seconds
     * ID 573 should have 18000 seconds
     * ID 1424 should have 7200 seconds

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
