### PR TITLE
fix(DB/EversongWoods): Remove sprint action from tigers

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1660252072288200163.sql
+++ b/data/sql/updates/pending_db_world/rev_1660252072288200163.sql
@@ -1,2 +1,1 @@
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (15651, 15652);
-DELETE FROM `smart_scripts` WHERE (`entryorguid` IN (15651, 15652)) AND (`action_param1` = 22863);
+DELETE FROM `smart_scripts` WHERE (`entryorguid` IN (15651, 15652)) AND (`source_type` = 0);

--- a/data/sql/updates/pending_db_world/rev_1660252072288200163.sql
+++ b/data/sql/updates/pending_db_world/rev_1660252072288200163.sql
@@ -1,0 +1,2 @@
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (15651, 15652);
+DELETE FROM `smart_scripts` WHERE (`entryorguid` IN (15651, 15652)) AND (`action_param1` = 22863);

--- a/data/sql/updates/pending_db_world/rev_1660252072288200163.sql
+++ b/data/sql/updates/pending_db_world/rev_1660252072288200163.sql
@@ -1,1 +1,1 @@
-DELETE FROM `smart_scripts` WHERE (`entryorguid` IN (15651, 15652)) AND (`source_type` = 0);
+DELETE FROM `smart_scripts` WHERE (`entryorguid` IN (15651, 15652)) AND (`action_param1` = 22863)  AND (`source_type` = 0);


### PR DESCRIPTION
Tigers were using sprint. Expected tigers should not use sprint.

Closes #12679

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove smartAI script action 22863 from the tigers that use it.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12679

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
```
.go c 55919
.go c 55988
```
1. Use above listed commands to go to mobs
2. Aggro and see if they cast sprint on aggro

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
