### PR TITLE
(DB/Translations) Neutral quests in Grizzly Hills

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1646749877159440400.sql
+++ b/data/sql/updates/pending_db_world/rev_1646749877159440400.sql
@@ -1,0 +1,389 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1646749877159440400');
+
+-- ¡Encuentra a Kurun! - ID 11981
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11981 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(11981, 'esES', '<Le hablas a Kurun del mensaje que te ha dado el terráneo caído.>$B$BLuchan con valentía, pero tiene razón. No superaremos a los enanos férreos de Thor Modan sin ayuda. Mis gigantes y los terráneos han luchado durante mucho tiempo contra el demonio de hierro, pero nuestros ejércitos no son suficientemente numerosos para ganar la batalla para Thor Modan. ¿Nos ayudarás?', 18019),
+(11981, 'esMX', '<Le hablas a Kurun del mensaje que te ha dado el terráneo caído.>$B$BLuchan con valentía, pero tiene razón. No superaremos a los enanos férreos de Thor Modan sin ayuda. Mis gigantes y los terráneos han luchado durante mucho tiempo contra el demonio de hierro, pero nuestros ejércitos no son suficientemente numerosos para ganar la batalla para Thor Modan. ¿Nos ayudarás?', 18019);
+
+-- Llueve destrucción - ID 11982
+DELETE FROM `quest_request_items_locale` WHERE `ID`=11982 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(11982, 'esES', '¿Qué tienes que informar?', 18019),
+(11982, 'esMX', '¿Qué tienes que informar?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11982 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(11982, 'esES', 'Con la misma rapidez con la que llenamos la trinchera, los enanos férreos la despejan. Con nuestro asalto desde arriba solo no conseguiremos tomar la ciudad. Tienes que ayudar a luchar en la plaza que hay abajo.', 18019),
+(11982, 'esMX', 'Con la misma rapidez con la que llenamos la trinchera, los enanos férreos la despejan. Con nuestro asalto desde arriba solo no conseguiremos tomar la ciudad. Tienes que ayudar a luchar en la plaza que hay abajo.', 18019);
+
+UPDATE `quest_template_locale` SET `ObjectiveText1`='Operaciones de los enanos férreos interrumpidas' WHERE `ID`=11982 AND `locale` IN ('esES', 'esMX');
+
+-- Llenar las jaulas - ID 11984
+DELETE FROM `quest_request_items_locale` WHERE `ID`=11984 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(11984, 'esES', '¿Has conseguido enjaular a un troll de hielo?', 18019),
+(11984, 'esMX', '¿Has conseguido enjaular a un troll de hielo?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11984 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(11984, 'esES', 'Buen trabajo, $c. Parece que Budd seguirá con nosotros un poco más.$B$BRecogeremos tu jaula ahora mismo. Aquí está tu parte de la recompensa.$B$BOh, y bienvenido al campamento. Si te quedas por aquí, seguro que te encontramos algún trabajillo...', 18019),
+(11984, 'esMX', 'Buen trabajo, $c. Parece que Budd seguirá con nosotros un poco más.$B$BRecogeremos tu jaula ahora mismo. Aquí está tu parte de la recompensa.$B$BOh, y bienvenido al campamento. Si te quedas por aquí, seguro que te encontramos algún trabajillo...', 18019);
+
+UPDATE `quest_template_locale` SET `ObjectiveText1`='Trol de hielo capturado vivo' WHERE `ID`=11984 AND `locale` IN ('esES', 'esMX');
+
+-- Abriendo brecha - ID 11985
+DELETE FROM `quest_request_items_locale` WHERE `ID`=11985 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(11985, 'esES', '¿Pudiste matar al Señor feudal?', 18019),
+(11985, 'esMX', '¿Pudiste matar al Señor feudal?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11985 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(11985, 'esES', 'Bien hecho, $n. La pérdida del comandante de los enanos férreos bastará para acabar con los defensores que quedan. Los terráneos deberían ahora ser capaces de encargarse de los supervivientes.', 18019),
+(11985, 'esMX', 'Bien hecho, $n. La pérdida del comandante de los enanos férreos bastará para acabar con los defensores que quedan. Los terráneos deberían ahora ser capaces de encargarse de los supervivientes.', 18019);
+
+-- ¿Tregua? - ID 11989
+DELETE FROM `quest_request_items_locale` WHERE `ID`=11989 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(11989, 'esES', "Buena elección, colega. No vah a vivir p'arrepentirte...", 18019),
+(11989, 'esMX', "Buena elección, colega. No vah a vivir p'arrepentirte...", 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11989 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(11989, 'esES', 'Síi...$B$BAhora ehtamoh unidoh por la sangre, colega. Un lazo verdadero.$B$BEhcucha con atención a Drakuru, $r. Hay mucho que hacer.', 18019),
+(11989, 'esMX', 'Síi...$B$BAhora ehtamoh unidoh por la sangre, colega. Un lazo verdadero.$B$BEhcucha con atención a Drakuru, $r. Hay mucho que hacer.', 18019);
+
+UPDATE `quest_template_locale` SET `ObjectiveText1`='Pacto de sangre con Drakuru' WHERE `ID`=11989 AND `locale` IN ('esES', 'esMX');
+
+-- Vial de visiones - ID 11990
+DELETE FROM `quest_request_items_locale` WHERE `ID`=11990 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(11990, 'esES', '¿Tieneh el material, colega?', 18019),
+(11990, 'esMX', '¿Tieneh el material, colega?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11990 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(11990, 'esES', '<Drakuru toma los ingredientes y los mezcla con gran habilidad en el vial.>$B$BEhto servirá, colega. Ahora eh hora de trabajar.', 18019),
+(11990, 'esMX', '<Drakuru toma los ingredientes y los mezcla con gran habilidad en el vial.>$B$BEhto servirá, colega. Ahora eh hora de trabajar.', 18019);
+
+-- Requiere interpretación - ID 11991
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11991 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(11991, 'esES', 'Aah, sí. Tú lo haceh bien, colega.$B$BLeeré loh muroh, se ven bien dehde aquí...', 18019),
+(11991, 'esMX', 'Aah, sí. Tú lo haceh bien, colega.$B$BLeeré loh muroh, se ven bien dehde aquí...', 18019);
+
+-- Es necesario hacer sacrificios - ID 12007
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12007 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12007, 'esES', '¿Hah cogío el ojo de los profetah, colega?', 18019),
+(12007, 'esMX', '¿Hah cogío el ojo de los profetah, colega?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12007 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12007, 'esES', "¡Ehto eh, colega!$B$BEh máh precioso de lo que m'ehperaba. Seguro que dará suerte a mi gente en ehtoh tiempoh ohcuroh.$B$BNo hay tiempo que perder, veamoh dónde s'ehconde el próximo artefacto.", 18019),
+(12007, 'esMX', "¡Ehto eh, colega!$B$BEh máh precioso de lo que m'ehperaba. Seguro que dará suerte a mi gente en ehtoh tiempoh ohcuroh.$B$BNo hay tiempo que perder, veamoh dónde s'ehconde el próximo artefacto.", 18019);
+
+-- Plaga chamuscada - ID 12029
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12029 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12029, 'esES', '¿Ya lo tienes hecho, $N?', 18019),
+(12029, 'esMX', '¿Ya lo tienes hecho, $N?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12029 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12029, 'esES', '¡Bien hesho!$B$B<Mack suelta una risa histérica.>$B$BAy, aay. Qué divertido... hip.', 18019),
+(12029, 'esMX', '¡Bien hesho!$B$B<Mack suelta una risa histérica.>$B$BAy, aay. Qué divertido... hip.', 18019);
+
+UPDATE `quest_template_locale` SET `ObjectiveText1`='Trols de la Plaga quemados' WHERE `ID`=12029 AND `locale` IN ('esES', 'esMX');
+
+-- Plaga chamuscada - ID 12038
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12038 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12038, 'esES', '¿Ya lo tienes hecho, $N?', 18019),
+(12038, 'esMX', '¿Ya lo tienes hecho, $N?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12038 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12038, 'esES', '¡Bien hesho!$B$B<Mack suelta una risa histérica.>$B$BAy, aay. Qué divertido... hip.', 18019),
+(12038, 'esMX', '¡Bien hesho!$B$B<Mack suelta una risa histérica.>$B$BAy, aay. Qué divertido... hip.', 18019);
+
+UPDATE `quest_template_locale` SET `ObjectiveText1`='Trols de la Plaga quemados' WHERE `ID`=12038 AND `locale` IN ('esES', 'esMX');
+
+-- Corazón de los ancestros - ID 12042
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12042 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12042, 'esES', 'Este desafortunado goblin tiene que haber desenterrado el corazón de los ancestros durante sus excavaciones en esta zona.$B$BSeguramente no tenía ni idea de su naturaleza.$B$BDecides que debe haberse pasado por alto en el caos que ha barrido la zona.', 18019),
+(12042, 'esMX', 'Este desafortunado goblin tiene que haber desenterrado el corazón de los ancestros durante sus excavaciones en esta zona.$B$BSeguramente no tenía ni idea de su naturaleza.$B$BDecides que debe haberse pasado por alto en el caos que ha barrido la zona.', 18019);
+
+-- Voces entre las ruinas - ID 12068
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12068 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12068, 'esES', "Qué bueno volver a ve'hte, $n.$B$B¿Has encontra'o las tablillas?", 18019),
+(12068, 'esMX', "Qué bueno volver a ve'hte, $n.$B$B¿Has encontra'o las tablillas?", 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12068 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12068, 'esES', "Lo conseguimos, $n.$B$BTenemos to's los componentes que necesitamos p'a ejecutar el ritual de limpieza.", 18019),
+(12068, 'esMX', "Lo conseguimos, $n.$B$BTenemos to's los componentes que necesitamos p'a ejecutar el ritual de limpieza.", 18019);
+
+-- Alentando a las tropas - ID 12070
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12070 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12070, 'esES', '¿Has transmitido mi bendición a los gigantes?', 18019),
+(12070, 'esMX', '¿Has transmitido mi bendición a los gigantes?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12070 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12070, 'esES', 'Has dado a nuestros aliados la fuerza para continuar luchando y por ello te doy las gracias. Sin embargo, debemos comenzar a idear una manera de poner fin a esta batalla antes de que nos ganen ventaja.', 18019),
+(12070, 'esMX', 'Has dado a nuestros aliados la fuerza para continuar luchando y por ello te doy las gracias. Sin embargo, debemos comenzar a idear una manera de poner fin a esta batalla antes de que nos ganen ventaja.', 18019);
+
+UPDATE `quest_template_locale` SET `ObjectiveText1`='Gigantes de las Colinas Pardas alentados', `ObjectiveText2`='Vengadores Runaférrea muertos' WHERE `ID`=12070 AND `locale` IN ('esES', 'esMX');
+
+-- Gavrock - ID 12081
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12081 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12081, 'esES', 'Sé que Kurun te agradece tu ayuda. La derrota de Thor Modan será un gran logro para nosotros, pero no liberará a nuestros hermanos.', 18019),
+(12081, 'esMX', 'Sé que Kurun te agradece tu ayuda. La derrota de Thor Modan será un gran logro para nosotros, pero no liberará a nuestros hermanos.', 18019);
+
+-- ¡Tralarí, tralará! - ID 12082
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12082 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12082, 'esES', 'Así que has sobrevivido a una aventurilla con nuestro buen amigo, ¿verdad?$B$BSolo con eso debería ser recompensa suficiente, pero me siento generoso.', 18019),
+(12082, 'esMX', 'Así que has sobrevivido a una aventurilla con nuestro buen amigo, ¿verdad?$B$BSolo con eso debería ser recompensa suficiente, pero me siento generoso.', 18019);
+
+UPDATE `quest_template_locale` SET `ObjectiveText1`='Harrison te ha escoltado a lugar seguro.' WHERE `ID`=12082 AND `locale` IN ('esES', 'esMX');
+
+-- Runas de coacción - ID 12093
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12093 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12093, 'esES', '¿Has neutralizado las runas de la costa?', 18019),
+(12093, 'esMX', '¿Has neutralizado las runas de la costa?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12093 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12093, 'esES', 'Bien. Ahora, debemos actuar sin dilación antes de que los hijos de hierro se den cuenta de que hemos anulado el poder dañino de sus runas.', 18019),
+(12093, 'esMX', 'Bien. Ahora, debemos actuar sin dilación antes de que los hijos de hierro se den cuenta de que hemos anulado el poder dañino de sus runas.', 18019);
+
+-- Poder latente - ID 12094
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12094 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12094, 'esES', '¿Has encontrado las antiguas piedras?', 18019),
+(12094, 'esMX', '¿Has encontrado las antiguas piedras?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12094 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12094, 'esES', 'Puedo detectar el poder con el que has imbuido al fragmento y espero que sea suficiente para romper la magia rúnica.', 18019),
+(12094, 'esMX', 'Puedo detectar el poder con el que has imbuido al fragmento y espero que sea suficiente para romper la magia rúnica.', 18019);
+
+UPDATE `quest_template_locale` SET `ObjectiveText1`='Conseguido el poder de la primera piedra antigua', `ObjectiveText2`='Conseguido el poder de la segunda piedra antigua', `ObjectiveText3`='Conseguido el poder de la tercera piedra antigua' WHERE `ID`=12094 AND `locale` IN ('esES', 'esMX');
+
+-- Por fin libres - ID 12099
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12099 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12099, 'esES', '¿Pudiste liberar a alguno de mis hermanos?', 18019),
+(12099, 'esMX', '¿Pudiste liberar a alguno de mis hermanos?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12099 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12099, 'esES', 'Así que no es algo seguro. Desearía que la suerte no tuviera nada que ver, pero al menos estamos en el buen camino. Sin tu ayuda esto nunca habría sido posible. Si descubres algo más sobre las maquinaciones de los enanos férreos y sus planes hacia los hijos de la piedra, búscanos, $n, y te escucharemos.', 18019),
+(12099, 'esMX', 'Así que no es algo seguro. Desearía que la suerte no tuviera nada que ver, pero al menos estamos en el buen camino. Sin tu ayuda esto nunca habría sido posible. Si descubres algo más sobre las maquinaciones de los enanos férreos y sus planes hacia los hijos de la piedra, búscanos, $n, y te escucharemos.', 18019);
+
+UPDATE `quest_template_locale` SET `ObjectiveText1`='Gigantes con runas liberados' WHERE `ID`=12099 AND `locale` IN ('esES', 'esMX');
+
+-- Encantado de carnecerte - ID 12113
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12113 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12113, 'esES', 'Me rugen las tripas, $r. ¿Pudiste juntar algo de comida?', 18019),
+(12113, 'esMX', 'Me rugen las tripas, $r. ¿Pudiste juntar algo de comida?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12113 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12113, 'esES', '¡Alucinante!$B$BNá mejor para una pinta que un buen bocao de carne.', 18019),
+(12113, 'esMX', '¡Alucinante!$B$BNá mejor para una pinta que un buen bocao de carne.', 18019);
+
+-- Terapia - ID 12114
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12114 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12114, 'esES', '¿Cómo va la caza de trolls?', 18019),
+(12114, 'esMX', '¿Cómo va la caza de trolls?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12114 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12114, 'esES', 'Gracias, $c.$B$BCuando tenga tiempo me daré un paseo y echaré un vistazo.', 18019),
+(12114, 'esMX', 'Gracias, $c.$B$BCuando tenga tiempo me daré un paseo y echaré un vistazo.', 18019);
+
+-- Requiere agallas… - ID 12116
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12116 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12116, 'esES', '¿Qué has encontrado para Kraz en esa cripta, $c?', 18019),
+(12116, 'esMX', '¿Qué has encontrado para Kraz en esa cripta, $c?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12116 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12116, 'esES', '¿Tripas? Una elección interesante, $r.$B$BKraz verá lo que puede adivinar de ellas. Gracias por aventurarte en las profundidades de ese lugar.', 18019),
+(12116, 'esMX', '¿Tripas? Una elección interesante, $r.$B$BKraz verá lo que puede adivinar de ellas. Gracias por aventurarte en las profundidades de ese lugar.', 18019);
+
+-- La marra de Drak'aguul - ID 12120
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12120 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12120, 'esES', '¿Encuentras la marra, $n?', 18019),
+(12120, 'esMX', '¿Encuentras la marra, $n?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12120 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12120, 'esES', 'Hasta ahora lo has hecho bien, $n, pero ahora viene la verdadera prueba.', 18019),
+(12120, 'esMX', 'Hasta ahora lo has hecho bien, $n, pero ahora viene la verdadera prueba.', 18019);
+
+-- Te veo al otro lado - ID 12121
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12121 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12121, 'esES', 'Presagiábamos tu venida, amigo. Has hecho bien en venir.', 18019),
+(12121, 'esMX', 'Presagiábamos tu venida, amigo. Has hecho bien en venir.', 18019);
+
+UPDATE `quest_template_locale` SET `ObjectiveText1`="Muerte a manos del señor de la guerra Jin'arrak" WHERE `ID`=12121 AND `locale` IN ('esES', 'esMX');
+
+-- La caza de Sasha - ID 12134
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12134 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12134, 'esES', '¿Ya te has ocupado de los cazadores del pueblo, $n?', 18019),
+(12134, 'esMX', '¿Ya te has ocupado de los cazadores del pueblo, $n?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12134 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12134, 'esES', 'La muerte de esos monstruos no me devolverá a mi padre... pero eso ahora no importa, ¿verdad?', 18019),
+(12134, 'esMX', 'La muerte de esos monstruos no me devolverá a mi padre... pero eso ahora no importa, ¿verdad?', 18019);
+
+-- Relá'hatee, coleega - ID 12137
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12137 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12137, 'esES', '¿Has terminado tu deber en la cripta, $c?', 18019),
+(12137, 'esMX', '¿Has terminado tu deber en la cripta, $c?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12137 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12137, 'esES', 'Has hecho lo correcto.$B$BPor favor, siéntate y escucha. Hay muchas cosas de las que tenemos que hablar.', 18019),
+(12137, 'esMX', 'Has hecho lo correcto.$B$BPor favor, siéntate y escucha. Hay muchas cosas de las que tenemos que hablar.', 18019);
+
+-- El final de Jin'arrak - ID 12152
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12152 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12152, 'esES', "¿Ha sido derrotado Jin'arrak, $N?", 18019),
+(12152, 'esMX', "¿Ha sido derrotado Jin'arrak, $N?", 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12152 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12152, 'esES', 'Ya está.$B$BTu ayuda desinteresada ha otorgado la paz eterna a muchas almas y ha acabado con miles de años de miseria.$B$BQue este acto ilumine tu alma y te libere de tus cargas, pues presiento que aún debes enfrentarte a muchos peligros.$B$BAdiós, $n.', 18019),
+(12152, 'esMX', 'Ya está.$B$BTu ayuda desinteresada ha otorgado la paz eterna a muchas almas y ha acabado con miles de años de miseria.$B$BQue este acto ilumine tu alma y te libere de tus cargas, pues presiento que aún debes enfrentarte a muchos peligros.$B$BAdiós, $n.', 18019);
+
+UPDATE `quest_template_locale` SET `ObjectiveText1`="Fin del señor de la guerra Jin'arrak" WHERE `ID`=12152 AND `locale` IN ('esES', 'esMX');
+
+-- La hora del huargo - ID 12164
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12164 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12164, 'esES', 'Es bueno verte, $N.', 18019),
+(12164, 'esMX', 'Es bueno verte, $N.', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12164 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12164, 'esES', 'Le hemos dado una buena, $n. Pero podría haber sido mejor.$B$BAlgo es seguro... no lo veremos por aquí nunca más.', 18019),
+(12164, 'esMX', 'Le hemos dado una buena, $n. Pero podría haber sido mejor.$B$BAlgo es seguro... no lo veremos por aquí nunca más.', 18019);
+
+UPDATE `quest_template_locale` SET `ObjectiveText1`='Varlam', `ObjectiveText2`='Selas', `ObjectiveText3`='Buchegore', `ObjectiveText4`='Sombra de Arugal derrotada' WHERE `ID`=12164 AND `locale` IN ('esES', 'esMX');
+
+-- Saluda a mi amiguito - ID 12190
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12190 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12190, 'esES', '¿Qué puedo hacer por ti?', 18019),
+(12190, 'esMX', '¿Qué puedo hacer por ti?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12190 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12190, 'esES', '¡Vaya! ¿El bueno de Prigmon te ha mandado hasta aquí? Con esto se debería poder hacer una gran comida. Solo necesito un par de cosas...', 18019),
+(12190, 'esMX', '¡Vaya! ¿El bueno de Prigmon te ha mandado hasta aquí? Con esto se debería poder hacer una gran comida. Solo necesito un par de cosas...', 18019);
+
+-- Hambre de osa - ID 12279
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12279 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12279, 'esES', 'Si no te das prisa, va a rugirle algo más que el estómago...', 18019),
+(12279, 'esMX', 'Si no te das prisa, va a rugirle algo más que el estómago...', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12279 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12279, 'esES', '¡Tú! ¡Tú no eres Joe el cojo!', 18019),
+(12279, 'esMX', '¡Tú! ¡Tú no eres Joe el cojo!', 18019);
+
+-- Una experiencia extracorporal - ID 12327
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12327 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12327, 'esES', '¿Sí, $n?', 18019),
+(12327, 'esMX', '¿Sí, $n?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12327 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12327, 'esES', '¿Aprendiste algo de tu visión? Mencionaste el Poblado Solsticio mientras estabas en trance... Es la segunda vez que alguien menciona el nombre de ese lugar hoy.', 18019),
+(12327, 'esMX', '¿Aprendiste algo de tu visión? Mencionaste el Poblado Solsticio mientras estabas en trance... Es la segunda vez que alguien menciona el nombre de ese lugar hoy.', 18019);
+
+-- La petición de Ruuna - ID 12328
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12328 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12328, 'esES', '¿Conseguiste el polvo, $n?', 18019),
+(12328, 'esMX', '¿Conseguiste el polvo, $n?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12328 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12328, 'esES', 'Bien. Esto servirá.$B$BLa poción estará preparada enseguida.', 18019),
+(12328, 'esMX', 'Bien. Esto servirá.$B$BLa poción estará preparada enseguida.', 18019);
+
+-- Destino y coincidencia - ID 12329
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12329 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12329, 'esES', 'Me preguntaba cuándo aparecerías. ¿Crees que podrías echarme una mano?', 18019),
+(12329, 'esMX', 'Me preguntaba cuándo aparecerías. ¿Crees que podrías echarme una mano?', 18019);
+
+-- Anatoly hablará - ID 12330
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12330 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12330, 'esES', 'Me alegro de verte de una pieza.', 18019),
+(12330, 'esMX', 'Me alegro de verte de una pieza.', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12330 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12330, 'esES', 'Por los pelos.$B$BTenemos que salvar a Anya. ¡Ya!', 18019),
+(12330, 'esMX', 'Por los pelos.$B$BTenemos que salvar a Anya. ¡Ya!', 18019);
+
+-- La promesa de una hermana - ID 12411
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12411 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12411, 'esES', 'No quiero estar aquí más tiempo. Los hombres huargen son malvados.', 18019),
+(12411, 'esMX', 'No quiero estar aquí más tiempo. Los hombres huargen son malvados.', 18019);
+
+-- Estofado de champiñones brillantes - ID 12483
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12483 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12483, 'esES', '¿Le has conseguido esos ingredientes al viejo Prigmon, $n?', 18019),
+(12483, 'esMX', '¿Le has conseguido esos ingredientes al viejo Prigmon, $n?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12483 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12483, 'esES', 'Oh, tron, ¡estofado de champiñones brillantes! Ya casi puedo saborearlo...', 18019),
+(12483, 'esMX', 'Oh, tron, ¡estofado de champiñones brillantes! Ya casi puedo saborearlo...', 18019);
+
+-- Kebab de Plaga - ID 12484
+DELETE FROM `quest_request_items_locale` WHERE `ID`=12484 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12484, 'esES', '¿Qué tienes ahí, $r?', 18019),
+(12484, 'esMX', '¿Qué tienes ahí, $r?', 18019);
+
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12484 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12484, 'esES', 'No hay ná mejó que ver arder a la Plaga... <hic>.$B$BHe esscrito una cansionsilla sobre esho. ¿La quieress eshcushar? Aquí va...', 18019),
+(12484, 'esMX', 'No hay ná mejó que ver arder a la Plaga... <hic>.$B$BHe esscrito una cansionsilla sobre esho. ¿La quieress eshcushar? Aquí va...', 18019);
+
+UPDATE `quest_template_locale` SET `ObjectiveText1`='Huesos momificados quemados' WHERE `ID`=12484 AND `locale` IN ('esES', 'esMX');
+
+-- Mi corazón está en tus manos - ID 12802
+DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12802 AND `locale` IN ('esES', 'esMX');
+INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(12802, 'esES', "¡Impresionante, colega! El destino ha sido generoso al unirnos.$B$BMuy pronto vengaré a mis hermanos limpiando Drak'Tharon, y tú recibirás el mayor tesoro de Drak'Tharon.", 18019),
+(12802, 'esMX', "¡Impresionante, colega! El destino ha sido generoso al unirnos.$B$BMuy pronto vengaré a mis hermanos limpiando Drak'Tharon, y tú recibirás el mayor tesoro de Drak'Tharon.", 18019);

--- a/data/sql/updates/pending_db_world/rev_1646749877159440400.sql
+++ b/data/sql/updates/pending_db_world/rev_1646749877159440400.sql
@@ -1,389 +1,153 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1646749877159440400');
 
--- ¡Encuentra a Kurun! - ID 11981
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11981 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(11981, 'esES', '<Le hablas a Kurun del mensaje que te ha dado el terráneo caído.>$B$BLuchan con valentía, pero tiene razón. No superaremos a los enanos férreos de Thor Modan sin ayuda. Mis gigantes y los terráneos han luchado durante mucho tiempo contra el demonio de hierro, pero nuestros ejércitos no son suficientemente numerosos para ganar la batalla para Thor Modan. ¿Nos ayudarás?', 18019),
-(11981, 'esMX', '<Le hablas a Kurun del mensaje que te ha dado el terráneo caído.>$B$BLuchan con valentía, pero tiene razón. No superaremos a los enanos férreos de Thor Modan sin ayuda. Mis gigantes y los terráneos han luchado durante mucho tiempo contra el demonio de hierro, pero nuestros ejércitos no son suficientemente numerosos para ganar la batalla para Thor Modan. ¿Nos ayudarás?', 18019);
-
--- Llueve destrucción - ID 11982
-DELETE FROM `quest_request_items_locale` WHERE `ID`=11982 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(11982, 'esES', '¿Qué tienes que informar?', 18019),
-(11982, 'esMX', '¿Qué tienes que informar?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11982 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(11982, 'esES', 'Con la misma rapidez con la que llenamos la trinchera, los enanos férreos la despejan. Con nuestro asalto desde arriba solo no conseguiremos tomar la ciudad. Tienes que ayudar a luchar en la plaza que hay abajo.', 18019),
-(11982, 'esMX', 'Con la misma rapidez con la que llenamos la trinchera, los enanos férreos la despejan. Con nuestro asalto desde arriba solo no conseguiremos tomar la ciudad. Tienes que ayudar a luchar en la plaza que hay abajo.', 18019);
-
 UPDATE `quest_template_locale` SET `ObjectiveText1`='Operaciones de los enanos férreos interrumpidas' WHERE `ID`=11982 AND `locale` IN ('esES', 'esMX');
-
--- Llenar las jaulas - ID 11984
-DELETE FROM `quest_request_items_locale` WHERE `ID`=11984 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(11984, 'esES', '¿Has conseguido enjaular a un troll de hielo?', 18019),
-(11984, 'esMX', '¿Has conseguido enjaular a un troll de hielo?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11984 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(11984, 'esES', 'Buen trabajo, $c. Parece que Budd seguirá con nosotros un poco más.$B$BRecogeremos tu jaula ahora mismo. Aquí está tu parte de la recompensa.$B$BOh, y bienvenido al campamento. Si te quedas por aquí, seguro que te encontramos algún trabajillo...', 18019),
-(11984, 'esMX', 'Buen trabajo, $c. Parece que Budd seguirá con nosotros un poco más.$B$BRecogeremos tu jaula ahora mismo. Aquí está tu parte de la recompensa.$B$BOh, y bienvenido al campamento. Si te quedas por aquí, seguro que te encontramos algún trabajillo...', 18019);
-
 UPDATE `quest_template_locale` SET `ObjectiveText1`='Trol de hielo capturado vivo' WHERE `ID`=11984 AND `locale` IN ('esES', 'esMX');
-
--- Abriendo brecha - ID 11985
-DELETE FROM `quest_request_items_locale` WHERE `ID`=11985 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(11985, 'esES', '¿Pudiste matar al Señor feudal?', 18019),
-(11985, 'esMX', '¿Pudiste matar al Señor feudal?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11985 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(11985, 'esES', 'Bien hecho, $n. La pérdida del comandante de los enanos férreos bastará para acabar con los defensores que quedan. Los terráneos deberían ahora ser capaces de encargarse de los supervivientes.', 18019),
-(11985, 'esMX', 'Bien hecho, $n. La pérdida del comandante de los enanos férreos bastará para acabar con los defensores que quedan. Los terráneos deberían ahora ser capaces de encargarse de los supervivientes.', 18019);
-
--- ¿Tregua? - ID 11989
-DELETE FROM `quest_request_items_locale` WHERE `ID`=11989 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(11989, 'esES', "Buena elección, colega. No vah a vivir p'arrepentirte...", 18019),
-(11989, 'esMX', "Buena elección, colega. No vah a vivir p'arrepentirte...", 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11989 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(11989, 'esES', 'Síi...$B$BAhora ehtamoh unidoh por la sangre, colega. Un lazo verdadero.$B$BEhcucha con atención a Drakuru, $r. Hay mucho que hacer.', 18019),
-(11989, 'esMX', 'Síi...$B$BAhora ehtamoh unidoh por la sangre, colega. Un lazo verdadero.$B$BEhcucha con atención a Drakuru, $r. Hay mucho que hacer.', 18019);
-
 UPDATE `quest_template_locale` SET `ObjectiveText1`='Pacto de sangre con Drakuru' WHERE `ID`=11989 AND `locale` IN ('esES', 'esMX');
-
--- Vial de visiones - ID 11990
-DELETE FROM `quest_request_items_locale` WHERE `ID`=11990 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(11990, 'esES', '¿Tieneh el material, colega?', 18019),
-(11990, 'esMX', '¿Tieneh el material, colega?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11990 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(11990, 'esES', '<Drakuru toma los ingredientes y los mezcla con gran habilidad en el vial.>$B$BEhto servirá, colega. Ahora eh hora de trabajar.', 18019),
-(11990, 'esMX', '<Drakuru toma los ingredientes y los mezcla con gran habilidad en el vial.>$B$BEhto servirá, colega. Ahora eh hora de trabajar.', 18019);
-
--- Requiere interpretación - ID 11991
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=11991 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(11991, 'esES', 'Aah, sí. Tú lo haceh bien, colega.$B$BLeeré loh muroh, se ven bien dehde aquí...', 18019),
-(11991, 'esMX', 'Aah, sí. Tú lo haceh bien, colega.$B$BLeeré loh muroh, se ven bien dehde aquí...', 18019);
-
--- Es necesario hacer sacrificios - ID 12007
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12007 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12007, 'esES', '¿Hah cogío el ojo de los profetah, colega?', 18019),
-(12007, 'esMX', '¿Hah cogío el ojo de los profetah, colega?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12007 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12007, 'esES', "¡Ehto eh, colega!$B$BEh máh precioso de lo que m'ehperaba. Seguro que dará suerte a mi gente en ehtoh tiempoh ohcuroh.$B$BNo hay tiempo que perder, veamoh dónde s'ehconde el próximo artefacto.", 18019),
-(12007, 'esMX', "¡Ehto eh, colega!$B$BEh máh precioso de lo que m'ehperaba. Seguro que dará suerte a mi gente en ehtoh tiempoh ohcuroh.$B$BNo hay tiempo que perder, veamoh dónde s'ehconde el próximo artefacto.", 18019);
-
--- Plaga chamuscada - ID 12029
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12029 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12029, 'esES', '¿Ya lo tienes hecho, $N?', 18019),
-(12029, 'esMX', '¿Ya lo tienes hecho, $N?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12029 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12029, 'esES', '¡Bien hesho!$B$B<Mack suelta una risa histérica.>$B$BAy, aay. Qué divertido... hip.', 18019),
-(12029, 'esMX', '¡Bien hesho!$B$B<Mack suelta una risa histérica.>$B$BAy, aay. Qué divertido... hip.', 18019);
-
 UPDATE `quest_template_locale` SET `ObjectiveText1`='Trols de la Plaga quemados' WHERE `ID`=12029 AND `locale` IN ('esES', 'esMX');
-
--- Plaga chamuscada - ID 12038
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12038 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12038, 'esES', '¿Ya lo tienes hecho, $N?', 18019),
-(12038, 'esMX', '¿Ya lo tienes hecho, $N?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12038 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12038, 'esES', '¡Bien hesho!$B$B<Mack suelta una risa histérica.>$B$BAy, aay. Qué divertido... hip.', 18019),
-(12038, 'esMX', '¡Bien hesho!$B$B<Mack suelta una risa histérica.>$B$BAy, aay. Qué divertido... hip.', 18019);
-
 UPDATE `quest_template_locale` SET `ObjectiveText1`='Trols de la Plaga quemados' WHERE `ID`=12038 AND `locale` IN ('esES', 'esMX');
-
--- Corazón de los ancestros - ID 12042
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12042 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12042, 'esES', 'Este desafortunado goblin tiene que haber desenterrado el corazón de los ancestros durante sus excavaciones en esta zona.$B$BSeguramente no tenía ni idea de su naturaleza.$B$BDecides que debe haberse pasado por alto en el caos que ha barrido la zona.', 18019),
-(12042, 'esMX', 'Este desafortunado goblin tiene que haber desenterrado el corazón de los ancestros durante sus excavaciones en esta zona.$B$BSeguramente no tenía ni idea de su naturaleza.$B$BDecides que debe haberse pasado por alto en el caos que ha barrido la zona.', 18019);
-
--- Voces entre las ruinas - ID 12068
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12068 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12068, 'esES', "Qué bueno volver a ve'hte, $n.$B$B¿Has encontra'o las tablillas?", 18019),
-(12068, 'esMX', "Qué bueno volver a ve'hte, $n.$B$B¿Has encontra'o las tablillas?", 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12068 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12068, 'esES', "Lo conseguimos, $n.$B$BTenemos to's los componentes que necesitamos p'a ejecutar el ritual de limpieza.", 18019),
-(12068, 'esMX', "Lo conseguimos, $n.$B$BTenemos to's los componentes que necesitamos p'a ejecutar el ritual de limpieza.", 18019);
-
--- Alentando a las tropas - ID 12070
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12070 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12070, 'esES', '¿Has transmitido mi bendición a los gigantes?', 18019),
-(12070, 'esMX', '¿Has transmitido mi bendición a los gigantes?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12070 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12070, 'esES', 'Has dado a nuestros aliados la fuerza para continuar luchando y por ello te doy las gracias. Sin embargo, debemos comenzar a idear una manera de poner fin a esta batalla antes de que nos ganen ventaja.', 18019),
-(12070, 'esMX', 'Has dado a nuestros aliados la fuerza para continuar luchando y por ello te doy las gracias. Sin embargo, debemos comenzar a idear una manera de poner fin a esta batalla antes de que nos ganen ventaja.', 18019);
-
 UPDATE `quest_template_locale` SET `ObjectiveText1`='Gigantes de las Colinas Pardas alentados', `ObjectiveText2`='Vengadores Runaférrea muertos' WHERE `ID`=12070 AND `locale` IN ('esES', 'esMX');
-
--- Gavrock - ID 12081
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12081 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12081, 'esES', 'Sé que Kurun te agradece tu ayuda. La derrota de Thor Modan será un gran logro para nosotros, pero no liberará a nuestros hermanos.', 18019),
-(12081, 'esMX', 'Sé que Kurun te agradece tu ayuda. La derrota de Thor Modan será un gran logro para nosotros, pero no liberará a nuestros hermanos.', 18019);
-
--- ¡Tralarí, tralará! - ID 12082
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12082 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12082, 'esES', 'Así que has sobrevivido a una aventurilla con nuestro buen amigo, ¿verdad?$B$BSolo con eso debería ser recompensa suficiente, pero me siento generoso.', 18019),
-(12082, 'esMX', 'Así que has sobrevivido a una aventurilla con nuestro buen amigo, ¿verdad?$B$BSolo con eso debería ser recompensa suficiente, pero me siento generoso.', 18019);
-
 UPDATE `quest_template_locale` SET `ObjectiveText1`='Harrison te ha escoltado a lugar seguro.' WHERE `ID`=12082 AND `locale` IN ('esES', 'esMX');
-
--- Runas de coacción - ID 12093
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12093 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12093, 'esES', '¿Has neutralizado las runas de la costa?', 18019),
-(12093, 'esMX', '¿Has neutralizado las runas de la costa?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12093 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12093, 'esES', 'Bien. Ahora, debemos actuar sin dilación antes de que los hijos de hierro se den cuenta de que hemos anulado el poder dañino de sus runas.', 18019),
-(12093, 'esMX', 'Bien. Ahora, debemos actuar sin dilación antes de que los hijos de hierro se den cuenta de que hemos anulado el poder dañino de sus runas.', 18019);
-
--- Poder latente - ID 12094
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12094 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12094, 'esES', '¿Has encontrado las antiguas piedras?', 18019),
-(12094, 'esMX', '¿Has encontrado las antiguas piedras?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12094 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12094, 'esES', 'Puedo detectar el poder con el que has imbuido al fragmento y espero que sea suficiente para romper la magia rúnica.', 18019),
-(12094, 'esMX', 'Puedo detectar el poder con el que has imbuido al fragmento y espero que sea suficiente para romper la magia rúnica.', 18019);
-
 UPDATE `quest_template_locale` SET `ObjectiveText1`='Conseguido el poder de la primera piedra antigua', `ObjectiveText2`='Conseguido el poder de la segunda piedra antigua', `ObjectiveText3`='Conseguido el poder de la tercera piedra antigua' WHERE `ID`=12094 AND `locale` IN ('esES', 'esMX');
-
--- Por fin libres - ID 12099
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12099 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12099, 'esES', '¿Pudiste liberar a alguno de mis hermanos?', 18019),
-(12099, 'esMX', '¿Pudiste liberar a alguno de mis hermanos?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12099 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12099, 'esES', 'Así que no es algo seguro. Desearía que la suerte no tuviera nada que ver, pero al menos estamos en el buen camino. Sin tu ayuda esto nunca habría sido posible. Si descubres algo más sobre las maquinaciones de los enanos férreos y sus planes hacia los hijos de la piedra, búscanos, $n, y te escucharemos.', 18019),
-(12099, 'esMX', 'Así que no es algo seguro. Desearía que la suerte no tuviera nada que ver, pero al menos estamos en el buen camino. Sin tu ayuda esto nunca habría sido posible. Si descubres algo más sobre las maquinaciones de los enanos férreos y sus planes hacia los hijos de la piedra, búscanos, $n, y te escucharemos.', 18019);
-
 UPDATE `quest_template_locale` SET `ObjectiveText1`='Gigantes con runas liberados' WHERE `ID`=12099 AND `locale` IN ('esES', 'esMX');
-
--- Encantado de carnecerte - ID 12113
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12113 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12113, 'esES', 'Me rugen las tripas, $r. ¿Pudiste juntar algo de comida?', 18019),
-(12113, 'esMX', 'Me rugen las tripas, $r. ¿Pudiste juntar algo de comida?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12113 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12113, 'esES', '¡Alucinante!$B$BNá mejor para una pinta que un buen bocao de carne.', 18019),
-(12113, 'esMX', '¡Alucinante!$B$BNá mejor para una pinta que un buen bocao de carne.', 18019);
-
--- Terapia - ID 12114
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12114 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12114, 'esES', '¿Cómo va la caza de trolls?', 18019),
-(12114, 'esMX', '¿Cómo va la caza de trolls?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12114 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12114, 'esES', 'Gracias, $c.$B$BCuando tenga tiempo me daré un paseo y echaré un vistazo.', 18019),
-(12114, 'esMX', 'Gracias, $c.$B$BCuando tenga tiempo me daré un paseo y echaré un vistazo.', 18019);
-
--- Requiere agallas… - ID 12116
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12116 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12116, 'esES', '¿Qué has encontrado para Kraz en esa cripta, $c?', 18019),
-(12116, 'esMX', '¿Qué has encontrado para Kraz en esa cripta, $c?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12116 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12116, 'esES', '¿Tripas? Una elección interesante, $r.$B$BKraz verá lo que puede adivinar de ellas. Gracias por aventurarte en las profundidades de ese lugar.', 18019),
-(12116, 'esMX', '¿Tripas? Una elección interesante, $r.$B$BKraz verá lo que puede adivinar de ellas. Gracias por aventurarte en las profundidades de ese lugar.', 18019);
-
--- La marra de Drak'aguul - ID 12120
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12120 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12120, 'esES', '¿Encuentras la marra, $n?', 18019),
-(12120, 'esMX', '¿Encuentras la marra, $n?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12120 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12120, 'esES', 'Hasta ahora lo has hecho bien, $n, pero ahora viene la verdadera prueba.', 18019),
-(12120, 'esMX', 'Hasta ahora lo has hecho bien, $n, pero ahora viene la verdadera prueba.', 18019);
-
--- Te veo al otro lado - ID 12121
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12121 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12121, 'esES', 'Presagiábamos tu venida, amigo. Has hecho bien en venir.', 18019),
-(12121, 'esMX', 'Presagiábamos tu venida, amigo. Has hecho bien en venir.', 18019);
-
 UPDATE `quest_template_locale` SET `ObjectiveText1`="Muerte a manos del señor de la guerra Jin'arrak" WHERE `ID`=12121 AND `locale` IN ('esES', 'esMX');
-
--- La caza de Sasha - ID 12134
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12134 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12134, 'esES', '¿Ya te has ocupado de los cazadores del pueblo, $n?', 18019),
-(12134, 'esMX', '¿Ya te has ocupado de los cazadores del pueblo, $n?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12134 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12134, 'esES', 'La muerte de esos monstruos no me devolverá a mi padre... pero eso ahora no importa, ¿verdad?', 18019),
-(12134, 'esMX', 'La muerte de esos monstruos no me devolverá a mi padre... pero eso ahora no importa, ¿verdad?', 18019);
-
--- Relá'hatee, coleega - ID 12137
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12137 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12137, 'esES', '¿Has terminado tu deber en la cripta, $c?', 18019),
-(12137, 'esMX', '¿Has terminado tu deber en la cripta, $c?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12137 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12137, 'esES', 'Has hecho lo correcto.$B$BPor favor, siéntate y escucha. Hay muchas cosas de las que tenemos que hablar.', 18019),
-(12137, 'esMX', 'Has hecho lo correcto.$B$BPor favor, siéntate y escucha. Hay muchas cosas de las que tenemos que hablar.', 18019);
-
--- El final de Jin'arrak - ID 12152
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12152 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12152, 'esES', "¿Ha sido derrotado Jin'arrak, $N?", 18019),
-(12152, 'esMX', "¿Ha sido derrotado Jin'arrak, $N?", 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12152 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12152, 'esES', 'Ya está.$B$BTu ayuda desinteresada ha otorgado la paz eterna a muchas almas y ha acabado con miles de años de miseria.$B$BQue este acto ilumine tu alma y te libere de tus cargas, pues presiento que aún debes enfrentarte a muchos peligros.$B$BAdiós, $n.', 18019),
-(12152, 'esMX', 'Ya está.$B$BTu ayuda desinteresada ha otorgado la paz eterna a muchas almas y ha acabado con miles de años de miseria.$B$BQue este acto ilumine tu alma y te libere de tus cargas, pues presiento que aún debes enfrentarte a muchos peligros.$B$BAdiós, $n.', 18019);
-
 UPDATE `quest_template_locale` SET `ObjectiveText1`="Fin del señor de la guerra Jin'arrak" WHERE `ID`=12152 AND `locale` IN ('esES', 'esMX');
-
--- La hora del huargo - ID 12164
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12164 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12164, 'esES', 'Es bueno verte, $N.', 18019),
-(12164, 'esMX', 'Es bueno verte, $N.', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12164 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12164, 'esES', 'Le hemos dado una buena, $n. Pero podría haber sido mejor.$B$BAlgo es seguro... no lo veremos por aquí nunca más.', 18019),
-(12164, 'esMX', 'Le hemos dado una buena, $n. Pero podría haber sido mejor.$B$BAlgo es seguro... no lo veremos por aquí nunca más.', 18019);
-
 UPDATE `quest_template_locale` SET `ObjectiveText1`='Varlam', `ObjectiveText2`='Selas', `ObjectiveText3`='Buchegore', `ObjectiveText4`='Sombra de Arugal derrotada' WHERE `ID`=12164 AND `locale` IN ('esES', 'esMX');
-
--- Saluda a mi amiguito - ID 12190
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12190 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12190, 'esES', '¿Qué puedo hacer por ti?', 18019),
-(12190, 'esMX', '¿Qué puedo hacer por ti?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12190 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12190, 'esES', '¡Vaya! ¿El bueno de Prigmon te ha mandado hasta aquí? Con esto se debería poder hacer una gran comida. Solo necesito un par de cosas...', 18019),
-(12190, 'esMX', '¡Vaya! ¿El bueno de Prigmon te ha mandado hasta aquí? Con esto se debería poder hacer una gran comida. Solo necesito un par de cosas...', 18019);
-
--- Hambre de osa - ID 12279
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12279 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12279, 'esES', 'Si no te das prisa, va a rugirle algo más que el estómago...', 18019),
-(12279, 'esMX', 'Si no te das prisa, va a rugirle algo más que el estómago...', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12279 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12279, 'esES', '¡Tú! ¡Tú no eres Joe el cojo!', 18019),
-(12279, 'esMX', '¡Tú! ¡Tú no eres Joe el cojo!', 18019);
-
--- Una experiencia extracorporal - ID 12327
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12327 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12327, 'esES', '¿Sí, $n?', 18019),
-(12327, 'esMX', '¿Sí, $n?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12327 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12327, 'esES', '¿Aprendiste algo de tu visión? Mencionaste el Poblado Solsticio mientras estabas en trance... Es la segunda vez que alguien menciona el nombre de ese lugar hoy.', 18019),
-(12327, 'esMX', '¿Aprendiste algo de tu visión? Mencionaste el Poblado Solsticio mientras estabas en trance... Es la segunda vez que alguien menciona el nombre de ese lugar hoy.', 18019);
-
--- La petición de Ruuna - ID 12328
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12328 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12328, 'esES', '¿Conseguiste el polvo, $n?', 18019),
-(12328, 'esMX', '¿Conseguiste el polvo, $n?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12328 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12328, 'esES', 'Bien. Esto servirá.$B$BLa poción estará preparada enseguida.', 18019),
-(12328, 'esMX', 'Bien. Esto servirá.$B$BLa poción estará preparada enseguida.', 18019);
-
--- Destino y coincidencia - ID 12329
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12329 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12329, 'esES', 'Me preguntaba cuándo aparecerías. ¿Crees que podrías echarme una mano?', 18019),
-(12329, 'esMX', 'Me preguntaba cuándo aparecerías. ¿Crees que podrías echarme una mano?', 18019);
-
--- Anatoly hablará - ID 12330
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12330 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12330, 'esES', 'Me alegro de verte de una pieza.', 18019),
-(12330, 'esMX', 'Me alegro de verte de una pieza.', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12330 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12330, 'esES', 'Por los pelos.$B$BTenemos que salvar a Anya. ¡Ya!', 18019),
-(12330, 'esMX', 'Por los pelos.$B$BTenemos que salvar a Anya. ¡Ya!', 18019);
-
--- La promesa de una hermana - ID 12411
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12411 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12411, 'esES', 'No quiero estar aquí más tiempo. Los hombres huargen son malvados.', 18019),
-(12411, 'esMX', 'No quiero estar aquí más tiempo. Los hombres huargen son malvados.', 18019);
-
--- Estofado de champiñones brillantes - ID 12483
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12483 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12483, 'esES', '¿Le has conseguido esos ingredientes al viejo Prigmon, $n?', 18019),
-(12483, 'esMX', '¿Le has conseguido esos ingredientes al viejo Prigmon, $n?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12483 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12483, 'esES', 'Oh, tron, ¡estofado de champiñones brillantes! Ya casi puedo saborearlo...', 18019),
-(12483, 'esMX', 'Oh, tron, ¡estofado de champiñones brillantes! Ya casi puedo saborearlo...', 18019);
-
--- Kebab de Plaga - ID 12484
-DELETE FROM `quest_request_items_locale` WHERE `ID`=12484 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
-(12484, 'esES', '¿Qué tienes ahí, $r?', 18019),
-(12484, 'esMX', '¿Qué tienes ahí, $r?', 18019);
-
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12484 AND `locale` IN ('esES', 'esMX');
-INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
-(12484, 'esES', 'No hay ná mejó que ver arder a la Plaga... <hic>.$B$BHe esscrito una cansionsilla sobre esho. ¿La quieress eshcushar? Aquí va...', 18019),
-(12484, 'esMX', 'No hay ná mejó que ver arder a la Plaga... <hic>.$B$BHe esscrito una cansionsilla sobre esho. ¿La quieress eshcushar? Aquí va...', 18019);
-
 UPDATE `quest_template_locale` SET `ObjectiveText1`='Huesos momificados quemados' WHERE `ID`=12484 AND `locale` IN ('esES', 'esMX');
 
--- Mi corazón está en tus manos - ID 12802
-DELETE FROM `quest_offer_reward_locale` WHERE `ID`=12802 AND `locale` IN ('esES', 'esMX');
+DELETE FROM `quest_offer_reward_locale` WHERE `ID` IN (11981, 11982, 11984, 11985, 11989, 11990, 11991, 12007, 12029, 12038, 12042, 12068, 12070, 12081, 12082, 12093, 12094, 12099, 12113, 12114, 12116, 12120, 12121, 12134, 12137, 12152, 12164, 12190, 12279, 12327, 12328, 12329, 12330, 12411, 12483, 12484, 12802) AND `locale` IN ('esES', 'esMX');
+
 INSERT INTO `quest_offer_reward_locale` (`ID`, `locale`, `RewardText`, `VerifiedBuild`) VALUES
+(11981, 'esES', '<Le hablas a Kurun del mensaje que te ha dado el terráneo caído.>$B$BLuchan con valentía, pero tiene razón. No superaremos a los enanos férreos de Thor Modan sin ayuda. Mis gigantes y los terráneos han luchado durante mucho tiempo contra el demonio de hierro, pero nuestros ejércitos no son suficientemente numerosos para ganar la batalla para Thor Modan. ¿Nos ayudarás?', 18019),
+(11981, 'esMX', '<Le hablas a Kurun del mensaje que te ha dado el terráneo caído.>$B$BLuchan con valentía, pero tiene razón. No superaremos a los enanos férreos de Thor Modan sin ayuda. Mis gigantes y los terráneos han luchado durante mucho tiempo contra el demonio de hierro, pero nuestros ejércitos no son suficientemente numerosos para ganar la batalla para Thor Modan. ¿Nos ayudarás?', 18019),
+(11982, 'esES', 'Con la misma rapidez con la que llenamos la trinchera, los enanos férreos la despejan. Con nuestro asalto desde arriba solo no conseguiremos tomar la ciudad. Tienes que ayudar a luchar en la plaza que hay abajo.', 18019),
+(11982, 'esMX', 'Con la misma rapidez con la que llenamos la trinchera, los enanos férreos la despejan. Con nuestro asalto desde arriba solo no conseguiremos tomar la ciudad. Tienes que ayudar a luchar en la plaza que hay abajo.', 18019),
+(11984, 'esES', 'Buen trabajo, $c. Parece que Budd seguirá con nosotros un poco más.$B$BRecogeremos tu jaula ahora mismo. Aquí está tu parte de la recompensa.$B$BOh, y bienvenido al campamento. Si te quedas por aquí, seguro que te encontramos algún trabajillo...', 18019),
+(11984, 'esMX', 'Buen trabajo, $c. Parece que Budd seguirá con nosotros un poco más.$B$BRecogeremos tu jaula ahora mismo. Aquí está tu parte de la recompensa.$B$BOh, y bienvenido al campamento. Si te quedas por aquí, seguro que te encontramos algún trabajillo...', 18019),
+(11985, 'esES', 'Bien hecho, $n. La pérdida del comandante de los enanos férreos bastará para acabar con los defensores que quedan. Los terráneos deberían ahora ser capaces de encargarse de los supervivientes.', 18019),
+(11985, 'esMX', 'Bien hecho, $n. La pérdida del comandante de los enanos férreos bastará para acabar con los defensores que quedan. Los terráneos deberían ahora ser capaces de encargarse de los supervivientes.', 18019),
+(11989, 'esES', 'Síi...$B$BAhora ehtamoh unidoh por la sangre, colega. Un lazo verdadero.$B$BEhcucha con atención a Drakuru, $r. Hay mucho que hacer.', 18019),
+(11989, 'esMX', 'Síi...$B$BAhora ehtamoh unidoh por la sangre, colega. Un lazo verdadero.$B$BEhcucha con atención a Drakuru, $r. Hay mucho que hacer.', 18019),
+(11990, 'esES', '<Drakuru toma los ingredientes y los mezcla con gran habilidad en el vial.>$B$BEhto servirá, colega. Ahora eh hora de trabajar.', 18019),
+(11990, 'esMX', '<Drakuru toma los ingredientes y los mezcla con gran habilidad en el vial.>$B$BEhto servirá, colega. Ahora eh hora de trabajar.', 18019),
+(11991, 'esES', 'Aah, sí. Tú lo haceh bien, colega.$B$BLeeré loh muroh, se ven bien dehde aquí...', 18019),
+(11991, 'esMX', 'Aah, sí. Tú lo haceh bien, colega.$B$BLeeré loh muroh, se ven bien dehde aquí...', 18019),
+(12007, 'esES', "¡Ehto eh, colega!$B$BEh máh precioso de lo que m'ehperaba. Seguro que dará suerte a mi gente en ehtoh tiempoh ohcuroh.$B$BNo hay tiempo que perder, veamoh dónde s'ehconde el próximo artefacto.", 18019),
+(12007, 'esMX', "¡Ehto eh, colega!$B$BEh máh precioso de lo que m'ehperaba. Seguro que dará suerte a mi gente en ehtoh tiempoh ohcuroh.$B$BNo hay tiempo que perder, veamoh dónde s'ehconde el próximo artefacto.", 18019),
+(12029, 'esES', '¡Bien hesho!$B$B<Mack suelta una risa histérica.>$B$BAy, aay. Qué divertido... hip.', 18019),
+(12029, 'esMX', '¡Bien hesho!$B$B<Mack suelta una risa histérica.>$B$BAy, aay. Qué divertido... hip.', 18019),
+(12038, 'esES', '¡Bien hesho!$B$B<Mack suelta una risa histérica.>$B$BAy, aay. Qué divertido... hip.', 18019),
+(12038, 'esMX', '¡Bien hesho!$B$B<Mack suelta una risa histérica.>$B$BAy, aay. Qué divertido... hip.', 18019),
+(12042, 'esES', 'Este desafortunado goblin tiene que haber desenterrado el corazón de los ancestros durante sus excavaciones en esta zona.$B$BSeguramente no tenía ni idea de su naturaleza.$B$BDecides que debe haberse pasado por alto en el caos que ha barrido la zona.', 18019),
+(12042, 'esMX', 'Este desafortunado goblin tiene que haber desenterrado el corazón de los ancestros durante sus excavaciones en esta zona.$B$BSeguramente no tenía ni idea de su naturaleza.$B$BDecides que debe haberse pasado por alto en el caos que ha barrido la zona.', 18019),
+(12068, 'esES', "Lo conseguimos, $n.$B$BTenemos to's los componentes que necesitamos p'a ejecutar el ritual de limpieza.", 18019),
+(12068, 'esMX', "Lo conseguimos, $n.$B$BTenemos to's los componentes que necesitamos p'a ejecutar el ritual de limpieza.", 18019),
+(12070, 'esES', 'Has dado a nuestros aliados la fuerza para continuar luchando y por ello te doy las gracias. Sin embargo, debemos comenzar a idear una manera de poner fin a esta batalla antes de que nos ganen ventaja.', 18019),
+(12070, 'esMX', 'Has dado a nuestros aliados la fuerza para continuar luchando y por ello te doy las gracias. Sin embargo, debemos comenzar a idear una manera de poner fin a esta batalla antes de que nos ganen ventaja.', 18019),
+(12081, 'esES', 'Sé que Kurun te agradece tu ayuda. La derrota de Thor Modan será un gran logro para nosotros, pero no liberará a nuestros hermanos.', 18019),
+(12081, 'esMX', 'Sé que Kurun te agradece tu ayuda. La derrota de Thor Modan será un gran logro para nosotros, pero no liberará a nuestros hermanos.', 18019),
+(12082, 'esES', 'Así que has sobrevivido a una aventurilla con nuestro buen amigo, ¿verdad?$B$BSolo con eso debería ser recompensa suficiente, pero me siento generoso.', 18019),
+(12082, 'esMX', 'Así que has sobrevivido a una aventurilla con nuestro buen amigo, ¿verdad?$B$BSolo con eso debería ser recompensa suficiente, pero me siento generoso.', 18019),
+(12093, 'esES', 'Bien. Ahora, debemos actuar sin dilación antes de que los hijos de hierro se den cuenta de que hemos anulado el poder dañino de sus runas.', 18019),
+(12093, 'esMX', 'Bien. Ahora, debemos actuar sin dilación antes de que los hijos de hierro se den cuenta de que hemos anulado el poder dañino de sus runas.', 18019),
+(12094, 'esES', 'Puedo detectar el poder con el que has imbuido al fragmento y espero que sea suficiente para romper la magia rúnica.', 18019),
+(12094, 'esMX', 'Puedo detectar el poder con el que has imbuido al fragmento y espero que sea suficiente para romper la magia rúnica.', 18019),
+(12099, 'esES', 'Así que no es algo seguro. Desearía que la suerte no tuviera nada que ver, pero al menos estamos en el buen camino. Sin tu ayuda esto nunca habría sido posible. Si descubres algo más sobre las maquinaciones de los enanos férreos y sus planes hacia los hijos de la piedra, búscanos, $n, y te escucharemos.', 18019),
+(12099, 'esMX', 'Así que no es algo seguro. Desearía que la suerte no tuviera nada que ver, pero al menos estamos en el buen camino. Sin tu ayuda esto nunca habría sido posible. Si descubres algo más sobre las maquinaciones de los enanos férreos y sus planes hacia los hijos de la piedra, búscanos, $n, y te escucharemos.', 18019),
+(12113, 'esES', '¡Alucinante!$B$BNá mejor para una pinta que un buen bocao de carne.', 18019),
+(12113, 'esMX', '¡Alucinante!$B$BNá mejor para una pinta que un buen bocao de carne.', 18019),
+(12114, 'esES', 'Gracias, $c.$B$BCuando tenga tiempo me daré un paseo y echaré un vistazo.', 18019),
+(12114, 'esMX', 'Gracias, $c.$B$BCuando tenga tiempo me daré un paseo y echaré un vistazo.', 18019),
+(12116, 'esES', '¿Tripas? Una elección interesante, $r.$B$BKraz verá lo que puede adivinar de ellas. Gracias por aventurarte en las profundidades de ese lugar.', 18019),
+(12116, 'esMX', '¿Tripas? Una elección interesante, $r.$B$BKraz verá lo que puede adivinar de ellas. Gracias por aventurarte en las profundidades de ese lugar.', 18019),
+(12120, 'esES', 'Hasta ahora lo has hecho bien, $n, pero ahora viene la verdadera prueba.', 18019),
+(12120, 'esMX', 'Hasta ahora lo has hecho bien, $n, pero ahora viene la verdadera prueba.', 18019),
+(12121, 'esES', 'Presagiábamos tu venida, amigo. Has hecho bien en venir.', 18019),
+(12121, 'esMX', 'Presagiábamos tu venida, amigo. Has hecho bien en venir.', 18019),
+(12134, 'esES', 'La muerte de esos monstruos no me devolverá a mi padre... pero eso ahora no importa, ¿verdad?', 18019),
+(12134, 'esMX', 'La muerte de esos monstruos no me devolverá a mi padre... pero eso ahora no importa, ¿verdad?', 18019),
+(12137, 'esES', 'Has hecho lo correcto.$B$BPor favor, siéntate y escucha. Hay muchas cosas de las que tenemos que hablar.', 18019),
+(12137, 'esMX', 'Has hecho lo correcto.$B$BPor favor, siéntate y escucha. Hay muchas cosas de las que tenemos que hablar.', 18019),
+(12152, 'esES', 'Ya está.$B$BTu ayuda desinteresada ha otorgado la paz eterna a muchas almas y ha acabado con miles de años de miseria.$B$BQue este acto ilumine tu alma y te libere de tus cargas, pues presiento que aún debes enfrentarte a muchos peligros.$B$BAdiós, $n.', 18019),
+(12152, 'esMX', 'Ya está.$B$BTu ayuda desinteresada ha otorgado la paz eterna a muchas almas y ha acabado con miles de años de miseria.$B$BQue este acto ilumine tu alma y te libere de tus cargas, pues presiento que aún debes enfrentarte a muchos peligros.$B$BAdiós, $n.', 18019),
+(12164, 'esES', 'Le hemos dado una buena, $n. Pero podría haber sido mejor.$B$BAlgo es seguro... no lo veremos por aquí nunca más.', 18019),
+(12164, 'esMX', 'Le hemos dado una buena, $n. Pero podría haber sido mejor.$B$BAlgo es seguro... no lo veremos por aquí nunca más.', 18019),
+(12190, 'esES', '¡Vaya! ¿El bueno de Prigmon te ha mandado hasta aquí? Con esto se debería poder hacer una gran comida. Solo necesito un par de cosas...', 18019),
+(12190, 'esMX', '¡Vaya! ¿El bueno de Prigmon te ha mandado hasta aquí? Con esto se debería poder hacer una gran comida. Solo necesito un par de cosas...', 18019),
+(12279, 'esES', '¡Tú! ¡Tú no eres Joe el cojo!', 18019),
+(12279, 'esMX', '¡Tú! ¡Tú no eres Joe el cojo!', 18019),
+(12327, 'esES', '¿Aprendiste algo de tu visión? Mencionaste el Poblado Solsticio mientras estabas en trance... Es la segunda vez que alguien menciona el nombre de ese lugar hoy.', 18019),
+(12327, 'esMX', '¿Aprendiste algo de tu visión? Mencionaste el Poblado Solsticio mientras estabas en trance... Es la segunda vez que alguien menciona el nombre de ese lugar hoy.', 18019),
+(12328, 'esES', 'Bien. Esto servirá.$B$BLa poción estará preparada enseguida.', 18019),
+(12328, 'esMX', 'Bien. Esto servirá.$B$BLa poción estará preparada enseguida.', 18019),
+(12329, 'esES', 'Me preguntaba cuándo aparecerías. ¿Crees que podrías echarme una mano?', 18019),
+(12329, 'esMX', 'Me preguntaba cuándo aparecerías. ¿Crees que podrías echarme una mano?', 18019),
+(12330, 'esES', 'Por los pelos.$B$BTenemos que salvar a Anya. ¡Ya!', 18019),
+(12330, 'esMX', 'Por los pelos.$B$BTenemos que salvar a Anya. ¡Ya!', 18019),
+(12411, 'esES', 'No quiero estar aquí más tiempo. Los hombres huargen son malvados.', 18019),
+(12411, 'esMX', 'No quiero estar aquí más tiempo. Los hombres huargen son malvados.', 18019),
+(12483, 'esES', 'Oh, tron, ¡estofado de champiñones brillantes! Ya casi puedo saborearlo...', 18019),
+(12483, 'esMX', 'Oh, tron, ¡estofado de champiñones brillantes! Ya casi puedo saborearlo...', 18019),
+(12484, 'esES', 'No hay ná mejó que ver arder a la Plaga... <hic>.$B$BHe esscrito una cansionsilla sobre esho. ¿La quieress eshcushar? Aquí va...', 18019),
+(12484, 'esMX', 'No hay ná mejó que ver arder a la Plaga... <hic>.$B$BHe esscrito una cansionsilla sobre esho. ¿La quieress eshcushar? Aquí va...', 18019),
 (12802, 'esES', "¡Impresionante, colega! El destino ha sido generoso al unirnos.$B$BMuy pronto vengaré a mis hermanos limpiando Drak'Tharon, y tú recibirás el mayor tesoro de Drak'Tharon.", 18019),
 (12802, 'esMX', "¡Impresionante, colega! El destino ha sido generoso al unirnos.$B$BMuy pronto vengaré a mis hermanos limpiando Drak'Tharon, y tú recibirás el mayor tesoro de Drak'Tharon.", 18019);
+
+DELETE FROM `quest_request_items_locale` WHERE `ID` IN (11982, 11984, 11985, 11989, 11990, 12007, 12029, 12038, 12068, 12070, 12093, 12094, 12099, 12113, 12114, 12116, 12120, 12134, 12137, 12152, 12164, 12190, 12279, 12327, 12328, 12330, 12483, 12484) AND `locale` IN ('esES', 'esMX');
+
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(11982, 'esES', '¿Qué tienes que informar?', 18019),
+(11982, 'esMX', '¿Qué tienes que informar?', 18019),
+(11984, 'esES', '¿Has conseguido enjaular a un troll de hielo?', 18019),
+(11984, 'esMX', '¿Has conseguido enjaular a un troll de hielo?', 18019),
+(11985, 'esES', '¿Pudiste matar al Señor feudal?', 18019),
+(11985, 'esMX', '¿Pudiste matar al Señor feudal?', 18019),
+(11989, 'esES', "Buena elección, colega. No vah a vivir p'arrepentirte...", 18019),
+(11989, 'esMX', "Buena elección, colega. No vah a vivir p'arrepentirte...", 18019),
+(11990, 'esES', '¿Tieneh el material, colega?', 18019),
+(11990, 'esMX', '¿Tieneh el material, colega?', 18019),
+(12007, 'esES', '¿Hah cogío el ojo de los profetah, colega?', 18019),
+(12007, 'esMX', '¿Hah cogío el ojo de los profetah, colega?', 18019),
+(12029, 'esES', '¿Ya lo tienes hecho, $N?', 18019),
+(12029, 'esMX', '¿Ya lo tienes hecho, $N?', 18019),
+(12038, 'esES', '¿Ya lo tienes hecho, $N?', 18019),
+(12038, 'esMX', '¿Ya lo tienes hecho, $N?', 18019),
+(12068, 'esES', "Qué bueno volver a ve'hte, $n.$B$B¿Has encontra'o las tablillas?", 18019),
+(12068, 'esMX', "Qué bueno volver a ve'hte, $n.$B$B¿Has encontra'o las tablillas?", 18019),
+(12070, 'esES', '¿Has transmitido mi bendición a los gigantes?', 18019),
+(12070, 'esMX', '¿Has transmitido mi bendición a los gigantes?', 18019),
+(12093, 'esES', '¿Has neutralizado las runas de la costa?', 18019),
+(12093, 'esMX', '¿Has neutralizado las runas de la costa?', 18019),
+(12094, 'esES', '¿Has encontrado las antiguas piedras?', 18019),
+(12094, 'esMX', '¿Has encontrado las antiguas piedras?', 18019),
+(12099, 'esES', '¿Pudiste liberar a alguno de mis hermanos?', 18019),
+(12099, 'esMX', '¿Pudiste liberar a alguno de mis hermanos?', 18019),
+(12113, 'esES', 'Me rugen las tripas, $r. ¿Pudiste juntar algo de comida?', 18019),
+(12113, 'esMX', 'Me rugen las tripas, $r. ¿Pudiste juntar algo de comida?', 18019),
+(12114, 'esES', '¿Cómo va la caza de trolls?', 18019),
+(12114, 'esMX', '¿Cómo va la caza de trolls?', 18019),
+(12116, 'esES', '¿Qué has encontrado para Kraz en esa cripta, $c?', 18019),
+(12116, 'esMX', '¿Qué has encontrado para Kraz en esa cripta, $c?', 18019),
+(12120, 'esES', '¿Encuentras la marra, $n?', 18019),
+(12120, 'esMX', '¿Encuentras la marra, $n?', 18019),
+(12134, 'esES', '¿Ya te has ocupado de los cazadores del pueblo, $n?', 18019),
+(12134, 'esMX', '¿Ya te has ocupado de los cazadores del pueblo, $n?', 18019),
+(12137, 'esES', '¿Has terminado tu deber en la cripta, $c?', 18019),
+(12137, 'esMX', '¿Has terminado tu deber en la cripta, $c?', 18019),
+(12152, 'esES', "¿Ha sido derrotado Jin'arrak, $N?", 18019),
+(12152, 'esMX', "¿Ha sido derrotado Jin'arrak, $N?", 18019),
+(12164, 'esES', 'Es bueno verte, $N.', 18019),
+(12164, 'esMX', 'Es bueno verte, $N.', 18019),
+(12190, 'esES', '¿Qué puedo hacer por ti?', 18019),
+(12190, 'esMX', '¿Qué puedo hacer por ti?', 18019),
+(12279, 'esES', 'Si no te das prisa, va a rugirle algo más que el estómago...', 18019),
+(12279, 'esMX', 'Si no te das prisa, va a rugirle algo más que el estómago...', 18019),
+(12327, 'esES', '¿Sí, $n?', 18019),
+(12327, 'esMX', '¿Sí, $n?', 18019),
+(12328, 'esES', '¿Conseguiste el polvo, $n?', 18019),
+(12328, 'esMX', '¿Conseguiste el polvo, $n?', 18019),
+(12330, 'esES', 'Me alegro de verte de una pieza.', 18019),
+(12330, 'esMX', 'Me alegro de verte de una pieza.', 18019),
+(12483, 'esES', '¿Le has conseguido esos ingredientes al viejo Prigmon, $n?', 18019),
+(12483, 'esMX', '¿Le has conseguido esos ingredientes al viejo Prigmon, $n?', 18019),
+(12484, 'esES', '¿Qué tienes ahí, $r?', 18019),
+(12484, 'esMX', '¿Qué tienes ahí, $r?', 18019);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add the texts of the tables `quest_request_items_locale` and `quest_offer_reward_locale`. As well as some `ObjectiveText` from the `quest_template_locale` table that are untranslated.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## List of translated quests

- [x] 11981 - Find Kurun!
- [x] 11982 - Raining Down Destruction
- [x] 11984 - Filling the Cages
- [x] 11985 - Into the Breach
- [x] 11989 - Truce?
- [x] 11990 - Vial of Visions
- [x] 11991 - Subject to Interpretation
- [x] 12007 - Sacrifices Must be Made
- [x] 12029 - Seared Scourge
- [x] 12038 - Seared Scourge
- [x] 12042 - Heart of the Ancients
- [x] 12068 - Voices From the Dust
- [x] 12070 - Rallying the Troops
- [x] 12081 - Gavrock
- [x] 12082 - Dun-da-Dun-tah!
- [x] 12093 - Runes of Compulsion
- [x] 12094 - Latent Power
- [x] 12099 - Free at Last
- [x] 12113 - Nice to Meat You
- [x] 12114 - Therapy
- [x] 12116 - It Takes Guts....
- [x] 12120 - Drak'aguul's Mallet
- [x] 12121 - See You on the Other Side
- [x] 12134 - Sasha's Hunt
- [x] 12137 - Chill Out, Mon
- [x] 12152 - Jin'arrak's End
- [x] 12190 - Say Hello to My Little Friend
- [x] 12279 - A Bear of an Appetite
- [x] 12327 - Out of Body Experience
- [x] 12328 - Ruuna's Request
- [x] 12329 - Fate and Coincidence
- [x] 12330 - Anatoly Will Talk
- [x] 12411 - A Sister's Pledge
- [x] 12483 - Shimmercap Stew
- [x] 12484 - Scourgekabob
- [x] 12802 - My Heart is in Your Hands

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- The tests were made inside the game, executing one by one the SQL queries, which I have them in separate files, but I put them together, all in one file, to make it easier to apply and test.
- At the time of executing the queries, both separately and as a whole, none of them presented conflicts.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. If you take missions from that area, you will notice, with the client in Spanish, many of the texts mentioned are untranslated.
2. You apply the SQL, delete the game client cache folder, and enter to test the quests.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
