### PR TITLE
Fix (core) DK starter zone quest Client Crash

### DIFF
--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -111,6 +111,10 @@ public:
                     break;
                 case EVENT_LAUNCH:
                     {
+                        if (Player* player = me->GetCharmerOrOwnerPlayerOrPlayerItself())
+                        {
+                            player->AddAura(SPELL_EYE_OF_ACHERUS_VISUAL, player);
+                        }
                         me->SetSpeed(MOVE_FLIGHT, 5.0f, true);
 
                         const Position EYE_DESTINATION_1 = { me->GetPositionX() - 40.0f, me->GetPositionY(), me->GetPositionZ() + 10.0f, 0.0f };
@@ -118,6 +122,10 @@ public:
 
                         me->GetMotionMaster()->MovePoint(EYE_POINT_DESTINATION_1, EYE_DESTINATION_1);
                         me->GetMotionMaster()->MovePoint(EYE_POINT_DESTINATION_2, EYE_DESTINATION_2);
+                        if (Player* player = me->GetCharmerOrOwnerPlayerOrPlayerItself())
+                        {
+                            player->RemoveAura(SPELL_EYE_OF_ACHERUS_VISUAL);
+                        }
                         break;
                     }
                 case EVENT_REGAIN_CONTROL:


### PR DESCRIPTION
This fixes the client side crash for the dk starter area while flying as the EYE OF ACHERUS, apparrently if the player lacks the visual spell on his character the client would crash. This is something I just was NOT ABLE to identify in debugger, however, true story also by the way, @TheDdraig made a suggestion while being both exceedly stoned and highly intoxicate in a discord voice session that he came up with the insane nonsensible approach that actually solved the issue 100%.

Co-Authored-By: TheDdraig <62179779+TheDdraig@users.noreply.github.com>

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Adds visual and removes visuals during the event launch case of the Eye of Acherus.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes Unspecified

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds
- Performs

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Do quest dk start quest https://www.wowhead.com/quest=12641/death-comes-from-on-high
2. observe no client side crash.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
