### PR TITLE
fix(DB/Spells): Prince Taldaram's Conjure Flame should proc off from …

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1648400638105454700.sql
+++ b/data/sql/updates/pending_db_world/rev_1648400638105454700.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1648400638105454700');
+
+DELETE FROM `spell_proc_event` WHERE `entry`=71756;
+INSERT INTO `spell_proc_event` (`entry`, `procEx`, `procPhase`) VALUES
+(71756,1027,2);


### PR DESCRIPTION
…absorbed damage.

Fixes #1569

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #1569

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Go inside icc , u will need at leat 5 -6 players
start the fight the Princes , wait until taldaram casts his Conjure Flame
See that when the player that is targetted and run away, the players that are positioned beteween the sphere and player does reduce the size and the final damage of the sphere if some or all of them are shielded , they will take damage and the sphere will count them as if they've take damage from it.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
