### PR TITLE
fix(DB/loot): Remove AQ40 Idols from AQ20

### DIFF
--- a/data/sql/updates/pending_db_world/Remove-AQ40-idols-from-AQ20.sql
+++ b/data/sql/updates/pending_db_world/Remove-AQ40-idols-from-AQ20.sql
@@ -21,3 +21,4 @@ OR Entry = 15355 #Anubisath Guardian
 OR Entry = 15386 #Major Yeggeth
 OR Entry = 15392 #Captain Tuubid
 );
+

--- a/data/sql/updates/pending_db_world/Remove-AQ40-idols-from-AQ20.sql
+++ b/data/sql/updates/pending_db_world/Remove-AQ40-idols-from-AQ20.sql
@@ -1,24 +1,24 @@
 DELETE FROM creature_loot_template
-WHERE (
-Item = 20874 #Idol of the Sun
-OR Item = 20875 #Idol of Night
-OR Item = 20876 #Idol of Death
-OR Item = 20877 #Idol of the Sage
-OR Item = 20878 #Idol of Rebirth
-OR Item = 20879 #Idol of Life
-OR Item = 20881 #Idol of Strife
-OR Item = 20882 #Idol of War
-) AND (
-Entry = 15318 #Hive'Zara Drone
-OR Entry = 15323 #Hive'Zara Sandstalker
-OR Entry = 15325 #Hive'Zara Wasp
-OR Entry = 15327 #Hive'Zara Stinger
-OR Entry = 15333 #Silicate Feeder
-OR Entry = 15336 #Hive'Zara Tail Lasher
-OR Entry = 15338 #Obsidian Destroyer
-OR Entry = 15343 #Qiraji Swarmguard
-OR Entry = 15355 #Anubisath Guardian
-OR Entry = 15386 #Major Yeggeth
-OR Entry = 15392 #Captain Tuubid
+WHERE Item IN (
+	20874, #Idol of the Sun
+	20875, #Idol of Night
+	20876, #Idol of Death
+	20877, #Idol of the Sage
+	20878, #Idol of Rebirth
+	20879, #Idol of Life
+	20881, #Idol of Strife
+	20882  #Idol of War
+) AND Entry IN (
+	15318, #Hive'Zara Drone
+	15323, #Hive'Zara Sandstalker
+	15325, #Hive'Zara Wasp
+	15327, #Hive'Zara Stinger
+	15333, #Silicate Feeder
+	15336, #Hive'Zara Tail Lasher
+	15338, #Obsidian Destroyer
+	15343, #Qiraji Swarmguard
+	15355, #Anubisath Guardian
+	15386, #Major Yeggeth
+	15392  #Captain Tuubid
 );
 

--- a/data/sql/updates/pending_db_world/Remove-AQ40-idols-from-AQ20.sql
+++ b/data/sql/updates/pending_db_world/Remove-AQ40-idols-from-AQ20.sql
@@ -1,0 +1,23 @@
+DELETE FROM creature_loot_template
+WHERE (
+Item = 20874 #Idol of the Sun
+OR Item = 20875 #Idol of Night
+OR Item = 20876 #Idol of Death
+OR Item = 20877 #Idol of the Sage
+OR Item = 20878 #Idol of Rebirth
+OR Item = 20879 #Idol of Life
+OR Item = 20881 #Idol of Strife
+OR Item = 20882 #Idol of War
+) AND (
+Entry = 15318 #Hive'Zara Drone
+OR Entry = 15323 #Hive'Zara Sandstalker
+OR Entry = 15325 #Hive'Zara Wasp
+OR Entry = 15327 #Hive'Zara Stinger
+OR Entry = 15333 #Silicate Feeder
+OR Entry = 15336 #Hive'Zara Tail Lasher
+OR Entry = 15338 #Obsidian Destroyer
+OR Entry = 15343 #Qiraji Swarmguard
+OR Entry = 15355 #Anubisath Guardian
+OR Entry = 15386 #Major Yeggeth
+OR Entry = 15392 #Captain Tuubid
+);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove the AQ40 idols from AQ20.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes none, I didn't bother opening an issue.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Wowhead only shows that the AQ40 idols only drops from Temple of Ahn'Qiraj.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- I ran the following query and it gave me nothing after I executed the deletion.
```SQL
SELECT *
FROM /*acore_world.*/creature_loot_template
WHERE Item IN (
	20874, #Idol of the Sun
	20875, #Idol of Night
	20876, #Idol of Death
	20877, #Idol of the Sage
	20878, #Idol of Rebirth
	20879, #Idol of Life
	20881, #Idol of Strife
	20882  #Idol of War
) AND Entry IN (
	15318, #Hive'Zara Drone
	15323, #Hive'Zara Sandstalker
	15325, #Hive'Zara Wasp
	15327, #Hive'Zara Stinger
	15333, #Silicate Feeder
	15336, #Hive'Zara Tail Lasher
	15338, #Obsidian Destroyer
	15343, #Qiraji Swarmguard
	15355, #Anubisath Guardian
	15386, #Major Yeggeth
	15392  #Captain Tuubid
)
```

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.Run the above's select query, you'll see 18 lines that only have mobs from AQ20 having AQ40 idols drops.
2.Do the delete query, you'll see 18 lines deleted.
3.Run the select query, you won't see any lines.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
