### PR TITLE
fix (db): Smolderthorn Berserker not attacking

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1645476483912365838.sql
+++ b/data/sql/updates/pending_db_world/rev_1645476483912365838.sql
@@ -6,7 +6,8 @@ UPDATE `creature` SET `MovementType`='2' WHERE  `guid`=43101;
 
 -- link guid to waypoint
 DELETE FROM `creature_addon` WHERE `guid`=43101;
-INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES (43101, 926800, 0, 0, 0, 0, 3, NULL);
+INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES 
+(43101, 926800, 0, 0, 0, 0, 3, NULL);
 
 -- waypoints are transferred to waypoint_data
 DELETE FROM `waypoint_data` WHERE `id`=926800;

--- a/data/sql/updates/pending_db_world/rev_1645476483912365838.sql
+++ b/data/sql/updates/pending_db_world/rev_1645476483912365838.sql
@@ -1,0 +1,22 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1645476483912365838');
+
+-- Smolderthorn Berserker guid 43101
+-- adjust npc to use waypoints
+UPDATE `creature` SET `MovementType`='2' WHERE  `guid`=43101;
+
+-- link guid to waypoint
+DELETE FROM `creature_addon` WHERE `guid`=43101;
+INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES (43101, 926800, 0, 0, 0, 0, 3, NULL);
+
+-- waypoints are transferred to waypoint_data
+DELETE FROM `waypoint_data` WHERE `id`=926800;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES 
+(926800, 0, -53.6383, -442.827, 78.2854, 0, 0, 0, 0, 100, 0),
+(926800, 1, -53.2897, -405.473, 77.7616, 0, 0, 0, 0, 100, 0),
+(926800, 2, -52.7996, -389.966, 77.7702, 0, 0, 0, 0, 100, 0);
+
+-- delete troublesome smart scripts
+DELETE FROM `smart_scripts` WHERE  `entryorguid`=-43101;
+
+-- delete exsisting waypoints
+DELETE FROM `waypoints` WHERE `entry`=926800;


### PR DESCRIPTION
Smolderthorn Berserker guid 43101 was not attacking due to it being assigned some weird funky smart script instead of just giving it normal pathing waypoints.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Moves its guid specific sai to just waypoint pathing

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/2938
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10782

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- builds
- performs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 43101
2. observe the npc moving back and forth on its path
3. npc can now attack

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
