### PR TITLE
Core/Auras: INVISIBILITY_UNK10 also applies the flag PLAYER_FIELD_BYTE…

### DIFF
--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -349,14 +349,15 @@ public:
         m_flags = 0;
     }
 
-    [[nodiscard]] T_FLAGS  GetFlags() const { return m_flags; }
-    [[nodiscard]] bool     HasFlag(FLAG_TYPE flag) const { return m_flags & (1 << flag); }
-    void     AddFlag(FLAG_TYPE flag) { m_flags |= (1 << flag); }
-    void     DelFlag(FLAG_TYPE flag) { m_flags &= ~(1 << flag); }
+    [[nodiscard]] T_FLAGS GetFlags() const { return m_flags; }
+    [[nodiscard]] bool HasFlag(FLAG_TYPE flag) const { return m_flags & (1 << flag); }
+    bool HasFlag(FLAG_TYPE flag) const { return m_flags & (1 << flag); }
+    void AddFlag(FLAG_TYPE flag) { m_flags |= (1 << flag); }
+    void DelFlag(FLAG_TYPE flag) { m_flags &= ~(1 << flag); }
 
     [[nodiscard]] T_VALUES GetValue(FLAG_TYPE flag) const { return m_values[flag]; }
-    void     SetValue(FLAG_TYPE flag, T_VALUES value) { m_values[flag] = value; }
-    void     AddValue(FLAG_TYPE flag, T_VALUES value) { m_values[flag] += value; }
+    void SetValue(FLAG_TYPE flag, T_VALUES value) { m_values[flag] = value; }
+    void AddValue(FLAG_TYPE flag, T_VALUES value) { m_values[flag] += value; }
 
 private:
     T_VALUES m_values[ARRAY_SIZE];

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -351,7 +351,6 @@ public:
 
     [[nodiscard]] T_FLAGS GetFlags() const { return m_flags; }
     [[nodiscard]] bool HasFlag(FLAG_TYPE flag) const { return m_flags & (1 << flag); }
-    bool HasFlag(FLAG_TYPE flag) const { return m_flags & (1 << flag); }
     void AddFlag(FLAG_TYPE flag) { m_flags |= (1 << flag); }
     void DelFlag(FLAG_TYPE flag) { m_flags &= ~(1 << flag); }
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1537,7 +1537,7 @@ void AuraEffect::HandleModInvisibility(AuraApplication const* aurApp, uint8 mode
     if (apply)
     {
         // apply glow vision
-        if (target->GetTypeId() == TYPEID_PLAYER && type == INVISIBILITY_GENERAL)
+        if (target->GetTypeId() == TYPEID_PLAYER && (type == INVISIBILITY_GENERAL || type == INVISIBILITY_UNK10))
             target->SetByteFlag(PLAYER_FIELD_BYTES2, PLAYER_FIELD_BYTES_2_OFFSET_AURA_VISION, PLAYER_FIELD_BYTE2_INVISIBILITY_GLOW);
 
         target->m_invisibility.AddFlag(type);
@@ -1568,14 +1568,14 @@ void AuraEffect::HandleModInvisibility(AuraApplication const* aurApp, uint8 mode
             }
             if (!found)
             {
+                target->m_invisibility.DelFlag(type);
+
                 // if not have invisibility auras of type INVISIBILITY_GENERAL
                 // remove glow vision
-                if (target->GetTypeId() == TYPEID_PLAYER && type == INVISIBILITY_GENERAL)
+                if (target->GetTypeId() == TYPEID_PLAYER && !target->m_invisibility.HasFlag(INVISIBILITY_GENERAL) && !target->m_invisibility.HasFlag(INVISIBILITY_UNK10))
                 {
                     target->RemoveByteFlag(PLAYER_FIELD_BYTES2, PLAYER_FIELD_BYTES_2_OFFSET_AURA_VISION, PLAYER_FIELD_BYTE2_INVISIBILITY_GLOW);
                 }
-
-                target->m_invisibility.DelFlag(type);
             }
         }
 


### PR DESCRIPTION
…2_INVISIBILITY_GLOW

* cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/230f40f359c80b102f344ed55adc12f246a97051)

Co-Authored-By: Meji <2695278+meji46@users.noreply.github.com>

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
