### PR TITLE
fix(Core/ZulGurub): Hazza'rah improvements

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1656487501551472500.sql
+++ b/data/sql/updates/pending_db_world/rev_1656487501551472500.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `DamageModifier` = 26 WHERE `entry` = 15163;

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4295,6 +4295,12 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Dispel = DISPEL_NONE;
     });
 
+    // Summon Nightmare Illusions
+    ApplySpellFix({ 24681, 24728, 24729 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].MiscValueB = 64;
+    });
+
     for (uint32 i = 0; i < GetSpellInfoStoreSize(); ++i)
     {
         SpellInfo* spellInfo = mSpellInfoMap[i];


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change wait timer for Nightmare Illusions
-  Nightmare Illusions are now despawned after being killed.
-  Change their damage and their spawn mode.
-  Chain burn will only be casted if Hazza'rah has more than 5% of mana.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12235

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game everything except chain burn.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.event stop 27
.event stop 29
.event stop 30
.event start 28
.additem 19931
.go xyz -11905 -1911 66 309
use the brazier and engage Hazza'rah

else:
.go xyz -11905 -1911 66 309
.npc add temp 15083
check the issues.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] The pct of mana to cast chain burn is totally guessed. To get an exact value we should go to ptr and test doing tiny amounts of damage, which can be really tedious.
