### PR TITLE
fix(Core/RuinsOfAhnQiraj): re-enter the instance after Buru died

### DIFF
--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
@@ -99,10 +99,7 @@ struct boss_buru : public BossAI
 
     void JustDied(Unit* killer) override
     {
-        if (InstanceScript* pInstance = me->GetInstanceScript())
-        {
-            pInstance->DoRemoveAurasDueToSpellOnPlayers(SPELL_CREEPING_PLAGUE);
-        }
+        instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_CREEPING_PLAGUE);
         BossAI::JustDied(killer);
     }
 

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
@@ -97,12 +97,13 @@ struct boss_buru : public BossAI
             ChaseNewVictim();
     }
 
-    void JustDied(Unit* /*killer*/) override
+    void JustDied(Unit* killer) override
     {
         if (InstanceScript* pInstance = me->GetInstanceScript())
         {
             pInstance->DoRemoveAurasDueToSpellOnPlayers(SPELL_CREEPING_PLAGUE);
         }
+        BossAI::JustDied(killer);
     }
 
     void KilledUnit(Unit* victim) override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Call the method to update the encounter state... x.x Dumb me.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/3931

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to AQ 20 with a raid group and kill Buru.
2. Leave the instance and try to enter again.
