### PR TITLE
fix(DB/creature, pools): ZG Before Bats cont. Troll 3-pack

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1658607158126098600.sql
+++ b/data/sql/updates/pending_db_world/rev_1658607158126098600.sql
@@ -26,7 +26,6 @@ INSERT INTO `pool_pool` (`pool_id`, `mother_pool`, `chance`, `description`) VALU
 (478, 476, 50, 'ZG Before Bats Troll 3-Pack with 2x entry 11351');
 
 INSERT INTO `pool_creature` (`guid`, `pool_entry`, `description`) VALUES
-
 (12814, 477, 'ZG Before Bats Troll 3-Pack entry 11831'),
 (12815, 477, 'ZG Before Bats Troll 3-Pack entry 11831'),
 (12816, 477, 'ZG Before Bats Troll 3-Pack entry 11351'),

--- a/data/sql/updates/pending_db_world/rev_1658607158126098600.sql
+++ b/data/sql/updates/pending_db_world/rev_1658607158126098600.sql
@@ -1,0 +1,36 @@
+--
+-- Maintenance on ZG Before Bats Part 3:  Pooling Part 2 Troll Pack before Bat Area
+-- Formations shouldn't be needed on this pack (they agro properly without) 
+
+-- Pool Troll pack before Bat area (49120, 49121, 49122) with it's counterpart, (created as 12814, 12815, 12816) 
+DELETE FROM `creature` WHERE `guid` BETWEEN 12814 AND 12816;
+INSERT INTO `creature` (`guid`, `id1`, `id2`, `id3`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES 
+(12814, 11831, 0, 0, 309, 0, 0, 1, 1, 1, -12007.2, -1492.45, 82.0241, 1.39626, 7200, 0, 0, 0, 0, 0, 0, 0, 0, '', 0),
+(12815, 11831, 0, 0, 309, 0, 0, 1, 1, 1, -12008.5, -1484.79, 79.1498, 4.87654, 7200, 0, 0, 0, 0, 0, 0, 0, 0, '', 0),
+(12816, 11351, 0, 0, 309, 0, 0, 1, 1, 1, -12004.5, -1483.46, 79.5746, 4.71553, 7200, 0, 0, 0, 0, 0, 0, 0, 0, '', 0);
+
+DELETE FROM `pool_template` WHERE `entry` BETWEEN 476 AND 478;
+DELETE FROM `pool_pool` WHERE `pool_id` BETWEEN 476 AND 478;
+DELETE FROM `pool_pool` WHERE `mother_pool` BETWEEN 476 AND 478;
+DELETE FROM `pool_creature` WHERE `pool_entry` BETWEEN 476 AND 478;
+DELETE FROM `pool_creature` WHERE `guid` IN (49120, 49121, 49122, 12814, 12815, 12816);
+
+
+INSERT INTO `pool_template` (`entry`, `max_limit`, `description`) VALUES
+(476, 1, 'ZG Before Bats Troll 3-Pack'),
+(477, 3, 'ZG Before Bats Troll 3-Pack with 2x entry 11831 50% 1/2'),
+(478, 3, 'ZG Before Bats Troll 3-Pack with 2x entry 11351 50% 2/2');
+
+INSERT INTO `pool_pool` (`pool_id`, `mother_pool`, `chance`, `description`) VALUES 
+(477, 476, 50, 'ZG Before Bats Troll 3-Pack with 2x entry 11831'),
+(478, 476, 50, 'ZG Before Bats Troll 3-Pack with 2x entry 11351');
+
+INSERT INTO `pool_creature` (`guid`, `pool_entry`, `description`) VALUES
+
+(12814, 477, 'ZG Before Bats Troll 3-Pack entry 11831'),
+(12815, 477, 'ZG Before Bats Troll 3-Pack entry 11831'),
+(12816, 477, 'ZG Before Bats Troll 3-Pack entry 11351'),
+
+(49120, 478, 'ZG Before Bats Troll 3-Pack entry 11351'),
+(49121, 478, 'ZG Before Bats Troll 3-Pack entry 11351'),
+(49122, 478, 'ZG Before Bats Troll 3-Pack entry 11831');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Creates the two ways this pack can spawn.
![image](https://user-images.githubusercontent.com/91289495/180621881-bbc91136-6f39-43a6-8eb5-1722d2de493f.png)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Classic/retail/sniff

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Rebooted server until both variations were seen in ZG. 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  Enter ZG
2.   .go c 49120
3.  Reboot server until you see both variations


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
