### PR TITLE
fix(DB/Pathing): Add missing pathing to Ironforge Mountaineer

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1646081535601402400.sql
+++ b/data/sql/updates/pending_db_world/rev_1646081535601402400.sql
@@ -1,0 +1,18 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1646081535601402400');
+
+SET @NPC := 225;
+SET @PATH := @NPC * 10;
+
+DELETE FROM `creature_addon` WHERE `guid` = @NPC;
+INSERT INTO `creature_addon` (`guid`, `path_id`) VALUES (@NPC, @PATH);
+UPDATE `creature` SET `MovementType` = 2 WHERE `guid` = @NPC;
+
+DELETE FROM `waypoint_data` WHERE `id` = @PATH;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`) VALUES
+(@PATH, 1, -5711.44, -553.78, 398.49, 0, 0),
+(@PATH, 2, -5701.5, -556.94, 399.42, 0, 0),
+(@PATH, 3, -5690.68, -562.23, 399.75, 0, 0),
+(@PATH, 4, -5686.02, -576.38, 401.57, 0, 0),
+(@PATH, 5, -5703.14, -576.05, 401.19, 0, 0),
+(@PATH, 6, -5712.95, -566.86, 399.93, 0, 0),
+(@PATH, 7, -5719.97, -550.44, 398.7, 0, 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add missing pathing to Ironforge Mountaineer GUID 225.
-  Values are from Vmangos

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Vmangos

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Followed NPC, path seems correct. Previously was standing still.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go creature 225
2. Observe pathing

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
