### PR TITLE
Fix(DB/Item): Bonereaver's Edge proc

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1643324466347472100.sql
+++ b/data/sql/updates/pending_db_world/rev_1643324466347472100.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1643324466347472100');
+
+UPDATE `item_template` SET `spellppmRate_1` = 3 WHERE `entry` = 17076;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Correct ppm for the weapon's proc.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10374
- Closes https://github.com/chromiecraft/chromiecraft/issues/2875

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Based on VMangos.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .add 17076
2. Verify that the weapon now procs normally. 

