### PR TITLE
fix(DB): Fire elemental invasion event start NPC

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1643502379399332300.sql
+++ b/data/sql/updates/pending_db_world/rev_1643502379399332300.sql
@@ -1,9 +1,0 @@
-INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1643502379399332300');
-
-DELETE FROM `command` WHERE `name` = 'go quest';
-INSERT INTO `command` (`name`, `security`, `help`) VALUES
-('go quest', 1, 'Syntax: .go quest <starter/ender> <quest>.\nTeleports you to the quest starter/ender creature or object.');
-
-DELETE FROM `acore_string` WHERE `entry` = 5082;
-INSERT INTO `acore_string` (`entry`, `content_default`, `locale_deDE`) VALUES
-(5082, 'Incorrect syntax. Specify either \'starter\' or \'ender\'.', 'Falsche syntax. Entweder \'starter\' oder \'ender\' angeben.');

--- a/data/sql/updates/pending_db_world/rev_1643631058068860400.sql
+++ b/data/sql/updates/pending_db_world/rev_1643631058068860400.sql
@@ -1,0 +1,8 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1643631058068860400');
+
+-- Added by mistake during another PR
+DELETE FROM `game_event_creature` WHERE `eventEntry` = 13 AND `guid` = 14461;
+
+-- Adding Boss to Game event 13: Elemental Invasions
+DELETE FROM `game_event_creature` WHERE `eventEntry` = 13 AND `guid` = 247200;
+INSERT INTO `game_event_creature` (`eventEntry`, `guid`) VALUES (13, 247200);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removed wrong entry added to the event
- Added the correct GUID for the Baron in Fire elemental Invasion

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes not reported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
not needed

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested but I have other 3 PRs for the other elemental bosses with the correct GUID so if it works for them, it works for Baron as well.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to the middle of Ungoro, you can use command `.tele ungoro` or `.go c 247200`
2. Kill the boss that spawns there
3. Use the command to start the Elemental Invasion event, which should be something like `.event start 13``
4. The boss has to re-spawn

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
