### PR TITLE
chore: restore googletest main repo reference

### DIFF
--- a/src/cmake/googletest-download.cmake
+++ b/src/cmake/googletest-download.cmake
@@ -22,7 +22,7 @@ ExternalProject_Add(
         SOURCE_DIR "@GOOGLETEST_DOWNLOAD_ROOT@/googletest-src"
         BINARY_DIR "@GOOGLETEST_DOWNLOAD_ROOT@/googletest-build"
         GIT_REPOSITORY
-        https://github.com/Helias/googletest.git
+        https://github.com/google/googletest.git
         GIT_TAG
         main
         CONFIGURE_COMMAND ""


### PR DESCRIPTION
related of https://github.com/azerothcore/azerothcore-wotlk/pull/11902

## Changes Proposed:
-  restore the googletest repo reference

## Issues Addressed:
- related of https://github.com/google/googletest/pull/3859
- https://github.com/google/googletest/issues/3858
