### PR TITLE
Crash Fix (Core\Script) NPC_FINKLE_EINHORN AI not initializing,

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
@@ -105,6 +105,8 @@ public:
 
         void OnCreatureCreate(Creature* creature) override
         {
+            LootType loot;
+
             switch (creature->GetEntry())
             {
                 case NPC_UROK_MAGUS:
@@ -168,7 +170,8 @@ public:
                         creature->DisappearAndDie();
                     break;
                 case NPC_FINKLE_EINHORN:
-                    creature->AI()->Talk(SAY_FINKLE_GANG);
+                    if (GetBossState(DATA_THE_BEAST) == DONE && loot == LOOT_SKINNING)
+                        creature->AI()->Talk(SAY_FINKLE_GANG);
                     break;
                 case NPC_CHROMATIC_ELITE_GUARD:
                     AddMinion(creature, true);


### PR DESCRIPTION
Fix for https://github.com/azerothcore/azerothcore-wotlk/issues/9088

The Beast Crashes when skinned, this PR corrects it.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Initilaize AI to avoid Null Pointer Error


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/9088

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds, compiles, no crash on skinning the Beast


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.additem 12709 - skining dagger
.setskill 173 400 - dagger skill if needed
.setskill 393 400 - skinning 
.cast 10768

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Test
- [ ] Criticize me, this is a extreme rush job before a doctor's appointment.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
