### PR TITLE
fix(DB/SpellProcEvent) Hand of Justice Fix

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1648383353183302321.sql
+++ b/data/sql/updates/pending_db_world/rev_1648383353183302321.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1648383353183302321');
+-- This updates the existing proc to allow trinket to pop on any melee damage including melee spells
+UPDATE `spell_proc_event` SET `SchoolMask`='1' AND `ProcFlags`='20' WHERE `entry`='15600';


### PR DESCRIPTION
## Changes Proposed:
-  Updated existing proc as this already existed in spell_proc_event however all values were set to 0 and only custom chance was showing at 2%, this way should be avoided as this table overwrites the proc values in dbc table, aka taking prio over them.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #9423
- Closes https://github.com/chromiecraft/chromiecraft/issues/2433

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- Already reported and should proc on any melee hit, this should include any melee spell damage, but it only procs on auto attack as mentioned in the reported issue

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Performed
- Build

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Do .additem 11815 and equip the trinket.
2. I suggest you update the chance to 100% purely for testing, atm its set to 2% `UPDATE `spell_proc_event` SET `CustomChance='100' WHERE `entry`='15600'; in order to check if Crusader Strike from Paladin procs it, or Windfury, Lava Lash from Shamans