### PR TITLE
feat(core/logger): fix and bringing to a unified style warnings of server loading logs…

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -64,7 +64,7 @@ void SmartWaypointMgr::LoadFromDB()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 SmartAI Waypoint Paths. DB table `waypoints` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 SmartAI Waypoint Paths. DB table `waypoints` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -136,7 +136,7 @@ void SmartAIMgr::LoadSmartAIFromDB()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 SmartAI scripts. DB table `smart_scripts` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 SmartAI scripts. DB table `smart_scripts` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -2455,7 +2455,7 @@ void AchievementGlobalMgr::LoadAchievementCriteriaList()
 
     if (sAchievementCriteriaStore.GetNumRows() == 0)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 achievement criteria.");
+        LOG_WARN("server.loading", ">> Loaded 0 achievement criteria.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2604,7 +2604,7 @@ void AchievementGlobalMgr::LoadAchievementReferenceList()
 
     if (sAchievementStore.GetNumRows() == 0)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 achievement references.");
+        LOG_WARN("server.loading", ">> Loaded 0 achievement references.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2635,7 +2635,7 @@ void AchievementGlobalMgr::LoadAchievementCriteriaData()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 additional achievement criteria data. DB table `achievement_criteria_data` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 additional achievement criteria data. DB table `achievement_criteria_data` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2776,7 +2776,7 @@ void AchievementGlobalMgr::LoadCompletedAchievements()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 completed achievements. DB table `character_achievement` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 completed achievements. DB table `character_achievement` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2818,7 +2818,7 @@ void AchievementGlobalMgr::LoadRewards()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 achievement rewards. DB table `achievement_reward` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 achievement rewards. DB table `achievement_reward` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2939,7 +2939,7 @@ void AchievementGlobalMgr::LoadRewardLocales()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 achievement reward locale strings.  DB table `achievement_reward_locale` is empty");
+        LOG_WARN("server.loading", ">> Loaded 0 achievement reward locale strings.  DB table `achievement_reward_locale` is empty");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Addons/AddonMgr.cpp
+++ b/src/server/game/Addons/AddonMgr.cpp
@@ -42,7 +42,7 @@ namespace AddonMgr
         QueryResult result = CharacterDatabase.Query("SELECT name, crc FROM addons");
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 known addons. DB table `addons` is empty!");
+            LOG_WARN("server.loading", ">> Loaded 0 known addons. DB table `addons` is empty!");
             LOG_INFO("server.loading", " ");
             return;
         }

--- a/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -493,7 +493,7 @@ void AuctionHouseMgr::LoadAuctionItems()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 auction items. DB table `auctionhouse` or `item_instance` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 auction items. DB table `auctionhouse` or `item_instance` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -538,7 +538,7 @@ void AuctionHouseMgr::LoadAuctions()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 auctions. DB table `auctionhouse` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 auctions. DB table `auctionhouse` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Battlegrounds/ArenaTeamMgr.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeamMgr.cpp
@@ -157,7 +157,7 @@ void ArenaTeamMgr::LoadArenaTeams()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 arena teams. DB table `arena_team` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 arena teams. DB table `arena_team` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -663,7 +663,7 @@ void BattlegroundMgr::LoadBattleMastersEntry()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 battlemaster entries. DB table `battlemaster_entry` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 battlemaster entries. DB table `battlemaster_entry` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Chat/Channels/ChannelMgr.cpp
+++ b/src/server/game/Chat/Channels/ChannelMgr.cpp
@@ -56,7 +56,7 @@ void ChannelMgr::LoadChannels()
     QueryResult result = CharacterDatabase.Query("SELECT channelId, name, team, announce, ownership, password FROM channels ORDER BY channelId ASC");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 channels. DB table `channels` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 channels. DB table `channels` is empty.");
         return;
     }
 
@@ -171,7 +171,7 @@ void ChannelMgr::LoadChannelRights()
     QueryResult result = CharacterDatabase.Query("SELECT name, flags, speakdelay, joinmessage, delaymessage, moderators FROM channels_rights");
     if (!result)
     {
-        LOG_INFO("server.loading", ">>  Loaded 0 Channel Rights!");
+        LOG_WARN("server.loading", ">> Loaded 0 Channel Rights!");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -935,7 +935,7 @@ void ConditionMgr::LoadConditions(bool isReload)
 
     if (!result)
     {
-        LOG_ERROR("server.loading", ">> Loaded 0 conditions. DB table `conditions` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 conditions. DB table `conditions` is empty!");
         return;
     }
 

--- a/src/server/game/Conditions/DisableMgr.cpp
+++ b/src/server/game/Conditions/DisableMgr.cpp
@@ -63,7 +63,7 @@ namespace DisableMgr
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 disables. DB table `disables` is empty!");
+            LOG_WARN("server.loading", ">> Loaded 0 disables. DB table `disables` is empty!");
             LOG_INFO("server.loading", " ");
             return;
         }

--- a/src/server/game/Entities/Creature/CreatureGroups.cpp
+++ b/src/server/game/Entities/Creature/CreatureGroups.cpp
@@ -86,7 +86,7 @@ void FormationMgr::LoadCreatureFormations()
     QueryResult result = WorldDatabase.Query("SELECT leaderGUID, memberGUID, dist, angle, groupAI, point_1, point_2 FROM creature_formations ORDER BY leaderGUID");
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">>  Loaded 0 creatures in formations. DB table `creature_formations` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 creatures in formations. DB table `creature_formations` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Entities/Item/ItemEnchantmentMgr.cpp
+++ b/src/server/game/Entities/Item/ItemEnchantmentMgr.cpp
@@ -73,7 +73,7 @@ void LoadRandomEnchantmentsTable()
     }
     else
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 Item Enchantment definitions. DB table `item_enchantment_template` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 Item Enchantment definitions. DB table `item_enchantment_template` is empty.");
         LOG_INFO("server.loading", " ");
     }
 }

--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -246,7 +246,7 @@ void GameEventMgr::LoadFromDB()
         if (!result)
         {
             mGameEvent.clear();
-            LOG_ERROR("sql.sql", ">> Loaded 0 game events. DB table `game_event` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 game events. DB table `game_event` is empty.");
             LOG_INFO("server.loading", " ");
             return;
         }
@@ -314,7 +314,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 game event saves in game events. DB table `game_event_save` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 game event saves in game events. DB table `game_event_save` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -359,7 +359,7 @@ void GameEventMgr::LoadFromDB()
         QueryResult result = WorldDatabase.Query("SELECT eventEntry, prerequisite_event FROM game_event_prerequisite");
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 game event prerequisites in game events. DB table `game_event_prerequisite` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 game event prerequisites in game events. DB table `game_event_prerequisite` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -410,7 +410,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 creatures in game events. DB table `game_event_creature` is empty");
+            LOG_WARN("server.loading", ">> Loaded 0 creatures in game events. DB table `game_event_creature` is empty");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -458,7 +458,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 gameobjects in game events. DB table `game_event_gameobject` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 gameobjects in game events. DB table `game_event_gameobject` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -507,7 +507,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 model/equipment changes in game events. DB table `game_event_model_equip` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 model/equipment changes in game events. DB table `game_event_model_equip` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -566,7 +566,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 quests additions in game events. DB table `game_event_creature_quest` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 quests additions in game events. DB table `game_event_creature_quest` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -606,7 +606,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 go quests additions in game events. DB table `game_event_gameobject_quest` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 go quests additions in game events. DB table `game_event_gameobject_quest` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -646,7 +646,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 quest event conditions in game events. DB table `game_event_quest_condition` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 quest event conditions in game events. DB table `game_event_quest_condition` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -688,7 +688,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 conditions in game events. DB table `game_event_condition` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 conditions in game events. DB table `game_event_condition` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -729,7 +729,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 condition saves in game events. DB table `game_event_condition_save` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 condition saves in game events. DB table `game_event_condition_save` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -776,7 +776,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 npcflags in game events. DB table `game_event_npcflag` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 npcflags in game events. DB table `game_event_npcflag` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -815,7 +815,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 seasonal quests additions in game events. DB table `game_event_seasonal_questrelation` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 seasonal quests additions in game events. DB table `game_event_seasonal_questrelation` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -861,7 +861,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 vendor additions in game events. DB table `game_event_npc_vendor` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 vendor additions in game events. DB table `game_event_npc_vendor` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -926,7 +926,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 battleground holidays in game events. DB table `game_event_battleground_holiday` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 battleground holidays in game events. DB table `game_event_battleground_holiday` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -964,7 +964,7 @@ void GameEventMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 pools for game events. DB table `game_event_pool` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 pools for game events. DB table `game_event_pool` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -1012,7 +1012,7 @@ void GameEventMgr::LoadHolidayDates()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 holiday dates. DB table `holiday_dates` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 holiday dates. DB table `holiday_dates` is empty.");
         return;
     }
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -497,7 +497,7 @@ void ObjectMgr::LoadCreatureTemplates()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 creature template definitions. DB table `creature_template` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 creature template definitions. DB table `creature_template` is empty.");
         return;
     }
 
@@ -663,7 +663,7 @@ void ObjectMgr::LoadCreatureTemplateResistances()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 creature template resistance definitions. DB table `creature_template_resistance` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 creature template resistance definitions. DB table `creature_template_resistance` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -709,7 +709,7 @@ void ObjectMgr::LoadCreatureTemplateSpells()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 creature template spell definitions. DB table `creature_template_spell` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 creature template spell definitions. DB table `creature_template_spell` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -755,7 +755,7 @@ void ObjectMgr::LoadCreatureTemplateAddons()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 creature template addon definitions. DB table `creature_template_addon` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 creature template addon definitions. DB table `creature_template_addon` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -1235,7 +1235,7 @@ void ObjectMgr::LoadCreatureAddons()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 creature addon definitions. DB table `creature_addon` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 creature addon definitions. DB table `creature_addon` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -1336,7 +1336,7 @@ void ObjectMgr::LoadGameObjectAddons()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 gameobject addon definitions. DB table `gameobject_addon` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 gameobject addon definitions. DB table `gameobject_addon` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -1446,7 +1446,7 @@ void ObjectMgr::LoadEquipmentTemplates()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 creature equipment templates. DB table `creature_equip_template` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 creature equipment templates. DB table `creature_equip_template` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -1535,7 +1535,7 @@ void ObjectMgr::LoadCreatureMovementOverrides()
                                              "LEFT JOIN creature_template_movement AS ctm ON ctm.CreatureId = c.id1");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 creature movement overrides. DB table `creature_movement_override` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 creature movement overrides. DB table `creature_movement_override` is empty!");
         return;
     }
 
@@ -1660,7 +1660,7 @@ void ObjectMgr::LoadCreatureModelInfo()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 creature model definitions. DB table `creature_model_info` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 creature model definitions. DB table `creature_model_info` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -1718,7 +1718,7 @@ void ObjectMgr::LoadLinkedRespawn()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 linked respawns. DB table `linked_respawn` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 linked respawns. DB table `linked_respawn` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -1949,7 +1949,7 @@ void ObjectMgr::LoadTempSummons()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 temp summons. DB table `creature_summon_groups` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 temp summons. DB table `creature_summon_groups` is empty.");
         return;
     }
 
@@ -2042,7 +2042,7 @@ void ObjectMgr::LoadCreatures()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 creatures. DB table `creature` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 creatures. DB table `creature` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2367,7 +2367,7 @@ void ObjectMgr::LoadGameobjects()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 gameobjects. DB table `gameobject` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 gameobjects. DB table `gameobject` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2617,7 +2617,7 @@ void ObjectMgr::LoadItemTemplates()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 item templates. DB table `item_template` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 item templates. DB table `item_template` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -3223,7 +3223,7 @@ void ObjectMgr::LoadItemSetNames()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 item set names. DB table `item_set_names` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 item set names. DB table `item_set_names` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -3295,7 +3295,7 @@ void ObjectMgr::LoadVehicleTemplateAccessories()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 vehicle template accessories. DB table `vehicle_template_accessory` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 vehicle template accessories. DB table `vehicle_template_accessory` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -3351,7 +3351,7 @@ void ObjectMgr::LoadVehicleAccessories()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 Vehicle Accessories in {} ms", GetMSTimeDiffToNow(oldMSTime));
+        LOG_WARN("server.loading", ">> Loaded 0 Vehicle Accessories in {} ms", GetMSTimeDiffToNow(oldMSTime));
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -3391,7 +3391,7 @@ void ObjectMgr::LoadPetLevelInfo()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 level pet stats definitions. DB table `pet_levelstats` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 level pet stats definitions. DB table `pet_levelstats` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -3532,7 +3532,7 @@ void ObjectMgr::LoadPlayerInfo()
         if (!result)
         {
             LOG_INFO("server.loading", " ");
-            LOG_ERROR("sql.sql", ">> Loaded 0 player create definitions. DB table `playercreateinfo` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 player create definitions. DB table `playercreateinfo` is empty.");
             exit(1);
         }
         else
@@ -3618,7 +3618,7 @@ void ObjectMgr::LoadPlayerInfo()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 custom player create items. DB table `playercreateinfo_item` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 custom player create items. DB table `playercreateinfo_item` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -3689,7 +3689,7 @@ void ObjectMgr::LoadPlayerInfo()
 
         if (!result)
         {
-            LOG_ERROR("server.loading", ">> Loaded 0 player create skills. DB table `playercreateinfo_skills` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 player create skills. DB table `playercreateinfo_skills` is empty.");
         }
         else
         {
@@ -3763,7 +3763,7 @@ void ObjectMgr::LoadPlayerInfo()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 player create spells. DB table `playercreateinfo_spell_custom` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 player create spells. DB table `playercreateinfo_spell_custom` is empty.");
         }
         else
         {
@@ -3821,7 +3821,7 @@ void ObjectMgr::LoadPlayerInfo()
 
         if (!result)
         {
-            LOG_ERROR("server.loading", ">> Loaded 0 player create cast spells. DB table `playercreateinfo_cast_spell` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 player create cast spells. DB table `playercreateinfo_cast_spell` is empty.");
         }
         else
         {
@@ -3879,7 +3879,7 @@ void ObjectMgr::LoadPlayerInfo()
 
         if (!result)
         {
-            LOG_ERROR("sql.sql", ">> Loaded 0 player create actions. DB table `playercreateinfo_action` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 player create actions. DB table `playercreateinfo_action` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -4007,7 +4007,7 @@ void ObjectMgr::LoadPlayerInfo()
 
         if (!result)
         {
-            LOG_ERROR("sql.sql", ">> Loaded 0 level stats definitions. DB table `player_levelstats` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 level stats definitions. DB table `player_levelstats` is empty.");
             LOG_INFO("server.loading", " ");
             exit(1);
         }
@@ -4120,7 +4120,7 @@ void ObjectMgr::LoadPlayerInfo()
 
         if (!result)
         {
-            LOG_ERROR("sql.sql", ">> Loaded 0 xp for level definitions. DB table `player_xp_for_level` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 xp for level definitions. DB table `player_xp_for_level` is empty.");
             LOG_INFO("server.loading", " ");
             exit(1);
         }
@@ -4310,7 +4310,7 @@ void ObjectMgr::LoadQuests()
                          " FROM quest_template");
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 quests definitions. DB table `quest_template` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 quests definitions. DB table `quest_template` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -4352,7 +4352,7 @@ void ObjectMgr::LoadQuests()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 quest details. DB table `quest_details` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 quest details. DB table `quest_details` is empty.");
     }
     else
     {
@@ -4375,7 +4375,7 @@ void ObjectMgr::LoadQuests()
 
     if (!result)
     {
-        LOG_ERROR("server.loading", ">> Loaded 0 quest request items. DB table `quest_request_items` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 quest request items. DB table `quest_request_items` is empty.");
     }
     else
     {
@@ -4398,7 +4398,7 @@ void ObjectMgr::LoadQuests()
 
     if (!result)
     {
-        LOG_ERROR("server.loading", ">> Loaded 0 quest reward emotes. DB table `quest_offer_reward` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 quest reward emotes. DB table `quest_offer_reward` is empty.");
     }
     else
     {
@@ -4423,7 +4423,7 @@ void ObjectMgr::LoadQuests()
 
     if (!result)
     {
-        LOG_ERROR("server.loading", ">> Loaded 0 quest template addons. DB table `quest_template_addon` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 quest template addons. DB table `quest_template_addon` is empty.");
     }
     else
     {
@@ -5079,7 +5079,7 @@ void ObjectMgr::LoadScripts(ScriptsType type)
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 script definitions. DB table `{}` is empty!", tableName);
+        LOG_WARN("server.loading", ">> Loaded 0 script definitions. DB table `{}` is empty!", tableName);
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -5477,7 +5477,7 @@ void ObjectMgr::LoadSpellScriptNames()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell script names. DB table `spell_script_names` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 spell script names. DB table `spell_script_names` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -5606,7 +5606,7 @@ void ObjectMgr::LoadPageTexts()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 page texts. DB table `page_text` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 page texts. DB table `page_text` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -5685,7 +5685,7 @@ void ObjectMgr::LoadInstanceTemplate()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 instance templates. DB table `page_text` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 instance templates. DB table `page_text` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -5735,7 +5735,7 @@ void ObjectMgr::LoadInstanceEncounters()
     QueryResult result = WorldDatabase.Query("SELECT entry, creditType, creditEntry, lastEncounterDungeon FROM instance_encounters");
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 instance encounters, table is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 instance encounters, table is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -5837,7 +5837,7 @@ void ObjectMgr::LoadGossipText()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 npc texts, table is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 npc texts, table is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -6064,7 +6064,7 @@ void ObjectMgr::LoadQuestAreaTriggers()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 quest trigger points. DB table `areatrigger_involvedrelation` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 quest trigger points. DB table `areatrigger_involvedrelation` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -6136,7 +6136,7 @@ void ObjectMgr::LoadQuestGreetings()
     QueryResult result = WorldDatabase.Query("SELECT ID, Type, GreetEmoteType, GreetEmoteDelay, Greeting FROM quest_greeting");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 quest greetings. DB table `quest_greeting` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 quest greetings. DB table `quest_greeting` is empty.");
         return;
     }
 
@@ -6191,7 +6191,7 @@ void ObjectMgr::LoadQuestGreetingsLocales()
     QueryResult result = WorldDatabase.Query("SELECT ID, Type, Locale, Greeting FROM quest_greeting_locale");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 quest_greeting locales. DB table `quest_greeting_locale` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 quest_greeting locales. DB table `quest_greeting_locale` is empty.");
         return;
     }
 
@@ -6306,7 +6306,7 @@ void ObjectMgr::LoadTavernAreaTriggers()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 tavern triggers. DB table `areatrigger_tavern` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 tavern triggers. DB table `areatrigger_tavern` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -6344,7 +6344,7 @@ void ObjectMgr::LoadAreaTriggerScripts()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 areatrigger scripts. DB table `areatrigger_scripts` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 areatrigger scripts. DB table `areatrigger_scripts` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -6485,7 +6485,7 @@ void ObjectMgr::LoadAreaTriggers()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 area trigger definitions. DB table `areatrigger` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 area trigger definitions. DB table `areatrigger` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -6536,7 +6536,7 @@ void ObjectMgr::LoadAreaTriggerTeleports()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 area trigger teleport definitions. DB table `areatrigger_teleport` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 area trigger teleport definitions. DB table `areatrigger_teleport` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -6622,7 +6622,7 @@ void ObjectMgr::LoadAccessRequirements()
     QueryResult access_template_result = WorldDatabase.Query("SELECT id, map_id, difficulty, min_level, max_level, min_avg_item_level FROM dungeon_access_template");
     if (!access_template_result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 access requirement definitions. DB table `dungeon_access_template` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 access requirement definitions. DB table `dungeon_access_template` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -7008,7 +7008,7 @@ void ObjectMgr::LoadGameObjectTemplate()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 gameobject definitions. DB table `gameobject_template` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 gameobject definitions. DB table `gameobject_template` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -7188,7 +7188,7 @@ void ObjectMgr::LoadGameObjectTemplateAddons()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 gameobject template addon definitions. DB table `gameobject_template_addon` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 gameobject template addon definitions. DB table `gameobject_template_addon` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -7251,7 +7251,7 @@ void ObjectMgr::LoadExplorationBaseXP()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 BaseXP definitions. DB table `exploration_basexp` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 BaseXP definitions. DB table `exploration_basexp` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -7291,7 +7291,7 @@ void ObjectMgr::LoadPetNames()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 pet name parts. DB table `pet_name_generation` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 pet name parts. DB table `pet_name_generation` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -7459,7 +7459,7 @@ void ObjectMgr::LoadReputationOnKill()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 creature award reputation definitions. DB table `creature_onkill_reputation` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 creature award reputation definitions. DB table `creature_onkill_reputation` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -7640,7 +7640,7 @@ void ObjectMgr::LoadPointsOfInterest()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 Points of Interest definitions. DB table `points_of_interest` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 Points of Interest definitions. DB table `points_of_interest` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -7688,7 +7688,7 @@ void ObjectMgr::LoadQuestPOI()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 quest POI definitions. DB table `quest_poi` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 quest POI definitions. DB table `quest_poi` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -7761,7 +7761,7 @@ void ObjectMgr::LoadNPCSpellClickSpells()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 spellclick spells. DB table `npc_spellclick_spells` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spellclick spells. DB table `npc_spellclick_spells` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -7850,7 +7850,7 @@ void ObjectMgr::LoadQuestRelationsHelper(QuestRelations& map, std::string const&
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 quest relations from `{}`, table is empty.", table);
+        LOG_WARN("server.loading", ">> Loaded 0 quest relations from `{}`, table is empty.", table);
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -7949,7 +7949,7 @@ void ObjectMgr::LoadReservedPlayersNames()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 reserved player names. DB table `reserved_name` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 reserved player names. DB table `reserved_name` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -8170,7 +8170,7 @@ void ObjectMgr::LoadGameObjectForQuests()
 
     if (sObjectMgr->GetGameObjectTemplates()->empty())
     {
-        LOG_INFO("server.loading", ">> Loaded 0 GameObjects for quests");
+        LOG_WARN("server.loading", ">> Loaded 0 GameObjects for quests");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -8245,7 +8245,7 @@ bool ObjectMgr::LoadAcoreStrings()
     QueryResult result = WorldDatabase.Query("SELECT entry, content_default, locale_koKR, locale_frFR, locale_deDE, locale_zhCN, locale_zhTW, locale_esES, locale_esMX, locale_ruRU FROM acore_string");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 acore strings. DB table `acore_strings` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 acore strings. DB table `acore_strings` is empty.");
         LOG_INFO("server.loading", " ");
         return false;
     }
@@ -8295,7 +8295,7 @@ void ObjectMgr::LoadFishingBaseSkillLevel()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 areas for fishing base skill level. DB table `skill_fishing_base_level` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 areas for fishing base skill level. DB table `skill_fishing_base_level` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -8436,7 +8436,7 @@ void ObjectMgr::LoadGameTele()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 GameTeleports. DB table `game_tele` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 GameTeleports. DB table `game_tele` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -8576,7 +8576,7 @@ void ObjectMgr::LoadMailLevelRewards()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 level dependent mail rewards. DB table `mail_level_reward` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 level dependent mail rewards. DB table `mail_level_reward` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -8723,7 +8723,7 @@ void ObjectMgr::LoadTrainerSpell()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">>  Loaded 0 Trainers. DB table `npc_trainer` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 Trainers. DB table `npc_trainer` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -8805,7 +8805,7 @@ void ObjectMgr::LoadVendors()
     if (!result)
     {
         LOG_INFO("server.loading", " ");
-        LOG_ERROR("sql.sql", ">>  Loaded 0 Vendors. DB table `npc_vendor` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 Vendors. DB table `npc_vendor` is empty!");
         return;
     }
 
@@ -8851,7 +8851,7 @@ void ObjectMgr::LoadGossipMenu()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 gossip_menu entries. DB table `gossip_menu` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 gossip_menu entries. DB table `gossip_menu` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -8891,7 +8891,7 @@ void ObjectMgr::LoadGossipMenuItems()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 gossip_menu_option IDs. DB table `gossip_menu_option` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 gossip_menu_option IDs. DB table `gossip_menu_option` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -9157,7 +9157,7 @@ void ObjectMgr::LoadBroadcastTexts()
     QueryResult result = WorldDatabase.Query("SELECT ID, LanguageID, MaleText, FemaleText, EmoteID1, EmoteID2, EmoteID3, EmoteDelay1, EmoteDelay2, EmoteDelay3, SoundEntriesID, EmotesID, Flags FROM broadcast_text");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 broadcast texts. DB table `broadcast_text` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 broadcast texts. DB table `broadcast_text` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -9241,7 +9241,7 @@ void ObjectMgr::LoadBroadcastTextLocales()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 broadcast text locales. DB table `broadcast_text_locale` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 broadcast text locales. DB table `broadcast_text_locale` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -9307,7 +9307,7 @@ void ObjectMgr::LoadCreatureClassLevelStats()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 creature base stats. DB table `creature_classlevelstats` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 creature base stats. DB table `creature_classlevelstats` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -9390,7 +9390,7 @@ void ObjectMgr::LoadFactionChangeAchievements()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 faction change achievement pairs. DB table `player_factionchange_achievement` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 faction change achievement pairs. DB table `player_factionchange_achievement` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -9426,7 +9426,7 @@ void ObjectMgr::LoadFactionChangeItems()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 faction change item pairs. DB table `player_factionchange_items` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 faction change item pairs. DB table `player_factionchange_items` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -9462,7 +9462,7 @@ void ObjectMgr::LoadFactionChangeQuests()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 faction change quest pairs. DB table `player_factionchange_quests` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 faction change quest pairs. DB table `player_factionchange_quests` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -9498,7 +9498,7 @@ void ObjectMgr::LoadFactionChangeReputations()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 faction change reputation pairs. DB table `player_factionchange_reputations` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 faction change reputation pairs. DB table `player_factionchange_reputations` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -9534,7 +9534,7 @@ void ObjectMgr::LoadFactionChangeSpells()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 faction change spell pairs. DB table `player_factionchange_spells` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 faction change spell pairs. DB table `player_factionchange_spells` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -9570,7 +9570,7 @@ void ObjectMgr::LoadFactionChangeTitles()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 faction change title pairs. DB table `player_factionchange_title` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 faction change title pairs. DB table `player_factionchange_title` is empty.");
         return;
     }
 
@@ -9664,7 +9664,7 @@ void ObjectMgr::LoadGameObjectQuestItems()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 gameobject quest items. DB table `gameobject_questitem` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 gameobject quest items. DB table `gameobject_questitem` is empty.");
         return;
     }
 
@@ -9694,7 +9694,7 @@ void ObjectMgr::LoadCreatureQuestItems()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 creature quest items. DB table `creature_questitem` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 creature quest items. DB table `creature_questitem` is empty.");
         return;
     }
 
@@ -9725,7 +9725,7 @@ void ObjectMgr::LoadQuestMoneyRewards()
     QueryResult result = WorldDatabase.Query("SELECT `Level`, Money0, Money1, Money2, Money3, Money4, Money5, Money6, Money7, Money8, Money9 FROM `quest_money_reward` ORDER BY `Level`");
     if (!result)
     {
-        LOG_ERROR("server.loading", ">> Loaded 0 quest money rewards. DB table `quest_money_reward` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 quest money rewards. DB table `quest_money_reward` is empty.");
         return;
     }
 

--- a/src/server/game/Groups/GroupMgr.cpp
+++ b/src/server/game/Groups/GroupMgr.cpp
@@ -121,7 +121,7 @@ void GroupMgr::LoadGroups()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 group definitions. DB table `groups` is empty!");
+            LOG_WARN("server.loading", ">> Loaded 0 group definitions. DB table `groups` is empty!");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -161,7 +161,7 @@ void GroupMgr::LoadGroups()
         QueryResult result = CharacterDatabase.Query("SELECT guid, memberGuid, memberFlags, subgroup, roles FROM group_member ORDER BY guid");
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 group members. DB table `group_member` is empty!");
+            LOG_WARN("server.loading", ">> Loaded 0 group members. DB table `group_member` is empty!");
             LOG_INFO("server.loading", " ");
         }
         else

--- a/src/server/game/Guilds/GuildMgr.cpp
+++ b/src/server/game/Guilds/GuildMgr.cpp
@@ -106,7 +106,7 @@ void GuildMgr::LoadGuilds()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 guild definitions. DB table `guild` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 guild definitions. DB table `guild` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -146,7 +146,7 @@ void GuildMgr::LoadGuilds()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 guild ranks. DB table `guild_rank` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 guild ranks. DB table `guild_rank` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -187,7 +187,7 @@ void GuildMgr::LoadGuilds()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 guild members. DB table `guild_member` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 guild members. DB table `guild_member` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -223,7 +223,7 @@ void GuildMgr::LoadGuilds()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 guild bank tab rights. DB table `guild_bank_right` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 guild bank tab rights. DB table `guild_bank_right` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -257,7 +257,7 @@ void GuildMgr::LoadGuilds()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 guild event logs. DB table `guild_eventlog` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 guild event logs. DB table `guild_eventlog` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -292,7 +292,7 @@ void GuildMgr::LoadGuilds()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 guild bank event logs. DB table `guild_bank_eventlog` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 guild bank event logs. DB table `guild_bank_eventlog` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -327,7 +327,7 @@ void GuildMgr::LoadGuilds()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 guild bank tabs. DB table `guild_bank_tab` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 guild bank tabs. DB table `guild_bank_tab` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -364,7 +364,7 @@ void GuildMgr::LoadGuilds()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 guild bank tab items. DB table `guild_bank_item` or `item_instance` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 guild bank tab items. DB table `guild_bank_item` or `item_instance` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else

--- a/src/server/game/Loot/LootItemStorage.cpp
+++ b/src/server/game/Loot/LootItemStorage.cpp
@@ -43,7 +43,7 @@ void LootItemStorage::LoadStorageFromDB()
     PreparedQueryResult result = CharacterDatabase.Query(stmt);
     if (!result)
     {
-        LOG_INFO("server.loading", ">>  Loaded 0 stored items!");
+        LOG_WARN("server.loading", ">> Loaded 0 stored items!");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -1923,7 +1923,7 @@ void LoadLootTemplates_Creature()
     if (count)
         LOG_INFO("server.loading", ">> Loaded {} creature loot templates in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
     else
-        LOG_ERROR("sql.sql", ">> Loaded 0 creature loot templates. DB table `creature_loot_template` is empty");
+        LOG_WARN("server.loading", ">> Loaded 0 creature loot templates. DB table `creature_loot_template` is empty");
 
     LOG_INFO("server.loading", " ");
 }
@@ -1958,7 +1958,7 @@ void LoadLootTemplates_Disenchant()
     if (count)
         LOG_INFO("server.loading", ">> Loaded {} disenchanting loot templates in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
     else
-        LOG_ERROR("sql.sql", ">> Loaded 0 disenchanting loot templates. DB table `disenchant_loot_template` is empty");
+        LOG_WARN("server.loading", ">> Loaded 0 disenchanting loot templates. DB table `disenchant_loot_template` is empty");
     LOG_INFO("server.loading", " ");
 }
 
@@ -1983,7 +1983,7 @@ void LoadLootTemplates_Fishing()
     if (count)
         LOG_INFO("server.loading", ">> Loaded {} fishing loot templates in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
     else
-        LOG_ERROR("sql.sql", ">> Loaded 0 fishing loot templates. DB table `fishing_loot_template` is empty");
+        LOG_WARN("server.loading", ">> Loaded 0 fishing loot templates. DB table `fishing_loot_template` is empty");
 
     LOG_INFO("server.loading", " ");
 }
@@ -2019,7 +2019,7 @@ void LoadLootTemplates_Gameobject()
     if (count)
         LOG_INFO("server.loading", ">> Loaded {} gameobject loot templates in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
     else
-        LOG_ERROR("sql.sql", ">> Loaded 0 gameobject loot templates. DB table `gameobject_loot_template` is empty");
+        LOG_WARN("server.loading", ">> Loaded 0 gameobject loot templates. DB table `gameobject_loot_template` is empty");
 
     LOG_INFO("server.loading", " ");
 }
@@ -2045,7 +2045,7 @@ void LoadLootTemplates_Item()
     if (count)
         LOG_INFO("server.loading", ">> Loaded {} item loot templates in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
     else
-        LOG_ERROR("sql.sql", ">> Loaded 0 item loot templates. DB table `item_loot_template` is empty");
+        LOG_WARN("server.loading", ">> Loaded 0 item loot templates. DB table `item_loot_template` is empty");
 
     LOG_INFO("server.loading", " ");
 }
@@ -2076,7 +2076,7 @@ void LoadLootTemplates_Milling()
     if (count)
         LOG_INFO("server.loading", ">> Loaded {} milling loot templates in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
     else
-        LOG_ERROR("sql.sql", ">> Loaded 0 milling loot templates. DB table `milling_loot_template` is empty");
+        LOG_WARN("server.loading", ">> Loaded 0 milling loot templates. DB table `milling_loot_template` is empty");
 
     LOG_INFO("server.loading", " ");
 }
@@ -2112,7 +2112,7 @@ void LoadLootTemplates_Pickpocketing()
     if (count)
         LOG_INFO("server.loading", ">> Loaded {} pickpocketing loot templates in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
     else
-        LOG_ERROR("sql.sql", ">> Loaded 0 pickpocketing loot templates. DB table `pickpocketing_loot_template` is empty");
+        LOG_WARN("server.loading", ">> Loaded 0 pickpocketing loot templates. DB table `pickpocketing_loot_template` is empty");
 
     LOG_INFO("server.loading", " ");
 }
@@ -2143,7 +2143,7 @@ void LoadLootTemplates_Prospecting()
     if (count)
         LOG_INFO("server.loading", ">> Loaded {} prospecting loot templates in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
     else
-        LOG_ERROR("sql.sql", ">> Loaded 0 prospecting loot templates. DB table `prospecting_loot_template` is empty");
+        LOG_WARN("server.loading", ">> Loaded 0 prospecting loot templates. DB table `prospecting_loot_template` is empty");
 
     LOG_INFO("server.loading", " ");
 }
@@ -2169,7 +2169,7 @@ void LoadLootTemplates_Mail()
     if (count)
         LOG_INFO("server.loading", ">> Loaded {} mail loot templates in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
     else
-        LOG_ERROR("sql.sql", ">> Loaded 0 mail loot templates. DB table `mail_loot_template` is empty");
+        LOG_WARN("server.loading", ">> Loaded 0 mail loot templates. DB table `mail_loot_template` is empty");
 
     LOG_INFO("server.loading", " ");
 }
@@ -2205,7 +2205,7 @@ void LoadLootTemplates_Skinning()
     if (count)
         LOG_INFO("server.loading", ">> Loaded {} skinning loot templates in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
     else
-        LOG_ERROR("sql.sql", ">> Loaded 0 skinning loot templates. DB table `skinning_loot_template` is empty");
+        LOG_WARN("server.loading", ">> Loaded 0 skinning loot templates. DB table `skinning_loot_template` is empty");
 
     LOG_INFO("server.loading", " ");
 }
@@ -2249,7 +2249,7 @@ void LoadLootTemplates_Spell()
     if (count)
         LOG_INFO("server.loading", ">> Loaded {} spell loot templates in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
     else
-        LOG_ERROR("sql.sql", ">> Loaded 0 spell loot templates. DB table `spell_loot_template` is empty");
+        LOG_WARN("server.loading", ">> Loaded 0 spell loot templates. DB table `spell_loot_template` is empty");
     LOG_INFO("server.loading", " ");
 }
 
@@ -2268,7 +2268,7 @@ void LoadLootTemplates_Player()
     }
     else
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 player loot templates. DB table `player_loot_template` is empty");
+        LOG_WARN("server.loading", ">> Loaded 0 player loot templates. DB table `player_loot_template` is empty");
     }
 
     LOG_INFO("server.loading", " ");

--- a/src/server/game/Maps/TransportMgr.cpp
+++ b/src/server/game/Maps/TransportMgr.cpp
@@ -55,7 +55,7 @@ void TransportMgr::LoadTransportTemplates()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 transport templates. DB table `gameobject_template` has no transports!");
+        LOG_WARN("server.loading", ">> Loaded 0 transport templates. DB table `gameobject_template` has no transports!");
         return;
     }
 

--- a/src/server/game/Misc/GameGraveyard.cpp
+++ b/src/server/game/Misc/GameGraveyard.cpp
@@ -36,7 +36,7 @@ void Graveyard::LoadGraveyardFromDB()
     QueryResult result = WorldDatabase.Query("SELECT ID, Map, x, y, z, Comment FROM game_graveyard");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 graveyard. Table `game_graveyard` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 graveyard. Table `game_graveyard` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -362,7 +362,7 @@ void Graveyard::LoadGraveyardZones()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 graveyard-zone links. DB table `graveyard_zone` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 graveyard-zone links. DB table `graveyard_zone` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Movement/Waypoints/WaypointMgr.cpp
+++ b/src/server/game/Movement/Waypoints/WaypointMgr.cpp
@@ -52,7 +52,7 @@ void WaypointMgr::Load()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 waypoints. DB table `waypoint_data` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 waypoints. DB table `waypoint_data` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/OutdoorPvP/OutdoorPvPMgr.cpp
+++ b/src/server/game/OutdoorPvP/OutdoorPvPMgr.cpp
@@ -52,7 +52,7 @@ void OutdoorPvPMgr::InitOutdoorPvP()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 outdoor PvP definitions. DB table `outdoorpvp_template` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 outdoor PvP definitions. DB table `outdoorpvp_template` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Petitions/PetitionMgr.cpp
+++ b/src/server/game/Petitions/PetitionMgr.cpp
@@ -45,7 +45,7 @@ void PetitionMgr::LoadPetitions()
     QueryResult result = CharacterDatabase.Query("SELECT ownerguid, petitionguid, name, type FROM petition");
     if (!result)
     {
-        LOG_INFO("server.loading", ">>  Loaded 0 Petitions!");
+        LOG_WARN("server.loading", ">> Loaded 0 Petitions!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -70,7 +70,7 @@ void PetitionMgr::LoadSignatures()
     QueryResult result = CharacterDatabase.Query("SELECT petitionguid, playerguid, player_account FROM petition_sign");
     if (!result)
     {
-        LOG_INFO("server.loading", ">>  Loaded 0 Petition signs!");
+        LOG_WARN("server.loading", ">> Loaded 0 Petition signs!");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -581,7 +581,7 @@ void PoolMgr::LoadFromDB()
         if (!result)
         {
             mPoolTemplate.clear();
-            LOG_INFO("server.loading", ">> Loaded 0 object pools. DB table `pool_template` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 object pools. DB table `pool_template` is empty.");
             LOG_INFO("server.loading", " ");
             return;
         }
@@ -614,7 +614,7 @@ void PoolMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 creatures in  pools. DB table `pool_creature` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 creatures in  pools. DB table `pool_creature` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -672,7 +672,7 @@ void PoolMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 gameobjects in  pools. DB table `pool_gameobject` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 gameobjects in  pools. DB table `pool_gameobject` is empty.");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -742,7 +742,7 @@ void PoolMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 pools in pools");
+            LOG_WARN("server.loading", ">> Loaded 0 pools in pools");
             LOG_INFO("server.loading", " ");
         }
         else
@@ -832,7 +832,7 @@ void PoolMgr::LoadFromDB()
 
         if (!result)
         {
-            LOG_INFO("server.loading", ">> Loaded 0 quests in pools");
+            LOG_WARN("server.loading", ">> Loaded 0 quests in pools");
             LOG_INFO("server.loading", " ");
         }
         else

--- a/src/server/game/Scripting/ScriptSystem.cpp
+++ b/src/server/game/Scripting/ScriptSystem.cpp
@@ -48,7 +48,7 @@ void SystemMgr::LoadScriptWaypoints()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 Script Waypoints. DB table `script_waypoint` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 Script Waypoints. DB table `script_waypoint` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Skills/SkillDiscovery.cpp
+++ b/src/server/game/Skills/SkillDiscovery.cpp
@@ -54,7 +54,7 @@ void LoadSkillDiscoveryTable()
 
     if (!result)
     {
-        LOG_ERROR("sql.sql", ">> Loaded 0 skill discovery definitions. DB table `skill_discovery_template` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 skill discovery definitions. DB table `skill_discovery_template` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Skills/SkillExtraItems.cpp
+++ b/src/server/game/Skills/SkillExtraItems.cpp
@@ -60,7 +60,7 @@ void LoadSkillPerfectItemTable()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell perfection definitions. DB table `skill_perfect_item_template` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell perfection definitions. DB table `skill_perfect_item_template` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -146,7 +146,7 @@ void LoadSkillExtraItemTable()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell specialization definitions. DB table `skill_extra_item_template` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell specialization definitions. DB table `skill_extra_item_template` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -1300,7 +1300,7 @@ void SpellMgr::LoadSpellRanks()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell rank records. DB table `spell_ranks` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell rank records. DB table `spell_ranks` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -1411,7 +1411,7 @@ void SpellMgr::LoadSpellRequired()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell required records. DB table `spell_required` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell required records. DB table `spell_required` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -1528,7 +1528,7 @@ void SpellMgr::LoadSpellTargetPositions()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell target coordinates. DB table `spell_target_position` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell target coordinates. DB table `spell_target_position` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -1632,7 +1632,7 @@ void SpellMgr::LoadSpellGroups()
     QueryResult result = WorldDatabase.Query("SELECT id, spell_id, special_flag FROM spell_group");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell group definitions. DB table `spell_group` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell group definitions. DB table `spell_group` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -1692,7 +1692,7 @@ void SpellMgr::LoadSpellGroupStackRules()
     QueryResult result = WorldDatabase.Query("SELECT group_id, stack_rule FROM spell_group_stack_rules");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell group stack rules. DB table `spell_group_stack_rules` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell group stack rules. DB table `spell_group_stack_rules` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -1743,7 +1743,7 @@ void SpellMgr::LoadSpellProcEvents()
     QueryResult result = WorldDatabase.Query("SELECT entry, SchoolMask, SpellFamilyName, SpellFamilyMask0, SpellFamilyMask1, SpellFamilyMask2, procFlags, procEx, procPhase, ppmRate, CustomChance, Cooldown FROM spell_proc_event");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell proc event conditions. DB table `spell_proc_event` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell proc event conditions. DB table `spell_proc_event` is empty.");
         return;
     }
 
@@ -1837,7 +1837,7 @@ void SpellMgr::LoadSpellProcs()
     QueryResult result = WorldDatabase.Query("SELECT spellId, schoolMask, spellFamilyName, spellFamilyMask0, spellFamilyMask1, spellFamilyMask2, typeMask, spellTypeMask, spellPhaseMask, hitMask, attributesMask, ratePerMinute, chance, cooldown, charges FROM spell_proc");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell proc conditions and data. DB table `spell_proc` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell proc conditions and data. DB table `spell_proc` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -1975,7 +1975,7 @@ void SpellMgr::LoadSpellBonusess()
     QueryResult result = WorldDatabase.Query("SELECT entry, direct_bonus, dot_bonus, ap_bonus, ap_dot_bonus FROM spell_bonus_data");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell bonus data. DB table `spell_bonus_data` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell bonus data. DB table `spell_bonus_data` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2016,7 +2016,7 @@ void SpellMgr::LoadSpellThreats()
     QueryResult result = WorldDatabase.Query("SELECT entry, flatMod, pctMod, apPctMod FROM spell_threat");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 aggro generating spells. DB table `spell_threat` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 aggro generating spells. DB table `spell_threat` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2057,7 +2057,7 @@ void SpellMgr::LoadSpellMixology()
     QueryResult result = WorldDatabase.Query("SELECT entry, pctMod FROM spell_mixology");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 mixology bonuses. DB table `spell_mixology` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 mixology bonuses. DB table `spell_mixology` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2115,7 +2115,7 @@ void SpellMgr::LoadSpellPetAuras()
     QueryResult result = WorldDatabase.Query("SELECT spell, effectId, pet, aura FROM spell_pet_auras");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell pet auras. DB table `spell_pet_auras` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell pet auras. DB table `spell_pet_auras` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2219,7 +2219,7 @@ void SpellMgr::LoadSpellEnchantProcData()
     QueryResult result = WorldDatabase.Query("SELECT entry, customChance, PPMChance, procEx FROM spell_enchant_proc_data");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell enchant proc event conditions. DB table `spell_enchant_proc_data` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell enchant proc event conditions. DB table `spell_enchant_proc_data` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2263,7 +2263,7 @@ void SpellMgr::LoadSpellLinked()
     QueryResult result = WorldDatabase.Query("SELECT spell_trigger, spell_effect, type FROM spell_linked_spell");
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 linked spells. DB table `spell_linked_spell` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 linked spells. DB table `spell_linked_spell` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2505,7 +2505,7 @@ void SpellMgr::LoadSpellAreas()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell area requirements. DB table `spell_area` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell area requirements. DB table `spell_area` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -2776,7 +2776,7 @@ void SpellMgr::LoadSpellInfoCustomAttributes()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 spell custom attributes from DB. DB table `spell_custom_attr` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 spell custom attributes from DB. DB table `spell_custom_attr` is empty.");
     }
     else
     {

--- a/src/server/game/Texts/CreatureTextMgr.cpp
+++ b/src/server/game/Texts/CreatureTextMgr.cpp
@@ -91,7 +91,7 @@ void CreatureTextMgr::LoadCreatureTexts()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 ceature texts. DB table `creature_texts` is empty.");
+        LOG_WARN("server.loading", ">> Loaded 0 ceature texts. DB table `creature_texts` is empty.");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Tickets/TicketMgr.cpp
+++ b/src/server/game/Tickets/TicketMgr.cpp
@@ -313,7 +313,7 @@ void TicketMgr::LoadTickets()
     PreparedQueryResult result = CharacterDatabase.Query(stmt);
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 GM tickets. DB table `gm_ticket` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 GM tickets. DB table `gm_ticket` is empty!");
 
         return;
     }

--- a/src/server/game/Warden/WardenCheckMgr.cpp
+++ b/src/server/game/Warden/WardenCheckMgr.cpp
@@ -50,7 +50,7 @@ void WardenCheckMgr::LoadWardenChecks()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 Warden checks. DB table `warden_checks` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 Warden checks. DB table `warden_checks` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }
@@ -176,7 +176,7 @@ void WardenCheckMgr::LoadWardenOverrides()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 Warden action overrides. DB table `warden_action` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 Warden action overrides. DB table `warden_action` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }

--- a/src/server/game/Weather/WeatherMgr.cpp
+++ b/src/server/game/Weather/WeatherMgr.cpp
@@ -96,7 +96,7 @@ namespace WeatherMgr
 
         if (!result)
         {
-            LOG_ERROR("sql.sql", ">> Loaded 0 weather definitions. DB table `game_weather` is empty.");
+            LOG_WARN("server.loading", ">> Loaded 0 weather definitions. DB table `game_weather` is empty.");
             LOG_INFO("server.loading", " ");
             return;
         }

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -2196,7 +2196,7 @@ void World::LoadAutobroadcasts()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 autobroadcasts definitions. DB table `autobroadcast` is empty for this realm!");
+        LOG_WARN("server.loading", ">> Loaded 0 autobroadcasts definitions. DB table `autobroadcast` is empty for this realm!");
         return;
     }
 
@@ -3319,7 +3319,7 @@ void World::LoadWorldStates()
 
     if (!result)
     {
-        LOG_INFO("server.loading", ">> Loaded 0 world states. DB table `worldstates` is empty!");
+        LOG_WARN("server.loading", ">> Loaded 0 world states. DB table `worldstates` is empty!");
         LOG_INFO("server.loading", " ");
         return;
     }


### PR DESCRIPTION
…to be more visible at server startup

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  `LOG_ERROR("server.loading", ">> Loaded 0` , `LOG_INFO("server.loading", ">> Loaded 0` and `LOG_ERROR("sql.sql", ">> Loaded 0` changed to `LOG_WARN("server.loading", ">> Loaded 0`
-  Now all of them correctly handles by logger config

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
![изображение](https://user-images.githubusercontent.com/25766571/157744074-18b1551b-c1ad-4707-881b-b59f8c0ebc90.png)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Watch to server console on server start. All Warnings must be brown and logged according to your logger config

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
