### PR TITLE
fix(DB/item_template_locale): Add Spanish translation for 'Wand of Allistarj'

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1650071065104177600.sql
+++ b/data/sql/updates/pending_db_world/rev_1650071065104177600.sql
@@ -2,6 +2,6 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1650071065104177600');
 
 DELETE FROM `item_template_locale` WHERE `ID`=13065 AND `locale` IN ('esES','esMX');
 INSERT INTO `item_template_locale` (`ID`, `locale`, `Name`, `Description`, `VerifiedBuild`) VALUES
-(13065, 'esES', 'Varita de Allistarj', '', '0'),
-(13065, 'esMX', 'Varita de Allistarj', '', '0');
+(13065, 'esES', 'Varita de Allistarj', '', 0),
+(13065, 'esMX', 'Varita de Allistarj', '', 0);
 

--- a/data/sql/updates/pending_db_world/rev_1650071065104177600.sql
+++ b/data/sql/updates/pending_db_world/rev_1650071065104177600.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1650071065104177600');
+
+DELETE FROM `item_template_locale` WHERE `ID`=13065 AND `locale` IN ('esES','esMX');
+INSERT INTO `item_template_locale` (`ID`, `locale`, `Name`, `Description`, `VerifiedBuild`) VALUES
+(13065, 'esES', 'Varita de Allistarj', '', '0'),
+(13065, 'esMX', 'Varita de Allistarj', '', '0');
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add esES/esMX translation for [Wand of Allistarj](https://classic.wowhead.com/item=13065/wand-of-allistarj)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11411
- Closes https://github.com/chromiecraft/chromiecraft/issues/3357

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://es.classic.wowhead.com/item=13065/varita-de-allistarj

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
