### PR TITLE
fix(DB/Gameobject): Zul'Gurub - Fix Entrance Gate

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1650360263328185762.sql
+++ b/data/sql/updates/pending_db_world/rev_1650360263328185762.sql
@@ -1,3 +1,5 @@
 INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1650360263328185762');
 
-DELETE FROM `gameobject` WHERE `guid` = 28668 AND `id` = 180323;
+DELETE FROM `gameobject` WHERE (`id` = 180323) AND (`guid` IN (28668));
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(28668, 180323, 309, 1977, 1977, 1, 1, -11916.2, -1221.09, 92.258, -1.5708, 0, 0, -0.707107, 0.707107, 900, 100, 1, '', 0);

--- a/data/sql/updates/pending_db_world/rev_1650360263328185762.sql
+++ b/data/sql/updates/pending_db_world/rev_1650360263328185762.sql
@@ -1,3 +1,3 @@
-INSERT INTO version_db_world (sql_rev) VALUES ('1650360263328185762');
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1650360263328185762');
 
-DELETE FROM gameobject WHERE guid = 28668 AND id = 180323;
+DELETE FROM `gameobject` WHERE `guid` = 28668 AND `id` = 180323;

--- a/data/sql/updates/pending_db_world/rev_1650360263328185762.sql
+++ b/data/sql/updates/pending_db_world/rev_1650360263328185762.sql
@@ -1,0 +1,3 @@
+INSERT INTO version_db_world (sql_rev) VALUES ('1650360263328185762');
+
+DELETE FROM gameobject WHERE guid = 28668 AND id = 180323;

--- a/data/sql/updates/pending_db_world/rev_1650360263328185762.sql
+++ b/data/sql/updates/pending_db_world/rev_1650360263328185762.sql
@@ -2,4 +2,4 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1650360263328185762');
 
 DELETE FROM `gameobject` WHERE (`id` = 180323) AND (`guid` IN (28668));
 INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
-(28668, 180323, 309, 1977, 1977, 1, 1, -11916.2, -1221.09, 92.258, -1.5708, 0, 0, -0.707107, 0.707107, 900, 100, 1, '', 0);
+(28668, 180323, 309, 1977, 1977, 1, 1, -11916.8, -1221.22, 92.5045, -1.5708, 0, 0, -0.707107, 0.707107, 600, 100, 1, '', 0);


### PR DESCRIPTION
Fix the double gate at the entrance of Zul'Gurub - issue(https://github.com/azerothcore/azerothcore-wotlk/issues/11350)

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Move one of two gates at the entrance of Zul'Gurub

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11350

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested IG

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .tele zulgurub

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
