### PR TITLE
fix(Core/Scripts): Rajaxx should drop aggro after Thundercrash

### DIFF
--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_rajaxx.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_rajaxx.cpp
@@ -96,6 +96,7 @@ struct boss_rajaxx : public BossAI
                     break;
                 case EVENT_THUNDERCRASH:
                     DoCastSelf(SPELL_THUNDERCRASH);
+                    me->GetThreatMgr().ResetAllThreat();
                     events.ScheduleEvent(EVENT_THUNDERCRASH, 21s);
                     break;
                 default:


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  ResetAllThreat after cast Thundercrash

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

https://classic.wowhead.com/guides/general-rajaxx-ruins-of-ahnqiraj-strategy

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Engage Rajaxx
2. Wait Thundercrash
3. Look if you got a drop threat

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
