### PR TITLE
fix (Quest 9740): The Sun Gate

### DIFF
--- a/data/sql/updates/pending_db_world/q9740_fix_20220809
+++ b/data/sql/updates/pending_db_world/q9740_fix_20220809
@@ -1,2 +1,0 @@
-
-UPDATE `conditions` SET `ConditionValue3` = 0 WHERE `SourceTypeOrReferenceId` = 22 AND `SourceGroup` = 2 AND `SourceEntry` = 182026;

--- a/data/sql/updates/pending_db_world/q9740_fix_20220809
+++ b/data/sql/updates/pending_db_world/q9740_fix_20220809
@@ -1,0 +1,2 @@
+
+UPDATE conditions SET ConditionValue3 = 0 WHERE SourceTypeOrReferenceId = 22 AND SourceGroup = 2 AND SourceEntry = 182026;

--- a/data/sql/updates/pending_db_world/q9740_fix_20220809
+++ b/data/sql/updates/pending_db_world/q9740_fix_20220809
@@ -1,2 +1,2 @@
 
-UPDATE conditions SET ConditionValue3 = 0 WHERE SourceTypeOrReferenceId = 22 AND SourceGroup = 2 AND SourceEntry = 182026;
+UPDATE `conditions` SET `ConditionValue3` = 0 WHERE `SourceTypeOrReferenceId` = 22 AND `SourceGroup` = 2 AND `SourceEntry` = 182026;

--- a/data/sql/updates/pending_db_world/q9740_fix_20220809.sql
+++ b/data/sql/updates/pending_db_world/q9740_fix_20220809.sql
@@ -1,0 +1,2 @@
+
+UPDATE `conditions` SET `ConditionValue3` = 0 WHERE `SourceTypeOrReferenceId` = 22 AND `SourceGroup` = 2 AND `SourceEntry` = 182026;


### PR DESCRIPTION
Fix to quest 9740 The Sun Gate. Gate can't be desactivated and this fix it.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fix the Sun Portal that can't be desactivated 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes [issue 12518](https://github.com/azerothcore/azerothcore-wotlk/issues/12518)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Adquire quest 9740 "The Sun Portal" in NPC Vindicator Aesom
2. Go to Sun portal location
3. Disable portal controllers
4. Disable Sun portal

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
