### PR TITLE
fix(db): 4 NPCS in sw shadowglen with "wait" movetype location fixed

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1639812684867509600.sql
+++ b/data/sql/updates/pending_db_world/rev_1639812684867509600.sql
@@ -1,9 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1639812684867509600');
 
 -- Source: TBC Classic 2.5.2.41446
-
 DELETE FROM creature WHERE guid IN (47284, 47286, 47334, 47344);
-
 INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
 /* Grell Camp stay mobs placement */
 (47284, 1988, 0, 0, 0, 1, 1, 0, 0, 10267.1, 964.477, 1340.85, 0.844044, 120, 0, 0, 1, 0, 0, 0, 0, 0, '', 0),

--- a/data/sql/updates/pending_db_world/rev_1639812684867509600.sql
+++ b/data/sql/updates/pending_db_world/rev_1639812684867509600.sql
@@ -1,0 +1,12 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1639812684867509600');
+
+-- Source: TBC Classic 2.5.2.41446
+/* Grell Camp stay mobs placement */
+REPLACE INTO `creature` (`guid`, `id`, `position_x`, `position_y`, `position_z`, `orientation`, `wander_distance`, `MovementType`) VALUES (47286, 1988, 10265.5, 967.318, 1340.81, 6.18836, 0, 0);
+
+REPLACE INTO `creature` (`guid`, `id`, `position_x`, `position_y`, `position_z`, `orientation`, `wander_distance`, `MovementType`) VALUES (47284, 1988, 10267.1, 964.477, 1340.85, 0.844044, 0, 0);
+
+/* Grellkin Camp stay mobs placement */
+REPLACE INTO `creature` (`guid`, `id`, `position_x`, `position_y`, `position_z`, `orientation`, `wander_distance`, `MovementType`) VALUES (47334, 1989, 10331.1, 1036.3, 1339.32, 5.85673, 0, 0);
+
+REPLACE INTO `creature` (`guid`, `id`, `position_x`, `position_y`, `position_z`, `orientation`, `wander_distance`, `MovementType`) VALUES (47344, 1989, 10339.1, 1040.53, 1339.32, 4.86607, 0, 0);

--- a/data/sql/updates/pending_db_world/rev_1639812684867509600.sql
+++ b/data/sql/updates/pending_db_world/rev_1639812684867509600.sql
@@ -1,12 +1,13 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1639812684867509600');
 
 -- Source: TBC Classic 2.5.2.41446
-/* Grell Camp stay mobs placement */
-delete from creature where guid=47284 or guid=47286;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES (47284, 1988, 0, 0, 0, 1, 1, 0, 0, 10267.1, 964.477, 1340.85, 0.844044, 120, 0, 0, 1, 0, 0, 0, 0, 0, '', 0);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES (47286, 1988, 0, 0, 0, 1, 1, 0, 0, 10265.5, 967.318, 1340.81, 6.18836, 120, 0, 0, 1, 0, 0, 0, 0, 0, '', 0);
 
+DELETE FROM creature WHERE guid IN(47284, 47286, 47334, 47344);
+
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+/* Grell Camp stay mobs placement */
+(47284, 1988, 0, 0, 0, 1, 1, 0, 0, 10267.1, 964.477, 1340.85, 0.844044, 120, 0, 0, 1, 0, 0, 0, 0, 0, '', 0),
+(47286, 1988, 0, 0, 0, 1, 1, 0, 0, 10265.5, 967.318, 1340.81, 6.18836, 120, 0, 0, 1, 0, 0, 0, 0, 0, '', 0),
 /* Grellkin Camp stay mobs placement */
-delete from creature where guid=47334 or guid=47344;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES (47334, 1989, 0, 0, 0, 1, 1, 0, 0, 10331.1, 1036.3, 1339.32, 5.85673, 120, 0, 0, 1, 0, 0, 0, 0, 0, '', 0);
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES (47344, 1989, 0, 0, 0, 1, 1, 0, 0, 10339.1, 1040.53, 1339.32, 4.86607, 120, 0, 0, 1, 0, 0, 0, 0, 0, '', 0);
+(47334, 1989, 0, 0, 0, 1, 1, 0, 0, 10331.1, 1036.3, 1339.32, 5.85673, 120, 0, 0, 1, 0, 0, 0, 0, 0, '', 0),
+(47344, 1989, 0, 0, 0, 1, 1, 0, 0, 10339.1, 1040.53, 1339.32, 4.86607, 120, 0, 0, 1, 0, 0, 0, 0, 0, '', 0);

--- a/data/sql/updates/pending_db_world/rev_1639812684867509600.sql
+++ b/data/sql/updates/pending_db_world/rev_1639812684867509600.sql
@@ -2,11 +2,11 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1639812684867509600');
 
 -- Source: TBC Classic 2.5.2.41446
 /* Grell Camp stay mobs placement */
-REPLACE INTO `creature` (`guid`, `id`, `position_x`, `position_y`, `position_z`, `orientation`, `wander_distance`, `MovementType`) VALUES (47286, 1988, 10265.5, 967.318, 1340.81, 6.18836, 0, 0);
-
-REPLACE INTO `creature` (`guid`, `id`, `position_x`, `position_y`, `position_z`, `orientation`, `wander_distance`, `MovementType`) VALUES (47284, 1988, 10267.1, 964.477, 1340.85, 0.844044, 0, 0);
+delete from creature where guid=47284 or guid=47286;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES (47284, 1988, 0, 0, 0, 1, 1, 0, 0, 10267.1, 964.477, 1340.85, 0.844044, 120, 0, 0, 1, 0, 0, 0, 0, 0, '', 0);
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES (47286, 1988, 0, 0, 0, 1, 1, 0, 0, 10265.5, 967.318, 1340.81, 6.18836, 120, 0, 0, 1, 0, 0, 0, 0, 0, '', 0);
 
 /* Grellkin Camp stay mobs placement */
-REPLACE INTO `creature` (`guid`, `id`, `position_x`, `position_y`, `position_z`, `orientation`, `wander_distance`, `MovementType`) VALUES (47334, 1989, 10331.1, 1036.3, 1339.32, 5.85673, 0, 0);
-
-REPLACE INTO `creature` (`guid`, `id`, `position_x`, `position_y`, `position_z`, `orientation`, `wander_distance`, `MovementType`) VALUES (47344, 1989, 10339.1, 1040.53, 1339.32, 4.86607, 0, 0);
+delete from creature where guid=47334 or guid=47344;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES (47334, 1989, 0, 0, 0, 1, 1, 0, 0, 10331.1, 1036.3, 1339.32, 5.85673, 120, 0, 0, 1, 0, 0, 0, 0, 0, '', 0);
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES (47344, 1989, 0, 0, 0, 1, 1, 0, 0, 10339.1, 1040.53, 1339.32, 4.86607, 120, 0, 0, 1, 0, 0, 0, 0, 0, '', 0);

--- a/data/sql/updates/pending_db_world/rev_1639812684867509600.sql
+++ b/data/sql/updates/pending_db_world/rev_1639812684867509600.sql
@@ -2,7 +2,7 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1639812684867509600');
 
 -- Source: TBC Classic 2.5.2.41446
 
-DELETE FROM creature WHERE guid IN(47284, 47286, 47334, 47344);
+DELETE FROM creature WHERE guid IN (47284, 47286, 47334, 47344);
 
 INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
 /* Grell Camp stay mobs placement */


### PR DESCRIPTION
2 Grell and 2 Grellkin were incorrectly placed.

Uploaded sniff that was taken while working/exploring to submissions.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Place mobs in the correct location-  

## SOURCE:
Packets for area 04 have been submitted prior to this PR
![image](https://user-images.githubusercontent.com/91289495/146633622-ddc6dfca-f238-4bdf-9eb1-106d5b9a028b.png)


## Tests Performed:
- Mobs checked against source.
- SQL tested 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  .go c 47286 (47284 is nearby)
     .go c 47334 (47344 is nearby)
2.  Compare to classic servers  (read below if they do not match exactly)

## Known Issues and TODO List:
Some interesting behavior was discovered, a "scare" mechanic.  It can make the mobs move to new locations as they run away from any active combat.  Both Grell and Grellkin have this mechanic.  If you go to check these mobs against classic and do not see them in the correct location, be sure to clear the camp (or at least kill the ones with the behavior we emulate as "stay" movement), its likely they had the scare mechanic go off and were never killed afterward.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
