### PR TITLE
fix(Core/Battleground/PvPstats): correct bracket_id for AV

### DIFF
--- a/data/sql/updates/pending_db_characters/rev_1644943100668922283.sql
+++ b/data/sql/updates/pending_db_characters/rev_1644943100668922283.sql
@@ -1,5 +1,5 @@
 INSERT INTO `version_db_characters` (`sql_rev`) VALUES ('1644943100668922283');
 
-UPDATE pvpstats_battlegrounds
-SET bracket_id = bracket_id + 1
-WHERE TYPE = 1;
+UPDATE `pvpstats_battlegrounds`
+SET `bracket_id = `bracket_id` + 1
+WHERE `type` = 1;

--- a/data/sql/updates/pending_db_characters/rev_1644943100668922283.sql
+++ b/data/sql/updates/pending_db_characters/rev_1644943100668922283.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_characters` (`sql_rev`) VALUES ('1644943100668922283');
+
+UPDATE pvpstats_battlegrounds
+SET bracket_id = bracket_id + 1
+WHERE TYPE = 1;

--- a/data/sql/updates/pending_db_characters/rev_1644943100668922283.sql
+++ b/data/sql/updates/pending_db_characters/rev_1644943100668922283.sql
@@ -1,5 +1,5 @@
 INSERT INTO `version_db_characters` (`sql_rev`) VALUES ('1644943100668922283');
 
 UPDATE `pvpstats_battlegrounds`
-SET `bracket_id = `bracket_id` + 1
+SET `bracket_id` = `bracket_id` + 1
 WHERE `type` = 1;

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -2017,5 +2017,5 @@ void Battleground::RewardXPAtKill(Player* killer, Player* victim)
 
 uint8 Battleground::GetUniqueBracketId() const
 {
-    return GetMinLevel() / 10;
+    return GetMaxLevel() / 10;
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10675


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in game (with the instructions below)



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Make sure `Battleground.StoreStatistics.Enable = 1` is set
2. Do BGs and check that the table [pvpstats_battlegrounds](https://www.azerothcore.org/wiki/pvpstats_battlegrounds) is correctly set (check the value of `bracket_id`)
3. Try different BGs including Alterac Valley and Warsong Gulch

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
