### PR TITLE
fix(DB/Loot) Fel cone loot incorrect

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1639529374031815939.sql
+++ b/data/sql/updates/pending_db_world/rev_1639529374031815939.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1639529374031815939');
+
+-- Fix Fel cone loot
+DELETE FROM `gameobject_loot_template` WHERE `Entry`=1701 AND `Item`<>3418;


### PR DESCRIPTION
## Changes Proposed:
-  Fix loot mindlessly copied from web.

## Issues Addressed:
- Closes #9603

## SOURCE:
Done this quest a few times. It should only contain one item, a fel cone.

## Tests Performed:
- none


## How to Test the Changes:
1. .add quest 489
2. loot fel cones