### PR TITLE
feat(Core/Pathing): Add path_id to PathEndReached

### DIFF
--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -133,7 +133,7 @@ public:
     virtual void MovementInform(uint32 /*type*/, uint32 /*id*/) {}
 
     // Called at MovePath End
-    virtual void PathEndReached() {}
+    virtual void PathEndReached(uint32 /*pathId*/) {}
 
     void OnCharmed(bool apply) override;
 

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -137,8 +137,8 @@ bool WaypointMovementGenerator<Creature>::StartMove(Creature* creature)
         // Xinef: moved the upper IF here
         if ((i_currentNode == i_path->size() - 1) && !repeating) // If that's our last waypoint
         {
+            creature->AI()->PathEndReached(path_id);
             creature->GetMotionMaster()->Initialize();
-            creature->AI()->PathEndReached();
             return false;
         }
 


### PR DESCRIPTION
## Changes Proposed:
-  After using function on a script I am working on I realized it would be helpful to know the path Id you just reached the end of if you have multiple paths. 

## Issues Addressed:
- Closes 

## SOURCE:
Me

## Tests Performed:
- Tested in game on an in progress script. Works perfectly.

## How to Test the Changes:
1. At end of a path use a check for correct path number in void PathEndReached().
