### PR TITLE
feat(core/pool): Adjust GameObject pools in world via config

### DIFF
--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -749,7 +749,7 @@ void PoolMgr::LoadFromDB()
                 {
                     std::vector<std::string> directives = explode(sWorld->getGameObjectConfig(), ';');
                     std::string configDescription;
-                    
+
                     uint32 target_pool_id;
 
                     bool found = false;
@@ -779,7 +779,7 @@ void PoolMgr::LoadFromDB()
                         // check if correct pool, target_pool_id=0 means no pool specified, its global
                         if (target_pool_id != 0 && target_pool_id != pool_id)
                             continue;
-                        
+
                         std::string description = fields[3].GetString();
 
                         // check if correct description or empty (which means global, any description matches)

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -613,7 +613,7 @@ void PoolMgr::LoadFromDB()
             uint32 pool_id = fields[0].GetUInt32();
 
             PoolTemplateData& pPoolTemplate = mPoolTemplate[pool_id];
-            pPoolTemplate.MaxLimit  = fields[1].GetUInt32();
+            pPoolTemplate.MaxLimit = fields[1].GetUInt32();
 
             ++count;
         } while (result->NextRow());

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -571,6 +571,25 @@ void PoolMgr::Initialize()
     mCreatureSearchMap.clear();
 }
 
+std::vector<std::string> PoolMgr::explode(const std::string& str, const char& ch) {
+    std::string next;
+    std::vector<std::string> result;
+
+    for (std::string::const_iterator it = str.begin(); it != str.end(); it++) {
+        if (*it == ch) {
+            if (!next.empty()) {
+                result.push_back(next);
+                next.clear();
+            }
+        } else {
+            next += *it;
+        }
+    }
+    if (!next.empty())
+         result.push_back(next);
+    return result;
+}
+
 void PoolMgr::LoadFromDB()
 {
     // Pool templates

--- a/src/server/game/Pools/PoolMgr.h
+++ b/src/server/game/Pools/PoolMgr.h
@@ -131,6 +131,8 @@ public:
     void ChangeDailyQuests();
     void ChangeWeeklyQuests();
 
+    std::vector<std::string> explode(const std::string& str, const char& ch);
+
     PooledQuestRelation mQuestCreatureRelation;
     PooledQuestRelation mQuestGORelation;
 

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2141,6 +2141,8 @@ void Spell::EffectOpenLock(SpellEffIndex effIndex)
     if (gameObjTarget)
     {
         GameObjectTemplate const* goInfo = gameObjTarget->GetGOInfo();
+        LOG_DEBUG("spells.objects", "Object: template: %u | type: %i | guid: %u",
+            goInfo->entry, goInfo->type, gameObjTarget->GetSpawnId());
         // Arathi Basin banner opening. // TODO: Verify correctness of this check
         if ((goInfo->type == GAMEOBJECT_TYPE_BUTTON && goInfo->button.noDamageImmune) ||
                 (goInfo->type == GAMEOBJECT_TYPE_GOOBER && goInfo->goober.losOK))

--- a/src/server/game/World/IWorld.h
+++ b/src/server/game/World/IWorld.h
@@ -587,6 +587,7 @@ public:
     virtual std::string const& GetRealmName() const = 0;
     virtual void SetRealmName(std::string name) = 0;
     virtual void RemoveOldCorpses() = 0;
+    virtual std::string getGameObjectConfig() = 0;
 };
 
 #endif //AZEROTHCORE_IWORLD_H

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1426,6 +1426,9 @@ void World::LoadConfigSettings(bool reload)
     // Realm Availability
     m_bool_configs[CONFIG_REALM_LOGIN_ENABLED] = sConfigMgr->GetOption<bool>("World.RealmAvailability", true);
 
+    // GameObject pool nodes allowed scale
+    m_GameObjectConfig = sConfigMgr->GetOption<std::string>("Pool.GameObject", "");
+
     // call ScriptMgr if we're reloading the configuration
     sScriptMgr->OnAfterConfigLoad(reload);
 }

--- a/src/server/game/World/World.h
+++ b/src/server/game/World/World.h
@@ -279,6 +279,8 @@ public:
     void setRate(Rates rate, float value) { rate_values[rate] = value; }
     /// Get a server rate (see #Rates)
     float getRate(Rates rate) const { return rate_values[rate]; }
+    // Config to control active gameobjects spawns 
+    std::string getGameObjectConfig() { return m_GameObjectConfig; }
 
     /// Set a server configuration element (see #WorldConfigs)
     void setBoolConfig(WorldBoolConfigs index, bool value)
@@ -429,6 +431,7 @@ private:
     void DetectDBCLang();
     bool m_allowMovement;
     std::string m_dataPath;
+    std::string m_GameObjectConfig;
 
     // for max speed access
     static float m_MaxVisibleDistanceOnContinents;

--- a/src/server/game/World/World.h
+++ b/src/server/game/World/World.h
@@ -279,7 +279,7 @@ public:
     void setRate(Rates rate, float value) { rate_values[rate] = value; }
     /// Get a server rate (see #Rates)
     float getRate(Rates rate) const { return rate_values[rate]; }
-    // Config to control active gameobjects spawns 
+    // Config to control active gameobjects spawns
     std::string getGameObjectConfig() { return m_GameObjectConfig; }
 
     /// Set a server configuration element (see #WorldConfigs)

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3913,7 +3913,7 @@ Metric.OverallStatusInterval = 1
 #                     Adjust all Sungrass pool(s) to 45% more
 #
 #                     Pool.GameObject = "Tin,0.2,50002;"
-#                     Adjust all tin in Jangolode Mine {50002} of westfall to 20% // Orginally 15 now 3 mines max appear
+#                     Adjust all tin in Jangolode Mine {50002} of westfall to 20% // Originally 15 now 3 mines max appear
 #
 #                     Pool.GameObject = "*,0.0;"
 #                     Disables all GameObject pools, good for debugging objects not associated to any pool

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3887,3 +3887,41 @@ Metric.OverallStatusInterval = 1
 
 #
 ###################################################################################################
+
+###################################################################################################
+# POOL SETTINGS
+#
+# Control the appearance of pools by using directives to apply to their Max_Limits
+#
+#    Pool.GameObject
+#        Description: Change appearance of GameObjects, does not affect Quest or Creature pools
+#        Default:     "" - (Disabled)
+#                     "needle,rate,pool_id;" - (Enabled)
+#
+#        Needle:      Can be used to identify a pertictular GameObject i.e Silverleaf
+#                     This string is matched in the 'pool_gameobject' table 'description' field
+#                     * indicates wildcard for match anything, case matters!!
+#
+#        Rate:        The multiplier for scaling up or down the max_limit for the pool(s)
+#
+#        Pool_id:     You can match the directive to an exact pool id
+#
+#        Format:      Pool.GameObject = Needle {string} Description, rate {float}, pool_id {int} [optional]
+#
+#        Examples:
+#                     Pool.GameObject = "Sungrass,1.45;"
+#                     Adjust all Sungrass pool(s) to 45% more
+#
+#                     Pool.GameObject = "Tin,0.2,50002;"
+#                     Adjust all tin in Jangolode Mine {50002} of westfall to 20% // Orginally 15 now 3 mines max appear
+#
+#                     Pool.GameObject = "*,0.0;"
+#                     Disables all GameObject pools, good for debugging objects not associated to any pool
+#                     * is wildcard includes anything, including empty description
+#
+#                     Pool.GameObject = "Copper,0.1;Peacebloom,0.01,920;Silver Vein,0.0;Briarthorn,0.2;Dark Iron,0.2;Colbalt,0.2;"
+#                     Example of a chain of directives, first directive matched will be the one applied to a pool
+#
+#        Logging:     Use Logger.spells.objects to see information about a perticular object when you gather it {i.e. unlock it}
+
+Pool.GameObject = ""


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Based on issues reported with mining and herb nodes being too close or too many. I have created a way of targeting specific pools or many pools with directives in `worldserver.conf` 

The issues reported are apparently database related have mostly the issue of not being associated to a pool. As the will spawn  and respawn without minding the `max_limit` of the pool of that area.

So this feature will serve two purposes:

1. A means of production game servers to tweak their pools
i.e the following config: `Pool.GameObject = "Tin,0.2,50002;"` Adjust all tin in Jangolode Mine {50002} of westfall to 20% // Originally 15 now 3 mines max appear
2. Can be used to debug and look for issues in certain areas
i.e. `Pool.GameObject = "*,0.0,50002;" `Disables all GameObjects in Pool to see what is not in that pool, or `Pool.GameObject = "*,0.0;" `to see all GameObjects in world thats not in a pool, also added additional logging for interacting with a gameobjects, `Logger.spells.objects`, it will display the Object template id, guid of object and type. You can then confirm its existence in `pool_gameobject`  table


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes (kinda, its a work around until database is cleaned up)
https://github.com/azerothcore/azerothcore-wotlk/issues/2211

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
Tested multiple config options in game, heres some I documented
```
Pool.GameObject = "*,1.5" ==> Adjust all GameObjects pools to 150% more, needs comma to signify no description
Pool.GameObject = "Tin,0.2,50002;" ==> adjust all tin in Jangolode Mine of westfall to 20% // Orginally 18 now 3 mines
Pool.GameObject = "Copper,0.1;Tin,0.01,920;Silver,0.0;Gold,0.2;Iron,0.2;Mithril,0.2;Truesilver,0.2;Thorium,0.2;Dark Iron,0.2;Colbalt,0.2;"
```

It still needs more testing



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Read the new config setting at bottom of `src/server/worldserver/worldserver.conf.dist`
2. Build your own config in your config
3. Restart game server
4. Get a herb or mining GM (if you want data on nodes you will need to set your characters_skill to appropriate level, for instance character of GUID of 10 find, value `UPDATE characters_skill SET value = 150 WHERE guid = 10 AND skill = 186` this sets your characters mining skill to 150. I do not know of a GM command for this.)
5. Look at he nodes around the area and notice they change before and after the config changes. Any node not disappearing or respecting your directive you can verify if its missing from the `pool_gameobjects` table. Its expected to be either missing or wrong data in pool tables.
6. You can also fix gameobjects by associating them to a pool near by and then watch them be affected by your directives.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
I notice chests are not in pools, it would be nice if someone can find one with a pool to test
Need more herb testing, I mostly tested mines in Westall and Elwynn Forest.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
