### PR TITLE
fix(DB/creature_loot_template): Sunstrider Isle Quest Rate Fixes

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1664444955521407200.sql
+++ b/data/sql/updates/pending_db_world/rev_1664444955521407200.sql
@@ -1,0 +1,15 @@
+--
+-- Yougotta 00001-00005 Sunstider Isle Part 1-5
+-- ITEM Tainted Arcane Silver (20483) should be 100% drop rate off NPC Tainted Arcane Wraith (15298) for QUEST Tainted Arcane Sliver (8338) (ALREADY CORRECT)
+
+-- ITEM Lynx Collar (20797) should be 100% drop rate off NPCs Springpaw Cub (15366), Springpaw Lynx (15372) for QUEST Unfortunate Measures (8326)
+
+UPDATE `creature_loot_template` SET `Chance`='100' WHERE  `Entry`=15366 AND `Item`=20797 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `creature_loot_template` SET `Chance`='100' WHERE  `Entry`=15372 AND `Item`=20797 AND `Reference`=0 AND `GroupId`=0;
+
+-- ITEM Arcane Silver (20482) "0.6777893639207508" over 959 repetitions rounded to 2/3rds (70% is also in likely margin of error, but 66.67% is closer to seen and given as second opinion so it will be the standard I go by) drop rate off NPCs Mana Wyrm (15274), Feral Tender (15294), Arcane Wraith (15273), Tainted Arcane Wraith (15298) for QUEST A Fistful of Silvers (8336)
+
+UPDATE `creature_loot_template` SET `Chance`='66.67' WHERE  `Entry`=15274 AND `Item`=20482 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `creature_loot_template` SET `Chance`='66.67' WHERE  `Entry`=15294 AND `Item`=20482 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `creature_loot_template` SET `Chance`='66.67' WHERE  `Entry`=15273 AND `Item`=20482 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `creature_loot_template` SET `Chance`='66.67' WHERE  `Entry`=15298 AND `Item`=20482 AND `Reference`=0 AND `GroupId`=0;


### PR DESCRIPTION
WOTLK quest rate corrections continued

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  ITEM Lynx Collar (20797) should be 100% drop rate off NPCs Springpaw Cub (15366), Springpaw Lynx (15372) for QUEST Unfortunate Measures (8326)
-  ITEM Arcane Silver (20482) "0.6777893639207508" over 959 repetitions rounded to 2/3rds (70% is also in likely margin of error, but 66.67% is closer to seen and given as second opinion so it will be the standard I go by) drop rate off NPCs Mana Wyrm (15274), Feral Tender (15294), Arcane Wraith (15273), Tainted Arcane Wraith (15298) for QUEST A Fistful of Silvers (8336)

(For those of you who care about numbers and how this is derived, I use the margin of error/sampling error formula to determine how much effort I need to put into a given issue, and using that you can derive there is a 99.99% chance that it is ±5.898% of the number arrived at, with higher likelihood weighted toward the center [90% chance its within ±2.482%], either way, its extremely unlikely to be 80% it's currently set to so even if this is an anomaly most fixes done this way will be an improvement and even the ones falling outside the margin of error should also be more correct than prior, if I do every quest in the game prolly 1-2 of them will be wrong but the vast majority will be improved)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Classic WOTLK / sniffed almost 1,000 kills regarding Arcane Silvers

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested locally, works


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  create a new blood elf and add quests 8336 and 8326
2.  test impacted mobs for quest drops (wyrms, cubs, lynxs, arcane wraths, feral tenders, tainted arcane wraiths)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- Checked other quest drops, this area should be done for this kind of stuff.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
