### PR TITLE
Fix(DB/Events): Omen can regen health out of combat

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1643130456835888100.sql
+++ b/data/sql/updates/pending_db_world/rev_1643130456835888100.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1643130456835888100');
+
+UPDATE `creature_template` SET `RegenHealth` = 1 WHERE `entry` = 15467;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Omen should be able to regen health out of combat. 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10338

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .event start 7
2. .go ga 230
3. .additem 21574 20 and use until Omen is summoned
4. Engage
5. Do damage to him
6. Die or .gm on
7. He should regen health.

