### PR TITLE
feat(DB): MySQL PreparedStatement Affected Row Count

### DIFF
--- a/src/server/database/Database/MySQLConnection.cpp
+++ b/src/server/database/Database/MySQLConnection.cpp
@@ -304,7 +304,7 @@ bool MySQLConnection::_Query(PreparedStatementBase* stmt, MySQLPreparedStatement
     m_mStmt->ClearParameters();
 
     *pResult = reinterpret_cast<MySQLResult*>(mysql_stmt_result_metadata(msql_STMT));
-    *pRowCount = mysql_stmt_num_rows(msql_STMT);
+    *pRowCount = mysql_stmt_affected_rows(msql_STMT);
     *pFieldCount = mysql_stmt_field_count(msql_STMT);
 
     return true;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

**This PR is not just meant as a change to the MySQL Query function for Premared Statements but mostly as a base for an open discussion about the change.**
@Nyeriah and I talked about this a bit but a change to functions associated with the Database should not be made unless it is certain that it will not cause any issues.

## Changes Proposed:
-  Correctly count the affected Rows on `UPDATE`, `DELETE` and `INSERT` queries using Prepared Statements

## Description

In #11958 I am using a `SELECT` Query to determine the amount of deserter debuffs with certain constraints in the Database, just to have feedback for the number of affected rows by the following `DELETE` Query.
I have tried to use a `DELETE` query only with the plain SQL query function as well as with the Prepared Statement query function. Sadly neither give feedback about the amount of affected rows.
As @Nyeriah pointed out correctly, this is highly inefficient, especially with a table associated with characters just for some feedback on the removed deserter debuffs.

So after looking into the matter a bit deeper, it seems like I have found the issue.

### Query Function with plain SQL Queries
The whole function can be found below
https://github.com/azerothcore/azerothcore-wotlk/blob/448f9494c5ead8761f7f1effec7faef90ddeb36f/src/server/database/Database/MySQLConnection.cpp#L329-L368
which is called by
https://github.com/azerothcore/azerothcore-wotlk/blob/448f9494c5ead8761f7f1effec7faef90ddeb36f/src/server/database/Database/MySQLConnection.cpp#L313-L327

returning false will lead to the function calling it to return a `nullptr`

The number of affected rows is gained by using `mysql_affected_rows`
<details>
<summary>Code for Affected Rows</summary>

https://github.com/azerothcore/azerothcore-wotlk/blob/448f9494c5ead8761f7f1effec7faef90ddeb36f/src/server/database/Database/MySQLConnection.cpp#L351-L353
</details>

Since a `DELETE` query, for instance, will not have a result, it will always return a `nullptr`, meaning the whole ResultSet, including the actual number of affected rows (which might be > 0) will not exist.
<details>
<summary>Code of Result Check</summary>

https://github.com/azerothcore/azerothcore-wotlk/blob/448f9494c5ead8761f7f1effec7faef90ddeb36f/src/server/database/Database/MySQLConnection.cpp#L356-L357
</details>

Because basically all uses of this function (including those in modules) will check whether the result exists, changing this would only cause chaos though.

Interestingly enough the Function for Prepared Statements works a bit differently.

### Query Function with Prepared Statements
The whole function can be found below
https://github.com/azerothcore/azerothcore-wotlk/blob/448f9494c5ead8761f7f1effec7faef90ddeb36f/src/server/database/Database/MySQLConnection.cpp#L260-L311
which is called by
https://github.com/azerothcore/azerothcore-wotlk/blob/448f9494c5ead8761f7f1effec7faef90ddeb36f/src/server/database/Database/MySQLConnection.cpp#L535-L551

Here the issue is a completely different one.
We try to get the values for the affected rows by calling `mysql_stmt_num_rows`
<details>
<summary>Code for Affected Rows</summary>

https://github.com/azerothcore/azerothcore-wotlk/blob/448f9494c5ead8761f7f1effec7faef90ddeb36f/src/server/database/Database/MySQLConnection.cpp#L306-L308
</details>

The problem is that the affected rows will always be `0` because `mysql_stmt_num_rows` only returns a value when`mysql_stmt_store_result` is used to buffer the entire result set in the statement handler (Source: [MySQLDocs/mysql-stmt-num-rows](https://dev.mysql.com/doc/c-api/8.0/en/mysql-stmt-num-rows.html)). Though I'm not entirely sure if I didn't miss anything here.

For that reason changing `mysql_stmt_num_rows` to `mysql_stmt_affected_rows` will actually return the correct value for a `DELETE` query.
But now there is an issue with the number of affected rows in `SELECT` queries, which returns a value of `-1`. This results in finally returning `18446744073709551615` as the number of affected rows as it is a `uint64`.
Of course, we can just make a check whether or not the value is `rowCount < 0` and return 0 if so.

I can't find an issue with this though, to be honest, since I couldn't find any function actually using `GetRowCount()` with Prepared Statements in the code.
<details>
<summary>Code for GetRowCount</summary>

https://github.com/azerothcore/azerothcore-wotlk/blob/de13bf426e162ee10cbd5470cec74122d1d4afa0/src/server/database/Database/QueryResult.h#L81
</details>

Also I found it a bit weird that a few checks for the affected row count will return a nullptr if failed even though it is always 0 if i'm not mistaken.
<details>
<summary>Check 1</summary>

https://github.com/azerothcore/azerothcore-wotlk/blob/336166c83e209d77c339ffeaef96f9fe77ed19e8/src/server/database/Database/DatabaseWorkerPool.cpp#L203-L220
</details>
<details>
<summary>Check 2</summary>

https://github.com/azerothcore/azerothcore-wotlk/blob/5969df4e303121cca77166df28aa0e9ff2f17e9f/src/server/database/Database/QueryHolder.cpp#L46-L57
</details>

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran and debugged various SQL queries using the `Query(PreparedStatementBase* stmt)` function


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run the server
2. Extensively test actions which cause a SQL query with a Prepared Statement to be called (`SELECT`, `UPDATE`, `DELETE` and `INSERT`)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
