### PR TITLE
fix(DB/Pathing): Add Missing Hakkari Oracle Pathing

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1646088431493180100.sql
+++ b/data/sql/updates/pending_db_world/rev_1646088431493180100.sql
@@ -1,0 +1,16 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1646088431493180100');
+
+SET @NPC := 733;
+SET @PATH := @NPC * 10;
+
+UPDATE `creature_addon` SET `path_id` = @PATH WHERE `guid` = @NPC;
+UPDATE `creature` SET `MovementType` = 2 WHERE `guid` = @NPC;
+
+DELETE FROM `waypoint_data` WHERE `id` = @PATH;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`) VALUES
+(@PATH, 1, -11916.5, -1089.93, 77.2794, 100, 0),
+(@PATH, 2, -11916.5, -1072.16, 77.2796, 100, 0),
+(@PATH, 3, -11916.5, -1084.36, 77.2798, 100, 0),
+(@PATH, 4, -11916.1, -1116.62, 77.2792, 100, 0),
+(@PATH, 5, -11916, -1142.12, 77.2789, 100, 0),
+(@PATH, 6, -11916.1, -1121.86, 77.282, 100, 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add missing pathing to Hakkari Oracle outside Zul'Gurub
-  Waypoint values are from Vmangos

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Vmangos

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Followed NPC, path is now looks correct


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go creature 733
2. Observe pathing

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
