### PR TITLE
fix(DB/quest_template_addon): The Brokering of Peace Quest Order

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1644600270428016400.sql
+++ b/data/sql/updates/pending_db_world/rev_1644600270428016400.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1644600270428016400');
+
+UPDATE `quest_template_addon` SET `PrevQuestID` = 8481 WHERE `ID` IN (8484, 8485);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Require quest 8481 before 8485 or 8484.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6855

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Described in:
https://github.com/azerothcore/azerothcore-wotlk/issues/6855

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
![Capture](https://user-images.githubusercontent.com/98835050/153639777-2dc541d7-6f08-40d4-a3d3-ac9e468d0493.PNG)



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.     .modify reputation 576 42000
2.     Go to your rep window, select Timbermaw, and unclick "At War"
3.     .go c 39065
4.     See only one quest available
5.     Complete quest, now next is available

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
