### PR TITLE
Fix(Core/BWL): Do not open Nefarian door until Chromaggus is defeated

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
@@ -129,7 +129,9 @@ public:
                     AddDoor(go, true);
                     nefarianDoorGUID = go->GetGUID();
                     if (GetBossState(DATA_CHROMAGGUS) != DONE)
+                    {
                         HandleGameObject(ObjectGuid::Empty, false, go);
+                    }
                     break;
                 case GO_PORTCULLIS_CHROMAGGUS:
                     AddDoor(go, true);
@@ -205,6 +207,7 @@ public:
                     {
                         HandleGameObject(nefarianDoorGUID, true);
                     }
+                    break;
                 case DATA_NEFARIAN:
                     switch (state)
                     {
@@ -335,7 +338,7 @@ public:
         EventMap _events;
     };
 
-    InstanceScript* GetInstanceScript(InstanceMap* map) const
+    InstanceScript* GetInstanceScript(InstanceMap* map) const override
     {
         return new instance_blackwing_lair_InstanceMapScript(map);
     }
@@ -376,7 +379,7 @@ public:
         }
     };
 
-    SpellScript* GetSpellScript() const
+    SpellScript* GetSpellScript() const override
     {
         return new spell_bwl_shadowflame_SpellScript;
     }

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
@@ -123,8 +123,13 @@ public:
                 case GO_PORTCULLIS_VAELASTRASZ:
                 case GO_PORTCULLIS_BROODLORD:
                 case GO_PORTCULLIS_THREEDRAGONS:
+                    AddDoor(go, true);
+                    break;
                 case GO_PORTCULLIS_NEFARIAN:
                     AddDoor(go, true);
+                    nefarianDoorGUID = go->GetGUID();
+                    if (GetBossState(DATA_CHROMAGGUS) != DONE)
+                        HandleGameObject(ObjectGuid::Empty, false, go);
                     break;
                 case GO_PORTCULLIS_CHROMAGGUS:
                     AddDoor(go, true);
@@ -145,16 +150,16 @@ public:
 
             switch (go->GetEntry())
             {
-            case GO_PORTCULLIS_RAZORGORE:
-            case GO_PORTCULLIS_VAELASTRASZ:
-            case GO_PORTCULLIS_BROODLORD:
-            case GO_PORTCULLIS_THREEDRAGONS:
-            case GO_PORTCULLIS_CHROMAGGUS:
-            case GO_PORTCULLIS_NEFARIAN:
-                AddDoor(go, false);
-                break;
-            default:
-                break;
+                case GO_PORTCULLIS_RAZORGORE:
+                case GO_PORTCULLIS_VAELASTRASZ:
+                case GO_PORTCULLIS_BROODLORD:
+                case GO_PORTCULLIS_THREEDRAGONS:
+                case GO_PORTCULLIS_CHROMAGGUS:
+                case GO_PORTCULLIS_NEFARIAN:
+                    AddDoor(go, false);
+                    break;
+                default:
+                    break;
             }
         }
 
@@ -195,6 +200,11 @@ public:
                     }
                     SetData(DATA_EGG_EVENT, NOT_STARTED);
                     break;
+                case DATA_CHROMAGGUS:
+                    if (state == DONE)
+                    {
+                        HandleGameObject(nefarianDoorGUID, true);
+                    }
                 case DATA_NEFARIAN:
                     switch (state)
                     {
@@ -313,6 +323,7 @@ public:
         ObjectGuid chromaggusGUID;
         ObjectGuid chromaggusDoorGUID;
         ObjectGuid nefarianGUID;
+        ObjectGuid nefarianDoorGUID;
         ObjectGuid victorNefariusGUID;
 
         // Razorgore


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Correctly handle the door for nefarian.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10428

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go ga id 179117
2. If you already killed Chromaggus, it should be open, if not, closed.
3. If closed, kill Chromaggus, it should open.

