### PR TITLE
fix(DB/Spells): Rogue Armor Energize proc chance

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1647426130709105800.sql
+++ b/data/sql/updates/pending_db_world/rev_1647426130709105800.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1647426130709105800');
+
+UPDATE `spell_proc_event` SET `ppmRate` = 1 WHERE `entry` = 27787;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  ppmRate should be 1 instead of 3, according to the sources.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/2901
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10448

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Equip 4 pieces of Shadowcraft or Darkmantle armor set.
2. Attack anything and wait for it to proc.

