### PR TITLE
Feat(Core/Pathing) Path End Reached

### DIFF
--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -132,6 +132,9 @@ public:
     // Called at waypoint reached or point movement finished
     virtual void MovementInform(uint32 /*type*/, uint32 /*id*/) {}
 
+    // Called at MovePath End
+    virtual void PathEndReached() {}
+
     void OnCharmed(bool apply) override;
 
     // Called at reaching home after evade

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -138,6 +138,7 @@ bool WaypointMovementGenerator<Creature>::StartMove(Creature* creature)
         if ((i_currentNode == i_path->size() - 1) && !repeating) // If that's our last waypoint
         {
             creature->GetMotionMaster()->Initialize();
+            creature->AI()->PathEndReached();
             return false;
         }
 


### PR DESCRIPTION
## Changes Proposed:
-  Add the ability to know when a non repeating path has completed without the need to know the number of points. 
-  This works in c++ script atm using void PathEndReached().

I have never been a fan of pausing pathing to do actions. This simple addition will give the ability to have multiple paths between actions and randomize the time before calling new path rather than a set a pause time in one path allowing more control over scripting.

The only important point in a path is when it ends. Pausing is wrong. We can now script properly.

## Issues Addressed:

## SOURCE:
Me

## Tests Performed:
- Tested on a script I am working on for Eastvale logging camp.

## How to Test the Changes:
1. You would need to script an npc with a non repeating path in c++ and do an action in void PathEndReached()

## Known Issues and TODO List:
- Will need to get this added to SAI.
