### PR TITLE
fix(DB/Loot): Remove wrongly added ring from Ragnaros loot

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1648255016918528600.sql
+++ b/data/sql/updates/pending_db_world/rev_1648255016918528600.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1648255016918528600');
+
+DELETE FROM `creature_loot_template` WHERE `Entry` = 11502 AND `Item` = 17982;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove from Ragnaros loot, it doesn't belong there.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11129
- Closes https://github.com/chromiecraft/chromiecraft/issues/3235

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran the sql. No need to test really.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Ragnaros and check the ring is not dropping anymore.

