### PR TITLE
Fix (DB\Loot) Copper Bolt Loot fix

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1641313085677965557.sql
+++ b/data/sql/updates/pending_db_world/rev_1641313085677965557.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1641313085677965557');
+
+-- Removes Handful of Copper Bolt loot from creatures who are not suppose to have it
+DELETE FROM `creature_loot_template` WHERE  `Entry`=2044 AND `Item`=4359 AND `Reference`=0 AND `GroupId`=0;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=2673 AND `Item`=4359 AND `Reference`=0 AND `GroupId`=1;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=6250 AND `Item`=4359 AND `Reference`=0 AND `GroupId`=0;

--- a/data/sql/updates/pending_db_world/rev_1641313085677965557.sql
+++ b/data/sql/updates/pending_db_world/rev_1641313085677965557.sql
@@ -1,6 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1641313085677965557');
 
 -- Removes Handful of Copper Bolt loot from creatures who are not suppose to have it
-DELETE FROM `creature_loot_template` WHERE  `Entry`=2044 AND `Item`=4359 AND `Reference`=0 AND `GroupId`=0;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=2673 AND `Item`=4359 AND `Reference`=0 AND `GroupId`=1;
-DELETE FROM `creature_loot_template` WHERE  `Entry`=6250 AND `Item`=4359 AND `Reference`=0 AND `GroupId`=0;
+DELETE FROM `creature_loot_template` WHERE (`Entry` IN (2044, 2673, 6250)) AND (`Item`= 4359);


### PR DESCRIPTION
Removes the loot from 3 creatures who should not have the loot per udb audit.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes the Loot from 3 creatures who should not have the loot item.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10005
- Closes https://github.com/chromiecraft/chromiecraft/issues/2530
## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
UDB Sniff Team
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds
- Performs

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Item is removed from 3 creatures who should not have it

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
