### PR TITLE
fix(Core/Unit): DualWield Off-hand hit penalty

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -18561,8 +18561,11 @@ float Unit::MeleeSpellMissChance(Unit const* victim, WeaponAttackType attType, i
     //calculate miss chance
     float missChance = victim->GetUnitMissChance(attType);
 
-    if (!spellId && haveOffhandWeapon())
+    // Check if dual wielding, add additional miss penalty - when mainhand has on next swing spell, offhand doesnt suffer penalty
+    if (!spellId && (attType != RANGED_ATTACK) && haveOffhandWeapon() && (!m_currentSpells[CURRENT_MELEE_SPELL] || !m_currentSpells[CURRENT_MELEE_SPELL]->IsNextMeleeSwingSpell()))
+    {
         missChance += 19;
+    }
 
     // bonus from skills is 0.04%
     //miss_chance -= skillDiff * 0.04f;


### PR DESCRIPTION
When mainhand has on next swing spell, offhand doesnt suffer penalty
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Implement changes that are present in CMangos and VMangos core

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12767

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

This change is present in CMangos and VMangos. See links below

VMangos
Unit.cpp
`float Unit::MeleeMissChanceCalc(Unit const* pVictim, WeaponAttackType attType) const`
https://github.com/vmangos/core/blob/d7e2dee88304745540527d6a9f33dd0b9aeddc9c/src/game/Objects/Unit.cpp

CMangos
Unit.cpp
`float Unit::CalculateEffectiveMissChance(const Unit *victim, WeaponAttackType attType, const SpellEntry* ability) const`

https://github.com/cmangos/mangos-classic/blob/master/src/game/Entities/Unit.cpp

Difference between these two is `!m_currentSpells[CURRENT_MELEE_SPELL]`, CMangos more restrictive, checks spellInfo flag

I based the PR on CMangos.

There's a difference in IsNextMeleeSwing CMangos vs ACore, but found that I did not need to change it.

Mangos Classic 

```
inline bool IsNextMeleeSwingSpell(SpellEntry const* spellInfo)
{
	return spellInfo->HasAttribute(SPELL_ATTR_ON_NEXT_SWING_NO_DAMAGE) || spellInfo->HasAttribute(SPELL_ATTR_ON_NEXT_SWING);
}

```

Acore
```
bool Spell::IsNextMeleeSwingSpell() const
{
    return m_spellInfo->HasAttribute(SPELL_ATTR0_ON_NEXT_SWING_NO_DAMAGE);
}
```

With node-dbc-reader
`npm run start -- --search="{*} == 47450" --columns=ID Spell`
see output https://gist.github.com/SoglaHash/de0c5419e706ec1bf2cf4e944df63037

Flag 1024
``` 
SPELL_ATTR0_ON_NEXT_SWING                    = 0x00000400, // TITLE On next melee (type 2) DESCRIPTION Both "on next swing" attributes have identical handling in server & client
```

Flag 4
```
SPELL_ATTR0_ON_NEXT_SWING_NO_DAMAGE          = 0x00000004, // TITLE On next melee (type 1) DESCRIPTION Both "on next swing" attributes have identical handling in server & client
```
heroic strike: type 1 is set. OK
cleave: type 2 is not set. Type 1 is set. OK
ACore will check OK for both

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

Attack ingame on a dummy, process described in https://github.com/azerothcore/azerothcore-wotlk/issues/12767

debugger set conditional breakpoint
`attType == OFF_ATTACK`

and compare miss chance before `victim->GetUnitMissChance(attType)` and after `missChance`

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Do steps described in https://github.com/azerothcore/azerothcore-wotlk/issues/12767

Also test cleave

heroic strike learned by player
.learn 47450
cleave
.learn 47520

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
