### PR TITLE
fix(Scripts/Ulduar): Flame Leviathan first time engage

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -260,7 +260,6 @@ public:
 
             me->setActive(true);
             me->SetHomePosition(322.4f, -14.3f, 409.8f, 3.23f);
-            TurnGates(true, false);
             TurnHealStations(false);
             ActivateTowers();
             if (m_pInstance)
@@ -368,11 +367,13 @@ public:
                 else if (_speakTimer > 41000 && _speakTimer < 60000)
                 {
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
-                    me->SendMonsterMove(380.4f, -14.3f, 409.8f, 2000);
-                    me->UpdatePosition(380.4f, -14.3f, 409.8f, me->GetOrientation());
+                    //me->MonsterMoveWithSpeed(380.4f, -14.5f, 409.8f, 1000);
+					TurnGates(true, false);
+					me->MonsterMoveWithSpeed(322.39f, -14.5f, 409.8f, 100.0f);
+					me->UpdatePosition(322.39f, -14.5f, 409.8f, me->GetOrientation());
                     _speakTimer = 60000;
                 }
-                else if (_speakTimer > 61500)
+                else if (_speakTimer > 63500)
                 {
                     me->SetInCombatWithZone();
                     if (!me->GetVictim())

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -367,7 +367,6 @@ public:
                 else if (_speakTimer > 41000 && _speakTimer < 60000)
                 {
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
-                    //me->MonsterMoveWithSpeed(380.4f, -14.5f, 409.8f, 1000);
 					TurnGates(true, false);
 					me->MonsterMoveWithSpeed(322.39f, -14.5f, 409.8f, 100.0f);
 					me->UpdatePosition(322.39f, -14.5f, 409.8f, me->GetOrientation());

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -367,9 +367,9 @@ public:
                 else if (_speakTimer > 41000 && _speakTimer < 60000)
                 {
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
-					TurnGates(true, false);
-					me->MonsterMoveWithSpeed(322.39f, -14.5f, 409.8f, 100.0f);
-					me->UpdatePosition(322.39f, -14.5f, 409.8f, me->GetOrientation());
+                    TurnGates(true, false);
+                    me->MonsterMoveWithSpeed(322.39f, -14.5f, 409.8f, 100.0f);
+                    me->UpdatePosition(322.39f, -14.5f, 409.8f, me->GetOrientation());
                     _speakTimer = 60000;
                 }
                 else if (_speakTimer > 63500)

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -178,6 +178,7 @@ enum Misc
     ACTION_DELAY_CANNON             = 5,
     ACTION_DESTROYED_TURRET         = 6,
 };
+const Position homePos = {322.39f, -14.5f, 409.8f, 3.14f};
 
 ///////////////////////////////////////////
 //
@@ -259,7 +260,7 @@ public:
             Talk(FLAME_LEVIATHAN_SAY_AGGRO);
 
             me->setActive(true);
-            me->SetHomePosition(322.4f, -14.3f, 409.8f, 3.23f);
+            me->SetHomePosition(homePos);
             TurnHealStations(false);
             ActivateTowers();
             if (m_pInstance)
@@ -273,8 +274,8 @@ public:
         {
             if (m_pInstance && m_pInstance->GetData(TYPE_LEVIATHAN) == SPECIAL)
             {
-                me->SetHomePosition(322.4f, -14.3f, 409.8f, 3.23f);
-                me->UpdatePosition(322.4f, -14.3f, 409.8f, 3.23f);
+                me->SetHomePosition(homePos);
+                me->UpdatePosition(homePos);
                 me->StopMovingOnCurrentPos();
             }
 
@@ -367,9 +368,9 @@ public:
                 else if (_speakTimer > 41000 && _speakTimer < 60000)
                 {
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
-                    TurnGates(true, false);
-                    me->MonsterMoveWithSpeed(322.39f, -14.5f, 409.8f, 100.0f);
-                    me->UpdatePosition(322.39f, -14.5f, 409.8f, me->GetOrientation());
+					TurnGates(true, false);
+					me->MonsterMoveWithSpeed(homePos.GetPositionX(),homePos.GetPositionY(), homePos.GetPositionZ(), 100.0f);
+					me->UpdatePosition(homePos);
                     _speakTimer = 60000;
                 }
                 else if (_speakTimer > 63500)

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -368,9 +368,9 @@ public:
                 else if (_speakTimer > 41000 && _speakTimer < 60000)
                 {
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
-					TurnGates(true, false);
-					me->MonsterMoveWithSpeed(homePos.GetPositionX(), homePos.GetPositionY(), homePos.GetPositionZ(), 100.0f);
-					me->UpdatePosition(homePos);
+                    TurnGates(true, false);
+                    me->MonsterMoveWithSpeed(homePos.GetPositionX(), homePos.GetPositionY(), homePos.GetPositionZ(), 100.0f);
+                    me->UpdatePosition(homePos);
                     _speakTimer = 60000;
                 }
                 else if (_speakTimer > 63500)

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -369,7 +369,7 @@ public:
                 {
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
 					TurnGates(true, false);
-					me->MonsterMoveWithSpeed(homePos.GetPositionX(),homePos.GetPositionY(), homePos.GetPositionZ(), 100.0f);
+					me->MonsterMoveWithSpeed(homePos.GetPositionX(), homePos.GetPositionY(), homePos.GetPositionZ(), 100.0f);
 					me->UpdatePosition(homePos);
                     _speakTimer = 60000;
                 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Please, let me know if this is the correct way to do a script PR, thanks!

## Changes Proposed:
-  Fix timing on gate breaking, combat engage and underground pathing.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #10808 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.youtube.com/watch?v=00p_Ni58YGE (Also in the #10808 issue)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

https://user-images.githubusercontent.com/46330494/155529534-7b83db6c-8b31-4f18-8d1e-48b738222fd0.mp4



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 137039 (Steelforged Defender, in front of FL gate)
2. .npc add 33060 (Salvaged Siege Engine)
3. Kill the 2 Ulduar Colossus (While inside the Siege Engine, can .die them)


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
