### PR TITLE
fix(DB/LookingForGroup): Leaving dungeon does not give deserter

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1660681693491912819.sql
+++ b/data/sql/updates/pending_db_world/rev_1660681693491912819.sql
@@ -4,6 +4,4 @@ INSERT INTO `lfg_dungeon_template`
 `VerifiedBuild`)
 VALUES
 (2, 'Scholomance', 196.37, 127.05, 134.91, 6.09, 0),
-(276, 'Blackrock Depths - Upper City', 458.32, 26.52, -70.67, 4.95, 0),
-(44, 'Upper Blackrock Spire', 78.5083, -225.044, 49.839, 5.1, 0);
-
+(276, 'Blackrock Depths - Upper City', 458.32, 26.52, -70.67, 4.95, 0);

--- a/data/sql/updates/pending_db_world/rev_1660681693491912819.sql
+++ b/data/sql/updates/pending_db_world/rev_1660681693491912819.sql
@@ -1,0 +1,9 @@
+DELETE FROM `lfg_dungeon_template` WHERE `dungeonId` IN (2, 44, 276);
+INSERT INTO `lfg_dungeon_template`
+(`dungeonId`, `name`, `position_x`, `position_y`, `position_z`, `orientation`,
+`VerifiedBuild`)
+VALUES
+(2, 'Scholomance', 196.37, 127.05, 134.91, 6.09, 0),
+(276, 'Blackrock Depths - Upper City', 458.32, 26.52, -70.67, 4.95, 0),
+(44, 'Upper Blackrock Spire', 78.5083, -225.044, 49.839, 5.1, 0);
+

--- a/data/sql/updates/pending_db_world/rev_1660681693491912819.sql
+++ b/data/sql/updates/pending_db_world/rev_1660681693491912819.sql
@@ -1,4 +1,4 @@
-DELETE FROM `lfg_dungeon_template` WHERE `dungeonId` IN (2, 44, 276);
+DELETE FROM `lfg_dungeon_template` WHERE `dungeonId` IN (2, 276);
 INSERT INTO `lfg_dungeon_template`
 (`dungeonId`, `name`, `position_x`, `position_y`, `position_z`, `orientation`,
 `VerifiedBuild`)


### PR DESCRIPTION
Some dungeons do not give desert when leaving. This aims to fix BRD - Prison and Scholomance 

LFG dungeons listed in `lfgdungeonsDBC` https://wow.tools/dbc/?dbc=lfgdungeons&build=3.3.5.12340#page=1
that are not in `lfg_dungeon_template` (https://gist.github.com/SoglaHash/c93663feec0a47a63f5adc057c0a1d5f) do not give deserter accurately.

for instance: Blackrock Depths - Upper City, Scholomance and Slave Pens

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added missing Blackrock Depths - Upper City and Scholomance to `lfg_dungeon_template`

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12676

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
Tested queueing LFG for Blackrock Depths - Upper City, LBRS and Scolomance. Leaving applies deserter correctly.

Also tested Slave Pens, this does not give deserter accurately but is included in TODO

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Make a 5man party with appropriate level. lvl 60 should work to test scholo and BRD upper
2. Q for RDF or q as specific q
3. Leave group a character
4. Check if debuff is applied

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Slave Pens does not give deserter. I'm assuming neither do other TBC/WOTLK instances not listed in `lfg_dungeon_template` but that are listed in  `lfgdungeonsDBC`
<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
