### PR TITLE
fix(DB/EversongWoods): Repair Flag wrongly set

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1662131908035510198.sql
+++ b/data/sql/updates/pending_db_world/rev_1662131908035510198.sql
@@ -1,3 +1,3 @@
 --
-UPDATE `creature_template` SET `npcflag` = `npc_flag`&~(4096) WHERE (`entry` = 16280);
-UPDATE `creature_template` set `npcflag` = `npc_flag`&~(4096) where (`entry` = 16278);
+UPDATE `creature_template` SET `npcflag` = `npcflag`&~(4096) WHERE (`entry` = 16280);
+UPDATE `creature_template` set `npcflag` = `npcflag`&~(4096) where (`entry` = 16278);

--- a/data/sql/updates/pending_db_world/rev_1662131908035510198.sql
+++ b/data/sql/updates/pending_db_world/rev_1662131908035510198.sql
@@ -1,3 +1,2 @@
 --
-UPDATE `creature_template` SET `npcflag` = `npcflag`&~(4096) WHERE (`entry` = 16280);
-UPDATE `creature_template` set `npcflag` = `npcflag`&~(4096) where (`entry` = 16278);
+UPDATE `creature_template` SET `npcflag` = `npcflag`&~(4096) WHERE `entry` IN (16280, 16278);

--- a/data/sql/updates/pending_db_world/rev_1662131908035510198.sql
+++ b/data/sql/updates/pending_db_world/rev_1662131908035510198.sql
@@ -1,0 +1,3 @@
+--
+UPDATE `creature_template` SET `npcflag` = `npc_flag`&~(4096) WHERE (`entry` = 16280);
+UPDATE `creature_template` set `npcflag` = `npc_flag`&~(4096) where (`entry` = 16278);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
original author https://github.com/Warglaive of https://github.com/azerothcore/azerothcore-wotlk/pull/12544 

I noticed the riding trainer also has repair flag set by mistake (unless its a blizzlike bug).

I checked the other NPCs on map 530 and only these 2 have the wrong repair flag set

![repairflags](https://user-images.githubusercontent.com/74299960/188195923-7cb6947d-3d80-4358-8615-c4e2a8e300f7.png)

-  SQL & Python script used in https://gist.github.com/SoglaHash/39be7c76082674442ad8c954f999c9cb

## Changes Proposed:
-  Remove repair flag from riding trainer and leatherworking trainer

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Leatherworking trainer 
` .go c 56986`
4. Riding trainer 
  `.go c 56988`


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
