### PR TITLE
(hack/db) improve position of objects around Shady Inn (dustwallow marsh)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1636799867064749300.sql
+++ b/data/sql/updates/pending_db_world/rev_1636799867064749300.sql
@@ -1,0 +1,21 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1636799867064749300');
+
+-- shield
+DELETE FROM `gameobject` WHERE `id` = 20992;
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(6821, 20992, 1, 0, 0, 1, 1, -3734.65, -2530.93, 73.2862, 0, 0, 0.707107, 0, 0.707107, 0, 100, 1, '', 0);
+
+-- badge
+DELETE FROM `gameobject` WHERE `id` = 21042;
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(6376, 21042, 1, 0, 0, 1, 1, -3721.85, -2541.17, 69.785, -0.000001, 0.556657, -0.434788, 0.43101, 0.561536, 0, 100, 1, '', 0);
+
+-- fake hoofprint
+DELETE FROM `gameobject` WHERE `id` = 187272;
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(10175, 187272, 1, 0, 0, 1, 1, -3701.37, -2535.18, 69, 3.03687, 0, 0, -0.99863, -0.0523374, 900, 100, 1, '', 0);
+
+-- quest hoofprint
+DELETE FROM `gameobject` WHERE `id` = 187273;
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(10167, 187273, 1, 0, 0, 1, 1, -3700.58, -2534.09, 68.8, 3.05433, 0, 0, -0.999048, -0.0436174, 0, 100, 1, '', 0);

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -298,6 +298,8 @@ bool GameObject::Create(ObjectGuid::LowType guidlow, uint32 name_id, Map* map, u
         // used switch since there should be more
         case 181233: // maexxna portal effect
         case 181575: // maexxna portal
+        case 20992: // theramore black shield
+        case 21042: // theramore guard badge
             SetLocalRotation(rotation);
             break;
         default:


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- add 2 exceptions for badge and shield so that they actually use the DB quaternions
- add data to said quaternions
- Move hoofprints a bit so they are less stuck in the ground

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7946

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Went there, objects are in a more reasonable position, though not perfect.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to shady inn at dustwallow marsh .go gameobject 10175 and assess
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
