### PR TITLE
(DB/loot): Addressed drop style to be proper for Fire Hardened Mail

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1655244193594772800.sql
+++ b/data/sql/updates/pending_db_world/rev_1655244193594772800.sql
@@ -1,0 +1,16 @@
+--
+DELETE FROM `creature_loot_template` WHERE item=6838;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
+(1111, 6838, 0, 100, 1, 1, 2, 1, 1, 'Leech Stalker - Scorched Spider Fang'),
+(1111, 6838, 0, 50, 1, 1, 3, 1, 1, 'Leech Stalker - Scorched Spider Fang'),
+(4040, 6838, 0, 100, 1, 1, 2, 1, 1, 'Cave Stalker - Scorched Spider Fang'),
+(4040, 6838, 0, 50, 1, 1, 3, 1, 1, 'Cave Stalker - Scorched Spider Fang');
+
+DELETE FROM `creature_loot_template` WHERE item=6839;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
+(4031, 6839, 0, 100, 1, 1, 2, 1, 1, 'Fledgling Chimaera - Charred Horn'),
+(4031, 6839, 0, 34, 1, 1, 3, 1, 1, 'Fledgling Chimaera - Charred Horn'),
+(4031, 6839, 0, 34, 1, 1, 4, 1, 1, 'Fledgling Chimaera - Charred Horn'),
+(4032, 6839, 0, 100, 1, 1, 2, 1, 1, 'Young Chimaera - Charred Horn'),
+(4032, 6839, 0, 34, 1, 1, 3, 1, 1, 'Young Chimaera - Charred Horn'),
+(4032, 6839, 0, 34, 1, 1, 4, 1, 1, 'Young Chimaera - Charred Horn');


### PR DESCRIPTION
Quest drops properly drop individual stacks in loot window.

What's left of #12007 that isn't fixed by #12024 (Extra Notes section)

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Makes the loot appear as it should (unstacked drops).  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
TBC Classic / packet sniff

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested as explained below, works as expected.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  .quest add 1701
2.  .tele to wetlands and goto spider cave, get a few drops
3.  .tele charred (vale) and kill a few chimaeras 


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
