### PR TITLE
fix(Scripts/TempleOfAhnQiraj): Correct Battleguard Sartura spell ids

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_sartura.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_sartura.cpp
@@ -33,8 +33,8 @@ enum Sartura
     SAY_DEATH           = 2,
 
     SPELL_WHIRLWIND     = 26083,
-    SPELL_ENRAGE        = 28747,            //Not sure if right ID.
-    SPELL_ENRAGEHARD    = 28798,
+    SPELL_ENRAGE        = 8269,
+    SPELL_BERSERK       = 27680,
 
     //Guard Spell
     SPELL_WHIRLWINDADD  = 26038,
@@ -166,7 +166,7 @@ public:
                 {
                     if (!HealthAbovePct(20) && !me->IsNonMeleeSpellCast(false))
                     {
-                        DoCast(me, SPELL_ENRAGE);
+                        DoCast(me, SPELL_ENRAGE, true);
                         Enraged = true;
                     }
                 }
@@ -176,7 +176,7 @@ public:
                 {
                     if (EnrageHard_Timer <= diff)
                     {
-                        DoCast(me, SPELL_ENRAGEHARD);
+                        DoCast(me, SPELL_BERSERK, true);
                         EnragedHard = true;
                     }
                     else EnrageHard_Timer -= diff;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Correct Sartura's enrage spell ids from sniffs
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
