### PR TITLE
fix (core/logger) Corrected count of Broadcast Text Locales shown by logger on server start

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -9246,6 +9246,7 @@ void ObjectMgr::LoadBroadcastTextLocales()
         return;
     }
 
+    uint32 locales_count = 0;
     do
     {
         Field* fields = result->Fetch();
@@ -9265,9 +9266,10 @@ void ObjectMgr::LoadBroadcastTextLocales()
 
         AddLocaleString(fields[2].Get<std::string>(), locale, bct->second.MaleText);
         AddLocaleString(fields[3].Get<std::string>(), locale, bct->second.FemaleText);
+        locales_count++;
     } while (result->NextRow());
 
-    LOG_INFO("server.loading", ">> Loaded {} Broadcast Text Locales in {} ms", uint32(_broadcastTextStore.size()), GetMSTimeDiffToNow(oldMSTime));
+    LOG_INFO("server.loading", ">> Loaded {} Broadcast Text Locales in {} ms", locales_count, GetMSTimeDiffToNow(oldMSTime));
     LOG_INFO("server.loading", " ");
 }
 


### PR DESCRIPTION
## Changes Proposed:
-  Previously, the server showed the number of lines for enUS instead of the amount of other localizations.
  
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested by starting server. Now it shows correct value of records in `broadcast_text_locale`
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Apply changes, compile and start the server. 
If something went wrong, you'll se old results:
![изображение](https://user-images.githubusercontent.com/25766571/157343300-93c99f7a-54d5-4a3f-b811-256bc32b8336.png)

In other case it must show correct result, something like this:
![изображение](https://user-images.githubusercontent.com/25766571/157343501-a5f5b56d-ac60-46c1-ae60-a4a9ecda5afa.png)
 
<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
