### PR TITLE
fix(Scripts/ICC): Change trigger flag for Battle Ecperience spell

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1650555787208782000.sql
+++ b/data/sql/updates/pending_db_world/rev_1650555787208782000.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1650555787208782000');
+
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_igb_battle_experience_check';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(71201, 'spell_igb_battle_experience_check');

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
@@ -1515,7 +1515,7 @@ struct gunship_npc_AI : public ScriptedAI
         {
             me->SetFacingTo(Slot->TargetPosition.GetOrientation());
             me->m_Events.AddEvent(new BattleExperienceEvent(me), me->m_Events.CalculateTime(BattleExperienceEvent::ExperiencedTimes[0]));
-            me->CastSpell(me, SPELL_BATTLE_EXPERIENCE, true);
+            me->CastSpell(me, SPELL_BATTLE_EXPERIENCE, false);
             me->SetReactState(REACT_AGGRESSIVE);
         }
     }
@@ -1579,7 +1579,7 @@ struct npc_gunship_boarding_addAI : public ScriptedAI
         {
             me->SetFacingTo(Slot->TargetPosition.GetOrientation());
             me->m_Events.AddEvent(new BattleExperienceEvent(me), me->m_Events.CalculateTime(BattleExperienceEvent::ExperiencedTimes[0]));
-            me->CastSpell(me, SPELL_BATTLE_EXPERIENCE, true);
+            me->CastSpell(me, SPELL_BATTLE_EXPERIENCE, false);
             me->SetReactState(REACT_AGGRESSIVE);
 
             Position const& otherTransportPos = Instance->GetData(DATA_TEAMID_IN_INSTANCE) == TEAM_HORDE ? OrgrimsHammerTeleportExit : SkybreakerTeleportExit;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
@@ -1515,7 +1515,7 @@ struct gunship_npc_AI : public ScriptedAI
         {
             me->SetFacingTo(Slot->TargetPosition.GetOrientation());
             me->m_Events.AddEvent(new BattleExperienceEvent(me), me->m_Events.CalculateTime(BattleExperienceEvent::ExperiencedTimes[0]));
-            me->CastSpell(me, SPELL_BATTLE_EXPERIENCE, false);
+            me->CastSpell(me, SPELL_BATTLE_EXPERIENCE, true);
             me->SetReactState(REACT_AGGRESSIVE);
         }
     }
@@ -1579,7 +1579,7 @@ struct npc_gunship_boarding_addAI : public ScriptedAI
         {
             me->SetFacingTo(Slot->TargetPosition.GetOrientation());
             me->m_Events.AddEvent(new BattleExperienceEvent(me), me->m_Events.CalculateTime(BattleExperienceEvent::ExperiencedTimes[0]));
-            me->CastSpell(me, SPELL_BATTLE_EXPERIENCE, false);
+            me->CastSpell(me, SPELL_BATTLE_EXPERIENCE, true);
             me->SetReactState(REACT_AGGRESSIVE);
 
             Position const& otherTransportPos = Instance->GetData(DATA_TEAMID_IN_INSTANCE) == TEAM_HORDE ? OrgrimsHammerTeleportExit : SkybreakerTeleportExit;
@@ -2719,6 +2719,22 @@ public:
     }
 };
 
+// 71201 - Battle Experience - proc should never happen, handled in script
+class spell_igb_battle_experience_check : public AuraScript
+{
+    PrepareAuraScript(spell_igb_battle_experience_check);
+
+    bool CheckProc(ProcEventInfo& /*eventInfo*/)
+    {
+        return false;
+    }
+
+    void Register() override
+    {
+        DoCheckProc += AuraCheckProcFn(spell_igb_battle_experience_check::CheckProc);
+    }
+};
+
 void AddSC_boss_icecrown_gunship_battle()
 {
     new npc_gunship();
@@ -2750,4 +2766,5 @@ void AddSC_boss_icecrown_gunship_battle()
     new spell_igb_below_zero();
     new spell_igb_on_gunship_deck();
     new achievement_im_on_a_boat();
+    RegisterSpellScript(spell_igb_battle_experience_check);
 }


### PR DESCRIPTION
* closes https://github.com/azerothcore/azerothcore-wotlk/issues/6785

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  This spell doesn't have a trigger spell
-  * cherry-pick part of commit (https://github.com/TrinityCore/TrinityCore/commit/5b8e68ee6335ecbc9fea253eaceecb20c50aa41e)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
