### PR TITLE
fix(DB/creature): ZG entrance creature improvement

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1657581203983147300.sql
+++ b/data/sql/updates/pending_db_world/rev_1657581203983147300.sql
@@ -4,17 +4,17 @@
 /* these paths do not exist, the creatures do tho and belong where they end up without the pathing */
 DELETE FROM `creature_addon` WHERE `guid` IN (49116, 49117, 49119);
 DELETE FROM `waypoint_data` WHERE `id` IN (491160, 491170, 491190);
-UPDATE `creature` SET `MovementType`='0' WHERE `guid` IN (49116, 49117, 49119);
+UPDATE `creature` SET `MovementType`=0 WHERE `guid` IN (49116, 49117, 49119);
 
 -- Below comments are research notes
 
 /* Trolls in front in Huts Can be Priests or Axe Throwers, outside huts are Axe Throwers */
-UPDATE `creature` SET `id2`='11350' WHERE  `guid`=49115;
-UPDATE `creature` SET `id2`='11350' WHERE  `guid`=49742;
+UPDATE `creature` SET `id2`=11350 WHERE  `guid`=49115;
+UPDATE `creature` SET `id2`=11350 WHERE  `guid`=49742;
 
 /* All paired snakes can be either type, but there are some complexities on bigger packs.  Adder/Adder is slightly less common than the other combos, except when it's not.  Leaving it 50/50 is prolly fine on all 2 packs. */
-UPDATE `creature` SET `id1`='11371' WHERE `guid` IN (49739, 49740, 49091, 49090, 49089, 49088);
-UPDATE `creature` SET `id2`='11372' WHERE `guid` IN (49739, 49740, 49091, 49090, 49089, 49088);
+UPDATE `creature` SET `id1`=11371 WHERE `guid` IN (49739, 49740, 49091, 49090, 49089, 49088);
+UPDATE `creature` SET `id2`=11372 WHERE `guid` IN (49739, 49740, 49091, 49090, 49089, 49088);
 
 /* (3) Bridge Entrance Patrol seen Axe/Priest and Axe/Axe */
-UPDATE `creature` SET `id2`='11350' WHERE  `guid`=49752;
+UPDATE `creature` SET `id2`=11350 WHERE  `guid`=49752;

--- a/data/sql/updates/pending_db_world/rev_1657581203983147300.sql
+++ b/data/sql/updates/pending_db_world/rev_1657581203983147300.sql
@@ -1,0 +1,20 @@
+--
+/* Maintenance on ZG Entranceway mobs part 1 Unpooled */
+
+/* these paths do not exist, the creatures do tho and belong where they end up without the pathing */
+DELETE FROM `creature_addon` WHERE `guid` IN (49116, 49117, 49119);
+DELETE FROM `waypoint_data` WHERE `id` IN (491160, 491170, 491190);
+UPDATE `creature` SET `MovementType`='0' WHERE `guid` IN (49116, 49117, 49119);
+
+-- Below comments are research notes
+
+/* Trolls in front in Huts Can be Priests or Axe Throwers, outside huts are Axe Throwers */
+UPDATE `creature` SET `id2`='11350' WHERE  `guid`=49115;
+UPDATE `creature` SET `id2`='11350' WHERE  `guid`=49742;
+
+/* All paired snakes can be either type, but there are some complexities on bigger packs.  Adder/Adder is slightly less common than the other combos, except when it's not.  Leaving it 50/50 is prolly fine on all 2 packs. */
+UPDATE `creature` SET `id1`='11371' WHERE `guid` IN (49739, 49740, 49091, 49090, 49089, 49088);
+UPDATE `creature` SET `id2`='11372' WHERE `guid` IN (49739, 49740, 49091, 49090, 49089, 49088);
+
+/* (3) Bridge Entrance Patrol seen Axe/Priest and Axe/Axe */
+UPDATE `creature` SET `id2`='11350' WHERE  `guid`=49752;


### PR DESCRIPTION
Adds researched packs to possible spawns

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  A few general fixes (removed defunct patrols)
-  Implemented research as followed from notes: 
```
--Before first bridge 
Trolls in front in Huts Can be Priests or Axe Throwers, outside huts are Axe Throwers
All paired snakes can be either type, but there are some complexities on bigger packs.  Adder/Adder is slightly less common than the other combos, except when it's not.  Leaving it 50/50 is prolly fine on all 2 packs.
(3) Bridge Entrance Patrol seen Axe/Priest and Axe/Axe
```

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Sniff data along with personal research.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Runs and tested without error.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  .tele ZG and check out the area

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- Pooling is required on the snake pack, I am holding off on that for now.  Part 2 of this are will come soon

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
