### PR TITLE
fix(Core): Instance Reset Exploit Fix

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2959,7 +2959,7 @@ bool InstanceMap::AddPlayerToMap(Player* player)
                 return false;
             }
         }
-        else if (playerBind && playerBind->save != mapSave)
+        else if (player->GetSession()->PlayerLoading() && playerBind && playerBind->save != mapSave)
         {
             // Prevent "Convert to Raid" exploit to reset instances
             return false;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2959,6 +2959,11 @@ bool InstanceMap::AddPlayerToMap(Player* player)
                 return false;
             }
         }
+        else if (playerBind && playerBind->save != mapSave)
+        {
+            // Prevent "Convert to Raid" exploit to reset instances
+            return false;
+        }
         else
         {
             playerBind = sInstanceSaveMgr->PlayerBindToInstance(player->GetGUID(), mapSave, false, player);

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -673,11 +673,6 @@ void WorldSession::LogoutPlayer(bool save)
             }
         }
 
-        // If the player has a countdown to be removed from instance and logs out, send them to the beginning of the instance
-        // Prevents instance farming exploit
-        if (_player->m_HomebindTimer && (_player->GetMap()->IsDungeon() || _player->GetMap()->IsRaidOrHeroicDungeon()))
-            _player->TeleportToEntryPoint();
-
         //! Broadcast a logout message to the player's friends
         sSocialMgr->SendFriendStatus(_player, FRIEND_OFFLINE, _player->GetGUID(), true);
         sSocialMgr->RemovePlayerSocial(_player->GetGUID());

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -679,7 +679,7 @@ void WorldSession::LogoutPlayer(bool save)
         if (_player->m_HomebindTimer && (_player->GetMap()->IsDungeon() || _player->GetMap()->IsRaidOrHeroicDungeon()))
             _player->TeleportToEntryPoint();
 
-            //! Broadcast a logout message to the player's friends
+        //! Broadcast a logout message to the player's friends
         sSocialMgr->SendFriendStatus(_player, FRIEND_OFFLINE, _player->GetGUID(), true);
         sSocialMgr->RemovePlayerSocial(_player->GetGUID());
 

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -50,7 +50,6 @@
 #include "World.h"
 #include "WorldPacket.h"
 #include "WorldSocket.h"
-#include "../Entities/Player/Player.h"
 #include <zlib.h>
 
 namespace


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  When a player logs out during a "not your instance" homebind timer, they are sent to beginning of the instance
-  Also an optimization to only check map players when logging out within an instance - previously would unnecessary fetch all players on non-instance maps when anyone in a group logged out.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12447

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested yet! Please help test. Thanks!


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Follow steps in original issue report
2. Ensure no longer can re-log in at boss location

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- I do not know proper Blizz-like behavior when logging out with a homebind timer. It is possible correct behavior should be to go to homebind location or graveyard rather than instance entrance. If someone can confirm this behavior is different, we can change it, but I think we should merge this first to fix the farming exploit.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
