### PR TITLE
fix(Scripts/ICC): gossip in boss Deathbringer Saurfang

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1657762683954396900.sql
+++ b/data/sql/updates/pending_db_world/rev_1657762683954396900.sql
@@ -1,0 +1,12 @@
+UPDATE `broadcast_text_locale` SET `MaleText`="Esta es nuestra batalla final. El paso del tiempo se hará eco de lo que aquí ocurra. Sin importar el resultado, sabrán que luchamos con honor. ¡Que luchamos por la libertad y la seguridad de nuestro pueblo!" WHERE `ID`=36923 AND `locale` IN ('esEs', 'esMX');
+
+UPDATE `creature_text` SET `BroadcastTextId`=37037 WHERE `CreatureID`=38607 AND `GroupID`=13 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37043 WHERE `CreatureID`=38607 AND `GroupID`=14 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37046 WHERE `CreatureID`=38607 AND `GroupID`=15 AND `ID`=0;
+
+UPDATE `creature_template` SET `gossip_menu_id`=10953, `npcflag`=`npcflag`|1 WHERE `entry`=37187;
+
+DELETE FROM `gossip_menu` WHERE `MenuID`=10953;
+
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES
+(10953, 15217);

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
@@ -750,8 +750,8 @@ public:
         InstanceScript* instance = creature->GetInstanceScript();
         if (instance && instance->GetBossState(DATA_DEATHBRINGER_SAURFANG) != DONE && instance->GetBossState(DATA_DEATHBRINGER_SAURFANG) != IN_PROGRESS)
         {
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "We are ready to go, High Overlord. The Lich King must fall!", 631, -ACTION_START_EVENT);
-            SendGossipMenuFor(player, DEFAULT_GOSSIP_MESSAGE, creature->GetGUID());
+            AddGossipItemFor(player, 10953, 0, GOSSIP_SENDER_INFO, -ACTION_START_EVENT);
+            SendGossipMenuFor(player, player->GetGossipTextId(10953, creature), creature->GetGUID());
         }
 
         return true;
@@ -964,8 +964,8 @@ public:
         InstanceScript* instance = creature->GetInstanceScript();
         if (instance && instance->GetBossState(DATA_DEATHBRINGER_SAURFANG) != DONE && instance->GetBossState(DATA_DEATHBRINGER_SAURFANG) != IN_PROGRESS)
         {
-            AddGossipItemFor(player, 0, "Let it begin...", 631, -ACTION_START_EVENT + 1);
-            SendGossipMenuFor(player, DEFAULT_GOSSIP_MESSAGE, creature->GetGUID());
+            AddGossipItemFor(player, 10933, 0, GOSSIP_SENDER_INFO, -ACTION_START_EVENT + 1);
+            SendGossipMenuFor(player, player->GetGossipTextId(10933, creature), creature->GetGUID());
         }
 
         return true;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

### Changes Proposed:
-  The hardcore code is removed from the gossip and replaced with the database code.
-  Some broadcast_text, from the intro, are updated.

### Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

### SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

### Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game

### How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .tele IcecrownCitadelRaid
2. The first broadcast_text, belong to the dialogues at the entrance of the instance, after you kill the first adds of the ladder (in the alliance). In the horde, I had no problems.
3. The `gossip` and the `npc_text`, belong to the npc, which start the 4 boss event.

### Screenshot

![WoWScrnShot_071422_155930](https://user-images.githubusercontent.com/2810187/179063163-5143b66d-db44-4c1c-aba0-6caad9d4ae40.jpg)

![WoWScrnShot_071522_022601](https://user-images.githubusercontent.com/2810187/179169492-1b099a60-fac6-4255-8222-1acbe6d397d4.jpg)

The script does not fix the problem currently found in the event. It only adds the functionality of being able to read the gossip from the database and add some missing broadcast_text.

### Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

---
<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
### How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
