### PR TITLE
fix(DB/loot): Add missing Warlock grimoires to AQ20 loot

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1662632661986479800.sql
+++ b/data/sql/updates/pending_db_world/rev_1662632661986479800.sql
@@ -1,0 +1,6 @@
+--
+DELETE FROM `reference_loot_template` WHERE `Entry`=34024 AND `Item` BETWEEN 21281 AND 21283;
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Chance`, `GroupId`, `Comment`) VALUES
+(34024, 21281, 0, 3, 'Grimoire of Shadow Bolt X'),
+(34024, 21282, 0, 3, 'Grimoire of Immolate VIII'),
+(34024, 21283, 0, 3, 'Grimoire of Corruption VII');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Adds items Grimoire of Shadow Bolt X, Grimoire of Immolate VIII and Grimoire of Corruption VII to reference entry 34024

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/4042

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Cmangos Classic

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go c 144603`
2. kill the boss until one of the 3 items drop

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
