### PR TITLE
fix(DB): Gorbold Steelhand incorrectly has Cataclysm Gossip Text

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1643928221060796100.sql
+++ b/data/sql/updates/pending_db_world/rev_1643928221060796100.sql
@@ -1,4 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1643928221060796100');
 
 UPDATE `gossip_menu` SET `TextID`=3218 WHERE `MenuID`=12726 AND `TextID`=17861;
-DELETE FROM 'npc_text' WHERE `ID`=17861;
+DELETE FROM `npc_text` WHERE `ID`=17861;

--- a/data/sql/updates/pending_db_world/rev_1643928221060796100.sql
+++ b/data/sql/updates/pending_db_world/rev_1643928221060796100.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1643928221060796100');
+
+UPDATE `gossip_menu` SET `TextID`=3218 WHERE `MenuID`=12726 AND `TextID`=17861;

--- a/data/sql/updates/pending_db_world/rev_1643928221060796100.sql
+++ b/data/sql/updates/pending_db_world/rev_1643928221060796100.sql
@@ -1,3 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1643928221060796100');
 
 UPDATE `gossip_menu` SET `TextID`=3218 WHERE `MenuID`=12726 AND `TextID`=17861;
+DELETE FROM 'npc_text' WHERE `ID`=17861;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Corrects Gossip text for NPC Gorbold Steelhand (NPC 6301). His current text is from Cataclysm expansion.
- Correct WotLK text was already in DB, so just need to be set correctly.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Original WotLK leveling video:
https://youtu.be/P8cXHJcb50o?t=2m19s

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
![Capture](https://user-images.githubusercontent.com/98835050/152442867-30901dd8-1eb8-4a6d-a634-af5ef811193c.PNG)



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go creature 37980
2. See gossip text is now correct

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
