### PR TITLE
fix(Script/Quest): Mystery of the Infinite minor adjustments & zone_dragonblight move to db from hardcode

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1652973605826504900.sql
+++ b/data/sql/updates/pending_db_world/rev_1652973605826504900.sql
@@ -1,0 +1,3 @@
+-- (Quest)Mystery of the Infinite NPC: "Future You", remove SAI (unused)
+UPDATE `creature_template` SET `AIName` = '' WHERE `entry` = 27899;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 27899 AND `source_type` = 0;

--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -451,7 +451,7 @@ public:
                             return;
                         }
 
-                        ShowNozdormu(); 
+                        ShowNozdormu();
                         if (Player* player = GetPlayer())
                             player->GroupEventHappens(IsFuture() ? QUEST_MYSTERY_OF_THE_INFINITE : QUEST_MYSTERY_OF_THE_INFINITE_REDUX, me);
 

--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -274,28 +274,50 @@ public:
 
 enum hourglass
 {
-    NPC_FUTURE_HOURGLASS            = 27840,
-    NPC_FUTURE_YOU                  = 27899,
+    NPC_FUTURE_HOURGLASS                = 27840,
+    NPC_FUTURE_YOU                      = 27899,
 
-    NPC_PAST_HOURGLASS              = 32327,
-    NPC_PAST_YOU                    = 32331,
+    NPC_PAST_HOURGLASS                  = 32327,
+    NPC_PAST_YOU                        = 32331,
 
-    NPC_INFINITE_ASSAILANT          = 27896,
-    NPC_INFINITE_CHRONO_MAGUS       = 27898,
-    NPC_INFINITE_DESTROYER          = 27897,
-    NPC_INFINITE_TIMERENDER         = 27900,
+    NPC_INFINITE_ASSAILANT              = 27896,
+    NPC_INFINITE_CHRONO_MAGUS           = 27898,
+    NPC_INFINITE_DESTROYER              = 27897,
+    NPC_INFINITE_TIMERENDER             = 27900,
 
-    SPELL_CLONE_CASTER              = 49889,
-    SPELL_TELEPORT_EFFECT           = 52096,
+    SPELL_CLONE_CASTER                  = 49889,
+    SPELL_TELEPORT_EFFECT               = 52096,
 
-    EVENT_START_EVENT               = 1,
-    EVENT_FIGHT_1                   = 2,
-    EVENT_FIGHT_2                   = 3,
-    EVENT_CHECK_FINISH              = 4,
-    EVENT_FINISH_EVENT              = 5,
+    EVENT_START_EVENT                   = 1,
+    EVENT_FIGHT_1                       = 2,
+    EVENT_FIGHT_2                       = 3,
+    EVENT_CHECK_FINISH                  = 4,
+    EVENT_FINISH_EVENT                  = 5,
 
-    QUEST_MYSTERY_OF_THE_INFINITE   = 12470,
+    QUEST_MYSTERY_OF_THE_INFINITE       = 12470,
     QUEST_MYSTERY_OF_THE_INFINITE_REDUX = 13343,
+};
+
+enum hourglassText
+{
+    // Both NPC_PAST_YOU and NPC_FUTURE_YOU share the same creature_text GroupIDs
+    // Start
+    SAY_HOURGLASS_START_1                 = 1,
+    SAY_HOURGLASS_START_2                 = 2,
+
+    // Random whispers during the fight
+    SAY_HOURGLASS_RANDOM_1                = 3,
+    SAY_HOURGLASS_RANDOM_2                = 4,
+    SAY_HOURGLASS_RANDOM_3                = 5,
+    SAY_HOURGLASS_RANDOM_4                = 6,
+    SAY_HOURGLASS_RANDOM_5                = 7,
+    SAY_HOURGLASS_RANDOM_6                = 8,
+    SAY_HOURGLASS_RANDOM_7                = 9,
+    SAY_HOURGLASS_RANDOM_8                = 10,
+
+    // End
+    SAY_HOURGLASS_END_1                   = 11,
+    SAY_HOURGLASS_END_2                   = 12,
 };
 
 class npc_hourglass_of_eternity : public CreatureScript
@@ -312,24 +334,26 @@ public:
     {
         npc_hourglass_of_eternityAI(Creature* c) : ScriptedAI(c) {}
 
-        ObjectGuid summonerGUID;
-        ObjectGuid futureGUID;
+        ObjectGuid pGUID;
+        ObjectGuid copyGUID;
         EventMap events;
         uint8 count[3];
         uint8 phase;
+        uint8 randomTalk;
+        uint8 lastRandomTalk;
 
-        bool IsFuture() { return me->GetEntry() == NPC_FUTURE_HOURGLASS; }
+        bool IsFuture() {return me->GetEntry() == NPC_FUTURE_HOURGLASS;}
         void InitializeAI() override
         {
             if (me->ToTempSummon())
                 if (Unit* summoner = me->ToTempSummon()->GetSummonerUnit())
                 {
-                    summonerGUID = summoner->GetGUID();
+                    pGUID = summoner->GetGUID();
                     float x, y, z;
                     me->GetNearPoint(summoner, x, y, z, me->GetCombatReach(), 0.0f, rand_norm() * 2 * M_PI);
                     if (Creature* cr = summoner->SummonCreature((IsFuture() ? NPC_FUTURE_YOU : NPC_PAST_YOU), x, y, z, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 210000))
                     {
-                        futureGUID = cr->GetGUID();
+                        copyGUID = cr->GetGUID();
                         summoner->CastSpell(cr, SPELL_CLONE_CASTER, true);
                         cr->SetFaction(summoner->GetFaction());
                         cr->SetReactState(REACT_AGGRESSIVE);
@@ -345,8 +369,8 @@ public:
             events.ScheduleEvent(EVENT_START_EVENT, 4000);
         }
 
-        Player* getSummoner() { return ObjectAccessor::GetPlayer(*me, summonerGUID); }
-        Creature* getFuture() { return ObjectAccessor::GetCreature(*me, futureGUID); }
+        Player* GetPlayer() {return ObjectAccessor::GetPlayer(*me, pGUID);}
+        Creature* GetCopy() {return ObjectAccessor::GetCreature(*me, copyGUID);}
 
         uint32 randEntry()
         {
@@ -359,13 +383,13 @@ public:
             switch (events.ExecuteEvent())
             {
                 case EVENT_START_EVENT:
-                    if (Creature* cr = getFuture())
-                        cr->Whisper(IsFuture() ? "Hey there, $N, don't be alarmed. It's me... you... from the future. I'm here to help." : "Whoa! You're me, but from the future! Hey, my equipment got an upgrade! Cool!", LANG_UNIVERSAL, getSummoner());
+                    if (Creature* cr = GetCopy())
+                        cr->AI()->Talk(SAY_HOURGLASS_START_1, GetPlayer());
                     events.ScheduleEvent(EVENT_FIGHT_1, 7000);
                     break;
                 case EVENT_FIGHT_1:
-                    if (Creature* cr = getFuture())
-                        cr->Whisper(IsFuture() ? "Heads up... here they come. I'll help as much as I can. Let's just keep them off the hourglass!" : "Here come the Infinites! I've got to keep the hourglass safe. Can you help?", LANG_UNIVERSAL, getSummoner());
+                    if (Creature* cr = GetCopy())
+                        cr->AI()->Talk(SAY_HOURGLASS_START_2, GetPlayer());
                     events.ScheduleEvent(EVENT_FIGHT_2, 6000);
                     break;
                 case EVENT_FIGHT_2:
@@ -413,19 +437,21 @@ public:
                             return;
                         }
 
-                        if (Player* player = getSummoner())
+                        if (Player* player = GetPlayer)
                             player->GroupEventHappens(IsFuture() ? QUEST_MYSTERY_OF_THE_INFINITE : QUEST_MYSTERY_OF_THE_INFINITE_REDUX, me);
 
-                        me->Whisper(IsFuture() ? "Look, $N, the hourglass has revealed Nozdormu!" : "What the heck? Nozdormu is up there!", LANG_UNIVERSAL, getSummoner());
+                        if (Creature* cr = GetCopy())
+                            cr->AI()->Talk(SAY_HOURGLASS_END_1, GetPlayer());
                         events.ScheduleEvent(EVENT_FINISH_EVENT, 6000);
                         break;
                     }
                 case EVENT_FINISH_EVENT:
                     {
-                        me->Whisper(IsFuture() ? "Farewell, $N. Keep us alive and get some better equipment!" : "I feel like I'm being pulled away through time. Thanks for the help....", LANG_UNIVERSAL, getSummoner());
+                        if (Creature* cr = GetCopy())
+                            cr->AI()->Talk(SAY_HOURGLASS_END_2, GetPlayer());
                         me->DespawnOrUnsummon(500);
-                        if (getFuture())
-                            getFuture()->DespawnOrUnsummon(500);
+                        if (GetCopy())
+                            GetCopy()->DespawnOrUnsummon(500);
                         break;
                     }
             }
@@ -433,37 +459,12 @@ public:
 
         void randomWhisper()
         {
-            std::string text = "";
-            switch(urand(0, IsFuture() ? 7 : 5))
-            {
-                case 0:
-                    text = IsFuture() ? "What? Am I here alone. We both have a stake at this, you know!" : "This equipment looks cool and all, but couldn't we have done a little better? Are you even raiding?";
-                    break;
-                case 1:
-                    text = IsFuture() ? "No matter what, you can't die, because would mean that I would cease to exist, right? But, I was here before when I was you. I'm so confused!" : "Chromie said that if I don't do this just right, I might wink out of existence. If I go, then you go!";
-                    break;
-                case 2:
-                    text = IsFuture() ? "Sorry, but Chromie said that I couldn't reveal anything about your future to you. She said that if I did, I would cease to exist." : "I just want you to know that if we get through this alive, I'm making sure that we turn out better than you. No offense.";
-                    break;
-                case 3:
-                    text = IsFuture() ? "Look at you fight; no wonder I turned to drinking." : "Looks like I'm an underachiever.";
-                    break;
-                case 4:
-                    text = IsFuture() ? "Wow, I'd forgotten how inexperienced I used to be." : "Wait a minute! If you're here, then that means that in the not-so-distant future I'm going to be you helping me? Are we stuck in a time loop?!";
-                    break;
-                case 5:
-                    text = IsFuture() ? "I can't believe that I used to wear that." : "I think I'm going to turn to drinking after this.";
-                    break;
-                case 6:
-                    text = "Listen. I'm not supposed to tell you this, but there's going to be this party that you're invited to. Whatever you do, DO NOT DRINK THE PUNCH!";
-                    break;
-                case 7:
-                    text = "Wish I could remember how many of the Infinite Dragonflight were going to try to stop you. This fight was so long ago.";
-                    break;
-            }
+            randomTalk = urand(SAY_HOURGLASS_RANDOM_1, SAY_HOURGLASS_RANDOM_8); // 3 to 10
+            if (randomTalk == lastRandomTalk ? randomWhisper() : continue;) // Do not send 2 of the same "random whisper" one after another
 
-            if (Creature* cr = getFuture())
-                cr->Whisper(text, LANG_UNIVERSAL, getSummoner());
+            if (Creature* cr = GetCopy())
+                cr->AI()->Talk(randomTalk, GetPlayer);
+            lastRandomTalk = randomTalk;
         }
     };
 };

--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -300,7 +300,7 @@ enum hourglass
 
 enum hourglassText
 {
-    // Both NPC_PAST_YOU and NPC_FUTURE_YOU share the same creature_text GroupIDs
+    // (All are whispers) Both NPC_PAST_YOU and NPC_FUTURE_YOU share the same creature_text GroupIDs
     // Start
     SAY_HOURGLASS_START_1                 = 1,
     SAY_HOURGLASS_START_2                 = 2,
@@ -437,7 +437,7 @@ public:
                             return;
                         }
 
-                        if (Player* player = GetPlayer)
+                        if (Player* player = GetPlayer())
                             player->GroupEventHappens(IsFuture() ? QUEST_MYSTERY_OF_THE_INFINITE : QUEST_MYSTERY_OF_THE_INFINITE_REDUX, me);
 
                         if (Creature* cr = GetCopy())
@@ -457,14 +457,19 @@ public:
             }
         }
 
-        void randomWhisper()
+        void randomWhisper() // Do not repeat the same line
         {
             randomTalk = urand(SAY_HOURGLASS_RANDOM_1, SAY_HOURGLASS_RANDOM_8); // 3 to 10
-            if (randomTalk == lastRandomTalk ? randomWhisper() : continue;) // Do not send 2 of the same "random whisper" one after another
-
-            if (Creature* cr = GetCopy())
-                cr->AI()->Talk(randomTalk, GetPlayer);
-            lastRandomTalk = randomTalk;
+            if (randomTalk == lastRandomTalk)
+            {
+                randomWhisper();
+            }
+            else
+            {
+                if (Creature* cr = GetCopy())
+                    cr->AI()->Talk(randomTalk, GetPlayer());
+                lastRandomTalk = randomTalk;
+            }
         }
     };
 };
@@ -497,7 +502,7 @@ public:
 
         void MoveInLineOfSight(Unit* who) override
         {
-            if (!me->GetVictim() && who->GetEntry() >= NPC_INFINITE_ASSAILANT && who->GetEntry() <= NPC_INFINITE_TIMERENDER)
+            if (!me->GetVictim() && !who->IsFlying() && who->GetEntry() >= NPC_INFINITE_ASSAILANT && who->GetEntry() <= NPC_INFINITE_TIMERENDER)
                 AttackStart(who);
         }
 

--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -284,7 +284,9 @@ enum hourglass
     NPC_INFINITE_CHRONO_MAGUS               = 27898,
     NPC_INFINITE_DESTROYER                  = 27897,
     NPC_INFINITE_TIMERENDER                 = 27900,
+    NPC_NOZDORMU                            = 27925,
 
+    SPELL_NOZDORMU_INVIS                    = 50013,
     SPELL_CLONE_CASTER                      = 49889,
     SPELL_TELEPORT_EFFECT                   = 52096,
 
@@ -377,6 +379,18 @@ public:
             return NPC_INFINITE_ASSAILANT + urand(0, 2);
         }
 
+        void ShowNozdormu()
+        {
+            if (Creature* cr = me->FindNearestCreature(NPC_NOZDORMU, 100.0f, true))
+                cr->RemoveAura(SPELL_NOZDORMU_INVIS);
+        }
+
+        void HideNozdormu()
+        {
+            if (Creature* cr = me->FindNearestCreature(NPC_NOZDORMU, 100.0f, true))
+                cr->AddAura(SPELL_NOZDORMU_INVIS, cr);
+        }
+
         void UpdateAI(uint32 diff) override
         {
             events.Update(diff);
@@ -437,16 +451,21 @@ public:
                             return;
                         }
 
+                        ShowNozdormu(); 
                         if (Player* player = GetPlayer())
                             player->GroupEventHappens(IsFuture() ? QUEST_MYSTERY_OF_THE_INFINITE : QUEST_MYSTERY_OF_THE_INFINITE_REDUX, me);
 
                         if (Creature* cr = GetCopy())
+                        {
+                            cr->SetFacingToObject(me->FindNearestCreature(NPC_NOZDORMU, 100.0f, true));
                             cr->AI()->Talk(SAY_HOURGLASS_END_1, GetPlayer());
+                        }
                         events.ScheduleEvent(EVENT_FINISH_EVENT, 6000);
                         break;
                     }
                 case EVENT_FINISH_EVENT:
                     {
+                        HideNozdormu();
                         if (Creature* cr = GetCopy())
                             cr->AI()->Talk(SAY_HOURGLASS_END_2, GetPlayer());
                         me->DespawnOrUnsummon(500);

--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -274,50 +274,50 @@ public:
 
 enum hourglass
 {
-    NPC_FUTURE_HOURGLASS                = 27840,
-    NPC_FUTURE_YOU                      = 27899,
+    NPC_FUTURE_HOURGLASS                    = 27840,
+    NPC_FUTURE_YOU                          = 27899,
 
-    NPC_PAST_HOURGLASS                  = 32327,
-    NPC_PAST_YOU                        = 32331,
+    NPC_PAST_HOURGLASS                      = 32327,
+    NPC_PAST_YOU                            = 32331,
 
-    NPC_INFINITE_ASSAILANT              = 27896,
-    NPC_INFINITE_CHRONO_MAGUS           = 27898,
-    NPC_INFINITE_DESTROYER              = 27897,
-    NPC_INFINITE_TIMERENDER             = 27900,
+    NPC_INFINITE_ASSAILANT                  = 27896,
+    NPC_INFINITE_CHRONO_MAGUS               = 27898,
+    NPC_INFINITE_DESTROYER                  = 27897,
+    NPC_INFINITE_TIMERENDER                 = 27900,
 
-    SPELL_CLONE_CASTER                  = 49889,
-    SPELL_TELEPORT_EFFECT               = 52096,
+    SPELL_CLONE_CASTER                      = 49889,
+    SPELL_TELEPORT_EFFECT                   = 52096,
 
-    EVENT_START_EVENT                   = 1,
-    EVENT_FIGHT_1                       = 2,
-    EVENT_FIGHT_2                       = 3,
-    EVENT_CHECK_FINISH                  = 4,
-    EVENT_FINISH_EVENT                  = 5,
+    EVENT_START_EVENT                       = 1,
+    EVENT_FIGHT_1                           = 2,
+    EVENT_FIGHT_2                           = 3,
+    EVENT_CHECK_FINISH                      = 4,
+    EVENT_FINISH_EVENT                      = 5,
 
-    QUEST_MYSTERY_OF_THE_INFINITE       = 12470,
-    QUEST_MYSTERY_OF_THE_INFINITE_REDUX = 13343,
+    QUEST_MYSTERY_OF_THE_INFINITE           = 12470,
+    QUEST_MYSTERY_OF_THE_INFINITE_REDUX     = 13343,
 };
 
 enum hourglassText
 {
     // (All are whispers) Both NPC_PAST_YOU and NPC_FUTURE_YOU share the same creature_text GroupIDs
     // Start
-    SAY_HOURGLASS_START_1                 = 1,
-    SAY_HOURGLASS_START_2                 = 2,
+    SAY_HOURGLASS_START_1                   = 1,
+    SAY_HOURGLASS_START_2                   = 2,
 
     // Random whispers during the fight
-    SAY_HOURGLASS_RANDOM_1                = 3,
-    SAY_HOURGLASS_RANDOM_2                = 4,
-    SAY_HOURGLASS_RANDOM_3                = 5,
-    SAY_HOURGLASS_RANDOM_4                = 6,
-    SAY_HOURGLASS_RANDOM_5                = 7,
-    SAY_HOURGLASS_RANDOM_6                = 8,
-    SAY_HOURGLASS_RANDOM_7                = 9,
-    SAY_HOURGLASS_RANDOM_8                = 10,
+    SAY_HOURGLASS_RANDOM_1                  = 3,
+    SAY_HOURGLASS_RANDOM_2                  = 4,
+    SAY_HOURGLASS_RANDOM_3                  = 5,
+    SAY_HOURGLASS_RANDOM_4                  = 6,
+    SAY_HOURGLASS_RANDOM_5                  = 7,
+    SAY_HOURGLASS_RANDOM_6                  = 8,
+    SAY_HOURGLASS_RANDOM_7                  = 9,
+    SAY_HOURGLASS_RANDOM_8                  = 10,
 
     // End
-    SAY_HOURGLASS_END_1                   = 11,
-    SAY_HOURGLASS_END_2                   = 12,
+    SAY_HOURGLASS_END_1                     = 11,
+    SAY_HOURGLASS_END_2                     = 12,
 };
 
 class npc_hourglass_of_eternity : public CreatureScript


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
All of the creature text tables are correctly populated for both npcs (Future & Past)

## Changes Proposed:
- [SQL] Removed the unused SAI from Future You
- Added couple of the missing lines (Source)
- Added IsFlying check to the NPCS in attempt to stop them from attacking the unattackable drakes in the area) STILL HAPPENS ON TIME TO TIME IDK, probably needs some more checks
- Added Nozdormu appearing for a brief period at the end of the roleplay
## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Completes moving zone_dragonblight entirely to DB (Unless I've missed something) 🤔 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowpedia.fandom.com/wiki/Mystery_of_the_Infinite
https://wowpedia.fandom.com/wiki/Mystery_of_the_Infinite,_Redux
https://www.wowhead.com/quest=13343/mystery-of-the-infinite-redux#comments:id=456274:reply=59375 (3.x.x)
And any video of the quest for Nozdormu appearing (although it's for longer time, but it can cause issues)
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go xyz 4111 -405 120 571 
2. .q add 12470
3. .q add 13343 -- Redux (past you)
4. Check if the correct lines are being used.
5. Nozdormu should appear for a brief period above the pile of bones upon successful completion of either quests.

<details>

<summary> Creature texts for the 2 NPCs </summary>

Highlighted text is the random whispers you receive while doing the encounter. Top 2 are on start, last 2 are at the end.

Past You:
![Past You](https://user-images.githubusercontent.com/46330494/169352481-ab1c1cf3-5102-4412-a882-81d31c856d76.png)

Future You:
![Future You](https://user-images.githubusercontent.com/46330494/169352658-3a6b89b0-d31e-48b2-9642-ec819d07570d.png)

</details>

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [x] (added) Quest is missing the part where Nozdormu actually appears above the bone pile. (end of the fight)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
