### PR TITLE
fix(DB/Scripts): Greater Windstone Bosses

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1656632586022126700.sql
+++ b/data/sql/updates/pending_db_world/rev_1656632586022126700.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `smart_scripts` SET `event_param1` = 5000, `event_param2` = 5000 WHERE `entryorguid` IN (15203, 15204, 15205, 15305) AND `event_type` = 1;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change Greater Windstone Bosses to begin combat after 5 seconds instead of 10 seconds, because they are set to despawn after being out of combat for 5 seconds
- Resolves issues with despawning after summoning
-  If we prefer to have wait 10 seconds, a other option is to make the despawn out of combat timer longer instead. Vmangos appears to use a 5 second timer despawn as well, though, so I think the implementation of this PR is Blizz-like.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/3675
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12171

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Summoned all bosses, now correctly start combat and do not despawn


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Summon boss at greater windstone, ensure combat starts and boss does not despawn

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
