### PR TITLE
fix(DB/Creature): Force the correct modelid on spawn of Enchanted Tiki Warriors

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1657261273976252267.sql
+++ b/data/sql/updates/pending_db_world/rev_1657261273976252267.sql
@@ -1,2 +1,2 @@
--- Delete modelid2 that was causing conflict to Enchanted Tiki Warriors
-UPDATE `creature_template` SET `modelid2` = 0 WHERE (`entry` = 28882);
+-- Change modelid1 that was an infernal to Enchanted Tiki Warriors
+UPDATE `creature_template` SET `modelid1` = 25749 WHERE (`entry` = 28882);

--- a/data/sql/updates/pending_db_world/rev_1657261273976252267.sql
+++ b/data/sql/updates/pending_db_world/rev_1657261273976252267.sql
@@ -1,2 +1,2 @@
--- Change modelid1 that was an infernal to Enchanted Tiki Warriors
-UPDATE `creature_template` SET `modelid1` = 25749 WHERE (`entry` = 28882);
+-- Change modelid1 that was an infernal to Enchanted Tiki Warriors modelid (25749) and delete modelid2 to not duplicate
+UPDATE `creature_template` SET `modelid1` = 25749, `modelid2` = 0 WHERE (`entry` = 28882);

--- a/data/sql/updates/pending_db_world/rev_1657261273976252267.sql
+++ b/data/sql/updates/pending_db_world/rev_1657261273976252267.sql
@@ -1,0 +1,2 @@
+-- Delete modelid2 that was causing conflict to Enchanted Tiki Warriors
+UPDATE `creature_template` SET `modelid2` = 0 WHERE (`entry` = 28882);

--- a/data/sql/updates/pending_db_world/rev_1657261273976252267.sql
+++ b/data/sql/updates/pending_db_world/rev_1657261273976252267.sql
@@ -1,2 +1,5 @@
--- Change modelid1 that was an infernal to Enchanted Tiki Warriors modelid (25749) and delete modelid2 to not duplicate
-UPDATE `creature_template` SET `modelid1` = 25749, `modelid2` = 0 WHERE (`entry` = 28882);
+-- On spawn set the modelID to model 25749 to fix the golem model
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 28882) AND (`source_type` = 0) AND (`id` IN (2));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(28882, 0, 2, 0, 11, 0, 100, 1, 0, 0, 0, 0, 0, 3, 0, 25749, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enchanted Tiki Warrior - On Respawn - Morph To Model 25749 (No Repeat)');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added the script on SAI to morph the creatures to the model id 25749.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12094

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowwiki-archive.fandom.com/wiki/Enchanted_Tiki_Warrior
Youtube videos

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- .go c id 28882
- Check no infernals are around


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 28882
2. Check no infernals are around


Tests

![tiki1](https://user-images.githubusercontent.com/87535580/177932912-3183b33e-7191-42fd-8b7d-8360a7399490.jpg)

![tiki2](https://user-images.githubusercontent.com/87535580/177932930-60366385-4db8-4557-bdcc-fb7bb43e0f4e.jpg)

![tiki3](https://user-images.githubusercontent.com/87535580/177932943-abf21565-cdc6-4f22-9340-9045a8a5f5b7.jpg)


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
