### PR TITLE
fix(DB/Creature): Dual Spawning Creature Update

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1641913700930614616.sql
+++ b/data/sql/updates/pending_db_world/rev_1641913700930614616.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1641913700930614616');
+
+-- Timbermaw Mystic and Timbermaw Woodbender, Timbermaw Hold, Felwood
+UPDATE `creature` SET `Creature_id1`=11552,`Creature_id2`=11553, `chance_id1`=50 WHERE `guid` IN 
+(39353,39354,39360,39685,39721);
+
+-- Skeletal Horrors and Skeletal Fiends, Raven Hill, Duskwood
+UPDATE `creature` SET `Creature_id1`=202,`Creature_id2`=531, `chance_id1`=50 WHERE `guid` IN 
+(4927,4941,4943,4944,4945,4946,4969,4972,4973,4974,4993,5038,5039,5040,5041,5042,5043,5139,5140,5160,5163,5168,5176,5178,5942,5958,5959,5961);


### PR DESCRIPTION
## Changes Proposed:
-  Update several spawn points to use Dual Spawning

## Issues Addressed:
- Closes 

## SOURCE:
Official

## Tests Performed:
- Tested in game.

## How to Test the Changes:
1. .tele RavenHill kill fiends and horrors
2. .tele Timbermawhold