### PR TITLE
fix(Scripts/ZulGurub): Fixed Jindo's Healing Ward Totem.

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
@@ -34,12 +34,12 @@ enum Say
 enum Spells
 {
     SPELL_BRAINWASHTOTEM            = 24262,
-    SPELL_POWERFULLHEALINGWARD      = 24309, // HACKED Totem summoned by script because the spell totems will not cast.
+    SPELL_POWERFULLHEALINGWARD      = 24309,
     SPELL_HEX                       = 24053,
     SPELL_DELUSIONSOFJINDO          = 24306,
     SPELL_SHADEOFJINDO              = 24308, // HACKED
     //Healing Ward Spell
-    SPELL_HEAL                      = 38588, // HACKED Totems are not working right. Right heal spell ID is 24311 but this spell is not casting...
+    SPELL_HEAL                      = 24311,
     //Shade of Jindo Spell
     SPELL_SHADOWSHOCK               = 19460,
     SPELL_INVISIBLE                 = 24699
@@ -104,9 +104,8 @@ public:
                         DoCast(me, SPELL_BRAINWASHTOTEM);
                         events.ScheduleEvent(EVENT_BRAINWASHTOTEM, urand(18000, 26000));
                         break;
-                    case EVENT_POWERFULLHEALINGWARD: // HACK
-                        //DoCast(me, SPELL_POWERFULLHEALINGWARD);
-                        me->SummonCreature(14987, me->GetPositionX() + 3, me->GetPositionY() - 2, me->GetPositionZ(), 0, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 30000);
+                    case EVENT_POWERFULLHEALINGWARD:
+                        DoCastSelf(SPELL_POWERFULLHEALINGWARD, true);
                         events.ScheduleEvent(EVENT_POWERFULLHEALINGWARD, urand(14000, 20000));
                         break;
                     case EVENT_HEX:


### PR DESCRIPTION
Fixed #11763

<!-- First of all, THANK YOU for your contribution. --> 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11763

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Fight with Jindo and wait until Healing Totem is dropped and see if it's healing the boss.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
