### PR TITLE
fix(DB/Creatures): Added `CREATURE_FLAG_EXTRA_IGNORE_PATHFINDING` fla…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1651348454142593100.sql
+++ b/data/sql/updates/pending_db_world/rev_1651348454142593100.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `flags_extra`=`flags_extra`|0x20000000 WHERE `entry`=8236;


### PR DESCRIPTION
…g to Muck Frenzy.

Fixes #6317

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Core recognizes this tunnel as a non-swimmable area, so the fish cannot go out (mmaps polyrefs are invalid).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6317
- Closes https://github.com/chromiecraft/chromiecraft/issues/838

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
.go c 13576
aggro

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
