### PR TITLE
fix(DB): Remove `acore.world` from 2022_07_05_00.sql

### DIFF
--- a/data/sql/updates/db_world/2022_07_05_00.sql
+++ b/data/sql/updates/db_world/2022_07_05_00.sql
@@ -1,7 +1,7 @@
 -- DB update 2022_07_03_07 -> 2022_07_05_00
 --
 DELETE FROM `waypoint_data` WHERE  `id`=518940;
-INSERT INTO `acore_world`.`waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`) VALUES 
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`) VALUES 
 (518940, 1, 3866.84, -672.53, 328.888),
 (518940, 2, 3866.84, -672.534, 328.888),
 (518940, 3, 3818.17, -768.04, 314.71),


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes `acore_world` from committed SQL file.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unopened issue.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Untested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Let the worldserver populate the world DB with this query included.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
