### PR TITLE
fix(Core): Crashfix.

### DIFF
--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -243,6 +243,11 @@ void WorldSession::HandleBattlemasterJoinOpcode(WorldPacket& recvData)
             }
         });
 
+        if (err)
+        {
+            err = grp->CanJoinBattlegroundQueue(bg, bgQueueTypeId, 0, bg->GetMaxPlayersPerTeam(), false, 0);
+        }
+
         if (err <= 0)
         {
             grp->DoForAllMembers([err](Player* member)
@@ -254,9 +259,6 @@ void WorldSession::HandleBattlemasterJoinOpcode(WorldPacket& recvData)
 
             return;
         }
-
-        ASSERT(err > 0);
-        err = grp->CanJoinBattlegroundQueue(bg, bgQueueTypeId, 0, bg->GetMaxPlayersPerTeam(), false, 0);
 
         isPremade = (grp->GetMembersCount() >= bg->GetMinPlayersPerTeam() && bgTypeId != BATTLEGROUND_RB);
         uint32 avgWaitTime = 0;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11697

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Form group of 3 people
Leader joins Alterac Valley as party
Leader joins Warsong Gulch as party
Leader leaves Alterac Valley
Leader leaves Warsong Gulch
2nd player leaves ONLY Alterac Valley
3rd player leaves both queues
Leader tries to queue Warsong Gulch - error
Leader joins Alterac Valley as party - all okay
Leader joins Arathi Basin - error. Cannot queue up for more than 2 queues (2nd player is still in WSG queue)
No crash anymore

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
