### PR TITLE
fix(Scripts/Spells): Moonkin Form passive aura should not proc off fr…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1661075973663887000.sql
+++ b/data/sql/updates/pending_db_world/rev_1661075973663887000.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id`=24905;
+INSERT INTO `spell_script_names` VALUES
+(24905,'spell_dru_moonkin_form_passive_proc');

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -1150,6 +1150,27 @@ class spell_dru_berserk : public SpellScript
     }
 };
 
+// 24905 - Moonkin Form (Passive) (Passive)
+class spell_dru_moonkin_form_passive_proc : public AuraScript
+{
+    PrepareAuraScript(spell_dru_moonkin_form_passive_proc);
+
+    bool CheckProc(ProcEventInfo& eventInfo)
+    {
+        if (SpellInfo const* spellInfo = eventInfo.GetSpellInfo())
+        {
+            return !spellInfo->IsAffectingArea();
+        }
+
+        return false;
+    }
+
+    void Register() override
+    {
+        DoCheckProc += AuraCheckProcFn(spell_dru_moonkin_form_passive_proc::CheckProc);
+    }
+};
+
 void AddSC_druid_spell_scripts()
 {
     RegisterSpellScript(spell_dru_bear_form_passive);
@@ -1185,4 +1206,5 @@ void AddSC_druid_spell_scripts()
     RegisterSpellScript(spell_dru_typhoon);
     RegisterSpellScript(spell_dru_t10_restoration_4p_bonus);
     RegisterSpellScript(spell_dru_wild_growth);
+    RegisterSpellScript(spell_dru_moonkin_form_passive_proc);
 }

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -1150,7 +1150,7 @@ class spell_dru_berserk : public SpellScript
     }
 };
 
-// 24905 - Moonkin Form (Passive) (Passive)
+// 24905 - Moonkin Form (Passive)
 class spell_dru_moonkin_form_passive_proc : public AuraScript
 {
     PrepareAuraScript(spell_dru_moonkin_form_passive_proc);


### PR DESCRIPTION
…om AoE spells.

Fixes #12435

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12435
- Closes https://github.com/chromiecraft/chromiecraft/issues/3774

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Be a druid
Go into moonkin form (get lots of crit, forgot the name of the debug rings)
Cast Starfall/Hurricane
Look at your mana/combatlog

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
