### PR TITLE
fix(Scripts/ZulGurub): Wushoolay - improvements:

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_wushoolay.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_wushoolay.cpp
@@ -28,14 +28,16 @@ EndScriptData */
 
 enum Spells
 {
-    SPELL_LIGHTNINGCLOUD        = 25033,
-    SPELL_LIGHTNINGWAVE         = 24819
+    SPELL_LIGHTNING_CLOUD       = 25033,
+    SPELL_CHAIN_LIGHTNING       = 24680,
+    SPELL_FORKED_LIGHTNING      = 24682
 };
 
 enum Events
 {
-    EVENT_LIGHTNINGCLOUD        = 1,
-    EVENT_LIGHTNINGWAVE         = 2
+    EVENT_LIGHTNING_CLOUD       = 1,
+    EVENT_CHAIN_LIGHTNING       = 2,
+    EVENT_FORKED_LIGHTNING      = 3
 };
 
 class boss_wushoolay : public CreatureScript
@@ -47,21 +49,12 @@ public:
     {
         boss_wushoolayAI(Creature* creature) : BossAI(creature, DATA_EDGE_OF_MADNESS) { }
 
-        void Reset() override
-        {
-            _Reset();
-        }
-
-        void JustDied(Unit* /*killer*/) override
-        {
-            _JustDied();
-        }
-
         void EnterCombat(Unit* /*who*/) override
         {
             _EnterCombat();
-            events.ScheduleEvent(EVENT_LIGHTNINGCLOUD, urand(5000, 10000));
-            events.ScheduleEvent(EVENT_LIGHTNINGWAVE, urand(8000, 16000));
+            events.ScheduleEvent(EVENT_LIGHTNING_CLOUD, 7s, 15s);
+            events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 12s, 16s);
+            events.ScheduleEvent(EVENT_FORKED_LIGHTNING, 8s, 12s);
         }
 
         void UpdateAI(uint32 diff) override
@@ -78,13 +71,23 @@ public:
             {
                 switch (eventId)
                 {
-                    case EVENT_LIGHTNINGCLOUD:
-                        DoCastVictim(SPELL_LIGHTNINGCLOUD, true);
-                        events.ScheduleEvent(EVENT_LIGHTNINGCLOUD, urand(15000, 20000));
+                    case EVENT_LIGHTNING_CLOUD:
+                        if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
+                        {
+                            me->CastSpell(target->GetPositionX(), target->GetPositionY(), target->GetPositionZ(), SPELL_LIGHTNING_CLOUD, false);
+                        }
+                        events.ScheduleEvent(EVENT_LIGHTNING_CLOUD, 9s, 20s);
                         break;
-                    case EVENT_LIGHTNINGWAVE:
-                        DoCast(SelectTarget(SelectTargetMethod::Random, 0, 100, true), SPELL_LIGHTNINGWAVE);
-                        events.ScheduleEvent(EVENT_LIGHTNINGWAVE, urand(12000, 16000));
+                    case EVENT_CHAIN_LIGHTNING:
+                        if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
+                        {
+                            DoCast(target, SPELL_CHAIN_LIGHTNING);
+                        }
+                        events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 12s, 24s);
+                        break;
+                    case EVENT_FORKED_LIGHTNING:
+                        DoCastAOE(SPELL_FORKED_LIGHTNING);
+                        events.ScheduleEvent(EVENT_FORKED_LIGHTNING, 8s, 20s);
                         break;
                     default:
                         break;


### PR DESCRIPTION
Added missing spells and events.
Removed invalid spells
Corrected event timers.
Fixes #11627

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11627

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

If the Summoning Event is implemented:
`.event stop 27`
`.event stop 28`
`.event stop 29`
`.event start 30`
`.additem 19931`
`.go xyz -11905 -1911 66 309`
use the brazier and engage Renataki

else:
`.go xyz -11905 -1911 66 309`
`.npc add temp 15085`

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
