### PR TITLE
fix(Core/TemporarySummon) New event to despawn OOC

### DIFF
--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -104,7 +104,24 @@ void TempSummon::Update(uint32 diff)
 
                 break;
             }
+        case TEMPSUMMON_TIMED_DESPAWN_OOC_ALIVE:
+            {
+                // if m_deathState is DEAD, CORPSE was skipped
+                if (!IsInCombat() && m_deathState != CORPSE)
+                {
+                    if (m_timer <= diff)
+                    {
+                        UnSummon();
+                        return;
+                    }
 
+                    m_timer -= diff;
+                }
+                else if (m_timer != m_lifetime)
+                    m_timer = m_lifetime;
+
+                break;
+            }
         case TEMPSUMMON_CORPSE_TIMED_DESPAWN:
             {
                 if (m_deathState == CORPSE)

--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -106,7 +106,6 @@ void TempSummon::Update(uint32 diff)
             }
         case TEMPSUMMON_TIMED_DESPAWN_OOC_ALIVE:
             {
-                // if m_deathState is DEAD, CORPSE was skipped
                 if (!IsInCombat() && m_deathState != CORPSE)
                 {
                     if (m_timer <= diff)

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -46,6 +46,7 @@ enum TempSummonType
     TEMPSUMMON_DEAD_DESPAWN                = 7,             // despawns when the creature disappears
     TEMPSUMMON_MANUAL_DESPAWN              = 8,             // despawns when UnSummon() is called
     TEMPSUMMON_DESPAWNED                   = 9,             // xinef: DONT USE, INTERNAL USE ONLY
+    TEMPSUMMON_TIMED_DESPAWN_OOC_ALIVE     = 10,            // despawns after a specified time after the creature is out of combat and alive
 };
 
 enum PhaseMasks

--- a/src/server/scripts/Kalimdor/zone_silithus.cpp
+++ b/src/server/scripts/Kalimdor/zone_silithus.cpp
@@ -1187,6 +1187,7 @@ public:
             player->CastSpell(player, spellInfoTrigger->Id, false);
             if (TempSummon* summons = go->SummonCreature(npc, go->GetPositionX(), go->GetPositionY(), go->GetPositionZ(), player->GetOrientation() - M_PI, TEMPSUMMON_TIMED_DESPAWN_OOC_ALIVE, 6000))
             {
+                summons->SetCorpseDelay(5 * MINUTE);
                 summons->SetTarget(player->GetGUID());
                 summons->SetLootRecipient(player);
                 summons->CastSpell(summons, SPELL_SPAWN_IN, false);

--- a/src/server/scripts/Kalimdor/zone_silithus.cpp
+++ b/src/server/scripts/Kalimdor/zone_silithus.cpp
@@ -1185,8 +1185,7 @@ public:
                 return;
             }
             player->CastSpell(player, spellInfoTrigger->Id, false);
-            // @todo: this is not correct! should despawn 5-6 seconds when out of combat, but can't be handled by tempsummon timer alone apparently
-            if (TempSummon* summons = go->SummonCreature(npc, go->GetPositionX(), go->GetPositionY(), go->GetPositionZ(), player->GetOrientation() - M_PI, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 5 * 60 * 1000))
+            if (TempSummon* summons = go->SummonCreature(npc, go->GetPositionX(), go->GetPositionY(), go->GetPositionZ(), player->GetOrientation() - M_PI, TEMPSUMMON_TIMED_DESPAWN_OOC_ALIVE, 6000))
             {
                 summons->SetTarget(player->GetGUID());
                 summons->SetLootRecipient(player);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Implement new tempsummon event: `TEMPSUMMON_TIMED_DESPAWN_OOC_ALIVE`
-  Apply `TEMPSUMMON_TIMED_DESPAWN_OOC_ALIVE `to wind stone summons in Silithus to fix issues addressed
- Manually set corpse delay to 5minutes

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes  https://github.com/azerothcore/azerothcore-wotlk/issues/9913
- Closes https://github.com/chromiecraft/chromiecraft/issues/2689
- Properly fixes https://github.com/azerothcore/azerothcore-wotlk/pull/9914

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

1. Tested ingame: See my video below
2. Build works


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

```
.go c 42971
.additem 20406
.additem 20407
.additem 20408
.additem 20422
.additem 20451
wear items
use [Greater Wind Stone] near

```
Do above steps twice, kill one, and second one to gm on

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

N/A 

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
