### PR TITLE
fix(Scripts/ZulGurub): Jindo cannot attack targets affected by Hex.

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
@@ -110,12 +110,7 @@ public:
                         events.ScheduleEvent(EVENT_POWERFULLHEALINGWARD, urand(14000, 20000));
                         break;
                     case EVENT_HEX:
-                        if (Unit* target = me->GetVictim())
-                        {
-                            DoCast(target, SPELL_HEX, true);
-                            if (DoGetThreat(target))
-                                DoModifyThreatPercent(target, -80);
-                        }
+                        DoCastVictim(SPELL_HEX, true);
                         events.ScheduleEvent(EVENT_HEX, urand(12000, 20000));
                         break;
                     case EVENT_DELUSIONSOFJINDO: // HACK
@@ -173,6 +168,11 @@ public:
             }
 
             DoMeleeAttackIfReady();
+        }
+
+        bool CanAIAttack(Unit const* target) const override
+        {
+            return !target->HasAura(SPELL_HEX);
         }
     };
 


### PR DESCRIPTION
Fixed #11556

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11556

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Go to ZG - Jin'do with 2 chars
get hexed
notice second target is now the primary target

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
