### PR TITLE
fix(Core/Spells): Added some exceptions to `SPELL_AURA_PREVENT_REGENE…

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -20296,3 +20296,33 @@ void Unit::Whisper(uint32 textId, Player* target, bool isBossWhisper /*= false*/
     ChatHandler::BuildChatPacket(data, isBossWhisper ? CHAT_MSG_RAID_BOSS_WHISPER : CHAT_MSG_MONSTER_WHISPER, LANG_UNIVERSAL, this, target, bct->GetText(locale, getGender()), 0, "", locale);
     target->SendDirectMessage(&data);
 }
+
+bool Unit::CanRestoreMana(SpellInfo const* spellInfo)
+{
+    // Aura of Despair
+    if (HasAuraType(SPELL_AURA_PREVENT_REGENERATE_POWER))
+    {
+        // Exceptions
+        switch (spellInfo->Id)
+        {
+            case 30824: // Shamanistic Rage
+            case 31786: // Spiritual Attunement
+            case 31930: // Judgements of the Wise
+            case 34075: // Aspect of the Viper
+            case 34720: // Thrill of the hunt
+            case 47755: // Rapture
+            case 63337: // Saronite Vapors (regenerate mana)
+            case 63375: // Improved stormstrike
+            case 64372: // Lifebloom
+                return true;
+            case 54428: // Divine Plea - only with talent Guarded by the Light
+                return HasSpell(53583);
+            default:
+                break;
+        }
+
+        return false;
+    }
+
+    return true;
+}

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2527,6 +2527,8 @@ public:
     void ProcessPositionDataChanged(PositionFullTerrainStatus const& data) override;
     virtual void ProcessTerrainStatusUpdate();
 
+    bool CanRestoreMana(SpellInfo const* spellInfo);
+
 protected:
     explicit Unit (bool isWorldObject);
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -6745,6 +6745,11 @@ void AuraEffect::HandleObsModPowerAuraTick(Unit* target, Unit* caster) const
     if (GetBase()->IsPermanent() && target->GetPower(PowerType) == target->GetMaxPower(PowerType))
         return;
 
+    if (PowerType == POWER_MANA && !target->CanRestoreMana(GetSpellInfo()))
+    {
+        return;
+    }
+
     // ignore negative values (can be result apply spellmods to aura damage
     uint32 amount = std::max(m_amount, 0) * target->GetMaxPower(PowerType) / 100;
     LOG_DEBUG("spells.aura.effect", "PeriodicTick: %s energize %s for %u dmg inflicted by %u",
@@ -6777,6 +6782,11 @@ void AuraEffect::HandlePeriodicEnergizeAuraTick(Unit* target, Unit* caster) cons
     // don't regen when permanent aura target has full power
     if (GetBase()->IsPermanent() && target->GetPower(PowerType) == target->GetMaxPower(PowerType))
         return;
+
+    if (PowerType == POWER_MANA && !target->CanRestoreMana(GetSpellInfo()))
+    {
+        return;
+    }
 
     // ignore negative values (can be result apply spellmods to aura damage
     int32 amount = std::max(m_amount, 0);

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1382,6 +1382,11 @@ void Spell::EffectPowerDrain(SpellEffIndex effIndex)
     if (!unitTarget || !unitTarget->IsAlive() || unitTarget->getPowerType() != PowerType || damage < 0)
         return;
 
+    if (PowerType == POWER_MANA && !unitTarget->CanRestoreMana(GetSpellInfo()))
+    {
+        return;
+    }
+
     // add spell damage bonus
     damage = m_caster->SpellDamageBonusDone(unitTarget, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE);
     damage = unitTarget->SpellDamageBonusTaken(m_caster, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE);
@@ -1913,6 +1918,11 @@ void Spell::EffectEnergize(SpellEffIndex effIndex)
     if (unitTarget->GetMaxPower(power) == 0)
         return;
 
+    if (power == POWER_MANA && !unitTarget->CanRestoreMana(GetSpellInfo()))
+    {
+        return;
+    }
+
     // Some level depends spells
     int level_multiplier = 0;
     int level_diff = 0;
@@ -2024,6 +2034,11 @@ void Spell::EffectEnergizePct(SpellEffIndex effIndex)
     uint32 maxPower = unitTarget->GetMaxPower(power);
     if (maxPower == 0)
         return;
+
+    if (power == POWER_MANA && !unitTarget->CanRestoreMana(GetSpellInfo()))
+    {
+        return;
+    }
 
     uint32 gain = CalculatePct(maxPower, damage);
     m_caster->EnergizeBySpell(unitTarget, m_spellInfo->Id, gain, power);


### PR DESCRIPTION
…RATE_POWER` auras.

Fixes #2042

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #2042

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Enter Ulduar.
Fight General Vezax.
Run out of mana and switch to Aspect of the Viper.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
