### PR TITLE
fix(Core/Creature): Move hardcoded text/gossips to DB - boss_xt002

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -91,7 +91,7 @@ enum NPCs
     NPC_PILE_TRIGGER            = 33337,
 };
 
-enum XT002Text 
+enum XT002Text
 {
     SAY_AGGRO                   = 0,
     SAY_HEART_OPENED            = 1,

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -104,7 +104,7 @@ enum XT002Text
     SAY_EMOTE_HEART_OPENED      = 8,
     SAY_EMOTE_HEART_CLOSED      = 9,
     SAY_EMOTE_TYMPANIC_TANTRUM  = 10,
-    SAY_EMOTE_SCRAPBOT          = 11, 
+    SAY_EMOTE_SCRAPBOT          = 11,
 };
 
 enum Misc

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -91,7 +91,7 @@ enum NPCs
     NPC_PILE_TRIGGER            = 33337,
 };
 
-enum XT002Text
+enum Texts
 {
     SAY_AGGRO                   = 0,
     SAY_HEART_OPENED            = 1,
@@ -101,10 +101,10 @@ enum XT002Text
     SAY_BERSERK                 = 5,
     SAY_DEATH                   = 6,
     SAY_SUMMON                  = 7,
-    SAY_EMOTE_HEART_OPENED      = 8,
-    SAY_EMOTE_HEART_CLOSED      = 9,
-    SAY_EMOTE_TYMPANIC_TANTRUM  = 10,
-    SAY_EMOTE_SCRAPBOT          = 11,
+    EMOTE_HEART_OPENED          = 8,
+    EMOTE_HEART_CLOSED          = 9,
+    EMOTE_TYMPANIC_TANTRUM      = 10,
+    EMOTE_SCRAPBOT              = 11,
 };
 
 enum Misc
@@ -271,7 +271,7 @@ public:
 
                 me->CastSpell(me, SPELL_HEARTBREAK, true);
 
-                Talk(SAY_EMOTE_HEART_CLOSED);
+                Talk(EMOTE_HEART_CLOSED);
                 events.ScheduleEvent(EVENT_REMOVE_EMOTE, 4000);
                 return;
             }
@@ -346,7 +346,7 @@ public:
                     events.ScheduleEvent(EVENT_GRAVITY_BOMB, 10000, 1);
                     break;
                 case EVENT_TYMPANIC_TANTARUM:
-                    Talk(SAY_EMOTE_TYMPANIC_TANTRUM);
+                    Talk(EMOTE_TYMPANIC_TANTRUM);
                     Talk(SAY_TYMPANIC_TANTRUM);
                     me->CastSpell(me, SPELL_TYMPANIC_TANTARUM, true);
                     events.RepeatEvent(60000);
@@ -358,7 +358,7 @@ public:
 
                 // Animation events
                 case EVENT_START_SECOND_PHASE:
-                    Talk(SAY_EMOTE_HEART_OPENED);
+                    Talk(EMOTE_HEART_OPENED);
                     me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
                     if (Unit* heart = me->GetVehicleKit() ? me->GetVehicleKit()->GetPassenger(HEART_VEHICLE_SEAT) : nullptr)
                         heart->GetAI()->DoAction(ACTION_AWAKEN_HEART);
@@ -607,7 +607,7 @@ public:
                     }
 
                     if (!urand(0, 2))
-                        pXT002->AI()->Talk(SAY_EMOTE_SCRAPBOT);
+                        pXT002->AI()->Talk(EMOTE_SCRAPBOT);
 
                     me->DespawnOrUnsummon(1);
                 }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -93,15 +93,18 @@ enum NPCs
 
 enum Sounds
 {
-    XT_SOUND_AGGRO              = 15724,
-    XT_SOUND_HEART_OPEN         = 15725,
-    XT_SOUND_HEART_CLOSED       = 15726,
-    XT_SOUND_TANTARUM           = 15727,
-    XT_SOUND_SLAY1              = 15728,
-    XT_SOUND_SLAY2              = 15729,
-    XT_SOUND_ENRAGE             = 15730,
-    XT_SOUND_DEATH              = 15731,
-    XT_SOUND_SUMMON             = 15732,
+    SAY_AGGRO                   = 0,
+    SAY_HEART_OPENED            = 1,
+    SAY_HEART_CLOSED            = 2,
+    SAY_TYMPANIC_TANTRUM        = 3,
+    SAY_SLAY                    = 4,
+    SAY_BERSERK                 = 5,
+    SAY_DEATH                   = 6,
+    SAY_SUMMON                  = 7,
+    SAY_EMOTE_HEART_OPENED      = 8,
+    SAY_EMOTE_HEART_CLOSED      = 9,
+    SAY_EMOTE_TYMPANIC_TANTRUM  = 10,
+    SAY_EMOTE_SCRAPBOT          = 11, 
 };
 
 enum Misc
@@ -203,8 +206,7 @@ public:
             RescheduleEvents(); // Other events are scheduled here
 
             me->setActive(true);
-            me->Yell("New toys? For me? I promise I won't break them this time!", LANG_UNIVERSAL);
-            me->PlayDirectSound(XT_SOUND_AGGRO);
+            Talk(SAY_AGGRO);
 
             if (m_pInstance)
             {
@@ -223,23 +225,13 @@ public:
         {
             if (victim->GetTypeId() == TYPEID_PLAYER && !urand(0, 2))
             {
-                if (urand(0, 1))
-                {
-                    me->Yell("I... I think I broke it.", LANG_UNIVERSAL);
-                    me->PlayDirectSound(XT_SOUND_SLAY1);
-                }
-                else
-                {
-                    me->Yell("I guess it doesn't bend that way.", LANG_UNIVERSAL);
-                    me->PlayDirectSound(XT_SOUND_SLAY2);
-                }
+                Talk(SAY_SLAY);
             }
         }
 
         void JustDied(Unit* /*killer*/) override
         {
-            me->Yell("You are bad... Toys... Very... Baaaaad!", LANG_UNIVERSAL);
-            me->PlayDirectSound(XT_SOUND_DEATH);
+            Talk(SAY_DEATH);
 
             if (m_pInstance)
             {
@@ -279,7 +271,7 @@ public:
 
                 me->CastSpell(me, SPELL_HEARTBREAK, true);
 
-                me->TextEmote("XT-002 Deconstructor's heart is severed from his body.", nullptr, true);
+                Talk(SAY_EMOTE_HEART_CLOSED);
                 events.ScheduleEvent(EVENT_REMOVE_EMOTE, 4000);
                 return;
             }
@@ -329,8 +321,7 @@ public:
                         me->SetControlled(true, UNIT_STATE_STUNNED);
                         me->SetByteValue(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_STAND_STATE, UNIT_STAND_STATE_SUBMERGED); // submerge with animation
 
-                        me->Yell("So tired. I will rest for just a moment!", LANG_UNIVERSAL);
-                        me->PlayDirectSound(XT_SOUND_HEART_OPEN);
+                        Talk(SAY_HEART_OPENED);
 
                         events.CancelEventGroup(1);
                         events.ScheduleEvent(EVENT_START_SECOND_PHASE, 5000);
@@ -355,21 +346,19 @@ public:
                     events.ScheduleEvent(EVENT_GRAVITY_BOMB, 10000, 1);
                     break;
                 case EVENT_TYMPANIC_TANTARUM:
-                    me->TextEmote("XT-002 Deconstructor begins to cause the earth to quake.", nullptr, true);
-                    me->Yell("NO! NO! NO! NO! NO!", LANG_UNIVERSAL);
-                    me->PlayDirectSound(XT_SOUND_TANTARUM);
+                    Talk(SAY_EMOTE_TYMPANIC_TANTRUM);
+                    Talk(SAY_TYMPANIC_TANTRUM);
                     me->CastSpell(me, SPELL_TYMPANIC_TANTARUM, true);
                     events.RepeatEvent(60000);
                     return;
                 case EVENT_ENRAGE:
-                    me->Yell("I'm tired of these toys. I don't want to play anymore!", LANG_UNIVERSAL);
-                    me->PlayDirectSound(XT_SOUND_ENRAGE);
+                    Talk(SAY_BERSERK);
                     me->CastSpell(me, SPELL_XT002_ENRAGE, true);
                     break;
 
                 // Animation events
                 case EVENT_START_SECOND_PHASE:
-                    me->TextEmote("XT-002 Deconstructor's heart is exposed and leaking energy.", nullptr, true);
+                    Talk(SAY_EMOTE_HEART_OPENED);
                     me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
                     if (Unit* heart = me->GetVehicleKit() ? me->GetVehicleKit()->GetPassenger(HEART_VEHICLE_SEAT) : nullptr)
                         heart->GetAI()->DoAction(ACTION_AWAKEN_HEART);
@@ -383,8 +372,7 @@ public:
                         return;
                     }
 
-                    me->Yell("I'm ready to play!", LANG_UNIVERSAL);
-                    me->PlayDirectSound(XT_SOUND_HEART_CLOSED);
+                    Talk(SAY_HEART_CLOSED);
 
                     me->SetByteValue(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_STAND_STATE, UNIT_STAND_STATE_STAND); // emerge
                     // Hide heart
@@ -619,7 +607,7 @@ public:
                     }
 
                     if (!urand(0, 2))
-                        me->TextEmote("XT-002 Deconstructor consumes scrap bot to repair himself.", nullptr, true);
+                        pXT002->AI()->Talk(SAY_EMOTE_SCRAPBOT);
 
                     me->DespawnOrUnsummon(1);
                 }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -91,7 +91,7 @@ enum NPCs
     NPC_PILE_TRIGGER            = 33337,
 };
 
-enum Sounds
+enum XT002Text 
 {
     SAY_AGGRO                   = 0,
     SAY_HEART_OPENED            = 1,


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Part of https://github.com/azerothcore/azerothcore-wotlk/projects/15 but xt was not on the list. (Going trough entirety of ulduar)
All of the creature_text is already in DB
However, SAY_SUMMON is not linked with BroadcastTextId and I cannot find any video source of it actually being used. (Except TC boss script, but still, no actual proof)
## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes none

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game with sound
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 136054
2. Pull (with sound enabled)
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
