### PR TITLE
fix(DB/ZulGurub): Hoodoo Piles should not melee atack their targets.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1656749058349666900.sql
+++ b/data/sql/updates/pending_db_world/rev_1656749058349666900.sql
@@ -1,0 +1,6 @@
+--
+UPDATE `creature_template` SET `flags_extra`=130 WHERE `entry`=15047;
+
+DELETE FROM `smart_scripts` WHERE `entryorguid`=15047 AND `source_type`=0;
+INSERT INTO `smart_scripts` VALUES
+(15047,0,0,0,1,0,100,1,500,500,0,0,0,11,24178,0,0,0,0,0,23,0,0,0,0,0,0,0,0,'Gurubashi - OOC - Cast Will of Hakkar');

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2056,17 +2056,16 @@ void GameObject::CastSpell(Unit* target, uint32 spellId)
     bool self = false;
     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
-        if (spellInfo->Effects[i].TargetA.GetTarget() == TARGET_UNIT_CASTER)
+        if (spellInfo->Effects[i].TargetA.GetReferenceType() == TARGET_REFERENCE_TYPE_CASTER && !spellInfo->Effects[i].TargetB.GetTarget())
         {
             self = true;
             break;
         }
     }
 
-    if (self)
+    if (self && target && target->GetGUID() != GetGUID())
     {
-        if (target)
-            target->CastSpell(target, spellInfo, true);
+        target->CastSpell(target, spellInfo, true);
         return;
     }
 


### PR DESCRIPTION
Will of Hakkar is casted on pile looter.
Fixes #12186

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12186

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go gameobject id 180229`
Loot it and see result.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
