### PR TITLE
fix (core): Load Order Adjustment GAME_EVENT_START hook

### DIFF
--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1235,9 +1235,6 @@ void GameEventMgr::ApplyNewEvent(uint16 event_id)
 
     LOG_DEBUG("gameevent", "GameEvent {} \"{}\" started.", event_id, mGameEvent[event_id].description);
 
-    //! Run SAI scripts with SMART_EVENT_GAME_EVENT_END
-    RunSmartAIScripts(event_id, true);
-
     // spawn positive event tagget objects
     GameEventSpawn(event_id);
     // un-spawn negative event tagged objects

--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1255,6 +1255,9 @@ void GameEventMgr::ApplyNewEvent(uint16 event_id)
     // update bg holiday
     UpdateBattlegroundSettings();
 
+    //! Run SAI scripts with SMART_EVENT_GAME_EVENT_START
+    RunSmartAIScripts(event_id, true);
+
     // If event's worldstate is 0, it means the event hasn't been started yet. In that case, reset seasonal quests.
     // When event ends (if it expires or if it's stopped via commands) worldstate will be set to 0 again, ready for another seasonal quest reset.
     if (sWorld->getWorldState(event_id) == 0)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

Huge thanks to @[pklloveyou](https://github.com/pklloveyou) for the details describing the issue.
This effect any and all Smartscripts using Smart Event 68 (10 total at this time of rev) and 69 (21 total at this time of rev)
Dealing both with event 85 Stitches Event and event 87 Scarlet Oracle

## Changes Proposed:
-  This will correct game event 85 and maybe others
- Load order issue
- Updated correct notes in source

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/pull/10920 as details were provided in conversation on that PR

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- build
- performs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. goto darkshire
2. .quest add 252 and turn in it
3. observe event 85 now triggers and wait for stitches to arrive from the east.

![image](https://user-images.githubusercontent.com/16887899/157277035-707313ae-0ff4-4ba7-a7ec-2240d579fffc.png)

![image](https://user-images.githubusercontent.com/16887899/157277067-12df52a1-fa70-4e17-ba69-d19d5b526937.png)
![image](https://user-images.githubusercontent.com/16887899/157277094-f1e56299-b359-4293-89c8-92a495ce4612.png)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
