### PR TITLE
fix(Core/Disables): Remove validation checks from DISABLE_TYPE_GAME_E…

### DIFF
--- a/src/server/game/Conditions/DisableMgr.cpp
+++ b/src/server/game/Conditions/DisableMgr.cpp
@@ -240,21 +240,6 @@ namespace DisableMgr
                     }
                     case DISABLE_TYPE_GAME_EVENT:
                     {
-                        GameEventMgr::GameEventDataMap const& events = sGameEventMgr->GetEventMap();
-
-                        if (entry < 1 || entry >= events.size())
-                        {
-                            LOG_ERROR("disable", "Event entry %u from `disables` does not exist, skipped.", entry);
-                            continue;
-                        }
-
-                        GameEventData const& eventData = events[entry];
-                        if (!eventData.isValid())
-                        {
-                            LOG_ERROR("disable", "Event entry %u from `disables` does not exist, skipped.", entry);
-                            continue;
-                        }
-
                         GameEventMgr::ActiveEvents const& activeEvents = sGameEventMgr->GetActiveEventList();
                         if (activeEvents.find(entry) != activeEvents.end())
                         {


### PR DESCRIPTION
…VENT

Disables are loaded before game events

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove validation checks from disables for events because disables are loaded before events, so they would always fail on startup, but they work fine with the .reload disables command
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
