### PR TITLE
fix(Core/Creature): Move hardcoded text/gossips to DB - boss_ignis

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
@@ -286,9 +286,9 @@ public:
             me->setActive(false);
         }
 
-        void KilledUnit(Unit* who) override
+        void KilledUnit(Unit* victim) override
         {
-            if (who->GetTypeId() == TYPEID_PLAYER)
+            if (victim->GetTypeId() == TYPEID_PLAYER)
                 Talk(SAY_SLAY);
         }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
@@ -57,7 +57,7 @@
 #define NPC_SCORCHED_GROUND             33123
 #define NPC_WATER_TRIGGER               22515
 
-enum IgnisText
+enum Texts
 {
     SAY_AGGRO       = 0,
     SAY_SUMMON      = 1,
@@ -66,7 +66,7 @@ enum IgnisText
     SAY_SLAY        = 4,
     SAY_BERSERK     = 5,
     SAY_DEATH       = 6,
-    SAY_EMOTE_JETS  = 7,
+    EMOTE_JETS      = 7,
 };
 
 #define ACHIEV_STOKIN_THE_FURNACE_EVENT 20951
@@ -362,7 +362,7 @@ public:
                     me->DisableRotate(false);
                     break;
                 case EVENT_SPELL_FLAME_JETS:
-                    Talk(SAY_EMOTE_JETS);
+                    Talk(EMOTE_JETS);
                     me->CastSpell(me->GetVictim(), S_FLAME_JETS, false);
                     events.RepeatEvent(25000);
                     break;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
@@ -57,26 +57,17 @@
 #define NPC_SCORCHED_GROUND             33123
 #define NPC_WATER_TRIGGER               22515
 
-#define TEXT_AGGRO                      "Insolent whelps! Your blood will temper the weapons used to reclaim this world!"
-#define TEXT_ACTIVATE_CONSTRUCT         "Arise, soldiers of the Iron Crucible! The Makers' will be done!"
-#define TEXT_SCORCH_1                   "Let the inferno consume you!"
-#define TEXT_SCORCH_2                   "BURN! Burn in the makers fire!"
-#define TEXT_SLAG_POT                   "I will burn away your impurities!"
-#define TEXT_SLAY_1                     "More scraps for the scrapheap!"
-#define TEXT_SLAY_2                     "Your bones will serve as kindling!"
-#define TEXT_BERSERK                    "Let it be finished!"
-#define TEXT_DEATH                      "I. Have. Failed."
-#define TEXT_FLAME_JETS                 "Ignis The Furnace Master begins to cast Flame Jets!"
-
-#define SOUND_AGGRO                     15564
-#define SOUND_ACTIVATE_CONSTRUCT        15565
-#define SOUND_SLAG_POT                  15566
-#define SOUND_SCORCH_1                  15567
-#define SOUND_SCORCH_2                  15568
-#define SOUND_SLAY_1                    15569
-#define SOUND_SLAY_2                    15570
-#define SOUND_BERSERK                   15571
-#define SOUND_DEATH                     15572
+enum IgnisText
+{
+    SAY_AGGRO       = 0,
+    SAY_SUMMON      = 1,
+    SAY_SLAG_POT    = 2,
+    SAY_SCORCH      = 3,
+    SAY_SLAY        = 4,
+    SAY_BERSERK     = 5,
+    SAY_DEATH       = 6,
+    SAY_EMOTE_JETS  = 7,
+};
 
 #define ACHIEV_STOKIN_THE_FURNACE_EVENT 20951
 
@@ -260,8 +251,7 @@ public:
             events.ScheduleEvent(EVENT_SPELL_FLAME_JETS, 32000);
             events.ScheduleEvent(EVENT_GRAB, 25000);
 
-            me->Yell(TEXT_AGGRO, LANG_UNIVERSAL);
-            me->PlayDirectSound(SOUND_AGGRO);
+            Talk(SAY_AGGRO);
             DoZoneInCombat();
 
             if( InstanceScript* m_pInstance = me->GetInstanceScript() )
@@ -296,24 +286,15 @@ public:
             me->setActive(false);
         }
 
-        void KilledUnit(Unit*  /*victim*/) override
+        void KilledUnit(Unit* who) override
         {
-            if( rand() % 2 )
-            {
-                me->Yell(TEXT_SLAY_1, LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_SLAY_1);
-            }
-            else
-            {
-                me->Yell(TEXT_SLAY_2, LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_SLAY_2);
-            }
+            if (who->GetTypeId() == TYPEID_PLAYER)
+                Talk(SAY_SLAY);
         }
 
         void JustDied(Unit* /*killer*/) override
         {
-            me->Yell(TEXT_DEATH, LANG_UNIVERSAL);
-            me->PlayDirectSound(SOUND_DEATH);
+            Talk(SAY_DEATH);
 
             if( me->GetInstanceScript() )
                 me->GetInstanceScript()->SetData(TYPE_IGNIS, DONE);
@@ -357,27 +338,18 @@ public:
                 case 0:
                     break;
                 case EVENT_ACTIVATE_CONSTRUCT:
+                    Talk(SAY_SUMMON);
                     me->CastCustomSpell(SPELL_ACTIVATE_CONSTRUCT, SPELLVALUE_MAX_TARGETS, 1, (Unit*)nullptr, false);
                     if (++counter >= 20)
                     {
-                        me->Yell(TEXT_BERSERK, LANG_UNIVERSAL);
-                        me->PlayDirectSound(SOUND_BERSERK);
+                        Talk(SAY_BERSERK);
                         me->CastSpell(me, SPELL_BERSERK, true);
                         break;
                     }
                     events.RepeatEvent(RAID_MODE(40000, 30000));
                     break;
                 case EVENT_SPELL_SCORCH:
-                    if( rand() % 2 )
-                    {
-                        me->Yell(TEXT_SCORCH_1, LANG_UNIVERSAL);
-                        me->PlayDirectSound(SOUND_SCORCH_1);
-                    }
-                    else
-                    {
-                        me->Yell(TEXT_SCORCH_2, LANG_UNIVERSAL);
-                        me->PlayDirectSound(SOUND_SCORCH_2);
-                    }
+                    Talk(SAY_SCORCH);
                     me->SetControlled(true, UNIT_STATE_ROOT);
                     me->DisableRotate(true);
                     me->SendMovementFlagUpdate();
@@ -390,7 +362,7 @@ public:
                     me->DisableRotate(false);
                     break;
                 case EVENT_SPELL_FLAME_JETS:
-                    me->TextEmote(TEXT_FLAME_JETS, nullptr, true);
+                    Talk(SAY_EMOTE_JETS);
                     me->CastSpell(me->GetVictim(), S_FLAME_JETS, false);
                     events.RepeatEvent(25000);
                     break;
@@ -429,8 +401,7 @@ public:
                             int8 pos = urand(0, playerGUIDs.size() - 1);
                             if( Player* pTarget = ObjectAccessor::GetPlayer(*me, playerGUIDs.at(pos)) )
                             {
-                                me->Yell(TEXT_SLAG_POT, LANG_UNIVERSAL);
-                                me->PlayDirectSound(SOUND_SLAG_POT);
+                                Talk(SAY_SLAG_POT);
                                 me->CastSpell(pTarget, SPELL_GRAB, false);
                             }
                         }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Part of https://github.com/azerothcore/azerothcore-wotlk/projects/15 Going trough the entirety of Ulduar
All of the creature_text is already in DB
## Changes Proposed:
-  Added the missing (wasn't being used before) SAY_SUMMON, source TC & [YT](https://www.youtube.com/watch?v=PYlfUoY9I3Y)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #4156
## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game with sound

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 136371
2. Pull (with sound enabled)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
