### PR TITLE
fix(DB/Spell): Set Lock and Load procPhase to 0, allowing Black Arrow to proc it.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1653383651000084300.sql
+++ b/data/sql/updates/pending_db_world/rev_1653383651000084300.sql
@@ -1,0 +1,2 @@
+-- (Hunter) Set Lock and Load PPM from DBC
+UPDATE `spell_proc_event` SET `procPhase`=0 WHERE `entry` = -56342;

--- a/data/sql/updates/pending_db_world/rev_1653383651000084300.sql
+++ b/data/sql/updates/pending_db_world/rev_1653383651000084300.sql
@@ -1,2 +1,2 @@
--- (Hunter) Set Lock and Load PPM from DBC
+-- (Hunter) Set Lock and Load procPhase to 0, allowing Black Arrow procs
 UPDATE `spell_proc_event` SET `procPhase`=0 WHERE `entry` = -56342;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Fix by @pklloveyou 
**Other LnL interactions are unaffected**
## Changes Proposed:
-  Set procPhase to 0 (previously was 4)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- https://github.com/azerothcore/azerothcore-wotlk/issues/10919
- https://github.com/azerothcore/azerothcore-wotlk/issues/11363

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested in-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Make a hunter
2. Learn the following talents, Lock and Load(3/3) & Black Arrow
3. Cast Black Arrow 
4. Wait for LnL proc

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
