### PR TITLE
fix(Core/BWL): Nefarian spawns

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1649370784577886400.sql
+++ b/data/sql/updates/pending_db_world/rev_1649370784577886400.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1649370784577886400');
+
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 23414 AND `spell_effect` IN (-1856, -1857, -26889);
+INSERT INTO spell_linked_spell (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES
+(23414, -1856, 2, 'Nefarian Rogue class call - Vanish'),
+(23414, -1857, 2, 'Nefarian Rogue class call - Vanish'),
+(23414, -26889, 2, 'Nefarian Rogue class call - Vanish');

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4160,14 +4160,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(152); // 150 yards
     });
 
-    // Shadowbolt Volley
-    ApplySpellFix({ 22665 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(152); // 150 yards
-        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(41); // 150 yards
-        spellInfo->AttributesEx2 |= SPELL_ATTR2_IGNORE_LINE_OF_SIGHT;
-    });
-
     ApplySpellFix({ 22247 }, [](SpellInfo* spellInfo)
     {
         spellInfo->AttributesCu |= SPELL_ATTR0_CU_DONT_BREAK_STEALTH;

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
@@ -284,7 +284,7 @@ public:
 
             if (action == ACTION_KILLED)
             {
-                summons.DespawnAll();
+                summons.DespawnEntry(NPC_BONE_CONSTRUCT);
                 Unit::Kill(me, me);
             }
         }

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
@@ -284,6 +284,7 @@ public:
 
             if (action == ACTION_KILLED)
             {
+                summons.DespawnAll();
                 Unit::Kill(me, me);
             }
         }

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
@@ -256,7 +256,7 @@ public:
 
                 me->SetVisible(true);
                 me->SetPhaseMask(1, true);
-                me->ReplaceAllNpcFlags(NPCFlags(1));
+                me->SetNpcFlag(UNIT_NPC_FLAG_GOSSIP);
                 me->SetFaction(FACTION_FRIENDLY);
                 me->SetStandState(UNIT_STAND_STATE_SIT_HIGH_CHAIR);
                 me->RemoveAura(SPELL_NEFARIANS_BARRIER);
@@ -472,7 +472,7 @@ public:
                 Talk(SAY_GAMESBEGIN_1);
                 events.ScheduleEvent(EVENT_START_EVENT, 4000);
                 me->SetFaction(FACTION_DRAGONFLIGHT_BLACK);
-                me->ReplaceAllNpcFlags(UNIT_NPC_FLAG_NONE);
+                me->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
                 me->SetStandState(UNIT_STAND_STATE_STAND);
                 me->SetUnitFlag(UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_NOT_SELECTABLE);
                 // Due to Nefarius despawning himself on Vael, we need to update the guid on instance to prevent unwanted behaviours as encounter not resetting at all.

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
@@ -400,6 +400,7 @@ public:
                         summon->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
                         summon->SetReactState(REACT_PASSIVE);
                         summon->SetStandState(UNIT_STAND_STATE_DEAD);
+                        summon->SetHomePosition(summon->GetPosition());
 
                         if (Creature* nefarius = instance->GetCreature(victorNefariusGUID))
                         {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Nefarian spawns from third phase should now spawn on their death's position.
-  Removed Shadowbolt Volley changes from a previous PR of mine, it seems its behavior was correct after all.
-  Rogue class call should not be removed by using Vanish.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11299

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to BWL and engage Nefarian with a Rogue.
2. Check skeletons position and Nefarius volley.
3. Try to vanish rogue call.


