### PR TITLE
fix(Scripts/ZulGurub): Added Sweeping Strikes to Gri'lek encounter.

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_grilek.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_grilek.cpp
@@ -30,7 +30,8 @@ enum Spells
 {
     SPELL_AVATAR                    = 24646, // Enrage Spell
     SPELL_GROUND_TREMOR             = 6524,
-    SPELL_ENTANGLING_ROOTS          = 24648
+    SPELL_ENTANGLING_ROOTS          = 24648,
+    SPELL_SWEEPING_STRIKES          = 18765
 };
 
 enum Events
@@ -39,7 +40,8 @@ enum Events
     EVENT_GROUND_TREMOR             = 2,
     EVENT_START_PURSUIT             = 3,
     EVENT_STOP_PURSUIT              = 4,
-    EVENT_ENTANGLING_ROOTS          = 5
+    EVENT_ENTANGLING_ROOTS          = 5,
+    EVENT_SWEEPING_STRIKES          = 6
 };
 
 class boss_grilek : public CreatureScript // grilek
@@ -65,6 +67,7 @@ public:
             events.ScheduleEvent(EVENT_AVATAR, 20s, 30s);
             events.ScheduleEvent(EVENT_GROUND_TREMOR, 15s, 25s);
             events.ScheduleEvent(EVENT_ENTANGLING_ROOTS, 5s, 15s);
+            events.ScheduleEvent(EVENT_SWEEPING_STRIKES, 30s);
         }
 
         void UpdateAI(uint32 diff) override
@@ -114,6 +117,10 @@ public:
                     case EVENT_ENTANGLING_ROOTS:
                         DoCastVictim(SPELL_ENTANGLING_ROOTS);
                         events.ScheduleEvent(EVENT_ENTANGLING_ROOTS, 10s, 20s);
+                        break;
+                    case EVENT_SWEEPING_STRIKES:
+                        DoCastSelf(SPELL_SWEEPING_STRIKES, true);
+                        events.ScheduleEvent(EVENT_SWEEPING_STRIKES, 30s);
                         break;
                     default:
                         break;


### PR DESCRIPTION
Fixes #12249

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12249

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.tele ZG`
`.npc add temp 15082`

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
