### PR TITLE
fix(Scripts/TempleOfAhnQiraj): Princess Huhuran's Poison Bolts should…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1661569695988798600.sql
+++ b/data/sql/updates/pending_db_world/rev_1661569695988798600.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_huhuran_poison_bolt';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(26052, 'spell_huhuran_poison_bolt');

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_huhuran.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_huhuran.cpp
@@ -148,8 +148,30 @@ class spell_huhuran_wyvern_sting : public AuraScript
     }
 };
 
+// 26052 - Poison Bolt
+class spell_huhuran_poison_bolt : public SpellScript
+{
+    PrepareSpellScript(spell_huhuran_poison_bolt);
+
+    void FilterTargets(std::list<WorldObject*>& targets)
+    {
+        uint32 const maxTargets = GetSpellInfo()->MaxAffectedTargets;
+        if (targets.size() > maxTargets)
+        {
+            targets.sort(Acore::ObjectDistanceOrderPred(GetCaster()));
+            targets.resize(maxTargets);
+        }
+    }
+
+    void Register() override
+    {
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_huhuran_poison_bolt::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENEMY);
+    }
+};
+
 void AddSC_boss_huhuran()
 {
     RegisterTempleOfAhnQirajCreatureAI(boss_huhuran);
     RegisterSpellScript(spell_huhuran_wyvern_sting);
+    RegisterSpellScript(spell_huhuran_poison_bolt);
 }


### PR DESCRIPTION
… hit the closest targets

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Princess Huhuran's Poison Bolts should…… hit the closest targets
- 
## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Needs to be raid tested

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
