### PR TITLE
fix(DB/SmartAI): Stinky's Escape Combat and Talk

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1662218420827674409.sql
+++ b/data/sql/updates/pending_db_world/rev_1662218420827674409.sql
@@ -1,0 +1,11 @@
+--
+-- Remove setting react state 2. Set react state when waypoint starts to 1
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 488000) AND (`source_type` = 9) AND (`id` IN (3,5));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(488000, 9, 5, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 53, 0, 4880, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, '"Stinky" Ignatz - Script - Start WP');
+-- Update talk target to victim for line 10
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 4880) AND (`source_type` = 0) AND (`id` IN (26));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(4880, 0, 26, 0, 0, 0, 100, 0, 1000, 1000, 30000, 30000, 0, 1, 10, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, '"Stinky" Ignatz - IC  - Say Line 10');
+-- Disable assist player
+UPDATE `creature_template` SET `type_flags` = `type_flags`&~4096 WHERE (`entry` = 4880);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
"Stinky" Ignatz does not attack NPCs and his IC dialogue targets the player instead of his target 

## Changes Proposed:
-  Remove setting react state 2. Set react state when waypoint starts to 1
- Update talk target to victim for line 10
- Disable assist player flag in template

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
Closes: https://github.com/azerothcore/azerothcore-wotlk/issues/7624

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
.go c 68946                                                                     
start quest
As described in the issue

1. Player attacks mob - Escortee does not react 
2. When Escortee gets attacked by a mob it should react

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
