### PR TITLE
fix(Scripts/Quest): Aggro Talk text targets player

### DIFF
--- a/src/server/scripts/Kalimdor/zone_ungoro_crater.cpp
+++ b/src/server/scripts/Kalimdor/zone_ungoro_crater.cpp
@@ -87,19 +87,25 @@ public:
                 switch (waypointId)
                 {
                     case 19:
-                        me->SummonCreature(ENTRY_STOMPER, -6391.69f, -1730.49f, -272.83f, 4.96f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 25000);
-                        Talk(SAY_AGGRO1, player);
+                        if (Creature* summoned = me->SummonCreature(ENTRY_STOMPER, -6391.69f, -1730.49f, -272.83f, 4.96f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 25000))
+                        {
+                            Talk(SAY_AGGRO1, summoned);
+                        }
                         break;
                     case 28:
                         Talk(SAY_SEARCH, player);
                         break;
                     case 38:
-                        me->SummonCreature(ENTRY_TARLORD, -6370.75f, -1382.84f, -270.51f, 6.06f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 25000);
-                        Talk(SAY_AGGRO2, player);
+                         if (Creature* summoned = me->SummonCreature(ENTRY_TARLORD, -6370.75f, -1382.84f, -270.51f, 6.06f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 25000))
+                         {
+                            Talk(SAY_AGGRO2, summoned);
+                         }
                         break;
                     case 49:
-                        me->SummonCreature(ENTRY_TARLORD1, -6324.44f, -1181.05f, -270.17f, 4.34f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 25000);
-                        Talk(SAY_AGGRO3, player);
+                        if (Creature* summoned = me->SummonCreature(ENTRY_TARLORD1, -6324.44f, -1181.05f, -270.17f, 4.34f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 25000))
+                        {
+                            Talk(SAY_AGGRO3, summoned);
+                        }
                         break;
                     case 55:
                         Talk(SAY_FINISH, player);


### PR DESCRIPTION
Aggro dialog targets player. It should target the summoned creature instead

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change target player to summoned

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12871

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
![12871_dialog](https://user-images.githubusercontent.com/74299960/188276039-a7a28d7d-9004-41ce-ba19-8a025702ba74.png)



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Add prequest
.quest add 4243
.go c 24268
.add 10561
start escort q


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
