### PR TITLE
fix (Core/Creature): Random Gender on respawn if Gender exsist for Entry

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -411,8 +411,7 @@ bool Creature::InitEntry(uint32 Entry, const CreatureData* data)
     }
 
     uint32 displayID = ObjectMgr::ChooseDisplayId(GetCreatureTemplate(), data);
-    CreatureModelInfo const* minfo = sObjectMgr->GetCreatureModelRandomGender(&displayID);
-    if (!minfo)                                             // Cancel load if no model defined
+    if (!sObjectMgr->GetCreatureModelRandomGender(&displayID))                                             // Cancel load if no model defined
     {
         LOG_ERROR("sql.sql", "Creature (Entry: %u) has no model defined in table `creature_template`, can't load. ", Entry);
         return false;
@@ -420,7 +419,6 @@ bool Creature::InitEntry(uint32 Entry, const CreatureData* data)
 
     SetDisplayId(displayID);
     SetNativeDisplayId(displayID);
-    SetByteValue(UNIT_FIELD_BYTES_0, 2, minfo->gender);
 
     // Load creature equipment
     if (!data || data->equipmentId == 0)                    // use default from the template
@@ -1062,12 +1060,10 @@ bool Creature::Create(ObjectGuid::LowType guidlow, Map* map, uint32 phaseMask, u
     LoadCreaturesAddon();
 
     uint32 displayID = GetNativeDisplayId();
-    CreatureModelInfo const* minfo = sObjectMgr->GetCreatureModelRandomGender(&displayID);
-    if (minfo && !IsTotem())                               // Cancel load if no model defined or if totem
+    if (sObjectMgr->GetCreatureModelRandomGender(&displayID) && !IsTotem())                               // Cancel load if no model defined or if totem
     {
         SetDisplayId(displayID);
         SetNativeDisplayId(displayID);
-        SetByteValue(UNIT_FIELD_BYTES_0, 2, minfo->gender);
     }
 
     //! Need to be called after LoadCreaturesAddon - MOVEMENTFLAG_HOVER is set there
@@ -1918,14 +1914,18 @@ void Creature::Respawn(bool force)
         SelectLevel();
 
         setDeathState(JUST_RESPAWNED);
+        // MDic - Acid_manifesto
+        // If creature has genders it will consider gender changing on respawn.
+        if (sObjectMgr->GetCreatureTemplate(m_originalEntry))
+        {
+            InitEntry(m_originalEntry);
+        }
 
         uint32 displayID = GetNativeDisplayId();
-        CreatureModelInfo const* minfo = sObjectMgr->GetCreatureModelRandomGender(&displayID);
-        if (minfo)                                             // Cancel load if no model defined
+        if (sObjectMgr->GetCreatureModelRandomGender(&displayID))                                             // Cancel load if no model defined
         {
             SetDisplayId(displayID);
             SetNativeDisplayId(displayID);
-            SetByteValue(UNIT_FIELD_BYTES_0, 2, minfo->gender);
         }
 
         GetMotionMaster()->InitDefault();

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1914,7 +1914,7 @@ void Creature::Respawn(bool force)
         SelectLevel();
 
         setDeathState(JUST_RESPAWNED);
-        // MDic - Acid_manifesto
+        // MDic - Acidmanifesto
         // If creature has genders it will consider gender changing on respawn.
         if (sObjectMgr->GetCreatureTemplate(m_originalEntry))
         {

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -1545,7 +1545,7 @@ void ObjectMgr::LoadCreatureMovementOverrides()
     LOG_INFO("server.loading", ">> Loaded " SZFMTD " movement overrides in %u ms", _creatureMovementOverrides.size(), GetMSTimeDiffToNow(oldMSTime));
 }
 
-CreatureModelInfo const* ObjectMgr::GetCreatureModelInfo(uint32 modelId)
+CreatureModelInfo const* ObjectMgr::GetCreatureModelInfo(uint32 modelId) const
 {
     CreatureModelContainer::const_iterator itr = _creatureModelStore.find(modelId);
     if (itr != _creatureModelStore.end())

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -740,7 +740,7 @@ public:
 
     CreatureTemplate const* GetCreatureTemplate(uint32 entry);
     [[nodiscard]] CreatureTemplateContainer const* GetCreatureTemplates() const { return &_creatureTemplateStore; }
-    CreatureModelInfo const* GetCreatureModelInfo(uint32 modelId);
+    CreatureModelInfo const* GetCreatureModelInfo(uint32 modelId) const;
     CreatureModelInfo const* GetCreatureModelRandomGender(uint32* displayID);
     static uint32 ChooseDisplayId(CreatureTemplate const* cinfo, CreatureData const* data = nullptr);
     static void ChooseCreatureFlags(CreatureTemplate const* cinfo, uint32& npcflag, uint32& unit_flags, uint32& dynamicflags, CreatureData const* data = nullptr);


### PR DESCRIPTION
If a creature has genders it will consider gender changing on respawn.
Currently if a creature has genders on Azerothcore, it is locked to the creature_model_info of the display id and will not cycle between gender if it has the gender of (0 = male, 1= female) when it respawns (NOT BLIZZLIKE) but only the model id of pre-exsisting gender.
Durning Sniff Team's Observation it was observed that creature entries with genders will respawn to other genders at random on official Blizzard Realm.
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  If creature has genders it will consider gender changing on respawn.
-  GetCreatureModelInfo to const
- Slight Code Reduction

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes None Reported

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Malcrom and sniff team observation.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds
- Performs 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. turn on gm mode so you can safely test with no issues regardless of toon
2. type in .go c 42766
3. now highlight and kill and .respawn the npc multiple times and observer that it will change genders.
4. Current NPC Cenarion Hold Sentry has Male and Female models, 2 male and 2 females. 50% chance to cycle thru gender. 25% to cycle thru each model id that is assigned to the creature entry. 

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
