### PR TITLE
Azuregos' Mark of Frost debuff should persist through wipe and reset

### DIFF
--- a/src/server/scripts/Kalimdor/boss_azuregos.cpp
+++ b/src/server/scripts/Kalimdor/boss_azuregos.cpp
@@ -27,7 +27,6 @@ enum Say
 {
     SAY_TELEPORT = 0,
     SAY_AGGRO,
-    SAY_KILL,
 };
 
 enum Spells
@@ -62,8 +61,6 @@ public:
 
         void Reset() override
         {
-            me->RemoveAurasDueToSpell(SPELL_MARK_OF_FROST_AURA);
-            _scheduler.CancelAll();
             me->SetNpcFlag(UNIT_NPC_FLAG_GOSSIP);
             me->RestoreFaction();
             me->GetMap()->DoForAllPlayers([&](Player* p)
@@ -71,7 +68,6 @@ public:
                     if (p->GetZoneId() == me->GetZoneId())
                     {
 
-                        p->RemoveAurasDueToSpell(SPELL_MARK_OF_FROST);
                         p->RemoveAurasDueToSpell(SPELL_AURA_OF_FROST);
                         p->RemoveAurasDueToSpell(SPELL_CHILL);
                         p->RemoveAurasDueToSpell(SPELL_FROST_BREATH);
@@ -83,7 +79,6 @@ public:
         {
             if (victim && victim->GetTypeId() == TYPEID_PLAYER)
             {
-                Talk(SAY_KILL);
                 victim->CastSpell(victim, SPELL_MARK_OF_FROST, true);
             }
         }

--- a/src/server/scripts/Kalimdor/boss_azuregos.cpp
+++ b/src/server/scripts/Kalimdor/boss_azuregos.cpp
@@ -62,6 +62,7 @@ public:
 
         void Reset() override
         {
+            _scheduler.CancelAll();
             me->SetNpcFlag(UNIT_NPC_FLAG_GOSSIP);
             me->RestoreFaction();
             me->GetMap()->DoForAllPlayers([&](Player* p)

--- a/src/server/scripts/Kalimdor/boss_azuregos.cpp
+++ b/src/server/scripts/Kalimdor/boss_azuregos.cpp
@@ -27,6 +27,7 @@ enum Say
 {
     SAY_TELEPORT = 0,
     SAY_AGGRO,
+    SAY_KILL,
 };
 
 enum Spells
@@ -79,6 +80,7 @@ public:
         {
             if (victim && victim->GetTypeId() == TYPEID_PLAYER)
             {
+                Talk(SAY_KILL);
                 victim->CastSpell(victim, SPELL_MARK_OF_FROST, true);
             }
         }


### PR DESCRIPTION
Fixes Issue https://github.com/azerothcore/azerothcore-wotlk/issues/11343

Changes Proposed:

- Removes removal of mark of frost debuff on Death
- Applies Mark of Frost to last player alive

Issues Addressed:
Closes

- Issue 11343

SOURCE:
Tests Performed:

- Tested in Small raid
- Wiped team
- Debuff persists
- Debuff applied to last player alive

How to Test the Changes:

1. In a group go to Azuregos
2. .go creature 52349
3. Wipe on Azuregos
4. Mark of Frost on Last Player to die?
5. Mark of Frost persist through death?
6. Joy

Known Issues and TODO List:
[ ]
[ ]
How to Test AzerothCore PRs
When a PR is ready to be tested, it will be marked as [WAITING TO BE TESTED].

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

REMEMBER: when testing a PR that changes something generic (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but especially check that the PR does not cause any regression (i.e. introducing new bugs).

For example: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but we should test Y and Z as well.