### PR TITLE
Fix (DB\Loot) Frigid Ring Reference Loot Fix

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1641307926630364064.sql
+++ b/data/sql/updates/pending_db_world/rev_1641307926630364064.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1641307926630364064');
+
+-- removes Frigid Ring from creature loot template
+DELETE FROM `creature_loot_template` WHERE  `Entry`=14457 AND `Item`=18679 AND `Reference`=0 AND `GroupId`=0;
+
+-- Add Frigid Ring to Reference Loot Template where it is suppose to be
+DELETE FROM `reference_loot_template` WHERE `Entry`=24016 AND `Item`=18679;
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
+(24016, 18679, 0, 0, 0, 1, 1, 1, 1, 'Frigid Ring');


### PR DESCRIPTION
Deletes Frigid Ring from Creature Loot and adds to Reference Loot where it is proper. Item is a area creatures drop not a single creature loot drop.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes Frigid Ring from Creature Loot
-  Adds Frigid Ring to Reference Loot Table

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/2370
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10003
## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds
- Performs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Rare drop, Kill any creature with reference loot table 24016

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
