### PR TITLE
fix(DB/Conditions): "Brewfest - apple trap - friendly DND" aura targe…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1664010686716176700.sql
+++ b/data/sql/updates/pending_db_world/rev_1664010686716176700.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry`=43450;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13,1,43450,0,0,1,0,43052,0,0,0,0,0,'','Brewfest - apple trap - friendly DND targets only players with aura Ram Fatigue');'

--- a/data/sql/updates/pending_db_world/rev_1664010686716176700.sql
+++ b/data/sql/updates/pending_db_world/rev_1664010686716176700.sql
@@ -1,4 +1,4 @@
 --
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry`=43450;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(13,1,43450,0,0,1,0,43052,0,0,0,0,0,'','Brewfest - apple trap - friendly DND targets only players with aura Ram Fatigue');'
+(13,1,43450,0,0,1,0,43052,0,0,0,0,0,'','Brewfest - apple trap - friendly DND targets only players with aura Ram Fatigue');


### PR DESCRIPTION
…ts only players with "Ram Fatigue" aura.

Fixes #13078

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13078
- Closes https://github.com/chromiecraft/chromiecraft/issues/4098

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go gameobject id 186331`
No red animtion above player

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
