### PR TITLE
feat(Core/Script): Spirit towers reset to neutral 6 hours after capture and save WorldState

### DIFF
--- a/src/server/scripts/OutdoorPvP/OutdoorPvPTF.cpp
+++ b/src/server/scripts/OutdoorPvP/OutdoorPvPTF.cpp
@@ -20,17 +20,18 @@
 #include "MapMgr.h"
 #include "ObjectMgr.h"
 #include "OutdoorPvP.h"
-#include "OutdoorPvPMgr.h"
 #include "Player.h"
 #include "ScriptMgr.h"
 #include "World.h"
 #include "WorldPacket.h"
+#include "GameTime.h"
 
 OutdoorPvPTF::OutdoorPvPTF()
 {
     m_TypeId = OUTDOOR_PVP_TF;
 
     m_IsLocked = false;
+    m_JustLocked = false;
     m_LockTimer = TF_LOCK_TIME;
     m_LockTimerUpdate = 0;
 
@@ -105,6 +106,71 @@ void OutdoorPvPTF::SendRemoveWorldStates(Player* player)
     }
 }
 
+void OutdoorPvPTF::SaveRequiredWorldStates() const
+{
+    sWorld->setWorldState(TF_UI_TOWER_COUNT_H, m_HordeTowersControlled);
+    sWorld->setWorldState(TF_UI_TOWER_COUNT_A, m_AllianceTowersControlled);
+
+    sWorld->setWorldState(TF_UI_TOWERS_CONTROLLED_DISPLAY, m_IsLocked);
+
+    // Save expiry as unix
+    uint32 const lockExpireTime = GameTime::GetGameTime().count() + (m_LockTimer / IN_MILLISECONDS);
+    sWorld->setWorldState(TF_UI_LOCKED_TIME_HOURS, lockExpireTime);
+}
+
+void OutdoorPvPTF::ResetZoneToTeamControlled(TeamId team)
+{
+    switch (team)
+    {
+    case TEAM_HORDE:
+        m_HordeTowersControlled = TF_TOWER_NUM;
+        m_AllianceTowersControlled = 0;
+        break;
+    case TEAM_ALLIANCE:
+        m_HordeTowersControlled = 0;
+        m_AllianceTowersControlled = TF_TOWER_NUM;
+        break;
+    case TEAM_NEUTRAL:
+        m_HordeTowersControlled = 0;
+        m_AllianceTowersControlled = 0;
+        break;
+    }
+
+    for (auto& [guid, tower] : m_capturePoints)
+    {
+        dynamic_cast<OPvPCapturePointTF*>(tower)->ResetToTeamControlled(team);
+    }
+
+    SendUpdateWorldState(TF_UI_TOWER_COUNT_H, m_HordeTowersControlled);
+    SendUpdateWorldState(TF_UI_TOWER_COUNT_A, m_AllianceTowersControlled);
+}
+
+void OPvPCapturePointTF::ResetToTeamControlled(TeamId team)
+{
+    switch (team)
+    {
+    case TEAM_HORDE:
+        m_State = OBJECTIVESTATE_HORDE;
+        m_OldState = OBJECTIVESTATE_HORDE;
+        m_team = TEAM_HORDE;
+        break;
+    case TEAM_ALLIANCE:
+        m_State = OBJECTIVESTATE_ALLIANCE;
+        m_OldState = OBJECTIVESTATE_ALLIANCE;
+        m_team = TEAM_ALLIANCE;
+        break;
+    case TEAM_NEUTRAL:
+        m_State = OBJECTIVESTATE_NEUTRAL;
+        m_OldState = OBJECTIVESTATE_NEUTRAL;
+        m_team = TEAM_NEUTRAL;
+        break;
+    }
+
+    m_value = 0.0f;
+    ChangeState();
+    SendChangePhase();
+}
+
 void OPvPCapturePointTF::UpdateTowerState()
 {
     m_PvP->SendUpdateWorldState(uint32(TFTowerWorldStates[m_TowerType].n), uint32(bool(m_TowerState & TF_TOWERSTATE_N)));
@@ -141,6 +207,7 @@ bool OutdoorPvPTF::Update(uint32 diff)
         {
             TeamApplyBuff(TEAM_ALLIANCE, TF_CAPTURE_BUFF);
             m_IsLocked = true;
+            m_JustLocked = true;
             SendUpdateWorldState(TF_UI_LOCKED_DISPLAY_NEUTRAL, uint32(0));
             SendUpdateWorldState(TF_UI_LOCKED_DISPLAY_HORDE, uint32(0));
             SendUpdateWorldState(TF_UI_LOCKED_DISPLAY_ALLIANCE, uint32(1));
@@ -150,6 +217,7 @@ bool OutdoorPvPTF::Update(uint32 diff)
         {
             TeamApplyBuff(TEAM_HORDE, TF_CAPTURE_BUFF);
             m_IsLocked = true;
+            m_JustLocked = true;
             SendUpdateWorldState(TF_UI_LOCKED_DISPLAY_NEUTRAL, uint32(0));
             SendUpdateWorldState(TF_UI_LOCKED_DISPLAY_HORDE, uint32(1));
             SendUpdateWorldState(TF_UI_LOCKED_DISPLAY_ALLIANCE, uint32(0));
@@ -160,17 +228,29 @@ bool OutdoorPvPTF::Update(uint32 diff)
             TeamCastSpell(TEAM_ALLIANCE, -TF_CAPTURE_BUFF);
             TeamCastSpell(TEAM_HORDE, -TF_CAPTURE_BUFF);
         }
+
         SendUpdateWorldState(TF_UI_TOWER_COUNT_A, m_AllianceTowersControlled);
         SendUpdateWorldState(TF_UI_TOWER_COUNT_H, m_HordeTowersControlled);
     }
+
     if (m_IsLocked)
     {
+        if (m_JustLocked)
+        {
+            m_JustLocked = false;
+            SaveRequiredWorldStates();
+        }
+
         // lock timer is down, release lock
         if (m_LockTimer < diff)
         {
             m_LockTimer = TF_LOCK_TIME;
             m_LockTimerUpdate = 0;
             m_IsLocked = false;
+
+            ResetZoneToTeamControlled(TEAM_NEUTRAL);
+            SaveRequiredWorldStates();
+
             SendUpdateWorldState(TF_UI_TOWERS_CONTROLLED_DISPLAY, uint32(1));
             SendUpdateWorldState(TF_UI_LOCKED_DISPLAY_NEUTRAL, uint32(0));
             SendUpdateWorldState(TF_UI_LOCKED_DISPLAY_HORDE, uint32(0));
@@ -182,20 +262,21 @@ bool OutdoorPvPTF::Update(uint32 diff)
             if (m_LockTimerUpdate < diff)
             {
                 m_LockTimerUpdate = TF_LOCK_TIME_UPDATE;
-                uint32 minutes_left = m_LockTimer / 60000;
-                hours_left = minutes_left / 60;
-                minutes_left -= hours_left * 60;
-                second_digit = minutes_left % 10;
-                first_digit = minutes_left / 10;
+                RecalculateClientUILockTime();
 
                 SendUpdateWorldState(TF_UI_LOCKED_TIME_MINUTES_FIRST_DIGIT, first_digit);
                 SendUpdateWorldState(TF_UI_LOCKED_TIME_MINUTES_SECOND_DIGIT, second_digit);
                 SendUpdateWorldState(TF_UI_LOCKED_TIME_HOURS, hours_left);
             }
-            else m_LockTimerUpdate -= diff;
+            else
+            {
+                m_LockTimerUpdate -= diff;
+            }
+
             m_LockTimer -= diff;
         }
     }
+
     return changed;
 }
 
@@ -251,7 +332,8 @@ bool OutdoorPvPTF::SetupOutdoorPvP()
     m_AllianceTowersControlled = 0;
     m_HordeTowersControlled = 0;
 
-    m_IsLocked = false;
+    m_IsLocked = bool(sWorld->getWorldState(TF_UI_TOWERS_CONTROLLED_DISPLAY));
+    m_JustLocked = false;
     m_LockTimer = TF_LOCK_TIME;
     m_LockTimerUpdate = 0;
     hours_left = 6;
@@ -269,6 +351,30 @@ bool OutdoorPvPTF::SetupOutdoorPvP()
     AddCapturePoint(new OPvPCapturePointTF(this, TF_TOWER_NE));
     AddCapturePoint(new OPvPCapturePointTF(this, TF_TOWER_SE));
     AddCapturePoint(new OPvPCapturePointTF(this, TF_TOWER_S));
+
+    if (m_IsLocked)
+    {
+        // Core shutdown while locked -- init from latest known data in WorldState
+        // Convert from unix
+        int32 const lockRemainingTime = int32((sWorld->getWorldState(TF_UI_LOCKED_TIME_HOURS) - GameTime::GetGameTime().count()) * IN_MILLISECONDS);
+        if (lockRemainingTime > 0)
+        {
+            m_LockTimer = lockRemainingTime;
+            RecalculateClientUILockTime();
+
+            uint32 const hordeTowers = uint32(sWorld->getWorldState(TF_UI_TOWER_COUNT_H));
+            uint32 const allianceTowers = uint32(sWorld->getWorldState(TF_UI_TOWER_COUNT_A));
+            TeamId const controllingTeam = hordeTowers > allianceTowers ? TEAM_HORDE : TEAM_ALLIANCE;
+
+            ResetZoneToTeamControlled(controllingTeam);
+        }
+        else
+        {
+            // Lock expired while core was offline
+            m_IsLocked = false;
+            SaveRequiredWorldStates();
+        }
+    }
 
     return true;
 }

--- a/src/server/scripts/OutdoorPvP/OutdoorPvPTF.h
+++ b/src/server/scripts/OutdoorPvP/OutdoorPvPTF.h
@@ -32,10 +32,10 @@ const uint32 OutdoorPvPTFBuffZones[OutdoorPvPTFBuffZonesNum] =
 };
 
 // locked for 6 hours after capture
-const uint32 TF_LOCK_TIME = 3600 * 6 * 1000;
+const uint32 TF_LOCK_TIME = 6 * HOUR * IN_MILLISECONDS;
 
 // update lock timer every 1/4 minute (overkill, but this way it's sure the timer won't "jump" 2 minutes at once.)
-const uint32 TF_LOCK_TIME_UPDATE = 15000;
+const uint32 TF_LOCK_TIME_UPDATE = 15 * IN_MILLISECONDS;
 
 // blessing of auchindoun
 #define TF_CAPTURE_BUFF 33377
@@ -138,6 +138,8 @@ public:
     bool HandlePlayerEnter(Player* player) override;
     void HandlePlayerLeave(Player* player) override;
 
+    void ResetToTeamControlled(TeamId team);
+
     void UpdateTowerState();
 
 protected:
@@ -162,6 +164,19 @@ public:
 
     void SendRemoveWorldStates(Player* player) override;
 
+    void SaveRequiredWorldStates() const;
+
+    void ResetZoneToTeamControlled(TeamId team);
+
+    void RecalculateClientUILockTime()
+    {
+        uint32 minutes_left = m_LockTimer / 60000;
+        hours_left = minutes_left / 60;
+        minutes_left -= hours_left * 60;
+        second_digit = minutes_left % 10;
+        first_digit = minutes_left / 10;
+    }
+
     uint32 GetAllianceTowersControlled() const;
     void SetAllianceTowersControlled(uint32 count);
 
@@ -172,6 +187,7 @@ public:
 
 private:
     bool m_IsLocked;
+    bool m_JustLocked;
     uint32 m_LockTimer;
     uint32 m_LockTimerUpdate;
 


### PR DESCRIPTION
## Changes Proposed:
-  After all 5 towers have been captured and the 6 hour lockout has passed all towers will reset back to neutral
-  WorldState is used to reinitialize capture state incase of a core crash / shutdown (Saving once all 5 towers have been captured)

## Issues Addressed:
- Closes #10548

## SOURCE:
https://wowpedia.fandom.com/wiki/Spirit_Tower

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Captured all 5 towers, restarted server to observe state reinit from DB
- Waited 10 minutes and restarted to test save timer
- Manually changed timer value in WorldState DB to test case where the lockout expired while core was offline

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.tele TheBoneWastes`
2. Capture all 5 towers
3. Restart core (timer will start at 6:00 and all towers should still be controlled by your faction)
4. Wait 10 minutes and restart core (timer will start at 5:50 and all towers should still be controlled by your faction)

This PR utilizes the `worldstates` table in `acore_characters` for persistence.
`SELECT * FROM worldstates WHERE entry IN (2622, 2621, 2620, 2509)`
2622 - Num of Horde towers captured
2621 - Num of Alliance towers captured
2620 - If the event is in the locked state (all towers captured by a faction)
2509 - Lock expiry in unix time

These can be manually changed to speed up testing (eg. don't have to wait 6 hours for the lockout) though a core restart is required to take effect.
State is saved when:
- All 5 towers have been captured.
- The lockout has ended

## For Reviewers:
Some WorldState entries used for DB saving are not the same values that are sent to the client:
`TF_UI_TOWERS_CONTROLLED_DISPLAY` is inverted
`TF_UI_LOCKED_TIME_HOURS` stores the full unix expiry time instead of just the number of hours

I chose to use these as nothing else used them and didn't seem necessary to create custom ones (plus they're used in similar ways). Let me know if this should be handled another way.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
