### PR TITLE
fix(DB/Gossip): Korfax missing text

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1651987971178548000.sql
+++ b/data/sql/updates/pending_db_world/rev_1651987971178548000.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `gossip_menu` WHERE `MenuID` IN (7106,7107);
+INSERT INTO `gossip_menu` VALUES (7106, 8363), (7107, 8364);
+
+UPDATE `gossip_menu_option` SET `ActionMenuID`=7099 WHERE  `MenuID`=7107 AND `OptionID`=0;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Added gossip_menu entries linking to existing npc_text.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #8571
- Closes chromiecraft/chromiecraft/issues/2120

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
![image](https://user-images.githubusercontent.com/61268368/167283511-b9515067-adbe-4ceb-9ba2-a84b37d8f298.png)



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.npc add 16112
Talk and ask about Dreadnaught armor

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
