### PR TITLE
PlayerUpdates.cpp: Use blizz-like progressive skillup chance.

### DIFF
--- a/src/server/game/Entities/Player/PlayerUpdates.cpp
+++ b/src/server/game/Entities/Player/PlayerUpdates.cpp
@@ -720,8 +720,7 @@ int ProgressiveSkillGainChance(int32 SkillValue, int32 LowChance, int32 HighChan
     return baseResult + (chanceDelta * progress * Coeff / cutoffDelta);
 }
 
-inline int SkillGainChance(uint32 SkillValue, uint32 GrayLevel,
-                           uint32 GreenLevel, uint32 YellowLevel)
+inline int SkillGainChance(uint32 SkillValue, uint32 GrayLevel, uint32 YellowLevel)
 {
     // Use a linear function for skillups instead of tiers.
     // This has the side effect of ignoring values for yellow/green.
@@ -754,22 +753,20 @@ bool Player::UpdateGatherSkill(uint32 SkillId, uint32 SkillValue,
     case SKILL_INSCRIPTION:
         return UpdateSkillPro(SkillId,
                               SkillGainChance(SkillValue, RedLevel + 100,
-                                              RedLevel + 50, RedLevel + 25) *
+                                              RedLevel + 50) *
                                   Multiplicator,
                               gathering_skill_gain);
     case SKILL_SKINNING:
         if (sWorld->getIntConfig(CONFIG_SKILL_CHANCE_SKINNING_STEPS) == 0)
             return UpdateSkillPro(SkillId,
                                   SkillGainChance(SkillValue, RedLevel + 100,
-                                                  RedLevel + 50,
-                                                  RedLevel + 25) *
+                                                  RedLevel + 50) *
                                       Multiplicator,
                                   gathering_skill_gain);
         else
             return UpdateSkillPro(
                 SkillId,
-                (SkillGainChance(SkillValue, RedLevel + 100, RedLevel + 50,
-                                 RedLevel + 25) *
+                (SkillGainChance(SkillValue, RedLevel + 100, RedLevel + 50) *
                  Multiplicator) >>
                     (SkillValue /
                      sWorld->getIntConfig(CONFIG_SKILL_CHANCE_SKINNING_STEPS)),
@@ -778,15 +775,13 @@ bool Player::UpdateGatherSkill(uint32 SkillId, uint32 SkillValue,
         if (sWorld->getIntConfig(CONFIG_SKILL_CHANCE_MINING_STEPS) == 0)
             return UpdateSkillPro(SkillId,
                                   SkillGainChance(SkillValue, RedLevel + 100,
-                                                  RedLevel + 50,
-                                                  RedLevel + 25) *
+                                                  RedLevel + 50) *
                                       Multiplicator,
                                   gathering_skill_gain);
         else
             return UpdateSkillPro(
                 SkillId,
-                (SkillGainChance(SkillValue, RedLevel + 100, RedLevel + 50,
-                                 RedLevel + 25) *
+                (SkillGainChance(SkillValue, RedLevel + 100, RedLevel + 50) *
                  Multiplicator) >>
                     (SkillValue /
                      sWorld->getIntConfig(CONFIG_SKILL_CHANCE_MINING_STEPS)),
@@ -827,8 +822,7 @@ bool Player::UpdateCraftSkill(uint32 spellid)
                                 _spell_idx->second->TrivialSkillLineRankHigh,
                                 (_spell_idx->second->TrivialSkillLineRankHigh +
                                  _spell_idx->second->TrivialSkillLineRankLow) /
-                                    2,
-                                _spell_idx->second->TrivialSkillLineRankLow),
+                                    2),
                 craft_skill_gain);
         }
     }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Make it so that the success chance of skilling up with a profession is on a linear slope rather than stepped.

## Issues Addressed:
- Recipes are color-coded to indicate roughly how successful the player will be in gaining a skill point from the craft. Currently, each color is represented directly by a percentage chance thoroughly: the default for all yellow and green skillups is 75% and 25% respectively. However, under the hood, it's actually a linear grade. This means just getting into yellow will come with a very high chance of success and the tail end of green will come with a very low chance of success. This is the way it works on both live and classic.

## SOURCE:
- In each of these videos, observe that "fresh" yellows have a better chance than yellows that are about to turn green.
- Alchemy 1-300 timelapse: https://www.youtube.com/watch?v=ywFRjzhv8WQ
- Engineering 1-300 timelapse: https://www.youtube.com/watch?v=-OXnztSm-3A

## Tests Performed:
- Tested using Leatherworking, First Aid, Tailoring
- Also tested with Runeforging, which is only really a profession in name

## How to Test the Changes:
1. First aid is probably the best candidate and where most players will craft the most yellow/green.
2. `.learn 3259` to get Apprentice First Aid.
3. `.additem 2589 200` to give yourself a bunch of Linen Cloth.
4. Craft using all of it. Notice how when the recipe first turns yellow it seems to go well, but at higher skills in yellow, it can take longer. The last point of green is most nasty.

## Known Issues and TODO List:
- What happens with the `SkillChance.Green` and `SkillChance.Yellow` values in the config? They will go unused when this patch is merged in its current state.
- In the future, it may be nice to be able to customize the curve of the falloff. But for now, it should be linear.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
