### PR TITLE
fix(Core): Fix indexing in UpdatePlayerSetting

### DIFF
--- a/src/server/game/Entities/Player/PlayerSettings.cpp
+++ b/src/server/game/Entities/Player/PlayerSettings.cpp
@@ -108,12 +108,13 @@ void Player::_SavePlayerSettings(CharacterDatabaseTransaction trans)
 void Player::UpdatePlayerSetting(std::string source, uint8 index, uint32 value)
 {
     auto itr = m_charSettingsMap.find(source);
+    uint8 size = index + 1;
 
     if (itr == m_charSettingsMap.end())
     {
         // Settings not found, initialize a new entry.
         PlayerSettingVector setting;
-        setting.resize(index + 1);
+        setting.resize(size);
 
         for (uint32 itr = 0; itr <= index; ++itr)
         {
@@ -127,9 +128,9 @@ void Player::UpdatePlayerSetting(std::string source, uint8 index, uint32 value)
     }
     else
     {
-        if (index + 1 > itr->second.size())
+        if (size > itr->second.size())
         {
-            itr->second.resize(index + 1);
+            itr->second.resize(size);
         }
         itr->second[index].value = value;
     }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fix player settings to work correctly with indexes greater than 0

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game using transmog module, seems to work


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Ensure player settings can save and load with more than one indexed value in the setting

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
