### PR TITLE
Fix(DB/Quests): Pre-quest requirement for Lorekeeper Lydros quests

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1640651539577989000.sql
+++ b/data/sql/updates/pending_db_world/rev_1640651539577989000.sql
@@ -1,0 +1,10 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1640651539577989000');
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` IN (7483, 7484, 7485)) AND (`SourceId` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(19, 0, 7483, 0, 1, 8, 0, 7482, 0, 0, 0, 0, 0, '', 'Libram of Rapidity - Available only if Elven Legends (Alliance) is completed'),
+(19, 0, 7484, 0, 1, 8, 0, 7482, 0, 0, 0, 0, 0, '', 'Libram of Focus - Available only if Elven Legends (Alliance) is completed'),
+(19, 0, 7485, 0, 1, 8, 0, 7482, 0, 0, 0, 0, 0, '', 'Libram of Protection - Available only if Elven Legends (Alliance) is completed'),
+(19, 0, 7483, 0, 2, 8, 0, 7481, 0, 0, 0, 0, 0, '', 'Libram of Rapidity - Available only if Elven Legends (Horde) is completed'),
+(19, 0, 7484, 0, 2, 8, 0, 7481, 0, 0, 0, 0, 0, '', 'Libram of Focus - Available only if Elven Legends (Horde) is completed'),
+(19, 0, 7485, 0, 2, 8, 0, 7481, 0, 0, 0, 0, 0, '', 'Libram of Protection - Available only if Elven Legends (Horde) is completed');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add conditions for both alliance and horde quests sides.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #8326
- Closes https://github.com/chromiecraft/chromiecraft/issues/2001

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 14368
2. Check if it has some daily quests. It should not have any (except for mages I think).
3. If you are horde: .q a 7481 / .q c 7481 / .q rew 7481 --- If you are alliance: .q a 7482 / .q c 7482 / .q rew 7482
4. Check if the dailies are available.