### PR TITLE
fix(DB/Creature): Make Skullsplitter Hunter and Panther more in line with other creatures with summoned pets

### DIFF
--- a/data/sql/updates/pending_db_world/skullsplitter.sql
+++ b/data/sql/updates/pending_db_world/skullsplitter.sql
@@ -1,0 +1,10 @@
+--
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 756) AND (`source_type` = 0);
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 669) AND (`source_type` = 0) AND (`id` IN (0));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(669, 0, 0, 0, 25, 0, 100, 1, 0, 0, 0, 0, 0, 11, 3621, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Skullsplitter Hunter - On Reset - Cast \'3621\' (No Repeat)');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 756;
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 669;
+
+DELETE FROM `creature` WHERE (`id1` = 756) AND (`guid` IN (1158, 1162, 1215, 1317, 1345, 1361, 1369, 1374, 1377, 1382, 1383, 1392, 1395));


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes unnecessary Skulsplitter Panther spawns
-  Removes the 3s SmartAI despawn timer from Skullsplitter Panthers
-  Make Skullsplitter Hunters summon their pets On Reset instead of On Aggro

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12197
- Closes https://github.com/chromiecraft/chromiecraft/issues/3681

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Like a lot of other patrolling/wandering creatures with summoned pets, their pets 'stutter-run' alongside their masters. E.g. Shadowpine Catlord and Murloc Hunter.
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
