### PR TITLE
Fix (DB\SmartScript\Quest) Catch and Release

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1641238616670655918.sql
+++ b/data/sql/updates/pending_db_world/rev_1641238616670655918.sql
@@ -1,0 +1,14 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1641238616670655918');
+
+-- Fixes issue: https://github.com/azerothcore/azerothcore-wotlk/issues/8146
+-- Made corrections to the original script, made it so you cant attack while its tagged like on retail
+-- Blacksilt Scout Update SAI
+SET @ENTRY := 17326;
+SET @SOURCETYPE := 0;
+UPDATE creature_template SET AIName="SmartAI" WHERE entry=@ENTRY;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=@ENTRY AND `source_type`=@SOURCETYPE;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES 
+(@ENTRY,@SOURCETYPE,0,1,8,0,100,0,30877,0,0,0,33,17654,0,0,0,0,0,16,0,0,0,0.0,0.0,0.0,0.0,"Blacksilt Scout - On Spellhit - Give Quest Credit"),
+(@ENTRY,@SOURCETYPE,1,2,61,0,100,0,0,0,0,0,18,770,0,0,0,0,0,1,0,0,0,0.0,0.0,0.0,0.0,"Link - Set Unattackable"),
+(@ENTRY,@SOURCETYPE,2,0,61,0,100,0,0,0,0,0,41,7000,0,0,0,0,0,1,0,0,0,0.0,0.0,0.0,0.0,"Link - Set Despawn"),
+(@ENTRY,@SOURCETYPE,3,0,11,0,100,0,0,0,0,0,19,770,0,0,0,0,0,1,0,0,0,0.0,0.0,0.0,0.0,"Spawn - Remove Unit Flags");


### PR DESCRIPTION
Catch and Release smart script fix for quest

## Changes Proposed:
-  Catch and Release Smart Script adjustment to prevent killing when tagged and now despawns

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8146

## SOURCE:
Sniff Team

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Build
- Performance


## How to Test the Changes:

1. Do quest Catch and Release and you will see quest now works like it does with retail.
2. When you Tag the scout with the quest item, please try to attack the scout and wait 7 seconds as this should despawn in that time

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
