### PR TITLE
fix(DB/SAI): invalid param errors

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1644944170239777436.sql
+++ b/data/sql/updates/pending_db_world/rev_1644944170239777436.sql
@@ -1,7 +1,7 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1644944170239777436');
 
-UPDATE `smart_scripts` SET `event_param1` = 0 WHERE `source_type` = 0 AND `action` = 11 AND `event` = 23 AND `entryorguid` = 17664;
-UPDATE `smart_scripts` SET `event_param1` = 0 WHERE `source_type` = 0 AND `action` = 71 AND `event` = 1 AND `entryorguid` IN (
+UPDATE `smart_scripts` SET `event_param1` = 0 WHERE `source_type` = 0 AND `action_type` = 11 AND `event_type` = 23 AND `entryorguid` = 17664;
+UPDATE `smart_scripts` SET `event_param1` = 0 WHERE `source_type` = 0 AND `action_type` = 71 AND `event_type` = 1 AND `entryorguid` IN (
     37887,
     38039,
     38040,

--- a/data/sql/updates/pending_db_world/rev_1644944170239777436.sql
+++ b/data/sql/updates/pending_db_world/rev_1644944170239777436.sql
@@ -1,0 +1,13 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1644944170239777436');
+
+UPDATE `smart_scripts` SET `event_param1` = 0 WHERE `source_type` = 0 AND `action` = 11 AND `event` = 23 AND `entryorguid` = 17664;
+UPDATE `smart_scripts` SET `event_param1` = 0 WHERE `source_type` = 0 AND `action` = 71 AND `event` = 1 AND `entryorguid` IN (
+    37887,
+    38039,
+    38040,
+    38041,
+    38042,
+    38043,
+    38044,
+    38045
+);

--- a/data/sql/updates/pending_db_world/rev_1644944170239777436.sql
+++ b/data/sql/updates/pending_db_world/rev_1644944170239777436.sql
@@ -1,13 +1,4 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1644944170239777436');
 
-UPDATE `smart_scripts` SET `event_param1` = 0 WHERE `source_type` = 0 AND `action_type` = 11 AND `event_type` = 23 AND `entryorguid` = 17664;
-UPDATE `smart_scripts` SET `event_param1` = 0 WHERE `source_type` = 0 AND `action_type` = 71 AND `event_type` = 1 AND `entryorguid` IN (
-    37887,
-    38039,
-    38040,
-    38041,
-    38042,
-    38043,
-    38044,
-    38045
-);
+UPDATE `smart_scripts` SET `event_param1` = 0 WHERE `entryorguid` IN (37887, 38039, 38041, 38042, 38043, 38044, 38045) AND `source_type` = 0 AND `id` = 1;
+UPDATE `smart_scripts` SET `event_param1` = 0 WHERE `entryorguid` = 17664 AND `source_type` = 0 AND `id` = 23;


### PR DESCRIPTION
```
SmartAIMgr: Entry 17664 SourceType 0 Event 23 Action 11 has unused event_param1 with value 22, it must be 0, skipped.
SmartAIMgr: Entry 37887 SourceType 0 Event 1 Action 72 has unused event_param1 with value 1048, it must be 0, skipped.
SmartAIMgr: Entry 38039 SourceType 0 Event 1 Action 72 has unused event_param1 with value 948, it must be 0, skipped.
SmartAIMgr: Entry 38040 SourceType 0 Event 1 Action 72 has unused event_param1 with value 10948, it must be 0, skipped.
SmartAIMgr: Entry 38041 SourceType 0 Event 1 Action 72 has unused event_param1 with value 10948, it must be 0, skipped.
SmartAIMgr: Entry 38042 SourceType 0 Event 1 Action 72 has unused event_param1 with value 10948, it must be 0, skipped.
SmartAIMgr: Entry 38043 SourceType 0 Event 1 Action 72 has unused event_param1 with value 10948, it must be 0, skipped.
SmartAIMgr: Entry 38044 SourceType 0 Event 1 Action 72 has unused event_param1 with value 10948, it must be 0, skipped.
SmartAIMgr: Entry 38045 SourceType 0 Event 1 Action 72 has unused event_param1 with value 10948, it must be 0, skipped.
```