### PR TITLE
Fix solve Issue Ruthlessness

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1646503273471117785.sql
+++ b/data/sql/updates/pending_db_world/rev_1646503273471117785.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1646503273471117785');
+
+INSERT INTO `acore_world`.`spell_script_names` (`spell_id`, `ScriptName`) VALUES (14161, 'spell_rog_ruthlessness');

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -44,6 +44,23 @@ enum RogueSpells
     SPELL_ROGUE_TRICKS_OF_THE_TRADE_PROC        = 59628,
 };
 
+/* Returns true if the spell is a finishing move.
+ * A finishing move is a spell that cost combo points */
+Optional<int32> GetFinishingMoveCPCost(Spell const* spell)
+{
+    if (!spell)
+        return { };
+
+    return spell->GetPowerTypeCostAmount(POWER_COMBO_POINTS);
+}
+
+/* Return true if the spell is a finishing move.
+ * A finishing move is a spell that cost combo points */
+bool IsFinishingMove(Spell const* spell)
+{
+    return GetFinishingMoveCPCost(spell).has_value();
+}
+
 class spell_rog_savage_combat : public AuraScript
 {
     PrepareAuraScript(spell_rog_savage_combat);
@@ -677,12 +694,12 @@ class spell_rog_ruthlessness : public AuraScript
 {
     PrepareAuraScript(spell_rog_ruthlessness);
 
-    void HandleProc(AuraEffect* aurEff, ProcEventInfo& procInfo)
+    void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
     {
         Unit* target = GetTarget();
 
         if (Optional<int32> cost = GetFinishingMoveCPCost(procInfo.GetProcSpell()))
-            if (roll_chance_i(aurEff->GetSpellEffectInfo().PointsPerResource * (*cost)))
+            if (target && roll_chance_i(aurEff->GetSpellEffectInfo().PointsPerResource * (*cost)))
                 target->ModifyPower(POWER_COMBO_POINTS, 1);
     }
 

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -673,7 +673,6 @@ class spell_rog_tricks_of_the_trade_proc : public AuraScript
 };
 
 // 14161 - Ruthlessness
-
 class spell_rog_ruthlessness : public AuraScript
 {
     PrepareAuraScript(spell_rog_ruthlessness);
@@ -683,10 +682,16 @@ class spell_rog_ruthlessness : public AuraScript
         Unit* target = GetTarget();
 
         if (Optional<int32> cost = GetFinishingMoveCPCost(procInfo.GetProcSpell()))
-
             if (roll_chance_i(aurEff->GetSpellEffectInfo().PointsPerResource * (*cost)))
-
                 target->ModifyPower(POWER_COMBO_POINTS, 1);
+    }
+
+    void Register() override
+    {
+        OnEffectProc += AuraEffectProcFn(spell_rog_ruthlessness::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
+    }
+};
+
 
 void AddSC_rogue_spell_scripts()
 {

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -700,7 +700,7 @@ void AddSC_rogue_spell_scripts()
     RegisterSpellScript(spell_rog_cheat_death);
     RegisterSpellScript(spell_rog_deadly_poison);
     new spell_rog_killing_spree();
-    new spell_rog_ruthlessness();
+    RegisterSpellScript(spell_rog_ruthlessness);
     RegisterSpellScript(spell_rog_nerves_of_steel);
     RegisterSpellScript(spell_rog_preparation);
     RegisterSpellScript(spell_rog_prey_on_the_weak);

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -692,7 +692,6 @@ class spell_rog_ruthlessness : public AuraScript
     }
 };
 
-
 void AddSC_rogue_spell_scripts()
 {
     RegisterSpellScript(spell_rog_savage_combat);

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -675,20 +675,12 @@ class spell_rog_tricks_of_the_trade_proc : public AuraScript
 // 14161 - Ruthlessness
 
 class spell_rog_ruthlessness : public AuraScript
-
 {
-
     PrepareAuraScript(spell_rog_ruthlessness);
 
-
-
     void HandleProc(AuraEffect* aurEff, ProcEventInfo& procInfo)
-
     {
-
         Unit* target = GetTarget();
-
-
 
         if (Optional<int32> cost = GetFinishingMoveCPCost(procInfo.GetProcSpell()))
 

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -672,6 +672,30 @@ class spell_rog_tricks_of_the_trade_proc : public AuraScript
     }
 };
 
+// 14161 - Ruthlessness
+
+class spell_rog_ruthlessness : public AuraScript
+
+{
+
+    PrepareAuraScript(spell_rog_ruthlessness);
+
+
+
+    void HandleProc(AuraEffect* aurEff, ProcEventInfo& procInfo)
+
+    {
+
+        Unit* target = GetTarget();
+
+
+
+        if (Optional<int32> cost = GetFinishingMoveCPCost(procInfo.GetProcSpell()))
+
+            if (roll_chance_i(aurEff->GetSpellEffectInfo().PointsPerResource * (*cost)))
+
+                target->ModifyPower(POWER_COMBO_POINTS, 1);
+
 void AddSC_rogue_spell_scripts()
 {
     RegisterSpellScript(spell_rog_savage_combat);
@@ -680,6 +704,7 @@ void AddSC_rogue_spell_scripts()
     RegisterSpellScript(spell_rog_cheat_death);
     RegisterSpellScript(spell_rog_deadly_poison);
     new spell_rog_killing_spree();
+    new spell_rog_ruthlessness();
     RegisterSpellScript(spell_rog_nerves_of_steel);
     RegisterSpellScript(spell_rog_preparation);
     RegisterSpellScript(spell_rog_prey_on_the_weak);


### PR DESCRIPTION
the Rogue's talent never triggers #10328



## Changes Proposed:
-  All Finishing Moves now have a X chance to gain on Spellhit 1 Combopoint

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10328

## Credits:
Original TC Cherry Pick https://github.com/TrinityCore/TrinityCore/commit/a3d06f2f329a6d21b9a79aed8b39f1d56fa933e6
Co-Authored-By: matanshukry [matanshukry@gmail.com](mailto:matanshukry@gmail.com)
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
- Tested on older Azeroth Core Rev. f96b027ffd3d


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. create a Rogue character
2. skill Ruthless
3. test all finishing moves

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]


## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
