### PR TITLE
fix(DB): Stonetalon and Ashenvale Horde Quest Emotes

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1645306739640504900.sql
+++ b/data/sql/updates/pending_db_world/rev_1645306739640504900.sql
@@ -1,0 +1,101 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1645306739640504900');
+
+/* Blood Feeders */
+DELETE FROM `quest_details` WHERE `ID`=6461;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (6461,1,0,0,0,0,0,0,0,0);
+
+/* Jin'Zil's Forest Magic */
+DELETE FROM `quest_details` WHERE `ID`=1058;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (1058,4,6,0,0,0,0,0,0,0);
+
+/* Report to Kadrak */
+DELETE FROM `quest_details` WHERE `ID`=6542;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (6542,1,1,0,0,0,0,0,0,0);
+
+/* Boulderslide Ravine */
+DELETE FROM `quest_details` WHERE `ID`=6421;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (6421,1,0,0,0,0,0,0,0,0);
+
+/* Earthen Arise */
+DELETE FROM `quest_details` WHERE `ID`=6481;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (6481,1,0,0,0,0,0,0,0,0);
+
+/* Cenarius' Legacy */
+DELETE FROM `quest_details` WHERE `ID`=1087;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (1087,1,1,0,0,0,0,0,0,0);
+
+/* Ordanus */
+DELETE FROM `quest_details` WHERE `ID`=1088;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (1088,5,0,0,0,0,0,0,0,0);
+
+/* The Den */
+DELETE FROM `quest_details` WHERE `ID`=1089;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (1089,1,0,0,0,0,0,0,0,0);
+
+/* Cycle of Rebirth */
+DELETE FROM `quest_details` WHERE `ID`=6301;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (6301,1,0,0,0,0,0,0,0,0);
+
+/* New Life */
+DELETE FROM `quest_details` WHERE `ID`=6381;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (6381,1,0,0,0,0,0,0,0,0);
+
+/* Harpies Threaten */
+DELETE FROM `quest_details` WHERE `ID`=6282;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (6282,1,0,0,0,0,0,0,0,0);
+
+/* Bloodfury Bloodline */
+DELETE FROM `quest_details` WHERE `ID`=6283;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (6283,1,0,0,0,0,0,0,0,0);
+
+/* Calling in the Reserves */
+DELETE FROM `quest_details` WHERE `ID`=5881;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (5881,1,0,0,0,0,0,0,0,0);
+
+/* Ashenvale Outrunners */
+DELETE FROM `quest_details` WHERE `ID`=6503;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (6503,5,0,0,0,0,0,0,0,0);
+
+/* The Ashenvale Hunt */
+DELETE FROM `quest_details` WHERE `ID`=6382;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (6382,1,0,0,0,0,0,0,0,0);
+
+/* The Ashenvale Hunt */
+DELETE FROM `quest_details` WHERE `ID`=235;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (235,22,1,0,0,0,0,0,0,0);
+
+/* The Ashenvale Hunt */
+DELETE FROM `quest_details` WHERE `ID`=742;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (742,22,1,0,0,0,0,0,0,0);
+
+/* Stonetalon Standstill */
+DELETE FROM `quest_details` WHERE `ID`=25;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (25,6,1,0,0,0,0,0,0,0);
+
+/* Je'neu of the Earthen Ring */
+DELETE FROM `quest_details` WHERE `ID`=824;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (824,1,0,0,0,0,0,0,0,0);
+
+/* Warsong Supplies */
+DELETE FROM `quest_details` WHERE `ID`=6571;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (6571,1,0,0,0,0,0,0,0,0);
+
+/* Amongst the Ruins */
+UPDATE `quest_details` SET `Emote1`=1 WHERE `ID`=6921;
+
+/* The Essence of Aku'Mai */
+UPDATE `quest_details` SET `Emote1`=1 WHERE `ID`=6563;
+
+/* Allegiance to the Old Gods */
+DELETE FROM `quest_details` WHERE `ID`=6565;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (6565,1,0,0,0,0,0,0,0,0);
+
+/* Destroy the Legion */
+UPDATE `quest_details` SET `Emote1`=5 WHERE `ID`=9534;
+
+/* Never Again! */
+DELETE FROM `quest_details` WHERE `ID`=9536;
+INSERT INTO `quest_details` (`ID`, `Emote1`, `Emote2`, `Emote3`, `Emote4`, `EmoteDelay1`, `EmoteDelay2`, `EmoteDelay3`, `EmoteDelay4`, `VerifiedBuild`) VALUES (9536,25,1,0,0,0,0,0,0,0);
+
+/* The Lost Pages */
+UPDATE `quest_details` SET `Emote1`=1, `Emote2`=1 WHERE `ID`=6504;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add missing emotes for Horde quests in Stonetalon and Ashenvale
-  All values taken from TrinityCore
- Many values from TC PR were already present; I only include the missing values
- Co-authored-by: ZenoX92

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
TrinityCore: https://github.com/TrinityCore/TrinityCore/commit/aa9723369ec313d14aa2f4623f5c1e28066a3845

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested several quests, worked as intended


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .tele stonetalon
2. Accept and complete quests listed in comments, see emotes are correct

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
