### PR TITLE
Core/Authserver: Fix uninitialized variable, fixes changing realms aFter logging in to world

### DIFF
--- a/src/server/authserver/Server/AuthSession.cpp
+++ b/src/server/authserver/Server/AuthSession.cpp
@@ -847,7 +847,7 @@ bool AuthSession::VerifyVersion(uint8 const* a, int32 aLength, Acore::Crypto::SH
     if (!sConfigMgr->GetOption<bool>("StrictVersionCheck", false))
         return true;
 
-    Acore::Crypto::SHA1::Digest zeros;
+    Acore::Crypto::SHA1::Digest zeros = { };
     Acore::Crypto::SHA1::Digest const* versionHash = nullptr;
 
     if (!isReconnect)

--- a/src/server/authserver/Server/AuthSession.cpp
+++ b/src/server/authserver/Server/AuthSession.cpp
@@ -847,8 +847,8 @@ bool AuthSession::VerifyVersion(uint8 const* a, int32 aLength, Acore::Crypto::SH
     if (!sConfigMgr->GetOption<bool>("StrictVersionCheck", false))
         return true;
 
-    Acore::Crypto::SHA1::Digest zeros = { };
-    Acore::Crypto::SHA1::Digest const* versionHash = nullptr;
+    Acore::Crypto::SHA1::Digest zeros{};
+    Acore::Crypto::SHA1::Digest const* versionHash{ nullptr };
 
     if (!isReconnect)
     {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11388 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
[Pick up from TC](https://github.com/TrinityCore/TrinityCore/commit/4ec52fb160c9bd5ab43a305756e4e4066c857994)
Co-Authored-By: Shauren <[shauren.trinity@gmail.com](mailto:shauren.trinity@gmail.com)>

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Need to test


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
