### PR TITLE
fix(Scripts/Zulgurub): Jindo should cast Hex only if there are at lea…

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
@@ -126,7 +126,10 @@ public:
                         events.ScheduleEvent(EVENT_POWERFULLHEALINGWARD, urand(14000, 20000));
                         break;
                     case EVENT_HEX:
-                        DoCastVictim(SPELL_HEX, true);
+                        if (me->GetThreatMgr().getThreatList().size() > 1)
+                        {
+                            DoCastVictim(SPELL_HEX, true);
+                        }
                         events.ScheduleEvent(EVENT_HEX, urand(12000, 20000));
                         break;
                     case EVENT_DELUSIONSOFJINDO: // HACK
@@ -188,7 +191,10 @@ public:
 
         bool CanAIAttack(Unit const* target) const override
         {
-            return !target->HasAura(SPELL_HEX);
+            if (me->GetThreatMgr().getThreatList().size() > 1 && me->GetThreatMgr().getOnlineContainer().getMostHated()->getTarget() == target)
+                return !target->HasAura(SPELL_HEX);
+
+            return true;
         }
     };
 


### PR DESCRIPTION
…st 2 valid targets in raid.

Jindo should attack hexxed target if it's the only valid attack target.
Fixes #12203

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12203

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go c id 11380`
Go solo, see if Hex is cast or not.
Go with at least 2 characters, allow one to die, and then see if the boss still casts Hex
Go with 2 characters, place one far away from the fight, see if Hex resets the boss

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
