### PR TITLE
fix(Scripts/BlackrockSpire): Scarshield Infiltrator

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1661953746218069448.sql
+++ b/data/sql/updates/pending_db_world/rev_1661953746218069448.sql
@@ -1,0 +1,60 @@
+--
+DELETE FROM `areatrigger_scripts` WHERE `entry` = 1946;
+INSERT INTO `areatrigger_scripts` (`entry`, `ScriptName`) VALUES (1946, 'at_scarshield_infiltrator');
+
+-- Update Position and set kneel animation
+-- VMangos Position: https://github.com/vmangos/core/blob/5073ba81290178612580acba6991bfba8bed632d/sql/migrations/20220402225440_world.sql
+UPDATE `creature` SET `position_x`=57.0545, `position_y`=-399.681, `position_z`=64.4311, `orientation`=2.94961, `MovementType`=0 WHERE `guid`=42798;
+DELETE FROM `creature_addon` WHERE `guid` = 42798;
+INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES (42798, 0, 0, 8, 0, 0, 0, NULL);
+
+-- Add condition to show gossip option
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 15) AND (`SourceGroup` = 12039);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 12039, 1, 0, 0, 2, 0, 12219, 1, 0, 0, 0, 0, '', 'Show gossip option if player has Unadorned Seal of Ascension'),
+(15, 12039, 0, 0, 0, 2, 0, 12219, 1, 0, 1, 0, 0, '', 'Show gossip option if player does not have Unadorned Seal of Ascension');
+
+-- Add condition to send the right gossip text
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 22) AND (`SourceEntry` = 10299);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(22, 4, 10299, 0, 0, 2, 0, 12219, 1, 0, 1, 0, 0, '', 'Show gossip if player does not have Unadorned Seal of Ascension'),
+(22, 5, 10299, 0, 0, 2, 0, 12219, 1, 0, 0, 0, 0, '', 'Show gossip if player has Unadorned Seal of Ascension');
+
+-- Link npc_text with gossip_menu
+DELETE FROM `gossip_menu` WHERE `MenuID` IN (12039, 12040, 12041, 12042, 12043, 12044, 12045, 12046, 12047, 12048);
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES (12039, 3301), (12039, 3311), (12040, 3302), (12041, 3303), (12042, 3304), (12043, 3305), (12044, 3306), (12045, 3307), (12046, 3308), (12047, 3309), (12048, 3310);
+
+-- Vaelan, Remove static Vaelan
+DELETE FROM `creature` WHERE `guid` = 42797 AND `id1`= 10296;
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `npcflag` = 0, `gossip_menu_id` = 12039, `MovementType` = 0 WHERE (`entry` = 10296);
+-- Scarshield Infiltrator
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `gossip_menu_id` = 0, `npcflag` = 0, `MovementType` = 0 WHERE (`entry` = 10299);
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 10299);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(10299, 0, 0, 0, 38, 0, 100, 1, 0, 1, 0, 0, 0, 80, 1029900, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - On Data Set 0 1 - Run Script (No Repeat)'),
+(10299, 0, 1, 0, 62, 0, 100, 0, 12039, 1, 0, 0, 0, 80, 1029901, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - On Gossip Option 1 Selected - Run Script'),
+(10299, 0, 2, 0, 62, 0, 100, 0, 12048, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - On Gossip Option 0 Selected - Close Gossip'),
+(10299, 0, 3, 0, 64, 0, 100, 0, 12039, 0, 0, 0, 0, 98, 12039, 3301, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - On Gossip Hello - Send Gossip'),
+(10299, 0, 4, 0, 64, 0, 100, 0, 12039, 0, 0, 0, 0, 98, 12039, 3311, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - On Gossip Hello - Send Gossip');
+
+-- Actionlist
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 1029900);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(1029900, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 11, 16037, 0, 0, 0, 0, 0, 21, 90, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Cast \'Mind Probe\''),
+(1029900, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 91, 8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Remove FlagStandstate Kneel'),
+(1029900, 9, 2, 0, 0, 0, 100, 0, 1500, 1500, 0, 0, 0, 3, 0, 9643, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Morph To Model 9643'),
+(1029900, 9, 3, 0, 0, 0, 100, 0, 1500, 1500, 0, 0, 0, 36, 10296, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Update Template To \'Vaelan\''),
+(1029900, 9, 4, 0, 0, 0, 100, 0, 1500, 1500, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 21, 90, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Set Orientation Closest Player'),
+(1029900, 9, 5, 0, 0, 0, 100, 0, 2500, 2500, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Say Line 0'),
+(1029900, 9, 6, 0, 0, 0, 100, 0, 8500, 8500, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Say Line 1'),
+(1029900, 9, 7, 0, 0, 0, 100, 0, 10500, 10500, 0, 0, 0, 81, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Set Npc Flags Gossip');
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 1029901);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(1029901, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Close Gossip'),
+(1029901, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 83, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Remove Npc Flags Gossip'),
+(1029901, 9, 2, 0, 0, 0, 100, 0, 100, 100, 0, 0, 0, 5, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Play Emote 1'),
+(1029901, 9, 3, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 11, 16051, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Cast \'Barrier of Light\''),
+(1029901, 9, 4, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 1, 2, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Say Line 2'),
+(1029901, 9, 5, 0, 0, 0, 100, 0, 7500, 7500, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Say Line 3'),
+(1029901, 9, 6, 0, 0, 0, 100, 0, 11500, 11500, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Add Npc Flags Questgiver');

--- a/data/sql/updates/pending_db_world/rev_1661953746218069448.sql
+++ b/data/sql/updates/pending_db_world/rev_1661953746218069448.sql
@@ -26,7 +26,7 @@ INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES (12039, 3301), (12039, 331
 
 -- Vaelan, Remove static Vaelan
 DELETE FROM `creature` WHERE `guid` = 42797 AND `id1`= 10296;
-UPDATE `creature_template` SET `AIName` = 'SmartAI', `gossip_menu_id` = 12039, `MovementType` = 0 WHERE (`entry` = 10296);
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `npcflag`=1|2, `gossip_menu_id` = 12039, `MovementType` = 0 WHERE (`entry` = 10296);
 -- Scarshield Infiltrator
 UPDATE `creature_template` SET `AIName` = 'SmartAI', `gossip_menu_id` = 0, `npcflag` = 0, `MovementType` = 0 WHERE (`entry` = 10299);
 

--- a/data/sql/updates/pending_db_world/rev_1661953746218069448.sql
+++ b/data/sql/updates/pending_db_world/rev_1661953746218069448.sql
@@ -26,7 +26,7 @@ INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES (12039, 3301), (12039, 331
 
 -- Vaelan, Remove static Vaelan
 DELETE FROM `creature` WHERE `guid` = 42797 AND `id1`= 10296;
-UPDATE `creature_template` SET `AIName` = 'SmartAI', `npcflag` = 0, `gossip_menu_id` = 12039, `MovementType` = 0 WHERE (`entry` = 10296);
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `gossip_menu_id` = 12039, `MovementType` = 0 WHERE (`entry` = 10296);
 -- Scarshield Infiltrator
 UPDATE `creature_template` SET `AIName` = 'SmartAI', `gossip_menu_id` = 0, `npcflag` = 0, `MovementType` = 0 WHERE (`entry` = 10299);
 
@@ -43,8 +43,8 @@ DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 1029900
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (1029900, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 11, 16037, 0, 0, 0, 0, 0, 21, 90, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Cast \'Mind Probe\''),
 (1029900, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 91, 8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Remove FlagStandstate Kneel'),
-(1029900, 9, 2, 0, 0, 0, 100, 0, 1500, 1500, 0, 0, 0, 3, 0, 9643, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Morph To Model 9643'),
-(1029900, 9, 3, 0, 0, 0, 100, 0, 1500, 1500, 0, 0, 0, 36, 10296, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Update Template To \'Vaelan\''),
+(1029900, 9, 2, 0, 0, 0, 100, 0, 1500, 1500, 0, 0, 0, 36, 10296, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Update Template To \'Vaelan\''),
+(1029900, 9, 3, 0, 0, 0, 100, 0, 1500, 1500, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Remove Npc Flags Gossip & Questgiver'),
 (1029900, 9, 4, 0, 0, 0, 100, 0, 1500, 1500, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 21, 90, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Set Orientation Closest Player'),
 (1029900, 9, 5, 0, 0, 0, 100, 0, 2500, 2500, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Say Line 0'),
 (1029900, 9, 6, 0, 0, 0, 100, 0, 8500, 8500, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Scarshield Infiltrator - Actionlist - Say Line 1'),

--- a/data/sql/updates/pending_db_world/rev_1661953746218069448.sql
+++ b/data/sql/updates/pending_db_world/rev_1661953746218069448.sql
@@ -1,6 +1,8 @@
 --
-DELETE FROM `areatrigger_scripts` WHERE `entry` = 1946;
-INSERT INTO `areatrigger_scripts` (`entry`, `ScriptName`) VALUES (1946, 'at_scarshield_infiltrator');
+DELETE FROM `areatrigger_scripts` WHERE `entry` IN (1946, 1986);
+INSERT INTO `areatrigger_scripts` (`entry`, `ScriptName`) VALUES
+(1986, 'near_scarshield_infiltrator'),
+(1946, 'at_scarshield_infiltrator');
 
 -- Update Position and set kneel animation
 -- VMangos Position: https://github.com/vmangos/core/blob/5073ba81290178612580acba6991bfba8bed632d/sql/migrations/20220402225440_world.sql
@@ -12,13 +14,17 @@ INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `e
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 15) AND (`SourceGroup` = 12039);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (15, 12039, 1, 0, 0, 2, 0, 12219, 1, 0, 0, 0, 0, '', 'Show gossip option if player has Unadorned Seal of Ascension'),
-(15, 12039, 0, 0, 0, 2, 0, 12219, 1, 0, 1, 0, 0, '', 'Show gossip option if player does not have Unadorned Seal of Ascension');
+(15, 12039, 1, 0, 0, 27, 0,   57, 3, 0, 0, 0, 0, '', 'Show gossip option if player is at least level 57'),
+(15, 12039, 0, 0, 0, 2, 0, 12219, 1, 0, 1, 0, 0, '', 'Show gossip option if player does not have Unadorned Seal of Ascension'),
+(15, 12039, 0, 0, 0, 27, 0,   57, 3, 0, 0, 0, 0, '', 'Show gossip option if player is at least level 57');
 
 -- Add condition to send the right gossip text
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 22) AND (`SourceEntry` = 10299);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(22, 4, 10299, 0, 0, 2, 0, 12219, 1, 0, 1, 0, 0, '', 'Show gossip if player does not have Unadorned Seal of Ascension'),
-(22, 5, 10299, 0, 0, 2, 0, 12219, 1, 0, 0, 0, 0, '', 'Show gossip if player has Unadorned Seal of Ascension');
+(22, 4, 10299, 0, 0,  2, 0, 12219, 1, 0, 1, 0, 0, '', 'Show gossip text if player does not have Unadorned Seal of Ascension'),
+(22, 4, 10299, 0, 1, 27, 0,    57, 3, 0, 1, 0, 0, '', 'Show gossip text if player is below level 57'),
+(22, 5, 10299, 0, 0,  2, 0, 12219, 1, 0, 0, 0, 0, '', 'Show gossip text if player has Unadorned Seal of Ascension'),
+(22, 5, 10299, 0, 0, 27, 0,    57, 3, 0, 0, 0, 0, '', 'Show gossip text if player is at least level 57');
 
 -- Link npc_text with gossip_menu
 DELETE FROM `gossip_menu` WHERE `MenuID` IN (12039, 12040, 12041, 12042, 12043, 12044, 12045, 12046, 12047, 12048);
@@ -26,9 +32,9 @@ INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES (12039, 3301), (12039, 331
 
 -- Vaelan, Remove static Vaelan
 DELETE FROM `creature` WHERE `guid` = 42797 AND `id1`= 10296;
-UPDATE `creature_template` SET `AIName` = 'SmartAI', `npcflag`=1|2, `gossip_menu_id` = 12039, `MovementType` = 0 WHERE (`entry` = 10296);
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `npcflag`=1|2, `gossip_menu_id` = 12039, `MovementType` = 0, `minlevel` = 55 WHERE (`entry` = 10296);
 -- Scarshield Infiltrator
-UPDATE `creature_template` SET `AIName` = 'SmartAI', `gossip_menu_id` = 0, `npcflag` = 0, `MovementType` = 0 WHERE (`entry` = 10299);
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `gossip_menu_id` = 0, `npcflag` = 0, `MovementType` = 0, `minlevel` = 55 WHERE (`entry` = 10299);
 
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 10299);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/blackrock_spire.h
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/blackrock_spire.h
@@ -76,6 +76,8 @@ enum CreaturesIds
     NPC_BLACKHAND_INCARCERATOR      = 10316,
     NPC_LORD_VICTOR_NEFARIUS        = 10162,
 
+    NPC_SCARSHIELD_INFILTRATOR      = 10299,
+
     NPC_SOLAKAR                     = 10264,
     NPC_ROOKERY_GUARDIAN            = 10258,
     NPC_ROOKERY_HATCHER             = 10683,
@@ -95,7 +97,8 @@ enum AdditionalData
     AREATRIGGER                     = 1,
     AREATRIGGER_DRAGONSPIRE_HALL    = 2046,
     AREATRIGGER_BLACKROCK_STADIUM   = 2026,
-    SAY_FINKLE_GANG                 = 0
+    SAY_FINKLE_GANG                 = 0,
+    ITEM_UNADORNED_SEAL             = 12219
 };
 
 enum GameObjectsIds

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
@@ -53,7 +53,8 @@ Position SolakarPosBoss  = Position(80.0f, -280.0f, 93.0f, 3.0f * M_PI / 2.0);
 enum Texts
 {
     SAY_NEFARIUS_REND_WIPE      = 11,
-    SAY_SOLAKAR_FIRST_HATCHER   = 0
+    SAY_SOLAKAR_FIRST_HATCHER   = 0,
+    SAY_SCARSHIELD_INF_WHISPER  = 0
 };
 
 MinionData const minionData[] =
@@ -823,10 +824,46 @@ public:
     }
 };
 
+class at_scarshield_infiltrator : public AreaTriggerScript
+{
+public:
+    at_scarshield_infiltrator() : AreaTriggerScript("at_scarshield_infiltrator") { }
+
+    bool OnTrigger(Player* player, const AreaTrigger* /*at*/) override
+    {
+        if (player && player->IsAlive())
+        {
+            if (Creature* creature = player->FindNearestCreature(NPC_SCARSHIELD_INFILTRATOR, 100.0f, true))
+            {
+                if (player->HasItemCount(ITEM_UNADORNED_SEAL))
+                {
+                    // Start transform into Vaelan
+                    creature->AI()->SetData(0, 1);
+                }
+                else if (creature->AI()->GetData(0) != 1) // transform has not started
+                {
+                    // Send whisper if not already sent
+                    std::list<ObjectGuid>::iterator itr = std::find(whisperedTargets.begin(), whisperedTargets.end(), player->GetGUID());
+                    if (itr == whisperedTargets.end())
+                    {
+                        creature->AI()->Talk(SAY_SCARSHIELD_INF_WHISPER, player);
+                        whisperedTargets.push_back(player->GetGUID());
+                    }
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+    private:
+        GuidList whisperedTargets;
+};
+
 void AddSC_instance_blackrock_spire()
 {
     new instance_blackrock_spire();
     new at_dragonspire_hall();
     new at_blackrock_stadium();
     new go_father_flame();
+    new at_scarshield_infiltrator();
 }

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
@@ -824,6 +824,37 @@ public:
     }
 };
 
+class near_scarshield_infiltrator : public AreaTriggerScript
+{
+public:
+    near_scarshield_infiltrator() : AreaTriggerScript("near_scarshield_infiltrator") { }
+
+    bool OnTrigger(Player* player, const AreaTrigger* /*at*/) override
+    {
+        if (player && player->IsAlive())
+        {
+            if (Creature* creature = player->FindNearestCreature(NPC_SCARSHIELD_INFILTRATOR, 100.0f, true))
+            {
+                bool transformHasStarted = creature->AI()->GetData(0) == 1;
+                if ((player->getLevel() < 57 || !player->HasItemCount(ITEM_UNADORNED_SEAL))  && !transformHasStarted)
+                {
+                    // Send whisper if not already sent
+                    std::list<ObjectGuid>::iterator itr = std::find(whisperedTargets.begin(), whisperedTargets.end(), player->GetGUID());
+                    if (itr == whisperedTargets.end())
+                    {
+                        creature->AI()->Talk(SAY_SCARSHIELD_INF_WHISPER, player);
+                        whisperedTargets.push_back(player->GetGUID());
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+    private:
+        GuidList whisperedTargets;
+};
+
 class at_scarshield_infiltrator : public AreaTriggerScript
 {
 public:
@@ -835,28 +866,15 @@ public:
         {
             if (Creature* creature = player->FindNearestCreature(NPC_SCARSHIELD_INFILTRATOR, 100.0f, true))
             {
-                if (player->HasItemCount(ITEM_UNADORNED_SEAL))
+                if (player->getLevel() >= 57 && player->HasItemCount(ITEM_UNADORNED_SEAL))
                 {
-                    // Start transform into Vaelan
-                    creature->AI()->SetData(0, 1);
+                    creature->AI()->SetData(0, 1); // Start transform into Vaelan
+                    return true;
                 }
-                else if (creature->AI()->GetData(0) != 1) // transform has not started
-                {
-                    // Send whisper if not already sent
-                    std::list<ObjectGuid>::iterator itr = std::find(whisperedTargets.begin(), whisperedTargets.end(), player->GetGUID());
-                    if (itr == whisperedTargets.end())
-                    {
-                        creature->AI()->Talk(SAY_SCARSHIELD_INF_WHISPER, player);
-                        whisperedTargets.push_back(player->GetGUID());
-                    }
-                }
-                return true;
             }
         }
         return false;
     }
-    private:
-        GuidList whisperedTargets;
 };
 
 void AddSC_instance_blackrock_spire()
@@ -865,5 +883,6 @@ void AddSC_instance_blackrock_spire()
     new at_dragonspire_hall();
     new at_blackrock_stadium();
     new go_father_flame();
+    new near_scarshield_infiltrator();
     new at_scarshield_infiltrator();
 }


### PR DESCRIPTION
Vaelan stands in a corner in Lower Blackrock Spire and always offers the Seal of Ascension quest
Scarshield Infiltrator stands there and does nothing

Before pic with areatriggers
![12687_areatrigger_BRS](https://user-images.githubusercontent.com/74299960/187753137-db0f30be-85cd-402c-b6eb-6e8f54d60d64.png)

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove static Vaelan
- Make Scarshield Infiltrator kneel and transform when player with unadorned seal of ascension triggers areatrigger
- Sends whisper like "not worthy of my knowledge" if seal not in bags and transform has not started
- Add missing NPC Texts to gossip
- Add script to Areatrigger 1946 to trigger transformation or whisper

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12687

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Similar change found in VMangos https://github.com/vmangos/core/blob/a01720f547f0d042b7989085a1a3558cc6e92a64/sql/old_migrations/20171124181306_world.sql

Gossip and transformation https://www.youtube.com/watch?v=75ZluW4Ae-g&t=196s

 Areatrigger 1946 https://www.youtube.com/watch?t=100&v=NaqkY_3OIoI&feature=youtu.be 

Recorded these 2 clips on classic wrath 

https://user-images.githubusercontent.com/74299960/190232632-a449ae38-5425-4af6-a689-2e70c78623e4.mp4


https://user-images.githubusercontent.com/74299960/190232649-7282b546-5bd2-41b7-bf93-7fe5288c0d98.mp4



## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Unadorned seal of ascension 
`.add 12219`
Go near triggers
 `.go trigger 1987`
Show trigger
`.debug areatrigger`
Reset instance
`.instance u all`

Test whisper

1. Go to 1986
2. No whisper when lvl 57 or higher AND unadorned seal is in bags. Else whisper

Test transform

1. Go to 1946
2. Trigger is only transformed when char is lvl 57 or above with unadorned seal in bags
3. Observe transformation

Test dialogue

1. Dialogue text "do not bring it any closer" if level at least 57 and unadorned seal in bags
2. No dialogue options if under lvl 57. Dialogue option shows "as you wish" if unadorned seal in bags to continue RP, else the "your kind" option shows to continue dialogue
3. Check if quest becomes available after RP "as you wish" 

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] After updating template to Vaelan, the gossip/quest option becomes available for <1second even though it's scripted to happen at the same time as the transform

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
