### PR TITLE
fix(Script) Quest "Deactivating the Spire"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1640365530283717518.sql
+++ b/data/sql/updates/pending_db_world/rev_1640365530283717518.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1640365530283717518');
+
+UPDATE `gameobject_template` SET `ScriptName` = "go_duskwither_spire_power_source" WHERE `entry` IN (180916, 180919, 180920);

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -1942,7 +1942,7 @@ class go_duskwither_spire_power_source : public GameObjectScript
 public:
     go_duskwither_spire_power_source() : GameObjectScript("go_duskwither_spire_power_source") {}
 
-    bool OnGossipHello(Player* /*player*/ player, GameObject* go) override
+    bool OnGossipHello(Player* /*player*/, GameObject* go) override
     {
         if (Creature* bunny = go->FindNearestCreature(NPC_POWER_SOURCE_INVISIBLE_BUNNY, 1.0f))
         {

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -1928,6 +1928,30 @@ public:
     }
 };
 
+/*########
+#### go_duskwither_spire_power_source
+#####*/
+
+enum DuskwitherSpirePowersource
+{
+    NPC_POWER_SOURCE_INVISIBLE_BUNNY = 17984
+};
+
+class go_duskwither_spire_power_source : public GameObjectScript
+{
+public:
+    go_duskwither_spire_power_source() : GameObjectScript("go_duskwither_spire_power_source") {}
+
+    bool OnGossipHello(Player* player, GameObject* go) override
+    {
+        if (Creature* bunny = go->FindNearestCreature(NPC_POWER_SOURCE_INVISIBLE_BUNNY, 1.0f))
+        {
+            bunny->DespawnOrUnsummon(0ms, 10s);
+        }
+        return false;
+    }
+};
+
 void AddSC_go_scripts()
 {
     // Ours
@@ -1943,6 +1967,7 @@ void AddSC_go_scripts()
     new go_flames();
     new go_heat();
     new go_bear_trap();
+    new go_duskwither_spire_power_source();
 
     // Theirs
     new go_brewfest_music();

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -1942,7 +1942,7 @@ class go_duskwither_spire_power_source : public GameObjectScript
 public:
     go_duskwither_spire_power_source() : GameObjectScript("go_duskwither_spire_power_source") {}
 
-    bool OnGossipHello(Player* player, GameObject* go) override
+    bool OnGossipHello(Player* /*player*/ player, GameObject* go) override
     {
         if (Creature* bunny = go->FindNearestCreature(NPC_POWER_SOURCE_INVISIBLE_BUNNY, 1.0f))
         {


### PR DESCRIPTION
## Changes Proposed:
- Update quest to deactivate the beams for 10 seconds on click like official.  
- I chose C++ over SAi for this scripting due to DespawnOrUnsummon forced respawn timer fails the first time in SAI and I wanted this to work correctly.

## Issues Addressed:

## SOURCE:
Sniff

## Tests Performed:
- Tested in game


## How to Test the Changes:
1. .quest add 8889
2. .go xyz 9334.2 -7880.1899 74.9103
3. do quest