### PR TITLE
fix(DB): Earthcaller gossips

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1652793617224967000.sql
+++ b/data/sql/updates/pending_db_world/rev_1652793617224967000.sql
@@ -1,0 +1,19 @@
+-- Gossips where already on the database, just not linked to each other
+DELETE FROM `gossip_menu` WHERE `MenuID` IN (5812, 5813, 5814, 5815, 5816);
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES 
+(5812, 6985),
+(5813, 6986),
+(5814, 6987),
+(5815, 6988),
+(5816, 6989);
+
+-- Conditions to display the first gossip menu option
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 15) AND (`SourceGroup` = 5812) AND (`SourceEntry` = 0) AND (`SourceId` = 0) AND (`ConditionTypeOrReference` IN (2, 47));
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 5812, 0, 0, 5, 2, 0, 18563, 1, 0, 0, 0, 0, '', 'If player has \'Bindings of the Windseeker\' Left half in inventory'),
+(15, 5812, 0, 0, 4, 2, 0, 18563, 1, 1, 0, 0, 0, '', 'If player has \'Bindings of the Windseeker\' Left half in bank'),
+(15, 5812, 0, 0, 2, 2, 0, 18563, 1, 0, 0, 0, 0, '', 'If player has \'Bindings of the Windseeker\' Left half in inventory'),
+(15, 5812, 0, 0, 3, 2, 0, 18564, 1, 1, 0, 0, 0, '', 'If player has \'Bindings of the Windseeker\' Left half in bank'),
+(15, 5812, 0, 0, 1, 47, 0, 7786, 74, 0, 0, 0, 0, '', 'If player has quest \'Thunderaan the Windseeker\'');
+
+UPDATE `creature_template` SET `gossip_menu_id` = 5812, `npcflag` = 3 WHERE (`entry` = 14348);


### PR DESCRIPTION

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Created missing gossip menus for npc and changed his flags to allow
  gossips.
- Conditions for when player has either bindings or is on quest 7786

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11774 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Reproduce the steps on the linked issue.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
