### PR TITLE
fix(Core/TempleOfAhnQiraj): Reduce player damage req for Ouro

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_ouro.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_ouro.cpp
@@ -250,6 +250,7 @@ struct boss_ouro : public BossAI
     void EnterCombat(Unit* who) override
     {
         Emerge();
+        me->LowerPlayerDamageReq(me->GetMaxHealth() - me->GetHealth());
 
         BossAI::EnterCombat(who);
     }

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_ouro.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_ouro.cpp
@@ -250,7 +250,6 @@ struct boss_ouro : public BossAI
     void EnterCombat(Unit* who) override
     {
         Emerge();
-        me->LowerPlayerDamageReq(me->GetMaxHealth() - me->GetHealth());
 
         BossAI::EnterCombat(who);
     }
@@ -292,6 +291,7 @@ struct npc_dirt_mound : ScriptedAI
         {
             creature->SetInCombatWithZone();
             creature->SetHealth(_ouroHealth);
+            creature->LowerPlayerDamageReq(creature->GetMaxHealth() - creature->GetHealth());
         }
     }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Reduce player damage requirement for loot. We need to do it each time it spawns or the players won't get loot in multiple phase fights.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes -

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Ouro and make it submerge multiple times with different amount of hp.
2. It should give loot when you kill it.

