### PR TITLE
fix(DB/Loot): Rot Hide Mongrel has incomplete loot table

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1661958107725070400.sql
+++ b/data/sql/updates/pending_db_world/rev_1661958107725070400.sql
@@ -1,0 +1,15 @@
+--
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 1675);
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(1675, 159, 0, 6, 0, 1, 2, 1, 1, 'Rot Hide Mongrel - Refreshing Spring Water'),
+(1675, 2589, 0, 44, 0, 1, 0, 1, 2, 'Rot Hide Mongrel - Linen Cloth'),
+(1675, 2834, 0, 31, 1, 1, 0, 1, 1, 'Rot Hide Mongrel - Embalming Ichor'),
+(1675, 3264, 0, 0.03, 1, 1, 0, 1, 1, 'Rot Hide Mongrel - Duskbat Wing'),
+(1675, 3300, 0, 0.01, 1, 1, 0, 1, 1, 'Rot Hide Mongrel - Rabbits Foot'),
+(1675, 4604, 0, 11, 0, 1, 2, 1, 1, 'Rot Hide Mongrel - Forest Mushroom Cap'),
+(1675, 11111, 11111, 0.1, 0, 1, 0, 1, 1, 'Rot Hide Mongrel - (ReferenceTable)'),
+(1675, 24073, 24073, 30, 0, 1, 1, 1, 1, 'Rot Hide Mongrel - (ReferenceTable)'),
+(1675, 24100, 24100, 5, 0, 1, 1, 1, 1, 'Rot Hide Mongrel - (ReferenceTable)'),
+(1675, 24720, 24720, 1, 0, 1, 1, 1, 1, 'Rot Hide Mongrel - (ReferenceTable)'),
+(1675, 24730, 24730, 1, 0, 1, 1, 1, 1, 'Rot Hide Mongrel - (ReferenceTable)'),
+(1675, 44007, 44007, 0.5, 0, 1, 1, 1, 1, 'Rot Hide Mongrel - (ReferenceTable)');

--- a/data/sql/updates/pending_db_world/rev_1661958107725070400.sql
+++ b/data/sql/updates/pending_db_world/rev_1661958107725070400.sql
@@ -4,7 +4,6 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (1675, 159, 0, 6, 0, 1, 2, 1, 1, 'Rot Hide Mongrel - Refreshing Spring Water'),
 (1675, 2589, 0, 44, 0, 1, 0, 1, 2, 'Rot Hide Mongrel - Linen Cloth'),
 (1675, 2834, 0, 31, 1, 1, 0, 1, 1, 'Rot Hide Mongrel - Embalming Ichor'),
-(1675, 3300, 0, 0.01, 1, 1, 0, 1, 1, 'Rot Hide Mongrel - Rabbits Foot'),
 (1675, 4604, 0, 11, 0, 1, 2, 1, 1, 'Rot Hide Mongrel - Forest Mushroom Cap'),
 (1675, 11111, 11111, 0.1, 0, 1, 0, 1, 1, 'Rot Hide Mongrel - (ReferenceTable)'),
 (1675, 24073, 24073, 30, 0, 1, 1, 1, 1, 'Rot Hide Mongrel - (ReferenceTable)'),

--- a/data/sql/updates/pending_db_world/rev_1661958107725070400.sql
+++ b/data/sql/updates/pending_db_world/rev_1661958107725070400.sql
@@ -4,7 +4,6 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (1675, 159, 0, 6, 0, 1, 2, 1, 1, 'Rot Hide Mongrel - Refreshing Spring Water'),
 (1675, 2589, 0, 44, 0, 1, 0, 1, 2, 'Rot Hide Mongrel - Linen Cloth'),
 (1675, 2834, 0, 31, 1, 1, 0, 1, 1, 'Rot Hide Mongrel - Embalming Ichor'),
-(1675, 3264, 0, 0.03, 1, 1, 0, 1, 1, 'Rot Hide Mongrel - Duskbat Wing'),
 (1675, 3300, 0, 0.01, 1, 1, 0, 1, 1, 'Rot Hide Mongrel - Rabbits Foot'),
 (1675, 4604, 0, 11, 0, 1, 2, 1, 1, 'Rot Hide Mongrel - Forest Mushroom Cap'),
 (1675, 11111, 11111, 0.1, 0, 1, 0, 1, 1, 'Rot Hide Mongrel - (ReferenceTable)'),


### PR DESCRIPTION
## Changes Proposed:
-  Rot Hide Mongrel loot table changed

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12808 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- https://www.wowhead.com/wotlk/quest=358
- https://www.wowhead.com/wotlk/npc=1675

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested on local AC windows server

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Add quest  `.quest add 358`
2. Teleport to NPC `.go creature 44663`
3. Kill Rot Hide Mongrel's and check drop

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
