### PR TITLE
fix(DB/Quest) "Unraveling the Mystery" has wrong quest marker

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1662107131127819900.sql
+++ b/data/sql/updates/pending_db_world/rev_1662107131127819900.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `quest_template_addon` WHERE (`ID` = 8314);
+INSERT INTO `quest_template_addon` (`ID`, `MaxLevel`, `AllowableClasses`, `SourceSpellID`, `PrevQuestID`, `NextQuestID`, `ExclusiveGroup`, `RewardMailTemplateID`, `RewardMailDelay`, `RequiredSkillID`, `RequiredSkillPoints`, `RequiredMinRepFaction`, `RequiredMaxRepFaction`, `RequiredMinRepValue`, `RequiredMaxRepValue`, `ProvidedItemCount`, `SpecialFlags`) VALUES
+(8314, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0);

--- a/data/sql/updates/pending_db_world/rev_1662107131127819900.sql
+++ b/data/sql/updates/pending_db_world/rev_1662107131127819900.sql
@@ -1,4 +1,2 @@
 --
-DELETE FROM `quest_template_addon` WHERE (`ID` = 8314);
-INSERT INTO `quest_template_addon` (`ID`, `MaxLevel`, `AllowableClasses`, `SourceSpellID`, `PrevQuestID`, `NextQuestID`, `ExclusiveGroup`, `RewardMailTemplateID`, `RewardMailDelay`, `RequiredSkillID`, `RequiredSkillPoints`, `RequiredMinRepFaction`, `RequiredMaxRepFaction`, `RequiredMinRepValue`, `RequiredMaxRepValue`, `ProvidedItemCount`, `SpecialFlags`) VALUES
-(8314, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0);
+UPDATE `quest_template_addon` SET `SpecialFlags` = 0 WHERE (`ID` = 8314);


### PR DESCRIPTION
## Changes Proposed:
-  Changed SpecialFlags in `quest_template_addon`

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes  #12756

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- https://wowgaming.altervista.org/aowow/?quest=8314

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested on local AC server


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  `.go creature 42752`
2. `.quest add 8309` `.quest add 8310`
3. `.quest complete 8309` `.quest complete 8310`
4. Finish both quests
5. Check [Unraveling the Mystery](https://wowgaming.altervista.org/aowow/?quest=8314)


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
