### PR TITLE
cute and fluffy AQ20

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1655264630631380100.sql
+++ b/data/sql/updates/pending_db_world/rev_1655264630631380100.sql
@@ -1,0 +1,6 @@
+--
+
+DELETE FROM `creature_addon` WHERE `guid`=144632;
+INSERT INTO `creature_addon` (`guid`, `auras`) VALUES 
+(144632, '8876'); -- Triggers SPELL_THRASH = 3391
+

--- a/data/sql/updates/pending_db_world/rev_1655264630631380100.sql
+++ b/data/sql/updates/pending_db_world/rev_1655264630631380100.sql
@@ -3,3 +3,9 @@ DELETE FROM `creature_addon` WHERE `guid`=144632;
 INSERT INTO `creature_addon` (`guid`, `auras`) VALUES 
 (144632, '8876'); -- Triggers SPELL_THRASH = 3391
 
+-- Immune to Taunt
+UPDATE `creature_template` SET `flags_extra`=`flags_extra`|256 WHERE `entry` IN 
+(15339, -- Ossirian
+15370, -- Buru
+15369); -- Ayamiss
+

--- a/data/sql/updates/pending_db_world/rev_1655264630631380100.sql
+++ b/data/sql/updates/pending_db_world/rev_1655264630631380100.sql
@@ -9,3 +9,11 @@ UPDATE `creature_template` SET `flags_extra`=`flags_extra`|256 WHERE `entry` IN
 15370, -- Buru
 15369); -- Ayamiss
 
+-- Disable exp on Buru egg / Hive'zara hatchling
+UPDATE `creature_template` SET `flags_extra`=`flags_extra`|64 WHERE `entry` IN (15514,15521);
+
+UPDATE `creature_template` SET `AIName`='SmartAI' WHERE `entry`=15521;
+DELETE FROM `smart_scripts` WHERE `entryorguid`= 15521 AND `source_type`= 0 AND `id`= 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `event_type`, `event_flags`, `event_param1`, `event_param2`, `action_type`, `action_param1`, `target_type`, `comment`) VALUES 
+(15521, 1, 1, 10000, 10000, 41, 500, 1, 'Hive\'Zara Hatchling - Out of Combat - Despawn (No Repeat)');
+

--- a/data/sql/updates/pending_db_world/rev_1655264630631380100.sql
+++ b/data/sql/updates/pending_db_world/rev_1655264630631380100.sql
@@ -1,5 +1,4 @@
 --
-
 DELETE FROM `creature_addon` WHERE `guid`=144632;
 INSERT INTO `creature_addon` (`guid`, `auras`) VALUES 
 (144632, '8876'); -- Triggers SPELL_THRASH = 3391

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ayamiss.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ayamiss.cpp
@@ -77,9 +77,7 @@ public:
 
     struct boss_ayamissAI : public BossAI
     {
-        boss_ayamissAI(Creature* creature) : BossAI(creature, DATA_AYAMISS)
-        {
-        }
+        boss_ayamissAI(Creature* creature) : BossAI(creature, DATA_AYAMISS) {}
 
         void Reset() override
         {
@@ -101,7 +99,9 @@ public:
                     break;
                 case NPC_HORNET:
                     if (Unit* target = SelectTarget(SelectTargetMethod::Random))
+                    {
                         who->AI()->AttackStart(target);
+                    }
                     break;
             }
         }
@@ -131,13 +131,11 @@ public:
         void EnterCombat(Unit* attacker) override
         {
             BossAI::EnterCombat(attacker);
-
             events.ScheduleEvent(EVENT_STINGER_SPRAY, urand(20000, 30000));
             events.ScheduleEvent(EVENT_POISON_STINGER, 5000);
             events.ScheduleEvent(EVENT_SUMMON_SWARMER, 5000);
             events.ScheduleEvent(EVENT_SWARMER_ATTACK, 60000);
             events.ScheduleEvent(EVENT_PARALYZE, 15000);
-
             me->SetCanFly(true);
             me->SetDisableGravity(true);
             me->GetMotionMaster()->MovePoint(POINT_AIR, AyamissAirPos);
@@ -149,7 +147,6 @@ public:
                 return;
 
             events.Update(diff);
-
             if (_phase == PHASE_AIR && me->GetHealthPct() < 70.0f)
             {
                 _phase = PHASE_GROUND;
@@ -169,7 +166,7 @@ public:
 
             if (!_enraged && me->GetHealthPct() < 20.0f)
             {
-                DoCast(me, SPELL_FRENZY);
+                DoCastSelf(SPELL_FRENZY);
                 Talk(EMOTE_FRENZY);
                 _enraged = true;
             }
@@ -179,7 +176,7 @@ public:
                 switch (eventId)
                 {
                     case EVENT_STINGER_SPRAY:
-                        DoCast(me, SPELL_STINGER_SPRAY);
+                        DoCastSelf(SPELL_STINGER_SPRAY);
                         events.ScheduleEvent(EVENT_STINGER_SPRAY, urand(15000, 20000));
                         break;
                     case EVENT_POISON_STINGER:
@@ -198,10 +195,15 @@ public:
                         break;
                     case EVENT_SWARMER_ATTACK:
                         for (ObjectGuid const& guid : _swarmers)
+                        {
                             if (Creature* swarmer = me->GetMap()->GetCreature(guid))
+                            {
                                 if (Unit* target = SelectTarget(SelectTargetMethod::Random))
+                                {
                                     swarmer->AI()->AttackStart(target);
-
+                                }
+                            }
+                        }
                         _swarmers.clear();
                         events.ScheduleEvent(EVENT_SWARMER_ATTACK, 60000);
                         break;
@@ -250,9 +252,15 @@ public:
         void MovementInform(uint32 type, uint32 id) override
         {
             if (type == POINT_MOTION_TYPE)
+            {
                 if (id == POINT_PARALYZE)
+                {
                     if (Player* target = ObjectAccessor::GetPlayer(*me, _instance->GetGuidData(DATA_PARALYZED)))
-                        DoCast(target, SPELL_FEED); // Omnomnom
+                    {
+                        DoCast(target, SPELL_FEED);
+                    }
+                }
+            }
         }
 
         void MoveInLineOfSight(Unit* who) override

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
@@ -75,9 +75,12 @@ public:
             BossAI::EnterEvadeMode(why);
 
             for (ObjectGuid const& guid : Eggs)
+            {
                 if (Creature* egg = me->GetMap()->GetCreature(guid))
+                {
                     egg->Respawn();
-
+                }
+            }
             Eggs.clear();
         }
 
@@ -85,20 +88,22 @@ public:
         {
             _EnterCombat();
             Talk(EMOTE_TARGET, who);
-            DoCast(me, SPELL_THORNS);
-
+            DoCastSelf(SPELL_THORNS);
             events.ScheduleEvent(EVENT_DISMEMBER, 5000);
             events.ScheduleEvent(EVENT_GATHERING_SPEED, 9000);
             events.ScheduleEvent(EVENT_FULL_SPEED, 60000);
-
             _phase = PHASE_EGG;
         }
 
         void DoAction(int32 action) override
         {
             if (action == ACTION_EXPLODE)
+            {
                 if (_phase == PHASE_EGG)
+                {
                     Unit::DealDamage(me, me, 45000);
+                }
+            }
         }
 
         void KilledUnit(Unit* victim) override
@@ -116,7 +121,6 @@ public:
             me->RemoveAurasDueToSpell(SPELL_GATHERING_SPEED);
             events.ScheduleEvent(EVENT_GATHERING_SPEED, 9000);
             events.ScheduleEvent(EVENT_FULL_SPEED, 60000);
-
             if (Unit* victim = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true))
             {
                 DoResetThreat();
@@ -138,7 +142,6 @@ public:
                 return;
 
             events.Update(diff);
-
             while (uint32 eventId = events.ExecuteEvent())
             {
                 switch (eventId)
@@ -148,14 +151,14 @@ public:
                         events.ScheduleEvent(EVENT_DISMEMBER, 5000);
                         break;
                     case EVENT_GATHERING_SPEED:
-                        DoCast(me, SPELL_GATHERING_SPEED);
+                        DoCastSelf(SPELL_GATHERING_SPEED);
                         events.ScheduleEvent(EVENT_GATHERING_SPEED, 9000);
                         break;
                     case EVENT_FULL_SPEED:
-                        DoCast(me, SPELL_FULL_SPEED);
+                        DoCastSelf(SPELL_FULL_SPEED);
                         break;
                     case EVENT_CREEPING_PLAGUE:
-                        DoCast(me, SPELL_CREEPING_PLAGUE);
+                        DoCastSelf(SPELL_CREEPING_PLAGUE);
                         events.ScheduleEvent(EVENT_CREEPING_PLAGUE, 6000);
                         break;
                     case EVENT_RESPAWN_EGG:
@@ -172,12 +175,12 @@ public:
 
             if (me->GetHealthPct() < 20.0f && _phase == PHASE_EGG)
             {
-                DoCast(me, SPELL_BURU_TRANSFORM); // Enrage
-                DoCast(me, SPELL_FULL_SPEED, true);
+                DoCastSelf(SPELL_BURU_TRANSFORM);
+                DoCastSelf(SPELL_FULL_SPEED, true);
                 me->RemoveAurasDueToSpell(SPELL_THORNS);
+                events.ScheduleEvent(EVENT_CREEPING_PLAGUE, 2000);
                 _phase = PHASE_TRANSFORM;
             }
-
             DoMeleeAttackIfReady();
         }
     private:
@@ -207,27 +210,40 @@ public:
         void EnterCombat(Unit* attacker) override
         {
             if (Creature* buru = me->GetMap()->GetCreature(_instance->GetGuidData(DATA_BURU)))
+            {
                 if (!buru->IsInCombat())
+                {
                     buru->AI()->AttackStart(attacker);
+                }
+            }
         }
 
         void JustSummoned(Creature* who) override
         {
             if (who->GetEntry() == NPC_HATCHLING)
+            {
                 if (Creature* buru = me->GetMap()->GetCreature(_instance->GetGuidData(DATA_BURU)))
+                {
                     if (Unit* target = buru->AI()->SelectTarget(SelectTargetMethod::Random))
+                    {
                         who->AI()->AttackStart(target);
+                    }
+                }
+            }
         }
 
         void JustDied(Unit* /*killer*/) override
         {
             DoCastAOE(SPELL_EXPLODE, true);
             DoCastAOE(SPELL_EXPLODE_2, true); // Unknown purpose
-            DoCast(me, SPELL_SUMMON_HATCHLING, true);
-
+            DoCastSelf(SPELL_SUMMON_HATCHLING);
             if (Creature* buru = me->GetMap()->GetCreature(_instance->GetGuidData(DATA_BURU)))
+            {
                 if (boss_buru::boss_buruAI* buruAI = dynamic_cast<boss_buru::boss_buruAI*>(buru->AI()))
+                {
                     buruAI->ManageRespawn(me->GetGUID());
+                }
+            }
         }
     private:
         InstanceScript* _instance;
@@ -251,13 +267,17 @@ public:
         void HandleAfterCast()
         {
             if (Creature* buru = GetCaster()->FindNearestCreature(NPC_BURU, 5.f))
+            {
                 buru->AI()->DoAction(ACTION_EXPLODE);
+            }
         }
 
         void HandleDummyHitTarget(SpellEffIndex /*effIndex*/)
         {
             if (Unit* target = GetHitUnit())
+            {
                 Unit::DealDamage(GetCaster(), target, -16 * GetCaster()->GetDistance(target) + 500);
+            }
         }
 
         void Register() override

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
@@ -180,17 +180,17 @@ public:
 
             if (me->GetHealthPct() < 20.0f && _phase == PHASE_EGG)
             {
-                _phase = PHASE_TRANSFORM;
                 DoCastSelf(SPELL_BURU_TRANSFORM);
                 DoCastSelf(SPELL_FULL_SPEED, true);
                 me->RemoveAurasDueToSpell(SPELL_THORNS);
                 events.CancelEvent(EVENT_DISMEMBER);
                 events.ScheduleEvent(EVENT_CREEPING_PLAGUE, 2000);
+                _phase = PHASE_TRANSFORM;
                 std::list<Creature*> RemainingEgg;
                 me->GetCreaturesWithEntryInRange(RemainingEgg, 100.0f, NPC_BURU_EGG);
                 for (std::list<Creature*>::const_iterator itr = RemainingEgg.begin(); itr != RemainingEgg.end(); ++itr)
                 {
-                    Unit::Kill(*itr, *itr);
+                    Unit::Kill(me, *itr);
                 }
             }
             DoMeleeAttackIfReady();
@@ -253,10 +253,10 @@ public:
                     DoCast(me, SPELL_EXPLODE, true);
                     DoCast(me, SPELL_EXPLODE_2, true);
                     DoCast(me, SPELL_BURU_EGG_TRIGGER, true);
-                    if (boss_buru::boss_buruAI* buruAI = dynamic_cast<boss_buru::boss_buruAI*>(buru->AI()))
-                    {
-                        buruAI->ManageRespawn(me->GetGUID());
-                    }
+                }
+                if (boss_buru::boss_buruAI* buruAI = dynamic_cast<boss_buru::boss_buruAI*>(buru->AI()))
+                {
+                    buruAI->ManageRespawn(me->GetGUID());
                 }
             }
             DoCast(me, SPELL_SUMMON_HATCHLING, true);

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
@@ -261,6 +261,7 @@ public:
             }
             DoCast(me, SPELL_SUMMON_HATCHLING, true);
         }
+
     private:
         InstanceScript* _instance;
     };

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_kurinnaxx.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_kurinnaxx.cpp
@@ -100,10 +100,6 @@ public:
                         {
                             target->CastSpell(target, SPELL_SANDTRAP, true);
                         }
-                        else
-                        {
-                            DoCastVictim(SPELL_SANDTRAP);
-                        }
                         events.ScheduleEvent(EVENT_SANDTRAP, urand(10000, 15000));
                         break;
                     case EVENT_WIDE_SLASH:

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_kurinnaxx.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_kurinnaxx.cpp
@@ -25,8 +25,8 @@ enum Spells
     SPELL_MORTALWOUND       = 25646,
     SPELL_SANDTRAP          = 25648,
     SPELL_ENRAGE            = 26527,
-    SPELL_SUMMON_PLAYER     = 26446,
-    SPELL_TRASH             =  3391, // Should perhaps be triggered by an aura? Couldn't find any though
+    //SPELL_SUMMON_PLAYER   = 26446,
+    SPELL_TRASH             = 3391,
     SPELL_WIDE_SLASH        = 25814
 };
 
@@ -34,13 +34,12 @@ enum Events
 {
     EVENT_MORTAL_WOUND      = 1,
     EVENT_SANDTRAP          = 2,
-    EVENT_TRASH             = 3,
-    EVENT_WIDE_SLASH        = 4
+    EVENT_WIDE_SLASH        = 3
 };
 
 enum Texts
 {
-    SAY_KURINAXX_DEATH      = 5, // Yelled by Ossirian the Unscarred
+    SAY_KURINAXX_DEATH      = 5 // Yell by 'Ossirian the Unscarred'
 };
 
 class boss_kurinnaxx : public CreatureScript
@@ -50,25 +49,22 @@ public:
 
     struct boss_kurinnaxxAI : public BossAI
     {
-        boss_kurinnaxxAI(Creature* creature) : BossAI(creature, DATA_KURINNAXX)
-        {
-        }
+        boss_kurinnaxxAI(Creature* creature) : BossAI(creature, DATA_KURINNAXX) {}
 
         void Reset() override
         {
             _Reset();
             _enraged = false;
-            events.ScheduleEvent(EVENT_MORTAL_WOUND, 8000);
-            events.ScheduleEvent(EVENT_SANDTRAP, urand(5000, 15000));
-            events.ScheduleEvent(EVENT_TRASH, 1000);
-            events.ScheduleEvent(EVENT_WIDE_SLASH, 11000);
+            events.ScheduleEvent(EVENT_MORTAL_WOUND, urand(8000, 10000));
+            events.ScheduleEvent(EVENT_SANDTRAP, urand(10000, 15000));
+            events.ScheduleEvent(EVENT_WIDE_SLASH, urand(12000, 15000));
         }
 
         void DamageTaken(Unit*, uint32& /*damage*/, DamageEffectType, SpellSchoolMask) override
         {
             if (!_enraged && HealthBelowPct(30))
             {
-                DoCast(me, SPELL_ENRAGE);
+                DoCastSelf(SPELL_ENRAGE);
                 _enraged = true;
             }
         }
@@ -77,7 +73,9 @@ public:
         {
             _JustDied();
             if (Creature* Ossirian = me->GetMap()->GetCreature(instance->GetGuidData(DATA_OSSIRIAN)))
+            {
                 sCreatureTextMgr->SendChat(Ossirian, SAY_KURINAXX_DEATH, nullptr, CHAT_MSG_ADDON, LANG_ADDON, TEXT_RANGE_ZONE);
+            }
         }
 
         void UpdateAI(uint32 diff) override
@@ -86,7 +84,6 @@ public:
                 return;
 
             events.Update(diff);
-
             if (me->HasUnitState(UNIT_STATE_CASTING))
                 return;
 
@@ -96,28 +93,27 @@ public:
                 {
                     case EVENT_MORTAL_WOUND:
                         DoCastVictim(SPELL_MORTALWOUND);
-                        events.ScheduleEvent(EVENT_MORTAL_WOUND, 8000);
+                        events.ScheduleEvent(EVENT_MORTAL_WOUND, urand(8000, 10000));
                         break;
                     case EVENT_SANDTRAP:
                         if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100, true))
+                        {
                             target->CastSpell(target, SPELL_SANDTRAP, true);
-                        else if (Unit* victim = me->GetVictim())
-                            victim->CastSpell(victim, SPELL_SANDTRAP, true);
-                        events.ScheduleEvent(EVENT_SANDTRAP, urand(5000, 15000));
+                        }
+                        else
+                        {
+                            DoCastVictim(SPELL_SANDTRAP);
+                        }
+                        events.ScheduleEvent(EVENT_SANDTRAP, urand(10000, 15000));
                         break;
                     case EVENT_WIDE_SLASH:
-                        DoCast(me, SPELL_WIDE_SLASH);
-                        events.ScheduleEvent(EVENT_WIDE_SLASH, 11000);
-                        break;
-                    case EVENT_TRASH:
-                        DoCast(me, SPELL_TRASH);
-                        events.ScheduleEvent(EVENT_WIDE_SLASH, 16000);
+                        DoCastSelf(SPELL_WIDE_SLASH);
+                        events.ScheduleEvent(EVENT_WIDE_SLASH, urand(12000, 15000));
                         break;
                     default:
                         break;
                 }
             }
-
             DoMeleeAttackIfReady();
         }
     private:

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_moam.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_moam.cpp
@@ -42,13 +42,13 @@ enum Events
     EVENT_DRAIN_MANA        = 2,
     EVENT_STONE_PHASE       = 3,
     EVENT_STONE_PHASE_END   = 4,
-    EVENT_WIDE_SLASH        = 5,
+    EVENT_WIDE_SLASH        = 5
 };
 
 enum Actions
 {
     ACTION_STONE_PHASE_START = 1,
-    ACTION_STONE_PHASE_END   = 2,
+    ACTION_STONE_PHASE_END   = 2
 };
 
 class boss_moam : public CreatureScript
@@ -58,9 +58,7 @@ public:
 
     struct boss_moamAI : public BossAI
     {
-        boss_moamAI(Creature* creature) : BossAI(creature, DATA_MOAM)
-        {
-        }
+        boss_moamAI(Creature* creature) : BossAI(creature, DATA_MOAM) {}
 
         void Reset() override
         {
@@ -93,10 +91,10 @@ public:
                     }
                 case ACTION_STONE_PHASE_START:
                     {
-                        DoCast(me, SPELL_SUMMON_MANA_FIEND_1);
-                        DoCast(me, SPELL_SUMMON_MANA_FIEND_2);
-                        DoCast(me, SPELL_SUMMON_MANA_FIEND_3);
-                        DoCast(me, SPELL_ENERGIZE);
+                        DoCastSelf(SPELL_SUMMON_MANA_FIEND_1);
+                        DoCastSelf(SPELL_SUMMON_MANA_FIEND_2);
+                        DoCastSelf(SPELL_SUMMON_MANA_FIEND_3);
+                        DoCastSelf(SPELL_ENERGIZE);
                         events.ScheduleEvent(EVENT_STONE_PHASE_END, 90000);
                         break;
                     }
@@ -115,7 +113,9 @@ public:
             if (me->GetPower(POWER_MANA) == me->GetMaxPower(POWER_MANA))
             {
                 if (_isStonePhase)
+                {
                     DoAction(ACTION_STONE_PHASE_END);
+                }
                 DoCastAOE(SPELL_ARCANE_ERUPTION);
                 me->SetPower(POWER_MANA, 0);
             }
@@ -123,7 +123,9 @@ public:
             if (_isStonePhase)
             {
                 if (events.ExecuteEvent() == EVENT_STONE_PHASE_END)
+                {
                     DoAction(ACTION_STONE_PHASE_END);
+                }
                 return;
             }
 
@@ -144,31 +146,34 @@ public:
                             {
                                 const std::list<HostileReference*>& threatlist = me->GetThreatMgr().getThreatList();
                                 for (std::list<HostileReference*>::const_iterator itr = threatlist.begin(); itr != threatlist.end(); ++itr)
+                                {
                                     if ((*itr)->getTarget()->GetTypeId() == TYPEID_PLAYER && (*itr)->getTarget()->getPowerType() == POWER_MANA)
+                                    {
                                         targetList.push_back((*itr)->getTarget());
+                                    }
+                                }
                             }
 
                             Acore::Containers::RandomResize(targetList, 5);
-
                             for (std::list<Unit*>::iterator itr = targetList.begin(); itr != targetList.end(); ++itr)
+                            {
                                 DoCast(*itr, SPELL_DRAIN_MANA);
-
+                            }
                             events.ScheduleEvent(EVENT_DRAIN_MANA, urand(5000, 15000));
                             break;
                         }/*
                         case EVENT_WIDE_SLASH:
-                            DoCast(me, SPELL_WIDE_SLASH);
+                            DoCastSelf(SPELL_WIDE_SLASH);
                             events.ScheduleEvent(EVENT_WIDE_SLASH, 11000);
                             break;
                         case EVENT_TRASH:
-                            DoCast(me, SPELL_TRASH);
+                            DoCastSelf(SPELL_TRASH);
                             events.ScheduleEvent(EVENT_WIDE_SLASH, 16000);
                             break;*/
                     default:
                         break;
                 }
             }
-
             DoMeleeAttackIfReady();
         }
     private:

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
@@ -34,11 +34,11 @@ enum Texts
 
 enum Spells
 {
-    SPELL_SILENCE               = 25195,
-    SPELL_CYCLONE               = 25189,
-    SPELL_STOMP                 = 25188,
+    SPELL_CURSE_OF_TONGUES      = 25195,
+    SPELL_ENVELOPING_WINDS      = 25189,
+    SPELL_WAR_STOMP             = 25188,
     SPELL_STRENGHT_OF_OSSIRIAN  = 25176,
-    SPELL_SUMMON                = 20477,
+    SPELL_SUMMON_PLAYER         = 20477,
     SPELL_SAND_STORM            = 25160,
     SPELL_SUMMON_CRYSTAL        = 25192
 };
@@ -222,7 +222,7 @@ public:
             events.Update(diff);
             if (me->GetDistance(me->GetVictim()) > 60.00f && me->GetDistance(me->GetVictim()) < 120.00f)
             {
-                DoCastVictim(SPELL_SUMMON);
+                DoCastVictim(SPELL_SUMMON_PLAYER);
             }
 
             bool ApplySupreme = true;
@@ -254,15 +254,15 @@ public:
                 switch (eventId)
                 {
                     case EVENT_SILENCE:
-                        DoCastAOE(SPELL_SILENCE);
+                        DoCastAOE(SPELL_CURSE_OF_TONGUES);
                         events.ScheduleEvent(EVENT_SILENCE, urand(20000, 30000));
                         break;
                     case EVENT_CYCLONE:
-                        DoCastVictim(SPELL_CYCLONE);
+                        DoCastVictim(SPELL_ENVELOPING_WINDS);
                         events.ScheduleEvent(EVENT_CYCLONE, 20000);
                         break;
                     case EVENT_STOMP:
-                        DoCastAOE(SPELL_STOMP);
+                        DoCastAOE(SPELL_WAR_STOMP);
                         events.ScheduleEvent(EVENT_STOMP, 30000);
                         break;
                     default:

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
@@ -25,37 +25,37 @@
 
 enum Texts
 {
-    SAY_SUPREME             = 0,
-    SAY_INTRO               = 1,
-    SAY_AGGRO               = 2,
-    SAY_SLAY                = 3,
-    SAY_DEATH               = 4
+    SAY_SUPREME                 = 0,
+    SAY_INTRO                   = 1,
+    SAY_AGGRO                   = 2,
+    SAY_SLAY                    = 3,
+    SAY_DEATH                   = 4
 };
 
 enum Spells
 {
-    SPELL_SILENCE           = 25195,
-    SPELL_CYCLONE           = 25189,
-    SPELL_STOMP             = 25188,
-    SPELL_SUPREME           = 25176,
-    SPELL_SUMMON            = 20477,
-    SPELL_SAND_STORM        = 25160,
-    SPELL_SUMMON_CRYSTAL    = 25192
+    SPELL_SILENCE               = 25195,
+    SPELL_CYCLONE               = 25189,
+    SPELL_STOMP                 = 25188,
+    SPELL_STRENGHT_OF_OSSIRIAN  = 25176,
+    SPELL_SUMMON                = 20477,
+    SPELL_SAND_STORM            = 25160,
+    SPELL_SUMMON_CRYSTAL        = 25192
 };
 
 enum Actions
 {
-    ACTION_TRIGGER_WEAKNESS = 1
+    ACTION_TRIGGER_WEAKNESS     = 1
 };
 
 enum Events
 {
-    EVENT_SILENCE           = 1,
-    EVENT_CYCLONE           = 2,
-    EVENT_STOMP             = 3
+    EVENT_SILENCE               = 1,
+    EVENT_CYCLONE               = 2,
+    EVENT_STOMP                 = 3
 };
 
-uint8 const NUM_CRYSTALS = 9;
+uint8 const NUM_CRYSTALS        = 9;
 
 Position CrystalCoordinates[NUM_CRYSTALS] =
 {
@@ -107,7 +107,7 @@ public:
             {
                 if (spell->Id == SpellWeakness[i])
                 {
-                    me->RemoveAurasDueToSpell(SPELL_SUPREME);
+                    me->RemoveAurasDueToSpell(SPELL_STRENGHT_OF_OSSIRIAN);
                     ((TempSummon*)caster)->UnSummon();
                     SpawnNextCrystal();
                 }
@@ -135,7 +135,7 @@ public:
             events.ScheduleEvent(EVENT_SILENCE, 30000);
             events.ScheduleEvent(EVENT_CYCLONE, 20000);
             events.ScheduleEvent(EVENT_STOMP, 30000);
-            DoCast(me, SPELL_SUPREME);
+            DoCast(me, SPELL_STRENGHT_OF_OSSIRIAN);
             Talk(SAY_AGGRO);
 
             Map* map = me->GetMap();
@@ -227,7 +227,7 @@ public:
 
             bool ApplySupreme = true;
 
-            if (me->HasAura(SPELL_SUPREME))
+            if (me->HasAura(SPELL_STRENGHT_OF_OSSIRIAN))
             {
                 ApplySupreme = false;
             }
@@ -245,7 +245,7 @@ public:
 
             if (ApplySupreme)
             {
-                DoCast(me, SPELL_SUPREME);
+                DoCast(me, SPELL_STRENGHT_OF_OSSIRIAN);
                 Talk(SAY_SUPREME);
             }
 

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
@@ -57,9 +57,6 @@ enum Events
 
 uint8 const NUM_CRYSTALS = 9;
 
-// You spin me right round, baby
-// right round like a record, baby
-// right round round round
 Position CrystalCoordinates[NUM_CRYSTALS] =
 {
     { -9394.230469f, 1951.808594f, 85.97733f, 0.0f },

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
@@ -117,9 +117,15 @@ public:
         void DoAction(int32 action) override
         {
             if (action == ACTION_TRIGGER_WEAKNESS)
+            {
                 if (Creature* Trigger = me->GetMap()->GetCreature(TriggerGUID))
+                {
                     if (!Trigger->HasUnitState(UNIT_STATE_CASTING))
+                    {
                         Trigger->CastSpell(Trigger, SpellWeakness[urand(0, 4)], false);
+                    }
+                }
+            }
         }
 
         void EnterCombat(Unit* /*who*/) override
@@ -129,7 +135,6 @@ public:
             events.ScheduleEvent(EVENT_SILENCE, 30000);
             events.ScheduleEvent(EVENT_CYCLONE, 20000);
             events.ScheduleEvent(EVENT_STOMP, 30000);
-
             DoCast(me, SPELL_SUPREME);
             Talk(SAY_AGGRO);
 
@@ -139,14 +144,14 @@ public:
 
             WorldPackets::Misc::Weather weather(WEATHER_STATE_HEAVY_SANDSTORM, 1.0f);
             map->SendToPlayers(weather.Write());
-
             for (uint8 i = 0; i < NUM_TORNADOS; ++i)
             {
                 Position Point = me->GetRandomPoint(RoomCenter, RoomRadius);
                 if (Creature* Tornado = me->GetMap()->SummonCreature(NPC_SAND_VORTEX, Point))
+                {
                     Tornado->CastSpell(Tornado, SPELL_SAND_STORM, true);
+                }
             }
-
             SpawnNextCrystal();
         }
 
@@ -171,14 +176,17 @@ public:
         void Cleanup()
         {
             if (GameObject* Crystal = me->GetMap()->GetGameObject(CrystalGUID))
+            {
                 Crystal->Use(me);
+            }
         }
 
         void SpawnNextCrystal()
         {
             if (CrystalIterator == NUM_CRYSTALS)
+            {
                 CrystalIterator = 0;
-
+            }
             if (Creature* Trigger = me->GetMap()->SummonCreature(NPC_OSSIRIAN_TRIGGER, CrystalCoordinates[CrystalIterator]))
             {
                 TriggerGUID = Trigger->GetGUID();
@@ -212,15 +220,17 @@ public:
                 return;
 
             events.Update(diff);
-
-            // No kiting!
             if (me->GetDistance(me->GetVictim()) > 60.00f && me->GetDistance(me->GetVictim()) < 120.00f)
+            {
                 DoCastVictim(SPELL_SUMMON);
+            }
 
             bool ApplySupreme = true;
 
             if (me->HasAura(SPELL_SUPREME))
+            {
                 ApplySupreme = false;
+            }
             else
             {
                 for (uint8 i = 0; i < NUM_WEAKNESS; ++i)
@@ -244,7 +254,7 @@ public:
                 switch (eventId)
                 {
                     case EVENT_SILENCE:
-                        DoCast(me, SPELL_SILENCE);
+                        DoCastAOE(SPELL_SILENCE);
                         events.ScheduleEvent(EVENT_SILENCE, urand(20000, 30000));
                         break;
                     case EVENT_CYCLONE:
@@ -252,14 +262,13 @@ public:
                         events.ScheduleEvent(EVENT_CYCLONE, 20000);
                         break;
                     case EVENT_STOMP:
-                        DoCast(me, SPELL_STOMP);
+                        DoCastAOE(SPELL_STOMP);
                         events.ScheduleEvent(EVENT_STOMP, 30000);
                         break;
                     default:
                         break;
                 }
             }
-
             DoMeleeAttackIfReady();
         }
     };

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_rajaxx.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_rajaxx.cpp
@@ -23,7 +23,7 @@
 enum Yells
 {
     // The time of our retribution is at hand! Let darkness reign in the hearts of our enemies! Sound: 8645 Emote: 35
-    SAY_ANDOROV_INTRO         = 0,   // Before for the first wave
+    SAY_ANDOROV_INTRO         = 0,   // Before the first wave
     SAY_ANDOROV_ATTACK        = 1,   // Beginning the event
 
     SAY_WAVE3                 = 0,
@@ -63,9 +63,7 @@ public:
 
     struct boss_rajaxxAI : public BossAI
     {
-        boss_rajaxxAI(Creature* creature) : BossAI(creature, DATA_RAJAXX)
-        {
-        }
+        boss_rajaxxAI(Creature* creature) : BossAI(creature, DATA_RAJAXX) {}
 
         void Reset() override
         {
@@ -92,7 +90,6 @@ public:
                 return;
 
             events.Update(diff);
-
             if (me->HasUnitState(UNIT_STATE_CASTING))
                 return;
 
@@ -105,14 +102,13 @@ public:
                         events.ScheduleEvent(EVENT_DISARM, 22000);
                         break;
                     case EVENT_THUNDERCRASH:
-                        DoCast(me, SPELL_THUNDERCRASH);
+                        DoCastSelf(SPELL_THUNDERCRASH);
                         events.ScheduleEvent(EVENT_THUNDERCRASH, 21000);
                         break;
                     default:
                         break;
                 }
             }
-
             DoMeleeAttackIfReady();
         }
     private:
@@ -136,7 +132,6 @@ class spell_rajaxx_thundercrash : public SpellScript
         {
             damage = 200;
         }
-
         SetHitDamage(damage);
     }
 

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/instance_ruins_of_ahnqiraj.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/instance_ruins_of_ahnqiraj.cpp
@@ -67,7 +67,9 @@ public:
         void SetGuidData(uint32 type, ObjectGuid data) override
         {
             if (type == DATA_PARALYZED)
+            {
                 _paralyzedGUID = data;
+            }
         }
 
         ObjectGuid GetGuidData(uint32 type) const override
@@ -131,7 +133,9 @@ public:
                 }
             }
             else
+            {
                 OUT_LOAD_INST_DATA_FAIL;
+            }
 
             OUT_LOAD_INST_DATA_COMPLETE;
         }

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/ruins_of_ahnqiraj.h
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/ruins_of_ahnqiraj.h
@@ -24,15 +24,15 @@
 
 enum DataTypes
 {
-    DATA_KURINNAXX          = 0,
-    DATA_RAJAXX             = 1,
-    DATA_MOAM               = 2,
-    DATA_BURU               = 3,
-    DATA_AYAMISS            = 4,
-    DATA_OSSIRIAN           = 5,
-    NUM_ENCOUNTER           = 6,
+    DATA_KURINNAXX              = 0,
+    DATA_RAJAXX                 = 1,
+    DATA_MOAM                   = 2,
+    DATA_BURU                   = 3,
+    DATA_AYAMISS                = 4,
+    DATA_OSSIRIAN               = 5,
+    NUM_ENCOUNTER               = 6,
 
-    DATA_PARALYZED          = 7
+    DATA_PARALYZED              = 7
 };
 
 enum Creatures
@@ -49,6 +49,7 @@ enum Creatures
     NPC_SAND_VORTEX             = 15428,
     NPC_OSSIRIAN_TRIGGER        = 15590,
     NPC_HATCHLING               = 15521,
+    NPC_BURU_EGG                = 15514,
     NPC_LARVA                   = 15555,
     NPC_SWARMER                 = 15546,
     NPC_HORNET                  = 15934


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/61223313/173739029-f00294c5-bb31-47ff-af5e-e842b096dd67.png)

### Changes:
**==== Kurinnaxx ====**
- Cleanup/refactor
- Migrate trash spell handling from script to db
- Guides state that cleave (WideSlash) applies the 'Mortal Wound' debuff but videos demonstrate that it does not apply them. Those are separate events.
source: https://youtu.be/EgazIWGM0n0?t=30 AND https://youtu.be/idACansl4-0?t=3 / https://youtu.be/idACansl4-0?t=14


**==== General Rajaxx ====**
- Cleanup/refactor


**==== Ossirian ====**
- Cleanup/refactor
- Add Immunity to Taunt


**==== Buru ====**
- Cleanup/refactor
- Schedule EVENT_CREEPING_PLAGUE
- Adjust timer for EVENT_CREEPING_PLAGUE
- Add Immunity to Taunt
- Let "Creeping Plague" tick 3 times before stacking up
- Remove EVENT_DISMEMBER on Phase2  |  https://youtu.be/D0nktm78pII?t=375
- Make all visual spell effects triggered to skip unit egg death
- Remove all 'Creeping Plague' stacks on Buru death
- Make the remaining eggs hatch at Phase 2 (won't respawn)  |  https://youtu.be/TyRheH9Cys0?t=382
- Disable experience gain on "Buru Egg" and "Hive'Zara Hatchling"
- Disable visual effects on eggs at "Phase2 forced hatch"
- Despawn "Hive'Zara Hatchling" after 10sec if out of combat


**==== Moam ====**
- Cleanup/refactor


**==== Ayamiss ====**
- Cleanup/refactor
- Add Immunity to Taunt

### Known issues:

**Kurinnaxx** 
* Sand traps require scripting.
* Timers require adjustment.

**General Rajaxx**
* Waves and dialogues are gonna need scripting.
* Timers require adjustment.
* Lt. General should be immune to Rajaxx's knockback attack

**Ossirian**
* Sand vortex triggers visible.
* Crystal object init is delayed (intended?).
* Timers require adjustment.

**Buru**
* Timers require adjustment.
* Egg is targeting the player.
* Eggs repositions if target within 0-3 yards.
* Buru missing damage reduction in Phase 1  |  [idea](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp#L335)
* Is better to make a proper Reset(); than sending the boss to Evade - will help set eggs correctly after wipe

**Moam**
* Timers require adjustment.

**Ayamiss**
* Timers require adjustment.