### PR TITLE
fix (core): BG Final Override to Final

### DIFF
--- a/src/server/game/Battlegrounds/ArenaScore.h
+++ b/src/server/game/Battlegrounds/ArenaScore.h
@@ -29,8 +29,8 @@ protected:
     ArenaScore(ObjectGuid playerGuid, TeamId team) :
         BattlegroundScore(playerGuid), PvPTeamId(team == TEAM_ALLIANCE ? PVP_TEAM_ALLIANCE : PVP_TEAM_HORDE) { }
 
-    void AppendToPacket(WorldPacket& data) final override;
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void AppendToPacket(WorldPacket& data) final;
+    void BuildObjectivesBlock(WorldPacket& data) final;
 
     // For Logging purpose
     std::string ToString() const override

--- a/src/server/game/Battlegrounds/ArenaScore.h
+++ b/src/server/game/Battlegrounds/ArenaScore.h
@@ -29,8 +29,8 @@ protected:
     ArenaScore(ObjectGuid playerGuid, TeamId team) :
         BattlegroundScore(playerGuid), PvPTeamId(team == TEAM_ALLIANCE ? PVP_TEAM_ALLIANCE : PVP_TEAM_HORDE) { }
 
-    void AppendToPacket(WorldPacket& data) override;
-    void BuildObjectivesBlock(WorldPacket& data) override;
+    void AppendToPacket(WorldPacket& data) final override;
+    void BuildObjectivesBlock(WorldPacket& data) final override;
 
     // For Logging purpose
     std::string ToString() const override

--- a/src/server/game/Battlegrounds/ArenaScore.h
+++ b/src/server/game/Battlegrounds/ArenaScore.h
@@ -29,8 +29,8 @@ protected:
     ArenaScore(ObjectGuid playerGuid, TeamId team) :
         BattlegroundScore(playerGuid), PvPTeamId(team == TEAM_ALLIANCE ? PVP_TEAM_ALLIANCE : PVP_TEAM_HORDE) { }
 
-    void AppendToPacket(WorldPacket& data) final override;
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void AppendToPacket(WorldPacket& data) override;
+    void BuildObjectivesBlock(WorldPacket& data) override;
 
     // For Logging purpose
     std::string ToString() const override

--- a/src/server/game/Battlegrounds/Zones/BattlegroundAB.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundAB.h
@@ -278,7 +278,7 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void BuildObjectivesBlock(WorldPacket& data) final;
 
     uint32 GetAttr1() const final override { return BasesAssaulted; }
     uint32 GetAttr2() const final override { return BasesDefended; }

--- a/src/server/game/Battlegrounds/Zones/BattlegroundAB.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundAB.h
@@ -278,10 +278,10 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) override;
+    void BuildObjectivesBlock(WorldPacket& data) final override;
 
-    uint32 GetAttr1() const override { return BasesAssaulted; }
-    uint32 GetAttr2() const override { return BasesDefended; }
+    uint32 GetAttr1() const final override { return BasesAssaulted; }
+    uint32 GetAttr2() const final override { return BasesDefended; }
 
     uint32 BasesAssaulted = 0;
     uint32 BasesDefended = 0;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundAB.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundAB.h
@@ -278,10 +278,10 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void BuildObjectivesBlock(WorldPacket& data) override;
 
-    uint32 GetAttr1() const final override { return BasesAssaulted; }
-    uint32 GetAttr2() const final override { return BasesDefended; }
+    uint32 GetAttr1() const override { return BasesAssaulted; }
+    uint32 GetAttr2() const override { return BasesDefended; }
 
     uint32 BasesAssaulted = 0;
     uint32 BasesDefended = 0;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundAV.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundAV.h
@@ -1595,7 +1595,7 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void BuildObjectivesBlock(WorldPacket& data) final;
 
     uint32 GraveyardsAssaulted = 0;
     uint32 GraveyardsDefended = 0;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundAV.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundAV.h
@@ -1595,7 +1595,7 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) override;
+    void BuildObjectivesBlock(WorldPacket& data) final override;
 
     uint32 GraveyardsAssaulted = 0;
     uint32 GraveyardsDefended = 0;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundAV.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundAV.h
@@ -1595,7 +1595,7 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void BuildObjectivesBlock(WorldPacket& data) override;
 
     uint32 GraveyardsAssaulted = 0;
     uint32 GraveyardsDefended = 0;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundEY.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundEY.h
@@ -369,7 +369,7 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void BuildObjectivesBlock(WorldPacket& data) final;
 
     uint32 GetAttr1() const final override { return FlagCaptures; }
 

--- a/src/server/game/Battlegrounds/Zones/BattlegroundEY.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundEY.h
@@ -369,9 +369,9 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void BuildObjectivesBlock(WorldPacket& data) override;
 
-    uint32 GetAttr1() const final override { return FlagCaptures; }
+    uint32 GetAttr1() const override { return FlagCaptures; }
 
     uint32 FlagCaptures = 0;
 };

--- a/src/server/game/Battlegrounds/Zones/BattlegroundEY.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundEY.h
@@ -369,9 +369,9 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) override;
+    void BuildObjectivesBlock(WorldPacket& data) final override;
 
-    uint32 GetAttr1() const override { return FlagCaptures; }
+    uint32 GetAttr1() const final override { return FlagCaptures; }
 
     uint32 FlagCaptures = 0;
 };

--- a/src/server/game/Battlegrounds/Zones/BattlegroundIC.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundIC.h
@@ -939,7 +939,7 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void BuildObjectivesBlock(WorldPacket& data) final;
 
     uint32 GetAttr1() const final override { return BasesAssaulted; }
     uint32 GetAttr2() const final override { return BasesDefended; }

--- a/src/server/game/Battlegrounds/Zones/BattlegroundIC.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundIC.h
@@ -939,10 +939,10 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) override;
+    void BuildObjectivesBlock(WorldPacket& data) final override;
 
-    uint32 GetAttr1() const override { return BasesAssaulted; }
-    uint32 GetAttr2() const override { return BasesDefended; }
+    uint32 GetAttr1() const final override { return BasesAssaulted; }
+    uint32 GetAttr2() const final override { return BasesDefended; }
 
     uint32 BasesAssaulted = 0;
     uint32 BasesDefended = 0;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundIC.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundIC.h
@@ -939,10 +939,10 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void BuildObjectivesBlock(WorldPacket& data) override;
 
-    uint32 GetAttr1() const final override { return BasesAssaulted; }
-    uint32 GetAttr2() const final override { return BasesDefended; }
+    uint32 GetAttr1() const override { return BasesAssaulted; }
+    uint32 GetAttr2() const override { return BasesDefended; }
 
     uint32 BasesAssaulted = 0;
     uint32 BasesDefended = 0;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSA.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSA.h
@@ -442,7 +442,7 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void BuildObjectivesBlock(WorldPacket& data) final;
 
     uint32 GetAttr1() const final override { return DemolishersDestroyed; }
     uint32 GetAttr2() const final override { return GatesDestroyed; }

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSA.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSA.h
@@ -442,10 +442,10 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) override;
+    void BuildObjectivesBlock(WorldPacket& data) final override;
 
-    uint32 GetAttr1() const override { return DemolishersDestroyed; }
-    uint32 GetAttr2() const override { return GatesDestroyed; }
+    uint32 GetAttr1() const final override { return DemolishersDestroyed; }
+    uint32 GetAttr2() const final override { return GatesDestroyed; }
 
     uint32 DemolishersDestroyed = 0;
     uint32 GatesDestroyed = 0;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSA.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSA.h
@@ -442,10 +442,10 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void BuildObjectivesBlock(WorldPacket& data) override;
 
-    uint32 GetAttr1() const final override { return DemolishersDestroyed; }
-    uint32 GetAttr2() const final override { return GatesDestroyed; }
+    uint32 GetAttr1() const override { return DemolishersDestroyed; }
+    uint32 GetAttr2() const override { return GatesDestroyed; }
 
     uint32 DemolishersDestroyed = 0;
     uint32 GatesDestroyed = 0;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
@@ -205,7 +205,7 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void BuildObjectivesBlock(WorldPacket& data) final;
 
     uint32 GetAttr1() const final override { return FlagCaptures; }
     uint32 GetAttr2() const final override { return FlagReturns; }

--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
@@ -205,10 +205,10 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) override;
+    void BuildObjectivesBlock(WorldPacket& data) final override;
 
-    uint32 GetAttr1() const override { return FlagCaptures; }
-    uint32 GetAttr2() const override { return FlagReturns; }
+    uint32 GetAttr1() const final override { return FlagCaptures; }
+    uint32 GetAttr2() const final override { return FlagReturns; }
 
     uint32 FlagCaptures = 0;
     uint32 FlagReturns = 0;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
@@ -205,10 +205,10 @@ protected:
         }
     }
 
-    void BuildObjectivesBlock(WorldPacket& data) final override;
+    void BuildObjectivesBlock(WorldPacket& data) override;
 
-    uint32 GetAttr1() const final override { return FlagCaptures; }
-    uint32 GetAttr2() const final override { return FlagReturns; }
+    uint32 GetAttr1() const override { return FlagCaptures; }
+    uint32 GetAttr2() const override { return FlagReturns; }
 
     uint32 FlagCaptures = 0;
     uint32 FlagReturns = 0;


### PR DESCRIPTION
Code factor fix, this needs to be done so we can merge In support of https://github.com/azerothcore/mod-cfbg/pull/94 and be green on the custom module build test.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  BG Final Override to Final
-  In support of https://github.com/azerothcore/mod-cfbg/pull/94

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- builds
- runs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. This is just a code factor and hopefully module support compile fix which is another pr

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
