### PR TITLE
fix(DB/creature_loot_template): Remove all Punctured Voodoo Dolls from mobs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1660709375823590700.sql
+++ b/data/sql/updates/pending_db_world/rev_1660709375823590700.sql
@@ -1,0 +1,4 @@
+--
+
+DELETE FROM `creature_loot_template` WHERE `item` IN (19813,19814,19815,19816,19817,19818,19819,19820,19821);
+

--- a/data/sql/updates/pending_db_world/rev_1660709375823590700.sql
+++ b/data/sql/updates/pending_db_world/rev_1660709375823590700.sql
@@ -2,3 +2,16 @@
 
 DELETE FROM `creature_loot_template` WHERE `item` IN (19813,19814,19815,19816,19817,19818,19819,19820,19821);
 
+UPDATE `creature_template` SET `lootid`=0 WHERE `entry` IN (
+15146, -- Mad Voidwalker
+15117, -- Chained Spirit
+15112, -- Brain Wash Totem
+15041, -- Spawn of Mar'li
+14988, -- Ohgan
+14987, -- Powerful Healing Ward
+14986, -- Shade of Jin'do
+14965, -- Frenzied Bloodseeker Bat
+14826, -- Sacrificed Troll
+14122, -- Massive Geyser
+11347); -- Zealot Lor'Khan
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Delete all [Punctured Voodoo Dolls](https://wowgaming.altervista.org/aowow/?search=punctured+voodoo+doll) that can drop from trash mobs in Zul'Gurub

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12755

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
[Classic - only obtainable from Jinxed Voodoo Piles](https://classic.wowhead.com/item=19819/punctured-voodoo-doll#contained-in-object)
[Woltk Classic - only obtainable from Jinxed Voodoo Piles](https://www.wowhead.com/wotlk/item=19819/punctured-voodoo-doll#contained-in-object)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
/* Affected rows: 142  Found rows: 0  Warnings: 0  Duration for 1 query: 0.937 sec. */

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
