### PR TITLE
Fix(DB/Spawn): Death Talon Overseer

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1643487408879682900.sql
+++ b/data/sql/updates/pending_db_world/rev_1643487408879682900.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1643487408879682900');
+
+UPDATE `creature` SET `id1` = 12461 WHERE `guid` IN (84573, 84589, 84590, 84591);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change spawn id from 12468

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10424

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Videos from issue

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. go c 84592
2. Adds near the Wyrmguard should be Overseers instead of Hatchers.
