### PR TITLE
Fix (DB/SAI) Valkyrion Harpoon Gun

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1651874393098969660.sql
+++ b/data/sql/updates/pending_db_world/rev_1651874393098969660.sql
@@ -1,0 +1,2 @@
+-- Fix Valkyrion Harpoon Gun SAI to set rooted on passenger exit
+UPDATE `smart_scripts` SET `event_type`=28, `event_flags`=0, `comment`='Valkyrion Harpoon Gun - On Passenger exit - Set Rooted On' WHERE `entryorguid`=30066;


### PR DESCRIPTION
## Changes Proposed:
- Rooted is set in creature_template_movement so the SAI to set rooted on spawn was useless.
- Since the rooted was being removed on player exit I changed SAI to root gun on player exit.

## Issues Addressed:
- Closes #11643

## SOURCE:
Me

## Tests Performed:
- Inserts
- Tested in game. Gun remains rooted.

## How to Test the Changes:
1. .go xyz 7354.860352 -80.268097 777.624817 571
2. .quest a 12953
3. mount a Valkyrion Harpoon Gun
4. use the ADWS of the keyboard to move it