### PR TITLE
fix(Core/TotemAI): Active totems should interrupt its spell casting i…

### DIFF
--- a/src/server/game/AI/CoreAI/TotemAI.cpp
+++ b/src/server/game/AI/CoreAI/TotemAI.cpp
@@ -60,8 +60,23 @@ void TotemAI::UpdateAI(uint32 /*diff*/)
     if (me->ToTotem()->GetTotemType() != TOTEM_ACTIVE)
         return;
 
-    if (!me->IsAlive() || me->IsNonMeleeSpellCast(false))
+    if (!me->IsAlive())
+    {
         return;
+    }
+
+    if (me->IsNonMeleeSpellCast(false))
+    {
+        if (Unit* victim = ObjectAccessor::GetUnit(*me, i_victimGuid))
+        {
+            if (!victim || !victim->IsAlive())
+            {
+                me->InterruptNonMeleeSpells(false);
+            }
+        }
+
+        return;
+    }
 
     // Search spell
     SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(me->ToTotem()->GetSpell());


### PR DESCRIPTION
…f current victim is dead.

Fixes #12669

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12669
- Closes https://github.com/chromiecraft/chromiecraft/issues/1873

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Atack a target, and reduce its HP low enough so it can be one-shoted by any spell.
Place Searing Totem down and make sure it starts its cast.
Kill the target.
The Searing Totem will interrupt the cast.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
