### PR TITLE
feat(Core/BattlegroundQueue): remove queue in all group if player leave

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -86,28 +86,29 @@ bool BattlegroundQueue::SelectionPool::KickGroup(const uint32 size)
 
     // find last group with proper size or largest
     bool foundProper = false;
-    auto groupToKick = SelectedGroups.begin();
-    for (auto& itr = groupToKick; itr != SelectedGroups.end(); ++itr)
+    GroupQueueInfo* groupToKick{ SelectedGroups.front() };
+
+    for (auto const& gInfo : SelectedGroups)
     {
         // if proper size - overwrite to kick last one
-        if (std::abs(int32((*itr)->Players.size()) - (int32)size) <= 1)
+        if (std::abs(int32(gInfo->Players.size()) - (int32)size) <= 1)
         {
-            groupToKick = itr;
+            groupToKick = gInfo;
             foundProper = true;
         }
-        else if (!foundProper && (*itr)->Players.size() >= (*groupToKick)->Players.size())
-            groupToKick = itr;
+        else if (!foundProper && gInfo->Players.size() >= groupToKick->Players.size())
+            groupToKick = gInfo;
     }
 
     // remove selected from pool
-    GroupQueueInfo* ginfo = (*groupToKick);
-    SelectedGroups.erase(groupToKick);
-    PlayerCount -= ginfo->Players.size();
+    auto playersCountInGroup{ groupToKick->Players.size() };
+    PlayerCount -= playersCountInGroup;
+    std::erase(SelectedGroups, groupToKick);
 
     if (foundProper)
         return false;
 
-    return (ginfo->Players.size() > size);
+    return playersCountInGroup > size;
 }
 
 // returns true if added or desired count not yet reached

--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -533,13 +533,20 @@ void WorldSession::HandleBattleFieldPortOpcode(WorldPacket& recvData)
     }
     else // leave queue
     {
-        bgQueue.RemovePlayer(_player->GetGUID(), true);
-        _player->RemoveBattlegroundQueueId(bgQueueTypeId);
+        for (auto const& playerGuid : ginfo.Players)
+        {
+            auto player = ObjectAccessor::FindConnectedPlayer(playerGuid);
+            if (!player)
+                continue;
 
-        sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_NONE, 0, 0, 0, TEAM_NEUTRAL);
-        SendPacket(&data);
+            bgQueue.RemovePlayer(playerGuid, true);
+            player->RemoveBattlegroundQueueId(bgQueueTypeId);
 
-        LOG_DEBUG("bg.battleground", "Battleground: player {} {} left queue for bgtype {}, queue type {}.", _player->GetName(), _player->GetGUID().ToString(), bg->GetBgTypeID(), bgQueueTypeId);
+            sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_NONE, 0, 0, 0, TEAM_NEUTRAL);
+            player->SendDirectMessage(&data);
+
+            LOG_DEBUG("bg.battleground", "Battleground: player {} {} left queue for bgtype {}, queue type {}.", player->GetName(), playerGuid.ToString(), bg->GetBgTypeID(), bgQueueTypeId);
+        }
 
         // player left queue, we should update it - do not update Arena Queue
         if (!ginfo.ArenaType)


### PR DESCRIPTION
## Changes Proposed:
- Fix crash at kick players from queue group
- Remove queue in all group if player any leave

## Issues Addressed:
- Part https://github.com/azerothcore/mod-cfbg/pull/111