### PR TITLE
fix(Core/TempleOfAhnQiraj): Huhuran timers + EventMap::Repeat

### DIFF
--- a/src/common/Utilities/EventMap.cpp
+++ b/src/common/Utilities/EventMap.cpp
@@ -106,6 +106,11 @@ void EventMap::Repeat(Milliseconds time)
     RepeatEvent(time.count());
 }
 
+void EventMap::Repeat(Milliseconds minTime, Milliseconds maxTime)
+{
+    RepeatEvent(randtime(minTime, maxTime).count());
+}
+
 uint32 EventMap::ExecuteEvent()
 {
     while (!Empty())

--- a/src/common/Utilities/EventMap.h
+++ b/src/common/Utilities/EventMap.h
@@ -199,6 +199,14 @@ public:
     void Repeat(Milliseconds time);
 
     /**
+    * @name RepeatEvent
+    * @brief Repeats the most recently executed event.
+    * @param minTime The minimum time until the event occurs as std::chrono type.
+    * @param maxTime The maximum time until the event occurs as std::chrono type.
+    */
+    void Repeat(Milliseconds minTime, Milliseconds maxTime);
+
+    /**
     * @name ExecuteEvent
     * @brief Returns the next event to execute and removes it from map.
     * @return Id of the event to execute.

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_huhuran.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_huhuran.cpp
@@ -35,8 +35,7 @@ enum Spells
     SPELL_WYVERN_STING          = 26180,
     SPELL_ACID_SPIT             = 26050,
     SPELL_WYVERN_STING_DAMAGE   = 26233,
-    SPELL_POISON_BOLT           = 26052,
-    SPELL_HARD_ENRAGE           = 26662
+    SPELL_POISON_BOLT           = 26052
 };
 
 enum Events
@@ -54,18 +53,18 @@ struct boss_huhuran : public BossAI
 
     void Reset() override
     {
-        _Reset();
+        BossAI::Reset();
         _berserk = false;
         _hardEnrage = false;
     }
 
     void EnterCombat(Unit* /*who*/) override
     {
-        events.ScheduleEvent(EVENT_FRENZY, urand(25000, 35000));
-        events.ScheduleEvent(EVENT_WYVERN_STING, urand(18000, 28000));
-        events.ScheduleEvent(EVENT_ACID_SPIT, 8000);
-        events.ScheduleEvent(EVENT_NOXIOUS_POISON, urand(10000, 20000));
-        events.ScheduleEvent(EVENT_HARD_ENRAGE, 300000);
+        events.ScheduleEvent(EVENT_FRENZY, 12s, 21s);
+        events.ScheduleEvent(EVENT_WYVERN_STING, 25s, 43s);
+        events.ScheduleEvent(EVENT_ACID_SPIT, 1s, 20s);
+        events.ScheduleEvent(EVENT_NOXIOUS_POISON, 10s, 22s);
+        events.ScheduleEvent(EVENT_HARD_ENRAGE, 5min);
     }
 
     void DamageTaken(Unit*, uint32& /*damage*/, DamageEffectType, SpellSchoolMask) override
@@ -74,6 +73,7 @@ struct boss_huhuran : public BossAI
         {
             DoCastSelf(SPELL_BERSERK, true);
             me->TextEmote(EMOTE_BERSERK);
+            events.CancelEvent(EVENT_FRENZY);
             _berserk = true;
         }
     }
@@ -91,39 +91,43 @@ struct boss_huhuran : public BossAI
                 case EVENT_FRENZY:
                     DoCastSelf(SPELL_FRENZY, true);
                     Talk(EMOTE_FRENZY_KILL);
-                    events.RepeatEvent(urand(25000, 35000));
+                    events.Repeat(12s, 21s);
                     break;
                 case EVENT_WYVERN_STING:
                     me->CastCustomSpell(SPELL_WYVERN_STING, SPELLVALUE_MAX_TARGETS, 10, me, true);
-                    events.RepeatEvent(urand(15000, 32000));
+                    events.Repeat(25s, 43s);
                     break;
                 case EVENT_ACID_SPIT:
                     DoCastVictim(SPELL_ACID_SPIT);
-                    events.RepeatEvent(urand(5000, 10000));
+                    events.Repeat(1s, 20s);
                     break;
                 case EVENT_NOXIOUS_POISON:
-                    DoCastRandomTarget(SPELL_NOXIOUS_POISON, 0, 100, true);
-                    events.RepeatEvent(urand(12000, 24000));
+                    DoCastRandomTarget(SPELL_NOXIOUS_POISON, 0, 100.f, true);
+                    events.Repeat(10s, 22s);
                     break;
                 case EVENT_HARD_ENRAGE:
                     if (!_hardEnrage)
                     {
-                        DoCastSelf(SPELL_HARD_ENRAGE, true);
+                        DoCastSelf(SPELL_BERSERK, true);
+                        events.CancelEvent(EVENT_FRENZY);
                         _hardEnrage = true;
                     }
                     else
                     {
                         DoCastAOE(SPELL_POISON_BOLT);
                     }
-                    events.RepeatEvent(3000);
+                    events.Repeat(2s);
+                    break;
+                default:
                     break;
             }
         }
         DoMeleeAttackIfReady();
     }
-    private:
-        bool _berserk;
-        bool _hardEnrage;
+
+private:
+    bool _berserk;
+    bool _hardEnrage;
 };
 
 // 26180 - Wyvern Sting


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added support to EventMap::Repeat for allowing 2 parameters of std::chrono.
-  Fixed timers according to sniffs
-  Cancel Frenzy event on enrage.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13092

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to huhuran and check the timers.
