### PR TITLE
fix(DB/Creature): BRD Detention Block - Link mobs in group pack

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1652731923594016000.sql
+++ b/data/sql/updates/pending_db_world/rev_1652731923594016000.sql
@@ -1,6 +1,6 @@
 -- Dungeon/BRD Link mobs in the 2 rooms before High Interrogator Gerstahn (no previous creature_formations for the listed GUIDs)
 -- Left room
-DELETE FROM creature_formations WHERE memberguid IN (90695,91054,91082,90850);
+DELETE FROM `creature_formations` WHERE `memberguid` IN (90695,91054,91082,90850);
 INSERT INTO `creature_formations` (`leaderGUID`, `memberGUID`, `dist`, `angle`, `groupAI`, `point_1`, `point_2`) VALUES
 (91054, 90695, 0, 0, 3, 0, 0),
 (91054, 91054, 0, 0, 3, 0, 0),
@@ -8,7 +8,7 @@ INSERT INTO `creature_formations` (`leaderGUID`, `memberGUID`, `dist`, `angle`, 
 (91054, 90850, 0, 0, 3, 0, 0);
 
 -- Right room
-DELETE FROM creature_formations WHERE memberguid IN (91037,45892,91076,90899,91087);
+DELETE FROM `creature_formations` WHERE `memberguid` IN (91037,45892,91076,90899,91087);
 INSERT INTO `creature_formations` (`leaderGUID`, `memberGUID`, `dist`, `angle`, `groupAI`, `point_1`, `point_2`) VALUES
 (91037, 91037, 0, 0, 3, 0, 0),
 (91037, 45892, 0, 0, 3, 0, 0),

--- a/data/sql/updates/pending_db_world/rev_1652731923594016000.sql
+++ b/data/sql/updates/pending_db_world/rev_1652731923594016000.sql
@@ -1,0 +1,17 @@
+-- Dungeon/BRD Link mobs in the 2 rooms before High Interrogator Gerstahn (no previous creature_formations for the listed GUIDs)
+-- Left room
+DELETE FROM creature_formations WHERE memberguid IN (90695,91054,91082,90850);
+INSERT INTO `creature_formations` (`leaderGUID`, `memberGUID`, `dist`, `angle`, `groupAI`, `point_1`, `point_2`) VALUES
+(91054, 90695, 0, 0, 3, 0, 0),
+(91054, 91054, 0, 0, 3, 0, 0),
+(91054, 91082, 0, 0, 3, 0, 0),
+(91054, 90850, 0, 0, 3, 0, 0);
+
+-- Right room
+DELETE FROM creature_formations WHERE memberguid IN (91037,45892,91076,90899,91087);
+INSERT INTO `creature_formations` (`leaderGUID`, `memberGUID`, `dist`, `angle`, `groupAI`, `point_1`, `point_2`) VALUES
+(91037, 91037, 0, 0, 3, 0, 0),
+(91037, 45892, 0, 0, 3, 0, 0),
+(91037, 91076, 0, 0, 3, 0, 0),
+(91037, 90899, 0, 0, 3, 0, 0),
+(91037, 91087, 0, 0, 3, 0, 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
formation table was empty for every single GUID in the sql

## Changes Proposed:
-  Linked both sides each, as the right side was also not pulling a mob

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8008

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://youtu.be/2GxM9F192MA?t=214 cata
https://www.youtube.com/watch?v=NuFeZPXZuG0 classic

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested in-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go xyz 358 -133 -65 230 3.3
2. Pull left from distance, all should come
3. Pull right from distance, all should come

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
