### PR TITLE
fix(CORE/Script): Quest "A Pawn on the Eternal Board" can't finish and hung up the worldserver.exe

### DIFF
--- a/src/server/scripts/Kalimdor/zone_silithus.cpp
+++ b/src/server/scripts/Kalimdor/zone_silithus.cpp
@@ -532,21 +532,21 @@ public:
                         break;
                     case 51:
                         {
-                            uint32 entries[4] = { 15423, 15424, 15414, 15422 };
-                            for (uint8 i = 0; i < 4; ++i)
-                            {
-                                Creature* mob = Fandral->FindNearestCreature(entries[i], 50.0f);
-                                while (mob)
-                                {
-                                    if (mob->IsInWorld())
-                                    {
-                                        Map* map = mob->GetMap();
-                                        map->RemoveFromMap(mob, false);
-                                    }
+                            std::list<Creature*> constructList;
 
-                                    mob = Fandral->FindNearestCreature(entries[i], 50.0f);
+                            me->GetCreatureListWithEntryInGrid(constructList, 15423, 100.0f);
+                            me->GetCreatureListWithEntryInGrid(constructList, 15424, 100.0f);
+                            me->GetCreatureListWithEntryInGrid(constructList, 15414, 100.0f);
+                            me->GetCreatureListWithEntryInGrid(constructList, 15422, 100.0f);
+
+                            if (!constructList.empty())
+                            {
+                                for (std::list<Creature*>::const_iterator itr = constructList.begin(); itr != constructList.end(); ++itr)
+                                {
+                                    (*itr)->RemoveFromWorld();
                                 }
                             }
+
                             break;
                         }
                     case 52:

--- a/src/server/scripts/Kalimdor/zone_silithus.cpp
+++ b/src/server/scripts/Kalimdor/zone_silithus.cpp
@@ -535,18 +535,23 @@ public:
                             uint32 entries[4] = { 15423, 15424, 15414, 15422 };
                             for (uint8 i = 0; i < 4; ++i)
                             {
-                                Unit* mob = player->FindNearestCreature(entries[i], 50, me);
+                                Creature* mob = Fandral->FindNearestCreature(entries[i], 50.0f);
                                 while (mob)
                                 {
-                                    mob->RemoveFromWorld();
-                                    mob = player->FindNearestCreature(15423, 50, me);
+                                    if (mob->IsInWorld())
+                                    {
+                                        Map* map = mob->GetMap();
+                                        map->RemoveFromMap(mob, false);
+                                    }
+
+                                    mob = Fandral->FindNearestCreature(entries[i], 50.0f);
                                 }
                             }
                             break;
                         }
                     case 52:
                         Fandral->GetMotionMaster()->MoveCharge(-8028.75f, 1538.795f, 2.61f, 4);
-                        Fandral->AI()->Talk(ANACHRONOS_SAY_9, me);
+                        Talk(ANACHRONOS_SAY_9);
                         break;
                     case 53:
                         Fandral->AI()->Talk(FANDRAL_SAY_6);
@@ -555,7 +560,8 @@ public:
                         Talk(ANACHRONOS_EMOTE_2);
                         break;
                     case 55:
-                        Fandral->SetVisible(false);
+                        //Fandral should not dispear atm.
+                        //Fandral->SetVisible(false);
                         break;
                     case 56:
                         Talk(ANACHRONOS_EMOTE_3);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  fix the script "npc_anachronos_the_ancient" which will hung up the server.
-  fix some logic errors in script "npc_anachronos_the_ancient".

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- build without errors 
- no server hung up/crash
- quest "A Pawn on the Eternal Board" can finished.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. accept the quest "A Pawn on the Eternal Board". (quest id: 8519)
2. view the quest animation.
3. confirm there is no server hung up/crash and the quest can finished.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
