### PR TITLE
fix(Core/ZulGurub): Mandokir charge and chained spirits

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1655583442917433100.sql
+++ b/data/sql/updates/pending_db_world/rev_1655583442917433100.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_mandokir_charge';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(24408, 'spell_mandokir_charge');

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -1363,12 +1363,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].Amplitude = 15000;
     });
 
-    // Threatening Gaze
-    ApplySpellFix({ 24314 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CAST;
-    });
-
     // Isle of Conquest
     ApplySpellFix({ 66551 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -1363,6 +1363,12 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].Amplitude = 15000;
     });
 
+    // Frightening Shout
+    ApplySpellFix({ 19134 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
+    });
+
     // Isle of Conquest
     ApplySpellFix({ 66551 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -1363,6 +1363,12 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].Amplitude = 15000;
     });
 
+    // Threatening Gaze
+    ApplySpellFix({ 24314 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CAST;
+    });
+
     // Frightening Shout
     ApplySpellFix({ 19134 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
@@ -318,7 +318,8 @@ public:
                         events.ScheduleEvent(EVENT_WATCH_PLAYER, urand(12000, 24000));
                         break;
                     case EVENT_CHARGE_PLAYER:
-                        DoCast(SelectTarget(SelectTargetMethod::MaxDistance, 0, 40, true), SPELL_CHARGE);
+                        if (Unit* target = SelectTarget(SelectTargetMethod::MinDistance, 0, FarthestTargetSelector(me, 40.f, false, true)))
+                            DoCast(target, SPELL_CHARGE);
                         events.ScheduleEvent(EVENT_FRIGHTENING_SHOUT, 500);
                         if (Unit* mainTarget = SelectTarget(SelectTargetMethod::MaxThreat, 0, 100.0f))
                         {

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
@@ -47,9 +47,9 @@ enum Spells
     SPELL_LEVEL_UP            = 24312,
     SPELL_EXECUTE             = 7160,
     SPELL_MANDOKIR_CLEAVE     = 20691,
-    SPELL_SUMMON_PLAYER           = 25104,
+    SPELL_SUMMON_PLAYER       = 25104,
 
-    SPELL_REVIVE                  = 24341 // chained spirit
+    SPELL_REVIVE              = 24341 // chained spirit
 };
 
 enum Events
@@ -71,8 +71,7 @@ enum Events
 enum Action
 {
     ACTION_START_REVIVE       = 1, // broodlord mandokir
-    ACTION_REVIVE             = 2, // chained spirit
-    ACTION_CHECK_TG_TARGET    = 3
+    ACTION_REVIVE             = 2 // chained spirit
 };
 
 enum Misc

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
@@ -413,7 +413,6 @@ public:
 };
 
 // Ohgan
-
 enum OhganSpells
 {
     SPELL_SUNDERARMOR         = 24317,
@@ -561,7 +560,6 @@ enum VilebranchSpells
     SPELL_DEMORALIZING_SHOUT  = 13730,
     SPELL_CLEAVE              = 15284
 };
-
 
 struct npc_vilebranch_speaker : public ScriptedAI
 {

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
@@ -172,7 +172,6 @@ public:
             reviveGUID.Clear();
             threateningTargetGUID.Clear();
             threatTGTarget = 0.f;
-            _scheduler.CancelAll();
         }
 
         void JustDied(Unit* /*killer*/) override
@@ -239,17 +238,7 @@ public:
                 {
                     if (threatTGTarget < me->GetThreatMgr().getThreat(playerGazed))
                     {
-                        if (!me->IsWithinLOSInMap(playerGazed))
-                        {
-                            DoCast(playerGazed, SPELL_SUMMON_PLAYER, true);
-                            _scheduler.Schedule(25ms, [this, playerGazed](TaskContext /*context*/)
-                                {
-                                    if (playerGazed)
-                                        DoCast(playerGazed, SPELL_THREATENING_GAZE_CHARGE);
-                                });
-                        }
-                        else
-                            DoCast(playerGazed, SPELL_THREATENING_GAZE_CHARGE);
+                        DoCast(playerGazed, SPELL_THREATENING_GAZE_CHARGE);
                     }
                 }
 
@@ -312,8 +301,6 @@ public:
 
             if (me->HasUnitState(UNIT_STATE_CASTING) || me->HasUnitState(UNIT_STATE_CHARGING))
                 return;
-
-            _scheduler.Update(diff);
 
             while (uint32 eventId = events.ExecuteEvent())
             {
@@ -403,7 +390,6 @@ public:
         ObjectGuid reviveGUID;
         ObjectGuid threateningTargetGUID;
         float threatTGTarget;
-        TaskScheduler _scheduler;
     };
 
     CreatureAI* GetAI(Creature* creature) const override

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
@@ -199,7 +199,7 @@ public:
             me->SummonCreature(NPC_OHGAN, me->GetPositionX() - 3, me->GetPositionY(), me->GetPositionZ(), me->GetOrientation(), TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 35000);
             for (int i = 0; i < CHAINED_SPIRIT_COUNT; ++i)
             {
-                Creature* chainedSpirit = me->SummonCreature(NPC_CHAINED_SPIRIT, PosSummonChainedSpirits[i], TEMPSUMMON_CORPSE_DESPAWN);
+                me->SummonCreature(NPC_CHAINED_SPIRIT, PosSummonChainedSpirits[i], TEMPSUMMON_CORPSE_DESPAWN);
             }
             DoZoneInCombat();
         }

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
@@ -615,11 +615,8 @@ class spell_threatening_gaze : public AuraScript
     {
         if (Unit* caster = GetCaster())
         {
-            if (Unit* target = GetTarget())
-            {
-                if (caster->GetAI())
-                    caster->GetAI()->DoAction(ACTION_CHECK_TG_TARGET);
-            }
+            if (caster->GetAI())
+                caster->GetAI()->DoAction(ACTION_CHECK_TG_TARGET);
         }
     }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Chained spirits should revive the nearest player instead of random. Also added a check to not select the same spirit for 2 players.
-  Mandokir should charge the farthest target possible.
-  Removed double debuff for Frightening Shout.
-  Added a check to not cast spells during charge.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11746
- Closes #11749
- Closes https://github.com/chromiecraft/chromiecraft/issues/3626

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Engage Mandokir with more than 2 players.
2. Let Mandokir or Ohgan kill players
3. See the nearest spirits revive the killed players.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Issues were not so clear, so I don't know if there is anything to be left or if I successfully addressed all the issues.