### PR TITLE
fix(DB/creature): correct movement type on a couple snakes (ZG Entrance 3)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1658273838607986200.sql
+++ b/data/sql/updates/pending_db_world/rev_1658273838607986200.sql
@@ -1,0 +1,3 @@
+--
+/* Movetype and wander distance corrections for Entranceway */
+UPDATE `creature` SET `wander_distance`='2', `MovementType`='1' WHERE  `guid` IN (49739, 49740);

--- a/data/sql/updates/pending_db_world/rev_1658273838607986200.sql
+++ b/data/sql/updates/pending_db_world/rev_1658273838607986200.sql
@@ -1,3 +1,3 @@
 --
 /* Movetype and wander distance corrections for Entranceway */
-UPDATE `creature` SET `wander_distance`='2', `MovementType`='1' WHERE  `guid` IN (49739, 49740);
+UPDATE `creature` SET `wander_distance`=2, `MovementType`=1 WHERE  `guid` IN (49739, 49740);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changes movement type and wander distance on two creatures in the ZG entrance way, finishing touches on the last 2 PRs  

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  .go c 49739, 49740
2.  observe movement

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- This specific entrance area might be completely done now in terms of movetype ids and pooling.  Hurray.  Next.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
