### PR TITLE
Fix (Scripts/BlackwingLair): Chromaggus shimmer timer adjustment, fre…

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_chromaggus.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_chromaggus.cpp
@@ -49,8 +49,8 @@ enum Spells
     SPELL_CHROMATIC_MUT_1                                  = 23174,   //Spell cast on player if they get all 5 debuffs
 
     SPELL_ELEMENTAL_SHIELD                                 = 22276,
-    SPELL_FRENZY                                           = 28371,   //The frenzy spell may be wrong
-    SPELL_ENRAGE                                           = 28747
+    SPELL_FRENZY                                           = 23128,   
+    SPELL_ENRAGE                                           = 23537
 };
 
 enum Events
@@ -239,7 +239,7 @@ public:
                             // Cast new random vulnerabilty on self
                             DoCast(me, SPELL_ELEMENTAL_SHIELD);
                             Talk(EMOTE_SHIMMER);
-                            events.ScheduleEvent(EVENT_SHIMMER, 45000);
+                            events.ScheduleEvent(EVENT_SHIMMER, 17000, 25000);
                             break;
                         }
                     case EVENT_BREATH_1:


### PR DESCRIPTION
…nzy and enrage changed

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Chromaggus should change his vulnerability randomly every 17 to 25 seconds
-  Changed enrage from 28747 to 23537
-  changed frenzy from 28371 to 23128

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
