### PR TITLE
DB/Creature: Add pre-cata equipment to 2 creatures

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1636665257418709911.sql
+++ b/data/sql/updates/pending_db_world/rev_1636665257418709911.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1636665257418709911');
+
+-- Ancient creature_equip_template with item models, first found item with that model
+UPDATE `creature_equip_template` SET `ItemID1`='1907', `ItemID2`='0' WHERE  `CreatureID`=3203 AND `ID`=1;
+
+-- Vmangos
+UPDATE `creature_equip_template` SET `ItemID1`='2177', `VerifiedBuild`='31727' WHERE  `CreatureID`=4667 AND `ID`=1;


### PR DESCRIPTION
TC & VMangos Cherry Pick

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add pre-cata equipment to 2 creatures from tc commit which is also also a vmagos cherrypick as well.

## Issues Addressed:
- Mentioned TC Issue: https://github.com/TrinityCore/TrinityCore/issues/27209 

## SOURCE:
[<!-- If you can, include a source that can strengthen your claim -->](https://github.com/TrinityCore/TrinityCore/commit/5a3c9c46f654c1cecf4aebb2c53e58e220c7aead)

## Tests Performed:
- Builds and compiles with no issues.

- https://tbc.wowhead.com/npc=3203/fizzle-darkstorm - Missing staff is now added
https://www.wowhead.com/item=1907/monster-staff-basic

- https://tbc.wowhead.com/npc=4667/burning-blade-shadowmage - Wrong staff, is now corrected to
https://www.wowhead.com/item=2177/monster-staff-ornate-mage-staff

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  perform a .npc add 3203 to observe they now have the correct staff
2.  perform a .npc add 4667 to observer they now have the correct staff


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
