### PR TITLE
fix(DB/creature_template_locale): Spanish totem translation

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1649705878401365511.sql
+++ b/data/sql/updates/pending_db_world/rev_1649705878401365511.sql
@@ -1,0 +1,9 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1649705878401365511');
+
+DELETE FROM `creature_template_locale` WHERE `entry` IN (30652,30653);
+INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `VerifiedBuild`) VALUES
+(30652, 'esES', 'Tótem de cólera II', '', '18019'),
+(30652, 'esMX', 'Tótem de cólera II', '', '18019'),
+(30653, 'esES', 'Tótem de cólera III', '', '18019'),
+(30653, 'esMX', 'Tótem de cólera III', '', '18019');
+

--- a/data/sql/updates/pending_db_world/rev_1649705878401365511.sql
+++ b/data/sql/updates/pending_db_world/rev_1649705878401365511.sql
@@ -1,6 +1,6 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1649705878401365511');
 
-DELETE FROM `creature_template_locale` WHERE `entry` IN (30652,30653);
+DELETE FROM `creature_template_locale` WHERE `entry` IN (30652,30653) AND locale IN ('esES','esMX');
 INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `VerifiedBuild`) VALUES
 (30652, 'esES', 'Tótem de cólera II', '', 18019),
 (30652, 'esMX', 'Tótem de cólera II', '', 18019),

--- a/data/sql/updates/pending_db_world/rev_1649705878401365511.sql
+++ b/data/sql/updates/pending_db_world/rev_1649705878401365511.sql
@@ -1,6 +1,6 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1649705878401365511');
 
-DELETE FROM `creature_template_locale` WHERE `entry` IN (30652,30653) AND locale IN ('esES','esMX');
+DELETE FROM `creature_template_locale` WHERE `entry` IN (30652,30653) AND `locale` IN ('esES','esMX');
 INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `VerifiedBuild`) VALUES
 (30652, 'esES', 'Tótem de cólera II', '', 18019),
 (30652, 'esMX', 'Tótem de cólera II', '', 18019),

--- a/data/sql/updates/pending_db_world/rev_1649705878401365511.sql
+++ b/data/sql/updates/pending_db_world/rev_1649705878401365511.sql
@@ -2,8 +2,8 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1649705878401365511');
 
 DELETE FROM `creature_template_locale` WHERE `entry` IN (30652,30653);
 INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `VerifiedBuild`) VALUES
-(30652, 'esES', 'Tótem de cólera II', '', '18019'),
-(30652, 'esMX', 'Tótem de cólera II', '', '18019'),
-(30653, 'esES', 'Tótem de cólera III', '', '18019'),
-(30653, 'esMX', 'Tótem de cólera III', '', '18019');
+(30652, 'esES', 'Tótem de cólera II', '', 18019),
+(30652, 'esMX', 'Tótem de cólera II', '', 18019),
+(30653, 'esES', 'Tótem de cólera III', '', 18019),
+(30653, 'esMX', 'Tótem de cólera III', '', 18019);
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add esES translation
-  Add esMX translation

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11371
- Closes https://github.com/chromiecraft/chromiecraft/issues/3333

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
esES/esMX language pack

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- Apply changes, run server, Use esES/esMX WoW client, create Shaman
- Summon Totem of Wrath ll and Totem of Wrathlll, those will be displayed as they should

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
