### PR TITLE
fix(Scripts/BFD): Fix problem with Aku'mai event being skippable after crash

### DIFF
--- a/src/server/scripts/Kalimdor/BlackfathomDeeps/blackfathom_deeps.h
+++ b/src/server/scripts/Kalimdor/BlackfathomDeeps/blackfathom_deeps.h
@@ -25,8 +25,9 @@ enum Data
     TYPE_FIRE2                  = 2,
     TYPE_FIRE3                  = 3,
     TYPE_FIRE4                  = 4,
-    TYPE_AKU_MAI                = 5,
-    MAX_ENCOUNTERS              = 6
+    TYPE_AKU_MAI_EVENT          = 5,
+    TYPE_AKU_MAI                = 6,
+    MAX_ENCOUNTERS              = 7
 };
 
 enum CreatureIds

--- a/src/server/scripts/Kalimdor/BlackfathomDeeps/instance_blackfathom_deeps.cpp
+++ b/src/server/scripts/Kalimdor/BlackfathomDeeps/instance_blackfathom_deeps.cpp
@@ -52,8 +52,13 @@ public:
                                      unit->GetEntry() == NPC_MURKSHALLOW_SOFTSHELL || unit->GetEntry() == NPC_AKU_MAI_SNAPJAW))
             {
                 if (--_requiredDeaths == 0)
-                    if (_encounters[TYPE_FIRE1] == DONE && _encounters[TYPE_FIRE2] == DONE && _encounters[TYPE_FIRE3] == DONE && _encounters[TYPE_FIRE4] == DONE)
+                {
+                    if (IsFireEncounterDone())
+                    {
                         HandleGameObject(_akumaiPortalGUID, true);
+                        SetBossState(TYPE_AKU_MAI_EVENT, DONE);
+                    }
+                }
             }
         }
 
@@ -80,7 +85,7 @@ public:
                         gameobject->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
                     break;
                 case GO_AKU_MAI_DOOR:
-                    if (_encounters[TYPE_FIRE1] == DONE && _encounters[TYPE_FIRE2] == DONE && _encounters[TYPE_FIRE3] == DONE && _encounters[TYPE_FIRE4] == DONE)
+                    if (IsFireEncounterDone() && GetBossState(TYPE_AKU_MAI_EVENT) == DONE)
                         HandleGameObject(ObjectGuid::Empty, true, gameobject);
                     _akumaiPortalGUID = gameobject->GetGUID();
                     break;
@@ -129,6 +134,11 @@ public:
                         _encounters[i] = NOT_STARTED;
                 }
             }
+        }
+
+        bool IsFireEncounterDone()
+        {
+            return _encounters[TYPE_FIRE1] == DONE && _encounters[TYPE_FIRE2] == DONE && _encounters[TYPE_FIRE3] == DONE && _encounters[TYPE_FIRE4] == DONE;
         }
 
     private:

--- a/src/server/scripts/Kalimdor/BlackfathomDeeps/instance_blackfathom_deeps.cpp
+++ b/src/server/scripts/Kalimdor/BlackfathomDeeps/instance_blackfathom_deeps.cpp
@@ -70,7 +70,7 @@ public:
                 case GO_FIRE_OF_AKU_MAI_2:
                 case GO_FIRE_OF_AKU_MAI_3:
                 case GO_FIRE_OF_AKU_MAI_4:
-                    if (_encounters[gameobject->GetEntry() - GO_FIRE_OF_AKU_MAI_1 + 1] == DONE)
+                    if (GetBossState(TYPE_AKU_MAI_EVENT) == DONE)
                     {
                         gameobject->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE);
                         gameobject->SetGoState(GO_STATE_ACTIVE);

--- a/src/server/scripts/Kalimdor/BlackfathomDeeps/instance_blackfathom_deeps.cpp
+++ b/src/server/scripts/Kalimdor/BlackfathomDeeps/instance_blackfathom_deeps.cpp
@@ -102,6 +102,7 @@ public:
                 case TYPE_FIRE3:
                 case TYPE_FIRE4:
                 case TYPE_AKU_MAI:
+                case TYPE_AKU_MAI_EVENT:
                     _encounters[type] = data;
                     break;
             }

--- a/src/server/scripts/Kalimdor/BlackfathomDeeps/instance_blackfathom_deeps.cpp
+++ b/src/server/scripts/Kalimdor/BlackfathomDeeps/instance_blackfathom_deeps.cpp
@@ -56,7 +56,7 @@ public:
                     if (IsFireEventDone())
                     {
                         HandleGameObject(_akumaiPortalGUID, true);
-                        SetBossState(TYPE_AKU_MAI_EVENT, DONE);
+                        _encounters[TYPE_AKU_MAI_EVENT] = DONE;
                     }
                 }
             }
@@ -70,7 +70,7 @@ public:
                 case GO_FIRE_OF_AKU_MAI_2:
                 case GO_FIRE_OF_AKU_MAI_3:
                 case GO_FIRE_OF_AKU_MAI_4:
-                    if (GetBossState(TYPE_AKU_MAI_EVENT) == DONE)
+                    if (_encounters[TYPE_AKU_MAI_EVENT] == DONE)
                     {
                         gameobject->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE);
                         gameobject->SetGoState(GO_STATE_ACTIVE);
@@ -85,7 +85,7 @@ public:
                         gameobject->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
                     break;
                 case GO_AKU_MAI_DOOR:
-                    if (IsFireEventDone() && GetBossState(TYPE_AKU_MAI_EVENT) == DONE)
+                    if (IsFireEventDone() && _encounters[TYPE_AKU_MAI_EVENT] == DONE)
                         HandleGameObject(ObjectGuid::Empty, true, gameobject);
                     _akumaiPortalGUID = gameobject->GetGUID();
                     break;

--- a/src/server/scripts/Kalimdor/BlackfathomDeeps/instance_blackfathom_deeps.cpp
+++ b/src/server/scripts/Kalimdor/BlackfathomDeeps/instance_blackfathom_deeps.cpp
@@ -53,7 +53,7 @@ public:
             {
                 if (--_requiredDeaths == 0)
                 {
-                    if (IsFireEncounterDone())
+                    if (IsFireEventDone())
                     {
                         HandleGameObject(_akumaiPortalGUID, true);
                         SetBossState(TYPE_AKU_MAI_EVENT, DONE);
@@ -85,7 +85,7 @@ public:
                         gameobject->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
                     break;
                 case GO_AKU_MAI_DOOR:
-                    if (IsFireEncounterDone() && GetBossState(TYPE_AKU_MAI_EVENT) == DONE)
+                    if (IsFireEventDone() && GetBossState(TYPE_AKU_MAI_EVENT) == DONE)
                         HandleGameObject(ObjectGuid::Empty, true, gameobject);
                     _akumaiPortalGUID = gameobject->GetGUID();
                     break;
@@ -137,7 +137,7 @@ public:
             }
         }
 
-        bool IsFireEncounterDone()
+        bool IsFireEventDone()
         {
             return _encounters[TYPE_FIRE1] == DONE && _encounters[TYPE_FIRE2] == DONE && _encounters[TYPE_FIRE3] == DONE && _encounters[TYPE_FIRE4] == DONE;
         }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution.

You're welcome

 -->

## Changes Proposed:
-  Add new state for when the overall event is completed to use for identifying the state of fight
-  When crash happends, and you re-enter, use this new state to determine whether if the door should be opened or not

## Issues Addressed:

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/9434

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:

_Scenarios tested:_

- Use all flames but not finishing event & crash (**Result**: Door closed, flames reusable)
- Use all flames and finish event  (**Result**: Door opens as intended)
- Use all flames and finish event & crash (**Result**: Door open, flames not reusable)

_Build_

> ========== Build: 3 succeeded, 0 failed, 15 up-to-date, 1 skipped ==========

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  `.go ga 32930`
2. use flames
3. exit worldserver or command `.server restart 1`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
