### PR TITLE
fix(Scripts/EmeraldDragons): fix summon player spam

### DIFF
--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -64,6 +64,7 @@ enum Events
     EVENT_SEEPING_FOG = 1,
     EVENT_NOXIOUS_BREATH,
     EVENT_TAIL_SWEEP,
+    EVENT_SUMMON_PLAYER,
 
     // Ysondre
     EVENT_LIGHTNING_WAVE,
@@ -102,6 +103,7 @@ struct emerald_dragonAI : public WorldBossAI
         events.ScheduleEvent(EVENT_TAIL_SWEEP, 4000);
         events.ScheduleEvent(EVENT_NOXIOUS_BREATH, urand(7500, 15000));
         events.ScheduleEvent(EVENT_SEEPING_FOG, urand(12500, 20000));
+        events.ScheduleEvent(EVENT_SUMMON_PLAYER, 1s);
     }
 
     // Target killed during encounter, mark them as suspectible for Aura Of Nature
@@ -133,6 +135,12 @@ struct emerald_dragonAI : public WorldBossAI
                 DoCast(me, SPELL_TAIL_SWEEP);
                 events.ScheduleEvent(EVENT_TAIL_SWEEP, 2000);
                 break;
+            case EVENT_SUMMON_PLAYER:
+                if (Unit* target = me->GetVictim())
+                    if (!target->IsWithinRange(me, 50.f))
+                        DoCast(target, SPELL_SUMMON_PLAYER);
+                events.ScheduleEvent(EVENT_SUMMON_PLAYER, 500ms);
+                break;
         }
     }
 
@@ -148,9 +156,6 @@ struct emerald_dragonAI : public WorldBossAI
 
         while (uint32 eventId = events.ExecuteEvent())
             ExecuteEvent(eventId);
-
-        if (Unit* target = SelectTarget(SelectTargetMethod::MaxThreat, 0, -50.0f, true))
-            DoCast(target, SPELL_SUMMON_PLAYER);
 
         DoMeleeAttackIfReady();
     }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Repeat the event every 500ms instead of every update.
-  Check for his actual target and don't use the other method <.<

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Built.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to any of the emerald dragons and engage with 2 chars
2. With the tank stay in melee range while you run away with the other, the one who isn't tanking should not be summoned ever.
3. Later try kiting with the tank, you should be ported as soon as you reach 50yds

