### PR TITLE
fix(Scripts/UpperBlackrockSpire): Missing Seal of Ascension event

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1661717784573839588.sql
+++ b/data/sql/updates/pending_db_world/rev_1661717784573839588.sql
@@ -1,0 +1,73 @@
+SET @VAELASTRASZ_UBRS     := 10538;
+SET @VAELASTRASZ_THE_RED  := 10340;
+SET @NEFARIUS             := 10162;
+SET @CALL_OF_VAELASTRASZ  := 16349;
+SET @CHROMATIC_PROTECTION := 16372;
+-- Add missing creature text: Vaelastrasz The Red, Vaelastrasz, Nefarius
+DELETE FROM `creature_text` WHERE `CreatureID` = @VAELASTRASZ_THE_RED AND `GroupID` IN (0,1);
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`)
+VALUES
+(@VAELASTRASZ_THE_RED, 0, 0, 'All is not lost! Battle these beasts without fear. Your wounds I shall heal, bones I shall mend. Be renewed, heroes!', 14, 0, 100.0, 5, 0, 0, 5748, 0, 'Vaelastrasz the Red'),
+(@VAELASTRASZ_THE_RED, 1, 0, 'You have come too far to fail. Stand back, mortals.',                                                                  14, 0, 100.0, 5, 0, 0, 5760, 0, 'Vaelastrasz the Red');
+DELETE FROM `creature_text` WHERE `CreatureID` = @VAELASTRASZ_UBRS AND `GroupID` IN (0,1);
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`)
+VALUES
+(@VAELASTRASZ_UBRS, 0, 0, 'You will suffer in this defeat, Nefarian!',                                  14, 0, 100.0, 5, 0, 0, 5761, 0, 'Vaelastrasz'),
+(@VAELASTRASZ_UBRS, 1, 0, 'You merely destroy an image, fool. I shall hunt you until the end of days.', 14, 0, 100.0, 5, 0, 0, 5778, 0, 'Vaelastrasz');
+DELETE FROM `creature_text` WHERE `CreatureID` = @NEFARIUS AND `GroupID` IN (15,16,17);
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`)
+VALUES
+(@NEFARIUS, 15, 0, 'Enough! Playtime is over!',                                                                 14, 0, 100.0, 22, 0, 0, 5596, 0, 'Lord Victor Nefarius (UBRS)'),
+(@NEFARIUS, 16, 0, 'Vaelastrasz, when this world belongs to the black flight, your flight shall know its end.', 14, 0, 100.0, 22, 0, 0, 5776, 0, 'Lord Victor Nefarius (UBRS)'),
+(@NEFARIUS, 17, 0, 'But for now, your death will have to suffice...',                                           14, 0, 100.0, 0,  0, 0, 5777, 0, 'Lord Victor Nefarius (UBRS)');
+
+-- Handle Seal of Ascension and passive aura proc Chromatic Protection with script
+DELETE FROM `event_scripts` WHERE `id`=4622;
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (@CALL_OF_VAELASTRASZ, @CHROMATIC_PROTECTION);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`)
+VALUES
+(@CALL_OF_VAELASTRASZ, 'spell_blackrock_spire_call_of_vaelastrasz'),
+(@CHROMATIC_PROTECTION, 'spell_gyth_chromatic_protection');
+
+-- Ring of Ascension only usable when inside Blackrock Spire AND Rend event started
+-- Show error message "SPELL_FAILED_INCORRECT_AREA" when not in BRS
+-- Show no error when trying to use the ring when not doing Rend event
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceGroup` = 0) AND (`SourceEntry` = @CALL_OF_VAELASTRASZ);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`)
+VALUES
+(17, 0, @CALL_OF_VAELASTRASZ, 0, 0, 4,  0, 1583, 0, 0, 0, 39,  0, '', 'Ring of Ascension on-use-effect only if inside Blackrock Spire'),
+(17, 0, @CALL_OF_VAELASTRASZ, 0, 0, 13, 0, 10,   1, 2, 0, 172, 0, '', 'Ring of Ascension on-use-effect only if boss state 10 (Rend) is IN_PROGRESS.'),
+(17, 0, @CALL_OF_VAELASTRASZ, 0, 0, 13, 0, 25,   0, 0, 0, 172, 0, '', 'Ring of Ascension on-use-effect only if boss state 25 (Vaelastrasz) is NOT_STARTED.');
+
+-- Set ScriptName Vaelastrasz the Red
+UPDATE `creature_template` SET `ScriptName`='npc_vaelastrasz_the_red' WHERE `entry` = @VAELASTRASZ_THE_RED;
+
+-- Chromatic Protection
+-- PROC_EX_NORMAL_HIT 	1 	0x0000001
+-- PROC_FLAG_TAKEN_SPELL_MAGIC_DMG_CLASS_NEG 	131072 	0x00020000 	Taken negative spell that has dmg class magic
+DELETE FROM `spell_proc_event` WHERE `entry` = @CHROMATIC_PROTECTION;
+INSERT INTO `spell_proc_event`
+(`entry`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `procFlags`, `procEx`, `procPhase`, `ppmRate`, `CustomChance`, `Cooldown`)
+VALUES
+(@CHROMATIC_PROTECTION, 0, 0, 0, 0, 0, 131072, 1, 0, 0.0, 100.0, 0);
+
+-- Allow corruption to be cast on Vaelastrasz
+-- Update comment to specify Vaelastrasz the Corrupt (BWL)
+SET @CORRUPTION:= 23642;
+UPDATE `conditions` SET `Comment` = 'Nefarius Corruption only affects Vaelastrasz the Corrupt'
+WHERE (`SourceTypeOrReferenceId` = 17) AND
+(`SourceGroup` = 0) AND (`SourceEntry` = @CORRUPTION) AND (`SourceId` = 0) AND
+(`ElseGroup` = 0);
+-- Add ElseGroup to also allow corruption to cast on Vaelastrasz (UBRS)
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND
+(`SourceGroup` = 0) AND (`SourceEntry` = @CORRUPTION) AND (`SourceId` = 0) AND
+(`ElseGroup` = 1);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`)
+VALUES
+(17, 0, @CORRUPTION, 0, 1, 31, 1, 3, 10538, 0, 0, 0, 0, '', 'Nefarius Corruption only affects Vaelastrasz');
+
+-- Vaelastrasz the Red, Vaelastrasz
+-- Update mechanic immune mask, same as Vaelastrasz the Corrupt
+-- Update flags_extra to 1073742080 IMMUNITY_KNOCKBACK - creature is immune to knockback effects
+-- Immune to PC interaction (256) and NPC interaction (512)
+UPDATE `creature_template` SET `mechanic_immune_mask` = 650854239, `unit_flags` = 256|512, `type_flags` = 0, `flags_extra` = 1073741824 WHERE `entry` IN (@VAELASTRASZ_THE_RED, @VAELASTRASZ_UBRS);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/blackrock_spire.h
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/blackrock_spire.h
@@ -51,7 +51,8 @@ enum DataTypes
     DATA_HALL_RUNE_6                = 21,
     DATA_HALL_RUNE_7                = 22,
     DATA_SOLAKAR_FLAMEWREATH        = 23,
-    DATA_MOR_GRAYHOOF               = 24
+    DATA_MOR_GRAYHOOF               = 24,
+    DATA_VAELASTRASZ                = 25
 };
 
 enum CreaturesIds
@@ -75,6 +76,8 @@ enum CreaturesIds
     NPC_BLACKHAND_VETERAN           = 9819,
     NPC_BLACKHAND_INCARCERATOR      = 10316,
     NPC_LORD_VICTOR_NEFARIUS        = 10162,
+    NPC_VAELASTRASZ_THE_RED         = 10340,
+    NPC_VAELASTRASZ_UBRS            = 10538,
 
     NPC_SCARSHIELD_INFILTRATOR      = 10299,
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_rend_blackhand.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_rend_blackhand.cpp
@@ -253,6 +253,7 @@ public:
                     {
                         case EVENT_START_1:
                             instance->SetBossState(DATA_WARCHIEF_REND_BLACKHAND, IN_PROGRESS);
+                            instance->SetData(DATA_VAELASTRASZ, NOT_STARTED);
 
                             if (Creature* victor = ObjectAccessor::GetCreature(*me, victorGUID))
                                 victor->AI()->Talk(SAY_NEFARIUS_0);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
@@ -24,6 +24,7 @@
 #include "ObjectMgr.h"
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
+#include "SpellScript.h"
 #include "blackrock_spire.h"
 
 uint32 const DragonspireMobs[3] = { NPC_BLACKHAND_DREADWEAVER, NPC_BLACKHAND_SUMMONER, NPC_BLACKHAND_VETERAN };
@@ -80,6 +81,7 @@ public:
         uint32 CurrentSolakarWave = 0;
         uint32 SolakarState       = NOT_STARTED; // there should be a global instance encounter state, where is it?
         GuidVector SolakarSummons;
+        uint32 VaelastraszState   = NOT_STARTED;
 
         instance_blackrock_spireMapScript(InstanceMap* map) : InstanceScript(map)
         {
@@ -89,6 +91,7 @@ public:
             CurrentSolakarWave = 0;
             SolakarState       = NOT_STARTED;
             SolakarSummons.clear();
+            VaelastraszState   = NOT_STARTED;
         }
 
         void CreatureLooted(Creature* creature, LootType loot) override
@@ -377,6 +380,9 @@ public:
                     }
                     SolakarState = data;
                     break;
+                case DATA_VAELASTRASZ:
+                    VaelastraszState = data;
+                    break;
                 case DATA_UROK_DOOMHOWL:
                     if (data == FAIL)
                     {
@@ -419,6 +425,10 @@ public:
             if (type == DATA_SOLAKAR_FLAMEWREATH)
             {
                 return SolakarState;
+            }
+            else if (type == DATA_VAELASTRASZ)
+            {
+                return VaelastraszState;
             }
             else
             {
@@ -874,6 +884,244 @@ public:
             }
         }
         return false;
+/*#####
+# npc_vaelastrasz_the_red and Seal of Ascension event
+#####*/
+
+// Set fixed spawn points so there's enough room for the dragon model
+Position VaelastraszTheRedPosNorth = Position(168.815506f, -420.311066f, 110.472298f, 3.141593f);
+Position VaelastraszTheRedPosSouth = Position(134.369049f, -420.311066f, 110.472298f, 6.283184f);
+
+// 16349 - Call of Vaelastrasz
+
+class spell_blackrock_spire_call_of_vaelastrasz : public SpellScript
+{
+    PrepareSpellScript(spell_blackrock_spire_call_of_vaelastrasz);
+
+    void OnEffect(SpellEffIndex /*effIndex*/)
+    {
+        if (Unit* caster = GetCaster())
+        {
+            if (InstanceScript* instance = caster->GetInstanceScript())
+            {
+                instance->SetData(DATA_VAELASTRASZ, IN_PROGRESS);
+                float distanceToNorthSpawn = caster->GetDistance2d(VaelastraszTheRedPosNorth.m_positionX, VaelastraszTheRedPosNorth.m_positionY);
+                float distanceToSouthSpawn = caster->GetDistance2d(VaelastraszTheRedPosSouth.m_positionX, VaelastraszTheRedPosSouth.m_positionY);
+                Position spawnPosition = distanceToNorthSpawn < distanceToSouthSpawn ? VaelastraszTheRedPosNorth : VaelastraszTheRedPosSouth;
+                // despawn is called by the CreatureAI
+                caster->SummonCreature(NPC_VAELASTRASZ_THE_RED, spawnPosition, TEMPSUMMON_TIMED_DESPAWN, 60 * IN_MILLISECONDS);
+            }
+        }
+    }
+
+    void Register() override
+    {
+        OnEffectLaunch += SpellEffectFn(spell_blackrock_spire_call_of_vaelastrasz::OnEffect, EFFECT_0, SPELL_EFFECT_SEND_EVENT);
+    }
+};
+
+enum Spells
+{
+    // Vaelastrasz the Red
+    SPELL_VAELAN_SPAWNS               = 16634, // Lightning Effect (Self cast)
+    SPELL_TOUCH_OF_VAELASTRASZ        = 16319, // AoE heal (Self cast)
+    // Vaelastrasz
+    SPELL_FLAMEBREATH                 = 16396, // Combat (Self cast)
+    SPELL_VAELASTRASZ_SPAWN           = 16354, // Self Cast Despawn (Self cast)
+    // Victor Nefarius
+    SPELL_NEFARIUS_CORRUPTION         = 23642,
+};
+
+enum ModelIds
+{
+    MODEL_VAELASTRASZ_UBRS    = 9909,
+    MODEL_VAELASTRASZ_THE_RED = 9912,
+};
+
+enum Says
+{
+    // Vaelastrasz the Red
+    SAY_RED_SUMMONED          = 0,
+    SAY_RED_BEFORE_TRANSFORM  = 1,
+    // Vaelastrasz
+    SAY_VAEL_SUMMONED         = 0,
+    SAY_VAEL_STOP_COMBAT      = 1,
+    // Victor Nefarius
+    SAY_NEFARIUS_15           = 15,
+    SAY_NEFARIUS_16           = 16,
+    SAY_NEFARIUS_17           = 17,
+};
+
+enum Events
+{
+    // Vaelastrasz the Red
+    EVENT_RED_1_TALK_BEFORE_TRANSFORM = 1,
+    EVENT_RED_2_TRANSFORM,
+    // Vaelastrasz
+    EVENT_VAEL_TALK_SUMMON,
+    EVENT_VAEL_1_START_COMBAT,
+    EVENT_NEFARIUS_TALK_1,
+    EVENT_NEFARIUS_TALK_2,
+    EVENT_NEFARIUS_TALK_3,
+    EVENT_NEFARIUS_CORRUPTION,
+    EVENT_VAEL_2_TRANSFORM,
+    EVENT_VAEL_3_DESPAWN,
+    EVENT_FLAME_BREATH,
+};
+
+class npc_vaelastrasz_the_red : public CreatureScript
+{
+public:
+    npc_vaelastrasz_the_red() : CreatureScript("npc_vaelastrasz_the_red") { }
+
+    struct npc_vaelastrasz_the_redAI : public CreatureAI
+    {
+        npc_vaelastrasz_the_redAI(Creature* creature) : CreatureAI(creature) { }
+
+        void IsSummonedBy(Unit* summoner) override
+        {
+            if (!summoner)
+            {
+                return;
+            }
+            _combatEnabled = false;
+            me->CastSpell(me, SPELL_VAELAN_SPAWNS, false);
+            me->SetFacingToObject(summoner);
+            Talk(SAY_RED_SUMMONED);
+            if (Creature* victor = me->FindNearestCreature(NPC_LORD_VICTOR_NEFARIUS, 100.0f))
+            {
+                _victorGUID = victor->GetGUID();
+            }
+            events.ScheduleEvent(EVENT_RED_1_TALK_BEFORE_TRANSFORM, 3s);
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            events.Update(diff);
+
+            while (uint32 eventId = events.ExecuteEvent())
+            {
+                switch (eventId)
+                {
+                    case EVENT_RED_1_TALK_BEFORE_TRANSFORM:
+                        Talk(SAY_RED_BEFORE_TRANSFORM);
+                        events.ScheduleEvent(EVENT_RED_2_TRANSFORM, 2s);
+                        break;
+                    case EVENT_RED_2_TRANSFORM:
+                        me->CastSpell(me, SPELL_TOUCH_OF_VAELASTRASZ, false);
+                        me->SetEntry(NPC_VAELASTRASZ_UBRS);
+                        me->SetDisplayId(MODEL_VAELASTRASZ_UBRS);
+                        events.ScheduleEvent(EVENT_VAEL_TALK_SUMMON, 1s);
+                        events.ScheduleEvent(EVENT_VAEL_1_START_COMBAT, 5s);
+                        break;
+                    case EVENT_VAEL_TALK_SUMMON:
+                        Talk(SAY_VAEL_SUMMONED);
+                        break;
+                    case EVENT_VAEL_1_START_COMBAT:
+                        _combatEnabled = true;
+                        me->SetImmuneToNPC(false);
+                        if (Creature* gyth = me->FindNearestCreature(NPC_GYTH, 100.0f, true))
+                        {
+                            me->AddThreat(gyth, 1000000.f);
+                            me->AI()->AttackStart(gyth);
+                        }
+                        if (Creature* rend = me->FindNearestCreature(NPC_WARCHIEF_REND_BLACKHAND, 100.0f, true))
+                        {
+                            if (!rend->IsImmuneToNPC() && rend->isTargetableForAttack())
+                            {
+                                me->AddThreat(rend, 100000.f);
+                                if (!me->FindNearestCreature(NPC_GYTH, 100.0f, true))
+                                {
+                                    me->AI()->AttackStart(rend);
+                                }
+                            }
+                        }
+                        _events2.ScheduleEvent(EVENT_FLAME_BREATH, 5s);
+                        events.ScheduleEvent(EVENT_NEFARIUS_TALK_1, 500ms);
+                        break;
+                    case EVENT_NEFARIUS_TALK_1:
+                        if (Creature* victor = ObjectAccessor::GetCreature(*me, _victorGUID))
+                        {
+                            victor->GetMotionMaster()->Clear(); // stop pacing
+                            victor->GetMotionMaster()->MoveIdle();
+                            victor->StopMovingOnCurrentPos();
+                            victor->SetFacingToObject(me);
+                            victor->AI()->Talk(SAY_NEFARIUS_15);
+                        }
+                        events.ScheduleEvent(EVENT_NEFARIUS_TALK_2, 6s);
+                        break;
+                    case EVENT_NEFARIUS_TALK_2:
+                        if (Creature* victor = ObjectAccessor::GetCreature(*me, _victorGUID))
+                        {
+                            victor->SetFacingToObject(me);
+                            victor->AI()->Talk(SAY_NEFARIUS_16);
+                        }
+                        events.ScheduleEvent(EVENT_NEFARIUS_TALK_3, 5s);
+                        break;
+                    case EVENT_NEFARIUS_TALK_3:
+                        if (Creature* victor = ObjectAccessor::GetCreature(*me, _victorGUID))
+                        {
+                            victor->SetFacingToObject(me);
+                            victor->AI()->Talk(SAY_NEFARIUS_17);
+                        }
+                        events.ScheduleEvent(EVENT_NEFARIUS_CORRUPTION, 5s);
+                        break;
+                    case EVENT_NEFARIUS_CORRUPTION:
+                        _combatEnabled = false;
+                        me->AttackStop();
+                        me->RemoveAllAuras();
+                        me->StopMovingOnCurrentPos();
+                        me->SetFaction(FACTION_FRIENDLY);
+                        if (Creature* victor = ObjectAccessor::GetCreature(*me, _victorGUID))
+                        {
+                            victor->SetFacingToObject(me);
+                            victor->CastSpell(me, SPELL_NEFARIUS_CORRUPTION, TRIGGERED_CAST_DIRECTLY);
+                        }
+                        events.ScheduleEvent(EVENT_VAEL_2_TRANSFORM, 1s);
+                        break;
+                    case EVENT_VAEL_2_TRANSFORM:
+                        Talk(SAY_VAEL_STOP_COMBAT);
+                        me->SetDisplayId(MODEL_VAELASTRASZ_THE_RED);
+                        events.ScheduleEvent(EVENT_VAEL_3_DESPAWN, 500ms);
+                        break;
+                    case EVENT_VAEL_3_DESPAWN:
+                        DoCast(me, SPELL_VAELASTRASZ_SPAWN);
+                        me->DespawnOrUnsummon(1500);
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            if (!_combatEnabled || !UpdateVictim() || me->HasUnitState(UNIT_STATE_CASTING))
+            {
+                return;
+            }
+
+            _events2.Update(diff);
+
+            switch (_events2.ExecuteEvent())
+            {
+                case EVENT_FLAME_BREATH:
+                    me->CastSpell(me, SPELL_FLAMEBREATH, false);
+                    break;
+                default:
+                    break;
+            }
+
+            DoMeleeAttackIfReady();
+            return;
+        }
+
+    private:
+        ObjectGuid _victorGUID;
+        bool _combatEnabled;
+        EventMap _events2;
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return GetBlackrockSpireAI<npc_vaelastrasz_the_redAI>(creature);
     }
 };
 
@@ -885,4 +1133,6 @@ void AddSC_instance_blackrock_spire()
     new go_father_flame();
     new near_scarshield_infiltrator();
     new at_scarshield_infiltrator();
+    RegisterSpellScript(spell_blackrock_spire_call_of_vaelastrasz);
+    new npc_vaelastrasz_the_red();
 }

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
@@ -884,6 +884,9 @@ public:
             }
         }
         return false;
+    }
+};
+
 /*#####
 # npc_vaelastrasz_the_red and Seal of Ascension event
 #####*/


### PR DESCRIPTION
Using seal of ascension during the arena event  does not start event

Seal of ascension does not give chromatic protection buffs

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add missing event 
- Add chromatic protection proc

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/9069

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://youtu.be/E3i998lGwYM?t=34 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Matched recordings of the event with the source video to get timing correct

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
See "Expected Blizzlike Behaviour" details in issue https://github.com/azerothcore/azerothcore-wotlk/issues/9069

2 clients may be useful, 1 that starts the event with the ring and 1 with GM mode on to observe.

Start arena event 

.go c 137967
start Gyth and Rend event
.cheat cooldown
.additem 12344

Observe Vael event matches https://youtu.be/E3i998lGwYM?t=34

Ring can only be used once per encounter.

Ring cannot be used outside Rend event and only once per attempt. 

Gyth breaths should buff player wearing ring with chromatic protection buffs

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] 5s after Vaelastrasz spawns, he should attack. I've had issues where does not move or attack.
When Nefarius shouts "Enough! Playtime is over!", Vael should attack

https://user-images.githubusercontent.com/74299960/187093430-0ddca089-45fe-4319-bd8d-1cbc529e9fa9.mp4



<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
