### PR TITLE
fix(Scripts/RuinsOfAhnQiraj): Restructure Ayamiss task scheduling during landing

### DIFF
--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ayamiss.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ayamiss.cpp
@@ -89,11 +89,6 @@ struct boss_ayamiss : public BossAI
         _enraged = false;
         SetCombatMovement(false);
         _scheduler.CancelAll();
-
-        _scheduler.SetValidator([this]
-        {
-            return !me->HasUnitState(UNIT_STATE_CASTING);
-        });
     }
 
     void JustSummoned(Creature* who) override

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ayamiss.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ayamiss.cpp
@@ -89,6 +89,11 @@ struct boss_ayamiss : public BossAI
         _enraged = false;
         SetCombatMovement(false);
         _scheduler.CancelAll();
+
+        _scheduler.SetValidator([this]
+        {
+            return !me->HasUnitState(UNIT_STATE_CASTING);
+        });
     }
 
     void JustSummoned(Creature* who) override
@@ -126,6 +131,15 @@ struct boss_ayamiss : public BossAI
                 }
 
             }, 1s);
+
+            _scheduler.Schedule(5s, 8s, [this](TaskContext context) {
+                DoCastVictim(SPELL_LASH);
+                context.Repeat(8s, 15s);
+            }).Schedule(16s, [this](TaskContext context)
+            {
+                DoCastSelf(SPELL_THRASH);
+                context.Repeat();
+            });
         }
     }
 
@@ -210,17 +224,6 @@ struct boss_ayamiss : public BossAI
             me->SetDisableGravity(false);
             me->GetMotionMaster()->MovePath(me->GetEntry() * 10, false);
             DoResetThreat();
-
-            _scheduler.Schedule(5s, 8s, [this](TaskContext context) {
-                DoCastVictim(SPELL_LASH);
-                context.Repeat(8s, 15s);
-            }).Schedule(16s, [this](TaskContext context)
-            {
-                DoCastSelf(SPELL_THRASH);
-                context.Repeat();
-            });
-
-            _scheduler.DelayAll(5s);
             _scheduler.CancelGroup(PHASE_AIR);
         }
 
@@ -271,6 +274,7 @@ struct npc_hive_zara_larva : public ScriptedAI
         if (Creature* ayamiss = _instance->GetCreature(DATA_AYAMISS))
         {
             ayamiss->AI()->JustSummoned(summon);
+            summon->SetInCombatWithZone();
         }
     }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Move the scheduler to when it lands
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. pull ayamiss, check if it still cast spells, damage till it lands, check if it lands and if it casts p2 spells correctly
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
