### PR TITLE
fix(DB/Events): Apothecary Hummel should be linked to event

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1645520412284756500.sql
+++ b/data/sql/updates/pending_db_world/rev_1645520412284756500.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1645520412284756500');
+
+DELETE FROM `game_event_creature` WHERE `guid` = 146623;
+INSERT INTO `game_event_creature` (`eventEntry`, `guid`) VALUES
+(8, 146623);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add Apothecary Hummel to game_event_creature, I missed it on my last PR.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes none

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .tele sfk
2. Check if the apothecary is there, it should not.
3. .event start 8
4. Enter the instance again, it should be there.
