### PR TITLE
fix(DB/creature_template): Update AQ20 detection ranges

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1664206413363828800.sql
+++ b/data/sql/updates/pending_db_world/rev_1664206413363828800.sql
@@ -1,0 +1,16 @@
+-- Ossirian
+UPDATE `creature_template` SET `detection_range` = 37 WHERE (`entry` = 15339);
+-- Qiraji Gladiator
+UPDATE `creature_template` SET `detection_range` = 38.75 WHERE (`entry` = 15324);
+-- Qiraji Swarmguard
+UPDATE `creature_template` SET `detection_range` = 34.125 WHERE (`entry` = 15343);
+-- Hive'Zara Stinger & Wasp
+UPDATE `creature_template` SET `detection_range` = 28.75 WHERE (`entry` IN (15327, 15325));
+-- Obsidian Destroyer
+UPDATE `creature_template` SET `detection_range` = 36.5 WHERE (`entry` = 15338);
+-- Anubisath Guardian
+UPDATE `creature_template` SET `detection_range` = 35.25 WHERE (`entry` = 15355);
+-- Ayamiss
+UPDATE `creature_template` SET `detection_range` = 34.5 WHERE (`entry` = 15369);
+-- Hive'Zara Sandstalker & Soldier
+UPDATE `creature_template` SET `detection_range` = 28.75 WHERE (`entry` IN (15323, 15320));


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Updates detection ranges from those observed in retail
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unopened issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Retail

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.tele AQ20`
2. see if the the affected creatures are pulled from a larger distance

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
