### PR TITLE
Fix(DB/Loot): Evergreen Herb Casing should not drop random herbs

### DIFF
--- a/data/sql/updates/pending_db_world/morrowgrainherbs.sql
+++ b/data/sql/updates/pending_db_world/morrowgrainherbs.sql
@@ -1,0 +1,3 @@
+DELETE FROM `item_loot_template` WHERE (`Entry` = 11024) AND (`Item` IN (785, 2449, 2450, 3356, 3357, 3820, 3821, 4625, 8838, 8839, 8846, 49209));
+INSERT INTO `item_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(11024, 49209, 0, 63, 0, 1, 1, 1, 3, 'Evergreen Herb Casing - Mutated Morrowgrain');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove random herbs, add mutated morrowgrain herbs
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/3543
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11882

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->


    .additem 11024
    View loot in it

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
