### PR TITLE
fix(Scripts/Zul'Gurub): Prevent multiple spawns of Gazhranka

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_gahzranka.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_gahzranka.cpp
@@ -168,7 +168,7 @@ class spell_pagles_point_cast : public SpellScript
         {
             if (InstanceScript* instanceScript = caster->GetInstanceScript())
             {
-                if (!instanceScript->GetData(DATA_GAHZRANKA))
+                if (!instanceScript->GetData(DATA_GAHZRANKA) && !caster->FindNearestCreature(NPC_GAHZRANKA, 50.0f))
                 {
                     caster->m_Events.AddEventAtOffset([caster]()
                     {

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_gahzranka.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_gahzranka.cpp
@@ -177,8 +177,11 @@ class spell_pagles_point_cast : public SpellScript
                             lure->DespawnOrUnsummon(5s);
                             caster->m_Events.AddEventAtOffset([caster]()
                             {
-                                caster->CastSpell(caster, SPELL_SPLASH, true);
-                                caster->SummonCreature(NPC_GAHZRANKA, -11688.5f, -1723.74f, -5.78f, 0.f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 5 * DAY * IN_MILLISECONDS);
+                                if (!caster->FindNearestCreature(NPC_GAHZRANKA, 50.0f))
+                                {
+                                    caster->CastSpell(caster, SPELL_SPLASH, true);
+                                    caster->SummonCreature(NPC_GAHZRANKA, -11688.5f, -1723.74f, -5.78f, 0.f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 5 * DAY * IN_MILLISECONDS);
+                                }
                             }, 5s);
                         }
                     }, 2s);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Check if the boss is spawned
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12662
- Closes https://github.com/chromiecraft/chromiecraft/issues/3894

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Try to use the lure quickly in succession
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
