### PR TITLE
fix(Scripts/Spells): Script spell Itch (AQ20) and improve Consume (AQ20)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1658582043233714100.sql
+++ b/data/sql/updates/pending_db_world/rev_1658582043233714100.sql
@@ -1,0 +1,3 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` = 25185 AND `ScriptName` = 'spell_itch_aq20';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (25185, 'spell_itch_aq20');

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -4475,7 +4475,10 @@ class spell_gen_remove_impairing_auras : public SpellScript
 enum AQSpells
 {
     SPELL_CONSUME_LEECH_AQ20      = 25373,
-    SPELL_CONSUME_LEECH_HEAL_AQ20 = 25378
+    SPELL_CONSUME_LEECH_HEAL_AQ20 = 25378,
+    SPELL_CONSUME_SPIT_OUT        = 25383,
+
+    SPELL_HIVEZARA_CATALYST       = 25187
 };
 
 class spell_gen_consume : public AuraScript
@@ -4494,18 +4497,30 @@ public:
     {
         if (Unit* caster = GetCaster())
         {
+            if (!caster->IsAlive())
+            {
+                GetUnitOwner()->RemoveAurasDueToSpell(GetSpellInfo()->Id);
+                return;
+            }
+
             caster->CastSpell(GetUnitOwner(), _spellId1, true);
         }
     }
 
     void AfterRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
-        // Final heal only on duration end
-        if (GetTargetApplication() && GetTargetApplication()->GetRemoveMode() == AURA_REMOVE_BY_DEATH)
+        if (GetTargetApplication())
         {
             if (Unit* caster = GetCaster())
             {
-                caster->CastSpell(caster, _spellId2, true);
+                if (GetTargetApplication()->GetRemoveMode() == AURA_REMOVE_BY_DEATH)
+                {
+                    caster->CastSpell(caster, _spellId2, true);
+                }
+                else if (GetTargetApplication()->GetRemoveMode() == AURA_REMOVE_BY_EXPIRE)
+                {
+                    caster->CastSpell(GetTarget(), SPELL_CONSUME_SPIT_OUT, true);
+                }
             }
         }
     }
@@ -4519,6 +4534,40 @@ public:
 private:
     uint32 _spellId1;
     uint32 _spellId2;
+};
+
+class spell_gen_apply_aura_after_expiration : public AuraScript
+{
+    PrepareAuraScript(spell_gen_apply_aura_after_expiration);
+
+public:
+    spell_gen_apply_aura_after_expiration(uint32 spellId, uint32 effect, uint32 aura) : AuraScript(), _spellId(spellId), _effect(effect), _aura(aura) { }
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ _spellId });
+    }
+
+    void AfterRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        if (GetTargetApplication() && GetTargetApplication()->GetRemoveMode() == AURA_REMOVE_BY_EXPIRE)
+        {
+            if (Unit* caster = GetCaster())
+            {
+                caster->CastSpell(GetTarget(), _spellId, true);
+            }
+        }
+    }
+
+    void Register() override
+    {
+        AfterEffectRemove += AuraEffectRemoveFn(spell_gen_apply_aura_after_expiration::AfterRemove, _effect, _aura, AURA_EFFECT_HANDLE_REAL);
+    }
+
+private:
+    uint32 _spellId;
+    uint32 _effect;
+    uint32 _aura;
 };
 
 void AddSC_generic_spell_scripts()
@@ -4656,4 +4705,5 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_arcane_charge);
     RegisterSpellScript(spell_gen_remove_impairing_auras);
     RegisterSpellScriptWithArgs(spell_gen_consume, "spell_consume_aq20", SPELL_CONSUME_LEECH_AQ20, SPELL_CONSUME_LEECH_HEAL_AQ20);
+    RegisterSpellScriptWithArgs(spell_gen_apply_aura_after_expiration, "spell_itch_aq20", SPELL_HIVEZARA_CATALYST, EFFECT_0, SPELL_AURA_DUMMY);
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Apply Hive'Zara Catalyst on Itch removal
-  Implement Spit out after consume expires and the target survives & remove consume if the ooze dies

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
