### PR TITLE
fix(Core/Spells): Razorgore's Explosion ignores LoS.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1648906248199850600.sql
+++ b/data/sql/updates/pending_db_world/rev_1648906248199850600.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1648906248199850600');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry`=20038;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13,1,20038,0,0,31,0,4,0,0,0,0,0,'','Explosion targets players');

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4252,6 +4252,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     ApplySpellFix({ 20038 }, [](SpellInfo* spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_IGNORE_LINE_OF_SIGHT;
     });
 
     for (uint32 i = 0; i < GetSpellInfoStoreSize(); ++i)

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4252,6 +4252,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     ApplySpellFix({ 20038 }, [](SpellInfo* spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);
+        spellInfo->Attributes |= SPELL_ATTR0_NO_IMMUNITIES;
         spellInfo->AttributesEx2 |= SPELL_ATTR2_IGNORE_LINE_OF_SIGHT;
     });
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
@@ -79,7 +79,6 @@ public:
         void Reset() override
         {
             _Reset();
-            _died = false;
             _charmerGUID.Clear();
             secondPhase = false;
             summons.DespawnAll();
@@ -91,6 +90,18 @@ public:
             if (secondPhase)
             {
                 _JustDied();
+            }
+            else
+            {
+                // Respawn shorty in case of failure during phase 1.
+                me->SetCorpseRemoveTime(25);
+                me->SetRespawnTime(30);
+                me->SaveRespawnTime();
+
+                // Might not be required, safe measure.
+                me->SetLootRecipient(nullptr);
+
+                instance->SetData(DATA_EGG_EVENT, FAIL);
             }
         }
 
@@ -191,24 +202,11 @@ public:
 
         void DamageTaken(Unit*, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
-            if (!secondPhase && damage >= me->GetHealth() && !_died)
+            if (!secondPhase && damage >= me->GetHealth())
             {
-                // This is required because he kills himself with the explosion spell, causing a loop.
-                _died = true;
-
                 Talk(SAY_DEATH);
                 DoCastAOE(SPELL_EXPLODE_ORB);
                 DoCastAOE(SPELL_EXPLOSION);
-
-                // Respawn shorty in case of failure during phase 1.
-                me->SetCorpseRemoveTime(25);
-                me->SetRespawnTime(30);
-                me->SaveRespawnTime();
-
-                // Might not be required, safe measure.
-                me->SetLootRecipient(nullptr);
-
-                instance->SetData(DATA_EGG_EVENT, FAIL);
             }
         }
 
@@ -256,7 +254,6 @@ public:
 
     private:
         bool secondPhase;
-        bool _died;
         ObjectGuid _charmerGUID;
         GuidVector _summonGUIDS;
     };


### PR DESCRIPTION
Fixes #11180

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11180

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Hide a player with a columns or an other gameobject
Kill razorgore during the P1/P2

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
