### PR TITLE
fix(DB/gossip_menu): wrong TextId for NPC's

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1649549626279664100.sql
+++ b/data/sql/updates/pending_db_world/rev_1649549626279664100.sql
@@ -1,6 +1,11 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1649549626279664100');
 
 -- Gryan Stoutmantle gossip
-UPDATE `gossip_menu` SET `TextID` = 50020 WHERE `MenuID` = 57024;
--- Farmer_Furlbrow gossip
-UPDATE `gossip_menu` SET `TextID` = 50019 WHERE `MenuID` = 57023;
+DELETE FROM `gossip_menu` WHERE `MenuID` = 61029;
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES (61029, 50020);
+UPDATE `creature_template` SET `gossip_menu_id` = 61029 WHERE `entry` = 234;
+
+-- Farmer_Furlbrow
+DELETE FROM `gossip_menu` WHERE `MenuID` = 61030;
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES (61030, 50019);
+UPDATE `creature_template` SET `gossip_menu_id` = 61030 WHERE `entry` = 237;

--- a/data/sql/updates/pending_db_world/rev_1649549626279664100.sql
+++ b/data/sql/updates/pending_db_world/rev_1649549626279664100.sql
@@ -1,0 +1,6 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1649549626279664100');
+
+-- Gryan Stoutmantle gossip
+UPDATE `gossip_menu` SET `TextID` = 50020 WHERE `MenuID` = 57024;
+-- Farmer_Furlbrow gossip
+UPDATE `gossip_menu` SET `TextID` = 50019 WHERE `MenuID` = 57023;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Proper gossip text for Farmer Furlbrow & Gryan Stoutmantle

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11307 
- Closes [#3263](https://github.com/chromiecraft/chromiecraft/issues/3263)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowpedia.fandom.com/wiki/Farmer_Furlbrow
https://wowpedia.fandom.com/wiki/Gryan_Stoutmantle

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Checked gossips is correct


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go c id 237`,  `.go c id 234`
2. Right click NPC and confirm Welcome gossip is correct.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
