### PR TITLE
fix(Scripts/BlackiwingLair): Rogues should be teleported in front of …

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
@@ -1014,49 +1014,42 @@ class spell_class_call_handler : public SpellScript
         if (SpellInfo const* spellInfo = GetSpellInfo())
         {
             targets.remove_if([spellInfo](WorldObject const* target) -> bool
+            {
+                Player const* player = target->ToPlayer();
+                if (!player || player->getClass() == CLASS_DEATH_KNIGHT) // ignore all death knights from whatever spell, for some reason the condition below is not working x.x
                 {
-                    Player const* player = target->ToPlayer();
-                    if (!player || player->getClass() == CLASS_DEATH_KNIGHT) // ignore all death knights from whatever spell, for some reason the condition below is not working x.x
-                    {
-                        return true;
-                    }
+                    return true;
+                }
 
-                    auto it = classCallSpells.find(spellInfo->Id);
-                    if (it != classCallSpells.end()) // should never happen but only to be sure.
-                    {
-                        return target->ToPlayer()->getClass() != it->second;
-                    }
+                auto it = classCallSpells.find(spellInfo->Id);
+                if (it != classCallSpells.end()) // should never happen but only to be sure.
+                {
+                    return target->ToPlayer()->getClass() != it->second;
+                }
 
-                    return false;
-                });
+                return false;
+            });
         }
     }
 
-    void HandleOnHitRogue()
+    void HandleOnHitRogue(SpellEffIndex /*effIndex*/)
     {
         Unit* caster = GetCaster();
         Unit* target = GetHitUnit();
-
         if (!caster || !target)
         {
             return;
         }
 
-        float angle = rand_norm() * 2 * M_PI;
-        Position tp = caster->GetPosition();
-        tp.m_positionX += std::cos(angle) * 5.f;
-        tp.m_positionY += std::sin(angle) * 5.f;
-        float z = tp.m_positionZ + 0.5f;
-        caster->UpdateAllowedPositionZ(tp.GetPositionX(), tp.GetPositionY(), z);
-        target->NearTeleportTo(tp.GetPositionX(), tp.GetPositionY(), z, angle - M_PI);
-        target->UpdatePositionData();
+        Position tp = caster->GetFirstCollisionPosition(5.f, 0.f);
+        target->NearTeleportTo(tp.GetPositionX(), tp.GetPositionY(), tp.GetPositionZ(), tp.GetOrientation());
     }
 
     void HandleOnHitWarlock()
     {
-        if (GetHitUnit())
+        if (Unit* target = GetHitUnit())
         {
-            GetHitUnit()->CastSpell(GetHitUnit(), SPELL_SUMMON_INFERNALS, true);
+            target->CastSpell(target, SPELL_SUMMON_INFERNALS, true);
         }
     }
 
@@ -1066,7 +1059,7 @@ class spell_class_call_handler : public SpellScript
 
         if (m_scriptSpellId == SPELL_ROGUE)
         {
-            OnHit += SpellHitFn(spell_class_call_handler::HandleOnHitRogue);
+            OnEffectLaunchTarget += SpellEffectFn(spell_class_call_handler::HandleOnHitRogue, EFFECT_0, SPELL_EFFECT_APPLY_AURA);
         }
         else if (m_scriptSpellId == SPELL_WARLOCK)
         {


### PR DESCRIPTION
…Nefarian during Class Call event.

Fixes #11366

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11366
- Closes https://github.com/chromiecraft/chromiecraft/issues/3326

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Be a rogue
Engage Nefarian
Rogue Class Call happens
Rogue is telepored you in front of Nefarian.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
