### PR TITLE
fix(Scripts/World: Spawn adds should scale with raid size

### DIFF
--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -273,9 +273,7 @@ public:
 
                 for (const auto attacker : attackers)
                 {
-                    if (Player* pPlayer = attacker->GetSource()->GetOwner()->ToPlayer())
-                        if (pPlayer && pPlayer->IsAlive() && !pPlayer->IsGameMaster())
-                            ++attackersCount;
+                    ++attackersCount;
                 }
 
                 uint8 amount = attackersCount < 20 ? attackersCount * 0.75f : 15;

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -276,7 +276,7 @@ public:
                     ++attackersCount;
                 }
 
-                uint8 amount = attackersCount < 20 ? attackersCount * 0.75f : 15;
+                uint8 amount = attackersCount < 30 ? attackersCount * 0.5f : 15;
                 amount = amount < 1 ? 1 : amount;
 
                 for (uint8 i = 0; i < amount; ++i)

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -277,7 +277,7 @@ public:
                 }
 
                 uint8 amount = attackersCount < 20 ? attackersCount * 0.75f : 15;
-                amount = amount < 3 ? 3 : amount;
+                amount = amount < 1 ? 1 : amount;
 
                 for (uint8 i = 0; i < amount; ++i)
                     DoCast(me, SPELL_SUMMON_DRUID_SPIRITS, true);

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -268,7 +268,20 @@ public:
             {
                 Talk(SAY_YSONDRE_SUMMON_DRUIDS);
 
-                for (uint8 i = 0; i < 10; ++i)
+                auto const& attackers = me->GetThreatMgr().getThreatList();
+                uint8 attackersCount = 0;
+
+                for (const auto attacker : attackers)
+                {
+                    if (Player* pPlayer = attacker->GetSource()->GetOwner()->ToPlayer())
+                        if (pPlayer && pPlayer->IsAlive() && !pPlayer->IsGameMaster())
+                            ++attackersCount;
+                }
+
+                uint8 amount = attackersCount < 20 ? attackersCount * 0.75f : 15;
+                amount = amount < 3 ? 3 : amount;
+
+                for (uint8 i = 0; i < amount; ++i)
                     DoCast(me, SPELL_SUMMON_DRUID_SPIRITS, true);
                 ++_stage;
             }

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -273,7 +273,8 @@ public:
 
                 for (const auto attacker : attackers)
                 {
-                    ++attackersCount;
+                    if ((*attacker)->ToPlayer() && (*attacker)->IsAlive())
+                        ++attackersCount;
                 }
 
                 uint8 amount = attackersCount < 30 ? attackersCount * 0.5f : 15;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Spawn adds will scale with raid size. Max is set to 15 adds.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12279

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Cherry-pick: https://github.com/vmangos/core/blob/development/src/scripts/world/dragons_of_nightmare/boss_ysondre.cpp

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- None

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 14887
2. engage Ysondre with different number of raiders
3. .damage 90000
4. Count the number of adds

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
