### PR TITLE
fix(Core): DBCDatabaseLoader FT_NA_BYTE handling

### DIFF
--- a/src/server/shared/DataStores/DBCDatabaseLoader.cpp
+++ b/src/server/shared/DataStores/DBCDatabaseLoader.cpp
@@ -104,9 +104,10 @@ char* DBCDatabaseLoader::Load(uint32& records, char**& indexTable)
                     break;
                 case FT_SORT:
                 case FT_NA:
+                case FT_NA_BYTE:
                     break;
                 default:
-                    ASSERT(false, "Unsupported data type '%c' in table '{}'", *dbcFormat, _sqlTableName);
+                    ASSERT(false, "Unsupported data type {} in table '{}'", *dbcFormat, _sqlTableName);
                     return nullptr;
             }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- It seems FT_NA_BYTE was accidentally not handled in DBCDatabaseLoader
- This caused a crash when loading any DBC data with this data type
- Also fix the error message

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- No longer crashes


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Add data to any table with X datatype
2. Start server, no longer crashes on startup

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
