### PR TITLE
fix(Core/BWL): Victor Nefarius encounter not resetting properly

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
@@ -470,6 +470,8 @@ public:
                 me->SetUInt32Value(UNIT_NPC_FLAGS, 0);
                 me->SetStandState(UNIT_STAND_STATE_STAND);
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_NOT_SELECTABLE);
+                // Due to Nefarius despawning himself on Vael, we need to update the guid on instance to prevent unwanted behaviours as encounter not resetting at all.
+                instance->SetGuidData(DATA_LORD_VICTOR_NEFARIUS, me->GetGUID());
             }
         }
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
@@ -357,6 +357,18 @@ public:
             return ObjectGuid::Empty;
         }
 
+        void SetGuidData(uint32 type, ObjectGuid data) override
+        {
+            switch (type)
+            {
+                case DATA_LORD_VICTOR_NEFARIUS:
+                    victorNefariusGUID = data;
+                    break;
+                default:
+                    break;
+            }
+        }
+
         void OnUnitDeath(Unit* unit) override
         {
             switch (unit->GetEntry())


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Update the guid stored on instance for Nefarius when we start the encounter (we only need to this once tbh, but whatever).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes none addressed.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Defeat Vaelastrasz and then go to Victor Nefarius.
2. Start the encounter and wipe with some spawns killed or kill enough adds until he spawns Nefarian.
3. The encounter should reset or you should engage Nefarian properly.


