### PR TITLE
fix(DB/SAI): Lava Spawn SmartAI

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1663791124305237700.sql
+++ b/data/sql/updates/pending_db_world/rev_1663791124305237700.sql
@@ -8,4 +8,5 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (12265, 0, 1, 2, 0, 0, 100, 0, 12000, 12000, 12000, 12000, 0, 11, 19569, 3, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
 (12265, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 11, 19570, 3, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
 (12265, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Say Line 0'),
-(12265, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Despawn Instant');
+(12265, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Despawn Instant'),
+(12265, 0, 5, 0, 1, 0, 100, 0, 10000, 10000, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - Out of Combat - Despawn Instant');

--- a/data/sql/updates/pending_db_world/rev_1663791124305237700.sql
+++ b/data/sql/updates/pending_db_world/rev_1663791124305237700.sql
@@ -1,0 +1,11 @@
+-- Lava Spawn (12265)
+DELETE FROM `creature_text` WHERE `CreatureID`=12265 AND `BroadcastTextId`=7570;
+INSERT INTO `creature_text` (`CreatureID`, `Text`, `Type`, `Probability`, `BroadcastTextId`, `comment`) VALUES (12265, '%s splits into two new Lava Spawns!', 16, 100, 7570, 'Lava Spawn');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 12265);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(12265, 0, 0, 0, 0, 0, 100, 0, 1000, 3000, 3000, 3000, 0, 11, 19391, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Fireball\''),
+(12265, 0, 1, 2, 0, 0, 100, 0, 12000, 12000, 12000, 12000, 0, 11, 19569, 32, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
+(12265, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 11, 19570, 32, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
+(12265, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Say Line 0'),
+(12265, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Despawn Instant');

--- a/data/sql/updates/pending_db_world/rev_1663791124305237700.sql
+++ b/data/sql/updates/pending_db_world/rev_1663791124305237700.sql
@@ -5,7 +5,7 @@ INSERT INTO `creature_text` (`CreatureID`, `Text`, `Type`, `Probability`, `Broad
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 12265);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (12265, 0, 0, 0, 0, 0, 100, 0, 1000, 3000, 3000, 3000, 0, 11, 19391, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Fireball\''),
-(12265, 0, 1, 2, 0, 0, 100, 0, 12000, 12000, 12000, 12000, 0, 11, 19569, 32, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
-(12265, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 11, 19570, 32, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
+(12265, 0, 1, 2, 0, 0, 100, 0, 12000, 12000, 12000, 12000, 0, 11, 19569, 3, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
+(12265, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 11, 19570, 3, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
 (12265, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Say Line 0'),
 (12265, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Despawn Instant');

--- a/data/sql/updates/pending_db_world/rev_1663791124305237700.sql
+++ b/data/sql/updates/pending_db_world/rev_1663791124305237700.sql
@@ -5,8 +5,7 @@ INSERT INTO `creature_text` (`CreatureID`, `Text`, `Type`, `Probability`, `Broad
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 12265);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (12265, 0, 0, 0, 0, 0, 100, 0, 1000, 3000, 3000, 3000, 0, 11, 19391, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Fireball\''),
-(12265, 0, 1, 2, 0, 0, 100, 0, 12000, 12000, 12000, 12000, 0, 11, 19569, 3, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
+(12265, 0, 1, 2, 0, 0, 100, 0, 12000, 12000, 12000, 12000, 0, 11, 19569, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
 (12265, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 11, 19570, 3, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
-(12265, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Say Line 0'),
-(12265, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Despawn Instant'),
-(12265, 0, 5, 0, 1, 0, 100, 0, 10000, 10000, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - Out of Combat - Despawn Instant');
+(12265, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - After Splitting - Say Line 0'),
+(12265, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - After Splitting - Despawn Instant');

--- a/data/sql/updates/pending_db_world/rev_1663791124305237700.sql
+++ b/data/sql/updates/pending_db_world/rev_1663791124305237700.sql
@@ -5,7 +5,7 @@ INSERT INTO `creature_text` (`CreatureID`, `Text`, `Type`, `Probability`, `Broad
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 12265);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (12265, 0, 0, 0, 0, 0, 100, 0, 1000, 3000, 3000, 3000, 0, 11, 19391, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Fireball\''),
-(12265, 0, 1, 2, 0, 0, 100, 0, 12000, 12000, 12000, 12000, 0, 11, 19569, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
+(12265, 0, 1, 2, 0, 0, 100, 0, 15000, 15000, 15000, 15000, 0, 11, 19569, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
 (12265, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 0, 11, 19570, 3, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - In Combat - Cast \'Split\''),
 (12265, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - After Splitting - Say Line 0'),
 (12265, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lava Spawn - After Splitting - Despawn Instant');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removed duplicated entries in smart_scripts
-  Ported script from Mangos.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unopened issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Vmangos & Cmangos

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .npc add temp 12265
2. See if it casts Fireball
3. See if it splits into 2 other Lava Spawns, emotes and despawns the original.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
