### PR TITLE
(DB/auth) Delete auto incrementable in account

### DIFF
--- a/data/sql/base/db_auth/account.sql
+++ b/data/sql/base/db_auth/account.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS `account` (
   `totaltime` INT unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_username` (`username`)
-) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8mb4 COMMENT='Account System';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Account System';
 
 -- Дамп данных таблицы acore_auth.account: ~0 rows (приблизительно)
 DELETE FROM `account`;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Previously, about 10 accounts were created by default, so when they were removed, the auto incrementing option was left in the table structure.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Generally, when I create a server, I have to remember to remove that option, because otherwise, the accounts start to be generated from id 11.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. If you remove the option, the beads start from id 1. Otherwise, they start at id 11.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
