### PR TITLE
fix (db\event\npc): Relocks npc Great-father Winter's Helper back to …

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1641691196999738438.sql
+++ b/data/sql/updates/pending_db_world/rev_1641691196999738438.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1641691196999738438');
+
+-- relocks npc Great-father Winter's Helper back to winter veil.
+DELETE FROM `game_event_creature` WHERE `guid`=3566 AND `eventEntry`=2;
+INSERT INTO `game_event_creature` (`eventEntry`, `guid`) VALUES (2, 3566);

--- a/data/sql/updates/pending_db_world/rev_1641691196999738438.sql
+++ b/data/sql/updates/pending_db_world/rev_1641691196999738438.sql
@@ -1,5 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1641691196999738438');
 
 -- relocks npc Great-father Winter's Helper back to winter veil.
-DELETE FROM `game_event_creature` WHERE `guid`=3566 AND `eventEntry`=2;
-INSERT INTO `game_event_creature` (`eventEntry`, `guid`) VALUES (2, 3566);
+DELETE FROM `game_event_creature` WHERE `guid` IN  (3566, 3565) AND `eventEntry`=2;
+INSERT INTO `game_event_creature` (`eventEntry`, `guid`) VALUES 
+(2, 3566),
+(2, 3565);


### PR DESCRIPTION
…winter veil

A commit somewhere seem to affected this one npc from being locked to winter veil and shows presistent in orgrimmar and ironforge with no event lock in the data base. This reintroduces the event lock on him back to event 2 winter veil.

I have rebuilt the db 2 times as well just to ensure there is no custom alterations. and npc was still present and not locked.
This will fix it.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  relocks npc Great-father Winter's Helper back to winter veil in orgrimmar and ironforge.


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Previous Databse back up from last month.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- builds 
- performs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Observer winterveil npc is no longer present in orgrimmar and ironforge when even it is no current.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
