### PR TITLE
fix(Core/Handlers): remove the uint8 cap from guild bank max stacks per day

### DIFF
--- a/src/server/game/Handlers/GuildHandler.cpp
+++ b/src/server/game/Handlers/GuildHandler.cpp
@@ -186,7 +186,7 @@ void WorldSession::HandleGuildRankOpcode(WorldPackets::Guild::GuildSetRankPermis
 
     for (uint8 tabId = 0; tabId < GUILD_BANK_MAX_TABS; ++tabId)
     {
-        rightsAndSlots[tabId] = GuildBankRightsAndSlots(tabId, uint8(packet.TabFlags[tabId]), uint8(packet.TabWithdrawItemLimit[tabId]));
+        rightsAndSlots[tabId] = GuildBankRightsAndSlots(tabId, uint8(packet.TabFlags[tabId]), packet.TabWithdrawItemLimit[tabId]);
     }
 
     LOG_DEBUG("guild", "CMSG_GUILD_RANK [%s]: Rank: %s (%u)", GetPlayerInfo().c_str(), packet.RankName.c_str(), packet.RankID);


### PR DESCRIPTION
Fix for TabWithdrawItemLimit

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  remove the problematic cast to uint8 to allow guild bank max stacks per day to be greater than 255.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10041

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Should be obvious...

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Compiled on Debian 11 x86 and x64
- Tested to set max stacks per day and it worked as intended.
- Cheked the value in the DB table guild_bank_right and it was correct as expected.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Ingame:
1. press o
2. click guild
3. click options
4. select a rank
5. select a tab
6. enter value above 255 at stacks per day
7. click accept
8. click options again and see the changed value for stacks per day

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- maybe encapsulate packet.TabFlags[tabId] in a uint32 ?

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
