### PR TITLE
fix(Core/Event): Hourly bell: Dwarf horn sound should only play once

### DIFF
--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -1877,6 +1877,12 @@ public:
                     uint8 _rings = (local_tm.tm_hour) % 12;
                     _rings = (_rings == 0) ? 12 : _rings; // 00:00 and 12:00
 
+                    // Dwarf hourly horn should only play a single time, each time the next hour begins.
+                    if (_soundId == BELLTOLLDWARFGNOME)
+                    {
+                        _rings = 1;
+                    }
+
                     // Schedule ring event
                     for (auto i = 0; i < _rings; ++i)
                     {


### PR DESCRIPTION
## Changes Proposed:
Dwarf hourly horn should only play a single time, each time the next hour begins.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11328

## SOURCE:

## Tests Performed:
- tested in game

## How to Test the Changes:
1. tele ironforge (or any other place where dwarf horn sound is used, like Kharanos)
2. `.event start 73`
3. sound is played once

## Known Issues and TODO List:
- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
