### PR TITLE
fix(Core/Spell): Mixology does not grant benefits

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1585,7 +1585,7 @@ void Aura::HandleAuraSpecificMods(AuraApplication const* aurApp, Unit* caster, b
                 {
                     if (sSpellMgr->GetSpellGroup(GetId()) == 1) /*Elixirs*/
                     {
-                        if (caster->HasSpell(GetSpellInfo()->Effects[EFFECT_0].TriggerSpell))
+                        if (GetSpellInfo()->Effects[EFFECT_0].TriggerSpell > 0)
                         {
                             for (int i = 0; i < MAX_SPELL_EFFECTS; ++i)
                                 if (GetEffect(i))


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Found during https://github.com/azerothcore/azerothcore-wotlk/pull/12982 that Mixology does not work.

## Changes Proposed:
- Change the condition to see if there's a triggered spell

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

`acore_world.spell_mixology`
|entry|pctMod|
|-----|------|
|28497|44.4|
|33721|40.0|
|53746|44.4|
...

28497, Elixir of Mighty Agility (item: 39666)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Alliance alch trainer
.go c 79832
.setskill 171 450 450
can learn mixology from trainer

Add Elixir of Mighty Agility
.additem 39666 20

1. Use elixir without mixology: +45 agility and 1 hour duration

2. Use elixir with mixology: +45 agility plus 44.4% bonus (+64 agility) for 2 hours. 

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
