### PR TITLE
fix(DB/Creature): Apply 'Permanent Feign Death' to Citizen of New Avalon

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1638644587511744300.sql
+++ b/data/sql/updates/pending_db_world/rev_1638644587511744300.sql
@@ -1,0 +1,11 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1638644587511744300');
+
+/* Apply 'Permanent Feign Death' aura to Citizen of New Avalon
+*/
+
+DELETE FROM `creature_addon` WHERE (`guid` IN (129727, 129769));
+
+INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(129727, 0, 0, 0, 0, 0, 0, '29266');
+INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(129769, 0, 0, 0, 0, 0, 0, '29266');

--- a/data/sql/updates/pending_db_world/rev_1638644587511744300.sql
+++ b/data/sql/updates/pending_db_world/rev_1638644587511744300.sql
@@ -6,6 +6,5 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1638644587511744300');
 DELETE FROM `creature_addon` WHERE (`guid` IN (129727, 129769));
 
 INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
-(129727, 0, 0, 0, 0, 0, 0, '29266');
-INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(129727, 0, 0, 0, 0, 0, 0, '29266'),
 (129769, 0, 0, 0, 0, 0, 0, '29266');


### PR DESCRIPTION
## Changes Proposed:
-  Apply Aura [29266](https://classic.wowhead.com/spell=29266/permanent-feign-death) to Citizen of New Avalon in Death Knight Base during DK starting experience.  Confirmed to be correct aura via sniffs (thanks @acidmanifesto)
-  Match dead Scarlet Crusaders in the same room.

## Tests Performed:
[Before](https://i.imgur.com/ny08I6R.jpg)

[After](https://i.imgur.com/9lUnyhn.jpg)


## How to Test the Changes:
.go c 129727



