### PR TITLE
fix(Scripts/ZulGurub): Massive Geyser should not attack players.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1653824974575032300.sql
+++ b/data/sql/updates/pending_db_world/rev_1653824974575032300.sql
@@ -1,0 +1,5 @@
+--
+UPDATE `smart_scripts` SET `event_type`=60 WHERE `entryorguid`=14122 AND `source_type`=0 AND `id`=0;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=14122 AND `source_type`=0 AND `id`=1;
+INSERT INTO `smart_scripts` VALUES
+(14122,0,1,0,54,0,100,0,0,0,0,0,0,8,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Hydrospawn - on summon - set passive react');

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_gahzranka.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_gahzranka.cpp
@@ -29,7 +29,7 @@ EndScriptData */
 enum Spells
 {
     SPELL_FROSTBREATH               = 16099,
-    SPELL_MASSIVEGEYSER             = 22421, // Not working. (summon)
+    SPELL_MASSIVEGEYSER             = 22421,
     SPELL_SLAM                      = 24326
 };
 


### PR DESCRIPTION
Fixes #11563

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11563

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.additem 19975 5`
`.additem 19974`
`.go xyz -11695 -1770 13 309` Teleports to Pagle's Pointe
Engage Gahz'ranka
Observe the combat log once the Massive Geyser is summoned

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
