### PR TITLE
fix(Scripts/World): Emerald Dragon's Dream Fog should chase switch ta…

### DIFF
--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -740,7 +740,7 @@ public:
     {
         PrepareSpellScript(spell_dream_fog_sleep_SpellScript);
 
-        void HandleEffect(SpellEffIndex effIndex)
+        void HandleEffect(SpellEffIndex /*effIndex*/)
         {
             if (Unit* caster = GetCaster())
             {

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -195,24 +195,18 @@ public:
             _scheduler.Schedule(1s, [this](TaskContext context)
             {
                 // Chase target, but don't attack - otherwise just roam around
-                if (Creature* dragon = ObjectAccessor::GetCreature(*me, _dragonGUID))
+                if (Unit* chaseTarget = GetRandomUnitFromDragonThreatList())
                 {
-                    if (dragon->GetAI())
-                    {
-                        if (Unit* chaseTarget = dragon->GetAI()->SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true))
-                        {
-                            me->GetMotionMaster()->Clear(false);
-                            me->GetMotionMaster()->MoveChase(chaseTarget, 0.2f);
-                            _targetGUID = chaseTarget->GetGUID();
-                            context.Repeat(15s, 30s);
-                        }
-                        else
-                        {
-                            me->GetMotionMaster()->Clear(false);
-                            me->GetMotionMaster()->MoveRandom(25.0f);
-                            context.Repeat(2500ms);
-                        }
-                    }
+                    me->GetMotionMaster()->Clear(false);
+                    me->GetMotionMaster()->MoveChase(chaseTarget, 0.2f);
+                    _targetGUID = chaseTarget->GetGUID();
+                    context.Repeat(15s, 30s);
+                }
+                else
+                {
+                    me->GetMotionMaster()->Clear(false);
+                    me->GetMotionMaster()->MoveRandom(25.0f);
+                    context.Repeat(2500ms);
                 }
 
                 // Seeping fog movement is slow enough for a player to be able to walk backwards and still outpace it
@@ -240,6 +234,19 @@ public:
             {
                 _dragonGUID = guid;
             }
+        }
+
+        Unit* GetRandomUnitFromDragonThreatList()
+        {
+            if (Creature* dragon = ObjectAccessor::GetCreature(*me, _dragonGUID))
+            {
+                if (dragon->GetAI())
+                {
+                    return dragon->GetAI()->SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true);
+                }
+            }
+
+            return nullptr;
         }
 
         void UpdateAI(uint32 diff) override

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -201,7 +201,9 @@ public:
                     {
                         if (Unit* chaseTarget = dragon->GetAI()->SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true))
                         {
-                            ChaseTarget(chaseTarget);
+                            me->GetMotionMaster()->Clear(false);
+                            me->GetMotionMaster()->MoveChase(chaseTarget, 0.2f);
+                            _targetGUID = chaseTarget->GetGUID();
                             context.Repeat(15s, 30s);
                         }
                         else
@@ -230,13 +232,6 @@ public:
 
                 context.Repeat();
             });
-        }
-
-        void ChaseTarget(Unit* target)
-        {
-            me->GetMotionMaster()->Clear(false);
-            me->GetMotionMaster()->MoveChase(target, 0.2f);
-            _targetGUID = target->GetGUID();
         }
 
         void SetGUID(ObjectGuid guid, int32 type) override


### PR DESCRIPTION
…rgets once reaching their chase target

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-   Emerald Dragon's Dream Fog should chase switch targets once reaching their chase target
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Engage dragons with 2-3 characters
2. let the fogs pop up
3. see if they switch targets once they reach you

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
