### PR TITLE
fix (core): Smart Script Clean up\Code Reduction

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1795,7 +1795,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             {
                 if (!targets->empty())
                 {
-                    me->SetFacingToObject(*targets->begin());
+                    me->SetFacingTo(e.target.o);
                     if (e.action.orientation.quickChange)
                         me->SetInFront(*targets->begin());
                 }

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1797,7 +1797,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 {
                     me->SetFacingTo(e.target.o);
                     if (e.action.orientation.quickChange)
-                        me->SetInFront(*targets->begin());
+                        me->SetOrientation(e.target.o);
                 }
             delete targets;
             }

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -118,6 +118,7 @@ void SmartScript::ProcessEventsFor(SMART_EVENT e, Unit* unit, uint32 var0, uint3
 
 void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, uint32 var1, bool bvar, const SpellInfo* spell, GameObject* gob)
 {
+    ObjectList* targets = GetTargets(e, unit);
     //calc random
     if (e.GetEventType() != SMART_EVENT_LINK && e.event.event_chance < 100 && e.event.event_chance)
     {
@@ -139,7 +140,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
     {
         case SMART_ACTION_TALK:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 Creature* talker = e.target.type == 0 ? me : nullptr;
                 Unit* talkTarget = nullptr;
                 if (targets)
@@ -190,7 +190,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SIMPLE_TALK:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (targets)
                 {
                     for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
@@ -212,7 +211,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_PLAY_EMOTE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (targets)
                 {
                     for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
@@ -231,7 +229,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SOUND:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (targets)
                 {
                     for (auto& target : *targets)
@@ -253,7 +250,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_RANDOM_SOUND:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -419,7 +415,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_FACTION:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (targets)
                 {
                     for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
@@ -453,7 +448,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_MORPH_TO_ENTRY_OR_MODEL:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -496,7 +490,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_FAIL_QUEST:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -515,7 +508,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_OFFER_QUEST:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -551,7 +543,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_REACT_STATE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -568,7 +559,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_RANDOM_EMOTE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -632,7 +622,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 if (!me)
                     break;
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -651,7 +640,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_CALL_AREAEXPLOREDOREVENTHAPPENS:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -679,7 +667,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_CAST:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -743,7 +730,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 if (!tempLastInvoker)
                     break;
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -769,7 +755,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_ADD_AURA:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -788,7 +773,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_ACTIVATE_GOBJECT:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -814,7 +798,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_RESET_GOBJECT:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -833,7 +816,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_EMOTE_STATE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -852,7 +834,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_UNIT_FLAG:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -880,7 +861,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_REMOVE_UNIT_FLAG:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -960,7 +940,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 if (!GetBaseObject())
                     break;
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1000,7 +979,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 if (!GetBaseObject())
                     break;
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1020,7 +998,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_REMOVEAURASFROMSPELL:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1054,7 +1031,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 if (!IsSmart())
                     break;
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                 {
                     CAST_AI(SmartAI, me->AI())->StopFollow(false);
@@ -1141,7 +1117,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 }
                 else // Specific target type
                 {
-                    ObjectList* targets = GetTargets(e, unit);
                     if (!targets)
                         break;
 
@@ -1214,7 +1189,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                     break;
                 }
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1225,7 +1199,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_UPDATE_TEMPLATE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1247,7 +1220,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_IN_COMBAT_WITH_ZONE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1275,7 +1247,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_CALL_FOR_HELP:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1307,7 +1278,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_FORCE_DESPAWN:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1337,7 +1307,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_INGAME_PHASE_MASK:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1354,7 +1323,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_MOUNT_TO_ENTRY_OR_MODEL:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1382,7 +1350,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_INVINCIBILITY_HP_LEVEL:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1406,7 +1373,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_DATA:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1441,7 +1407,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_VISIBILITY:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1454,7 +1419,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_ACTIVE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1469,7 +1433,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 if (!me)
                     break;
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1482,7 +1445,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_ATTACK_STOP:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                 {
                     break;
@@ -1499,7 +1461,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SUMMON_CREATURE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 WorldObject* summoner = GetBaseObject() ? GetBaseObject() : unit;
                 if (!summoner)
                     break;
@@ -1567,7 +1528,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 if (!GetBaseObject())
                     break;
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (targets)
                 {
                     float x, y, z, o;
@@ -1599,7 +1559,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_KILL_UNIT:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1621,7 +1580,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_ADD_ITEM:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1638,7 +1596,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_REMOVE_ITEM:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1655,13 +1612,11 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_STORE_TARGET_LIST:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 StoreTargetList(targets, e.action.storeTargets.id);
                 break;
             }
         case SMART_ACTION_TELEPORT:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1692,7 +1647,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_RUN:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1758,7 +1712,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
                 // Xinef: ensure that SMART_ESCORT_TARGETS contains at least one player reference
                 bool stored = false;
-                ObjectList* targets = GetTargets(e, unit);
                 if (targets)
                 {
                     for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
@@ -1814,48 +1767,44 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 break;
             }
         case SMART_ACTION_SET_ORIENTATION:
+        {
+            if (!me)
+                break;
+
+            if (e.action.orientation.random > 0)
             {
-                if (!me)
-                    break;
-
-                if (e.action.orientation.random > 0)
-                {
-                    float randomOri = frand(0.0f, 2 * M_PI);
-                    me->SetFacingTo(randomOri);
-                    if (e.action.orientation.quickChange)
-                        me->SetOrientation(randomOri);
-                    break;
-                }
-
-                if (e.GetTargetType() == SMART_TARGET_SELF)
-                {
-                    me->SetFacingTo((me->HasUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT) && me->GetTransGUID() ? me->GetTransportHomePosition() : me->GetHomePosition()).GetOrientation());
-                    if (e.action.orientation.quickChange)
-                        me->SetOrientation((me->HasUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT) && me->GetTransGUID() ? me->GetTransportHomePosition() : me->GetHomePosition()).GetOrientation());
-                }
-                else if (e.GetTargetType() == SMART_TARGET_POSITION)
-                {
-                    me->SetFacingTo(e.target.o);
-                    if (e.action.orientation.quickChange)
-                        me->SetOrientation(e.target.o);
-                }
-                else if (ObjectList* targets = GetTargets(e, unit))
-                {
-                    if (!targets->empty())
-                    {
-                        me->SetFacingToObject(*targets->begin());
-                        if (e.action.orientation.quickChange)
-                            me->SetInFront(*targets->begin());
-                    }
-
-                    delete targets;
-                }
-
+                float randomOri = frand(0.0f, 2 * M_PI);
+                me->SetFacingTo(randomOri);
+                if (e.action.orientation.quickChange)
+                    me->SetOrientation(randomOri);
                 break;
             }
+            if (e.GetTargetType() == SMART_TARGET_SELF)
+            {
+                me->SetFacingTo((me->HasUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT) && me->GetTransGUID() ? me->GetTransportHomePosition() : me->GetHomePosition()).GetOrientation());
+                if (e.action.orientation.quickChange)
+                    me->SetOrientation((me->HasUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT) && me->GetTransGUID() ? me->GetTransportHomePosition() : me->GetHomePosition()).GetOrientation());
+            }
+            else if (e.GetTargetType() == SMART_TARGET_POSITION)
+            {
+                me->SetFacingTo(e.target.o);
+                if (e.action.orientation.quickChange)
+                    me->SetOrientation(e.target.o);
+            }
+            else if (targets)
+            {
+                if (!targets->empty())
+                {
+                    me->SetFacingToObject(*targets->begin());
+                    if (e.action.orientation.quickChange)
+                        me->SetInFront(*targets->begin());
+                }
+            delete targets;
+            }
+            break;
+        }
         case SMART_ACTION_PLAYMOVIE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1936,7 +1885,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_MOVE_TO_POS_TARGET:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     return;
 
@@ -1954,7 +1902,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_RESPAWN_TARGET:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1977,7 +1924,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_CLOSE_GOSSIP:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -1990,7 +1936,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_EQUIP:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2072,7 +2017,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             break;
         case SMART_ACTION_OVERRIDE_SCRIPT_BASE_OBJECT:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2117,7 +2061,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 float attackDistance = float(e.action.setRangedMovement.distance);
                 float attackAngle = float(e.action.setRangedMovement.angle) / 180.0f * M_PI;
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (targets)
                 {
                     for (ObjectList::iterator itr = targets->begin(); itr != targets->end(); ++itr)
@@ -2160,7 +2103,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_NPC_FLAG:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2173,7 +2115,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_ADD_NPC_FLAG:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2186,7 +2127,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_REMOVE_NPC_FLAG:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2203,7 +2143,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 if (!casters)
                     break;
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                 {
                     delete casters; // casters already validated, delete now
@@ -2272,7 +2211,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                     break;
                 }
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (targets)
                 {
                     for (ObjectList::iterator itr = targets->begin(); itr != targets->end(); ++itr)
@@ -2302,7 +2240,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                     break;
                 }
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (targets)
                 {
                     for (ObjectList::iterator itr = targets->begin(); itr != targets->end(); ++itr)
@@ -2325,7 +2262,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_ACTIVATE_TAXI:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2338,7 +2274,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_RANDOM_MOVE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2370,7 +2305,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_UNIT_FIELD_BYTES_1:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
                 for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
@@ -2382,7 +2316,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_REMOVE_UNIT_FIELD_BYTES_1:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2395,7 +2328,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_INTERRUPT_SPELL:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2408,7 +2340,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SEND_GO_CUSTOM_ANIM:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2421,7 +2352,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_DYNAMIC_FLAG:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2434,7 +2364,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_ADD_DYNAMIC_FLAG:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2447,7 +2376,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_REMOVE_DYNAMIC_FLAG:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2473,7 +2401,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                     break;
                 }
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2499,7 +2426,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_GO_SET_LOOT_STATE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2512,8 +2438,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_GO_SET_GO_STATE:
             {
-                ObjectList* targets = GetTargets(e, unit);
-
                 if (!targets)
                 {
                     break;
@@ -2532,7 +2456,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SEND_TARGET_TO_TARGET:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2571,7 +2494,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
                 LOG_DEBUG("sql.sql", "SmartScript::ProcessAction:: SMART_ACTION_SEND_GOSSIP_MENU: gossipMenuId {}, gossipNpcTextId {}",
                                e.action.sendGossipMenu.gossipMenuId, e.action.sendGossipMenu.gossipNpcTextId);
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2591,7 +2513,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_HOME_POS:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (targets)
                 {
                     float x, y, z, o;
@@ -2647,7 +2568,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         }*/
         case SMART_ACTION_SET_HEALTH_REGEN:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2660,7 +2580,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_ROOT:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2673,7 +2592,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_GO_FLAG:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2686,7 +2604,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_ADD_GO_FLAG:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2699,7 +2616,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_REMOVE_GO_FLAG:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2727,8 +2643,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_POWER:
             {
-                ObjectList* targets = GetTargets(e, unit);
-
                 if (targets)
                     for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
                         if (IsUnit(*itr))
@@ -2739,8 +2653,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_ADD_POWER:
             {
-                ObjectList* targets = GetTargets(e, unit);
-
                 if (targets)
                     for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
                         if (IsUnit(*itr))
@@ -2751,8 +2663,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_REMOVE_POWER:
             {
-                ObjectList* targets = GetTargets(e, unit);
-
                 if (targets)
                     for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
                         if (IsUnit(*itr))
@@ -2795,7 +2705,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 float distanceToClosest = std::numeric_limits<float>::max();
                 WayPoint* closestWp = nullptr;
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (targets)
                 {
                     for (ObjectList::iterator itr = targets->begin(); itr != targets->end(); ++itr)
@@ -2843,7 +2752,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_GO_STATE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2856,7 +2764,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_EXIT_VEHICLE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2869,7 +2776,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_UNIT_MOVEMENT_FLAGS:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2885,7 +2791,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_COMBAT_DISTANCE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2909,7 +2814,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_SIGHT_DIST:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2922,7 +2826,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_FLEE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2935,7 +2838,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_ADD_THREAT:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2948,7 +2850,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_LOAD_EQUIPMENT:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2967,7 +2868,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_HOVER:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2980,7 +2880,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_ADD_IMMUNITY:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -2993,7 +2892,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_REMOVE_IMMUNITY:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -3006,7 +2904,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_FALL:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -3024,7 +2921,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_REMOVE_ALL_GAMEOBJECTS:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -3037,7 +2933,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_STOP_MOTION:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -3055,7 +2950,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_NO_ENVIRONMENT_UPDATE:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -3068,7 +2962,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_ZONE_UNDER_ATTACK:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -3091,7 +2984,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_PLAYER_TALK:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 char const* text = sObjectMgr->GetAcoreString(e.action.playerTalk.textId, DEFAULT_LOCALE);
 
                 if (targets)
@@ -3107,7 +2999,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 if (!me)
                     break;
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -3157,7 +3048,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 if (!me)
                     break;
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -3242,7 +3132,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_CU_ENCOUNTER_START:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                     break;
 
@@ -3266,7 +3155,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 int32 const actionId = e.action.doAction.isNegative ? -e.action.doAction.actionId : e.action.doAction.actionId;
                 if (!e.action.doAction.instanceTarget)
                 {
-                    ObjectList* targets = GetTargets(e, unit);
                     if (!targets)
                     {
                         break;
@@ -3319,7 +3207,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_CORPSE_DELAY:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                 {
                     break;
@@ -3338,7 +3225,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_SET_HEALTH_PCT:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                 {
                     break;
@@ -3361,7 +3247,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 uint32 speedFraction = e.action.movementSpeed.speedFraction;
                 float speed = float(speedInteger) + float(speedFraction) / std::pow(10, std::floor(std::log10(float(speedFraction ? speedFraction : 1)) + 1));
 
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                 {
                     break;
@@ -3380,7 +3265,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
         case SMART_ACTION_PLAY_CINEMATIC:
             {
-                ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
                 {
                     break;


### PR DESCRIPTION
No need to repeat ObjectList* targets = GetTargets(e, unit); over 100 times in the same void you sinners.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Stop repeating yourself

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds
- Performs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Nothing to test
2. Nothing Broke
3. Yes i even ensure SMART_ACTION_SET_ORIENTATION still works.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
