### PR TITLE
Fix (DB\Loot) Remove Tree Frog Loot

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1640969804388366165.sql
+++ b/data/sql/updates/pending_db_world/rev_1640969804388366165.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1640969804388366165');
+
+-- removes loot id 7549 link from Tree Frog
+UPDATE `creature_template` SET `lootid`=0 WHERE  `entry`=7549;
+
+-- Removes Loot from creature Tree Frog NPC ID 7549
+DELETE FROM `creature_loot_template` WHERE  `Entry`=7549 AND `Item`=18255 AND `Reference`=0 AND `GroupId`=0;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=7549 AND `Item`=18297 AND `Reference`=0 AND `GroupId`=0;


### PR DESCRIPTION
Tree Frog has no loot. This is comical that we had it like this for so long.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove Loot Link to Tree Frog
-  Remove Tree frod loot table

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Tree Frogs never had loot. No Pet ever had Loot.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Kill Tree Frog
- Observer no more loot.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Kill Tree Frog
2. Observe No more loot.
3. I repeated myself didn't I?

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
