### PR TITLE
fix(DB): Remove Jingling Bell from creature loot

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1640718198383728700.sql
+++ b/data/sql/updates/pending_db_world/rev_1640718198383728700.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1640718198383728700');
+
+-- Remove 'Jingling Bell' from being looted by a creature.
+DELETE FROM `creature_loot_template` WHERE `Item`=21308;

--- a/data/sql/updates/pending_db_world/rev_1640718198383728700.sql
+++ b/data/sql/updates/pending_db_world/rev_1640718198383728700.sql
@@ -1,4 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1640718198383728700');
 
--- Remove 'Jingling Bell' from being looted by a creature.
+-- Remove 'Jingling Bell' should not drop from any creature
 DELETE FROM `creature_loot_template` WHERE `Item`=21308;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Generally remove Jingling Bell from creature loot. _(today, only  creature Lava Surger drops it)_

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/9866

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
> Jingling Bell is one of the four possible pets inside gifts under the big tree in Ironforge and Orgrimmar during the Feast of Winter Veil seasonal event.

https://wowwiki-archive.fandom.com/wiki/Jingling_Bell#Source
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- SQL applies
- SQL doesn't remove item from unwanted creature loot. _(should be none)_
- Verified Jingling bell to still drop from Gaily Wrapped Present

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Following query should retrieve 0 results.

> SELECT *
FROM creature_loot_template
WHERE Item = 21308


And this query should show you a drop from `Gaily Wrapped Present`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
