### PR TITLE
fix(Core/Waypoint Show): Fixed error with waypoint show.

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1356,6 +1356,8 @@ void Creature::SaveToDB(uint32 mapid, uint8 spawnMask, uint32 phaseMask)
     stmt = WorldDatabase.GetPreparedStatement(WORLD_INS_CREATURE);
     stmt->setUInt32(index++, m_spawnId);
     stmt->setUInt32(index++, GetEntry());
+    stmt->setUInt32(index++, 0);
+    stmt->setFloat(index++, 100.0f);
     stmt->setUInt16(index++, uint16(mapid));
     stmt->setUInt8(index++, spawnMask);
     stmt->setUInt32(index++, GetPhaseMask());


### PR DESCRIPTION
## Changes Proposed:
-  Fix an error, I introduced with multi id spawning, when showing waypoints.

## Issues Addressed:
- Closes 

## SOURCE:

## Tests Performed:
- Tested in game. no longer getting errors in console when showing waypoints in gm mode. 
- 
## How to Test the Changes:
1. Select a pathing creature.
2. Type ".wp show on" while in gm mode.