### PR TITLE
fix(Core/Smart Scripts): Add param5 flag for range event

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3431,7 +3431,7 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
                 if (me->IsInRange(me->GetVictim(), (float)e.event.minMaxRepeat.min, (float)e.event.minMaxRepeat.max))
                     ProcessTimedAction(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax, me->GetVictim());
                 else
-                {   
+                {
                     if (!e.event.minMaxRepeat.controller)
                         RecalcTimer(e, 500, 500); // xinef: make it predictable "Malcrom: This seems to be done to standardize min, max start rather than using the range values for the timer."
                     else

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3430,8 +3430,14 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
 
                 if (me->IsInRange(me->GetVictim(), (float)e.event.minMaxRepeat.min, (float)e.event.minMaxRepeat.max))
                     ProcessTimedAction(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax, me->GetVictim());
-                else // xinef: make it predictable
-                    RecalcTimer(e, 500, 500);
+                else
+                {   
+                    if (!e.event.minMaxRepeat.controller)
+                        RecalcTimer(e, 500, 500); // xinef: make it predictable "Malcrom: This seems to be done to standardize min, max start rather than using the range values for the timer."
+                    else
+                        RecalcTimer(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax); // Malcrom: if param5 value is greater than 0 first action will not happen until after repeat timer fires.
+                }
+
                 break;
             }
         case SMART_EVENT_VICTIM_CASTING:

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3437,7 +3437,6 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
                     else
                         RecalcTimer(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax); // Malcrom: if param5 value is greater than 0 first action will not happen until after repeat timer fires.
                 }
-
                 break;
             }
         case SMART_EVENT_VICTIM_CASTING:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -221,6 +221,7 @@ struct SmartEvent
             uint32 max;
             uint32 repeatMin;
             uint32 repeatMax;
+            uint32 controller;
         } minMaxRepeat;
 
         struct


### PR DESCRIPTION
## Changes Proposed:
-  Add ability to set flag in param5 to prevent Range Event from activating on entering combat thus only after the repeat timer occurs.

## Issues Addressed:
The Range Event is a much better choice for the Frost Nova spell over In Combat timers due to the fact that the spell should not be cast unless the player is in range.

Currently the event will cast the spell in entering combat which is not desirable.

## SOURCE:
Malcrom

## Tests Performed:
- Tested in game with and without flag

## How to Test the Changes:
1. Recompile with changes
2. Test without flag
3. Insert ```UPDATE `smart_scripts` SET `event_type`=9, `event_chance`=75, `event_param1`=0, `event_param2`=8, `event_param3`=10000, `event_param4`=15000, `event_param5`=0, `action_param2`=1, `target_type`=1, `comment`="Boulderfist Magus - Within 0-8 Range - Cast 'Frost Nova'" WHERE `entryorguid`=2567 AND `source_type`=0 AND `id`=3;``` 
4. .go c 14665
5. enter combat
6. Test with flag
7. Insert ```UPDATE `smart_scripts` SET `event_type`=9, `event_chance`=75, `event_param1`=0, `event_param2`=8, `event_param3`=10000, `event_param4`=15000, `event_param5`=1, `action_param2`=1, `target_type`=1, `comment`="Boulderfist Magus - Within 0-8 Range - Cast 'Frost Nova'" WHERE `entryorguid`=2567 AND `source_type`=0 AND `id`=3;``` 

After testing you should see the Frost Nova is cast in entering combat without flag and not until repeat timer occurs with flag.