### PR TITLE
fix(Core/BWL): Orb of Command areatrigger

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1649799370491572700.sql
+++ b/data/sql/updates/pending_db_world/rev_1649799370491572700.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1649799370491572700');
+
+DELETE FROM `areatrigger_scripts` WHERE `entry` = 3847;
+INSERT INTO `areatrigger_scripts` (`entry`, `ScriptName`) VALUES
+(3847, 'at_orb_of_command');

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
@@ -644,8 +644,33 @@ public:
     }
 };
 
+enum orb_of_command_misc
+{
+    QUEST_BLACKHANDS_COMMAND = 7761,
+    MAP_BWL                  = 469
+};
+
+const Position orbOfCommandTP = { -7672.46f, -1107.19f, 396.65f, 0.59f };
+
+class at_orb_of_command : public AreaTriggerScript
+{
+public:
+    at_orb_of_command() : AreaTriggerScript("at_orb_of_command") { }
+
+    bool OnTrigger(Player* player, AreaTrigger const* trigger) override
+    {
+        if (!player->IsAlive() && player->GetQuestRewardStatus(QUEST_BLACKHANDS_COMMAND))
+        {
+            player->TeleportTo(MAP_BWL, orbOfCommandTP.m_positionX, orbOfCommandTP.m_positionY, orbOfCommandTP.m_positionZ, orbOfCommandTP.m_orientation);
+            return true;
+        }
+        return false;
+    }
+};
+
 void AddSC_instance_blackwing_lair()
 {
     new instance_blackwing_lair();
     new spell_bwl_shadowflame();
+    new at_orb_of_command();
 }

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
@@ -657,7 +657,7 @@ class at_orb_of_command : public AreaTriggerScript
 public:
     at_orb_of_command() : AreaTriggerScript("at_orb_of_command") { }
 
-    bool OnTrigger(Player* player, AreaTrigger const* trigger) override
+    bool OnTrigger(Player* player, AreaTrigger const* /*trigger*/) override
     {
         if (!player->IsAlive() && player->GetQuestRewardStatus(QUEST_BLACKHANDS_COMMAND))
         {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add the script for the areatrigger used for death players.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11377

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Die in BWL and release.
2. Go near the Orb of Command.
3. You should be tped to BWL again.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] This is a hack but there isn't another way to have it fixed right now.

