### PR TITLE
fix (core): Npc gossip error logging

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -1195,7 +1195,7 @@ void ObjectMgr::CheckCreatureTemplate(CreatureTemplate const* cInfo)
     }
     else if ((!cInfo->GossipMenuId && (cInfo->npcflag & UNIT_NPC_FLAG_GOSSIP)) && !(cInfo->flags_extra & CREATURE_FLAG_EXTRA_MODULE))
     {
-        LOG_ERROR("sql.sql", "Creature (Entry: {}) has npcflag UNIT_NPC_FLAG_GOSSIP (1), but gossip menu is unassigned.", cInfo->Entry);
+        LOG_INFO("sql.sql", "Creature (Entry: {}) has npcflag UNIT_NPC_FLAG_GOSSIP (1), but gossip menu is unassigned.", cInfo->Entry);
     }
 }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
in this change #9665 several NPCs were broken when changing `npcflag`=`npcflag`|1 (Trainers, Missions) and fixing them when starting the worldserver shows an error in the console example of this error PR #11980 

example:

Creature (Entry: 18991) has npcflag UNIT_NPC_FLAG_GOSSIP (1), but gossip menu is unassigned.
Creature (Entry: 18990) has npcflag UNIT_NPC_FLAG_GOSSIP (1), but gossip menu is unassigned.

* It may not be the correct solution but it is a way that does not show those errors anymore and makes it possible to repair several broken missions and trainers

Staff Edit Begin by @acidmanifesto 
TC Cherry Pick: https://github.com/TrinityCore/TrinityCore/pull/24375
Co-Authored-By: [Sorikoff](https://github.com/Sorikoff)
Co-Authored-By: [@jackpoz ](https://github.com/jackpoz)
Co-Authored-By: [@Shauren ](https://github.com/Shauren)
End of Staff Edit by @acidmanifesto 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Test In-Game
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Compile this PR + PR #11980 
2. It no longer shows the error when starting the worldserver


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
