### PR TITLE
fix(DB): Water Invasion improvements

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1642521638013653400.sql
+++ b/data/sql/updates/pending_db_world/rev_1642521638013653400.sql
@@ -1,0 +1,24 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1642521638013653400');
+
+SET @WATER_ELEMENTAL_RIFT = 179665;
+SET @WATERY_INVADER = 14458;
+SET @PRINCESS_TEMPESTRIA = 14457;
+
+-- Adding Boss to Game event 13: Elemental Invasions
+DELETE FROM `game_event_creature` WHERE `eventEntry` = 13 AND `guid` = @PRINCESS_TEMPESTRIA;
+INSERT INTO `game_event_creature` (`eventEntry`, `guid`) VALUES (13, @PRINCESS_TEMPESTRIA);
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 1 AND `entryorguid` = @WATER_ELEMENTAL_RIFT);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(@WATER_ELEMENTAL_RIFT, 1, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 22, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Water Elemental Rift - On Respawn - Set Event Phase 1'),
+(@WATER_ELEMENTAL_RIFT, 1, 1, 2, 60, 1, 100, 0, 0, 1000, 30000, 30000, 0, 12, @WATERY_INVADER, 6, 120000, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Water Elemental Rift - On Update - Summon Creature \'Watery Invader\' (Phase 1)'),
+(@WATER_ELEMENTAL_RIFT, 1, 2, 0, 61, 0, 100, 0, 0, 1000, 30000, 30000, 0, 63, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Water Elemental Rift - On Update - (After spawning Invader) Increase counter by 1'),
+(@WATER_ELEMENTAL_RIFT, 1, 3, 0, 77, 0, 100, 0, 1, 3, 0, 0, 0, 22, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'On Counter set to 3 (3 Watery Invaders Spawned) - Set Event Phase 2'),
+(@WATER_ELEMENTAL_RIFT, 1, 4, 0, 77, 0, 100, 0, 1, 2, 0, 0, 0, 22, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'On Counter set to 2 (2 Watery Invaders Spawned) - Set Event Phase 1');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = @WATERY_INVADER);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(@WATERY_INVADER, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 89, 30, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Watery Invader - On Just Summoned - Start Random Movement'),
+(@WATERY_INVADER, 0, 1, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 63, 1, 1, 0, 1, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Watery Invader - On Just Died - Remove 1 counter from Rift'),
+(@WATERY_INVADER, 0, 2, 0, 0, 0, 100, 0, 2000, 5000, 5000, 8000, 0, 11, 20005, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Watery Invader - In Combat - Cast \'Chilled\''),
+(@WATERY_INVADER, 0, 3, 0, 0, 0, 100, 0, 3000, 5000, 8000, 15000, 0, 11, 19133, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Watery Invader - In Combat - Cast \'Frost Shock\'');

--- a/data/sql/updates/pending_db_world/rev_1642521638013653400.sql
+++ b/data/sql/updates/pending_db_world/rev_1642521638013653400.sql
@@ -2,7 +2,7 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1642521638013653400');
 
 SET @WATER_ELEMENTAL_RIFT = 179665;
 SET @WATERY_INVADER = 14458;
-SET @PRINCESS_TEMPESTRIA = 14457;
+SET @PRINCESS_TEMPESTRIA = 247210;
 
 -- Adding Boss to Game event 13: Elemental Invasions
 DELETE FROM `game_event_creature` WHERE `eventEntry` = 13 AND `guid` = @PRINCESS_TEMPESTRIA;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Improved Water Elemental Rift's SmartAI to summon 3 Invaders per rift
Maximum.
- Invaders don't despawn until killed, even after Princess Tempestria dies.
- Improved Watery Invader's SmartAI to make the Rifts work and their
in-combat AI with VMangos spells and timers.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #7418
- Closes https://github.com/chromiecraft/chromiecraft/issues/1455

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Vmangos

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not Tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check how many maximum Watery Invaders spawn per rift (3)
2. After Killing an invader another should spawn about 30s later
3. After killing Princess Tempestria the Rifts should despawn but not the Watery Invaders.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
