### PR TITLE
fix(Core): Correct Quest Details Display at Max Level

### DIFF
--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -450,10 +450,26 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* quest, ObjectGuid npcGU
                 data << uint32(0);
         }
 
-        uint8 playerLevel = _session->GetPlayer() ? _session->GetPlayer()->getLevel() : 0;
-        data << uint32(quest->GetRewOrReqMoney(playerLevel));
-        uint32 questXp = uint32(quest->XPValue(playerLevel) * _session->GetPlayer()->GetQuestRate());
-        sScriptMgr->OnQuestComputeXP(_session->GetPlayer(), quest, questXp);
+        uint32 moneyRew = 0;
+        Player* player = _session->GetPlayer();
+        uint8 playerLevel = player ? player->getLevel() : 0;
+        if (player && (player->getLevel() >= sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL) || sScriptMgr->ShouldBeRewardedWithMoneyInsteadOfExp(player)))
+        {
+            moneyRew = quest->GetRewMoneyMaxLevel();
+        }
+        moneyRew += quest->GetRewOrReqMoney(player ? player->getLevel() : 0); // reward money (below max lvl)
+        data << moneyRew;
+        uint32 questXp;
+        if (player && !sScriptMgr->ShouldBeRewardedWithMoneyInsteadOfExp(player))
+        {
+            questXp = uint32(quest->XPValue(playerLevel) * player->GetQuestRate());
+        }
+        else
+        {
+            questXp = 0;
+
+        }
+        sScriptMgr->OnQuestComputeXP(player, quest, questXp);
         data << questXp;
     }
 
@@ -535,7 +551,16 @@ void PlayerMenu::SendQuestQueryResponse(Quest const* quest) const
     if (quest->HasFlag(QUEST_FLAGS_HIDDEN_REWARDS))
         data << uint32(0);                                  // Hide money rewarded
     else
-        data << uint32(quest->GetRewOrReqMoney(_session->GetPlayer() ? _session->GetPlayer()->getLevel() : 0)); // reward money (below max lvl)
+    {
+        uint32 moneyRew = 0;
+        Player* player = _session->GetPlayer();
+        if (player && (player->getLevel() >= sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL) || sScriptMgr->ShouldBeRewardedWithMoneyInsteadOfExp(player)))
+        {
+            moneyRew = quest->GetRewMoneyMaxLevel();
+        }
+        moneyRew += quest->GetRewOrReqMoney(player ? player->getLevel() : 0); // reward money (below max lvl)
+        data << moneyRew;
+    }
 
     data << uint32(quest->GetRewMoneyMaxLevel());           // used in XP calculation at client
     data << uint32(quest->GetRewSpell());                   // reward spell, this spell will display (icon) (cast if RewSpellCast == 0)
@@ -679,11 +704,26 @@ void PlayerMenu::SendQuestGiverOfferReward(Quest const* quest, ObjectGuid npcGUI
             data << uint32(0);
     }
 
-    uint8 playerLevel = _session->GetPlayer() ? _session->GetPlayer()->getLevel() : 0;
+    uint32 moneyRew = 0;
+    Player* player = _session->GetPlayer();
+    uint8 playerLevel = player ? player->getLevel() : 0;
+    if (player && (player->getLevel() >= sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL) || sScriptMgr->ShouldBeRewardedWithMoneyInsteadOfExp(player)))
+    {
+        moneyRew = quest->GetRewMoneyMaxLevel();
+    }
+    moneyRew += quest->GetRewOrReqMoney(player ? player->getLevel() : 0); // reward money (below max lvl)
+    data << moneyRew;
+    uint32 questXp;
+    if (player && !sScriptMgr->ShouldBeRewardedWithMoneyInsteadOfExp(player))
+    {
+        questXp = uint32(quest->XPValue(playerLevel) * player->GetQuestRate());
+    }
+    else
+    {
+        questXp = 0;
 
-    data << uint32(quest->GetRewOrReqMoney(playerLevel));
-    uint32 questXp = uint32(quest->XPValue(playerLevel) * _session->GetPlayer()->GetQuestRate());
-    sScriptMgr->OnQuestComputeXP(_session->GetPlayer(), quest, questXp);
+    }
+    sScriptMgr->OnQuestComputeXP(player, quest, questXp);
     data << questXp;
 
     // rewarded honor points. Multiply with 10 to satisfy client

--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -467,7 +467,6 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* quest, ObjectGuid npcGU
         else
         {
             questXp = 0;
-
         }
         sScriptMgr->OnQuestComputeXP(player, quest, questXp);
         data << questXp;
@@ -721,7 +720,6 @@ void PlayerMenu::SendQuestGiverOfferReward(Quest const* quest, ObjectGuid npcGUI
     else
     {
         questXp = 0;
-
     }
     sScriptMgr->OnQuestComputeXP(player, quest, questXp);
     data << questXp;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2526,7 +2526,9 @@ void Player::InitStatsForLevel(bool reapplyMods)
     PlayerLevelInfo info;
     sObjectMgr->GetPlayerLevelInfo(getRace(true), getClass(), getLevel(), &info);
 
-    SetUInt32Value(PLAYER_FIELD_MAX_LEVEL, sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL));
+    uint32 maxPlayerLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
+    sScriptMgr->OnSetMaxLevel(this, maxPlayerLevel);
+    SetUInt32Value(PLAYER_FIELD_MAX_LEVEL, maxPlayerLevel);
     SetUInt32Value(PLAYER_NEXT_LEVEL_XP, sObjectMgr->GetXPForLevel(getLevel()));
 
     // reset before any aura state sources (health set/aura apply)

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -621,6 +621,14 @@ void ScriptMgr::OnFirstLogin(Player* player)
     });
 }
 
+void ScriptMgr::OnSetMaxLevel(Player* player, uint32& maxPlayerLevel)
+{
+    ExecuteScript<PlayerScript>([&](PlayerScript* script)
+    {
+        script->OnSetMaxLevel(player, maxPlayerLevel);
+    });
+}
+
 bool ScriptMgr::CanJoinInBattlegroundQueue(Player* player, ObjectGuid BattlemasterGuid, BattlegroundTypeId BGTypeID, uint8 joinAsGroup, GroupJoinBattlegroundResult& err)
 {
     auto ret = IsValidBoolScript<PlayerScript>([&](PlayerScript* script)

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -1208,6 +1208,8 @@ public:
 
     virtual void OnFirstLogin(Player* /*player*/) { }
 
+    virtual void OnSetMaxLevel(Player* /*player*/, uint32& /*maxPlayerLevel*/) { }
+
     [[nodiscard]] virtual bool CanJoinInBattlegroundQueue(Player* /*player*/, ObjectGuid /*BattlemasterGuid*/, BattlegroundTypeId /*BGTypeID*/, uint8 /*joinAsGroup*/, GroupJoinBattlegroundResult& /*err*/) { return true; }
     virtual bool ShouldBeRewardedWithMoneyInsteadOfExp(Player* /*player*/) { return false; }
 
@@ -2268,6 +2270,7 @@ public: /* PlayerScript */
     void OnAfterUpdateAttackPowerAndDamage(Player* player, float& level, float& base_attPower, float& attPowerMod, float& attPowerMultiplier, bool ranged);
     void OnBeforeInitTalentForLevel(Player* player, uint8& level, uint32& talentPointsForLevel);
     void OnFirstLogin(Player* player);
+    void OnSetMaxLevel(Player* player, uint32& maxPlayerLevel);
     void OnPlayerCompleteQuest(Player* player, Quest const* quest);
     void OnBattlegroundDesertion(Player* player, BattlegroundDesertionType const desertionType);
     bool CanJoinInBattlegroundQueue(Player* player, ObjectGuid BattlemasterGuid, BattlegroundTypeId BGTypeID, uint8 joinAsGroup, GroupJoinBattlegroundResult& err);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fixes several issue with quest reward display:
- Shows correct money value received if player is at max level
- Respect MaxPlayerLevel config setting and ShouldBeRewardedWithMoneyInsteadOfExp Hook when determining XP and Money to display
- Add OnSetMaxLevel hook to be able to programmatically set max level client data value, used together with ShouldBeRewardedWithmoneyInsteadOfExp to ensure proper client display of money and XP

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue
- Also closes https://github.com/ZhengPeiRu21/mod-individual-progression/issues/27

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in game at Quest Details menu, Reward Quest menu, and Quest Log menu at not max level, max level set through Config at 60 and at 80, and with ShouldBeRewardedWithMoneyInsteadOfExp hook value on and off.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Look at above mentioned menus at various level cap settings.
2. Please ensure to clear client cache between changing levels and config settings, as this data is cached

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- Quest Log details UI still does not show correct XP value when modified by Rate.XP.Quest config or through OnBeforeComputeQuestXP hook, but this is handled entirely client side and cannot be fixed

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
