### PR TITLE
Fix(DB/BWL): Vaelastrasz trash

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1642175085880779000.sql
+++ b/data/sql/updates/pending_db_world/rev_1642175085880779000.sql
@@ -1,0 +1,13 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1642175085880779000');
+
+-- Based on the wrong creatures' position.
+-- Left group
+UPDATE `creature` SET `position_x` = -7462.55, `position_y` = -1015.27, `position_z` = 408.75, `orientation` = 2.26 WHERE `guid` = 84605;
+UPDATE `creature` SET `position_x` = -7484.4, `position_y` = -992.57, `position_z` = 408.74, `orientation` = 2.28 WHERE `guid` = 84606;
+UPDATE `creature` SET `position_x` = -7469.89, `position_y` = -1004.51, `position_z` = 408.74, `orientation` = 2.17 WHERE `guid` = 84616;
+-- Right group
+UPDATE `creature` SET `position_x` = -7505.69, `position_y` = -1007.07, `position_z` = 408.73, `orientation` = 2.19 WHERE `guid` = 84603;
+UPDATE `creature` SET `position_x` = -7491.17, `position_y` = -1035.6, `position_z` = 408.74, `orientation` = 2.26 WHERE `guid` = 84614;
+UPDATE `creature` SET `position_x` = -7494.95, `position_y` = -1022.22, `position_z` = 408.73, `orientation` = 2.19 WHERE `guid` = 84615;
+
+DELETE FROM `creature` WHERE `guid` IN (84513, 84514, 84515, 84516, 84517, 84518);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Put the goblins on the current npc's positions. It might need a sniff to check if they are correct. The "event" is already scripted.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #9031

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Apply the sql.
2. .go c 84605
3. run to the door to trigger the areatrigger 3626 and the event gets executed. See that the goblins run through the waypoints and despawn.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Sniffs?
