### PR TITLE
Fix(DB/Creature): Set correct faction flag for Aggi Rumplestomp.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1650793025980507979.sql
+++ b/data/sql/updates/pending_db_world/rev_1650793025980507979.sql
@@ -2,4 +2,3 @@ UPDATE `creature_template` SET `faction` = 1216 WHERE (`entry` = 13086);
 UPDATE `creature_template` SET `faction` = 1216 WHERE (`entry` = 22670);
 UPDATE `creature_template` SET `faction` = 1216 WHERE (`entry` = 31918);
 UPDATE `creature_template` SET `faction` = 1216 WHERE (`entry` = 37234);
-

--- a/data/sql/updates/pending_db_world/rev_1650793025980507979.sql
+++ b/data/sql/updates/pending_db_world/rev_1650793025980507979.sql
@@ -1,5 +1,3 @@
-INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1650793025980507979');
-
 UPDATE `creature_template` SET `faction` = 1216 WHERE (`entry` = 13086);
 UPDATE `creature_template` SET `faction` = 1216 WHERE (`entry` = 22670);
 UPDATE `creature_template` SET `faction` = 1216 WHERE (`entry` = 31918);

--- a/data/sql/updates/pending_db_world/rev_1650793025980507979.sql
+++ b/data/sql/updates/pending_db_world/rev_1650793025980507979.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1650793025980507979');
+
+UPDATE `creature_template` SET `faction` = 1216 WHERE (`entry` = 13086);
+UPDATE `creature_template` SET `faction` = 1216 WHERE (`entry` = 22670);
+UPDATE `creature_template` SET `faction` = 1216 WHERE (`entry` = 31918);
+UPDATE `creature_template` SET `faction` = 1216 WHERE (`entry` = 37234);
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changes faction flag to be the same as the other creatures around him.
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/3403

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Coldtooth mine in AV and see if Aggi has no longer the Alliance Pvp symbol on his name and can be properly killed.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
