### PR TITLE
fix(Core/BattlegroundQueue): remove second queue if player enter bg

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -632,6 +632,15 @@ void BattlegroundMgr::SendToBattleground(Player* player, uint32 instanceId, Batt
 
         LOG_DEBUG("bg.battleground", "BattlegroundMgr::SendToBattleground: Sending {} to map {}, {} (bgType {})", player->GetName(), mapid, pos->ToString(), bgTypeId);
         player->TeleportTo(mapid, pos->GetPositionX(), pos->GetPositionY(), pos->GetPositionZ(), pos->GetOrientation());
+
+        for (uint8 i = 0; i < PLAYER_MAX_BATTLEGROUND_QUEUES; ++i)
+        {
+            if (BattlegroundQueueTypeId bgQueueTypeId = player->GetBattlegroundQueueTypeId(i))
+            {
+                player->RemoveBattlegroundQueueId(bgQueueTypeId);
+                sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId).RemovePlayer(player->GetGUID(), true);
+            }
+        }
     }
     else
     {


### PR DESCRIPTION
## Changes Proposed:
-  

## Issues Addressed:
- Closes #11055

## Tests Performed:
- Locally

## How to Test the Changes:
From #11055
```
Join the queue of two bg
enter the bg and observe the battlefield queue.
If the bg is opened, "join the bg" will be displayed again
```

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
