### PR TITLE
feat(DB/Locale): Update 12718 "frFR"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1648562925756409969.sql
+++ b/data/sql/updates/pending_db_world/rev_1648562925756409969.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1648562925756409969');
+
+DELETE FROM `quest_request_items_locale` WHERE `ID` = 12718 AND `locale` = "frFR" ;
+INSERT INTO `quest_request_items_locale` (`ID`, `locale`, `CompletionText`, `VerifiedBuild`) VALUES
+(12718,"frFR","La mixture toxique bouillonne dans le chaudron de peste, répandant une épaisse fumée aux alentours.$b$bAvez-vous plus de crânes de croisés à y jeter ?",18019);


### PR DESCRIPTION
update 12718 locale frFR entry in quest_request_items_locale table

This translation currently has a NULL value.
It is found within the suggestion that I made a trip PR #10888, which was closed and was to remove all NULL results with translation errors

