### PR TITLE
Fix (DB\Loot) Abyssal Crest Loot % correction

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1640972252071688181.sql
+++ b/data/sql/updates/pending_db_world/rev_1640972252071688181.sql
@@ -1,0 +1,12 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1640972252071688181');
+
+-- removes unverified corrections of loot drop of the abyssal crest with drop rate based on udb from consolidated sniffs
+DELETE FROM `creature_loot_template` WHERE `Entry`=15209 AND `Item`=20513 AND `Reference`=0 AND `GroupId`=0;
+DELETE FROM `creature_loot_template` WHERE `Entry`=15211 AND `Item`=20513 AND `Reference`=0 AND `GroupId`=0;
+DELETE FROM `creature_loot_template` WHERE `Entry`=15212 AND `Item`=20513 AND `Reference`=0 AND `GroupId`=0;
+DELETE FROM `creature_loot_template` WHERE `Entry`=15307 AND `Item`=20513 AND `Reference`=0 AND `GroupId`=0;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
+(15209, 20513, 0, 83.7314, 0, 1, 0, 1, 1, 'Crimson Templar - Abyssal Crest'),
+(15211, 20513, 0, 83.5982, 0, 1, 0, 1, 1, 'Azure Templar - Abyssal Crest'),
+(15212, 20513, 0, 83.8428, 0, 1, 0, 1, 1, 'Hoary Templar - Abyssal Crest'),
+(15307, 20513, 0, 83.9362, 0, 1, 0, 1, 1, 'Earthen Templar - Abyssal Crest');


### PR DESCRIPTION
Verified via UDB Loot per consolidated sniffs

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Corrects The % of the Abyssal Crest with verified % drop
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Corrects https://github.com/azerothcore/azerothcore-wotlk/pull/9857

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
UDB Consolidated Sniffs

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds
- Runs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Murder the 4 templars
2. Notice drop rates are not 100% as intended.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
