### PR TITLE
fix(Scripts/Emerald Dragons: Fixed Dream Fog following only one playe…

### DIFF
--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -154,6 +154,8 @@ struct emerald_dragonAI : public WorldBossAI
         {
             summon->AI()->SetGUID(me->GetGUID(), GUID_DRAGON);
         }
+
+        summons.Summon(summon);
     }
 
     void UpdateAI(uint32 diff) override
@@ -207,6 +209,7 @@ public:
                 }
                 else
                 {
+                    _targetGUID.Clear();
                     me->GetMotionMaster()->Clear();
                     me->GetMotionMaster()->MoveRandom(25.0f);
                     context.Repeat(2500ms);
@@ -239,7 +242,10 @@ public:
             {
                 if (dragon->GetAI())
                 {
-                    return dragon->GetAI()->SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true);
+                    return dragon->GetAI()->SelectTarget(SelectTargetMethod::Random, 0, [&](Unit* u)
+                    {
+                        return u && u->IsPlayer() && u->GetGUID() != _targetGUID;
+                    });
                 }
             }
 


### PR DESCRIPTION
…r per lifetime.

Fixes #12276

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12276

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Teleport to any of the following locations with at least 2 characters
`.tele twilightgrove`
`.tele seradane`
`.tele dreambough`
`.tele boughshadow`
2. See if Dream Fog changes targets every time it reaches its current one.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
