### PR TITLE
feat(db/locales): ruRU translation of the objectives field for quest 5624

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1646846735975559298.sql
+++ b/data/sql/updates/pending_db_world/rev_1646846735975559298.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1646846735975559298');
+
+-- Fixed ruRU translation of the objectives field for quest 5624
+UPDATE `quest_template_locale` SET `VerifiedBuild`=0, `Objectives`='Разыщите стражника Робертса и исцелите его раны, пользуясь "Малым исцелением" (уровень 2), а затем одарите его заклинанием "Слово силы: Стойкость", после чего вернитесь в Златоземье к жрице Жозетте.' WHERE `ID`=5624 AND `locale`='ruRU';


### PR DESCRIPTION
Fixed ruRU translation of the objectives field for quest 5624 - Garments of the Light.

## SOURCE:
Taken from https://github.com/TrinityCore/TrinityCore/issues/27861

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
