### PR TITLE
add (core\util): TimeToTimestampStr

### DIFF
--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <string>
 #include <utf8.h>
+#include <Timer.h>
 
 void stripLineInvisibleChars(std::string& str)
 {
@@ -104,6 +105,19 @@ std::string secsToTimeString(uint64 timeInSecs, bool shortText)
     }
 
     return str;
+}
+
+std::string TimeToTimestampStr(time_t t)
+{
+    tm aTm;
+    localtime_r(&t, &aTm);
+    //       YYYY   year
+    //       MM     month (2 digits 01-12)
+    //       DD     day (2 digits 01-31)
+    //       HH     hour (2 digits 00-23)
+    //       MM     minutes (2 digits 00-59)
+    //       SS     seconds (2 digits 00-59)
+    return Acore::StringFormat("%04d-%02d-%02d_%02d-%02d-%02d", aTm.tm_year + 1900, aTm.tm_mon + 1, aTm.tm_mday, aTm.tm_hour, aTm.tm_min, aTm.tm_sec);
 }
 
 Optional<int32> MoneyStringToMoney(std::string_view moneyString)

--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -46,6 +46,7 @@ AC_COMMON_API Optional<int32> MoneyStringToMoney(std::string_view moneyString);
 
 std::string secsToTimeString(uint64 timeInSecs, bool shortText = false);
 uint32 TimeStringToSecs(const std::string& timestring);
+std::string TimeToTimestampStr(time_t t);
 
 inline void ApplyPercentModFloatVar(float& var, float val, bool apply)
 {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Need a string to support logging with future anticheat module

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds
- Performs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Utilize TimeToTimestampStr and test output (this is from the anticheat module on my local not on repo just yet)
![image](https://user-images.githubusercontent.com/16887899/187088069-c613234c-e26c-4f4d-a323-477a8a5371b6.png)
2. Observe ban End showing YY-MM-DD-HH-MM-SS 

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
