### PR TITLE
fix(Scripts/ZulGurub): Fixed never-ending Thousand Blades during Rena…

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_renataki.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_renataki.cpp
@@ -212,9 +212,15 @@ public:
                                 DoCast(target, SPELL_THOUSAND_BLADES, false);
                             }
 
-                            _thousandBladesTargets.erase(itr);
-
-                            events.ScheduleEvent(EVENT_THOUSAND_BLADES, 500ms);
+                            if (_thousandBladesTargets.erase(itr) != _thousandBladesTargets.end())
+                            {
+                                events.ScheduleEvent(EVENT_THOUSAND_BLADES, 500ms);
+                            }
+                            else
+                            {
+                                _thousandBladesCount = urand(2, 5);
+                                events.ScheduleEvent(EVENT_THOUSAND_BLADES, 15s, 22s);
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
…taki encounter.

Fixes #12078

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12078
- Closes https://github.com/chromiecraft/chromiecraft/issues/3629

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.event stop 27`
`.event stop 28`
`.event stop 30`
`.event start 29`
`.additem 19931`
`.go xyz -11905 -1911 66 309`
use the brazier and engage Renataki

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
