### PR TITLE
fix(DB): Western Plaguelands monster reputation

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1641384460010602200.sql
+++ b/data/sql/updates/pending_db_world/rev_1641384460010602200.sql
@@ -1,0 +1,22 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1641384460010602200');
+
+-- Reputation level
+SET @REVERED = 6;
+SET @HONORED = 5;
+
+-- NPCs
+SET @CAULDRON_LORDS = 11075;
+SET @ARAJ = 1852;
+SET @GIBBERING_GHOUL = 8531;
+
+-- Monsters in Western Plaguelands reward 10 reputation until <= Revered (6)
+UPDATE `creature_onkill_reputation` SET `MaxStanding1` = @REVERED WHERE `creature_id` IN (8558, 1788, 11873, 1804, 12262, 12263, 8543, 8545);
+
+-- Gibbering Ghoul rewards 10 reputation until <= Honored (5)
+UPDATE `creature_onkill_reputation` SET `MaxStanding1` = @HONORED WHERE `creature_id` IN (@GIBBERING_GHOUL);
+
+-- Cauldron Lords should reward 30 reputation <= Honored (5)
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 30 WHERE `creature_id` IN (@CAULDRON_LORDS, @CAULDRON_LORDS + 1, @CAULDRON_LORDS + 2, @CAULDRON_LORDS + 3);
+
+-- Araj the Summoner should reward 50 reputation <= Honored (5)
+UPDATE `creature_onkill_reputation` SET `MaxStanding1` = @REVERED, `RewOnKillRepValue1` = 50 WHERE `creature_id` IN (@ARAJ);

--- a/data/sql/updates/pending_db_world/rev_1641384460010602200.sql
+++ b/data/sql/updates/pending_db_world/rev_1641384460010602200.sql
@@ -18,5 +18,5 @@ UPDATE `creature_onkill_reputation` SET `MaxStanding1` = @HONORED WHERE `creatur
 -- Cauldron Lords should reward 30 reputation <= Honored (5)
 UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 30 WHERE `creature_id` IN (@CAULDRON_LORDS, @CAULDRON_LORDS + 1, @CAULDRON_LORDS + 2, @CAULDRON_LORDS + 3);
 
--- Araj the Summoner should reward 50 reputation <= Honored (5)
+-- Araj the Summoner should reward 50 reputation <= Revered (6)
 UPDATE `creature_onkill_reputation` SET `MaxStanding1` = @REVERED, `RewOnKillRepValue1` = 50 WHERE `creature_id` IN (@ARAJ);


### PR DESCRIPTION


<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Changed reputation to monsters in Western Plaguelands according to the
  wiki, which was updated until patch 2.2

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #7130
- Closes https://github.com/chromiecraft/chromiecraft/issues/1232

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

https://wowpedia.fandom.com/wiki/Argent_Dawn?oldid=2384820

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- Not tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check the NPCs 8558, 1788, 11873, 1804, 12262, 12263, 8543, 8545, 11075, 1852, 853
2. They should award the same reputation as displayed on that table

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
