### PR TITLE
fix(Core/Player): fix pet support after dismount for warlock

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13774,7 +13774,7 @@ bool Player::CanResummonPet(uint32 spellid)
         else if (spellid == 52150)
             return false;
     }
-    else if (getClass() == CLASS_HUNTER || getClass() == CLASS_MAGE)
+    else if (getClass() == CLASS_HUNTER || getClass() == CLASS_MAGE || getClass() == CLASS_WARLOCK)
         return true;
 
     if (!HasSpell(spellid))


### PR DESCRIPTION
## Changes Proposed:
- Fix pet support after dismount for warlock

## Issues Addressed:
- Closes 

## Tests Performed:
- Locally

## How to Test the Changes:
1. be warlock
2. summon voidwalker or other pet
3. MOUNT UP
4. log out (hear the shard coming in inventory sound)
5. watch that you see your char having pet next to you on character screen
6. log in
7. Dismount: no pet
8. summon new pet
9. mount up
10. mount down : pet gone

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
