### PR TITLE
Feature(Smart Scripts/SMART_EVENT_RANGE): Proper fix to prevent Initial timer

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3424,25 +3424,25 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
                 break;
             }
         case SMART_EVENT_RANGE:
-        {
-            if (!me || !me->IsEngaged() || !me->GetVictim())
-                return;
-
-            if (me->IsInRange(me->GetVictim(), (float)e.event.rangeRepeat.minRange, (float)e.event.rangeRepeat.maxRange))
             {
-                if (e.event.rangeRepeat.onlyFireOnRepeat == 2)
+                if (!me || !me->IsEngaged() || !me->GetVictim())
+                    return;
+
+                if (me->IsInRange(me->GetVictim(), (float)e.event.rangeRepeat.minRange, (float)e.event.rangeRepeat.maxRange))
                 {
-                    e.event.rangeRepeat.onlyFireOnRepeat = 1;
-                    RecalcTimer(e, e.event.rangeRepeat.repeatMin, e.event.rangeRepeat.repeatMax);
+                    if (e.event.rangeRepeat.onlyFireOnRepeat == 2)
+                    {
+                        e.event.rangeRepeat.onlyFireOnRepeat = 1;
+                        RecalcTimer(e, e.event.rangeRepeat.repeatMin, e.event.rangeRepeat.repeatMax);
+                    }
+                    else
+                        ProcessTimedAction(e, e.event.rangeRepeat.repeatMin, e.event.rangeRepeat.repeatMax, me->GetVictim());
                 }
                 else
-                    ProcessTimedAction(e, e.event.rangeRepeat.repeatMin, e.event.rangeRepeat.repeatMax, me->GetVictim());
-            }
-            else
-                RecalcTimer(e, 500, 500); // make it predictable
+                    RecalcTimer(e, 500, 500); // make it predictable
 
-            break;
-        }
+                break;
+            }
         case SMART_EVENT_VICTIM_CASTING:
             {
                 if (!me || !me->IsEngaged())

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3424,21 +3424,25 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
                 break;
             }
         case SMART_EVENT_RANGE:
-            {
-                if (!me || !me->IsEngaged() || !me->GetVictim())
-                    return;
+        {
+            if (!me || !me->IsEngaged() || !me->GetVictim())
+                return;
 
-                if (me->IsInRange(me->GetVictim(), (float)e.event.minMaxRepeat.min, (float)e.event.minMaxRepeat.max))
-                    ProcessTimedAction(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax, me->GetVictim());
-                else
+            if (me->IsInRange(me->GetVictim(), (float)e.event.rangeRepeat.minRange, (float)e.event.rangeRepeat.maxRange))
+            {
+                if (e.event.rangeRepeat.onlyFireOnRepeat == 2)
                 {
-                    if (!e.event.minMaxRepeat.controller)
-                        RecalcTimer(e, 500, 500); // xinef: make it predictable "Malcrom: This seems to be done to standardize min, max start rather than using the range values for the timer."
-                    else
-                        RecalcTimer(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax); // Malcrom: if param5 value is greater than 0 first action will not happen until after repeat timer fires.
+                    e.event.rangeRepeat.onlyFireOnRepeat = 1;
+                    RecalcTimer(e, e.event.rangeRepeat.repeatMin, e.event.rangeRepeat.repeatMax);
                 }
-                break;
+                else
+                    ProcessTimedAction(e, e.event.rangeRepeat.repeatMin, e.event.rangeRepeat.repeatMax, me->GetVictim());
             }
+            else
+                RecalcTimer(e, 500, 500); // make it predictable
+
+            break;
+        }
         case SMART_EVENT_VICTIM_CASTING:
             {
                 if (!me || !me->IsEngaged())
@@ -4000,6 +4004,13 @@ void SmartScript::InitTimer(SmartScriptHolder& e)
     switch (e.GetEventType())
     {
         //set only events which have initial timers
+        case SMART_EVENT_RANGE:
+            // If onlyFireOnRepeat is true set to 2 before entering combat. Will be set back to 1 after entering combat to ignore initial firing.
+            if (e.event.rangeRepeat.onlyFireOnRepeat == 1)
+                e.event.rangeRepeat.onlyFireOnRepeat = 2;
+            // make it predictable
+            RecalcTimer(e, 500, 500);
+            break;
         case SMART_EVENT_NEAR_PLAYERS:
         case SMART_EVENT_NEAR_PLAYERS_NEGATION:
             RecalcTimer(e, e.event.nearPlayer.firstTimer, e.event.nearPlayer.firstTimer);

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -260,7 +260,6 @@ void SmartAIMgr::LoadSmartAIFromDB()
             case SMART_EVENT_TARGET_HEALTH_PCT:
             case SMART_EVENT_MANA_PCT:
             case SMART_EVENT_TARGET_MANA_PCT:
-            case SMART_EVENT_RANGE:
             case SMART_EVENT_FRIENDLY_HEALTH:
             case SMART_EVENT_FRIENDLY_HEALTH_PCT:
             case SMART_EVENT_FRIENDLY_MISSING_BUFF:
@@ -268,6 +267,13 @@ void SmartAIMgr::LoadSmartAIFromDB()
             case SMART_EVENT_TARGET_BUFFED:
                 if (temp.event.minMaxRepeat.repeatMin == 0 && temp.event.minMaxRepeat.repeatMax == 0)
                     temp.event.event_flags |= SMART_EVENT_FLAG_NOT_REPEATABLE;
+                break;
+            case SMART_EVENT_RANGE:
+                if (temp.event.rangeRepeat.repeatMin == 0 && temp.event.rangeRepeat.repeatMax == 0)
+                    temp.event.event_flags |= SMART_EVENT_FLAG_NOT_REPEATABLE;
+                // Will only work properly if value is 0 or 1
+                if (temp.event.rangeRepeat.onlyFireOnRepeat > 1)
+                    temp.event.rangeRepeat.onlyFireOnRepeat = 1;
                 break;
             case SMART_EVENT_VICTIM_CASTING:
             case SMART_EVENT_IS_BEHIND_TARGET:
@@ -472,7 +478,7 @@ bool SmartAIMgr::CheckUnusedEventParams(SmartScriptHolder const& e)
             case SMART_EVENT_DEATH: return NO_PARAMS;
             case SMART_EVENT_EVADE: return NO_PARAMS;
             case SMART_EVENT_SPELLHIT: return sizeof(SmartEvent::spellHit);
-            case SMART_EVENT_RANGE: return sizeof(SmartEvent::minMaxRepeat);
+            case SMART_EVENT_RANGE: return sizeof(SmartEvent::rangeRepeat);
             case SMART_EVENT_OOC_LOS: return sizeof(SmartEvent::los);
             case SMART_EVENT_RESPAWN: return sizeof(SmartEvent::respawn);
             case SMART_EVENT_TARGET_HEALTH_PCT: return sizeof(SmartEvent::minMaxRepeat);
@@ -911,7 +917,6 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
             case SMART_EVENT_MANA_PCT:
             case SMART_EVENT_TARGET_HEALTH_PCT:
             case SMART_EVENT_TARGET_MANA_PCT:
-            case SMART_EVENT_RANGE:
             case SMART_EVENT_DAMAGED:
             case SMART_EVENT_DAMAGED_TARGET:
             case SMART_EVENT_RECEIVE_HEAL:
@@ -919,6 +924,13 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
                     return false;
 
                 if (!IsMinMaxValid(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax))
+                    return false;
+                break;
+            case SMART_EVENT_RANGE:
+                if (!IsMinMaxValid(e, e.event.rangeRepeat.minRange, e.event.rangeRepeat.maxRange))
+                    return false;
+
+                if (!IsMinMaxValid(e, e.event.rangeRepeat.repeatMin, e.event.rangeRepeat.repeatMax))
                     return false;
                 break;
             case SMART_EVENT_SPELLHIT:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -221,8 +221,16 @@ struct SmartEvent
             uint32 max;
             uint32 repeatMin;
             uint32 repeatMax;
-            uint32 controller;
         } minMaxRepeat;
+
+        struct
+        {
+            uint32 minRange;
+            uint32 maxRange;
+            uint32 repeatMin;
+            uint32 repeatMax;
+            uint32 onlyFireOnRepeat;
+        } rangeRepeat;
 
         struct
         {


### PR DESCRIPTION
## Changes Proposed:
-  Please forgive my previous fix as I tested it with chance at 75 percent and by chance everything worked. I found out after that it didn't work and started on a proper fix.

## Issues Addressed:
This fix will, really really this time, prevent initial firing of ranged event and will not fire until repeat time has expired.

## SOURCE:
Me - tested at 100 percent this time.

## Tests Performed:
- tested in game at 100 percent this time.

## How to Test the Changes:

1. With flag ```UPDATE `smart_scripts` SET `event_type`=9, `event_chance`=100, `event_param1`=0, `event_param2`=8, `event_param3`=10000, `event_param4`=15000, `event_param5`=1, `action_param2`=1, `target_type`=1, `comment`="Boulderfist Magus - Within 0-8 Range - Cast 'Frost Nova'" WHERE `entryorguid`=2567 AND `source_type`=0 AND `id`=3;```
2. Without flag ```UPDATE `smart_scripts` SET `event_type`=9, `event_chance`=100, `event_param1`=0, `event_param2`=8, `event_param3`=10000, `event_param4`=15000, `event_param5`=0, `action_param2`=1, `target_type`=1, `comment`="Boulderfist Magus - Within 0-8 Range - Cast 'Frost Nova'" WHERE `entryorguid`=2567 AND `source_type`=0 AND `id`=3;```
3. .go c 14665
