### PR TITLE
fix(DB/creature_template): Import Vmangos values for Dragons of Nightmare and Azuregos

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1664655909869728000.sql
+++ b/data/sql/updates/pending_db_world/rev_1664655909869728000.sql
@@ -1,0 +1,68 @@
+-- Shade of Taerar
+UPDATE `creature_template` SET `DamageModifier` = 12.65, `ArmorModifier` = 1.05 WHERE (`entry` = 15302);
+
+DELETE FROM `creature_template_resistance` WHERE (`CreatureID` = 15302) AND (`School` IN (2, 3, 4, 5, 6));
+INSERT INTO `creature_template_resistance` (`CreatureID`, `School`, `Resistance`, `VerifiedBuild`) VALUES
+(15302, 2, 15, 0),
+(15302, 3, 15, 0),
+(15302, 4, 15, 0),
+(15302, 5, 15, 0),
+(15302, 6, 15, 0);
+
+-- Taerar
+UPDATE `creature_template` SET `DamageModifier` = 12.65, `ArmorModifier` = 1.3 WHERE (`entry` = 14890);
+
+DELETE FROM `creature_template_resistance` WHERE (`CreatureID` = 14890) AND (`School` IN (2, 3, 4, 5, 6));
+INSERT INTO `creature_template_resistance` (`CreatureID`, `School`, `Resistance`, `VerifiedBuild`) VALUES
+(14890, 2, 126, 0),
+(14890, 3, 126, 0),
+(14890, 4, 126, 0),
+(14890, 5, 126, 0),
+(14890, 6, 126, 0);
+
+-- Emeriss
+UPDATE `creature_template` SET `DamageModifier` = 10.3, `ArmorModifier` = 1.3 WHERE (`entry` = 14889);
+
+DELETE FROM `creature_template_resistance` WHERE (`CreatureID` = 14889) AND (`School` IN (2, 3, 4, 5, 6));
+INSERT INTO `creature_template_resistance` (`CreatureID`, `School`, `Resistance`, `VerifiedBuild`) VALUES
+(14889, 2, 126, 0),
+(14889, 3, 126, 0),
+(14889, 4, 126, 0),
+(14889, 5, 126, 0),
+(14889, 6, 126, 0);
+
+-- Lethon
+UPDATE `creature_template` SET `DamageModifier` = 19.55, `ArmorModifier` = 1.3 WHERE (`entry` = 14888);
+
+DELETE FROM `creature_template_resistance` WHERE (`CreatureID` = 14888) AND (`School` IN (2, 3, 4, 5, 6));
+INSERT INTO `creature_template_resistance` (`CreatureID`, `School`, `Resistance`, `VerifiedBuild`) VALUES
+(14888, 2, 126, 0),
+(14888, 3, 126, 0),
+(14888, 4, 126, 0),
+(14888, 5, 126, 0),
+(14888, 6, 126, 0);
+
+-- Ysondre
+UPDATE `creature_template` SET `DamageModifier` = 12.55, `ArmorModifier` = 1.3 WHERE (`entry` = 14887);
+
+DELETE FROM `creature_template_resistance` WHERE (`CreatureID` = 14887) AND (`School` IN (2, 3, 4, 5, 6));
+INSERT INTO `creature_template_resistance` (`CreatureID`, `School`, `Resistance`, `VerifiedBuild`) VALUES
+(14887, 2, 126, 0),
+(14887, 3, 126, 0),
+(14887, 4, 126, 0),
+(14887, 5, 126, 0),
+(14887, 6, 126, 0);
+
+-- Demented Druid Spirit
+UPDATE `creature_template` SET `DamageModifier` = 3.55, `BaseAttackTime` = 1410, `RangeAttackTime` = 1551, `ArmorModifier` = 0.35 WHERE (`entry` = 15260);
+
+-- Azuregos
+UPDATE `creature_template` SET `DamageModifier` = 20.45, `ArmorModifier` = 1.3 WHERE (`entry` = 6109);
+
+DELETE FROM `creature_template_resistance` WHERE (`CreatureID` = 6109) AND (`School` IN (2, 3, 4, 5, 6));
+INSERT INTO `creature_template_resistance` (`CreatureID`, `School`, `Resistance`, `VerifiedBuild`) VALUES
+(6109, 2, 126, 0),
+(6109, 3, 126, 0),
+(6109, 4, 300, 0),
+(6109, 5, 126, 0),
+(6109, 6, 300, 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Modifies DamMod for all Dragons of Nightmare, their adds and Azuregos
-  Lowers the bosses' damage across the board, and increases add damage

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unopened issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Engage the bosses Ysondre, Lethon, Emeriss, Taerar, Azuregos
2.  Engage the creatures Demented Druid Spirit, Shade of Taerar

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
