### PR TITLE
fix(DB/Creature) Greater Timberstrider position

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1641340369241454365.sql
+++ b/data/sql/updates/pending_db_world/rev_1641340369241454365.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1641340369241454365');
+
+#closes AC issue #9996
+DELETE FROM `creature` WHERE (`guid`=62817);
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(62817,17374,530,0,0,1,1,0,0,-3525.93,-12480.8,15.5967,4.46185,300,5,0,137,0,1,0,0,0,'',0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  fix position of Greater Timberstrider in Azuremyst Isle

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #9996

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- npc moved to proper position, sql applied


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 62817

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
