### PR TITLE
(DB/Conditions) Add condition to quest 374

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1661649172326868600.sql
+++ b/data/sql/updates/pending_db_world/rev_1661649172326868600.sql
@@ -1,0 +1,4 @@
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=19 AND `SourceEntry`=374;
+
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(19, 0, 374, 0, 0, 8, 0, 427, 0, 0, 0, 0, 0, '', 'Enable quest 374, only if the player has completed quest 427.');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

Co-authored-by: Mathematical <zajibrik@gmail.com>

## Changes Proposed:
-  Add a quest condition to quest 374 so that it can only be taken by the player, if he has completed and submitted quest 427.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12873
- Closes https://github.com/chromiecraft/chromiecraft/issues/3855

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- In-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go c 29798`
2. Try to obtain the quest without having completed the previous quest.
3. And then, do the test, to see that the quest is only available, if the requirement is completed.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
