### PR TITLE
fix(DB): Stitches Event Fix

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1648521257247923500.sql
+++ b/data/sql/updates/pending_db_world/rev_1648521257247923500.sql
@@ -1,0 +1,38 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1648521257247923500');
+
+-- Watcher Cutford
+DELETE FROM `waypoints` WHERE `entry` = 1436 AND `pointid` in (3,4,5,6,7,8,9,10,11,12,61);
+INSERT INTO `waypoints` (`entry`,`pointid`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`point_comment`) VALUES
+(1436,3,-10558.387,-1141.187,30.069,0,0,'Watcher Cutford'),
+(1436,4,-10559.6,-1132.51,30.067,0,0,'Watcher Cutford'),
+(1436,5,-10564.762,-1124.821,30.068,0,0,'Watcher Cutford'),
+(1436,6,-10574.529,-1125.063,29.168,0,0,'Watcher Cutford'),
+(1436,7,-10575.464,-1121.384,30.069,0,0,'Watcher Cutford'),
+(1436,8,-10575.654,-1107.854,30.07,0,0,'Watcher Cutford'),
+(1436,9,-10558.476,-1105.974,30.07,0,0,'Watcher Cutford'),
+(1436,10,-10555.148,-1105.574,31.429,0,0,'Watcher Cutford'),
+(1436,11,-10553.534,-1105.48,31.429,0,0,'Watcher Cutford'),
+(1436,12,-10552.769,-1106.959,31.429,0,0,'Watcher Cutford'),
+(1436,61,-10930.378,-386.031,40.059,1.0014,1000,'Watcher Cutford');
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 1436 AND `source_type` = 0 and `id` = 9;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(1436,0,9,0,40,0,100,0,61,1436,0,0,0,66,0,0,0,0,0,0,8,0,0,0,0,0,0,0,1.0014,'Watcher Cutford - On Waypoint 61 Reached - Set Orientation');
+
+-- Stitches
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 412 AND `source_type` = 0  and `id` in (2,3,17,44,45,46);
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(412,0,2,46,61,0,100,0,0,0,0,0,0,62,0,0,0,0,0,0,1,0,0,0,0,-10290.2,72.7811,38.8811,4.8015,'Stitches - On Respawn - Teleport'),
+(412,0,3,0,1,1,100,1,5000,5000,0,0,0,53,1,412,0,0,0,2,1,0,0,0,0,0,0,0,0,'Stitches - OOC (No Repeat) - Start Waypoint (Phase 1)'),  -- Bug workaround using phasing.  
+(412,0,17,44,40,0,100,0,91,412,0,0,0,55,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stitches - On Waypoint 91 Reached - Stop Waypoint'),
+(412,0,44,45,61,0,100,0,0,0,0,0,0,89,5,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stitches - Linked - Start Random Movement'),
+(412,0,45,0,61,0,100,0,0,0,0,0,0,22,2,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stitches - Linked - Event Phase 2'),
+(412,0,46,0,61,0,100,0,0,0,0,0,0,22,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Stitches - Linked - Event Phase 1');
+
+DELETE FROM `waypoints` WHERE `entry` = 412 AND `pointid` in (90,91);
+INSERT INTO `waypoints` (`entry`,`pointid`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`point_comment`) VALUES
+(412,90,-10553.888,-1185.983,27.936,0,0,'Stitches Event'),
+(412,91,-10563.188,-1177.061,28.084,4.9437,0,'Stitches Event'); -- Better end event location in front of fountain where he waits/patrols for event to end.
+
+-- Watcher Corwin and Sarys
+UPDATE creature SET `spawntimesecs` = 1200 WHERE `guid` in (6127,6133); -- Once these two die we don't need to see them again until the next Stitches event.


### PR DESCRIPTION
Fixes issue of Stitches running back to its waypoint start
- It appears there were a few changes to Azerothcore that modified elements to this event since it was created.
- It also appears that the Smart Script OOC no repeat seems to repeat anyway under specific circumstances.  Fixed this.
- Updated Watcher Cutford's waypoints to be more resilliant to his feet being under the floor as he runs.
- Updated the event spawned watchers (Corwin and Sarys) from respawning during the event after they have been killed. 
- Issue #6685 talked about Watcher Ladimore and Commander Althea Ebonlocke attacking Stitches.  This was dicussed in length on the original PR but was abandoned due to a few youtube sources (one in source section) and the idea that Blizzard had an issue with killing quest hub NPCs.   Althea is a quest hub NPC and Ladimore is a quest ender thus the civilian flag.  My own memory is that stitches didn't go on a killing spree when he came into town he just hung out in town and killed us all when we tried to leave the Inn.  Eventually he despawned.  Maybe when Wrath Classic comes I can get a better look.
- Also remember this event only lasts for 35 minutes from start to end.  At the 35 minute mark the event ends despawning stitches and any NPCs associated with the event.      

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6685

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.youtube.com/watch?v=xl8WHdd2iwE&ab_channel=LSmash
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Turned in quest and watched the event from beginning to end when stitches despawned
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
-- This is the correct way to test the stitches event. 
1. Go to Darkshire
2. .quest remove 252
3. .quest add 252
4. Turn in quest to Lord Ello Ebonlocke
5. Event should start with Watcher Cutford running in a few seconds later.
6. Wait for Stitches to come to town and defeat the three watchers (20 minute wait) and start random movement in the middle of the town.
7.  Wait for the event to end and stitches despawn (without him running off into the sunset to start whole event over. )
8.  Note: Watcher Keefer will respawn once and fight him and die a second time to him.  The bug happened about 5 seconds after that as he would run back to his starting waypoint and start the event over. 
## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
