### PR TITLE
fix(DB/EversongWoods): Add Eldinarcus Patrol

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1660309887806825183.sql
+++ b/data/sql/updates/pending_db_world/rev_1660309887806825183.sql
@@ -1,0 +1,1 @@
+UPDATE `creature` SET `wander_distance`=20.0,`MovementType`=1 WHERE `guid`=58019 AND `id1`=16854;


### PR DESCRIPTION
Eldinarcus is stationary and does not wander around his spawn

https://github.com/azerothcore/azerothcore-wotlk/issues/7462

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Add wander distance of 20 to Eldinarcus. 

I don't see any specific patrol points in the reference video (https://www.youtube.com/watch?v=iw6xT997OLg&t=841s) and 20 seems correct when testing


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/7462

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
```
.go c 58019
```
Observe patrol

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
