### PR TITLE
Refactor(DB/spell): Rename fields according to their DBC equivalent

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1644590484974206900.sql
+++ b/data/sql/updates/pending_db_world/rev_1644590484974206900.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1644590484974206900');
+
+ALTER TABLE `spell_dbc` CHANGE COLUMN `Field227` `EffectBonusMultiplier_1` FLOAT DEFAULT 0 NOT NULL;
+ALTER TABLE `spell_dbc` CHANGE COLUMN `Field228` `EffectBonusMultiplier_2` FLOAT DEFAULT 0 NOT NULL;
+ALTER TABLE `spell_dbc` CHANGE COLUMN `Field229` `EffectBonusMultiplier_3` FLOAT DEFAULT 0 NOT NULL;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
While working on https://github.com/azerothcore/Keira3/pull/1623 I noticed that in the table `spell_dbc` the EffectBonusMultiplier fields were named `Field227`, `Field228` and `Field229`. The name change would make the columns easier to identify and work with. (Also it makes using them in Keira easier). The new names would then be the same as in the DBC structure / the name commonly used.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- N/A

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- [wowdev wiki](https://wowdev.wiki/DB/Spell)
- DBCStructure.h
https://github.com/azerothcore/azerothcore-wotlk/blob/2933a535ff0c037f00ec2c93e27ecef91ce5f849/src/server/shared/DataStores/DBCStructure.h#L1670-L1672

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Query applied without errors
- Server is still usable without errors in the console/log.
- Casting a spell from the `spell_dbc` table worked fine.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Apply the sql script
2. Look at the structure of the `spell_dbc` table, `Field227`, `Field228` and `Field229` should be no longer existent and replaced by the fields `EffectBonusMultiplier_1`, `EffectBonusMultiplier_2` and `EffectBonusMultiplier_3`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- The query only runs successful when the table structure has the exact fields `Field227`, `Field228` and `Field229`. When using updates in order, it is no problem. If the structure was modified manually then the script will fail.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
