### PR TITLE
fix(Core): Crash on Mandokir gaze

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
@@ -719,11 +719,14 @@ public:
             {
                 if (Unit* target = GetTarget())
                 {
-                    if (Creature* caster = GetCaster()->ToCreature())
+                    if (Unit* caster = GetCaster())
                     {
-                        if (caster->IsAIEnabled)
+                        if (Creature* cCaster = caster->ToCreature())
                         {
-                            caster->AI()->SetGUID(target->GetGUID(), ACTION_CHARGE);
+                            if (cCaster->IsAIEnabled)
+                            {
+                                cCaster->AI()->SetGUID(target->GetGUID(), ACTION_CHARGE);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add a null check for caster, an aura can have a null caster.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes -

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Built, no test needed.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Possible crash: Go to mando, let him cast gaze on you, kill him while you still have the debuff, watch it crash.
2. Apply the PR and make sure there is no crash anymore.

