### PR TITLE
fix(Core/Packets): Continue processing packets even if player is not …

### DIFF
--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -52,6 +52,8 @@
 #include "WorldSocket.h"
 #include <zlib.h>
 
+#define MAX_PROCESSED_PACKETS_IN_SAME_WORLDSESSION_UPDATE 150
+
 namespace
 {
     std::string const DefaultPlayerName = "<none>";
@@ -427,7 +429,6 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
 
         deletePacket = true;
 
-#define MAX_PROCESSED_PACKETS_IN_SAME_WORLDSESSION_UPDATE 150
         processedPackets++;
 
         //process only a max amout of packets in 1 Update() call.

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -339,15 +339,15 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
                         QueuePacket(packet);
                     }*/
                 }
-                else if (_player->IsInWorld() && AntiDOS.EvaluateOpcode(*packet, currentTime))
+                else if (_player->IsInWorld())
                 {
-                    if (!sScriptMgr->CanPacketReceive(this, *packet))
+                    if (AntiDOS.EvaluateOpcode(*packet, currentTime))
                     {
-                        break;
+                        opHandle->Call(this, *packet);
+                        LogUnprocessedTail(packet);
                     }
-
-                    opHandle->Call(this, *packet);
-                    LogUnprocessedTail(packet);
+                    else
+                        processedPackets = MAX_PROCESSED_PACKETS_IN_SAME_WORLDSESSION_UPDATE;   // break out of packet processing loop
                 }
                 break;
             case STATUS_TRANSFER:


### PR DESCRIPTION
…in world

* cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/aee4f0350ea5610b663cb07fb097f2fad256809e)

Co-Authored-By: Giacomo Pozzoni <giacomopoz@gmail.com>

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
