### PR TITLE
feat(Core/Creature): Implement ModifyThreatPercentTemp() function

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3554,7 +3554,7 @@ void Creature::ModifyThreatPercentTemp(Unit* victim, int32 percent, Milliseconds
             getThreatMgr().modifyThreatPercent(victim, percent);
         }
 
-        TemporaryThreatModifierEvent* pEvent = new TemporaryThreatModifierEvent(*this, victim->GetGUID(), currentThreat, duration);
+        TemporaryThreatModifierEvent* pEvent = new TemporaryThreatModifierEvent(*this, victim->GetGUID(), currentThreat);
         m_Events.AddEvent(pEvent, m_Events.CalculateTime(duration.count()));
     }
 }

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -499,14 +499,13 @@ private:
 class TemporaryThreatModifierEvent : public BasicEvent
 {
 public:
-    TemporaryThreatModifierEvent(Creature& owner, ObjectGuid threatVictimGUID, float threatValue, Milliseconds resetTimer) : BasicEvent(), m_owner(owner), m_threatVictimGUID(threatVictimGUID), m_threatValue(threatValue), m_resetTimer(resetTimer) { }
+    TemporaryThreatModifierEvent(Creature& owner, ObjectGuid threatVictimGUID, float threatValue) : BasicEvent(), m_owner(owner), m_threatVictimGUID(threatVictimGUID), m_threatValue(threatValue) { }
     bool Execute(uint64 e_time, uint32 p_time) override;
 
 private:
     Creature& m_owner;
     ObjectGuid m_threatVictimGUID;
     float m_threatValue;
-    Milliseconds const m_resetTimer;
 };
 
 #endif

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -385,6 +385,8 @@ public:
 
     void SetAssistanceTimer(uint32 value) { m_assistanceTimer = value; }
 
+    void ModifyThreatPercentTemp(Unit* victim, int32 percent, Milliseconds duration);
+
 protected:
     bool CreateFromProto(ObjectGuid::LowType guidlow, uint32 Entry, uint32 vehId, const CreatureData* data = nullptr);
     bool InitEntry(uint32 entry, const CreatureData* data = nullptr);
@@ -492,6 +494,19 @@ public:
 private:
     Creature& m_owner;
     Seconds const m_respawnTimer;
+};
+
+class TemporaryThreatModifierEvent : public BasicEvent
+{
+public:
+    TemporaryThreatModifierEvent(Creature& owner, ObjectGuid threatVictimGUID, float threatPercent, Milliseconds resetTimer) : BasicEvent(), m_owner(owner), m_threatVictimGUID(threatVictimGUID), m_threatPercent(threatPercent), m_resetTimer(resetTimer) { }
+    bool Execute(uint64 e_time, uint32 p_time) override;
+
+private:
+    Creature& m_owner;
+    ObjectGuid m_threatVictimGUID;
+    int m_threatPercent;
+    Milliseconds const m_resetTimer;
 };
 
 #endif

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -499,13 +499,13 @@ private:
 class TemporaryThreatModifierEvent : public BasicEvent
 {
 public:
-    TemporaryThreatModifierEvent(Creature& owner, ObjectGuid threatVictimGUID, float threatPercent, Milliseconds resetTimer) : BasicEvent(), m_owner(owner), m_threatVictimGUID(threatVictimGUID), m_threatPercent(threatPercent), m_resetTimer(resetTimer) { }
+    TemporaryThreatModifierEvent(Creature& owner, ObjectGuid threatVictimGUID, float threatValue, Milliseconds resetTimer) : BasicEvent(), m_owner(owner), m_threatVictimGUID(threatVictimGUID), m_threatValue(threatValue), m_resetTimer(resetTimer) { }
     bool Execute(uint64 e_time, uint32 p_time) override;
 
 private:
     Creature& m_owner;
     ObjectGuid m_threatVictimGUID;
-    int m_threatPercent;
+    float m_threatValue;
     Milliseconds const m_resetTimer;
 };
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Implement a function to change threat temporarily, autoreseting after a brief amount of time
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Its for modules, no places uses it ingame, it doesn't crash the server 👍 
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
