### PR TITLE
Fix(Core/Spells): Exploit with silithyst aura

### DIFF
--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -5464,7 +5464,10 @@ public:
 
         void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
         {
-            GetCaster()->SummonGameObject(181597, GetCaster()->GetPositionX(), GetCaster()->GetPositionY(), GetCaster()->GetPositionZ(), 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 10 * IN_MILLISECONDS * MINUTE);
+            if (GetCaster()->IsMounted())
+            {
+                GetCaster()->SummonGameObject(181597, GetCaster()->GetPositionX(), GetCaster()->GetPositionY(), GetCaster()->GetPositionZ(), 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 10 * IN_MILLISECONDS * MINUTE);
+            }
         }
 
         void Register() override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Check if the player is mounted before spawning the gobject.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #8873
- Closes https://github.com/chromiecraft/chromiecraft/issues/2227

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Build and tested, works

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. The silithyst aura can be added with `.aura 29519`
2. For Horde, `.go c 43204` will get you to a nearby NPC.
3. For Alliance, `.go c 43205`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Check another way to exploit the spell.
