### PR TITLE
fix(Core): Correct Quest XP Display when modified by OnQuestCompleteXP Hook

### DIFF
--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -452,7 +452,9 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* quest, ObjectGuid npcGU
 
         uint8 playerLevel = _session->GetPlayer() ? _session->GetPlayer()->getLevel() : 0;
         data << uint32(quest->GetRewOrReqMoney(playerLevel));
-        data << uint32(quest->XPValue(playerLevel) * _session->GetPlayer()->GetQuestRate());
+        uint32 questXp = uint32(quest->XPValue(playerLevel) * _session->GetPlayer()->GetQuestRate());
+        sScriptMgr->OnQuestComputeXP(_session->GetPlayer(), quest, questXp);
+        data << questXp;
     }
 
     // rewarded honor points. Multiply with 10 to satisfy client
@@ -680,7 +682,9 @@ void PlayerMenu::SendQuestGiverOfferReward(Quest const* quest, ObjectGuid npcGUI
     uint8 playerLevel = _session->GetPlayer() ? _session->GetPlayer()->getLevel() : 0;
 
     data << uint32(quest->GetRewOrReqMoney(playerLevel));
-    data << uint32(quest->XPValue(playerLevel) * _session->GetPlayer()->GetQuestRate());
+    uint32 questXp = uint32(quest->XPValue(playerLevel) * _session->GetPlayer()->GetQuestRate());
+    sScriptMgr->OnQuestComputeXP(_session->GetPlayer(), quest, questXp);
+    data << questXp;
 
     // rewarded honor points. Multiply with 10 to satisfy client
     data << uint32(10 * quest->CalculateHonorGain(_session->GetPlayer()->GetQuestLevel(quest)));


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Show correct amount of XP that will be received if the amount is modified by the hook
-  Previously, correct amount would be award but the amount in the quest details would be incorrect

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
N/A

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in game, works now correctly


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Change Quest XP using OnBeforeQuestComputeXP hook
2. Check that the modified value now appears in quest details

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
