### PR TITLE
fix(Core): Implement ACHIEVEMENT_CRITERIA_DATA_TYPE_S_ITEM_QUALITY

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1656608960155325800.sql
+++ b/data/sql/updates/pending_db_world/rev_1656608960155325800.sql
@@ -1,4 +1,25 @@
 --
 DELETE FROM `achievement_criteria_data` WHERE `criteria_id` IN (6140, 6141);
-INSERT INTO `achievement_criteria_data` (`criteria_id`, `type`, `value1`, `value2`) VALUES (6140, 25, 4, 0);
-INSERT INTO `achievement_criteria_data` (`criteria_id`, `type`, `value1`, `value2`) VALUES (6141, 25, 5, 0);
+INSERT INTO `achievement_criteria_data` (`criteria_id`, `type`, `value1`, `value2`) VALUES
+(6140, 25, 4, 0),
+(6141, 25, 5, 0),
+(6142, 25, 4, 0),
+(4768, 25, 4, 0),
+(4769, 25, 4, 0),
+(4770, 25, 4, 0),
+(4771, 25, 4, 0),
+(4772, 25, 4, 0),
+(4773, 25, 4, 0),
+(4774, 25, 4, 0),
+(4775, 25, 4, 0),
+(4776, 25, 4, 0),
+(4777, 25, 4, 0),
+(4778, 25, 4, 0),
+(4779, 25, 4, 0),
+(4780, 25, 4, 0),
+(4781, 25, 4, 0),
+(4782, 25, 4, 0),
+(4783, 25, 4, 0),
+(4784, 25, 4, 0),
+(4785, 25, 4, 0),
+(4786, 25, 4, 0);

--- a/data/sql/updates/pending_db_world/rev_1656608960155325800.sql
+++ b/data/sql/updates/pending_db_world/rev_1656608960155325800.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `achievement_criteria_data` WHERE `criteria_id` IN (6140, 6141);
+INSERT INTO `achievement_criteria_data` (`criteria_id`, `type`, `value1`, `value2`) VALUES (6140, 25, 4, 0);
+INSERT INTO `achievement_criteria_data` (`criteria_id`, `type`, `value1`, `value2`) VALUES (6141, 25, 5, 0);

--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -242,6 +242,7 @@ bool AchievementCriteriaData::IsValid(AchievementCriteriaEntry const* criteria)
         case ACHIEVEMENT_CRITERIA_DATA_TYPE_BG_TEAMS_SCORES:
             return true;                                    // not check correctness node indexes
         case ACHIEVEMENT_CRITERIA_DATA_TYPE_S_EQUIPED_ITEM:
+        case ACHIEVEMENT_CRITERIA_DATA_TYPE_S_ITEM_QUALITY:
             if (equipped_item.item_quality >= MAX_ITEM_QUALITY)
             {
                 LOG_ERROR("sql.sql", "Table `achievement_criteria_requirement` (Entry: {} Type: {}) for requirement ACHIEVEMENT_CRITERIA_REQUIRE_S_EQUIPED_ITEM ({}) has unknown quality state in value1 ({}), ignored.",
@@ -433,6 +434,13 @@ bool AchievementCriteriaData::Meets(uint32 criteria_id, Player const* source, Un
                 return source && source->HasTitle(titleInfo->bit_index);
 
             return false;
+        }
+        case ACHIEVEMENT_CRITERIA_DATA_TYPE_S_ITEM_QUALITY:
+        {
+            ItemTemplate const* pProto = sObjectMgr->GetItemTemplate(miscvalue1);
+            if (!pProto)
+                return false;
+            return pProto->Quality == item.item_quality;
         }
         case ACHIEVEMENT_CRITERIA_DATA_TYPE_BG_TEAMS_SCORES:
         {

--- a/src/server/game/Achievements/AchievementMgr.h
+++ b/src/server/game/Achievements/AchievementMgr.h
@@ -68,8 +68,9 @@ enum AchievementCriteriaDataType
     ACHIEVEMENT_CRITERIA_DATA_TYPE_NTH_BIRTHDAY        = 22, // N                            login on day of N-th Birthday
     ACHIEVEMENT_CRITERIA_DATA_TYPE_S_KNOWN_TITLE       = 23, // title_id                     known (pvp) title, values from dbc
     ACHIEVEMENT_CRITERIA_DATA_TYPE_BG_TEAMS_SCORES     = 24, // winner_score   loser score   player's team win bg and their teams have exact scores
+    ACHIEVEMENT_CRITERIA_DATA_TYPE_S_ITEM_QUALITY      = 25  // item_quality
 };
-#define MAX_ACHIEVEMENT_CRITERIA_DATA_TYPE               25 // maximum value in AchievementCriteriaDataType enum
+#define MAX_ACHIEVEMENT_CRITERIA_DATA_TYPE               26 // maximum value in AchievementCriteriaDataType enum
 
 enum AchievementCommonCategories
 {
@@ -196,6 +197,11 @@ struct AchievementCriteriaData
             uint32 winner_score;
             uint32 loser_score;
         } teams_scores;
+        // ACHIEVEMENT_CRITERIA_DATA_TYPE_S_ITEM_QUALITY    = 25
+        struct
+        {
+            uint32 item_quality;
+        } item;
         // ...
         struct
         {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Implement missing achievement criteria type ACHIEVEMENT_CRITERIA_DATA_TYPE_S_ITEM_QUALITY
-  Import relevant achievement_criteria_data from TrinityCore DB

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/3711

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
TrinityCore

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds without errors
- Statistics now increment correctly


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Obtain Epic items, ensure legendary count does not increase
2. Obtain Legendary items, ensure legendary count increases

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
