### PR TITLE
Fix AI flee logic: creatures should finish casting any current spells before fleeing

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -4054,6 +4054,13 @@ void SmartScript::UpdateTimer(SmartScriptHolder& e, uint32 const diff)
             }
         }
 
+        // Delay flee for assist event if casting
+        if (e.GetActionType() == SMART_ACTION_FLEE_FOR_ASSIST && me && me->HasUnitState(UNIT_STATE_CASTING))
+        {
+            e.timer = 1;
+            return;
+        }
+
         e.active = true;//activate events with cooldown
         switch (e.GetEventType())//process ONLY timed events
         {


### PR DESCRIPTION
## Changes Proposed:
- Make AI finish cast before fleeing.
- Patch originally written for TrinityCore: https://github.com/TrinityCore/TrinityCore/pull/28228

## Issues Addressed:
- Currently, AI will cancel casting in order to flee. This is not how it worked in Wrath- they will finish casting, and then flee.

## SOURCE:
- Joana 42-43 STV grind, watch the warlock finish the cast before fleeing around the 8:30 mark https://youtu.be/NmuWN_3Qkec?t=509
- Continue watching the video and observe the behavior is consistent
- Also consider watching other parts of the speedrun where Joana fights humanoids that tend to run

## Tests Performed:
- Built and deployed to personal AC instance running on Linux
- Tested with enemies at Gold Coast Quarry in Westfall

## How to Test the Changes:
1. Either `.go c id 589` or `.tele GoldCoastQuarry`.
2. Get into combat with a Defias Pillager (which was id 589).
3. Damage the opponent below 15% health while they are casting.
4. Observe that they wait until finishing fireball before running for help.

## Known Issues and TODO List:
- When I wrote the TrinityCore patch, there was some special flee logic for BFD and Nagrand. This does not seem to be present in AC, but if there are any other such special flee logics, I may need to amend this PR. I did not spot any other places that this needed to be changed.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
