### PR TITLE
fix (conf): Added additional Cateloge NPC IDS

### DIFF
--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -1806,7 +1806,7 @@ NpcRegenHPTimeIfTargetIsUnreachable = 10
 #                                                                               Skip Dk Module, Racial Trait Swap Modules
 #        Default:     ""
 
-Creatures.CustomIDs = "190010,190010,55005,999991,25462,98888"
+Creatures.CustomIDs = "190010,55005,999991,25462,98888"
 
 #
 ###################################################################################################

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -1802,10 +1802,11 @@ NpcRegenHPTimeIfTargetIsUnreachable = 10
 #                     divided by "," without spaces.
 #                     It is implied that you do not use for these NPC dialogs data from "gossip_menu" table.
 #                     Server will skip these IDs during the definitions validation process.
-#        Example:     Creatures.CustomIDs = "190010,55005,999991" - Npc for Transmog, Guild-zone and 1v1-arena modules
+#        Example:     Creatures.CustomIDs = "190010,55005,999991,25462,98888" - Npcs for Transmog, Guild-zone, 1v1-arena modules
+#                                                                               Skip Dk Module, Racial Trait Swap Modules
 #        Default:     ""
 
-Creatures.CustomIDs = "190010"
+Creatures.CustomIDs = "190010,190010,55005,999991,25462,98888"
 
 #
 ###################################################################################################


### PR DESCRIPTION
This is soo we can get a proppery pass\fail status on npc catelog modules dealing with hard coded gossip

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add Azerothcore Cateloge NPC ID's to be exempt from gossip check failures due to them being hardcode.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds
- Performs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Start up with any of the listed modules npcs
2. Observer no errors or failures

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
