### PR TITLE
fix(Core/Wintergrasp): Reimplement Wintergrasp quests and fix vendors

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1650555535836713900.sql
+++ b/data/sql/updates/pending_db_world/rev_1650555535836713900.sql
@@ -1,0 +1,47 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1650555535836713900');
+
+DELETE FROM `player_loot_template` WHERE (`Entry` IN (1, 0)) AND (`Item` IN (43323, 43314, 44809, 43324, 44808, 43322));
+INSERT INTO `player_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
+(0, 43323, 0, 100, 1, 1, 0, 5, 5, 'Wintergrasp - Alliance - Quiver of Dragonbone Arrows'),
+(1, 43323, 0, 100, 1, 1, 0, 5, 5, 'Wintergrasp - Horde - Quiver of Dragonbone Arrows'),
+(0, 43314, 0, 100, 1, 1, 0, 5, 5, 'Wintergrasp - Alliance - Eternal Ember'),
+(1, 43314, 0, 100, 1, 1, 0, 5, 5, 'Wintergrasp - Horde - Eternal Ember'),
+(0, 44809, 0, 100, 1, 1, 0, 5, 5, 'Wintergrasp - Alliance - Horde Herb Pouch'),
+(1, 43324, 0, 100, 1, 1, 0, 5, 5, 'Wintergrasp - Horde - Alliance Herb Pouch'),
+(0, 44808, 0, 100, 1, 1, 0, 5, 5, 'Wintergrasp - Alliance - Imbued Horde Armor'),
+(1, 43322, 0, 100, 1, 1, 0, 5, 5, 'Wintergrasp - Horde - Enchanted Alliance Breastplates');
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 28) AND (`SourceGroup` IN (0, 1)) AND (`SourceEntry` IN (43323, 43314, 44809, 43324, 44808, 43322));
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(28, 0, 43323, 0, 0, 23, 0, 4587, 0, 0, 0, 0, 0, '', 'Alliance - Quiver of Dragonbone Arrows - drop in The Forest of Shadows'),
+(28, 0, 43323, 0, 0, 47, 0, 13154, 8, 0, 0, 0, 0, '', 'Alliance - Quiver of Dragonbone Arrows - drop while quest 13154 is in progress'),
+(28, 0, 43323, 0, 1, 23, 0, 4587, 0, 0, 0, 0, 0, '', 'Alliance - Quiver of Dragonbone Arrows - drop in The Forest of Shadows'),
+(28, 0, 43323, 0, 1, 47, 0, 13196, 8, 0, 0, 0, 0, '', 'Alliance - Quiver of Dragonbone Arrows - drop while quest 13196 is in progress'),
+(28, 1, 43323, 0, 0, 23, 0, 4587, 0, 0, 0, 0, 0, '', 'Horde - Quiver of Dragonbone Arrows - drop in The Forest of Shadows'),
+(28, 1, 43323, 0, 0, 47, 0, 13193, 8, 0, 0, 0, 0, '', 'Horde - Quiver of Dragonbone Arrows - drop while quest 13193 is in progress'),
+(28, 1, 43323, 0, 1, 23, 0, 4587, 0, 0, 0, 0, 0, '', 'Horde - Quiver of Dragonbone Arrows - drop in The Forest of Shadows'),
+(28, 1, 43323, 0, 1, 47, 0, 13199, 8, 0, 0, 0, 0, '', 'Horde - Quiver of Dragonbone Arrows - drop while quest 13199 is in progress'),
+(28, 0, 43314, 0, 0, 23, 0, 4584, 0, 0, 0, 0, 0, '', 'Alliance - Eternal Ember - drop in The Cauldron of Flames'),
+(28, 0, 43314, 0, 0, 47, 0, 13197, 8, 0, 0, 0, 0, '', 'Alliance - Eternal Ember - drop while quest 13197 is in progress'),
+(28, 0, 43314, 0, 1, 23, 0, 4584, 0, 0, 0, 0, 0, '', 'Alliance - Eternal Ember - drop in The Cauldron of Flames'),
+(28, 0, 43314, 0, 1, 47, 0, 236, 8, 0, 0, 0, 0, '', 'Alliance - Eternal Ember - drop while quest 236 is in progress'),
+(28, 1, 43314, 0, 0, 23, 0, 4584, 0, 0, 0, 0, 0, '', 'Horde - Eternal Ember - drop in The Cauldron of Flames'),
+(28, 1, 43314, 0, 0, 47, 0, 13191, 8, 0, 0, 0, 0, '', 'Horde - Eternal Ember - drop while quest 13191 is in progress'),
+(28, 1, 43314, 0, 1, 23, 0, 4584, 0, 0, 0, 0, 0, '', 'Horde - Eternal Ember - drop in The Cauldron of Flames'),
+(28, 1, 43314, 0, 1, 47, 0, 13200, 8, 0, 0, 0, 0, '', 'Horde - Eternal Ember - drop while quest 13200 is in progress'),
+(28, 0, 44809, 0, 0, 23, 0, 4590, 0, 0, 0, 0, 0, '', 'Alliance - Horde Herb Pouch - drop in The Steppe of Life'),
+(28, 0, 44809, 0, 0, 47, 0, 13156, 8, 0, 0, 0, 0, '', 'Alliance - Horde Herb Pouch - drop while quest 13156 is in progress'),
+(28, 0, 44809, 0, 1, 23, 0, 4590, 0, 0, 0, 0, 0, '', 'Alliance - Horde Herb Pouch - drop in The Steppe of Life'),
+(28, 0, 44809, 0, 1, 47, 0, 13195, 8, 0, 0, 0, 0, '', 'Alliance - Horde Herb Pouch - drop while quest 13195 is in progress'),
+(28, 1, 43324, 0, 0, 23, 0, 4590, 0, 0, 0, 0, 0, '', 'Horde - Alliance Herb Pouch - drop in The Steppe of Life'),
+(28, 1, 43324, 0, 0, 47, 0, 13194, 8, 0, 0, 0, 0, '', 'Horde - Alliance Herb Pouch - drop while quest 13194 is in progress'),
+(28, 1, 43324, 0, 1, 23, 0, 4590, 0, 0, 0, 0, 0, '', 'Horde - Alliance Herb Pouch - drop in The Steppe of Life'),
+(28, 1, 43324, 0, 1, 47, 0, 13201, 8, 0, 0, 0, 0, '', 'Horde - Alliance Herb Pouch - drop while quest 13201 is in progress'),
+(28, 0, 44808, 0, 0, 23, 0, 4585, 0, 0, 0, 0, 0, '', 'Alliance - Imbued Horde Armor - drop in Glacial Falls'),
+(28, 0, 44808, 0, 0, 47, 0, 13198, 8, 0, 0, 0, 0, '', 'Alliance - Imbued Horde Armor - drop while quest 13198 is in progress'),
+(28, 0, 44808, 0, 1, 23, 0, 4585, 0, 0, 0, 0, 0, '', 'Alliance - Imbued Horde Armor - drop in Glacial Falls'),
+(28, 0, 44808, 0, 1, 47, 0, 13153, 8, 0, 0, 0, 0, '', 'Alliance - Imbued Horde Armor - drop while quest 13153 is in progress'),
+(28, 1, 43322, 0, 0, 23, 0, 4585, 0, 0, 0, 0, 0, '', 'Horde - Enchanted Alliance Breastplates - drop in Glacial Falls'),
+(28, 1, 43322, 0, 0, 47, 0, 13192, 8, 0, 0, 0, 0, '', 'Horde - Enchanted Alliance Breastplates - drop while quest 13192 is in progress'),
+(28, 1, 43322, 0, 1, 23, 0, 4585, 0, 0, 0, 0, 0, '', 'Horde - Enchanted Alliance Breastplates - drop in Glacial Falls'),
+(28, 1, 43322, 0, 1, 47, 0, 13202, 8, 0, 0, 0, 0, '', 'Horde - Enchanted Alliance Breastplates - drop while quest 13202 is in progress');

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -218,6 +218,8 @@ enum WintergraspNpcs
     NPC_QUEST_SOUTHERN_TOWER_KILL                   = 35074,
     NPC_QUEST_VEHICLE_PROTECTED                     = 31284,
     NPC_QUEST_PVP_KILL_VEHICLE                      = 31093,
+    NPC_QUEST_PVP_KILL_HORDE                        = 39019,
+    NPC_QUEST_PVP_KILL_ALLIANCE                     = 31086,
 };
 
 struct BfWGCoordGY

--- a/src/server/game/Entities/Player/PlayerQuest.cpp
+++ b/src/server/game/Entities/Player/PlayerQuest.cpp
@@ -2255,8 +2255,12 @@ bool Player::HasQuestForItem(uint32 itemid, uint32 excludeQuestId /* 0 */, bool 
 
             // hide quest if player is in raid-group and quest is no raid quest
             if (GetGroup() && GetGroup()->isRaidGroup() && !qinfo->IsAllowedInRaid(GetMap()->GetDifficulty()))
-                if (!InBattleground()) //there are two ways.. we can make every bg-quest a raidquest, or add this code here.. i don't know if this can be exploited by other quests, but i think all other quests depend on a specific area.. but keep this in mind, if something strange happens later
+            {
+                if (!InBattleground() && !GetGroup()->isBFGroup()) //there are two ways.. we can make every bg-quest a raidquest, or add this code here.. i don't know if this can be exploited by other quests, but i think all other quests depend on a specific area.. but keep this in mind, if something strange happens later
+                {
                     continue;
+                }
+            }
 
             // There should be no mixed ReqItem/ReqSource drop
             // This part for ReqItem drop


### PR DESCRIPTION
## Changes Proposed:
-  Added player loot for quest items
-  Give player kill credit to all in range (same as vehicle kills)
- Added vendor check to WG CreatureScript
- Added WG control check in GetDialogStatus to resolve inconsistency between quest available icon and actually available quests

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- TODO of #9198

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowwiki-archive.fandom.com/wiki/Wintergrasp_quests

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Completed all Wintergrasp quests to test drops / kill credit
- Win 10 x64 / Ubuntu 20.04 x64

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Effected quests:
```
# Alliance:
Victory in Wintergrasp - 13181
No Mercy for the Merciless - 13179, 13177
Defend the Siege - 13222
Stop the Siege - 13186
A Rare Herb - 13156, 13195
Bones and Arrows - 13196, 13154
Fueling the Demolishers - 236, 13197
Warding the Warriors - 13153, 13198
Southern Sabotage - 13538

# Horde:
Victory in Wintergrasp - 13183
Defend the Siege - 13223
Stop the Siege - 13185
Slay them all! - 13180, 13178
Healing with Roses - 13194, 13201
Bones and Arrows - 13199, 13193
Fueling the Demolishers - 13191, 13200
Jinxing the Walls - 13202
Warding the Walls - 13192
Toppling the Towers - 13539
```

1. Apply the DB patch
2. Try to complete any of the above quests

- No Mercy for the Merciless / Slay them all! require your victim to have the `First Lieutenant` rank (go kill some guard npcs to get it)
- Rotation quests (A Rare Herb, Bones and Arrows, etc...) will only drop quest items when in the area specified by the quest
- Hoodoo Master Fu'Jin / Sorceress Kaylana will have a vendor gossip option

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
