### PR TITLE
(DB/Fix) Position Quest Body and Heart

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1652493536788924600.sql
+++ b/data/sql/updates/pending_db_world/rev_1652493536788924600.sql
@@ -1,0 +1,2 @@
+
+UPDATE `quest_template` SET `Flags`=`Flags`|10 WHERE `ID` IN (6001, 6002);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  The main idea of the pull request is to show the player the place where the mission should be performed. After investigating and testing several values in the `quest_poi` and `quest_poi_points` tables, it occurred to me, to check other missions that are similar, and I found that the ones that worked correctly, had the flag number 10. I did the test, and indeed, after applying the flag, the position within the map changes, showing the player, where to perform the mission.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Inside the game
- Windows 10

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Try to perform the mission, before applying the changes, and you will notice that it does not indicate the position where you have to go, on the contrary, the mission points to the same NPC that gives you the quest.
2. Then apply the SQL and you will see what I leave in the images below.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

## Screenshots

![quest_druid_horde](https://user-images.githubusercontent.com/2810187/168406941-e1a2c63f-181f-4c77-854d-c40f28173fcb.jpg)

![quest_druid_alliance](https://user-images.githubusercontent.com/2810187/168406957-b6173a07-4918-4a3d-8948-9f0a5437999d.jpg)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
