### PR TITLE
fix(DB/creature_template): Remove Incorrect Loot

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1658940484513440700.sql
+++ b/data/sql/updates/pending_db_world/rev_1658940484513440700.sql
@@ -1,0 +1,3 @@
+--
+DELETE FROM `creature_loot_template` WHERE `Entry` IN (4625,11374,12352,27213,27414);
+UPDATE `creature_template` SET `lootid` = 0 WHERE `entry` IN (4625,11374,12352,27213,27414);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove incorrect loot from several creatures that should not have
-  Note that this is slightly different from original TC PR - I did not remove pickpocket loot from 12352 because it appears it should have it is correct (https://www.wowhead.com/wotlk/npc=12352/scarlet-trooper)
- Co-authored by offl

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
From TrinityCore https://github.com/TrinityCore/TrinityCore/commit/74ed066aa34fbd30161136d5989e99bbe34ab72d

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- SQL runs, no DB issues


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Test that creatures listed no longer drop loot

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- If someone wants to confirm that Scarlet Trooper cannot be pickpocketed on retail, we can remove that loot as well, but otherwise I think we can remain as is - we are currently consistent with WoWHead.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
