### PR TITLE
fix(Scripts/ZulGurub): Jindo the Hexxer - improvements.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1657968102568754700.sql
+++ b/data/sql/updates/pending_db_world/rev_1657968102568754700.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `ScriptName`='npc_brain_wash_totem' WHERE `entry`=15112;

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
@@ -68,6 +68,9 @@ struct boss_jindo : public BossAI
         events.ScheduleEvent(EVENT_TELEPORT, 5000);
 
         Talk(SAY_AGGRO);
+
+        me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_NONE);
+        _scheduler.CancelAll();
     }
 
     void JustSummoned(Creature* summon) override
@@ -76,14 +79,14 @@ struct boss_jindo : public BossAI
 
         switch (summon->GetEntry())
         {
-        case NPC_BRAIN_WASH_TOTEM:
-            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1))
-            {
-                summon->CastSpell(target, summon->m_spells[0], true);
-            }
-            break;
-        default:
-            break;
+            case NPC_BRAIN_WASH_TOTEM:
+                if (Unit* target = SelectTarget(SelectTargetMethod::Random, me->GetThreatMgr().getThreatList().size() > 1 ? 1 : 0))
+                {
+                    summon->CastSpell(target, summon->m_spells[0], true);
+                }
+                break;
+            default:
+                break;
         }
     }
 
@@ -91,20 +94,21 @@ struct boss_jindo : public BossAI
     {
         if (_EnterEvadeMode(evadeReason))
         {
-            me->AddUnitState(UNIT_STATE_EVADE);
             Reset();
             me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_DANCE);
 
-            me->m_Events.AddEventAtOffset([&]()
+            _scheduler.Schedule(4s, [this](TaskContext /*context*/)
             {
                 me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_NONE);
                 me->GetMotionMaster()->MoveTargetedHome();
-            }, 4s);
+            });
         }
     }
 
     void UpdateAI(uint32 diff) override
     {
+        _scheduler.Update(diff);
+
         if (!UpdateVictim())
             return;
 
@@ -153,6 +157,9 @@ struct boss_jindo : public BossAI
 
         return true;
     }
+
+private:
+    TaskScheduler _scheduler;
 };
 
 //Healing Ward

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
@@ -80,6 +80,7 @@ struct boss_jindo : public BossAI
         switch (summon->GetEntry())
         {
             case NPC_BRAIN_WASH_TOTEM:
+                summon->SetReactState(REACT_PASSIVE);
                 if (Unit* target = SelectTarget(SelectTargetMethod::Random, me->GetThreatMgr().getThreatList().size() > 1 ? 1 : 0))
                 {
                     summon->CastSpell(target, summon->m_spells[0], true);
@@ -100,6 +101,7 @@ struct boss_jindo : public BossAI
             _scheduler.Schedule(4s, [this](TaskContext /*context*/)
             {
                 me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_NONE);
+                me->AddUnitState(UNIT_STATE_EVADE);
                 me->GetMotionMaster()->MoveTargetedHome();
             });
         }
@@ -289,11 +291,23 @@ class spell_delusions_of_jindo : public SpellScript
     }
 };
 
+struct npc_brain_wash_totem : public ScriptedAI
+{
+    npc_brain_wash_totem(Creature* creature) : ScriptedAI(creature)
+    {
+    }
+
+    void EnterEvadeMode(EvadeReason /*evadeReason*/) override
+    {
+    }
+};
+
 void AddSC_boss_jindo()
 {
     RegisterZulGurubCreatureAI(boss_jindo);
     RegisterZulGurubCreatureAI(npc_healing_ward);
     RegisterZulGurubCreatureAI(npc_shade_of_jindo);
+    RegisterZulGurubCreatureAI(npc_brain_wash_totem);
     RegisterSpellScript(spell_random_aggro);
     RegisterSpellScript(spell_delusions_of_jindo);
 }


### PR DESCRIPTION
Jindo can be re-aggroed when he soft reset.
Jindo can cast Brain Wash Totem while soloing.
Fixes #12338

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12338

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go c 49655` solo, engage boss
wait for a Brain Wash Totem cast, see if it works.
after the Brain Wash wears off, try to attack the boss to restart combat (you should have a 4-5s window before he completely resets)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
