### PR TITLE
fix(Scripts/Temple of AhnQiraj): Sartura's Sundering Cleave should be…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1664616629895100900.sql
+++ b/data/sql/updates/pending_db_world/rev_1664616629895100900.sql
@@ -1,0 +1,2 @@
+--
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger`=26084;

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_sartura.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_sartura.cpp
@@ -49,14 +49,15 @@ enum events
     EVENT_SPELL_BERSERK             = 4,
     EVENT_SARTURA_AGGRO_RESET       = 5,
     EVENT_SARTURA_AGGRO_RESET_END   = 6,
+    EVENT_SARTURA_SUNDERING_CLEAVE  = 7,
 
     // Sartura's Royal Guard
-    EVENT_GUARD_WHIRLWIND           = 7,
-    EVENT_GUARD_WHIRLWIND_RANDOM    = 8,
-    EVENT_GUARD_WHIRLWIND_END       = 9,
-    EVENT_GUARD_KNOCKBACK           = 10,
-    EVENT_GUARD_AGGRO_RESET         = 11,
-    EVENT_GUARD_AGGRO_RESET_END     = 12
+    EVENT_GUARD_WHIRLWIND           = 8,
+    EVENT_GUARD_WHIRLWIND_RANDOM    = 9,
+    EVENT_GUARD_WHIRLWIND_END       = 10,
+    EVENT_GUARD_KNOCKBACK           = 11,
+    EVENT_GUARD_AGGRO_RESET         = 12,
+    EVENT_GUARD_AGGRO_RESET_END     = 13
 };
 
 struct boss_sartura : public BossAI
@@ -99,6 +100,7 @@ struct boss_sartura : public BossAI
         events.ScheduleEvent(EVENT_SARTURA_WHIRLWIND, 30000);
         events.ScheduleEvent(EVENT_SARTURA_AGGRO_RESET, urand(45000, 55000));
         events.ScheduleEvent(EVENT_SPELL_BERSERK, 10 * 60000);
+        events.ScheduleEvent(EVENT_SARTURA_SUNDERING_CLEAVE, 2400ms, 3s);
     }
 
     void JustDied(Unit* /*killer*/) override
@@ -154,7 +156,6 @@ struct boss_sartura : public BossAI
                     events.CancelEvent(EVENT_SARTURA_WHIRLWIND_RANDOM);
                     whirlwind = false;
                     events.ScheduleEvent(EVENT_SARTURA_WHIRLWIND, urand(25000, 40000));
-                    DoCastVictim(SPELL_SUNDERING_CLEAVE, true);
                     break;
                 case EVENT_SARTURA_AGGRO_RESET:
                     if (aggroReset == false)
@@ -194,6 +195,18 @@ struct boss_sartura : public BossAI
                     {
                         DoCastSelf(SPELL_BERSERK);
                         berserked = true;
+                    }
+                    break;
+                case EVENT_SARTURA_SUNDERING_CLEAVE:
+                    if (whirlwind)
+                    {
+                        Milliseconds whirlwindTimer = events.GetTimeUntilEvent(EVENT_SARTURA_WHIRLWIND_END);
+                        events.RescheduleEvent(EVENT_SARTURA_SUNDERING_CLEAVE, whirlwindTimer + 500ms);
+                    }
+                    else
+                    {
+                        DoCastVictim(SPELL_SUNDERING_CLEAVE, true);
+                        events.RescheduleEvent(EVENT_SARTURA_SUNDERING_CLEAVE, 2400ms, 3s);
                     }
                     break;
                 default:

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_sartura.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_sartura.cpp
@@ -205,7 +205,7 @@ struct boss_sartura : public BossAI
                     }
                     else
                     {
-                        DoCastVictim(SPELL_SUNDERING_CLEAVE, true);
+                        DoCastVictim(SPELL_SUNDERING_CLEAVE, false);
                         events.RescheduleEvent(EVENT_SARTURA_SUNDERING_CLEAVE, 2400ms, 3s);
                     }
                     break;

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_sartura.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_sartura.cpp
@@ -121,14 +121,6 @@ struct boss_sartura : public BossAI
         }
     }
 
-    void SpellHit(Unit* /*caster*/, SpellInfo const* spell) override
-    {
-        if (spell->Id != SPELL_SUNDERING_CLEAVE)
-            return;
-
-        me->RemoveAura(SPELL_SUNDERING_CLEAVE);
-    }
-
     void UpdateAI(uint32 diff) override
     {
         if (!UpdateVictim())
@@ -162,6 +154,7 @@ struct boss_sartura : public BossAI
                     events.CancelEvent(EVENT_SARTURA_WHIRLWIND_RANDOM);
                     whirlwind = false;
                     events.ScheduleEvent(EVENT_SARTURA_WHIRLWIND, urand(25000, 40000));
+                    DoCastVictim(SPELL_SUNDERING_CLEAVE, true);
                     break;
                 case EVENT_SARTURA_AGGRO_RESET:
                     if (aggroReset == false)
@@ -236,14 +229,6 @@ struct npc_sartura_royal_guard : public ScriptedAI
         events.ScheduleEvent(EVENT_GUARD_WHIRLWIND, 30000);
         events.ScheduleEvent(EVENT_GUARD_AGGRO_RESET, urand(45000, 55000));
         events.ScheduleEvent(EVENT_GUARD_KNOCKBACK, 10000);
-    }
-
-    void SpellHit(Unit* /*caster*/, SpellInfo const* spell) override
-    {
-        if (spell->Id != SPELL_SUNDERING_CLEAVE)
-            return;
-
-        me->RemoveAura(SPELL_SUNDERING_CLEAVE);
     }
 
     void UpdateAI(uint32 diff) override


### PR DESCRIPTION
… casted on Whirlwind end.

Fixed #13047

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13047

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
.go c id 15516
see Sundering Cleave is casted on Whirlwind end

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
