### PR TITLE
fix(DB/Creature_loot): Increase drop rate of Ritual Salve

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1653810747543320600.sql
+++ b/data/sql/updates/pending_db_world/rev_1653810747543320600.sql
@@ -1,2 +1,2 @@
 -- Adjust drop rate of Ritual salve to 72% (based by a sniffer with 325 kills)
-UPDATE  `creature_loot_template` SET `Chance` = 72 WHERE `Entry` = 2953 AND `Item` = 6634;
+UPDATE `creature_loot_template` SET `Chance` = 72 WHERE `Entry` = 2953 AND `Item` = 6634;

--- a/data/sql/updates/pending_db_world/rev_1653810747543320600.sql
+++ b/data/sql/updates/pending_db_world/rev_1653810747543320600.sql
@@ -1,9 +1,2 @@
---
-DELETE FROM `creature_loot_template` WHERE (`Entry` = 2953);
-INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(2953, 0, 11111, 0.2, 0, 1, 0, 1, 1, 'Bristleback Shaman - (Small Pouch ReferenceTable)'),
-(2953, 0, 20000, 30, 0, 1, 0, 1, 1, 'Bristleback Shaman - (Grey 1-5 EXP 0 ReferenceTable)'),
-(2953, 0, 20014, 30, 0, 1, 0, 1, 1, 'Bristleback Shaman - (Food 1-5 EXP 0 ReferenceTable)'),
-(2953, 1388, 0, 2, 0, 1, 0, 1, 1, 'Bristleback Shaman - Crooked Staff'),
-(2953, 4770, 0, 90, 1, 1, 0, 1, 1, 'Bristleback Shaman - Bristleback Belt'),
-(2953, 6634, 0, 80, 1, 1, 0, 1, 1, 'Bristleback Shaman - Ritual Salve');
+-- Adjust drop rate of Ritual salve to 72% (based by a sniffer with 325 kills)
+UPDATE  `creature_loot_template` SET `Chance` = 72 WHERE `Entry` = 2953 AND `Item` = 6634;

--- a/data/sql/updates/pending_db_world/rev_1653810747543320600.sql
+++ b/data/sql/updates/pending_db_world/rev_1653810747543320600.sql
@@ -1,0 +1,9 @@
+--
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 2953);
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(2953, 0, 11111, 0.2, 0, 1, 0, 1, 1, 'Bristleback Shaman - (Small Pouch ReferenceTable)'),
+(2953, 0, 20000, 30, 0, 1, 0, 1, 1, 'Bristleback Shaman - (Grey 1-5 EXP 0 ReferenceTable)'),
+(2953, 0, 20014, 30, 0, 1, 0, 1, 1, 'Bristleback Shaman - (Food 1-5 EXP 0 ReferenceTable)'),
+(2953, 1388, 0, 2, 0, 1, 0, 1, 1, 'Bristleback Shaman - Crooked Staff'),
+(2953, 4770, 0, 90, 1, 1, 0, 1, 1, 'Bristleback Shaman - Bristleback Belt'),
+(2953, 6634, 0, 80, 1, 1, 0, 1, 1, 'Bristleback Shaman - Ritual Salve');


### PR DESCRIPTION

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Update drop rate to 72 % (based with test  on retail. Look below)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11875

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Drop rate confirm also with https://wotlkdb.com/?item=6634

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- None


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.Create a Tauren Shaman
2. Start Call of Earth questline from [Seer Ravenfeather](https://classic.wowhead.com/npc=5888/seer-ravenfeather)
3. See you are having difficulties gathering 2 Salves after more than 5 Shamans killed.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
