### PR TITLE
Fix(DB/smartscripts): Call of Water(5/6)(draenei) improvements

### DIFF
--- a/data/sql/updates/pending_db_world/callofwater.sql
+++ b/data/sql/updates/pending_db_world/callofwater.sql
@@ -1,0 +1,10 @@
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (6748, 17359);
+
+DELETE FROM `smart_scripts` WHERE ((`entryorguid` = 6748) AND (`source_type` = 0) AND (`id` IN (0, 1))) OR (`entryorguid` = 17359) AND (`source_type` = 0) AND (`id` IN (5, 7, 8, 9));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(6748, 0, 0, 0, 54, 0, 100, 513, 0, 0, 0, 0, 0, 22, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Water Spirit - On Just Summoned - Set Event Phase 1 (No Repeat)'),
+(6748, 0, 1, 0, 75, 1, 100, 1, 0, 17359, 30, 500, 0, 1, 0, 1500, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Water Spirit - On Distance To Creature - Say Line 0 (Phase 1) (No Repeat)'),
+(17359, 0, 5, 0, 0, 1, 100, 512, 5000, 5000, 5000, 5000, 0, 11, 9672, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Tel\'athion the Impure - In Combat - Cast \'Frostbolt\' (Phase 1)'),
+(17359, 0, 7, 0, 0, 1, 100, 512, 6200, 6200, 5000, 5000, 0, 11, 13339, 64, 0, 0, 0, 0, 5, 6748, 1, 0, 0, 0, 0, 0, 0, 'Tel\'athion the Impure - In Combat - Cast \'Fire Blast\' (Phase 1)'),
+(17359, 0, 8, 0, 9, 1, 100, 512, 0, 10, 13000, 13000, 0, 11, 11831, 64, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 'Tel\'athion the Impure - Within 0-10 Range - Cast \'Frost Nova\' (Phase 1)'),
+(17359, 0, 9, 0, 0, 1, 100, 512, 8000, 8000, 10000, 10000, 0, 11, 15735, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Tel\'athion the Impure - In Combat - Cast \'Arcane Missiles\' (Phase 1)');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Increases the range that water elementals check for tel'athion, so they help in combat
-  Set proper flags on tel'athion smartai abilities, so he does not just instant cast them.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7139
- Closes https://github.com/chromiecraft/chromiecraft/issues/810

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. be draenei, 20, shaman
2. .q add 9508
3. .tele bloodmyst isle and go to location of map
4. summon tel'athion.
5. Kill him/ evade, water elemetnals despawn
6. during combat, abilities have cast time.


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
