### PR TITLE
fix (db) Harpy Z Axis fix

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1649093998908343415.sql
+++ b/data/sql/updates/pending_db_world/rev_1649093998908343415.sql
@@ -2,5 +2,5 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1649093998908343415');
 
 -- readjust harpy npc from being above ground and not under mesh falling to its death
 DELETE FROM `creature` WHERE `guid`=51729;
-INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES 
-(51729, 5362, 1, 0, 0, 1, 1, 0, 0, -3090.12, 2781.57, 75.6233, 0.575489, 300, 15, 0, 2062, 1695, 1, 0, 0, 0, '', 0);
+INSERT INTO `creature` (`guid`, `id1`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES 
+(51729, 5362, 1, 0, 0, 1, 1, 0, -3090.12, 2781.57, 75.6233, 0.575489, 300, 15, 0, 2062, 1695, 1, 0, 0, 0, '', 0);

--- a/data/sql/updates/pending_db_world/rev_1649093998908343415.sql
+++ b/data/sql/updates/pending_db_world/rev_1649093998908343415.sql
@@ -3,4 +3,4 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1649093998908343415');
 -- readjust harpy npc from being above ground and not under mesh falling to its death
 DELETE FROM `creature` WHERE `guid`=51729;
 INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES 
-(51729, 5362, 1, 0, 0, 1, 1, 0, 0, -3090.12, 2781.57, 73.6233, 0.575489, 300, 15, 0, 2062, 1695, 1, 0, 0, 0, '', 0);
+(51729, 5362, 1, 0, 0, 1, 1, 0, 0, -3090.12, 2781.57, 75.6233, 0.575489, 300, 15, 0, 2062, 1695, 1, 0, 0, 0, '', 0);

--- a/data/sql/updates/pending_db_world/rev_1649093998908343415.sql
+++ b/data/sql/updates/pending_db_world/rev_1649093998908343415.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1649093998908343415');
+
+-- readjust harpy npc from being above ground and not under mesh falling to its death
+DELETE FROM `creature` WHERE `guid`=51729;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES 
+(51729, 5362, 1, 0, 0, 1, 1, 0, 0, -3090.12, 2781.57, 73.6233, 0.575489, 300, 15, 0, 2062, 1695, 1, 0, 0, 0, '', 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Adjust z axis of harpy npc to be above ground and not under which leads it to death
![image](https://user-images.githubusercontent.com/16887899/161603026-6582a811-2136-47f3-8ed6-2edeb17cde83.png)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11282
- Closes https://github.com/chromiecraft/chromiecraft/issues/3292

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds
- Performs

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 51729
2. observe npc is no longer undermeshing

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
