### PR TITLE
Fix(DB/Gossip): Angela Dosantos

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1643306978965271700.sql
+++ b/data/sql/updates/pending_db_world/rev_1643306978965271700.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1643306978965271700');
+
+UPDATE `gossip_menu_option` SET `OptionBroadcastTextID` = 12033 WHERE `MenuID` = 7130 AND `OptionID` = 0;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Use the right broadcast_text for the option.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8739
- Closes https://github.com/chromiecraft/chromiecraft/issues/2195

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Based on the previous gossip_menu_action broadcasts.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 16116
2. Go through the dialogs, the gossip with 'What?' shouldn't be empty as before.
