### PR TITLE
fix (core): Final Override to Final PT 2

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundAB.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundAB.h
@@ -280,8 +280,8 @@ protected:
 
     void BuildObjectivesBlock(WorldPacket& data) final;
 
-    uint32 GetAttr1() const final override { return BasesAssaulted; }
-    uint32 GetAttr2() const final override { return BasesDefended; }
+    uint32 GetAttr1() const override { return BasesAssaulted; }
+    uint32 GetAttr2() const override { return BasesDefended; }
 
     uint32 BasesAssaulted = 0;
     uint32 BasesDefended = 0;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundEY.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundEY.h
@@ -371,7 +371,7 @@ protected:
 
     void BuildObjectivesBlock(WorldPacket& data) final;
 
-    uint32 GetAttr1() const final override { return FlagCaptures; }
+    uint32 GetAttr1() const override { return FlagCaptures; }
 
     uint32 FlagCaptures = 0;
 };

--- a/src/server/game/Battlegrounds/Zones/BattlegroundIC.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundIC.h
@@ -941,8 +941,8 @@ protected:
 
     void BuildObjectivesBlock(WorldPacket& data) final;
 
-    uint32 GetAttr1() const final override { return BasesAssaulted; }
-    uint32 GetAttr2() const final override { return BasesDefended; }
+    uint32 GetAttr1() const override { return BasesAssaulted; }
+    uint32 GetAttr2() const override { return BasesDefended; }
 
     uint32 BasesAssaulted = 0;
     uint32 BasesDefended = 0;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSA.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSA.h
@@ -444,8 +444,8 @@ protected:
 
     void BuildObjectivesBlock(WorldPacket& data) final;
 
-    uint32 GetAttr1() const final override { return DemolishersDestroyed; }
-    uint32 GetAttr2() const final override { return GatesDestroyed; }
+    uint32 GetAttr1() const override { return DemolishersDestroyed; }
+    uint32 GetAttr2() const override { return GatesDestroyed; }
 
     uint32 DemolishersDestroyed = 0;
     uint32 GatesDestroyed = 0;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
@@ -207,8 +207,8 @@ protected:
 
     void BuildObjectivesBlock(WorldPacket& data) final;
 
-    uint32 GetAttr1() const final override { return FlagCaptures; }
-    uint32 GetAttr2() const final override { return FlagReturns; }
+    uint32 GetAttr1() const override { return FlagCaptures; }
+    uint32 GetAttr2() const override { return FlagReturns; }
 
     uint32 FlagCaptures = 0;
     uint32 FlagReturns = 0;


### PR DESCRIPTION
PT2, codefactor was green and then decided to complain about the other final overrides in BG

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  changed bg final override to final pt 2

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- builds
- performs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1 .PT2, codefactor was green and then decided to complain about the other final overrides in BG

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
