### PR TITLE
fix(Scripts/MoltenCore): Added loot recipient to Cache of the Firelord.

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/instance_molten_core.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/instance_molten_core.cpp
@@ -250,7 +250,11 @@ public:
 
             if (bossId == DATA_MAJORDOMO_EXECUTUS && state == DONE)
             {
-                DoRespawnGameObject(_cacheOfTheFirelordGUID, 7 * DAY);
+                if (GameObject* cache = instance->GetGameObject(_cacheOfTheFirelordGUID))
+                {
+                    cache->SetRespawnTime(7 * DAY);
+                    cache->SetLootRecipient(instance);
+                }
             }
             else if (bossId == DATA_GOLEMAGG)
             {


### PR DESCRIPTION
Fixes #12905

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12905
- Closes https://github.com/chromiecraft/chromiecraft/issues/4017

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

`.go creature 3328`
jump through window
group with second character
set loot to Free for all
on one char kill all bosses and majordomo's minions
`.summon` [player2]
[player2] can loot Cache of the Firelord
[Player2] leave instance before countdown

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
