### PR TITLE
feat (DB/gossip_menu): add missed Watcher of Norgannon texts

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1648134606612519725.sql
+++ b/data/sql/updates/pending_db_world/rev_1648134606612519725.sql
@@ -1,0 +1,18 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1648134606612519725');
+
+-- watcher_of_norgannon pages
+REPLACE INTO `gossip_menu` (`MenuID`, `TextID`) VALUES
+('1062', '1676'),
+('1063', '1675'),
+('1064', '1677'),
+('1065', '1678');
+
+-- watcher_of_norgannon dialogues
+REPLACE INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`, `BoxBroadcastTextID`, `VerifiedBuild`)
+VALUES 
+('1061', '0', '0', 'What function do you serve?', '4054', '1', '3', '1062', '0', '0', '0', null, '0', '0'),
+('1062', '0', '0', 'What are the Plates of Uldum?', '4056', '1', '3', '1063', '0', '0', '0', null, '0', '0'),
+('1063', '0', '0', 'Where are the Plates of Uldum?', '4057', '1', '3', '1064', '0', '0', '0', null, '0', '0'),
+('1064', '0', '0', 'Excuse me? We\'ve been \"rescheduled for visitation\"? What does that mean?!', '4058', '1', '3', '1065', '0', '0', '0', null, '0', '0'),
+('1065', '0', '0', 'So... what\'s inside Uldum?', '4059', '1', '3', '1066', '0', '0', '0', null, '0', '0'),
+('1066', '0', '0', 'I will return when I have the Plates of Uldum.', '4060', '1', '3', '0', '0', '0', '0', null, '0', '0');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- add missed pages and dialogues 


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] - **We have duplicated gossip_menu_options with those texts: 57000 - 57005. Does them used somewhere?**


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
