### PR TITLE
Fix issue skadi the ruthless emote

### DIFF
--- a/data/sql/updates/db_world/2022_05_04_01.sql
+++ b/data/sql/updates/db_world/2022_05_04_01.sql
@@ -1,3 +1,4 @@
+-- DB update 2022_05_04_00 -> 2022_05_04_01
 -- Fix scripted npcs at Falconwing Square
 
 -- Novice Ranger scripting missing

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
@@ -28,10 +28,13 @@ enum Misc
     // TEXTS
     SAY_AGGRO                           = 0,
     SAY_KILL                            = 1,
-    EMOTE_RANGE                         = 2,
     SAY_DEATH                           = 3,
     SAY_DRAKE_DEATH                     = 5,
     SAY_DRAKE_BREATH                    = 6,
+
+    // EMOTES
+    EMOTE_DEEP_BREATH                   = 0,
+    EMOTE_RANGE                         = 1,
 
     // SPELLS
     SPELL_CRUSH_N                       = 50234,
@@ -94,9 +97,6 @@ static Position SkadiPosition[] =
     {490.096f, -510.86f, 123.368f, 0.0f},
     {490.76f, -517.389f, 123.368f, 0.0f}
 };
-
-#define EMOTE_IN_RANGE   "Skadi the Ruthless is within range of the harpoon launchers"
-#define EMOTE_DRAKE_BREATH "Grauf takes a deep breath"
 
 enum phase
 {
@@ -365,8 +365,7 @@ public:
                 case 3:
                     if (m_pInstance)
                         m_pInstance->SetData(SKADI_IN_RANGE, 1);
-
-                    me->TextEmote(EMOTE_IN_RANGE, nullptr, true);
+                    Talk(EMOTE_RANGE);
                     me->SetFacingTo(M_PI);
                     break;
             }
@@ -467,7 +466,7 @@ public:
                         me->GetMotionMaster()->MovePoint(targetPoint, SkadiPosition[targetPoint].GetPositionX(), SkadiPosition[targetPoint].GetPositionY(), SkadiPosition[targetPoint].GetPositionZ());
                         if (targetPoint <= 1)
                         {
-                            me->TextEmote(EMOTE_DRAKE_BREATH, nullptr, true);
+                            Talk(EMOTE_DEEP_BREATH);
                             SpawnFlameTriggers(targetPoint);
                             me->CastSpell(me, SPELL_FREEZING_CLOUD_VISUAL, false);
                         }

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
@@ -96,6 +96,7 @@ static Position SkadiPosition[] =
 };
 
 #define EMOTE_IN_RANGE   "Skadi the Ruthless is within range of the harpoon launchers"
+#define EMOTE_DRAKE_BREATH "Grauf takes a deep breath"
 
 enum phase
 {
@@ -466,6 +467,7 @@ public:
                         me->GetMotionMaster()->MovePoint(targetPoint, SkadiPosition[targetPoint].GetPositionX(), SkadiPosition[targetPoint].GetPositionY(), SkadiPosition[targetPoint].GetPositionZ());
                         if (targetPoint <= 1)
                         {
+                            me->TextEmote(EMOTE_DRAKE_BREATH, nullptr, true);
                             SpawnFlameTriggers(targetPoint);
                             me->CastSpell(me, SPELL_FLAME_VISUAL, false);
                         }

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
@@ -41,9 +41,9 @@ enum Misc
     SPELL_WHIRLWIND_N                   = 50228,
     SPELL_WHIRLWIND_H                   = 50228,
 
-    SPELL_FLAME_VISUAL                  = 47592,
-    SPELL_FLAME_BREATH_N                = 47579,
-    SPELL_FLAME_BREATH_H                = 60020,
+    SPELL_FREEZING_CLOUD_VISUAL         = 47592,
+    SPELL_FREEZING_CLOUD_N              = 47579,
+    SPELL_FREEZING_CLOUD_H              = 60020,
 
     SPELL_LAUNCH_HARPOON                = 48642,
 
@@ -324,8 +324,8 @@ public:
 
         void SpellHitTarget(Unit* target, SpellInfo const* spellInfo) override
         {
-            if (spellInfo->Id == 47593) // SPELL_FLAME_VISUAL trigger
-                target->CastSpell(target, me->GetMap()->IsHeroic() ? SPELL_FLAME_BREATH_H : SPELL_FLAME_BREATH_N, true);
+            if (spellInfo->Id == 47593) // SPELL_FREEZING_CLOUD_VISUAL trigger
+                target->CastSpell(target, me->GetMap()->IsHeroic() ? SPELL_FREEZING_CLOUD_H : SPELL_FREEZING_CLOUD_N, true);
         }
 
         void SpawnFlameTriggers(uint8 point)
@@ -342,13 +342,13 @@ public:
             {
                 Creature* cr;
                 if ((cr = me->SummonCreature(NPC_BREATH_TRIGGER, 483, -484.9f, 105, 0, TEMPSUMMON_TIMED_OR_CORPSE_DESPAWN, 30000)))
-                    cr->CastSpell(cr, cr->GetMap()->IsHeroic() ? SPELL_FLAME_BREATH_H : SPELL_FLAME_BREATH_N, true);
+                    cr->CastSpell(cr, cr->GetMap()->IsHeroic() ? SPELL_FREEZING_CLOUD_H : SPELL_FREEZING_CLOUD_N, true);
                 if ((cr = me->SummonCreature(NPC_BREATH_TRIGGER, 471.0f, -484.7f, 105, 0, TEMPSUMMON_TIMED_OR_CORPSE_DESPAWN, 30000)))
-                    cr->CastSpell(cr, cr->GetMap()->IsHeroic() ? SPELL_FLAME_BREATH_H : SPELL_FLAME_BREATH_N, true);
+                    cr->CastSpell(cr, cr->GetMap()->IsHeroic() ? SPELL_FREEZING_CLOUD_H : SPELL_FREEZING_CLOUD_N, true);
 
                 for (uint8 j = 0; j < 7; j++)
                     if ((cr = me->SummonCreature(NPC_BREATH_TRIGGER, 477.0f, -507.0f + (j * 3), 105.0f, 0, TEMPSUMMON_TIMED_OR_CORPSE_DESPAWN, 30000)))
-                        cr->CastSpell(cr, cr->GetMap()->IsHeroic() ? SPELL_FLAME_BREATH_H : SPELL_FLAME_BREATH_N, true);
+                        cr->CastSpell(cr, cr->GetMap()->IsHeroic() ? SPELL_FREEZING_CLOUD_H : SPELL_FREEZING_CLOUD_N, true);
             }
         }
 
@@ -358,7 +358,7 @@ public:
             {
                 case 0:
                 case 1:
-                    me->RemoveAurasDueToSpell(SPELL_FLAME_VISUAL);
+                    me->RemoveAurasDueToSpell(SPELL_FREEZING_CLOUD_VISUAL);
                     me->SetFacingTo(M_PI * 2);
                     break;
                 case 2:
@@ -469,7 +469,7 @@ public:
                         {
                             me->TextEmote(EMOTE_DRAKE_BREATH, nullptr, true);
                             SpawnFlameTriggers(targetPoint);
-                            me->CastSpell(me, SPELL_FLAME_VISUAL, false);
+                            me->CastSpell(me, SPELL_FREEZING_CLOUD_VISUAL, false);
                         }
 
                         if (m_pInstance)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added Grauf's deep breath emote
-  Renamed SPELL_FLAME references to properly reflect correct spell name FREEZING_CLOUD

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- https://github.com/azerothcore/azerothcore-wotlk/issues/6741
- https://github.com/azerothcore/azerothcore-wotlk/issues/4153

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tesed in-game
- OS: Win10


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Teleport to Skadi the Ruthless in Utgarde Pinnacle
2. Start the encounter
3. Move to the harpoons
4. Wait for his breath

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
