### PR TITLE
fix(Core/BattlegroundQueue): Replace std::erase() with .remove() ...

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -103,7 +103,7 @@ bool BattlegroundQueue::SelectionPool::KickGroup(const uint32 size)
     // remove selected from pool
     auto playersCountInGroup{ groupToKick->Players.size() };
     PlayerCount -= playersCountInGroup;
-    std::erase(SelectedGroups, groupToKick);
+    SelectedGroups.remove(groupToKick);
 
     if (foundProper)
         return false;


### PR DESCRIPTION
... because std::erase cannot be compiled under linux without using any experimental features

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Removed std::erase and replaced it with Container.remove(element)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Fix build issues under linux introduced in https://github.com/azerothcore/azerothcore-wotlk/pull/12731

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds again on my machine with `c++ (Debian 8.3.0-6) 8.3.0`
```
[100%] Linking CXX executable worldserver
cd /tank/development/projects/azerothcore/build/src/server/apps && /usr/local/bin/cmake -E cmake_link_script CMakeFiles/worldserver.dir/link.txt --verbose=1
/usr/bin/c++ -O2 -g -DNDEBUG -pthread -lncurses  CMakeFiles/worldserver.dir/worldserver/Main.cpp.o CMakeFiles/worldserver.dir/worldserver/ACSoap/ACSoap.cpp.o CMakeFiles/worldserver.dir/worldserver/CommandLine/CliRunnable.cpp.o CMakeFiles/worldserver.dir/worldserver/RemoteAccess/RASession.cpp.o -o worldserver  -Wl,-rpath,::::::::::::::::::::::::::::::::: ../../../modules/libmodules.a ../scripts/libscripts.a ../game/libgame.a ../../../deps/gsoap/libgsoap.a /usr/lib/x86_64-linux-gnu/libreadline.so ../shared/libshared.a ../database/libdatabase.a /usr/lib/x86_64-linux-gnu/libmariadb.so ../../common/libcommon.a /usr/lib/x86_64-linux-gnu/libboost_system.so.1.74.0 /usr/lib/x86_64-linux-gnu/libboost_filesystem.so.1.74.0 /usr/lib/x86_64-linux-gnu/libboost_program_options.so.1.74.0 /usr/lib/x86_64-linux-gnu/libboost_iostreams.so.1.74.0 /usr/lib/x86_64-linux-gnu/libboost_regex.so.1.74.0 ../../../deps/argon2/libargon2.a ../../../deps/SFMT/libsfmt.a /usr/lib/x86_64-linux-gnu/libssl.so /usr/lib/x86_64-linux-gnu/libcrypto.so ../../../deps/jemalloc/libjemalloc.a -ldl -lstdc++fs ../../../deps/fmt/libfmt.a ../../../deps/g3dlite/libg3dlib.a -lpthread ../../../deps/recastnavigation/Detour/libDetour.a /usr/lib/x86_64-linux-gnu/libz.so
make[2]: Leaving directory '/tank/development/projects/azerothcore/build'
[100%] Built target worldserver
make[1]: Leaving directory '/tank/development/projects/azerothcore/build'
/usr/local/bin/cmake -E cmake_progress_start /tank/development/projects/azerothcore/build/CMakeFiles 0
```


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run `cmake -S. -Bbuild -DTOOLS_BUILD=all -DCMAKE_INSTALL_PREFIX=/tank/game_server/azerothcore/ -DWITH_WARNINGS=1 -DSCRIPTS=static -DMODULES=static -DCMAKE_VERBOSE_MAKEFILE=ON` and `(cd build; make)`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
