### PR TITLE
fix(Core/Chat): correct logic for using guild officer chat

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -463,7 +463,7 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
                 {
                     if (Guild* guild = sGuildMgr->GetGuildById(GetPlayer()->GetGuildId()))
                     {
-                        if (sScriptMgr->CanPlayerUseChat(GetPlayer(), type, lang, msg, guild))
+                        if (!sScriptMgr->CanPlayerUseChat(GetPlayer(), type, lang, msg, guild))
                         {
                             return;
                         }


### PR DESCRIPTION
## Changes Proposed:
- Change condition for hook `CanPlayerUseChat`

## Issues Addressed:
- Closes #9504