### PR TITLE
fix(DB/Creature): Adjust Lich King position during last phase of DK quest

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1638646536763994700.sql
+++ b/data/sql/updates/pending_db_world/rev_1638646536763994700.sql
@@ -6,4 +6,3 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1638646536763994700');
 DELETE FROM `creature` WHERE (`id` = 29110);
 INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
 (130896, 29110, 609, 0, 0, 1, 192, 0, 0, 2310.64, -5742.08, 161.3, 3.85123, 360, 0, 0, 27890000, 0, 0, 0, 0, 0, '', 0);
-

--- a/data/sql/updates/pending_db_world/rev_1638646536763994700.sql
+++ b/data/sql/updates/pending_db_world/rev_1638646536763994700.sql
@@ -5,4 +5,4 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1638646536763994700');
 
 DELETE FROM `creature` WHERE (`id` = 29110);
 INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
-(130896, 29110, 609, 0, 0, 1, 192, 0, 0, 2310.27, -5742.21, 161.207, 3.85718, 360, 0, 0, 27890000, 0, 0, 0, 0, 0, '', 0);
+(130896, 29110, 609, 0, 0, 1, 192, 0, 0, 2310.27, -5742.21, 161.21, 3.85718, 360, 0, 0, 27890000, 0, 0, 0, 0, 0, '', 0);

--- a/data/sql/updates/pending_db_world/rev_1638646536763994700.sql
+++ b/data/sql/updates/pending_db_world/rev_1638646536763994700.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1638646536763994700');
+
+/* Fix LK Positioning in last phase of Scarlet Enclave
+*/
+
+DELETE FROM `creature` WHERE (`id` = 29110);
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(130896, 29110, 609, 0, 0, 1, 192, 0, 0, 2310.64, -5742.08, 161.148, 3.85123, 360, 0, 0, 27890000, 0, 0, 0, 0, 0, '', 0);
+

--- a/data/sql/updates/pending_db_world/rev_1638646536763994700.sql
+++ b/data/sql/updates/pending_db_world/rev_1638646536763994700.sql
@@ -5,5 +5,5 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1638646536763994700');
 
 DELETE FROM `creature` WHERE (`id` = 29110);
 INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
-(130896, 29110, 609, 0, 0, 1, 192, 0, 0, 2310.64, -5742.08, 161.148, 3.85123, 360, 0, 0, 27890000, 0, 0, 0, 0, 0, '', 0);
+(130896, 29110, 609, 0, 0, 1, 192, 0, 0, 2310.64, -5742.08, 161.3, 3.85123, 360, 0, 0, 27890000, 0, 0, 0, 0, 0, '', 0);
 

--- a/data/sql/updates/pending_db_world/rev_1638646536763994700.sql
+++ b/data/sql/updates/pending_db_world/rev_1638646536763994700.sql
@@ -5,4 +5,4 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1638646536763994700');
 
 DELETE FROM `creature` WHERE (`id` = 29110);
 INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
-(130896, 29110, 609, 0, 0, 1, 192, 0, 0, 2310.64, -5742.08, 161.3, 3.85123, 360, 0, 0, 27890000, 0, 0, 0, 0, 0, '', 0);
+(130896, 29110, 609, 0, 0, 1, 192, 0, 0, 2310.27, -5742.21, 161.207, 3.85718, 360, 0, 0, 27890000, 0, 0, 0, 0, 0, '', 0);


### PR DESCRIPTION
## Changes Proposed:
-  Adjust Lich King position on platform so he consistently spawns on it
-  #9180 helped the problem but it wasn't consistent as his spawn coordinates clipped the model's feet into the platform, 50/50 chance of whether or not he'd stay or fall through onto the ground below

## Issues Addressed:
- Permanently closes #9175

## Tests Performed:
[After](https://i.imgur.com/dzxzwQm.jpg)

Feet are no longer clipped!

Before SQL, 5 server restarts yielded 2/5 times that LK stayed in position
After SQL, 5 server restarts yielded 5/5 times that LK stayed in position

## How to Test the Changes:
.go c 130896
