### PR TITLE
(DB/creature_template): Make Nefarian's Troops [trigger] invisible

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1659015925728207500.sql
+++ b/data/sql/updates/pending_db_world/rev_1659015925728207500.sql
@@ -1,0 +1,3 @@
+--
+UPDATE `creature_template` SET `unit_flags`=`unit_flags`|33554432 WHERE `entry`=14459;
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Adjust unit_falg

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12571
- Closes https://github.com/chromiecraft/chromiecraft/issues/3861 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
Applied SQL and tested:
![image](https://user-images.githubusercontent.com/61223313/181522646-b7b296e6-3c85-47f8-aa25-ecc785d644bc.png)


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
