### PR TITLE
fix(Scripts/BlackwingLair): Warrior Class Call should  not restore to…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1651936089141074200.sql
+++ b/data/sql/updates/pending_db_world/rev_1651936089141074200.sql
@@ -1,0 +1,2 @@
+--
+DELETE FROM `spell_script_names` WHERE `ScriptName`='aura_class_call_berserk';

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
@@ -1157,29 +1157,6 @@ class spell_class_call_polymorph : public SpellScript
     }
 };
 
-class aura_class_call_berserk : public AuraScript
-{
-    PrepareAuraScript(aura_class_call_berserk);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_WARRIOR_BERSERK });
-    }
-
-    void HandleOnEffectRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
-    {
-        if (Unit* target = GetTarget())
-        {
-            target->CastSpell(target, SPELL_WARRIOR_BERSERK);
-        }
-    }
-
-    void Register() override
-    {
-        OnEffectRemove += AuraEffectRemoveFn(aura_class_call_berserk::HandleOnEffectRemove, EFFECT_0, SPELL_AURA_MOD_SHAPESHIFT, AURA_EFFECT_HANDLE_REAL);
-    }
-};
-
 class spell_corrupted_totems : public SpellScript
 {
     PrepareSpellScript(spell_corrupted_totems);
@@ -1314,7 +1291,6 @@ void AddSC_boss_nefarian()
     RegisterSpellScript(aura_class_call_wild_magic);
     RegisterSpellScript(aura_class_call_siphon_blessing);
     RegisterSpellScript(spell_class_call_polymorph);
-    RegisterSpellScript(aura_class_call_berserk);
     RegisterSpellScript(spell_corrupted_totems);
     RegisterSpellScript(spell_shadowblink);
     RegisterSpellScript(spell_spawn_drakonid);


### PR DESCRIPTION
… default stance on removal.

Fixes #11391

<!-- First of all, THANK YOU for your contribution. -->  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11391
- Closes https://github.com/chromiecraft/chromiecraft/issues/3345

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Enter Blackwing Lair.
Engage Nefarian.
Get Warrior Class Call.
Be stuck in Berserker stance for the duration as you should
Drop out of Berserker Stance at the end of the Class Call and warrior must to manually return to desired stance.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
