### PR TITLE
fix(DB/gameobject): move three objects Half-Buried Bottle (2560) abov…

### DIFF
--- a/data/sql/updates/pending_db_world/half_buried_bottle.sql
+++ b/data/sql/updates/pending_db_world/half_buried_bottle.sql
@@ -1,6 +1,4 @@
 --
-DELETE FROM `gameobject` WHERE (`id` = 2560) AND (`guid` IN (11031, 11034, 11705));
-INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
-(11031, 2560, 0, 33, 311, 1, 1, -13734.8, -255.343, 0.508326, 0.523599, 0, 0, 0.258819, 0.965926, 900, 100, 1, '', 0),
-(11034, 2560, 0, 33, 302, 1, 1, -13912.6, -166.436, 2.541038, -0.296706, 0, 0, 0.147809, -0.989016, 900, 100, 1, '', 0),
-(11705, 2560, 0, 33, 297, 1, 1, -14592.1, -83.6838, 0.853386, -3.01942, 0, 0, 0.998135, -0.061048, 900, 100, 1, '', 0);
+UPDATE `gameobject` SET `position_z`=0.508326 WHERE  `guid`=11031 AND `id`=2560;
+UPDATE `gameobject` SET `position_z`=2.541038 WHERE  `guid`=11034 AND `id`=2560;
+UPDATE `gameobject` SET `position_z`=0.853386 WHERE  `guid`=11705 AND `id`=2560;

--- a/data/sql/updates/pending_db_world/half_buried_bottle.sql
+++ b/data/sql/updates/pending_db_world/half_buried_bottle.sql
@@ -1,0 +1,6 @@
+--
+DELETE FROM `gameobject` WHERE (`id` = 2560) AND (`guid` IN (11031, 11034, 11705));
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(11031, 2560, 0, 33, 311, 1, 1, -13734.8, -255.343, 0.508326, 0.523599, 0, 0, 0.258819, 0.965926, 900, 100, 1, '', 0),
+(11034, 2560, 0, 33, 302, 1, 1, -13912.6, -166.436, 2.541038, -0.296706, 0, 0, 0.147809, -0.989016, 900, 100, 1, '', 0),
+(11705, 2560, 0, 33, 297, 1, 1, -14592.1, -83.6838, 0.853386, -3.01942, 0, 0, 0.998135, -0.061048, 900, 100, 1, '', 0);


### PR DESCRIPTION
…e ground

Created by using .go gameobject, flying up to ground level, taking the Z-axis from .gps and subtracting 0.1 from the value (because they're half-buried).
Temporary change until a proper sniff can be made.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Moves objects 11031 11034 11705 above ground as they were previously underground and unreachable.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes part of https://github.com/azerothcore/azerothcore-wotlk/issues/12102

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go gameobject 11031`
2. `.go gameobject 11034`
3. `.go gameobject 11705`
4. see if they are all lootable and visible

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
