### PR TITLE
fix(Script/Freya): Change the way Elders are despawned

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -232,7 +232,6 @@ enum Misc
     ACTION_REMOVE_2_STACK                       = 2,
     ACTION_RESPAWN_TRIO                         = 1,
     ACTION_LUMBERJACKED                         = -1,
-    ACTION_ELDER_FREYA_KILLED                   = 1,
 
     EVENT_PHASE_ADDS                            = 1,
     EVENT_PHASE_FINAL                           = 2,
@@ -337,7 +336,7 @@ public:
                         continue;
 
                     if (Creature* e = ObjectAccessor::GetCreature(*me, _elderGUID[i]))
-                        e->AI()->DoAction(ACTION_ELDER_FREYA_KILLED);
+                        e->DespawnOrUnsummon();
 
                     ++_elderCount;
                 }
@@ -744,16 +743,6 @@ public:
 
             DoMeleeAttackIfReady();
         }
-
-        void DoAction(int32 action) override
-        {
-            switch (action)
-            {
-            case ACTION_ELDER_FREYA_KILLED:
-                me->DespawnOrUnsummon();
-                break;
-            }
-        }
     };
 };
 
@@ -867,16 +856,6 @@ public:
 
             DoMeleeAttackIfReady();
         }
-
-        void DoAction(int32 action) override
-        {
-            switch (action)
-            {
-            case ACTION_ELDER_FREYA_KILLED:
-                me->DespawnOrUnsummon();
-                break;
-            }
-        }
     };
 };
 
@@ -960,16 +939,6 @@ public:
             }
 
             DoMeleeAttackIfReady();
-        }
-
-        void DoAction(int32 action) override
-        {
-            switch (action)
-            {
-            case ACTION_ELDER_FREYA_KILLED:
-                me->DespawnOrUnsummon();
-                break;
-            }
         }
     };
 };


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Replace DoAction despawn with a DespawnOrUnsummon, as suggested by [Nyeriah ](https://github.com/azerothcore/azerothcore-wotlk/pull/11665/files/0645d71663877358c63e260bc6025f103a78d79b#diff-e8088b0bc012a572df7e19441fb0eb78ac22aa61901caa45c1dfc2d1269daa8aR340)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes none

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Source that elders should despawn and are not being killed after the fight is over. (unchanged behaviour here, just the method used to despawn them)
Freya has the 3 elder buffs in both videos
[video 1](https://youtu.be/C-SX1MCm2rc?t=601) - The player is facing the same direction where one of the elders should be, but he has despawned as the fight has come to an end.
[video 2 during the fight](https://youtu.be/IdRUDiXcM7o?t=412) - from a similar angle, showing that the elder is there, stunned during the fight
 
Comparison in the 2 videos



https://user-images.githubusercontent.com/46330494/167386431-446d2076-2b3e-467e-a109-87f097b0ebac.mp4





## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Untested (waiting for map version to be updated to test, will edit state after)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c 136554
2. Pull with at least 1 Elder alive
3. Kill Freya and see if the alive elder(s) despawn

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
