### PR TITLE
fix(Core/Movement): Do not remove/set UNIT_FLAG_SWIMMING when unit st…

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -19768,12 +19768,10 @@ bool Unit::SetSwim(bool enable)
     if (enable)
     {
         AddUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
-        SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SWIMMING);
     }
     else
     {
         RemoveUnitMovementFlag(MOVEMENTFLAG_SWIMMING);
-        RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SWIMMING);
     }
 
     return true;


### PR DESCRIPTION
…arts swimming.

Fixes #8896

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #8896
- Closes https://github.com/chromiecraft/chromiecraft/issues/2244

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
.go c 2607 - teleport to blood sail pirate on the boat
agro some NPCs and jump to water

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
