### PR TITLE
fix(DB/Creature): Update equipment for Burning Blade NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1647993341915438725.sql
+++ b/data/sql/updates/pending_db_world/rev_1647993341915438725.sql
@@ -1,0 +1,4 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1647993341915438725');
+
+-- Burning Blade npc weapons
+UPDATE `creature` SET `equipment_id` = 1 WHERE `id1` IN (4663,4664,4665,4666,4667);


### PR DESCRIPTION
## Changes Proposed:
-  Set missing equipment.

## Issues Addressed:
- Closes #10850

## SOURCE:
Whyy0416

## Tests Performed:
- Checked in game

## How to Test the Changes:
.go creature 27607 --Burning Blade Augur
.go creature 27631 --Burning Blade Reaver
.go creature 27657 --Burning Blade Adept
.go creature 27697 --Burning Blade Felsworn
.go creature 27741 --Burning Blade Shadowmage maybe this is fine.