### PR TITLE
fix(Core): CanAccountCreateCharacter hook parameters

### DIFF
--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -432,7 +432,7 @@ void WorldSession::HandleCharCreateOpcode(WorldPacket& recvData)
 
         std::function<void(PreparedQueryResult)> finalizeCharacterCreation = [this, createInfo](PreparedQueryResult result)
         {
-            if (!sScriptMgr->CanAccountCreateCharacter(createInfo, GetAccountId()))
+            if (!sScriptMgr->CanAccountCreateCharacter(GetAccountId(), createInfo->Race, createInfo->Class))
             {
                 SendCharCreate(CHAR_CREATE_DISABLED);
                 return;

--- a/src/server/game/Scripting/ScriptDefines/AccountScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/AccountScript.cpp
@@ -82,11 +82,11 @@ void ScriptMgr::OnFailedPasswordChange(uint32 accountId)
     });
 }
 
-bool ScriptMgr::CanAccountCreateCharacter(std::shared_ptr<CharacterCreateInfo> createInfo, uint32 accountId)
+bool ScriptMgr::CanAccountCreateCharacter(uint32 accountId, uint8 charRace, uint8 charClass)
 {
     auto ret = IsValidBoolScript<AccountScript>([&](AccountScript* script)
     {
-        return !script->CanAccountCreateCharacter(createInfo, accountId);
+        return !script->CanAccountCreateCharacter(accountId, charRace, charClass);
     });
 
     if (ret && *ret)

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -1461,7 +1461,7 @@ public:
     virtual void OnFailedPasswordChange(uint32 /*accountId*/) { }
 
     // Called when creating a character on the Account
-    [[nodiscard]] virtual bool CanAccountCreateCharacter(std::shared_ptr<CharacterCreateInfo> /*createInfo*/, uint32 /*accountId*/) { return true;}
+    [[nodiscard]] virtual bool CanAccountCreateCharacter(uint32 /*accountId*/, uint8 /*charRace*/, uint8 /*charClass*/) { return true;}
 };
 
 class GuildScript : public ScriptObject
@@ -2360,7 +2360,7 @@ public: /* AccountScript */
     void OnFailedEmailChange(uint32 accountId);
     void OnPasswordChange(uint32 accountId);
     void OnFailedPasswordChange(uint32 accountId);
-    bool CanAccountCreateCharacter(std::shared_ptr<CharacterCreateInfo> createInfo, uint32 accountId);
+    bool CanAccountCreateCharacter(uint32 accountId, uint8 charRace, uint8 charClass);
 
 public: /* GuildScript */
     void OnGuildAddMember(Guild* guild, Player* player, uint8& plRank);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  CharacterCreateInfo has protected access, so the previous parameters were not useful
-  Passes only the most useful parameters as arguments directly. Please submit an additional PR and add the other parameters if you are needing them in an AccountScript.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Works locally


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. This PR was just merged and this adjusts it to be usable, so I do not think any testing is necessary

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
