### PR TITLE
fix(DB/GameObject): Add missing Alliance Bonfire in Feralas

### DIFF
--- a/data/sql/updates/pending_db_world/extinguishing_kalimdor.sql
+++ b/data/sql/updates/pending_db_world/extinguishing_kalimdor.sql
@@ -1,0 +1,4 @@
+DELETE FROM `gameobject` WHERE (`id` = 187929);
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
+(21018, 187929, 1, 0, 0, 1, 1, -4392.56, 2198.47, 10.857, 2.46091, 0, 0, 0.942641, 0.333809, 120, 255, 1, '', 0),
+(164905, 187929, 1, 0, 0, 1, 1, -4412.02, 3480.24, 12.6312, 6.12709, 0, 0, 0.0779684, -0.996956, 300, 0, 1, '', 0);

--- a/data/sql/updates/pending_db_world/extinguishing_kalimdor.sql
+++ b/data/sql/updates/pending_db_world/extinguishing_kalimdor.sql
@@ -2,5 +2,5 @@ DELETE FROM `gameobject` WHERE (`id` = 187929);
 INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
 (164905, 187929, 1, 0, 0, 1, 1, -4412.02, 3480.24, 12.6312, 6.12709, 0, 0, 0.0779684, -0.996956, 300, 0, 1, '', 0);
 
-DELETE FROM `game_event_gameobject` WHERE `eventEntry` = '1' AND `guid` = '242532';
-INSERT INTO `game_event_gameobject` (`eventEntry`, `guid`) VALUES ('1', '164905'); 
+DELETE FROM `game_event_gameobject` WHERE `eventEntry` = 1 AND `guid` = 242532;
+INSERT INTO `game_event_gameobject` (`eventEntry`, `guid`) VALUES (1, 164905); 

--- a/data/sql/updates/pending_db_world/extinguishing_kalimdor.sql
+++ b/data/sql/updates/pending_db_world/extinguishing_kalimdor.sql
@@ -1,8 +1,6 @@
 DELETE FROM `gameobject` WHERE (`id` = 187929);
 INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
-(21018, 187929, 1, 0, 0, 1, 1, -4392.56, 2198.47, 10.857, 2.46091, 0, 0, 0.942641, 0.333809, 120, 255, 1, '', 0),
 (164905, 187929, 1, 0, 0, 1, 1, -4412.02, 3480.24, 12.6312, 6.12709, 0, 0, 0.0779684, -0.996956, 300, 0, 1, '', 0);
 
-DELETE FROM `game_event_gameobject` WHERE `eventEntry` = '1' AND `guid` = '242532'; 
-INSERT INTO `game_event_gameobject` (`eventEntry`, `guid`) VALUES ('1', '21018'); 
+DELETE FROM `game_event_gameobject` WHERE `eventEntry` = '1' AND `guid` = '242532';
 INSERT INTO `game_event_gameobject` (`eventEntry`, `guid`) VALUES ('1', '164905'); 

--- a/data/sql/updates/pending_db_world/extinguishing_kalimdor.sql
+++ b/data/sql/updates/pending_db_world/extinguishing_kalimdor.sql
@@ -2,3 +2,7 @@ DELETE FROM `gameobject` WHERE (`id` = 187929);
 INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`) VALUES
 (21018, 187929, 1, 0, 0, 1, 1, -4392.56, 2198.47, 10.857, 2.46091, 0, 0, 0.942641, 0.333809, 120, 255, 1, '', 0),
 (164905, 187929, 1, 0, 0, 1, 1, -4412.02, 3480.24, 12.6312, 6.12709, 0, 0, 0.0779684, -0.996956, 300, 0, 1, '', 0);
+
+DELETE FROM `game_event_gameobject` WHERE `eventEntry` = '1' AND `guid` = '242532'; 
+INSERT INTO `game_event_gameobject` (`eventEntry`, `guid`) VALUES ('1', '21018'); 
+INSERT INTO `game_event_gameobject` (`eventEntry`, `guid`) VALUES ('1', '164905'); 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add missing Spawn to Alliance Bonfire in Feralas.
-  Extinguishing Kalimdor Achivement work now correctly.
- Midsummer Bonfire

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
