### PR TITLE
Core/Object: Fix WorldObject::SetZoneScript unsafe cast to InstanceMap

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2272,8 +2272,8 @@ void WorldObject::SetZoneScript()
 {
     if (Map* map = FindMap())
     {
-        if (map->IsDungeon())
-            m_zoneScript = (ZoneScript*)map->ToInstanceMap()->GetInstanceScript();
+        if (InstanceMap* instanceMap = map->ToInstanceMap())
+            m_zoneScript = reinterpret_cast<ZoneScript*>(instanceMap->GetInstanceScript());
         else if (!map->IsBattlegroundOrArena())
         {
             uint32 zoneId = GetZoneId();


### PR DESCRIPTION
* cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/e9992066a5ccd7f085a56de09ea027240e8da873)

Co-Authored-By: HelloKitty <5829095+HelloKitty@users.noreply.github.com>

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change unsafe casting in WorldObject::SetZoneScript
-  Not seen a case where it causes a crash, but better to prevent a maybe edge case than not :D

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- None

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. When we create a Transport/Gob/CreatureFromProto we set SetZoneScript();
2. It's an edge case so there is no real test case as 99% of the times it would work with the old code.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
