### PR TITLE
 feat(Core/Command): Split respawn command

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1648810356834040900.sql
+++ b/data/sql/updates/pending_db_world/rev_1648810356834040900.sql
@@ -3,4 +3,4 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1648810356834040900');
 DELETE FROM `command` WHERE `name` IN ('respawn', 'respawn all');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('respawn', 2, 'Syntax: .respawn\nRespawn the selected unit without waiting respawn time expiration.'),
-('respawn all', 4, 'Syntax: .respawn all\nRespawn all nearest creatures and GO without waiting respawn time expiration.');
+('respawn all', 2, 'Syntax: .respawn all\nRespawn all nearest creatures and GO without waiting respawn time expiration.');

--- a/data/sql/updates/pending_db_world/rev_1648810356834040900.sql
+++ b/data/sql/updates/pending_db_world/rev_1648810356834040900.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1648810356834040900');
+
+DELETE FROM `command` WHERE `name` IN ('respawn', 'respawn all');
+INSERT INTO `command` (`name`, `security`, `help`) VALUES
+('respawn', 2, 'Syntax: .respawn\nRespawn the selected unit without waiting respawn time expiration.'),
+('respawn all', 4, 'Syntax: .respawn all\nRespawn all nearest creatures and GO without waiting respawn time expiration.');

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -119,6 +119,7 @@ public:
             { "setskill",          HandleSetSkillCommand,          SEC_GAMEMASTER,         Console::No  },
             { "pinfo",             HandlePInfoCommand,             SEC_GAMEMASTER,         Console::Yes },
             { "respawn",           HandleRespawnCommand,           SEC_GAMEMASTER,         Console::No  },
+            { "respawn all",       HandleRespawnAllCommand,        SEC_GAMEMASTER,         Console::No  },
             { "mute",              HandleMuteCommand,              SEC_GAMEMASTER,         Console::Yes },
             { "mutehistory",       HandleMuteInfoCommand,          SEC_GAMEMASTER,         Console::Yes },
             { "unmute",            HandleUnmuteCommand,            SEC_GAMEMASTER,         Console::Yes },
@@ -2333,7 +2334,6 @@ public:
     {
         Player* player = handler->GetSession()->GetPlayer();
 
-        // accept only explicitly selected target (not implicitly self targeting case)
         Unit* target = handler->getSelectedUnit();
         if (player->GetTarget() && target)
         {
@@ -2350,6 +2350,15 @@ public:
             }
             return true;
         }
+
+        handler->SendSysMessage(LANG_SELECT_CREATURE);
+        handler->SetSentErrorMessage(true);
+        return false;
+    }
+
+    static bool HandleRespawnAllCommand(ChatHandler* handler)
+    {
+        Player* player = handler->GetSession()->GetPlayer();
 
         CellCoord p(Acore::ComputeCellCoord(player->GetPositionX(), player->GetPositionY()));
         Cell cell(p);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add a subcommand to respawn command to behave like it does without target right now. Since this command is kinda dangerous, this would prevent respawning the whole grid by mistake.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11209

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Find a creature, kill it and try to respawn it without targeting it.
2. Try targeting and .respawn
3. Without targeting, .respawn all
4. Change the security of the command on DB and try again.

