### PR TITLE
fix(Core/Quests: Fixed displaying correct quest marks for autocomplet…

### DIFF
--- a/src/server/game/Entities/Player/PlayerQuest.cpp
+++ b/src/server/game/Entities/Player/PlayerQuest.cpp
@@ -1612,24 +1612,24 @@ QuestGiverStatus Player::GetQuestDialogStatus(Object* questgiver)
             continue;
 
         QuestStatus status = GetQuestStatus(questId);
-        if ((status == QUEST_STATUS_COMPLETE && !GetQuestRewardStatus(questId)) || (quest->IsAutoComplete() && CanTakeQuest(quest, false)))
+        if (status == QUEST_STATUS_COMPLETE && !GetQuestRewardStatus(questId))
         {
-            if (quest->IsRepeatable() || quest->IsDailyOrWeekly())
-            {
-                 result2 = DIALOG_STATUS_REWARD_REP;
-            }
-            else
-            {
-                result2 = DIALOG_STATUS_REWARD;
-            }
+            result2 = DIALOG_STATUS_REWARD;
         }
         else if (status == QUEST_STATUS_INCOMPLETE)
         {
             result2 = DIALOG_STATUS_INCOMPLETE;
         }
 
+        if (quest->IsAutoComplete() && CanTakeQuest(quest, false) && quest->IsRepeatable() && !quest->IsDailyOrWeekly())
+        {
+            result2 = DIALOG_STATUS_REWARD_REP;
+        }
+
         if (result2 > result)
+        {
             result = result2;
+        }
     }
 
     for (QuestRelations::const_iterator i = qr.first; i != qr.second; ++i)


### PR DESCRIPTION
…e/repeatable/daily completed quests.

Fixes #11237

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11237
- Closes https://github.com/chromiecraft/chromiecraft/issues/2989

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Start "Love is in the Air event` (`.event start 8`)
Don't do the quest "The First and the Last".
Complete the quest "A Gift for The King of Stormwind".
Turn in "A Gift..."

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
