### PR TITLE
fix(DB/Creatures): Arathi Basin Rare Critters:

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1661690424898681400.sql
+++ b/data/sql/updates/pending_db_world/rev_1661690424898681400.sql
@@ -1,0 +1,5 @@
+--
+UPDATE `creature` SET `phaseMask`=16 WHERE `guid` IN (246011,246009);
+UPDATE `creature` SET `phaseMask`=8 WHERE `guid` IN (246036,246098);
+
+UPDATE `creature_template` SET `unit_flags`=`unit_flags`|770 WHERE `entry` IN (15072,15065,15066,15071);


### PR DESCRIPTION
The critters should not be attackable.
Lady and Cleo should spawn under Alliance control.
Spike and Underfoot should spawn under Horde control.
Fixes #11995

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #11995
- Closes https://github.com/chromiecraft/chromiecraft/issues/671

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Queue Arathi Basin as Alliance.
Cap Blackmsith as Alliance.
Wait for Cleo and Lady to spawn. (They only spawn when BS is controlled by Alliance)
Attack Cleo and Lady.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
