### PR TITLE
fix(Core/Spells): Send proper caster's guid in SMSG_SPELL_START/SMSG_…

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4495,13 +4495,25 @@ void Spell::SendSpellStart()
     if (m_spellInfo->RuneCostID && m_spellInfo->PowerType == POWER_RUNE)
         castFlags |= CAST_FLAG_NO_GCD; // not needed, but Blizzard sends it
 
+    PackedGuid realCasterGUID = m_caster->GetPackGUID();
+    if (TempSummon const* tempSummon = m_caster->ToTempSummon())
+    {
+        if (tempSummon->GetEntry() == WORLD_TRIGGER)
+        {
+            if (GameObject* casterGameobject = tempSummon->GetSummonerGameObject())
+            {
+                realCasterGUID = casterGameobject->GetPackGUID();
+            }
+        }
+    }
+
     WorldPacket data(SMSG_SPELL_START, (8 + 8 + 4 + 4 + 2));
     if (m_CastItem)
         data << m_CastItem->GetPackGUID();
     else
-        data << m_caster->GetPackGUID();
+        data << realCasterGUID;
 
-    data << m_caster->GetPackGUID();
+    data << realCasterGUID;
     data << uint8(m_cast_count);                            // pending spell cast?
     data << uint32(m_spellInfo->Id);                        // spellId
     data << uint32(castFlags);                              // cast flags
@@ -4581,14 +4593,26 @@ void Spell::SendSpellGo()
     if (!m_spellInfo->StartRecoveryTime)
         castFlags |= CAST_FLAG_NO_GCD;
 
+    PackedGuid realCasterGUID = m_caster->GetPackGUID();
+    if (TempSummon const* tempSummon = m_caster->ToTempSummon())
+    {
+        if (tempSummon->GetEntry() == WORLD_TRIGGER)
+        {
+            if (GameObject* casterGameobject = tempSummon->GetSummonerGameObject())
+            {
+                realCasterGUID = casterGameobject->GetPackGUID();
+            }
+        }
+    }
+
     WorldPacket data(SMSG_SPELL_GO, 150);                    // guess size
 
     if (m_CastItem)
         data << m_CastItem->GetPackGUID();
     else
-        data << m_caster->GetPackGUID();
+        data << realCasterGUID;
 
-    data << m_caster->GetPackGUID();
+    data << realCasterGUID;
     data << uint8(m_cast_count);                            // pending spell cast?
     data << uint32(m_spellInfo->Id);                        // spellId
     data << uint32(castFlags);                              // cast flags

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
@@ -23,48 +23,49 @@
 
 enum Say
 {
-    SAY_EGGS_BROKEN1        = 0,
-    SAY_EGGS_BROKEN2        = 1,
-    SAY_EGGS_BROKEN3        = 2,
-    SAY_DEATH               = 3,
+    SAY_EGGS_BROKEN1            = 0,
+    SAY_EGGS_BROKEN2            = 1,
+    SAY_EGGS_BROKEN3            = 2,
+    SAY_DEATH                   = 3,
 
-    EMOTE_TROOPS_RETREAT    = 0
+    EMOTE_TROOPS_RETREAT        = 0
 };
 
 enum Spells
 {
-    SPELL_MINDCONTROL       = 19832,
-    SPELL_EGG_DESTROY       = 19873,
-    SPELL_MIND_EXHAUSTION   = 23958,
+    SPELL_MINDCONTROL           = 19832,
+    SPELL_MINDCONTROL_VISUAL    = 45537,
+    SPELL_EGG_DESTROY           = 19873,
+    SPELL_MIND_EXHAUSTION       = 23958,
 
-    SPELL_CLEAVE            = 19632,
-    SPELL_WARSTOMP          = 24375,
-    SPELL_FIREBALLVOLLEY    = 22425,
-    SPELL_CONFLAGRATION     = 23023,
+    SPELL_CLEAVE                = 19632,
+    SPELL_WARSTOMP              = 24375,
+    SPELL_FIREBALLVOLLEY        = 22425,
+    SPELL_CONFLAGRATION         = 23023,
 
-    SPELL_EXPLODE_ORB       = 20037,
-    SPELL_EXPLOSION         = 20038, // Instakill everything.
+    SPELL_EXPLODE_ORB           = 20037,
+    SPELL_EXPLOSION             = 20038, // Instakill everything.
 
-    SPELL_WARMING_FLAMES    = 23040,
+    SPELL_WARMING_FLAMES        = 23040,
 };
 
 enum Summons
 {
-    NPC_ELITE_DRACHKIN      = 12422,
-    NPC_ELITE_WARRIOR       = 12458,
-    NPC_WARRIOR             = 12416,
-    NPC_MAGE                = 12420,
-    NPC_WARLOCK             = 12459,
+    NPC_ELITE_DRACHKIN          = 12422,
+    NPC_ELITE_WARRIOR           = 12458,
+    NPC_WARRIOR                 = 12416,
+    NPC_MAGE                    = 12420,
+    NPC_WARLOCK                 = 12459,
 
-    GO_EGG                  = 177807
+    GO_EGG                      = 177807
 };
 
 enum EVENTS
 {
-    EVENT_CLEAVE            = 1,
-    EVENT_STOMP             = 2,
-    EVENT_FIREBALL          = 3,
-    EVENT_CONFLAGRATION     = 4
+    EVENT_CLEAVE                = 1,
+    EVENT_STOMP                 = 2,
+    EVENT_FIREBALL              = 3,
+    EVENT_CONFLAGRATION         = 4
 };
 
 class boss_razorgore : public CreatureScript
@@ -161,12 +162,14 @@ public:
                 if (Unit* charmer = ObjectAccessor::GetUnit(*me, _charmerGUID))
                 {
                     charmer->CastSpell(charmer, SPELL_MIND_EXHAUSTION, true);
+                    charmer->CastSpell(me, SPELL_MINDCONTROL_VISUAL, false);
                 }
             }
             else
             {
                 if (Unit* charmer = ObjectAccessor::GetUnit(*me, _charmerGUID))
                 {
+                    charmer->RemoveAurasDueToSpell(SPELL_MINDCONTROL_VISUAL);
                     me->TauntApply(charmer);
                 }
             }


### PR DESCRIPTION
…SPELL_GO packets in case of spells casted originally by gameobjects.

Added visual channeling when mind controlling Razorgore by player.
Fixes #11275

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11275

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Take the control of razorgore with orb
Go to the suppression room

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
