### PR TITLE
chore(Scripts/BlackwingLair): Another temporary solution to Chromaggu…

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_chromaggus.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_chromaggus.cpp
@@ -85,7 +85,7 @@ public:
             Acore::Containers::RandomResize(_breathSpells, 2);
 
             // Hack fix: This is here to prevent him from being pulled from the floor underneath, remove it once maps are fixed.
-            creature->SetReactState(REACT_PASSIVE);
+            creature->SetImmuneToAll(true);
         }
 
         void Initialize()
@@ -122,7 +122,7 @@ public:
             {
                 _playerGUID = guid;
                 // Hack fix: This is here to prevent him from being pulled from the floor underneath, remove it once maps are fixed.
-                me->SetReactState(REACT_AGGRESSIVE);
+                me->SetImmuneToAll(false);
             }
         }
 


### PR DESCRIPTION
…s being pulled through the floor

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Ammend https://github.com/azerothcore/azerothcore-wotlk/pull/11595
- Big sad for the hack, but map need fix sorry
-  Plz fix map 😢 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
