### PR TITLE
fix (DB) Cleanup broken items in item_refund_instance table

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -9759,3 +9759,19 @@ uint32 ObjectMgr::GetQuestMoneyReward(uint8 level, uint32 questMoneyDifficulty) 
 
     return 0;
 }
+
+void ObjectMgr::CleanupItemRefundInstance()
+{
+    LOG_INFO("server.loading", "CleanUp ItemRefundInstance...");
+    //QueryResult refundInstance_result = CharacterDatabase.Query("SELECT guid FROM characters.item_refund_instance");
+    QueryResult refundInstance_result = CharacterDatabase.Query("SELECT COUNT(*) FROM characters.item_refund_instance");
+    if (refundInstance_result)
+    {
+        uint32 refundInstance_count = (*refundInstance_result)[0].Get<uint64>();
+        if (refundInstance_count > 0)
+        {
+            CharacterDatabase.Execute("DELETE FROM characters.item_refund_instance WHERE item_guid NOT IN (SELECT guid FROM characters.item_instance)");
+        }
+    }
+    LOG_INFO("server.loading", " ");
+}

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -1404,7 +1404,8 @@ public:
     [[nodiscard]] bool IsTransportMap(uint32 mapId) const { return _transportMaps.count(mapId) != 0; }
 
     [[nodiscard]] uint32 GetQuestMoneyReward(uint8 level, uint32 questMoneyDifficulty) const;
-
+    void CleanupItemRefundInstance();
+    
 private:
     // first free id for selected id type
     uint32 _auctionId; // pussywizard: accessed by a single thread

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1658,6 +1658,7 @@ void World::SetInitialWorldSettings()
 
     LOG_INFO("server.loading", "Loading Items...");                         // must be after LoadRandomEnchantmentsTable and LoadPageTexts
     sObjectMgr->LoadItemTemplates();
+    sObjectMgr->CleanupItemRefundInstance();
 
     LOG_INFO("server.loading", "Loading Item set names...");                // must be after LoadItemPrototypes
     sObjectMgr->LoadItemSetNames();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Delete all items from `item_refund_instance` which not listed in `item_instance` table
- 
## Tests Performed:

-  Tested. There was 1700+ broken items deleted from this table in my server


## How to Test the Changes:

1.  Make backup of `item_refund_instance` table. Just for any case...
2.  Add non-existed items (1,3,5,7,...) into `item_instance` table and start server. All of them must be deleted.
3.  It will delete not only test items if your `item_refund_instance` table have them.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
