### PR TITLE
Fix(Core/Crash): possible crash due uninitialized value

### DIFF
--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -216,7 +216,7 @@ class SpellImplicitTargetInfo
 private:
     Targets _target;
 public:
-    SpellImplicitTargetInfo() {}
+    SpellImplicitTargetInfo() : _target(Targets(0)) {}
     SpellImplicitTargetInfo(uint32 target);
 
     bool IsArea() const;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Using default constructor without uninitialized value can cause a crash due to out of range value.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes none, this happened to me.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Server crashed while loading SpellInfoCustomAttributes. I debugged it which resulted in this: 
![image](https://user-images.githubusercontent.com/19627365/153140307-474861ad-f8df-4698-8ef5-7094fdc51658.png)
Where SpellId has the following SpellFix
![image](https://user-images.githubusercontent.com/19627365/153140350-eebe5397-b777-4b4d-9ab2-75a21ca5ef1d.png)
It is using an empty constructor for the assign, which without the uninitialized value, the variable can have trash and occasionally crashing the server due to out of range value when trying to use to retrieve information from its array.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Run worldserver.exe, it will explode sometimes.
