### PR TITLE
fix(DB/Creature): Improve Nefarian's Corrupted Infernal (14668)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1661366860302196200.sql
+++ b/data/sql/updates/pending_db_world/rev_1661366860302196200.sql
@@ -1,6 +1,5 @@
 --
-UPDATE `creature_template` SET `DamageModifier`=2.35, `ArmorModifier`=1.1 WHERE `entry`=14668;
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 14668;
+UPDATE `creature_template` SET `DamageModifier`=2.35, `ArmorModifier`=1.1, `AIName`='SmartAI' WHERE `entry`=14668;
 
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 14668) AND (`source_type` = 0) AND (`id` IN (0, 1));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1661366860302196200.sql
+++ b/data/sql/updates/pending_db_world/rev_1661366860302196200.sql
@@ -1,0 +1,8 @@
+--
+UPDATE `creature_template` SET `DamageModifier`=2.35, `ArmorModifier`=1.1 WHERE `entry`=14668;
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 14668;
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 14668) AND (`source_type` = 0) AND (`id` IN (0, 1));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(14668, 0, 0, 0, 0, 0, 100, 0, 3, 3, 3, 3, 0, 11, 20153, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Corrupted Infernal - In Combat - Cast \'Immolation\''),
+(14668, 0, 1, 0, 0, 0, 100, 0, 2, 5, 10, 12, 0, 11, 22703, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Corrupted Infernal - In Combat - Cast \'Inferno Effect\'');

--- a/data/sql/updates/pending_db_world/rev_1661366860302196200.sql
+++ b/data/sql/updates/pending_db_world/rev_1661366860302196200.sql
@@ -4,5 +4,5 @@ UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 14668;
 
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 14668) AND (`source_type` = 0) AND (`id` IN (0, 1));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(14668, 0, 0, 0, 0, 0, 100, 0, 3, 3, 3, 3, 0, 11, 20153, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Corrupted Infernal - In Combat - Cast \'Immolation\''),
-(14668, 0, 1, 0, 0, 0, 100, 0, 2, 5, 10, 12, 0, 11, 22703, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Corrupted Infernal - In Combat - Cast \'Inferno Effect\'');
+(14668, 0, 0, 0, 0, 0, 100, 0, 3000, 3000, 3000, 3000, 0, 11, 20153, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Corrupted Infernal - In Combat - Cast \'Immolation\''),
+(14668, 0, 1, 0, 0, 0, 100, 0, 2000, 5000, 10000, 12000, 0, 11, 22703, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Corrupted Infernal - In Combat - Cast \'Inferno Effect\'');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Imports Vmangos data for creature 14668.
-  Damage modifier was previously 1 and had no spells or AI scripts

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unopened issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Vmangos

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested with `.npc add temp 14668`

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Engage Nefarian with a Warlock, go into phase 2
2. Wait for the Class Call
3. See if Corrupted Infernals deal proximity damage (30) and occasionally stuns its target.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
