### PR TITLE
fix(DB/creature_template): Import AQ40 values from Vmangos missing in previous PR

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1662487488595481700.sql
+++ b/data/sql/updates/pending_db_world/rev_1662487488595481700.sql
@@ -2,8 +2,10 @@
 UPDATE `creature_template` SET `DamageModifier` = 1.05, `ArmorModifier` = 1.1 WHERE (`entry` = 15316);
 UPDATE `creature_template` SET `ArmorModifier` = 1.1 WHERE (`entry` = 15317);
 UPDATE `creature_template` SET `DamageModifier` = 20, `ArmorModifier` = 1.15 WHERE (`entry` = 15246);
+UPDATE `creature_template` SET `DamageModifier` = 3, `ArmorModifier` = 1.15 WHERE (`entry` = 15537);
+UPDATE `creature_template` SET `DamageModifier` = 9.75, `ArmorModifier` = 1.15 WHERE (`entry` = 15538);
 
-DELETE FROM `creature_template_resistance` WHERE `CreatureID` IN (15316,15317,15246);
+DELETE FROM `creature_template_resistance` WHERE `CreatureID` IN (15316,15317,15246,15537,15538);
 INSERT INTO `creature_template_resistance` (`CreatureID`, `School`, `Resistance`, `VerifiedBuild`) VALUES
 (15316, 2, 75, 0),
 (15316, 3, 75, 0),
@@ -19,4 +21,14 @@ INSERT INTO `creature_template_resistance` (`CreatureID`, `School`, `Resistance`
 (15246, 3, 75, 0),
 (15246, 4, 75, 0),
 (15246, 5, 75, 0),
-(15246, 6, 75, 0);
+(15246, 6, 75, 0),
+(15537, 2, 75, 0),
+(15537, 3, 75, 0),
+(15537, 4, 75, 0),
+(15537, 5, 75, 0),
+(15537, 6, 75, 0),
+(15538, 2, 115, 0),
+(15538, 3, 115, 0),
+(15538, 4, 115, 0),
+(15538, 5, 115, 0),
+(15538, 6, 115, 0);

--- a/data/sql/updates/pending_db_world/rev_1662487488595481700.sql
+++ b/data/sql/updates/pending_db_world/rev_1662487488595481700.sql
@@ -1,0 +1,22 @@
+-- I forgot these
+UPDATE `creature_template` SET `DamageModifier` = 1.05, `ArmorModifier` = 1.1 WHERE (`entry` = 15316);
+UPDATE `creature_template` SET `ArmorModifier` = 1.1 WHERE (`entry` = 15317);
+UPDATE `creature_template` SET `DamageModifier` = 20, `ArmorModifier` = 1.15 WHERE (`entry` = 15246);
+
+DELETE FROM `creature_template_resistance` WHERE (`CreatureID` = 15316) AND (`School` IN (2, 3, 4, 5, 6));
+INSERT INTO `creature_template_resistance` (`CreatureID`, `School`, `Resistance`, `VerifiedBuild`) VALUES
+(15316, 2, 75, 0),
+(15316, 3, 75, 0),
+(15316, 4, 75, 0),
+(15316, 5, 75, 0),
+(15316, 6, 75, 0),
+(15317, 2, 75, 0),
+(15317, 3, 75, 0),
+(15317, 4, 75, 0),
+(15317, 5, 75, 0),
+(15317, 6, 75, 0),
+(15246, 2, 75, 0),
+(15246, 3, 75, 0),
+(15246, 4, 75, 0),
+(15246, 5, 75, 0),
+(15246, 6, 75, 0);

--- a/data/sql/updates/pending_db_world/rev_1662487488595481700.sql
+++ b/data/sql/updates/pending_db_world/rev_1662487488595481700.sql
@@ -3,7 +3,7 @@ UPDATE `creature_template` SET `DamageModifier` = 1.05, `ArmorModifier` = 1.1 WH
 UPDATE `creature_template` SET `ArmorModifier` = 1.1 WHERE (`entry` = 15317);
 UPDATE `creature_template` SET `DamageModifier` = 20, `ArmorModifier` = 1.15 WHERE (`entry` = 15246);
 
-DELETE FROM `creature_template_resistance` WHERE (`CreatureID` = 15316) AND (`School` IN (2, 3, 4, 5, 6));
+DELETE FROM `creature_template_resistance` WHERE `CreatureID` IN (15316,15317,15246);
 INSERT INTO `creature_template_resistance` (`CreatureID`, `School`, `Resistance`, `VerifiedBuild`) VALUES
 (15316, 2, 75, 0),
 (15316, 3, 75, 0),


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Modifies values for entries 15316, 15317, 15246, 15537 and 15538
-  Also adds resistance values

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unopened issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Query ran multiple times
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
