### PR TITLE
fix(DB/EversongWoods): Quest Text Typo

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1660414598245080383.sql
+++ b/data/sql/updates/pending_db_world/rev_1660414598245080383.sql
@@ -1,0 +1,1 @@
+UPDATE `quest_offer_reward` SET `RewardText` = 'I no longer belong to this world and must admit defeat.  The land has forever changed and nothing will ever be the same. Leave the pendant here with me, maybe one day, long after the elves are gone, a new tree will grow on this very spot - amongst a burnt forest and the husks of dead treants. ' WHERE (`ID` = 10166);


### PR DESCRIPTION
sad typo in sad quest

![typo](https://user-images.githubusercontent.com/74299960/184506089-321b3ff1-b103-4f2f-a607-20c05be3f10d.png)

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
fixed typo with Keira3

![typo_fixed](https://user-images.githubusercontent.com/74299960/184506091-d63f645e-cab0-4042-a0e5-5c12725dc5ba.png)


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->


.quest add 10166

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
