### PR TITLE
fix(Scripts/AQ20): Ossirian movement speed

### DIFF
--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
@@ -129,9 +129,8 @@ struct boss_ossirian : public BossAI
     {
         BossAI::EnterCombat(who);
         events.Reset();
-        _speedUpCount = 0;
         me->SetSpeedRate(MOVE_RUN, 1.0f);
-        events.ScheduleEvent(EVENT_SPEEDUP, 1s);
+        events.ScheduleEvent(EVENT_SPEEDUP, 10s);
         events.ScheduleEvent(EVENT_SILENCE, 30s);
         events.ScheduleEvent(EVENT_CYCLONE, 20s);
         events.ScheduleEvent(EVENT_STOMP, 30s);
@@ -211,12 +210,6 @@ struct boss_ossirian : public BossAI
         BossAI::MoveInLineOfSight(who);
     }
 
-    void SpeedUpBoss()
-    {
-        float speed = 2.0f - (0.1f * (10 - ++_speedUpCount));
-        me->SetSpeedRate(MOVE_RUN, speed);
-    }
-
     void UpdateAI(uint32 diff) override
     {
         if (!UpdateVictim())
@@ -251,11 +244,7 @@ struct boss_ossirian : public BossAI
             switch (eventId)
             {
                 case EVENT_SPEEDUP:
-                    SpeedUpBoss();
-                    if (_speedUpCount < 10)
-                    {
-                        events.ScheduleEvent(EVENT_SPEEDUP, 1s);
-                    }
+                    me->SetSpeedRate(MOVE_RUN, 2.2f);
                     break;
                 case EVENT_SILENCE:
                     DoCastAOE(SPELL_CURSE_OF_TONGUES);
@@ -280,7 +269,6 @@ protected:
     ObjectGuid _triggerGUID;
     ObjectGuid _crystalGUID;
     uint8 _crystalIterator;
-    uint8 _speedUpCount;
     bool _saidIntro;
 };
 


### PR DESCRIPTION
On pull Ossirian movies too slow and is kiteable. He should speed up and
become no longer kitable.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Add event that repeats 10 times to speed up Ossirian from 1.0f to 2.0f in steps of 0.1f

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/3912

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->


1. Go to Ossirian
```
.go c 144601
```
2. Set Speed
```
.mod speed 1.3
.mod speed 1.08
```
3. Ranged pull and attempt to kite

In both cases he should catch up to the player

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- Ossirian aggro range is too small. He does not body pull accurately

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
