### PR TITLE
fix(DB/creature): ZG Before Bats Area Improvements

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1658282918588821000.sql
+++ b/data/sql/updates/pending_db_world/rev_1658282918588821000.sql
@@ -1,0 +1,21 @@
+--
+/* Snakes */
+UPDATE `creature` SET `id1`='11371' WHERE `guid` IN (49096, 49097);
+UPDATE `creature` SET `id2`='11372' WHERE `guid` IN (49096, 49097);
+
+/* Priest can be Axe thrower */
+UPDATE `creature` SET `id2`='11350' WHERE  `guid`=49754;
+
+/* Crocs movement is a scripted action that occurs about every 30 seconds, and all crocs do it--not normal random movement */
+UPDATE `creature` SET `wander_distance`='0', `MovementType`='0' WHERE `id1`=15043;
+
+/* Movetype and wander distance corrections for Snakes and Bats/Bat Riders */
+UPDATE `creature` SET `wander_distance`='2', `MovementType`='1' WHERE  `guid` IN (49096, 49097, 49190, 49191, 49192, 49193);
+
+/* Reposition a Snake */
+/* Reposition two Trolls */
+DELETE FROM `creature` WHERE `guid` IN (49121, 49122, 49097);
+INSERT INTO `creature` (`guid`, `id1`, `id2`, `id3`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(49097, 11371, 11372, 0, 309, 0, 0, 1, 1, 0, -11959.5, -1547.96, 40.6727, 3.1776, 7200, 0, 0, 15260, 0, 0, 0, 0, 0, '', 0),
+(49121, 11351, 0, 0, 309, 0, 0, 1, 1, 1, -12008.5, -1484.79, 79.1498, 4.87654, 7200, 0, 0, 21364, 0, 0, 0, 0, 0, '', 0),
+(49122, 11831, 0, 0, 309, 0, 0, 1, 1, 1, -12004.5, -1483.46, 79.5746, 4.71553, 7200, 0, 0, 24420, 12170, 0, 0, 0, 0, '', 0);

--- a/data/sql/updates/pending_db_world/rev_1658282918588821000.sql
+++ b/data/sql/updates/pending_db_world/rev_1658282918588821000.sql
@@ -1,13 +1,13 @@
 --
 /* Snakes */
-UPDATE `creature` SET `id1`='11371' WHERE `guid` IN (49096, 49097);
-UPDATE `creature` SET `id2`='11372' WHERE `guid` IN (49096, 49097);
+UPDATE `creature` SET `id1`=11371 WHERE `guid` IN (49096, 49097);
+UPDATE `creature` SET `id2`=11372 WHERE `guid` IN (49096, 49097);
 
 /* Priest can be Axe thrower */
-UPDATE `creature` SET `id2`='11350' WHERE  `guid`=49754;
+UPDATE `creature` SET `id2`=11350 WHERE  `guid`=49754;
 
 /* Crocs movement is a scripted action that occurs about every 30 seconds, and all crocs do it--not normal random movement */
-UPDATE `creature` SET `wander_distance`='0', `MovementType`='0' WHERE `id1`=15043;
+UPDATE `creature` SET `wander_distance`=0, `MovementType`=0 WHERE `id1`=15043;
 
 /* Reposition a Snake */
 /* Reposition two Trolls */
@@ -18,4 +18,4 @@ INSERT INTO `creature` (`guid`, `id1`, `id2`, `id3`, `map`, `zoneId`, `areaId`, 
 (49122, 11831, 0, 0, 309, 0, 0, 1, 1, 1, -12004.5, -1483.46, 79.5746, 4.71553, 7200, 0, 0, 24420, 12170, 0, 0, 0, 0, '', 0);
 
 /* Movetype and wander distance corrections for Snakes and Bats/Bat Riders */
-UPDATE `creature` SET `wander_distance`='2', `MovementType`='1' WHERE  `guid` IN (49096, 49097, 49190, 49191, 49192, 49193);
+UPDATE `creature` SET `wander_distance`=2, `MovementType`=1 WHERE  `guid` IN (49096, 49097, 49190, 49191, 49192, 49193);

--- a/data/sql/updates/pending_db_world/rev_1658282918588821000.sql
+++ b/data/sql/updates/pending_db_world/rev_1658282918588821000.sql
@@ -9,9 +9,6 @@ UPDATE `creature` SET `id2`='11350' WHERE  `guid`=49754;
 /* Crocs movement is a scripted action that occurs about every 30 seconds, and all crocs do it--not normal random movement */
 UPDATE `creature` SET `wander_distance`='0', `MovementType`='0' WHERE `id1`=15043;
 
-/* Movetype and wander distance corrections for Snakes and Bats/Bat Riders */
-UPDATE `creature` SET `wander_distance`='2', `MovementType`='1' WHERE  `guid` IN (49096, 49097, 49190, 49191, 49192, 49193);
-
 /* Reposition a Snake */
 /* Reposition two Trolls */
 DELETE FROM `creature` WHERE `guid` IN (49121, 49122, 49097);
@@ -19,3 +16,6 @@ INSERT INTO `creature` (`guid`, `id1`, `id2`, `id3`, `map`, `zoneId`, `areaId`, 
 (49097, 11371, 11372, 0, 309, 0, 0, 1, 1, 0, -11959.5, -1547.96, 40.6727, 3.1776, 7200, 0, 0, 15260, 0, 0, 0, 0, 0, '', 0),
 (49121, 11351, 0, 0, 309, 0, 0, 1, 1, 1, -12008.5, -1484.79, 79.1498, 4.87654, 7200, 0, 0, 21364, 0, 0, 0, 0, 0, '', 0),
 (49122, 11831, 0, 0, 309, 0, 0, 1, 1, 1, -12004.5, -1483.46, 79.5746, 4.71553, 7200, 0, 0, 24420, 12170, 0, 0, 0, 0, '', 0);
+
+/* Movetype and wander distance corrections for Snakes and Bats/Bat Riders */
+UPDATE `creature` SET `wander_distance`='2', `MovementType`='1' WHERE  `guid` IN (49096, 49097, 49190, 49191, 49192, 49193);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Update a few creature positions
-  Add a few extra ids
-  Remove movement from croc mobs until proper movement can be added.
-  Adjust movement type on bat pack.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Sourced from PTR or similar.

Notes:
```
--After first bridge 
49097 needs moved forward
Bat pack rotates positions (4 pools)
Front Troll can be a Priest or Axe Thrower, Adders can be any combo
Headhunter in Hut can also be witchdoctor, in front is always one of each 2 pools of 3  always match the hut directly in front
Seen 4-5 Crocs (6 Pools)
Crocs movement is a scripted action that occurs about every 30 seconds, not normal random movement.
```
Not all of these will be done in this PR (un-pooled changes only), additionally 2 more mobs were moved that were not mentioned (just out of position, 49121, 49122).


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Entered ZG and checked the Peninsula across the first bridge shown in map 
![image](https://user-images.githubusercontent.com/91289495/179882300-46069bca-4acc-484d-8bd2-5462239b409d.png)



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Check the packs on the map:
Crocs should not be moving.
Snake should be moved up and can be either type.
The Priest may spawn as an Axe Thrower (the remaining Axe Thrower is static)
The bat pack at the top of the hill should wander a small bit.
The 3 pack of trolls was slightly repositioned to correct positions.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

Pooling will be added in an upcoming PR.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
