### PR TITLE
fix(DB/Creature] Fix drop rate of Shaft of Tsol

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1650378083515345987.sql
+++ b/data/sql/updates/pending_db_world/rev_1650378083515345987.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1650378083515345987');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 6910) AND (`Item` IN (7741));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(6910, 7741, 0, 100, 0, 1, 0, 1, 1, 'Revelosh - The Shaft of Tsol');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change drop rate from Shaft of Tsol to 100 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11376 
- Closes https://github.com/chromiecraft/chromiecraft/issues/3336

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
Not tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- Kill Revelosh in Uldaman (id: 6910)
- Item should always loot

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
