### PR TITLE
fix(Core): Deserter overrides from BG and Command

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1620,7 +1620,11 @@ void Player::ProcessDelayedOperations()
         SaveToDB(false, false);
 
     if (m_DelayedOperations & DELAYED_SPELL_CAST_DESERTER)
-        CastSpell(this, 26013, true);               // Deserter
+    {
+        Aura* aura = GetAura(26013);
+        if (!aura || aura->GetDuration() <= 900000)
+            CastSpell(this, 26013, true);
+    }
 
     if (m_DelayedOperations & DELAYED_BG_MOUNT_RESTORE)
     {

--- a/src/server/scripts/Commands/cs_deserter.cpp
+++ b/src/server/scripts/Commands/cs_deserter.cpp
@@ -130,6 +130,20 @@ public:
             return true;
         }
 
+        int32 duration = 0;
+        if (QueryResult result = CharacterDatabase.Query("SELECT remainTime FROM character_aura WHERE guid = {} AND spell = {}", player->GetGUID().GetCounter(), isInstance ? LFG_SPELL_DUNGEON_DESERTER : BG_SPELL_DESERTER))
+        {
+            Field* fields = result->Fetch();
+            duration = fields[0].Get<int32>();
+
+            if (duration < 0 || uint32(duration) >= time * IN_MILLISECONDS)
+            {
+                handler->PSendSysMessage("Player %s already has a longer %s Deserter active.", handler->playerLink(player->GetName()), isInstance ? "Instance" : "Battleground");
+                return true;
+            }
+            CharacterDatabase.Query("DELETE FROM character_aura WHERE guid = {} AND spell = {}", player->GetGUID().GetCounter(), isInstance ? LFG_SPELL_DUNGEON_DESERTER : BG_SPELL_DESERTER);
+        }
+
         uint8 index = 0;
         CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_AURA);
         stmt->SetData(index++, player->GetGUID().GetCounter());

--- a/src/server/scripts/Commands/cs_deserter.cpp
+++ b/src/server/scripts/Commands/cs_deserter.cpp
@@ -117,8 +117,14 @@ public:
 
         if (target)
         {
-            Aura* aura = target->AddAura(isInstance ? LFG_SPELL_DUNGEON_DESERTER : BG_SPELL_DESERTER, target);
+            Aura* aura = target->GetAura(isInstance ? LFG_SPELL_DUNGEON_DESERTER : BG_SPELL_DESERTER);
+            if (aura && aura->GetDuration() >= (int32)time * IN_MILLISECONDS)
+            {
+                handler->PSendSysMessage("Player %s already has a longer %s Deserter active.", handler->playerLink(player->GetName()), isInstance ? "Instance" : "Battleground");
+                return true;
+            }
 
+            aura = target->AddAura(isInstance ? LFG_SPELL_DUNGEON_DESERTER : BG_SPELL_DESERTER, target);
             if (!aura)
             {
                 handler->SendSysMessage(LANG_BAD_VALUE);
@@ -136,7 +142,7 @@ public:
             Field* fields = result->Fetch();
             duration = fields[0].Get<int32>();
 
-            if (duration < 0 || uint32(duration) >= time * IN_MILLISECONDS)
+            if (duration < 0 || duration >= (int32)time * IN_MILLISECONDS)
             {
                 handler->PSendSysMessage("Player %s already has a longer %s Deserter active.", handler->playerLink(player->GetName()), isInstance ? "Instance" : "Battleground");
                 return true;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Battleground deserter now only overrides a deserter debuff if it has a shorter time remaining
- The deserter add command now only overrides a deserter debuff if it has a shorter time remaining
- The deserter add command no longer errors if the player already has a deserter debuff

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11955
- Closes #11914

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Deserter added multiple times on offline players
- Added deserter with 5 min and 30min to a player in a battleground and left


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Use the `.deserter add bg` command to add a deserter debuff to a player in a battleground
2. Leave the battleground with that player
3. Check the deserter debuff duration
4. Use the `.deserter add bg` on that player again with different values with the player being online and offline
5. Observe the outcome times

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
