### PR TITLE
fix (db\loot): Lord Kazzak

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1644933067546172773.sql
+++ b/data/sql/updates/pending_db_world/rev_1644933067546172773.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1644933067546172773');
+
+-- removes items to align with udb
+-- https://tbc.wowhead.com/item=22389/plans-sageblade
+-- https://tbc.wowhead.com/item=22390/plans-persuader
+DELETE FROM `creature_loot_template` WHERE  `Entry`=12397 AND `Item`=22389 AND `Reference`=0 AND `GroupId`=0;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=12397 AND `Item`=22390 AND `Reference`=0 AND `GroupId`=0;


### PR DESCRIPTION
UDB audit triggered by https://github.com/chromiecraft/chromiecraft/issues/2932 shows our loot for lord kazzak NPC 12397 matches exactly except for us having two additional items. Only one item is sourced on wowhead with a exceedingly low chance that suggests wowhead addon dilution and is only reported for classic section and not their tbc or retail. Other item is not reported on any other source which suggest was a vanity edit.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes https://tbc.wowhead.com/item=22389/plans-sageblade
-  Removes https://tbc.wowhead.com/item=22390/plans-persuader
-  Alighns NPC loot table fully to UDB Loot.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Sniff team, Light references to be consider with wowhead in their addon mining data.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds
- Performs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Lord Kazzak No longers drops 2 plans he currently has that he should not.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
