### PR TITLE
fix(DB\Loot): Cuergo's Hidden Treasure (9265)

### DIFF
--- a/data/sql/updates/pending_db_world/cuergo.sql
+++ b/data/sql/updates/pending_db_world/cuergo.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `item_loot_template` WHERE (`Entry` = 9265) AND (`Item` IN (9360, 9361));
+INSERT INTO `item_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(9265, 9360, 0, 92, 0, 1, 1, 1, 1, 'Cuergo\'s Hidden Treasure - Cuergo\'s Gold'),
+(9265, 9361, 0, 0, 0, 1, 1, 1, 1, 'Cuergo\'s Hidden Treasure - Cuergo\'s Gold with worm');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Places items 9361, 9360 in a GroupID inside loot from item 9265 so one is guaranteed to drop.
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12282
- Closes https://github.com/chromiecraft/chromiecraft/issues/3685

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The last PR that modified the loot table for item 9265 took values from Wowhead

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame. Opened 72 of them and one always dropped.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .additem 9265 x
2. open a high number of them, see if only one of the items Cuergo's Gold and Cuergo's Gold with Worm always drops

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
