### PR TITLE
fix(DB/Quest): An Unholy Alliance deprecations and fixes

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1638951999039996100.sql
+++ b/data/sql/updates/pending_db_world/rev_1638951999039996100.sql
@@ -1,0 +1,23 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1638951999039996100');
+
+/* Deprecate unused quest start item (pre-3.3, leads to Varimathras quests)
+*/
+
+UPDATE `item_template` SET `name` = 'Small Scroll [DEPRECATED]' WHERE (`entry` = 17008);
+
+/* Deprecate unused quest ID (pre-3.3, Varimathras is gone)
+*/
+
+UPDATE `quest_template` SET `LogTitle` = 'An Unholy Alliance [DEPRECATED]' WHERE (`ID` = 6522);
+UPDATE `quest_template` SET `LogTitle` = 'An Unholy Alliance [DEPRECATED]' WHERE (`ID` = 6521);
+
+/* Update Map POI Text for An Unholy Alliance
+*/
+
+UPDATE `quest_template` SET `QuestCompletionLog`='Return to Bragor Bloodfist at the Royal Quarter in the Undercity.' WHERE `ID`=14352;
+
+/* Unrelated quests that also had incorrect POI texts
+*/
+
+UPDATE `quest_template` SET `QuestCompletionLog`='Return to Bragor Bloodfist at the Royal Quarter in the Undercity.' WHERE `ID`=14351;
+UPDATE `quest_template` SET `QuestCompletionLog`='Return to Bragor Bloodfist at the Royal Quarter in the Undercity.' WHERE `ID`=14356;


### PR DESCRIPTION
## Changes Proposed:
-  Deprecate item Small Scroll ID: 17008.  Item does not drop from Charlga Razorflank since 3.3.  Item starts quest ID 6522 which leads into quest ID 6521 (I don't know why this is out of order like this, but it is)
-  Deprecate quests 6522 and 6521.  Varimathras is the quest ender for both of these and this NPC was removed from the game in 3.3
- Update quest POI for quest ID 14352 - this is the correct quest post-3.3 after Varimathas was removed
- Update quest POI for unrelated quests 14351 and 14356

## Issues Addressed:
- Closes #9054

## How To Test
.additem 49205, click show quest on map. 

## Notes
As of 3.3, Charlga Razorflank drops item (for horde players) Small Scroll ID: 49205 which starts quest 14352 (old: 6521).  AtlasLoot addon claims 17008 drops (if you have IDs on for it). 
