### PR TITLE
fix(DB/creature_template): Remove incorrect drops for Idol of Brutality

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1660710379331178100.sql
+++ b/data/sql/updates/pending_db_world/rev_1660710379331178100.sql
@@ -1,0 +1,4 @@
+--
+
+DELETE FROM `creature_loot_template` WHERE item =23198 AND entry !=10435; -- Magistrate Barthilas
+


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove [Idol of Brutality](https://wowgaming.altervista.org/aowow/?item=23198) from all mobs in DB except from [Magistrate Barthilas](https://wowgaming.altervista.org/aowow/?npc=10435) in Stratholme

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12757

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
[WoW Classic - dropped by](https://classic.wowhead.com/item=23198/idol-of-brutality#dropped-by)
[WOTLK Classic - dropped by](https://www.wowhead.com/wotlk/item=23198/idol-of-brutality#dropped-by)
* Comments only refer to Magistrate Barthilas as well on every patch

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- /* Affected rows: 52  Found rows: 0  Warnings: 0  Duration for 2 queries: 0.984 sec. */

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
