### PR TITLE
fix(CORE/Spells): Fix Scaling of some Guardians

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -6014,6 +6014,43 @@ void Spell::SummonGuardian(uint32 i, uint32 entry, SummonPropertiesEntry const* 
                 case 13049:
                     summonLevel = 55;
                     break;
+
+                // Cleansed Timberling Heart: Summon Timberling
+                case 5666:
+                    summonLevel = 7;
+                    break;
+
+                // Glowing Cat Figurine: Summon Ghost Saber
+                case 6084:
+                    // minLevel 19, maxLevel 20
+                    summonLevel = 20;
+                    break;
+
+                // Spiked Collar: Summon Felhunter
+                case 8176:
+                    summonLevel = 30;
+                    break;
+
+                // Dog Whistle: Summon Tracking Hound
+                case 9515:
+                    summonLevel = 30;
+                    break;
+
+                // Barov Peasant Caller: Death by Peasant
+                case 18307:
+                case 18308:
+                    summonLevel = 60;
+                    break;
+
+                // Thornling Seed: Plant Thornling
+                case 22792:
+                    summonLevel = 60;
+                    break;
+
+                // Cannonball Runner: Summon Crimson Cannon
+                case 6251:
+                    summonLevel = 61;
+                    break;
             }
         }
 
@@ -6054,6 +6091,11 @@ void Spell::SummonGuardian(uint32 i, uint32 entry, SummonPropertiesEntry const* 
 
         // xinef: set calculated level
         summon->SetLevel(summonLevel);
+
+        // if summonLevel changed, set stats for calculated level 
+        if (summonLevel != caster->getLevel()){
+            ((Guardian*)summon)->InitStatsForLevel(summonLevel);
+        }
 
         // xinef: if we have more than one guardian, change follow angle
         if (summon->HasUnitTypeMask(UNIT_MASK_MINION) && totalNumGuardians > 1)

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -6092,7 +6092,7 @@ void Spell::SummonGuardian(uint32 i, uint32 entry, SummonPropertiesEntry const* 
         // xinef: set calculated level
         summon->SetLevel(summonLevel);
 
-        // if summonLevel changed, set stats for calculated level 
+        // if summonLevel changed, set stats for calculated level
         if (summonLevel != caster->getLevel()){
             ((Guardian*)summon)->InitStatsForLevel(summonLevel);
         }

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -6093,7 +6093,8 @@ void Spell::SummonGuardian(uint32 i, uint32 entry, SummonPropertiesEntry const* 
         summon->SetLevel(summonLevel);
 
         // if summonLevel changed, set stats for calculated level
-        if (summonLevel != caster->getLevel()){
+        if (summonLevel != caster->getLevel())
+        {
             ((Guardian*)summon)->InitStatsForLevel(summonLevel);
         }
 


### PR DESCRIPTION
Guardians summoned by engineering and items have incorrect scaling. This will fix Guardians summoned by Engineering items some Guardians summoned by items to have appropriate level and stats.

As of now, `Guardian::InitStats` in `Creature/TemporarySummon.cpp +391` sets Stats based on the summoner level. This is not always correct as it allows lower-level guardians to scale to max-level content. For instance Timberling in #12446 when summoned by a lvl80 Player scales to lvl80 with lvl80 stats.

There is a fix in place for Engineering items to set the level to `skill/5`. Also for Dragon's Call the summoned guardian is set to lvl55. However this does not change the stats as they are scaled to Player level. So a lvl55 dragon summoned by a lvl80 is much stronger than a lvl55 summoned by a lvl55

Spawn animations before changes

https://user-images.githubusercontent.com/74299960/182790257-12d32ff5-c85b-43aa-b511-6bbb9019755d.mp4

Creature info before changes
`.creature info` Lvl55 Dragon  spawned by Level 80
![9999_before_dragon_80_stats](https://user-images.githubusercontent.com/74299960/182790443-206979b9-564a-485c-bc67-72c17614d08e.png)

`.creature info` Lvl55 Dragon  spawned by Level 55
![9999_before_dragon_55_stats](https://user-images.githubusercontent.com/74299960/182790445-94296e1e-1f89-46d4-baa9-f7d67f6df27a.png)


<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Expand on the fix that was already in place to set appropriate level 
-  If level changed then set appropriate stats

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes AzerothCore issue #12446

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
I set the summonLevel of these Guardians by looking up `minlevel,maxlevel` values in `creature_template` that are listed in their respective `item_template`. 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
I used the docker setup with the latest commit. I then build once without changes and went through process described in "How to Test Changes" below. I did the same after changes.

Spawn animations after changes

https://user-images.githubusercontent.com/74299960/182791207-aa936cf5-9c44-403b-a591-0b4de94e7e0f.mp4

Creature info after changes
`.creature info` Timberling  spawned by Level 55
![9999_after_timerling_55_stats](https://user-images.githubusercontent.com/74299960/182791611-f6fb5c99-a1ba-461e-9303-bd3b066b7faf.png)

`.creature info` Timberling  spawned by Level 80
![9999_after_timerling_80_stats](https://user-images.githubusercontent.com/74299960/182791614-b3a7fc1b-8932-4d4e-95c4-d6d4508c8e61.png)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Spawn from item not requiring engineering
|ItemID| SpellID | | 
|--|--|--|
|10847|| dragon's call|
| 5218 | 5666 | timerling |
| 3456 | 9515 | bloodhound |
| 5332 | 6084 | glowing | cat | figurine |
| 18297 | 22792|  thornling seed |
| 14023 | 18308 | barov  peasant  caller |
| 14022 | 18307 | barov  peasant  caller |
| 13382 | 6251 | cannonball  runner |
| 1187 | 8176 | spiked collar |

1. Add item with `.add itemID`
3. Use item and observe spawn action
4. Check level and stats of NPC info with `.npc info`

Spawn from item requiring Engineering
|ItemID| SpellID | | 
|--|--|--|
| 4366 | 4071 | target dummy |
|16022|| arcanite dragonling|

To test engineering items:
1. Set engineering skill `.learn 202`
2. Level up with `.level n` character so level is not equal to `skillevel/5` 
3. Set skill level `setskill 202 350` (`350/5=70`)
4. Add item with `.add itemID`
5. Use item and observe spawn action
6. Check level and stats of NPC info with `.npc info`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Setting level after spawning creates a levelup effect. There's a flag that can be disabled to not show this effect, however the level will only update server-side. Players nearby will also not see the updated level unless they go far away and when closer the level-up animation will play. Players that aren't nearby when spawning will see the correct level.

https://user-images.githubusercontent.com/74299960/182789587-a916a11b-7c14-4e19-b922-5470b1b75c60.mp4

No levelup effect as Guardians are already at the correct level.   

https://user-images.githubusercontent.com/74299960/182789598-a33f1196-70fb-410b-a037-89f16101b037.mp4

Example of Timberling scaling to level 7 when the flag is set to false
![9999_after_timberling_80_setlevel_bool_false](https://user-images.githubusercontent.com/74299960/182793585-7bc10cfa-574a-469a-a99f-12f57f28bf6e.png)

- [ ] "Target Dummy" has a boss level. The appropriate level and stats are set but still shows boss icon. 
- [ ] "Cannonball Runner" is listed in the DB as lvl 61 and I set it as such, however this might be inaccurate. Maybe 60? 
- [ ] Missing guardians such as: Vanquished Tentacle of C'Thun (itemid: 21579), skeletons spawned by Ony book,...
- [ ] This PR does not address issues with AI.
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
