### PR TITLE
fix(Core/RuinsOfAhnQiraj): Ossirian reset

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1658857216982492500.sql
+++ b/data/sql/updates/pending_db_world/rev_1658857216982492500.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `flags_extra` = `flags_extra`|0x80000000 WHERE `entry` = 15339;

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
@@ -168,6 +168,11 @@ struct boss_ossirian : public BossAI
         {
             crystal->Use(me);
         }
+
+        std::list<Creature*> vortexes;
+        me->GetCreaturesWithEntryInRange(vortexes, 200.f, NPC_SAND_VORTEX);
+        for (Creature* vortex : vortexes)
+            vortex->DespawnOrUnsummon();
     }
 
     void SpawnNextCrystal()


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Ossirian should perform a hard reset.
-  Vortexes should despawn on evade.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12467

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Ossirian and engage.
2. .combatstop
3. He should despawn and respawn after a while.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Crystals reset issues should be addressed in a separated PR as they have their proper issue.
