### PR TITLE
fix(Loot/CreatureLoot): AQ20 enchanting recipes

### DIFF
--- a/data/sql/updates/pending_db_world/aq20enchantloot.sql
+++ b/data/sql/updates/pending_db_world/aq20enchantloot.sql
@@ -1,0 +1,46 @@
+-- aq20 boss reference table
+DELETE FROM `reference_loot_template` WHERE (`Entry` = 34024) AND (`Item` IN (20727, 20728, 20729, 20730, 20731, 20734, 20736));
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(34024, 20727, 0, 0, 0, 1, 1, 1, 1, 'Formula: Enchant Gloves - Shadow Power'),
+(34024, 20728, 0, 0, 0, 1, 1, 1, 1, 'Formula: Enchant Gloves - Frost Power'),
+(34024, 20729, 0, 0, 0, 1, 1, 1, 1, 'Formula: Enchant Gloves - Fire Power'),
+(34024, 20730, 0, 0, 0, 1, 1, 1, 1, 'Formula: Enchant Gloves - Healing Power'),
+(34024, 20731, 0, 0, 0, 1, 1, 1, 1, 'Formula: Enchant Gloves - Superior Agility'),
+(34024, 20734, 0, 0, 0, 1, 1, 1, 1, 'Formula: Enchant Cloak - Stealth'),
+(34024, 20736, 0, 0, 0, 1, 1, 1, 1, 'Formula: Enchant Cloak - Dodge');
+
+-- kurinnaxx
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 15348) AND (`Item` IN (34024, 190024));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(15348, 34024, 34024, 100, 0, 1, 2, 1, 2, 'Kurinnaxx - (ReferenceTable)'),
+(15348, 190024, 34024, 1, 0, 1, 1, 1, 1, '');
+
+-- rajaxx
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 15341) AND (`Item` IN (34024, 190024));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(15341, 34024, 34024, 100, 0, 1, 3, 1, 2, 'General Rajaxx - (ReferenceTable)'),
+(15341, 190024, 34024, 1, 0, 1, 1, 1, 1, '');
+
+-- ossirian 
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 15339) AND (`Item` IN (34024, 190024));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(15339, 34024, 34024, 100, 0, 1, 3, 1, 2, 'Ossirian the Unscarred - (ReferenceTable)'),
+(15339, 190024, 34024, 1, 0, 1, 1, 1, 1, '');
+
+-- buru
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 15370) AND (`Item` IN (34024, 190024));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(15370, 34024, 34024, 100, 0, 1, 3, 1, 2, 'Buru the Gorger - (ReferenceTable)'),
+(15370, 190024, 34024, 1, 0, 1, 1, 1, 1, '');
+
+-- moam
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 15340) AND (`Item` IN (34024, 190024));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(15340, 34024, 34024, 100, 0, 1, 3, 1, 2, 'Moam - (ReferenceTable)'),
+(15340, 190024, 34024, 1, 0, 1, 1, 1, 1, '');
+
+-- Ayamiss the Hunter
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 15369) AND (`Item` IN (34024, 190024));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(15369, 34024, 34024, 100, 0, 1, 3, 1, 2, 'Ayamiss the Hunter - (ReferenceTable)'),
+(15369, 190024, 34024, 1, 0, 1, 1, 1, 1, '');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  sets correct loot for enchanting recipes in aq20
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Partially adresses https://github.com/chromiecraft/chromiecraft/issues/3915

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
cmangos

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
