### PR TITLE
chore(Scripts): remove double method calling for ZG script

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/instance_zulgurub.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/instance_zulgurub.cpp
@@ -91,8 +91,6 @@ public:
                 default:
                     break;
             }
-
-            InstanceScript::OnCreatureCreate(creature);
         }
 
         void OnGameObjectCreate(GameObject* go) override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove double InstanceScript::OnCreatureCreate

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes -

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Built. No further test needed.


