### PR TITLE
fix(Scripts/ZulGurub): Sacrificed Trolls should not be attackable by …

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1657968102568754700.sql
+++ b/data/sql/updates/pending_db_world/rev_1657968102568754700.sql
@@ -1,0 +1,3 @@
+--
+UPDATE `creature_template` SET `ScriptName`='npc_brain_wash_totem' WHERE `entry`=15112;
+UPDATE `creature_template` SET `faction`=28 WHERE `entry`=14826;

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
@@ -76,14 +76,15 @@ struct boss_jindo : public BossAI
 
         switch (summon->GetEntry())
         {
-        case NPC_BRAIN_WASH_TOTEM:
-            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1))
-            {
-                summon->CastSpell(target, summon->m_spells[0], true);
-            }
-            break;
-        default:
-            break;
+            case NPC_BRAIN_WASH_TOTEM:
+                summon->SetReactState(REACT_PASSIVE);
+                if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1))
+                {
+                    summon->CastSpell(target, summon->m_spells[0], true);
+                }
+                break;
+            default:
+                break;
         }
     }
 
@@ -282,11 +283,23 @@ class spell_delusions_of_jindo : public SpellScript
     }
 };
 
+struct npc_brain_wash_totem : public ScriptedAI
+{
+    npc_brain_wash_totem(Creature* creature) : ScriptedAI(creature)
+    {
+    }
+
+    void EnterEvadeMode(EvadeReason /*evadeReason*/) override
+    {
+    }
+};
+
 void AddSC_boss_jindo()
 {
     RegisterZulGurubCreatureAI(boss_jindo);
     RegisterZulGurubCreatureAI(npc_healing_ward);
     RegisterZulGurubCreatureAI(npc_shade_of_jindo);
+    RegisterZulGurubCreatureAI(npc_brain_wash_totem);
     RegisterSpellScript(spell_random_aggro);
     RegisterSpellScript(spell_delusions_of_jindo);
 }


### PR DESCRIPTION
…mind controlled players.

Fixes #12354

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12354

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go c id 11380` with 2+ characters
get mind controlled by Brain Wash Totem, see if the Sacrificed Troll creatures are valid targets

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
