### PR TITLE
fix(DB/creature): Grimscale Murloc improvements in Eversong Woods

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1664929532434519400.sql
+++ b/data/sql/updates/pending_db_world/rev_1664929532434519400.sql
@@ -4,4 +4,4 @@ UPDATE `creature` SET `id1`=15670, `id2`=15670, `id3`=15950 WHERE `id1` IN (1567
 UPDATE `creature` SET `id1`=15668, `id2`=15668, `id3`=15669 WHERE `id1` IN (15668, 15669);
 
 -- NPC Mmmrrrggglll (15937)'s spawn timer is just over 2 mins
-UPDATE `creature` SET `spawntimesecs`='130' WHERE  `guid`=41792;
+UPDATE `creature` SET `spawntimesecs`=130 WHERE  `guid`=41792;

--- a/data/sql/updates/pending_db_world/rev_1664929532434519400.sql
+++ b/data/sql/updates/pending_db_world/rev_1664929532434519400.sql
@@ -1,0 +1,7 @@
+--
+-- There are twice as many NPC Grimscale Forager (15670) as NPC Grimscale Seer (15950) and twice as many NPC Grimscale Murloc (15668) as NPC Grimscale Oracle (15669)
+UPDATE `creature` SET `id1`=15670, `id2`=15670, `id3`=15950 WHERE `id1` IN (15670, 15950);
+UPDATE `creature` SET `id1`=15668, `id2`=15668, `id3`=15669 WHERE `id1` IN (15668, 15669);
+
+-- NPC Mmmrrrggglll (15937)'s spawn timer is just over 2 mins
+UPDATE `creature` SET `spawntimesecs`='130' WHERE  `guid`=41792;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Shortens Mmmrrrggglll's spawn timer
-  Gives Grimscale NPCs proper (multiple) ids

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Sniff/Research

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Checked locally

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .tele Tranquilshore and look at the area, and see how they respawn as different types with melee bias.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- Spawn points in general might need checked, functionality wise it works
- At least one more PR is coming related to this area, maybe two if I can figure out the SAI needed

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
