### PR TITLE
fix (db) smartscript error fix Acherus Necromancer

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1647989885861421023.sql
+++ b/data/sql/updates/pending_db_world/rev_1647989885861421023.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1647989885861421023');
+
+DELETE FROM `smart_scripts` WHERE `entryorguid`=12939100 AND `source_type`=9 AND `id`=11 AND `link`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(12939100, 9, 11, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 1, 0, 5000, 0, 0, 0, 0, 19, 28391, 0, 0, 0, 0, 0, 0, 0, 'Acherus Necromancer - On Script - Say Line 0');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
![image](https://user-images.githubusercontent.com/16887899/159590352-b02026ca-1527-4ae0-8890-0fd4d900d51d.png)

## Changes Proposed:
-  changes from target 26 to 19

SMART_TARGET_CLOSEST_FRIENDLY               = 26,   // maxDist, playerOnly
to
SMART_TARGET_CLOSEST_CREATURE               = 19,   // CreatureEntry(0any), maxDist, dead?

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes Unreported

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds
- Performs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. stay in ebon hold and observe no more error on world screen.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
