### PR TITLE
fix(DB/creature template): Adjust Whitewhisker/Irondeep NPCs in Alterac Valley

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1657055583659435900.sql
+++ b/data/sql/updates/pending_db_world/rev_1657055583659435900.sql
@@ -1,12 +1,7 @@
 --
 
--- Standardize = Morloch / Taskmaster Snivvle
 UPDATE `creature_template` SET `exp`=0, `ManaModifier`=1 WHERE `entry`=11657;
 UPDATE `creature_template` SET `unit_flags`=`unit_flags`|512 WHERE `entry`=11677;
-
--- Fix level of "Irondeep Shaman"
 UPDATE `creature_template` SET `minlevel`=53, `maxlevel`=54 WHERE `entry`=11600;
-
--- Remove loot from Whitewhisker NPCs and Irondeep NPCs / leave pickpocket / cannot confirm for leaders (Morloch - Snivvle)
 UPDATE `creature_template` SET `lootid`=0,`mingold`=0, `maxgold`=0 WHERE `entry` IN (10987,11600,11602,11604,11605,10982,11603);
 

--- a/data/sql/updates/pending_db_world/rev_1657055583659435900.sql
+++ b/data/sql/updates/pending_db_world/rev_1657055583659435900.sql
@@ -1,0 +1,12 @@
+--
+
+-- Standardize = Morloch / Taskmaster Snivvle
+UPDATE `creature_template` SET `exp`=0, `ManaModifier`=1 WHERE `entry`=11657;
+UPDATE `creature_template` SET `unit_flags`=`unit_flags`|512 WHERE `entry`=11677;
+
+-- Fix level of "Irondeep Shaman"
+UPDATE `creature_template` SET `minlevel`=53, `maxlevel`=54 WHERE `entry`=11600;
+
+-- Remove loot from Whitewhisker NPCs and Irondeep NPCs / leave pickpocket / cannot confirm for leaders (Morloch - Snivvle)
+UPDATE `creature_template` SET `lootid`=0,`mingold`=0, `maxgold`=0 WHERE `entry` IN (10987,11600,11602,11604,11605,10982,11603);
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Standardize = Morloch / Taskmaster Snivvle
- Fix the level of "Irondeep Shaman"
- Remove loot from Whitewhisker NPCs and Irondeep NPCs / leave pickpocket / cannot confirm for leaders (Morloch - Snivvle)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12308
- Closes https://github.com/chromiecraft/chromiecraft/issues/3731
- Closes #12310
- Closes https://github.com/chromiecraft/chromiecraft/issues/3732
- Closes #12311
- Closes https://github.com/chromiecraft/chromiecraft/issues/3733

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
