### PR TITLE
Fix(DB/quest_greeting) gender check

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1651708009830546980.sql
+++ b/data/sql/updates/pending_db_world/rev_1651708009830546980.sql
@@ -1,0 +1,6 @@
+UPDATE `quest_greeting` SET `Greeting`='Hello, citizen.  You look like a $g man : woman; with a purpose - do you have business with the Stormwind Army?' WHERE `ID`=261;
+UPDATE `quest_greeting` SET `Greeting`='Hello, hello!  Welcome to my kitchen, $g sir : m''lady;!  This is where all of the Scarlet Raven Tavern''s finest delicacies are made.  Ah, just smell the wonderful aroma!' WHERE `ID`=272;
+UPDATE `quest_greeting` SET `Greeting`='Hey $Gbuddy:ma''am;, do you think you could give me a hand with something?  I''m really IN dire straits here...' WHERE `ID`=415;
+UPDATE `quest_greeting` SET `Greeting`='You watch where you step around here, $Glad:lass;.  You might not be a part of our outfit, but that doesn''t mean I won''t take a cane to you if you fall out of line!' WHERE `ID`=733;
+UPDATE `quest_greeting` SET `Greeting`='Greetings, $G lad : lass;. I''m Grelin Whitebeard. I''m here to examine the threat posed by the growing numbers of trolls in Coldridge Valley. What have I found? It''s a bit troubling...' WHERE `ID`=786;
+UPDATE `quest_greeting` SET `Greeting`='Good day, $glad:lass;! Perhaps you could help me with some things that need to be taken care of.' WHERE `ID`=3663;


### PR DESCRIPTION
## Changes Proposed:
-  Gender check in text eg. $glad:lass; has the semi colon replaced with a comma in AZ db thus not working properly.
-  Updated 6 incorrect text in quest_greeting by replacing comma with semi colon.

## Issues Addressed:
- Closes #3383 
- #11453

## SOURCE:
TC with help from @acidmanifesto 

## Tests Performed:
- tested in game on two of the 6 repaired

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 1398
2. open gossip