### PR TITLE
fix(Scripts/BlackwingLair): Razorgore's Orb of Domination should not …

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
@@ -200,6 +200,8 @@ public:
                     return NefarianLeftTunnel;
                 case DATA_NEFARIAN_RIGHT_TUNNEL:
                     return NefarianRightTunnel;
+                case DATA_EGG_EVENT:
+                    return EggEvent;
                 default:
                     break;
             }


### PR DESCRIPTION
…be usable during 2nd phase of the encounter.

Fixes #11566

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11566
- Closes https://github.com/chromiecraft/chromiecraft/issues/3433

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Enter BWL.
Engage Razorgore the Untamed.
Destroy all Eggs.
Try to use Orb of Domination once Phase 2 starts and all eggs are destroyed.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
