### PR TITLE
fix(DB/creature_text): Jin'do the Hexxer's RP - GRATS!

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1653350504760491620.sql
+++ b/data/sql/updates/pending_db_world/rev_1653350504760491620.sql
@@ -4,3 +4,9 @@ DELETE FROM `creature_text` WHERE `CreatureID`= 11380 AND `GroupID`=0 AND `ID`=0
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES 
 (11380, 0, 0, 'Grats!', 14, 0, 100, 0, 0, 0, 0, 3, 'mandokir SAY_GRATS_JINDO');
 
+-- Adjust dual dialogue on level up for Mandokir
+UPDATE `creature_text` SET `Probability`=75, `comment`='mandokir SAY_DING_KILL_1' WHERE `CreatureID`=11382 AND `GroupID`=1 AND `ID`=0;
+DELETE FROM `creature_text` WHERE `CreatureID`= 11382 AND `GroupID`=1 AND `ID`=1;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Probability`, `comment`) VALUES 
+('11382', '1', '1', 'Your deaths feed my strength!', '14', '25', 'mandokir SAY_DING_KILL_2');
+

--- a/data/sql/updates/pending_db_world/rev_1653350504760491620.sql
+++ b/data/sql/updates/pending_db_world/rev_1653350504760491620.sql
@@ -1,6 +1,6 @@
 
-UPDATE `broadcast_text` SET `MaleText`='Grats!' WHERE `ID`=10601;
+-- Change text and remove 10601 as the BroadcastTextId 'till sniff data
 DELETE FROM `creature_text` WHERE `CreatureID`= 11380 AND `GroupID`=0 AND `ID`=0;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES 
-(11380, 0, 0, 'Grats!', 14, 0, 100, 0, 0, 0, 10601, 3, 'mandokir SAY_GRATS_JINDO');
+(11380, 0, 0, 'Grats!', 14, 0, 100, 0, 0, 0, 0, 3, 'mandokir SAY_GRATS_JINDO');
 

--- a/data/sql/updates/pending_db_world/rev_1653350504760491620.sql
+++ b/data/sql/updates/pending_db_world/rev_1653350504760491620.sql
@@ -1,4 +1,5 @@
 
+UPDATE `broadcast_text` SET `MaleText`='Grats!' WHERE `ID`=10601;
 DELETE FROM `creature_text` WHERE `CreatureID`= 11380 AND `GroupID`=0 AND `ID`=0;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES 
 (11380, 0, 0, 'Grats!', 14, 0, 100, 0, 0, 0, 10601, 3, 'mandokir SAY_GRATS_JINDO');

--- a/data/sql/updates/pending_db_world/rev_1653350504760491620.sql
+++ b/data/sql/updates/pending_db_world/rev_1653350504760491620.sql
@@ -1,0 +1,5 @@
+
+DELETE FROM `creature_text` WHERE `CreatureID`= 11380 AND `GroupID`=0 AND `ID`=0;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES 
+(11380, 0, 0, 'Grats!', 14, 0, 100, 0, 0, 0, 10601, 3, 'mandokir SAY_GRATS_JINDO');
+

--- a/data/sql/updates/pending_db_world/update.sql
+++ b/data/sql/updates/pending_db_world/update.sql
@@ -1,5 +1,0 @@
-
-DELETE FROM `creature_text` WHERE `CreatureID`= 11380 AND `GroupID`=0 AND `ID`=0;
-INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES 
-(11380, 0, 0, 'Grats!', 14, 0, 100, 0, 0, 0, 10601, 3, 'mandokir SAY_GRATS_JINDO');
-

--- a/data/sql/updates/pending_db_world/update.sql
+++ b/data/sql/updates/pending_db_world/update.sql
@@ -1,0 +1,5 @@
+
+DELETE FROM `creature_text` WHERE `CreatureID`= 11380 AND `GroupID`=0 AND `ID`=0;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES 
+(11380, 0, 0, 'Hey! Grats, mon!', 14, 0, 100, 0, 0, 0, 10601, 3, 'mandokir SAY_GRATS_JINDO');
+

--- a/data/sql/updates/pending_db_world/update.sql
+++ b/data/sql/updates/pending_db_world/update.sql
@@ -1,5 +1,5 @@
 
 DELETE FROM `creature_text` WHERE `CreatureID`= 11380 AND `GroupID`=0 AND `ID`=0;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES 
-(11380, 0, 0, 'Hey! Grats, mon!', 14, 0, 100, 0, 0, 0, 10601, 3, 'mandokir SAY_GRATS_JINDO');
+(11380, 0, 0, 'Grats!', 14, 0, 100, 0, 0, 0, 10601, 3, 'mandokir SAY_GRATS_JINDO');
 


### PR DESCRIPTION
Pull Request by [sílker](https://www.chromiecraft.com/en/armory/?character/ChromieCraft/s%C3%ADlker)

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change text range
-  Change text to blizzlike

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11751

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

https://wowpedia.fandom.com/wiki/Jin%27do_the_Hexxer#Quotes

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- None

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go ZG
2. ENgage encounter
3. Let Broodlord kill you for him to level up and Jindo should say GRATS! which should be visible to youin chat

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
