### PR TITLE
fix(Core/Mage) Water Elemental wrongly ressurected at Spirit Healer

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13911,6 +13911,8 @@ bool Player::CanResummonPet(uint32 spellid)
         case CLASS_WARLOCK:
             return true;
         break;
+        default:
+        break;
     }
 
     return HasSpell(spellid);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13900,11 +13900,11 @@ bool Player::CanResummonPet(uint32 spellid)
     case CLASS_DEATH_KNIGHT:
         if (CanSeeDKPet())
             return true;
-        else if (spellid == 52150)
+        else if (spellid == 52150)  //Raise Dead
             return false;
         break;
     case CLASS_MAGE:
-        if (HasSpell(31687) && HasAura(70937))
+        if (HasSpell(31687) && HasAura(70937))  //Has [Summon Water Elemental] spell and [Glyph of Eternal Water].
             return true;
         break;
     case CLASS_HUNTER:

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13895,20 +13895,24 @@ void Player::ResummonPetTemporaryUnSummonedIfAny()
 
 bool Player::CanResummonPet(uint32 spellid)
 {
-    if (getClass() == CLASS_DEATH_KNIGHT)
+    switch (getClass())
     {
+    case CLASS_DEATH_KNIGHT:
         if (CanSeeDKPet())
             return true;
         else if (spellid == 52150)
             return false;
-    }
-    else if (getClass() == CLASS_HUNTER || getClass() == CLASS_MAGE || getClass() == CLASS_WARLOCK)
+        break;
+    case CLASS_MAGE:
+        if (HasSpell(31687) && HasAura(70937))
+            return true;
+        break;
+    case CLASS_HUNTER:
+    case CLASS_WARLOCK:
         return true;
+    }
 
-    if (!HasSpell(spellid))
-        return false;
-
-    return true;
+    return HasSpell(spellid);
 }
 
 bool Player::CanSeeSpellClickOn(Creature const* c) const

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13897,19 +13897,20 @@ bool Player::CanResummonPet(uint32 spellid)
 {
     switch (getClass())
     {
-    case CLASS_DEATH_KNIGHT:
-        if (CanSeeDKPet())
-            return true;
-        else if (spellid == 52150)  //Raise Dead
-            return false;
+        case CLASS_DEATH_KNIGHT:
+            if (CanSeeDKPet())
+                return true;
+            else if (spellid == 52150)  //Raise Dead
+                return false;
         break;
-    case CLASS_MAGE:
-        if (HasSpell(31687) && HasAura(70937))  //Has [Summon Water Elemental] spell and [Glyph of Eternal Water].
+        case CLASS_MAGE:
+            if (HasSpell(31687) && HasAura(70937))  //Has [Summon Water Elemental] spell and [Glyph of Eternal Water].
+                return true;
+            break;
+        case CLASS_HUNTER:
+        case CLASS_WARLOCK:
             return true;
         break;
-    case CLASS_HUNTER:
-    case CLASS_WARLOCK:
-        return true;
     }
 
     return HasSpell(spellid);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13902,7 +13902,7 @@ bool Player::CanResummonPet(uint32 spellid)
                 return true;
             else if (spellid == 52150)  //Raise Dead
                 return false;
-        break;
+            break;
         case CLASS_MAGE:
             if (HasSpell(31687) && HasAura(70937))  //Has [Summon Water Elemental] spell and [Glyph of Eternal Water].
                 return true;
@@ -13910,9 +13910,9 @@ bool Player::CanResummonPet(uint32 spellid)
         case CLASS_HUNTER:
         case CLASS_WARLOCK:
             return true;
-        break;
+            break;
         default:
-        break;
+            break;
     }
 
     return HasSpell(spellid);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Make `bool Player::CanResummonPet(uint32 spellid)` only use `getClass()` once
-  Mage needs both [Summon Water Elemental] spell and [Glyph of Eternal Water] to in order to be ressurected with the water elemental pet at the Spirit Healer.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12638
- Closes https://github.com/chromiecraft/chromiecraft/issues/3837
- Closes https://github.com/chromiecraft/chromiecraft/issues/3922

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Mage without talent and without glyph
- Mage with talent but no glyph
- Mage with both talent and glyph
- Mage without talent but with glyph

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Try to replicate https://github.com/azerothcore/azerothcore-wotlk/issues/12638

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
