### PR TITLE
fix(CORE/Naxxramas): Portals and Teleports

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1660200016038134112.sql
+++ b/data/sql/updates/pending_db_world/rev_1660200016038134112.sql
@@ -1,0 +1,64 @@
+SET @MAP_ID := 533;
+-- Fixes Naxxramas portals & teleport orbs
+-- Change portal animation from CCW to CW
+-- Delete double stacked portals outside Naxxramas in Dragonblight
+DELETE FROM `gameobject` WHERE `guid` IN (58826, 59714, 59738, 59743) AND `map` = 571;
+-- Swap opposite portal position
+-- 10man (id: 196467)
+DELETE FROM `gameobject` WHERE `guid` IN (151232, 151234, 151230, 151227);
+INSERT INTO `gameobject`
+(`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`,
+`position_x`, `position_y`, `position_z`, `orientation`, `rotation0`,
+`rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`,
+`ScriptName`, `VerifiedBuild`)
+VALUES
+(151234, 196467, 571, 0, 0, 1, 1, 3680.62, -1258.41, 244.434, 4.00824, 0.0, 0.0, 0.907575, -0.419889, 300, 0, 1, '', 0),
+(151230, 196467, 571, 0, 0, 1, 1, 3659.57, -1280.97, 244.434, 0.866651, 0.0, 0.0, 0.403068, 0.91517, 300, 0, 1, '', 0),
+(151232, 196467, 571, 0, 0, 1, 1, 3658.92, -1259.47, 244.434, 5.57904, 0.0, 0.0, 0.344844, -0.93866, 300, 0, 1, '', 0),
+(151227, 196467, 571, 0, 0, 1, 1, 3680.62, -1279.77, 244.434, 2.43745, 0.0, 0.0, 0.933127, 0.359547, 300, 0, 1, '', 0);
+-- Swap opposite portal position
+-- 25man (id: 192671)
+DELETE FROM `gameobject` WHERE `guid` IN (151228, 151229, 151231, 151233);
+INSERT INTO `gameobject`
+(`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`,
+`position_x`, `position_y`, `position_z`, `orientation`, `rotation0`,
+`rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`,
+`ScriptName`, `VerifiedBuild`)
+VALUES
+(151233, 192671, 571, 0, 0, 1, 1, 3680.62, -1258.41, 244.434, 4.00824, 0.0, 0.0, 0.907575, -0.419889, 300, 0, 1, '', 0),
+(151229, 192671, 571, 0, 0, 1, 1, 3659.57, -1280.97, 244.434, 0.866651, 0.0, 0.0, 0.403068, 0.91517, 300, 0, 1, '', 0),
+(151228, 192671, 571, 0, 0, 1, 1, 3680.62, -1279.77, 244.434, 2.43745, 0.0, 0.0, 0.933127, 0.359547, 300, 0, 1, '', 0),
+(151231, 192671, 571, 0, 0, 1, 1, 3658.92, -1259.47, 244.434, 5.57904, 0.0, 0.0, 0.352207, -0.935922, 300, 0, 1, '', 0);
+-- Remove unused portal object top of outside Naxxramas in Dragonblight
+DELETE FROM `gameobject` WHERE `guid` = 58826 AND `id` = 192613 AND `map` = 571;
+-- Remove unused portal object inside Naxxramas
+DELETE FROM `gameobject` WHERE `guid` = 65853 AND `map` = @MAP_ID;
+-- Remove double stacked portals inside Naxxramas
+ DELETE FROM `gameobject` WHERE `id` IN (192663, 192664, 192665, 192666) AND `map` = @MAP_ID;
+ -- Update AreaTriggerTeleport to middle of blue portal area
+ -- Fix position Orb of Naxxramas and areatrigger
+ SET @ORB_TP_TO_SAPPH:= 202278;
+ DELETE FROM `gameobject` WHERE `id` = @ORB_TP_TO_SAPPH AND `guid` = 268048 AND `map` = @MAP_ID;
+ INSERT INTO `gameobject`
+ (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`,
+ `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`,
+ `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`,
+ `ScriptName`, `VerifiedBuild`)
+ VALUES
+(268048, @ORB_TP_TO_SAPPH, @MAP_ID, 0, 0, 3, 1, 2997.5, -3437.73, 304.189, 5.95645, 0.0, 0.0,
+-0.162641, 0.986685, 300, 0, 1, '', 0);
+-- Update Teleport Positions of spells used by Naxxramas Portal and Orb of Naxxramas (id: 181575, ...) 
+SET @DEATH_KNIGHT_PORTAL_EFFECT:= 28444;
+SET @SAPPHIRON_ENTRY_SPELL:= 72617;
+SET @SAPPHIRON_EXIT_SPELL:= 72613;
+DELETE FROM `spell_target_position` WHERE `ID` IN (@DEATH_KNIGHT_PORTAL_EFFECT, @SAPPHIRON_EXIT_SPELL, @SAPPHIRON_ENTRY_SPELL);
+INSERT INTO `spell_target_position`
+(`ID`, `EffectIndex`, `MapID`, `PositionX`, `PositionY`, `PositionZ`, `Orientation`, `VerifiedBuild`)
+VALUES
+(@SAPPHIRON_ENTRY_SPELL, 0, @MAP_ID, 3498.300049, -5349.490234, 144.968002, 1.3698910, 0),
+(@SAPPHIRON_EXIT_SPELL, 0, @MAP_ID, 3038.98, -3434.47, 298.22, 1.994, 0),
+(@DEATH_KNIGHT_PORTAL_EFFECT, 0, @MAP_ID, 3005.51, -3434.64, 304.195, 6.2831, 0);
+-- AreaTrigger (id: 4156) Teleport to Sapphiron's Lair
+DELETE FROM `areatrigger_teleport` WHERE `ID` = 4156;
+DELETE FROM `areatrigger_scripts` WHERE `entry` = 4156;
+INSERT INTO `areatrigger_scripts` (`entry`, `ScriptName`) VALUES (4156, 'at_naxxramas_hub_portal');

--- a/src/server/scripts/Northrend/Naxxramas/instance_naxxramas.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/instance_naxxramas.cpp
@@ -640,6 +640,27 @@ public:
             return 0;
         }
 
+        bool AreAllWingsCleared() const
+        {
+            return (GetBossState(BOSS_MAEXXNA) == DONE) && (GetBossState(BOSS_LOATHEB) == DONE) && (GetBossState(BOSS_THADDIUS) == DONE) && (GetBossState(BOSS_HORSEMAN) == DONE);
+        }
+
+        bool CheckRequiredBosses(uint32 bossId, Player const* /* player */) const override
+        {
+            switch (bossId)
+            {
+                case BOSS_SAPPHIRON:
+                    if (!AreAllWingsCleared())
+                    {
+                        return false;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            return true;
+        }
+
         bool SetBossState(uint32 bossId, EncounterState state) override
         {
             // pull all the trash if not killed
@@ -1221,8 +1242,33 @@ public:
     };
 };
 
+const Position sapphironEntryTP = { 3498.300049f, -5349.490234f, 144.968002f, 1.3698910f };
+
+class at_naxxramas_hub_portal : public AreaTriggerScript
+{
+public:
+    at_naxxramas_hub_portal() : AreaTriggerScript("at_naxxramas_hub_portal") { }
+
+    bool OnTrigger(Player* player, AreaTrigger const* /*trigger*/) override
+    {
+        if (player->IsAlive() && !player->IsInCombat())
+        {
+            if (InstanceScript *instance = player->GetInstanceScript())
+            {
+                if (instance->CheckRequiredBosses(BOSS_SAPPHIRON))
+                {
+                    player->TeleportTo(533, sapphironEntryTP.m_positionX, sapphironEntryTP.m_positionY, sapphironEntryTP.m_positionZ, sapphironEntryTP.m_orientation);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+};
+
 void AddSC_instance_naxxramas()
 {
     new instance_naxxramas();
     new boss_naxxramas_misc();
+    new at_naxxramas_hub_portal();
 }


### PR DESCRIPTION
This fixes overlapping portals inside and outside Naxxramas. Their
rotation is also corrected (from CCW to CW). The post-boss
Naxxramas portals now teleport to the blue hub portal and it activates only
when all wings are cleared. This requirement can be bypassed with the
orbs, which are now correctly
casting their respective sapphiron entry/exit spells in addition to having the
correct position.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove duplicate green portal objects outside Naxxramas in Dragonblight
-  Remove duplicate green portal object inside Naxxramas
- Change animation of portals outside Naxx from CCW to CW
- Fix post-boss and Sapphiron entry/exit teleport spells  to the correct positions
- Fix position of the Orbs of Naxxramas
- Add allwingscleared requirement to the naxx hub portal
- Fix position of the hub portal teleport to the center of the blue portal

Useless purple portal object  inside and outside
![before_outside_unused_portal](https://user-images.githubusercontent.com/74299960/184081774-de82af3e-7adf-44e4-bac9-41a1bf9c8046.png)

![before_portal_obj_no_orb](https://user-images.githubusercontent.com/74299960/184082137-66678083-b0c9-446f-b664-4c582675f748.png)

10man portals are spinning CCW. 25man portals have duplicates and spinning CCW. 

https://user-images.githubusercontent.com/74299960/184081871-72b5fa3f-de66-49fb-8f39-efc90c9a182a.mp4

Teleport position to Sapph is too far forward, orb in the middle teleports to the ground, orb in the back teleports to where the char is standing.

![before_2_orbs_spawn_pos](https://user-images.githubusercontent.com/74299960/184081938-876d12d1-26ef-4f96-9478-07aba267c0b0.png)

## Issues Addressed:


## SOURCE:

00:00 Entrance Portal to Naxx25 shows 4 orbs CW
11:03 Naxxramas Portal to hub position, 25man portal inside Naxx, Position of Orb of Naxxramas (TP to Sapph)
31:40 TP Location to Sapphiron


https://www.youtube.com/watch?v=jIwKLtcbdq0

AutoTP to Sapph is not showing in this vid, but is present on beta https://youtu.be/flM7uylhUGU?t=5487  1:31:27

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

![after_SapphTP_fixed](https://user-images.githubusercontent.com/74299960/184082843-a75d1a0d-0000-4ed2-9c3a-2dacd8a54a04.png)


https://user-images.githubusercontent.com/74299960/184083357-41eba12b-7954-48e7-bb43-06ec944a0231.mp4



## How to Test the Changes:
25man difficulty
```
/script SetRaidDifficulty(2)
```
10man difficulty
```
/script SetRaidDifficulty(1) 
```
Teleport outside Naxxramas in Dragonblight
```
.tele Naxxramas
```

1. With ` .gm fly on` in Dragonblight go `.go xyz 3668 -1262 310` and check if purple portal is gone
2. Watch green portals outside/inside with 10m/25m difficulty. See they're spinning CW and there are no overlapping portals
3. Inside Naxx25 see that there are no overlapping green portals inside
4. Inside Naxx10/25 see that the portal floating above the hub is gone 
5. Inside Naxx10/25 see there is an orb at the hub that allows teleport to Sapphiron
6. Inside Naxx10/25 see there is an orb at the back of Sapp room that teleports down
7. Inside Naxx10/25 check that boss portals TP to the middle of blue hub (spellID: 28444)
8. Go to the blue portal trigger 4156 `.debug areatrigger` and trigger without wings cleared and once with (Thaddius, Maexxna, Horsemen, Loatheb should be dead), see if portal activates

You can check TP spells individually with
| Name       | cmd            | where                                                  |
|------------|----------------|--------------------------------------------------------|
| Exit Spell | `.learn 72613` | next to portal                                         |
| DK Portal  | `.learn 28444` | to blue portal facing north                            |
| Entry      | `.learn 72617` | to sapphiron, middle of blue room and facing sapphiron |                                                   
## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Portals inside Naxx25 still shows 2 orbs floating as they're part of the map and not game objects.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
