### PR TITLE
(Core/Commands): Introduce .npc guid

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1658266226251855400.sql
+++ b/data/sql/updates/pending_db_world/rev_1658266226251855400.sql
@@ -1,2 +1,3 @@
 --
+DELETE FROM `command` WHERE name = 'npc guid';
 INSERT INTO `command` (`name`, `security`, `help`) VALUES ('npc guid', 1, 'Synatx: .npc guid\r\n\r\nDisplays GUID, faction, NPC flags, Entry ID, Model ID for selected creature.');

--- a/data/sql/updates/pending_db_world/rev_1658266226251855400.sql
+++ b/data/sql/updates/pending_db_world/rev_1658266226251855400.sql
@@ -1,3 +1,3 @@
 --
 DELETE FROM `command` WHERE `name` = 'npc guid';
-INSERT INTO `command` (`name`, `security`, `help`) VALUES ('npc guid', 1, 'Synatx: .npc guid\r\n\r\nDisplays GUID, faction, NPC flags, Entry ID, Model ID for selected creature.');
+INSERT INTO `command` (`name`, `security`, `help`) VALUES ('npc guid', 1, 'Syntax: .npc guid\r\n\r\nDisplays GUID, faction, NPC flags, Entry ID, Model ID for selected creature.');

--- a/data/sql/updates/pending_db_world/rev_1658266226251855400.sql
+++ b/data/sql/updates/pending_db_world/rev_1658266226251855400.sql
@@ -1,0 +1,2 @@
+--
+INSERT INTO `command` (`name`, `security`, `help`) VALUES ('npc guid', 1, 'Synatx: .npc guid\r\n\r\nDisplays GUID, faction, NPC flags, Entry ID, Model ID for selected creature.');

--- a/data/sql/updates/pending_db_world/rev_1658266226251855400.sql
+++ b/data/sql/updates/pending_db_world/rev_1658266226251855400.sql
@@ -1,3 +1,3 @@
 --
-DELETE FROM `command` WHERE name = 'npc guid';
+DELETE FROM `command` WHERE `name` = 'npc guid';
 INSERT INTO `command` (`name`, `security`, `help`) VALUES ('npc guid', 1, 'Synatx: .npc guid\r\n\r\nDisplays GUID, faction, NPC flags, Entry ID, Model ID for selected creature.');

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -663,7 +663,6 @@ public:
             return false;
         }
 
-        CreatureTemplate const* cInfo = target->GetCreatureTemplate();
         uint32 faction = target->GetFaction();
         uint32 npcflags = target->GetNpcFlags();
         uint32 displayid = target->GetDisplayId();

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -575,7 +575,7 @@ public:
         handler->PSendSysMessage(LANG_CREATURE_FOLLOW_YOU_NOW, creature->GetName().c_str());
         return true;
     }
-      
+
     static bool HandleNpcInfoCommand(ChatHandler* handler)
     {
         Creature* target = handler->getSelectedCreature();

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -186,6 +186,7 @@ public:
         static ChatCommandTable npcCommandTable =
         {
             { "info",           HandleNpcInfoCommand,              SEC_GAMEMASTER, Console::No },
+            { "guid",           HandleNpcGuidCommand,              SEC_GAMEMASTER, Console::No },
             { "near",           HandleNpcNearCommand,              SEC_GAMEMASTER, Console::No },
             { "move",           HandleNpcMoveCommand,              SEC_GAMEMASTER, Console::No },
             { "playemote",      HandleNpcPlayEmoteCommand,         SEC_GAMEMASTER, Console::No },
@@ -574,7 +575,7 @@ public:
         handler->PSendSysMessage(LANG_CREATURE_FOLLOW_YOU_NOW, creature->GetName().c_str());
         return true;
     }
-
+      
     static bool HandleNpcInfoCommand(ChatHandler* handler)
     {
         Creature* target = handler->getSelectedCreature();
@@ -648,6 +649,37 @@ public:
                 handler->PSendSysMessage(spellSchoolImmunes[i].text, spellSchoolImmunes[i].flag);
             }
         }
+
+        return true;
+    }
+    static bool HandleNpcGuidCommand(ChatHandler* handler)
+    {
+        Creature* target = handler->getSelectedCreature();
+
+        if (!target)
+        {
+            handler->SendSysMessage(LANG_SELECT_CREATURE);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        CreatureTemplate const* cInfo = target->GetCreatureTemplate();
+        uint32 faction = target->GetFaction();
+        uint32 npcflags = target->GetNpcFlags();
+        uint32 displayid = target->GetDisplayId();
+        uint32 nativeid = target->GetNativeDisplayId();
+        uint32 entry = target->GetEntry();
+        uint32 id1 = 0;
+        uint32 id2 = 0;
+        uint32 id3 = 0;
+        if (CreatureData const* cData = target->GetCreatureData())
+        {
+            id1 = cData->id1;
+            id2 = cData->id2;
+            id3 = cData->id3;
+        }
+
+        handler->PSendSysMessage(LANG_NPCINFO_CHAR, target->GetSpawnId(), target->GetGUID().GetCounter(), entry, id1, id2, id3, displayid, nativeid, faction, npcflags);
 
         return true;
     }


### PR DESCRIPTION
(Core/Commands): Introduce .npc guid
.npc info is too robust and floods the screen
.npc guid will simply provide only the first part of .npc info's output
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Creates a new command named .npc guid which outputs only the first portion of .npc info

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- using .npc info to get simple information about creatures was too difficult to read in game, this begins to address that, though some may find it still outputs too much info

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. After compile, enter world on any char
2. use .npc guid on a creature
3. use .npc guid on yourself to make sure error outputs are correct

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- despite its name, it outputs a decent amount more than guid, I figure it can either be renamed or shortened more later and that I should keep my PR scope small especially since this is my first c++ commit on github

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
