### PR TITLE
fix(Scripts/BlackwingLair) Razorgore should not reset with only one raid member alive that is conflagrated

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
@@ -72,13 +72,13 @@ enum EVENTS
 class boss_razorgore : public CreatureScript
 {
 public:
-    boss_razorgore() : CreatureScript("boss_razorgore") {
-        _conflagrateThreat = 0.0f;
-    }
+    boss_razorgore() : CreatureScript("boss_razorgore") { }
 
     struct boss_razorgoreAI : public BossAI
     {
-        boss_razorgoreAI(Creature* creature) : BossAI(creature, DATA_RAZORGORE_THE_UNTAMED) { }
+        boss_razorgoreAI(Creature* creature) : BossAI(creature, DATA_RAZORGORE_THE_UNTAMED) {
+            _conflagrateThreat = 0.0f;
+        }
 
         void Reset() override
         {

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
@@ -250,8 +250,8 @@ public:
                         if (Unit* target = me->GetVictim())
                         {
                             _conflagrateTarget = me->GetVictim()->GetGUID();
-                            _conflagrateThreat = me->getThreatMgr().getThreat(me->GetVictim());
-                            me->getThreatMgr().modifyThreatPercent(target, -100);
+                            _conflagrateThreat = me->GetThreatMgr().getThreat(me->GetVictim());
+                            me->GetThreatMgr().modifyThreatPercent(target, -100);
                         }
                         events.ScheduleEvent(EVENT_CONFLAGRATION, 30000);
                         events.ScheduleEvent(EVENT_CHECK_CONFLAGRATION_TARGET, 10000);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
@@ -272,6 +272,8 @@ public:
         bool secondPhase;
         ObjectGuid _charmerGUID;
         GuidVector _summonGUIDS;
+        float _conflagrateThreat;
+        ObjectGuid _conflagrateTarget;
     };
 
     CreatureAI* GetAI(Creature* creature) const override

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
@@ -250,7 +250,7 @@ public:
                         if (Unit* target = me->GetVictim())
                         {
                             _conflagrateTarget = me->GetVictim()->GetGUID();
-                            _conflagrateThreat = me->GetThreatMgr().getThreat(me->GetVictim());
+                            _conflagrateThreat = me->GetThreatMgr().GetThreat(me->GetVictim());
                             me->GetThreatMgr().modifyThreatPercent(target, -100);
                         }
                         events.ScheduleEvent(EVENT_CONFLAGRATION, 30000);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
@@ -111,7 +111,7 @@ public:
 
         bool CanAIAttack(Unit const* target) const override
         {
-            return !(target->GetTypeId() == TYPEID_UNIT && !secondPhase) && !target->HasAura(SPELL_CONFLAGRATION);
+            return !(target->GetTypeId() == TYPEID_UNIT && !secondPhase);
         }
 
         void EnterCombat(Unit* /*victim*/) override

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
@@ -251,7 +251,7 @@ public:
                         {
                             _conflagrateTarget = me->GetVictim()->GetGUID();
                             _conflagrateThreat = me->GetThreatMgr().GetThreat(me->GetVictim());
-                            me->GetThreatMgr().modifyThreatPercent(target, -100);
+                            me->GetThreatMgr().ModifyThreatByPercent(target, -100);
                         }
                         events.ScheduleEvent(EVENT_CONFLAGRATION, 30000);
                         events.ScheduleEvent(EVENT_CHECK_CONFLAGRATION_TARGET, 10000);
@@ -259,7 +259,7 @@ public:
                     case EVENT_CHECK_CONFLAGRATION_TARGET:
                         if (Unit* target = ObjectAccessor::GetUnit(*me, _conflagrateTarget))
                         {
-                            me->GetThreatMgr().addThreat(target, _conflagrateThreat);
+                            me->GetThreatMgr().AddThreat(target, _conflagrateThreat);
                         }
                         break;
                 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Make it so that Razorgore's conflagrate functions like Drakkisath's conflagrate (which does this mechanic properly): threat is only temporarily reduced to zero
- Allow Razorgore to still attack conflagrated players if they are the only players left alive (as they will have 0 threat but still be eligible)

## Issues Addressed:
- This is a regression introduced with #11183 (although that partially addressed the issue, it was not entirely the correct fix)

## SOURCE:
- This shows what is supposed to happen when a solo player (only one on the threat table) is conflagrated: https://youtu.be/5FxU1dLJUs4?t=293 (starts 4:53)
- Notice how Razorgore continues attacking the conflagrated player because there's no one else on the threat table.

## Tests Performed:
- We built and ran AC, and entered BWL with 2 players to verify that targets switched appropriately during Conflagrate.
- We also ran it with 1 player to make sure the encounter did not reset due to Razorgore lacking eligible targets.

## How to Test the Changes:
Testing solo:
1. `.tele blackwinglair` and enter, alone, with no pets
2. Begin the encounter by killing the weak mobs on the left- but leave Razorgore loose
3. Observe that the fight does not reset when Razorgore conflags the player.
Testing intended:
1. `.tele blackwinglair` and enter with any number of friends
2. Begin the encounter by killing the weak mobs on the left- leave Razorgore loose
3. Observe that Razorgore's target changes when the tank is conflagrated.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- Not at this time.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
