### PR TITLE
Fix(DB): Unfired Plate Gauntlets should only require blacksmithing 225 to loot.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1650790172951548882.sql
+++ b/data/sql/updates/pending_db_world/rev_1650790172951548882.sql
@@ -3,3 +3,7 @@ INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1650790172951548882');
 DELETE FROM `gameobject_loot_template` WHERE (`Entry` = 13574) AND (`Item` IN (12812));
 INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (13574, 12812, 0, 100, 0, 1, 0, 1, 1, 'Unfired Plate Gauntlets - Unfired Plate Gauntlets');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=4 AND `SourceGroup`=13574;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(4, 13574, 12812, 0, 0, 7, 0, 164, 225, 0, 0, 0, 0, '', 'Unfired Plate Gauntlets while having Blacksmithing skill 225'),

--- a/data/sql/updates/pending_db_world/rev_1650790172951548882.sql
+++ b/data/sql/updates/pending_db_world/rev_1650790172951548882.sql
@@ -6,4 +6,4 @@ INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, 
 
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=4 AND `SourceGroup`=13574;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(4, 13574, 12812, 0, 0, 7, 0, 164, 225, 0, 0, 0, 0, '', 'Unfired Plate Gauntlets while having Blacksmithing skill 225'),
+(4, 13574, 12812, 0, 0, 7, 0, 164, 225, 0, 0, 0, 0, '', 'Unfired Plate Gauntlets while having Blacksmithing skill 225');

--- a/data/sql/updates/pending_db_world/rev_1650790172951548882.sql
+++ b/data/sql/updates/pending_db_world/rev_1650790172951548882.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1650790172951548882');
+
+DELETE FROM `gameobject_loot_template` WHERE (`Entry` = 13574) AND (`Item` IN (12812));
+INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(13574, 12812, 0, 100, 0, 1, 0, 1, 1, 'Unfired Plate Gauntlets - Unfired Plate Gauntlets');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Set loot condition on unfired plate gauntlets to blacksmithing 225
-  Removed quest requirement.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11472
- Closes https://github.com/chromiecraft/chromiecraft/issues/2343

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.go LBRS
loot the object Unfired Plate Gauntlets, and see it empty.
.setskill 164 225
.respawn all
loot it again and find the item inside

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
