### PR TITLE
fix(Core/Creature): Move hardcoded text/gossips to DB - boss_auriaya

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1651872810987186100.sql
+++ b/data/sql/updates/pending_db_world/rev_1651872810987186100.sql
@@ -1,0 +1,12 @@
+-- Clear Auriaya's creature_text (duplicate and EMOTE_DEATH missing), CN locale is also wrong
+DELETE FROM `creature_text` WHERE `CreatureID`=33515;
+
+-- EMOTE_DEATH has no BroadcastTextID
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(33515, 0, 0, 'Some things are better left alone!', 14, 0, 100, 0, 0, 15473, 34341, 0, 'Auriaya SAY_AGGRO'),
+(33515, 1, 0, 'The secret dies with you.', 14, 0, 100, 0, 0, 15474, 34354, 0, 'Auriaya SAY_SLAY_1'),
+(33515, 1, 1, 'There is no escape!', 14, 0, 100, 0, 0, 15475, 37177, 0, 'Auriaya SAY_SLAY_2'),
+(33515, 2, 0, 'You waste my time!', 14, 0, 100, 0, 0, 15477, 34358, 0, 'Auriaya SAY_BERSERK'),
+(33515, 3, 0, '%s screams in agony.', 16, 0, 100, 0, 0, 15476, 0, 0, 'Auriaya EMOTE_DEATH'),
+(33515, 4, 0, '%s begins to cast Terrifying Screech.', 41, 0, 100, 0, 0, 0, 34450, 0, 'Auriaya EMOTE_FEAR'),
+(33515, 5, 0, '%s begins to activate the Feral Defender!', 41, 0, 100, 0, 0, 0, 34162, 0, 'Auriaya EMOTE_DEFENDER');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
@@ -80,14 +80,14 @@ enum AuriayaEvents
     EVENT_ENRAGE                        = 10,
 };
 
-enum AuriayaSounds
+enum Texts
 {
-    SOUND_AGGRO                         = 15473,
-    SOUND_SLAY1                         = 15474,
-    SOUND_SLAY2                         = 15475,
-    SOUND_DEATH                         = 15476,
-    SOUND_BERSERK                       = 15477,
-    SOUND_WOUND                         = 15478,
+    SAY_AGGRO       = 0,
+    SAY_SLAY        = 1,
+    SAY_BERSERK     = 2,
+    EMOTE_DEATH     = 3,
+    EMOTE_FEAR      = 4,
+    EMOTE_DEFFENDER = 5,
 };
 
 enum Misc
@@ -186,26 +186,15 @@ public:
 
             summons.DoZoneInCombat(NPC_SANCTUM_SENTRY);
 
-            me->Yell("Some things are better left alone!", LANG_UNIVERSAL);
-            me->PlayDirectSound(SOUND_AGGRO);
+            Talk(SAY_AGGRO);
             me->setActive(true);
         }
 
-        void KilledUnit(Unit*  /*victim*/) override
+        void KilledUnit(Unit* victim) override
         {
-            if (urand(0, 2))
-                return;
-
-            if (urand(0, 1))
-            {
-                me->Yell("The secret dies with you!", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_SLAY1);
-            }
-            else
-            {
-                me->Yell("There is no escape!", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_SLAY2);
-            }
+            if (victim->GetTypeId() == TYPEID_PLAYER)
+                if (urand(0, 1))
+                    Talk(SAY_SLAY);
         }
 
         void JustDied(Unit* /*killer*/) override
@@ -216,8 +205,7 @@ public:
             EntryCheckPredicate pred(NPC_FERAL_DEFENDER);
             summons.DoAction(ACTION_DESPAWN_ADDS, pred);
             summons.DespawnAll();
-            me->TextEmote("Auriaya screams in agony.", nullptr, true);
-            me->PlayDirectSound(SOUND_DEATH);
+            Talk(EMOTE_DEATH);
         }
 
         void DoAction(int32 param) override
@@ -240,7 +228,7 @@ public:
             switch (events.ExecuteEvent())
             {
                 case EVENT_SUMMON_FERAL_DEFENDER:
-                    me->TextEmote("Auriaya begins to activate Feral Defender.", nullptr, true);
+                    Talk(EMOTE_DEFFENDER);
                     me->CastSpell(me, SPELL_ACTIVATE_FERAL_DEFENDER, true);
                     me->ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_INTERRUPT_CAST, true);
                     events.ScheduleEvent(EVENT_REMOVE_IMMUNE, 3000);
@@ -249,7 +237,7 @@ public:
                     me->ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_INTERRUPT_CAST, false);
                     break;
                 case EVENT_TERRIFYING_SCREECH:
-                    me->TextEmote("Auriaya begins to cast Terrifying Screech.", nullptr, true);
+                    Talk(EMOTE_FEAR);
                     me->CastSpell(me, SPELL_TERRIFYING_SCREECH, false);
                     events.RepeatEvent(35000);
                     break;
@@ -273,8 +261,7 @@ public:
                         break;
                     }
                 case EVENT_ENRAGE:
-                    me->TextEmote("You waste my time!", nullptr, true);
-                    me->PlayDirectSound(SOUND_BERSERK);
+                    Talk(SAY_BERSERK);
                     me->CastSpell(me, SPELL_ENRAGE, true);
                     break;
             }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
@@ -192,9 +192,11 @@ public:
 
         void KilledUnit(Unit* victim) override
         {
+            if (urand(0, 2))
+                return;     
+                
             if (victim->GetTypeId() == TYPEID_PLAYER)
-                if (urand(0, 1))
-                    Talk(SAY_SLAY);
+                Talk(SAY_SLAY);
         }
 
         void JustDied(Unit* /*killer*/) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
@@ -193,8 +193,8 @@ public:
         void KilledUnit(Unit* victim) override
         {
             if (urand(0, 2))
-                return;     
-                
+                return;
+
             if (victim->GetTypeId() == TYPEID_PLAYER)
                 Talk(SAY_SLAY);
         }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
@@ -192,11 +192,10 @@ public:
 
         void KilledUnit(Unit* victim) override
         {
-            if (urand(0, 2))
+            if (victim->GetTypeId() != TYPEID_PLAYER || urand(0, 2))
                 return;
 
-            if (victim->GetTypeId() == TYPEID_PLAYER)
-                Talk(SAY_SLAY);
+            Talk(SAY_SLAY);
         }
 
         void JustDied(Unit* /*killer*/) override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Part of https://github.com/azerothcore/azerothcore-wotlk/projects/15 Going trough the entirety of Ulduar
Please read TODO
## Changes Proposed:
-  SQL had a duplicate and was missing EMOTE_DEATH

Previous SQL state:
![ayayaya](https://user-images.githubusercontent.com/46330494/167228194-61239d15-3041-4a9d-80a0-c0fe39f66355.png)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes none

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Source for the scream sound ID is from TC/the script itself/YT

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game with sound


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 137496
2. Pull (with sound enabled)


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] I Have a minor question, how do we deal with if a specific creature_text groupID is missing from BroadcastTextId (EMOTE_DEATH in that case)?
Do we leave it at 0 or do we script it (revert it back to TextEmote hardscript + play sound)? Should it be sniffed (if possible), or it's simply there, in the BroadcastTextId table, but I failed to find it? Thanks.

- [ ] CN locale (for that npc) was broken prior to that (quick google translate, had the duplicate as well)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
