### PR TITLE
fix(Core/SAI): Allow scripts to target the summoner of a TempSummon

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3844,6 +3844,10 @@ ObjectList* SmartScript::GetTargets(SmartScriptHolder const& e, Unit* invoker /*
                     {
                         l->push_back(owner);
                     }
+                    else if (me->IsSummon() && me->ToTempSummon()->GetSummonerUnit())
+                    {
+                        l->push_back(me->ToTempSummon()->GetSummonerUnit());
+                    }
                 }
                 else if (go)
                 {


### PR DESCRIPTION
## Changes Proposed:
Allow scripts to target the summoner of a TempSummon, this was removed in PR #9372 (TempSummons do not use the same path as GetCharmerOrOwnerGUID())

## Issues Addressed:
- Closes #10760
- Closes #10123

## Tests Performed:
- Completed dungeon Pit of Saron

## How to Test the Changes:
1. `.tele PitOfSaron`
2. Kill the first two bosses and wait for the RP section to finish
3. Start running up the hill to Tryrannus
4. 10 creatures will spawn, once killed the next set will correctly spawn as you reach the top and the dungeon can be completed