### PR TITLE
fix(DB/Quest POI) Trial of the Sea Lion Quest Horde and Alliance

### DIFF
--- a/data/sql/updates/pending_db_world/Trial_of_the_Sea_Lion.sql
+++ b/data/sql/updates/pending_db_world/Trial_of_the_Sea_Lion.sql
@@ -1,0 +1,6 @@
+-- Horde "Trial of the Sea Lion" Quest ID 30 POI fix
+UPDATE `quest_poi` SET `WorldMapAreaId`=17 WHERE `QuestID`=30 AND `MapID`=1;
+UPDATE `quest_poi_points` SET `X`=1050, `Y`=-3119 WHERE `QuestID`=30 AND `Idx1`=2;
+-- Alliance "Trial of the Sea Lion" Quest ID 272 POI fix
+UPDATE `quest_poi` SET `WorldMapAreaId`=40 WHERE `QuestID`=272 AND `MapID`=0;
+UPDATE `quest_poi_points` SET `X`=-10172, `Y`=2391 WHERE `QuestID`=272 AND `Idx1`=2;

--- a/data/sql/updates/pending_db_world/Trial_of_the_Sea_Lion.sql
+++ b/data/sql/updates/pending_db_world/Trial_of_the_Sea_Lion.sql
@@ -1,6 +1,1 @@
--- Horde "Trial of the Sea Lion" Quest ID 30 POI fix
-UPDATE `quest_poi` SET `WorldMapAreaId`=17 WHERE `QuestID`=30 AND `MapID`=1;
-UPDATE `quest_poi_points` SET `X`=1050, `Y`=-3119 WHERE `QuestID`=30 AND `Idx1`=2;
--- Alliance "Trial of the Sea Lion" Quest ID 272 POI fix
-UPDATE `quest_poi` SET `WorldMapAreaId`=40 WHERE `QuestID`=272 AND `MapID`=0;
-UPDATE `quest_poi_points` SET `X`=-10172, `Y`=2391 WHERE `QuestID`=272 AND `Idx1`=2;
+


### PR DESCRIPTION
## Changes Proposed:
-  Update quest POI for druid quest.

## Issues Addressed:
- Closes #7456

## SOURCE:
.gps in game

## Tests Performed:
- Inserts
- Tested in game both sides

## How to Test the Changes:
1. Make druid
2. Horde .add quest 30 and check maps for The Barrens and Silverpine Forest.
3. Alliance .add quest 272 check maps for Darkshore and Westfall.

## Known Issues and TODO List:

PTR does not have quest helper. I had to get both xy values with .gps command so they may be off from official by 1 either way. Personally I feel this is not even an issue for this fix.
