### PR TITLE
fix(Core): Freeze on Lord Jaraxxus

### DIFF
--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp
@@ -118,11 +118,11 @@ public:
             if( pInstance )
                 pInstance->SetData(TYPE_JARAXXUS, NOT_STARTED);
 
-            // checked for safety
-            while( Creature* c = me->FindNearestCreature(NPC_INFERNAL_VOLCANO, 500.0f, true) )
-                c->DespawnOrUnsummon();
-            while( Creature* c = me->FindNearestCreature(NPC_NETHER_PORTAL, 500.0f, true) )
-                c->DespawnOrUnsummon();
+            std::list<Creature*> creatures;
+            me->GetCreatureListWithEntryInGrid(creatures, NPC_INFERNAL_VOLCANO, 500.f);
+            me->GetCreatureListWithEntryInGrid(creatures, NPC_NETHER_PORTAL, 500.f);
+            for (Creature* creature : creatures)
+                creature->DespawnOrUnsummon();
         }
 
         void EnterCombat(Unit* /*who*/) override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Get all creatures and despawn all at once.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12613

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Only built.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Jaraxxus and wipe on the add phase.
2. worldserver shouldn't freeze.


