### PR TITLE
Fix(Scripts/EmeraldDragons): Emerald dragons should 'enrage' at health per…

### DIFF
--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -577,11 +577,11 @@ public:
             --_shades;
         }
         
-         void DamageTaken(Unit*, uint32& /*damage*/, DamageEffectType, SpellSchoolMask) override
+        void DamageTaken(Unit*, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
             // At 75, 50 or 25 percent health, we need to activate the shades and go "banished"
             // Note: _stage holds the amount of times they have been summoned
-            if (!_banished && me->HealthBelowPctDamaged(100 - 25 * _stage))
+            if (!_banished && me->HealthBelowPctDamaged(100 - (25 * _stage), damage))
             {
                 _banished = true;
                 _banishedTimer = 60000;
@@ -593,9 +593,8 @@ public:
 
                 uint32 count = sizeof(TaerarShadeSpells) / sizeof(uint32);
                 for (uint32 i = 0; i < count; ++i)
-                    DoCastVictim(TaerarShadeSpells[i], true);
+                    DoCast(TaerarShadeSpells[i]);
                 _shades += count;
-
                 DoCast(SPELL_SHADE);
                 me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_NON_ATTACKABLE);
                 me->SetReactState(REACT_PASSIVE);

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -537,11 +537,6 @@ enum TaerarSpells
     SPELL_ARCANE_BLAST              = 24857,
 };
 
-uint32 const TaerarShadeSpells[] =
-{
-    SPELL_SUMMON_SHADE_1, SPELL_SUMMON_SHADE_2, SPELL_SUMMON_SHADE_3
-};
-
 class boss_taerar : public CreatureScript
 {
 public:
@@ -576,33 +571,6 @@ public:
         void SummonedCreatureDies(Creature* /*summon*/, Unit*) override
         {
             --_shades;
-        }
-
-        void DamageTaken(Unit*, uint32& /*damage*/, DamageEffectType, SpellSchoolMask) override
-        {
-            // At 75, 50 or 25 percent health, we need to activate the shades and go "banished"
-            // Note: _stage holds the amount of times they have been summoned
-            if (!_banished && !HealthAbovePct(100 - 25 * _stage))
-            {
-                _banished = true;
-                _banishedTimer = 60000;
-
-                me->InterruptNonMeleeSpells(false);
-                DoStopAttack();
-
-                Talk(SAY_TAERAR_SUMMON_SHADES);
-
-                uint32 count = sizeof(TaerarShadeSpells) / sizeof(uint32);
-                for (uint32 i = 0; i < count; ++i)
-                    DoCastVictim(TaerarShadeSpells[i], true);
-                _shades += count;
-
-                DoCast(SPELL_SHADE);
-                me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_NON_ATTACKABLE);
-                me->SetReactState(REACT_PASSIVE);
-
-                ++_stage;
-            }
         }
 
         void ExecuteEvent(uint32 eventId) override
@@ -647,6 +615,29 @@ public:
                 events.Update(diff);
 
                 return;
+            }
+            // At 75, 50 or 25 percent health, we need to activate the shades and go "banished"
+            // Note: _stage holds the amount of times they have been summoned
+            if (!_banished && !HealthAbovePct(100 - 25 * _stage))
+            {
+                _banished = true;
+                _banishedTimer = 60000;
+
+                me->InterruptNonMeleeSpells(false);
+                DoStopAttack();
+
+                Talk(SAY_TAERAR_SUMMON_SHADES);
+
+                DoCast(SPELL_SUMMON_SHADE_1);
+                DoCast(SPELL_SUMMON_SHADE_2);
+                DoCast(SPELL_SUMMON_SHADE_3);
+                _shades += 3;
+
+                DoCast(SPELL_SHADE);
+                me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_NON_ATTACKABLE);
+                me->SetReactState(REACT_PASSIVE);
+
+                ++_stage;
             }
 
             emerald_dragonAI::UpdateAI(diff);

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -262,9 +262,9 @@ public:
         }
 
         // Summon druid spirits on 75%, 50% and 25% health
-        void DamageTaken(Unit*, uint32& /*damage*/, DamageEffectType, SpellSchoolMask) override
+        void DamageTaken(Unit*, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
-            if (!HealthAbovePct(100 - 25 * _stage))
+            if (me->HealthBelowPctDamaged(100 - (25 * _stage), damage))
             {
                 Talk(SAY_YSONDRE_SUMMON_DRUIDS);
 
@@ -349,9 +349,9 @@ public:
             WorldBossAI::EnterCombat(who);
         }
 
-        void DamageTaken(Unit*, uint32& /*damage*/, DamageEffectType, SpellSchoolMask) override
+        void DamageTaken(Unit*, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
-            if (!HealthAbovePct(100 - 25 * _stage))
+            if (me->HealthBelowPctDamaged(100 - (25 * _stage), damage))
             {
                 Talk(SAY_LETHON_DRAW_SPIRIT);
                 DoCast(me, SPELL_DRAW_SPIRIT);
@@ -481,9 +481,9 @@ public:
             WorldBossAI::EnterCombat(who);
         }
 
-        void DamageTaken(Unit*, uint32& /*damage*/, DamageEffectType, SpellSchoolMask) override
+        void DamageTaken(Unit*, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
-            if (!HealthAbovePct(100 - 25 * _stage))
+            if (me->HealthBelowPctDamaged(100 - (25 * _stage), damage))
             {
                 Talk(SAY_EMERISS_CAST_CORRUPTION);
                 DoCast(me, SPELL_CORRUPTION_OF_EARTH, true);

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -576,7 +576,6 @@ public:
         {
             --_shades;
         }
-        
         void DamageTaken(Unit*, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
             // At 75, 50 or 25 percent health, we need to activate the shades and go "banished"

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -576,6 +576,7 @@ public:
         {
             --_shades;
         }
+        
         void DamageTaken(Unit*, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
             // At 75, 50 or 25 percent health, we need to activate the shades and go "banished"

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -537,6 +537,10 @@ enum TaerarSpells
     SPELL_ARCANE_BLAST              = 24857,
 };
 
+uint32 const TaerarShadeSpells[] =
+{
+    SPELL_SUMMON_SHADE_1, SPELL_SUMMON_SHADE_2, SPELL_SUMMON_SHADE_3
+};
 class boss_taerar : public CreatureScript
 {
 public:
@@ -628,10 +632,10 @@ public:
 
                 Talk(SAY_TAERAR_SUMMON_SHADES);
 
-                DoCast(SPELL_SUMMON_SHADE_1);
-                DoCast(SPELL_SUMMON_SHADE_2);
-                DoCast(SPELL_SUMMON_SHADE_3);
-                _shades += 3;
+                uint32 count = sizeof(TaerarShadeSpells) / sizeof(uint32);
+                for (uint32 i = 0; i < count; ++i)
+                    DoCast(TaerarShadeSpells[i]);
+                _shades += count;
 
                 DoCast(SPELL_SHADE);
                 me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_NON_ATTACKABLE);

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -576,7 +576,7 @@ public:
         {
             --_shades;
         }
-        
+
         void DamageTaken(Unit*, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
             // At 75, 50 or 25 percent health, we need to activate the shades and go "banished"


### PR DESCRIPTION
…centage 25/50/75

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-   fixed the function (thanks nyeriah)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11889

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  Tested
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

  Engage any of the emerald dragons
  .damage on him until he cast start the event


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
