### PR TITLE
fix(DB/linked_respawn): General Angerforge shouldn't respawn adds when dead.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1661702045258373700.sql
+++ b/data/sql/updates/pending_db_world/rev_1661702045258373700.sql
@@ -1,0 +1,8 @@
+-- General Angerforge
+SET @BOSS=45954;
+DELETE FROM `linked_respawn` WHERE `linkedGuid`=@BOSS AND `guid` IN (45955,45956,45958,45959);
+INSERT INTO `linked_respawn` (`guid`, `linkedGuid`, `linkType`) VALUES
+(45955, @BOSS, 0),
+(45956, @BOSS, 0),
+(45958, @BOSS, 0),
+(45959, @BOSS, 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Link them in linked_respawn

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/3737
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12874

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 9033
2. kill him and adds
3. see if adds respawn

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
