### PR TITLE
Fix(Core/Creature): Disable shredder should not attack creatures nearby

### DIFF
--- a/src/server/scripts/Kalimdor/zone_the_barrens.cpp
+++ b/src/server/scripts/Kalimdor/zone_the_barrens.cpp
@@ -590,7 +590,10 @@ public:
         void JustSummoned(Creature* summoned) override
         {
             if (summoned->GetEntry() == NPC_PILOT_WIZZ)
+            {
                 me->SetStandState(UNIT_STAND_STATE_DEAD);
+                me->RestoreFaction();
+            }
 
             if (summoned->GetEntry() == NPC_MERCENARY)
                 summoned->AI()->AttackStart(me);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Someone forgot to restore the faction upon destroying lol...

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6856
- Closes https://github.com/chromiecraft/chromiecraft/issues/1137

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 14387 and accept quest.
2. Escort the NPC to the end of quest trail.
3. Pull any aggressive mob around or let it come into Wizzlecrank's Shredder's pull range.
4. Observe the mech face sliding toward the enemy.
