### PR TITLE
fix(Core/Creature): Allow Multi id in areas with zone script

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1506,8 +1506,8 @@ bool Creature::CreateFromProto(ObjectGuid::LowType guidlow, uint32 Entry, uint32
     SetZoneScript();
     if (GetZoneScript() && data)
     {
-        Entry = GetZoneScript()->GetCreatureEntry(guidlow, data);
-        if (!Entry)
+        uint32 FirstEntry = GetZoneScript()->GetCreatureEntry(guidlow, data);
+        if (!FirstEntry)
             return false;
     }
 


### PR DESCRIPTION
## Changes Proposed:
-  This was preventing multi ids in certain zones

## Issues Addressed:
- Closes 

## SOURCE:
me

## Tests Performed:
- tested in game. Working

## How to Test the Changes:
1. ```UPDATE `creature` SET `id1`=18488, `id2`=18549 WHERE `guid` IN (68474,68475,68476,68477,68478);```
2. .go c 68474