### PR TITLE
fix(DB/Pathing): Add Missing Mosh'Ogg Warmonger Pathing

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1646089487915555800.sql
+++ b/data/sql/updates/pending_db_world/rev_1646089487915555800.sql
@@ -1,0 +1,27 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1646089487915555800');
+
+SET @NPC := 849;
+SET @PATH := @NPC * 10;
+
+DELETE FROM `creature_addon` WHERE `guid` = @NPC;
+INSERT INTO `creature_addon` (`guid`, `path_id`) VALUES (@NPC, @PATH);
+UPDATE `creature` SET `MovementType` = 2 WHERE `guid` = @NPC;
+
+DELETE FROM `waypoint_data` WHERE `id` = @PATH;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`) VALUES
+(@PATH, 1, -12378.6, -963.559, 15.3825, 0, 0),
+(@PATH, 2, -12389.1, -960.663, 19.123, 0, 0),
+(@PATH, 3, -12402, -953.174, 24.9704, 0, 0),
+(@PATH, 4, -12410.9, -950.4, 28.0988, 0, 0),
+(@PATH, 5, -12415.9, -942.535, 28.7172, 0, 0),
+(@PATH, 6, -12422.5, -930.758, 30.8608, 0, 0),
+(@PATH, 7, -12434.3, -915.714, 35.5984, 0, 0),
+(@PATH, 8, -12448.6, -909.005, 38.7702, 0, 0),
+(@PATH, 9, -12434.3, -915.714, 35.5984, 0, 0),
+(@PATH, 10, -12422.5, -930.758, 30.8608, 0, 0),
+(@PATH, 11, -12415.9, -942.535, 28.7172, 0, 0),
+(@PATH, 12, -12410.9, -950.4, 28.0988, 0, 0),
+(@PATH, 13, -12402, -953.174, 24.9704, 0, 0),
+(@PATH, 14, -12389.1, -960.663, 19.123, 0, 0),
+(@PATH, 15, -12378.6, -963.559, 15.3825, 0, 0),
+(@PATH, 16, -12369.5, -963.88, 12.9135, 0, 0);

--- a/data/sql/updates/pending_db_world/rev_1646089487915555800.sql
+++ b/data/sql/updates/pending_db_world/rev_1646089487915555800.sql
@@ -25,3 +25,56 @@ INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `positio
 (@PATH, 14, -12389.1, -960.663, 19.123, 0, 0),
 (@PATH, 15, -12378.6, -963.559, 15.3825, 0, 0),
 (@PATH, 16, -12369.5, -963.88, 12.9135, 0, 0);
+
+SET @NPC := 853;
+SET @PATH := @NPC * 10;
+
+DELETE FROM `creature_addon` WHERE `guid` = @NPC;
+INSERT INTO `creature_addon` (`guid`, `path_id`) VALUES (@NPC, @PATH);
+UPDATE `creature` SET `MovementType` = 2 WHERE `guid` = @NPC;
+
+DELETE FROM `waypoint_data` WHERE `id` = @PATH;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`) VALUES
+(@PATH, 1, -12360, -997.523, 11.4784, 100, 0),
+(@PATH, 2, -12357.6, -985.988, 13.5685, 100, 0),
+(@PATH, 3, -12354.6, -978.756, 13.4476, 100, 0),
+(@PATH, 4, -12354.1, -978.975, 13.382, 100, 0),
+(@PATH, 5, -12355.9, -982.584, 13.5899, 100, 0),
+(@PATH, 6, -12359.3, -989.846, 12.8712, 100, 0),
+(@PATH, 7, -12360.9, -993.477, 12.1879, 100, 0),
+(@PATH, 8, -12361.1, -997.291, 11.6832, 100, 0),
+(@PATH, 9, -12357.2, -1003.77, 9.11341, 100, 0),
+(@PATH, 10, -12352.2, -1010.01, 7.92257, 100, 0),
+(@PATH, 11, -12349.6, -1013.02, 8.13928, 100, 0),
+(@PATH, 12, -12348, -1016.79, 8.16116, 100, 0),
+(@PATH, 13, -12346.5, -1020.48, 7.7491, 100, 0),
+(@PATH, 14, -12335, -1034.68, 7.85564, 100, 0),
+(@PATH, 15, -12334.5, -1030.99, 8.1515, 100, 0),
+(@PATH, 16, -12338.7, -1024.88, 8.12575, 100, 0),
+(@PATH, 17, -12342.3, -1022.66, 7.9493, 100, 0),
+(@PATH, 18, -12345.3, -1020.53, 7.70349, 100, 0),
+(@PATH, 19, -12350.3, -1014.33, 8.01138, 100, 0),
+(@PATH, 20, -12354.8, -1007.67, 8.62256, 100, 0),
+(@PATH, 21, -12359, -1001.3, 9.76074, 100, 0);
+
+SET @NPC := 856;
+SET @PATH := @NPC * 10;
+
+DELETE FROM `creature_addon` WHERE `guid` = @NPC;
+INSERT INTO `creature_addon` (`guid`, `path_id`) VALUES (@NPC, @PATH);
+UPDATE `creature` SET `MovementType` = 2 WHERE `guid` = @NPC;
+
+DELETE FROM `waypoint_data` WHERE `id` = @PATH;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`) VALUES
+(@PATH, 1, -12330.2, -933.855, 9.33679, 0, 0),
+(@PATH, 2, -12309.3, -908.34, 8.68362, 0, 0),
+(@PATH, 3, -12287.8, -885.928, 7.72276, 0, 0),
+(@PATH, 4, -12271.6, -855.56, 7.95999, 0, 0),
+(@PATH, 5, -12256, -815.657, 9.87775, 0, 0),
+(@PATH, 6, -12246.8, -791.101, 12.5155, 0, 0),
+(@PATH, 7, -12256, -815.657, 9.87775, 0, 0),
+(@PATH, 8, -12271.6, -855.56, 7.95999, 0, 0),
+(@PATH, 9, -12287.8, -885.928, 7.72276, 0, 0),
+(@PATH, 10, -12309.3, -908.34, 8.68362, 0, 0),
+(@PATH, 11, -12330.2, -933.855, 9.33679, 0, 0),
+(@PATH, 12, -12351.4, -969, 13.033, 0, 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Adds missing pathing to several ogres in and around Mosh'Ogg Ogre Mound
-  Values are from VMangos

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Vmangos

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Followed NPC, pathing is now correct and patrols path down to mound


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go creature 849
2. Observe correct pathing

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
