### PR TITLE
fix(DB): Red Whelp Skinning loot

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1654271745339373800.sql
+++ b/data/sql/updates/pending_db_world/rev_1654271745339373800.sql
@@ -1,0 +1,18 @@
+-- Skinning loot: 100008
+SET @LOOT               = 100008;
+SET @RED_WHELP          = 1042;
+SET @LOST_WHELP         = 1043;
+SET @CRIMSON_WHELP      = 1069;
+SET @LIGHT_LEATHER      = 2318;
+SET @LIGHT_HIDE         = 783;
+SET @MEDIUM_LEATHER     = 2319;
+SET @MEDIUM_HIDE        = 4232;
+SET @RED_WHELP_SCALE    = 7287;
+
+UPDATE `creature_template` SET `skinloot`= 0 WHERE `skinloot`= @LOOT AND `entry` NOT IN (@RED_WHELP, @LOST_WHELP, @CRIMSON_WHELP);
+
+UPDATE `skinning_loot_template` SET `Comment` = 'Light Leather' WHERE `Item` = @LIGHT_LEATHER AND `Entry` = @LOOT;
+UPDATE `skinning_loot_template` SET `Comment` = 'Light Hide' WHERE `Item` = @LIGHT_HIDE AND `Entry` = @LOOT;
+UPDATE `skinning_loot_template` SET `Comment` = 'Medium Leather' WHERE `Item` = @MEDIUM_LEATHER AND `Entry` = @LOOT;
+UPDATE `skinning_loot_template` SET `Comment` = 'Medium Hide' WHERE `Item` = @MEDIUM_HIDE AND `Entry` = @LOOT;
+UPDATE `skinning_loot_template` SET `Comment` = 'Red Whelp Scale' WHERE `Item` = @RED_WHELP_SCALE AND `Entry` = @LOOT;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Removed wrong creatures from Red Whelp's skinning loot table
- Updated comments on respective items

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #6250

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
wowwiki and issue debate

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Try to skin the entries mention on the issue. Only the 3 whelps should be skinnable.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
