### PR TITLE
fix(Core/Players): fix trailing whitespaces being added as settings

### DIFF
--- a/src/server/game/Entities/Player/PlayerSettings.cpp
+++ b/src/server/game/Entities/Player/PlayerSettings.cpp
@@ -41,7 +41,7 @@ void Player::_LoadCharacterSettings(PreparedQueryResult result)
             std::string source = fields[0].GetString();;
             std::string data = fields[1].GetString();
 
-            std::vector<std::string_view> tokens = Acore::Tokenize(data, ' ', true);
+            std::vector<std::string_view> tokens = Acore::Tokenize(data, ' ', false);
 
             PlayerSettingVector setting;
             setting.resize(tokens.size());
@@ -50,9 +50,15 @@ void Player::_LoadCharacterSettings(PreparedQueryResult result)
 
             for (auto token : tokens)
             {
+                if (token.empty())
+                {
+                    continue;
+                }
+
                 PlayerSetting set;
                 set.value = Acore::StringTo<uint32>(token).value();
-                setting[++count] = set;
+                setting[count] = set;
+                ++count;
             }
 
             m_charSettingsMap[source] = setting;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove trailing whitespaces
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. settings announcer off
2. save
3. notice no extra 0s get added to the db after saving

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
