### PR TITLE
fix(DB/ZulGurub): Remove taunt immunity from Mar'li

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1656482750700107200.sql
+++ b/data/sql/updates/pending_db_world/rev_1656482750700107200.sql
@@ -1,0 +1,3 @@
+--
+-- Mar'li - Gri'lek
+UPDATE `creature_template` SET `flags_extra`=`flags_extra`&~256 WHERE `entry` IN (14510, 15082);

--- a/data/sql/updates/pending_db_world/rev_1656482750700107200.sql
+++ b/data/sql/updates/pending_db_world/rev_1656482750700107200.sql
@@ -1,3 +1,3 @@
 --
 -- Mar'li - Gri'lek
-UPDATE `creature_template` SET `flags_extra`=`flags_extra`&~256 WHERE `entry` IN (14510, 15082);
+UPDATE `creature_template` SET `flags_extra`=`flags_extra`&~256 WHERE `entry` = 14510;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove extra_flags from Mar'li

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes -

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- SQL Ran, should work...

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Mar'li and try to taunt, you should be able to taunt her.

