### PR TITLE
fix(Core/Spells): The Earthshatterer 8/9 set bonus should be removed …

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1829,6 +1829,11 @@ void Aura::HandleAuraSpecificMods(AuraApplication const* aurApp, Unit* caster, b
                 {
                     target->RemoveAurasDueToSpell(47017);
                 }
+                // Lightning Shield vs The Earthshatterer 8/9 set bonus
+                if (GetSpellInfo()->SpellFamilyFlags[0] & 0x00000400)
+                {
+                    target->RemoveAurasDueToSpell(28820);
+                }
                 break;
             }
             case SPELLFAMILY_DEATHKNIGHT:


### PR DESCRIPTION
…along with Lightning Shield removal.

Fixes #11633

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11633

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
create a shaman, level 60
`.additem set 527`
`.setskill 413 300`
equip 8/9 items
cast lightning shield
`.list auras` to see if aura `28820` is on you
Remove your Lightning Shield stacks
`.list auras` to see if aura `28820` is not on you anymore

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
