### PR TITLE
fix(Core/Creature): Move hardcoded text/gossips to DB and minor fixes - boss_freya

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -183,25 +183,26 @@ enum FreyaEvents
     EVENT_DETONATING_LASHER_FLAME_LASH          = 55,
 };
 
-enum FreyaSounds
+enum Texts
 {
-    // STONEBARK
-    SOUND_STONEBARK_AGGRO                       = 15500,
-    SOUND_STONEBARK_SLAY1                       = 15501,
-    SOUND_STONEBARK_SLAY2                       = 15502,
-    SOUND_STONEBARK_DEATH                       = 15503,
+    // Elder Brightleaf / Elder Ironbranch / Elder Stonebark
+    SAY_ELDER_AGGRO                              = 0,
+    SAY_ELDER_SLAY                               = 1,
+    SAY_ELDER_DEATH                              = 2,
 
-    // IRONBRANCH
-    SOUND_IRONBRANCH_AGGRO                      = 15493,
-    SOUND_IRONBRANCH_SLAY1                      = 15494,
-    SOUND_IRONBRANCH_SLAY2                      = 15495,
-    SOUND_IRONBRANCH_DEATH                      = 15496,
-
-    // BRIGHTLEAF
-    SOUND_BRIGHTLEAF_AGGRO                      = 15483,
-    SOUND_BRIGHTLEAF_SLAY1                      = 15485,
-    SOUND_BRIGHTLEAF_SLAY2                      = 15486,
-    SOUND_BRIGHTLEAF_DEATH                      = 15487,
+    // Freya
+    SAY_AGGRO                                    = 0,
+    SAY_AGGRO_WITH_ELDER                         = 1,
+    SAY_SLAY                                     = 2,
+    SAY_DEATH                                    = 3,
+    SAY_BERSERK                                  = 4,
+    SAY_SUMMON_CONSERVATOR                       = 5,
+    SAY_SUMMON_TRIO                              = 6,
+    SAY_SUMMON_LASHERS                           = 7,
+    EMOTE_LIFEBINDERS_GIFT                       = 8,
+    EMOTE_ALLIES_OF_NATURE                       = 9,
+    EMOTE_GROUND_TREMOR                          = 10,
+    EMOTE_IRON_ROOTS                             = 11,
 };
 
 enum FreyaNPCs
@@ -224,20 +225,6 @@ enum FreyaNPCs
     NPC_DETONATING_LASHER                       = 32918,
 };
 
-enum FreyaSouns
-{
-    SOUND_AGGRO                                 = 15526,
-    SOUND_ELDERS                                = 15527,
-    SOUND_CONSERVATOR                           = 15528,
-    SOUND_SLAY1                                 = 15529,
-    SOUND_SLAY2                                 = 15530,
-    SOUND_DEATH                                 = 15531,
-    SOUND_BERSERK                               = 15532,
-    SOUND_TRIO                                  = 15533,
-    SOUND_DETONATING                            = 15534,
-    SOUND_ASKHELP                               = 15535,
-};
-
 enum Misc
 {
     ACTION_REMOVE_10_STACK                      = 10,
@@ -245,6 +232,7 @@ enum Misc
     ACTION_REMOVE_2_STACK                       = 2,
     ACTION_RESPAWN_TRIO                         = 1,
     ACTION_LUMBERJACKED                         = -1,
+    ACTION_ELDER_FREYA_KILLED                   = 1,
 
     EVENT_PHASE_ADDS                            = 1,
     EVENT_PHASE_FINAL                           = 2,
@@ -322,32 +310,21 @@ public:
             if (victim->GetTypeId() != TYPEID_PLAYER || urand(0, 2))
                 return;
 
-            if (urand(0, 1))
-            {
-                me->Yell("Forgive me.", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_SLAY1);
-            }
-            else
-            {
-                me->Yell("From your death springs life anew!", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_SLAY2);
-            }
+            Talk(SAY_SLAY);
         }
 
         void DamageTaken(Unit*, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
-            // kaboom!
             if (damage >= me->GetHealth())
             {
-                me->Yell("His hold on me dissipates. I can see clearly once more. Thank you, heroes.", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_DEATH);
+                Talk(SAY_DEATH);
 
                 damage = 0;
+                me->SetReactState(REACT_PASSIVE);
                 me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                 me->SetFaction(FACTION_FRIENDLY);
-                me->SetHealth(me->GetMaxHealth());
-                me->CombatStop();
                 me->RemoveAllAuras();
+                me->AttackStop();
                 events.Reset();
 
                 summons.DespawnAll();
@@ -360,7 +337,7 @@ public:
                         continue;
 
                     if (Creature* e = ObjectAccessor::GetCreature(*me, _elderGUID[i]))
-                        Unit::Kill(e, e);
+                        e->AI()->DoAction(ACTION_ELDER_FREYA_KILLED);
 
                     ++_elderCount;
                 }
@@ -397,12 +374,12 @@ public:
         void SpawnWave()
         {
             _waveNumber = _waveNumber == 1 ? 3 : _waveNumber - 1;
+            Talk(EMOTE_ALLIES_OF_NATURE);
 
             // Wave of three
             if (_waveNumber == 1)
             {
-                me->Yell("Children, assist me!", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_TRIO);
+                Talk(SAY_SUMMON_TRIO);
                 me->SummonCreature(NPC_ANCIENT_WATER_SPIRIT, me->GetPositionX() + urand(5, 15), me->GetPositionY() + urand(5, 15), me->GetMapHeight(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ()));
                 me->SummonCreature(NPC_STORM_LASHER, me->GetPositionX() + urand(5, 15), me->GetPositionY() + urand(5, 15), me->GetMapHeight(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ()));
                 me->SummonCreature(NPC_SNAPLASHER, me->GetPositionX() + urand(5, 15), me->GetPositionY() + urand(5, 15), me->GetMapHeight(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ()));
@@ -410,15 +387,13 @@ public:
             // Ancient Conservator
             else if (_waveNumber == 2)
             {
-                me->Yell("Eonar, your servant requires aid!", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_CONSERVATOR);
+                Talk(SAY_SUMMON_CONSERVATOR);
                 me->SummonCreature(NPC_ANCIENT_CONSERVATOR, me->GetPositionX() + urand(5, 15), me->GetPositionY() + urand(5, 15), me->GetMapHeight(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ()), 0, TEMPSUMMON_CORPSE_DESPAWN);
             }
             // Detonating Lashers
             else if (_waveNumber == 3)
             {
-                me->Yell("The swarm of the elements shall overtake you!", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_DETONATING);
+                Talk(SAY_SUMMON_LASHERS);
                 for (uint8 i = 0; i < 10; ++i)
                     me->SummonCreature(NPC_DETONATING_LASHER, me->GetPositionX() + urand(5, 20), me->GetPositionY() + urand(5, 20), me->GetMapHeight(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ()), 0, TEMPSUMMON_CORPSE_DESPAWN);
             }
@@ -553,13 +528,11 @@ public:
 
             if (_elderGUID[0] || _elderGUID[1] || _elderGUID[2])
             {
-                me->Yell("Elders, grant me your strength!", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_ELDERS);
+                Talk(SAY_AGGRO_WITH_ELDER);
             }
             else
             {
-                me->Yell("The Conservatory must be protected!", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_AGGRO);
+                Talk(SAY_AGGRO);
             }
         }
 
@@ -595,6 +568,7 @@ public:
                     break;
                 case EVENT_FREYA_LIFEBINDER:
                     {
+                        Talk(EMOTE_LIFEBINDERS_GIFT);
                         events.RepeatEvent(45000);
                         float x, y, z;
                         for (uint8 i = 0; i < 10; ++i)
@@ -643,15 +617,16 @@ public:
                         break;
                     }
                 case EVENT_FREYA_BERSERK:
-                    me->Yell("You have strayed too far, wasted too much time!", LANG_UNIVERSAL);
-                    me->PlayDirectSound(SOUND_BERSERK);
+                    Talk(SAY_BERSERK);
                     me->CastSpell(me, SPELL_BERSERK, true);
                     break;
                 case EVENT_FREYA_GROUND_TREMOR:
+                    Talk(EMOTE_GROUND_TREMOR);
                     me->CastSpell(me, SPELL_GROUND_TREMOR_FREYA, false);
                     events.RepeatEvent(25000 + urand(0, 10000));
                     break;
                 case EVENT_FREYA_IRON_ROOT:
+                    Talk(EMOTE_IRON_ROOTS);
                     me->CastCustomSpell(SPELL_IRON_ROOTS_FREYA, SPELLVALUE_MAX_TARGETS, 1, me, false);
                     events.RepeatEvent(45000 + urand(0, 10000));
                     break;
@@ -706,24 +681,14 @@ public:
             if (urand(0, 1))
                 return;
 
-            if (urand(0, 1))
-            {
-                me->TextEmote("Angry roar");
-                me->PlayDirectSound(SOUND_STONEBARK_SLAY1);
-            }
-            else
-            {
-                me->Yell("Such a waste.", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_STONEBARK_SLAY2);
-            }
+            Talk(SAY_ELDER_SLAY);
         }
 
         void JustDied(Unit* killer) override
         {
             if (killer && me->GetEntry() == killer->GetEntry())
                 return;
-            me->Yell("Matron, flee! They are ruthless....", LANG_UNIVERSAL);
-            me->PlayDirectSound(SOUND_STONEBARK_DEATH);
+            Talk(SAY_ELDER_DEATH);
 
             // Lumberjacked
             if (me->GetInstanceScript())
@@ -737,8 +702,8 @@ public:
             events.ScheduleEvent(EVENT_STONEBARK_GROUND_TREMOR, 5000);
             events.ScheduleEvent(EVENT_STONEBARK_PETRIFIED_BARK, 20000);
 
-            me->Yell("This place will serve as your graveyard.", LANG_UNIVERSAL);
-            me->PlayDirectSound(SOUND_STONEBARK_AGGRO);
+            if (!me->HasAura(SPELL_DRAINED_OF_POWER)) // Prevents speech if combat is initiated by hardmode activation
+                Talk(SAY_ELDER_AGGRO);
         }
 
         void DamageTaken(Unit*, uint32& damage, DamageEffectType damageType, SpellSchoolMask damageSchoolMask) override
@@ -779,6 +744,16 @@ public:
 
             DoMeleeAttackIfReady();
         }
+
+        void DoAction(int32 action) override
+        {
+            switch (action)
+            {
+            case ACTION_ELDER_FREYA_KILLED:
+                me->DespawnOrUnsummon();
+                break;
+            }
+        }
     };
 };
 
@@ -812,24 +787,14 @@ public:
             if (urand(0, 1))
                 return;
 
-            if (urand(0, 1))
-            {
-                me->Yell("Fertilizer.", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_BRIGHTLEAF_SLAY1);
-            }
-            else
-            {
-                me->Yell("Your corpse will nourish the soil!", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_BRIGHTLEAF_SLAY2);
-            }
+            Talk(SAY_ELDER_SLAY);
         }
 
         void JustDied(Unit* killer) override
         {
             if (killer && me->GetEntry() == killer->GetEntry())
                 return;
-            me->Yell("Matron, one has fallen!", LANG_UNIVERSAL);
-            me->PlayDirectSound(SOUND_BRIGHTLEAF_DEATH);
+            Talk(SAY_ELDER_DEATH);
 
             // Lumberjacked
             if (me->GetInstanceScript())
@@ -843,8 +808,8 @@ public:
             events.ScheduleEvent(EVENT_BRIGHTLEAF_SOLAR_FLARE, 5000);
             events.ScheduleEvent(EVENT_BRIGHTLEAF_UNSTABLE_SUN_BEAM, 8000);
 
-            me->Yell("Matron, the Conservatory has been breached!", LANG_UNIVERSAL);
-            me->PlayDirectSound(SOUND_BRIGHTLEAF_AGGRO);
+            if (!me->HasAura(SPELL_DRAINED_OF_POWER)) // Prevents speech if combat is initiated by hardmode activation
+                Talk(SAY_ELDER_AGGRO);
         }
 
         void UpdateAI(uint32 diff) override
@@ -902,6 +867,16 @@ public:
 
             DoMeleeAttackIfReady();
         }
+
+        void DoAction(int32 action) override
+        {
+            switch (action)
+            {
+            case ACTION_ELDER_FREYA_KILLED:
+                me->DespawnOrUnsummon();
+                break;
+            }
+        }
     };
 };
 
@@ -933,24 +908,14 @@ public:
             if (urand(0, 1))
                 return;
 
-            if (urand(0, 1))
-            {
-                me->Yell("I return you whence you came!", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_IRONBRANCH_SLAY1);
-            }
-            else
-            {
-                me->Yell("BEGONE!", LANG_UNIVERSAL);
-                me->PlayDirectSound(SOUND_IRONBRANCH_SLAY2);
-            }
+            Talk(SAY_ELDER_SLAY);
         }
 
         void JustDied(Unit* killer) override
         {
             if (killer && me->GetEntry() == killer->GetEntry())
                 return;
-            me->Yell("Freya! They come for you.", LANG_UNIVERSAL);
-            me->PlayDirectSound(SOUND_IRONBRANCH_DEATH);
+            Talk(SAY_ELDER_DEATH);
 
             // Lumberjacked
             if (me->GetInstanceScript())
@@ -964,8 +929,8 @@ public:
             events.ScheduleEvent(EVENT_IRONBRANCH_IRON_ROOT, 15000);
             events.ScheduleEvent(EVENT_IRONBRANCH_THORN_SWARM, 3000);
 
-            me->Yell("Mortals have no place here!", LANG_UNIVERSAL);
-            me->PlayDirectSound(SOUND_IRONBRANCH_AGGRO);
+            if (!me->HasAura(SPELL_DRAINED_OF_POWER)) // Prevents speech if combat is initiated by hardmode activation
+                Talk(SAY_ELDER_AGGRO);
         }
 
         void UpdateAI(uint32 diff) override
@@ -995,6 +960,16 @@ public:
             }
 
             DoMeleeAttackIfReady();
+        }
+
+        void DoAction(int32 action) override
+        {
+            switch (action)
+            {
+            case ACTION_ELDER_FREYA_KILLED:
+                me->DespawnOrUnsummon();
+                break;
+            }
         }
     };
 };


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Part of https://github.com/azerothcore/azerothcore-wotlk/projects/15 Going trough the entirety of Ulduar
creature_text for Freya is already populated in the DB 
## Changes Proposed:
-  Added the following missing emotes:
- *EMOTE_ALLIES_OF_NATURE
- *EMOTE_LIFEBINDERS_GIFT
- *EMOTE_GROUND_TREMOR
- *EMOTE_IRON_ROOTS
- Alive Elders no longer talk if starting Freya hardmode.
- Fixed Freya instantly despawning after being defeated.
- Completing hardmode now despawn any alive Elders, instead of killing them. (This also fixes elders talking as if they've killed someone, themselves in that case, when killed by the previous code, `UNIT::Kill`)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes none

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
[YT](https://www.youtube.com/results?search_query=freya+wow)
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game with sound


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 136554
2. Interact with the Elders (kill/leave alive).
3. Pull (with sound enabled) and make sure none of the alive elders is speaking if engaging hardmode.
4. Verify that all of the previously missing emotes are there.
5. After defeating Freya hardmode pay attention to the elders, none should be speaking and they should despawn instead of being killed.
6. Freya should stay for couple (5) seconds after being successfully defeated, after that should despawn.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
