### PR TITLE
Disables the "all flight paths unlocked" after changefaction.

### DIFF
--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -2193,7 +2193,7 @@ void WorldSession::HandleCharFactionOrRaceChangeCallback(std::shared_ptr<Charact
             stmt->setUInt32(0, lowGuid);
             trans->Append(stmt);
 
-            if (level > 7)
+            /*if (level > 7)
             {
                 // Update Taxi path
                 // this doesn't seem to be 100% blizzlike... but it can't really be helped.
@@ -2220,7 +2220,7 @@ void WorldSession::HandleCharFactionOrRaceChangeCallback(std::shared_ptr<Charact
                 stmt->setString(0, taximaskstream.str());
                 stmt->setUInt32(1, lowGuid);
                 trans->Append(stmt);
-            }
+            }*/
 
             // Reset guild
             if (!sWorld->getBoolConfig(CONFIG_ALLOW_TWO_SIDE_INTERACTION_GUILD))


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  CharacterHandler.cpp has a weird conditional structure that unlocks all the flight paths for a player after a faction change. It even does have a comment `//this doesn't seem to be 100% blizzlike... but it can't really be helped.`. However, I'm not sure about the Blizzlike behaviour. After some research, some private servers forums says that it unlocks all the paths wheter or not you had them before. There's no info as far as I saw about how it works blizzzlike. 

- This pull request disables the unlocking.  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10315

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

This is the only info I managed to find but is not totally useful 

https://us.battle.net/support/en/article/178364

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

-  I checked Trinity Core's sourcer and it has something similar. The result is the same: unlocking all the paths.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Comment the conditional structre as this PR suggests
2. Create a new char and do .level 30 (The condition requires lvl 7+ but there are some other things one may want to avoid, like money conditions)
3. .char changefaction 
4. Visit a Flight master

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
