### PR TITLE
fix(Core/Weather): Wrong change type algorithm

### DIFF
--- a/src/server/game/Weather/Weather.cpp
+++ b/src/server/game/Weather/Weather.cpp
@@ -146,11 +146,11 @@ bool Weather::ReGenerate()
     uint32 chance3 = chance2 + m_weatherChances->data[season].stormChance;
 
     uint32 rnd = urand(0, 99);
-    if (rnd <= chance1)
+    if (rnd < chance1)
         m_type = WEATHER_TYPE_RAIN;
-    else if (rnd <= chance2)
+    else if (rnd < chance2)
         m_type = WEATHER_TYPE_SNOW;
-    else if (rnd <= chance3)
+    else if (rnd < chance3)
         m_type = WEATHER_TYPE_STORM;
     else
         m_type = WEATHER_TYPE_FINE;

--- a/src/server/game/Weather/Weather.cpp
+++ b/src/server/game/Weather/Weather.cpp
@@ -145,12 +145,12 @@ bool Weather::ReGenerate()
     uint32 chance2 = chance1 + m_weatherChances->data[season].snowChance;
     uint32 chance3 = chance2 + m_weatherChances->data[season].stormChance;
 
-    uint32 rnd = urand(0, 99);
-    if (rnd < chance1)
+    uint32 rnd = urand(1, 100);
+    if (rnd <= chance1)
         m_type = WEATHER_TYPE_RAIN;
-    else if (rnd < chance2)
+    else if (rnd <= chance2)
         m_type = WEATHER_TYPE_SNOW;
-    else if (rnd < chance3)
+    else if (rnd <= chance3)
         m_type = WEATHER_TYPE_STORM;
     else
         m_type = WEATHER_TYPE_FINE;


### PR DESCRIPTION
There's a rare bug that occurs where it starts raining in zones that
 shouldn't like Winterspring and Tanaris.

https://user-images.githubusercontent.com/74299960/184515714-7074c2e7-201d-4c7e-b4ff-bcddf75accb1.mp4

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change range to not include chance 0

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12711#issuecomment-1214226996

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowpedia.fandom.com/wiki/Weather_effects#Kalimdor_and_Eastern_Kingdoms

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

I changed the setting in `worldserver.conf.dist` and managed to get weather updates more frequently and was able to reproduce the issue.
```
#
#    ChangeWeatherInterval
#        Description: Time (in milliseconds) for weather update interval.
#        Default:     600000 - (10 min)
ChangeWeatherInterval = 20
```
I used vscode to set a conditional breakpoint when the rnd hits 0. And as you can see chance1 is the chance to rain in the zone and it'll change the type to rain.

![chance0_0_set_type_rain_bug](https://user-images.githubusercontent.com/74299960/184515721-13662a58-1480-4ae8-9e84-05859ddcadaf.png)

The randomness is also inaccurate. For example, for a zone with 5% chance to rain. The rnd value ranges [0,99]. With the `<=` operator,  it gives true on values `0,1,2,3,4,5` which is 6%. Changing the range to [1,100] would also correct the randomness to 5%.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Change `worldserver.conf.dist` to a low value 
1. Observe ingame to see if it rains in Tanaris, Winterspring
2. or set a breakpoint and investigate
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Isle of Quel'danas and Western Plaguelands both have rain_chances > 0 
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
