### PR TITLE
fix(Core/BattlegroundQueue): disable double queue in one bg

### DIFF
--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -216,7 +216,7 @@ void WorldSession::HandleBattlemasterJoinOpcode(WorldPacket& recvData)
         if (!grp || grp->GetLeaderGUID() != _player->GetGUID())
             return;
 
-        grp->DoForAllMembers([bg, &err, bgQueueTypeId, bgQueueTypeIdRandom, bgTypeId](Player* member)
+        grp->DoForAllMembers([&err, bgQueueTypeId, bgQueueTypeIdRandom, bgTypeId](Player* member)
         {
             if (member->InBattlegroundQueueForBattlegroundQueueType(bgQueueTypeIdRandom)) // queued for random bg, so can't queue for anything else
             {

--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -211,46 +211,65 @@ void WorldSession::HandleBattlemasterJoinOpcode(WorldPacket& recvData)
     else
     {
         Group* grp = _player->GetGroup();
+
         // no group or not a leader
         if (!grp || grp->GetLeaderGUID() != _player->GetGUID())
             return;
 
-        if (_player->InBattlegroundQueueForBattlegroundQueueType(bgQueueTypeIdRandom)) // queued for random bg, so can't queue for anything else
-            err = ERR_IN_RANDOM_BG;
-        else if (_player->InBattlegroundQueue() && bgTypeId == BATTLEGROUND_RB) // already in queue, so can't queue for random
-            err = ERR_IN_NON_RANDOM_BG;
-        else if (_player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_2v2) ||
-                 _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_3v3) ||
-                 _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5)) // can't be already queued for arenas
-            err = ERR_BATTLEGROUND_QUEUED_FOR_RATED;
+        grp->DoForAllMembers([bg, &err, bgQueueTypeId, bgQueueTypeIdRandom, bgTypeId](Player* member)
+        {
+            if (member->InBattlegroundQueueForBattlegroundQueueType(bgQueueTypeIdRandom)) // queued for random bg, so can't queue for anything else
+            {
+                err = ERR_IN_RANDOM_BG;
+            }
+            else if (member->InBattlegroundQueue() && bgTypeId == BATTLEGROUND_RB) // already in queue, so can't queue for random
+            {
+                err = ERR_IN_NON_RANDOM_BG;
+            }
+            else if (member->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_2v2) ||
+                member->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_3v3) ||
+                member->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5)) // can't be already queued for arenas
+            {
+                err = ERR_BATTLEGROUND_QUEUED_FOR_RATED;
+            }
+            else if (member->InBattlegroundQueueForBattlegroundQueueType(bgQueueTypeId)) // queued for this bg
+            {
+                err = ERR_BATTLEGROUND_NONE;
+            }
 
-        if (err > 0)
-            err = grp->CanJoinBattlegroundQueue(bg, bgQueueTypeId, 0, bg->GetMaxPlayersPerTeam(), false, 0);
+            if (err < 0)
+            {
+                return;
+            }
+        });
+
+        if (err <= 0)
+        {
+            grp->DoForAllMembers([err](Player* member)
+            {
+                WorldPacket data;
+                sBattlegroundMgr->BuildGroupJoinedBattlegroundPacket(&data, err);
+                member->GetSession()->SendPacket(&data);
+            });
+
+            return;
+        }
+
+        ASSERT(err > 0);
+        err = grp->CanJoinBattlegroundQueue(bg, bgQueueTypeId, 0, bg->GetMaxPlayersPerTeam(), false, 0);
 
         isPremade = (grp->GetMembersCount() >= bg->GetMinPlayersPerTeam() && bgTypeId != BATTLEGROUND_RB);
         uint32 avgWaitTime = 0;
 
-        if (err > 0)
-        {
-            GroupQueueInfo* ginfo = bgQueue.AddGroup(_player, grp, bgTypeId, bracketEntry, 0, false, isPremade, 0, 0);
-            avgWaitTime = bgQueue.GetAverageQueueWaitTime(ginfo);
-        }
+        GroupQueueInfo* ginfo = bgQueue.AddGroup(_player, grp, bgTypeId, bracketEntry, 0, false, isPremade, 0, 0);
+        avgWaitTime = bgQueue.GetAverageQueueWaitTime(ginfo);
 
         grp->DoForAllMembers([bg, err, bgQueueTypeId, avgWaitTime](Player* member)
         {
             WorldPacket data;
 
-            if (err <= 0)
-            {
-                sBattlegroundMgr->BuildGroupJoinedBattlegroundPacket(&data, err);
-                member->GetSession()->SendPacket(&data);
-                return;
-            }
-
-            uint32 queueSlot = member->AddBattlegroundQueueId(bgQueueTypeId);
-
             // send status packet
-            sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_WAIT_QUEUE, avgWaitTime, 0, 0, TEAM_NEUTRAL);
+            sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, member->AddBattlegroundQueueId(bgQueueTypeId), STATUS_WAIT_QUEUE, avgWaitTime, 0, 0, TEAM_NEUTRAL);
             member->GetSession()->SendPacket(&data);
 
             sBattlegroundMgr->BuildGroupJoinedBattlegroundPacket(&data, err);


### PR DESCRIPTION
## Changes Proposed:
-  
-  

## Issues Addressed:
- Closes 

## Tests Performed:
- Locally

## How to Test the Changes:
1. Press the queue button twice with the group
![image](https://user-images.githubusercontent.com/18329778/160261101-b3aa93b6-1d8e-465c-8d94-6409915ab970.png)


## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
