### PR TITLE
DB/Creature - restore deleted spawns

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1637271386614261100.sql
+++ b/data/sql/updates/pending_db_world/rev_1637271386614261100.sql
@@ -1,9 +1,6 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1637271386614261100');
 
-DELETE FROM `creature` WHERE `guid`=201207;
+DELETE FROM `creature` WHERE `guid` IN (201207, 201208);
 INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
-('201207','2110','631','0','0','15','1','0','0','16.1163','2211.13','30.199','0.679835','86400','0','0','1','0','0','0','0','0','','0');
-
-DELETE FROM `creature` WHERE `guid`=201208;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
-('201208','38054','631','0','0','15','1','0','0','-46.5868','2251.06','30.7375','3.83972','86400','0','0','17880','8814','0','0','0','0','','0');
+(201207,2110,631,0,0,15,1,0,0,16.1163,2211.13,30.199,0.679835,86400,0,0,1,0,0,0,0,0,'',0),
+(201208,38054,631,0,0,15,1,0,0,-46.5868,2251.06,30.7375,3.83972,86400,0,0,17880,8814,0,0,0,0,'',0);

--- a/data/sql/updates/pending_db_world/rev_1637271386614261100.sql
+++ b/data/sql/updates/pending_db_world/rev_1637271386614261100.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1637271386614261100');
+
+DELETE FROM `creature` WHERE `guid`=201207;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+('201207','2110','631','0','0','15','1','0','0','16.1163','2211.13','30.199','0.679835','86400','0','0','1','0','0','0','0','0','','0');
+
+DELETE FROM `creature` WHERE `guid`=201208;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+('201208','38054','631','0','0','15','1','0','0','-46.5868','2251.06','30.7375','3.83972','86400','0','0','17880','8814','0','0','0','0','','0');


### PR DESCRIPTION
## Changes Proposed:
Restore accidentally deleted creature spawns with new guids.

## Issues Addressed:
https://github.com/azerothcore/azerothcore-wotlk/pull/9200

## SOURCE:
-

## Tests Performed:
- checked that both new guids are free
- run sql, checked imgame


## How to Test the Changes:
1. go creature 201207 
2. go creature 201208 

## Known Issues and TODO List:
-

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
