### PR TITLE
fix(Core/Spells): Nefarius Corruption should only affect Vaelastrasz

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1644967518818105800.sql
+++ b/data/sql/updates/pending_db_world/rev_1644967518818105800.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1644967518818105800');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 17 AND `SourceGroup` = 0 AND `SourceEntry` = 23642;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(17, 0, 23642, 0, 0, 31, 1, 3, 13020, 0, 0, 0, 0, '', 'Nefarius Corruption only affects Vaelastrasz');

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4064,6 +4064,13 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_HITBYSPELL | AURA_INTERRUPT_FLAG_TAKE_DAMAGE;
     });
 
+    ApplySpellFix({ 23642 }, [](SpellInfo* spellInfo)
+        {
+            spellInfo->MaxAffectedTargets = 1;
+            spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+            spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        });
+
     // Conflagration, Horseman's Cleave
     ApplySpellFix({ 42380, 42587 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4066,11 +4066,11 @@ void SpellMgr::LoadSpellInfoCorrections()
 
     // Nefarius Corruption
     ApplySpellFix({ 23642 }, [](SpellInfo* spellInfo)
-        {
-            spellInfo->MaxAffectedTargets = 1;
-            spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-            spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-        });
+    {
+        spellInfo->MaxAffectedTargets = 1;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
 
     // Conflagration, Horseman's Cleave
     ApplySpellFix({ 42380, 42587 }, [](SpellInfo* spellInfo)

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4064,6 +4064,7 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_HITBYSPELL | AURA_INTERRUPT_FLAG_TAKE_DAMAGE;
     });
 
+    // Nefarius Corruption
     ApplySpellFix({ 23642 }, [](SpellInfo* spellInfo)
         {
             spellInfo->MaxAffectedTargets = 1;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change implicit target

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10661

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 13020
2. Start the encounter
3. See the green beam from Nefarius (it's called Corruption) only affects Vaelastrasz, and not him or anyone else.

