### PR TITLE
fix(DB/creature_loot):  Corrects all incorrect quest rates in Ammen Vale

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1664322385002360300.sql
+++ b/data/sql/updates/pending_db_world/rev_1664322385002360300.sql
@@ -1,7 +1,7 @@
 --
 -- Replenishing the Healing Crystals (9280 Draenei Version) (DROP QUEST)
 -- Vial of Moth Blood (item 22889): 50/50 
-UPDATE `creature_loot_template` SET `Chance`=100 WHERE  `Entry`=16517 AND `Item`=22934 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `creature_loot_template` SET `Chance`=100 WHERE `Entry`=16517 AND `Item`=22934 AND `Reference`=0 AND `GroupId`=0;
 
 -- What Must Be Done... (9293) (DROP QUEST)  (DONE)
 -- Lasher Sample (item 16517): 50/50

--- a/data/sql/updates/pending_db_world/rev_1664322385002360300.sql
+++ b/data/sql/updates/pending_db_world/rev_1664322385002360300.sql
@@ -5,4 +5,4 @@ UPDATE `creature_loot_template` SET `Chance`=100 WHERE `Entry`=16517 AND `Item`=
 
 -- What Must Be Done... (9293) (DROP QUEST)  (DONE)
 -- Lasher Sample (item 16517): 50/50
-UPDATE `creature_loot_template` SET `Chance`=100 WHERE  `Entry`=16520 AND `Item`=22889 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `creature_loot_template` SET `Chance`=100 WHERE `Entry`=16520 AND `Item`=22889 AND `Reference`=0 AND `GroupId`=0;

--- a/data/sql/updates/pending_db_world/rev_1664322385002360300.sql
+++ b/data/sql/updates/pending_db_world/rev_1664322385002360300.sql
@@ -1,0 +1,8 @@
+--
+-- Replenishing the Healing Crystals (9280 Draenei Version) (DROP QUEST)
+-- Vial of Moth Blood (item 22889): 50/50 
+UPDATE `creature_loot_template` SET `Chance`=100 WHERE  `Entry`=16517 AND `Item`=22934 AND `Reference`=0 AND `GroupId`=0;
+
+-- What Must Be Done... (9293) (DROP QUEST)  (DONE)
+-- Lasher Sample (item 16517): 50/50
+UPDATE `creature_loot_template` SET `Chance`=100 WHERE  `Entry`=16520 AND `Item`=22889 AND `Reference`=0 AND `GroupId`=0;


### PR DESCRIPTION
Despite the definitive title, its only two drops that were wrong :)

## Changes Proposed:
Replenishing the Healing Crystals (9280 Draenei Version) (DROP QUEST)
Vial of Moth Blood (item 22889): 100% rate
and
What Must Be Done... (9293) (DROP QUEST) 
Lasher Sample (item 16517): 100% rate


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.youtube.com/watch?v=M1_2pCRUr2M 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  Tested locally
 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. create a new draenei char, and add quests 9280 and 9293 to your log, they should now drop 100% of the time from the nearby related mobs.


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
