### PR TITLE
fix(Core/TempleOfAhnQiraj): Fankriss pull range

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_fankriss.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_fankriss.cpp
@@ -51,7 +51,10 @@ const std::array<uint32, 3> entangleSpells = { SPELL_ENTANGLE_RIGHT, SPELL_ENTAN
 
 struct boss_fankriss : public BossAI
 {
-    boss_fankriss(Creature* creature) : BossAI(creature, DATA_FANKRISS) { }
+    boss_fankriss(Creature* creature) : BossAI(creature, DATA_FANKRISS)
+    {
+        me->m_CombatDistance = 80.f;
+    }
 
     void Reset() override
     {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Increase its aggro range by 80.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13138
- Closes https://github.com/chromiecraft/chromiecraft/issues/4090

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Fankriss, you should enter combat with it immediately after entering its room.

