### PR TITLE
fix(DB/SkinningLootTemplate): emerald dragons should skin dreamscale

### DIFF
--- a/data/sql/updates/pending_db_world/emeralddragonsskinloot.sql
+++ b/data/sql/updates/pending_db_world/emeralddragonsskinloot.sql
@@ -1,5 +1,7 @@
 --
-DELETE FROM `skinning_loot_template` WHERE (`Entry` = 15412) AND (`Item` IN (15412, 20381));
+UPDATE `creature_template` SET `skinloot` = 14887 WHERE (`entry` IN (14887, 14888, 14889, 14890));
+
+DELETE FROM `skinning_loot_template` WHERE (`Entry` = 14887) AND (`Item` IN (15412, 20381));
 INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(15412, 15412, 0, 60, 0, 1, 1, 5, 8, ''),
-(15412, 20381, 0, 40, 0, 1, 1, 3, 5, '');
+(14887, 15412, 0, 60, 0, 1, 1, 5, 8, ''),
+(14887, 20381, 0, 40, 0, 1, 1, 3, 5, '');

--- a/data/sql/updates/pending_db_world/emeralddragonsskinloot.sql
+++ b/data/sql/updates/pending_db_world/emeralddragonsskinloot.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `skinning_loot_template` WHERE (`Entry` = 15412) AND (`Item` IN (15412, 20381));
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(15412, 15412, 0, 60, 0, 1, 1, 5, 8, ''),
+(15412, 20381, 0, 40, 0, 1, 1, 3, 5, '');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- uses own Skinning Loot ID
-  changes green scales to 5-8 60% chance
-  adds dreamscale 3-5 40% chance

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes no reported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

cmangos

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
