### PR TITLE
fix(Core/LFG): Prevent leaving LFG if in combat

### DIFF
--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -2104,15 +2104,25 @@ namespace lfg
         LfgTeleportError error = LFG_TELEPORTERROR_OK;
 
         if (!player->IsAlive())
+        {
             error = LFG_TELEPORTERROR_PLAYER_DEAD;
+        }
         else if (player->IsFalling() || player->HasUnitState(UNIT_STATE_JUMPING))
+        {
             error = LFG_TELEPORTERROR_FALLING;
+        }
         else if (player->IsMirrorTimerActive(FATIGUE_TIMER))
+        {
             error = LFG_TELEPORTERROR_FATIGUE;
+        }
         else if (player->GetVehicle())
+        {
             error = LFG_TELEPORTERROR_IN_VEHICLE;
-        else if (player->GetCharmGUID())
-            error = LFG_TELEPORTERROR_CHARMING;
+        }
+        else if (player->GetCharmGUID() || player->IsInCombat())
+        {
+            error = LFG_TELEPORTERROR_COMBAT;
+        }
         else
         {
             uint32 mapid = dungeon->map;

--- a/src/server/game/DungeonFinding/LFGMgr.h
+++ b/src/server/game/DungeonFinding/LFGMgr.h
@@ -89,7 +89,7 @@ namespace lfg
         LFG_TELEPORTERROR_IN_VEHICLE                 = 3,
         LFG_TELEPORTERROR_FATIGUE                    = 4,
         LFG_TELEPORTERROR_INVALID_LOCATION           = 6,
-        LFG_TELEPORTERROR_CHARMING                   = 8       // FIXME - It can be 7 or 8 (Need proper data)
+        LFG_TELEPORTERROR_COMBAT                     = 8       // FIXME - It can be 7 or 8 (Need proper data)
     };
 
     /// Queue join results


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Emit `LFG_TELEPORTERROR_COMBAT `(was `LFG_TELEPORTERROR_CHARMED`) if player is in combat when trying to leave LFG
-  Rename `LFG_TELEPORTERROR_CHARMED ` to  `LFG_TELEPORTERROR_COMBAT  `since the message is shown as below

> You can't do that while in combat

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes  https://github.com/azerothcore/azerothcore-wotlk/issues/9438

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
"Players may teleport in and out of the dungeon at any time if they are not in combat." - https://wowpedia.fandom.com/wiki/Dungeon_Finder?oldid=2357590 - from August 2010

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Message is shown and you don't get removed from group/dungeon if in combat attempting to leave
![image](https://user-images.githubusercontent.com/20321723/144448429-19c3d07d-5281-464f-ad11-3db2f69adafd.png)


- Build Pass
> ========== Build: 4 succeeded, 0 failed, 14 up-to-date, 1 skipped ==========


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.debug lfg`
2. Join solo or with someone to grief.
3. Get into combat, then use the LFG/RDF icon on the minimap to teleport out.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- See `LFGMgr.h`, when/if the **existing** todo is completed it's necessary to make sure the message output isn't changed for this scenario

> LFG_TELEPORTERROR_COMBAT                     = 8       // FIXME - It can be 7 or 8 (Need proper data)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
