### PR TITLE
fix(Core/BWL): Vaelastrasz

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_vaelastrasz.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_vaelastrasz.cpp
@@ -115,11 +115,6 @@ public:
             }
         }
 
-        void JustDied(Unit* /*killer*/) override
-        {
-            instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_ESSENCE_OF_THE_RED);
-        }
-
         void EnterCombat(Unit* victim) override
         {
             BossAI::EnterCombat(victim);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_vaelastrasz.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_vaelastrasz.cpp
@@ -42,10 +42,10 @@ enum Gossip
 
 enum Spells
 {
-   SPELL_ESSENCEOFTHERED              = 23513,
-   SPELL_FLAMEBREATH                  = 23461,
-   SPELL_FIRENOVA                     = 23462,
-   SPELL_TAILSWIPE                    = 15847,
+   SPELL_ESSENCE_OF_THE_RED           = 23513,
+   SPELL_FLAME_BREATH                 = 23461,
+   SPELL_FIRE_NOVA                    = 23462,
+   SPELL_TAIL_SWEEP                   = 15847,
    SPELL_CLEAVE                       = 19983,   //Chain cleave is most likely named something different and contains a dummy effect
    SPELL_NEFARIUS_CORRUPTION          = 23642,
    SPELL_RED_LIGHTNING                = 19484,
@@ -64,12 +64,11 @@ enum Events
     EVENT_SPEECH_5                  = 5,
     EVENT_SPEECH_6                  = 6,
     EVENT_SPEECH_7                  = 7,
-    EVENT_ESSENCEOFTHERED           = 8,
-    EVENT_FLAMEBREATH               = 9,
-    EVENT_FIRENOVA                  = 10,
-    EVENT_TAILSWIPE                 = 11,
-    EVENT_CLEAVE                    = 12,
-    EVENT_BURNINGADRENALINE         = 13,
+    EVENT_FLAME_BREATH              = 8,
+    EVENT_FIRE_NOVA                 = 9,
+    EVENT_TAIL_SWEEP                = 10,
+    EVENT_CLEAVE                    = 11,
+    EVENT_BURNING_ADRENALINE        = 12,
 };
 
 class boss_vaelastrasz : public CreatureScript
@@ -100,6 +99,7 @@ public:
         {
             _Reset();
             me->SetHealth(me->CountPctFromMaxHealth(30));
+            instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_ESSENCE_OF_THE_RED);
 
             if (!_introDone)
             {
@@ -115,19 +115,24 @@ public:
             }
         }
 
+        void JustDied(Unit* /*killer*/) override
+        {
+            instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_ESSENCE_OF_THE_RED);
+        }
+
         void EnterCombat(Unit* victim) override
         {
             BossAI::EnterCombat(victim);
 
-            DoCast(me, SPELL_ESSENCEOFTHERED);
+            DoCastAOE(SPELL_ESSENCE_OF_THE_RED);
             // now drop damage requirement to be able to take loot
             me->ResetPlayerDamageReq();
 
             events.ScheduleEvent(EVENT_CLEAVE, 10000);
-            events.ScheduleEvent(EVENT_FLAMEBREATH, 15000);
-            events.ScheduleEvent(EVENT_FIRENOVA, 20000);
-            events.ScheduleEvent(EVENT_TAILSWIPE, 11000);
-            events.ScheduleEvent(EVENT_BURNINGADRENALINE, 15000);
+            events.ScheduleEvent(EVENT_FLAME_BREATH, 15000);
+            events.ScheduleEvent(EVENT_FIRE_NOVA, 20000);
+            events.ScheduleEvent(EVENT_TAIL_SWEEP, 11000);
+            events.ScheduleEvent(EVENT_BURNING_ADRENALINE, 15000);
         }
 
         void BeginSpeech(Unit* target)
@@ -215,23 +220,19 @@ public:
                         events.ScheduleEvent(EVENT_CLEAVE, 15000);
                         DoCastVictim(SPELL_CLEAVE);
                         break;
-                    case EVENT_FLAMEBREATH:
-                        DoCastVictim(SPELL_FLAMEBREATH);
-                        events.ScheduleEvent(EVENT_FLAMEBREATH, 8000, 14000);
+                    case EVENT_FLAME_BREATH:
+                        DoCastVictim(SPELL_FLAME_BREATH);
+                        events.ScheduleEvent(EVENT_FLAME_BREATH, 8000, 14000);
                         break;
-                    case EVENT_FIRENOVA:
-                        DoCastVictim(SPELL_FIRENOVA);
-                        events.ScheduleEvent(EVENT_FIRENOVA, 15000);
+                    case EVENT_FIRE_NOVA:
+                        DoCastVictim(SPELL_FIRE_NOVA);
+                        events.ScheduleEvent(EVENT_FIRE_NOVA, 15000);
                         break;
-                    case EVENT_TAILSWIPE:
-                        //Only cast if we are behind
-                        /*if (!me->HasInArc(M_PI, me->GetVictim()))
-                        {
-                        DoCast(me->GetVictim(), SPELL_TAILSWIPE);
-                        }*/
-                        events.ScheduleEvent(EVENT_TAILSWIPE, 15000);
+                    case EVENT_TAIL_SWEEP:
+                        DoCastAOE(SPELL_TAIL_SWEEP);
+                        events.ScheduleEvent(EVENT_TAIL_SWEEP, 15000);
                         break;
-                    case EVENT_BURNINGADRENALINE:
+                    case EVENT_BURNING_ADRENALINE:
                     {
                         if (_burningAdrenalineCast < 2) // It's better to use TaskScheduler for this, but zzz
                         {
@@ -249,7 +250,7 @@ public:
                             me->CastSpell(me->GetVictim(), SPELL_BURNING_ADRENALINE, true);
                             _burningAdrenalineCast = 0;
                         }
-                        events.ScheduleEvent(EVENT_BURNINGADRENALINE, 15000);
+                        events.ScheduleEvent(EVENT_BURNING_ADRENALINE, 15000);
                         break;
                     }
                 }

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_vaelastrasz.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_vaelastrasz.cpp
@@ -99,7 +99,6 @@ public:
         {
             _Reset();
             me->SetHealth(me->CountPctFromMaxHealth(30));
-            instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_ESSENCE_OF_THE_RED);
 
             if (!_introDone)
             {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Make the code more readable and fix some orthographic errors.
-  Vaelastrasz now should cast Tail Sweep.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes none addressed

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Vaelastrasz and engage.
2. If you wipe or kill him, the aura of Essence of the Red should be removed from players.
3. While multiboxing, put some players behind him, you should be hit by Tail Sweep from time to time.

