### PR TITLE
fix(Scrips/BlackrockSpires): Added missing `_JustDied()` to Halycon s…

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_halycon.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_halycon.cpp
@@ -50,7 +50,6 @@ public:
         void Reset() override
         {
             _Reset();
-            Summoned = false;
         }
 
         void EnterCombat(Unit* /*who*/) override
@@ -62,10 +61,9 @@ public:
 
         void JustDied(Unit* /*killer*/) override
         {
+            _JustDied();
             me->SummonCreature(NPC_GIZRUL_THE_SLAVENER, SummonLocation, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 300000);
             Talk(EMOTE_DEATH);
-
-            Summoned = true;
         }
 
         void UpdateAI(uint32 diff) override
@@ -95,8 +93,6 @@ public:
             }
             DoMeleeAttackIfReady();
         }
-    private:
-        bool Summoned;
     };
 
     CreatureAI* GetAI(Creature* creature) const override


### PR DESCRIPTION
…cript.

Fixes #9953

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #9953
- Closes https://github.com/chromiecraft/chromiecraft/issues/2706

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
create party
.go ga 87893
get in combat with Halycon and go through event
.cast 7328 on dead character

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
