### PR TITLE
fix(DB/EversongWoods): Fix Angershade noise spam

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1660249698988810843.sql
+++ b/data/sql/updates/pending_db_world/rev_1660249698988810843.sql
@@ -1,0 +1,3 @@
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 15656) AND (`source_type` = 0) AND (`id` = 2);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(15656, 0, 2, 0, 75, 0, 100, 0, 0, 15958, 20, 1200, 0, 49, 0, 0, 0, 0, 0, 0, 19, 15402, 53, 0, 0, 0, 0, 0, 0, 'Angershade - On Distance To Creature - Start Attacking');


### PR DESCRIPTION
Angershade repeatedly tries to attack quest giver without quest (8488)
Unexpected Results being started.

Closes #12016

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changes to Smartscript so the mob only tries to attack quest giver when the summoned NPC is spawned

It checks for the summoned quest NPC (gharsul the remorseless) to be in 20 yard range. Previously it checked if quest giver was in 53 yard range (which it was) and tried to attack it, which it couldn't as her flags were set to be not attackable. Resulting in angershades within 53 yard to repeatedly try to attack it and make the attack noise.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12016
- Closes https://github.com/chromiecraft/chromiecraft/issues/3599

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.youtube.com/watch?v=1XzhPZ_CFT0

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
Tested 

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Go to the mob with `.go c 56105` and observe it doesn't make the attack noise every 1-3 seconds
2. Prepare quest status
```
.quest add 8487
.quest complete 8487
```
3. Accept quest "Unexpected Results" from Mirveda and check if quest mob (gharsul the remorseless) + 2 summoned Angershade mob AND  56105 Angershode attack the quest giver

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
