### PR TITLE
fix(Core): Crash on smart event: near players

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3869,7 +3869,7 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
 
             if (!units.empty())
             {
-                if (unit->GetTypeId() != TYPEID_PLAYER)
+                if (!unit || unit->GetTypeId() != TYPEID_PLAYER)
                     return;
 
                 if (units.size() >= e.event.nearPlayer.minCount)
@@ -3885,7 +3885,7 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
 
             if (!units.empty())
             {
-                if (unit->GetTypeId() != TYPEID_PLAYER)
+                if (!unit || unit->GetTypeId() != TYPEID_PLAYER)
                     return;
 
                 if (units.size() < e.event.nearPlayerNegation.minCount)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  add nullchecks to unit before dereference.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12478
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12465

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested, kinda obvious crash, not needed.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Engage some creature with that kind of SAI.
