### PR TITLE
fix(DB/Scripts): Fix Thrash Console Error

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1646684265912312000.sql
+++ b/data/sql/updates/pending_db_world/rev_1646684265912312000.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1646684265912312000');
+
+UPDATE `smart_scripts` SET `link` = 0 WHERE `entryorguid` = 5709 AND `source_type` = 0 AND `id` = 0;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  PR https://github.com/azerothcore/azerothcore-wotlk/pull/10869 fixed Thrash for many creature, but left a SmartAI linking error in Shade of Eranikus. This PR is fix that error.
-  Fixes console error: `SmartScript::ProcessAction: Entry 5709 SourceType 0, Event 0, Link Event 1 not found or invalid, skipped.`

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Fight Shade of Eranikus, no longer receive console error
- Thrash still working as intended with boss


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go creature 39842
2. No more console error

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
