### PR TITLE
fix(DB/Creature): Deliana and other npcs spawn time

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1659289474965390600.sql
+++ b/data/sql/updates/pending_db_world/rev_1659289474965390600.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature` SET `spawntimesecs` = 300 WHERE `id1` IN (11406, 14724, 16013, 22026);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  From TrinityCore (I'm assuming this is sniffed), set spawn times Deliana, High Priest Rohan, Bubulo Acerbus and Bahat to 5 minutes.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12578

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
TrinityCore's DB

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Ran the sql.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Kill one of the npcs and wait 5min until they respawn
