### PR TITLE
fix (core): Prevent Forced UpdateObjectVisibility Before in World

### DIFF
--- a/src/server/game/Entities/Player/PlayerUpdates.cpp
+++ b/src/server/game/Entities/Player/PlayerUpdates.cpp
@@ -1548,6 +1548,10 @@ void Player::UpdateVisibilityForPlayer(bool mapChange)
 
 void Player::UpdateObjectVisibility(bool forced, bool fromUpdate)
 {
+    // Prevent updating visibility if player is not in world (example: LoadFromDB sets drunkstate which updates invisibility while player is not in map)
+    if (!IsInWorld())
+        return;
+
     if (!forced)
         AddToNotify(NOTIFY_VISIBILITY_CHANGED);
     else if (!isBeingLoaded())


### PR DESCRIPTION
TC CHERRY PICK

This addresses a rarity issue that at times I have seen but never really thought much of.
This issue can cause GameObjects to render incorrectly on the client. 

Original PR that is closed on tc that readdress the issue with further conversation:
https://github.com/TrinityCore/TrinityCore/pull/27914

Original TC issues is here: 
https://github.com/TrinityCore/TrinityCore/issues/24846
https://github.com/TrinityCore/TrinityCore/issues/20401

TC Cherry Pick: https://github.com/TrinityCore/TrinityCore/commit/38dc5667ba13d5c1d094330b0f57ba0ee9b2dde5

Co-Authored-By: Shauren <shauren.trinity@gmail.com>
Co-Authored-By: Jurgis <326232+chemicstry@users.noreply.github.com>

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Prevent Forced UpdateObjectVisibility Before in World

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds
- Performs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
