### PR TITLE
Fix(core/scripts): issue 13325 - reset talents command

### DIFF
--- a/src/server/scripts/Commands/cs_reset.cpp
+++ b/src/server/scripts/Commands/cs_reset.cpp
@@ -252,7 +252,7 @@ public:
         else if (targetGuid)
         {
             CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_ADD_AT_LOGIN_FLAG);
-            stmt->SetData(0, uint16(AT_LOGIN_NONE | AT_LOGIN_RESET_PET_TALENTS));
+            stmt->SetData(0, uint16(AT_LOGIN_RESET_TALENTS | AT_LOGIN_RESET_PET_TALENTS));
             stmt->SetData(1, targetGuid.GetCounter());
             CharacterDatabase.Execute(stmt);
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  In file src\server\scripts\Commands\cs_reset.cpp in method HandleResetTalentsCommand:
- Change constant AT_LOGIN_NONE to AT_LOGIN_RESET_TALENTS

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes Issue 13325 https://github.com/azerothcore/azerothcore-wotlk/issues/13325#issue-1398587152

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
None.  Observed behavior.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Does it build without errors? Yes
- Did you test in-game? Yes
- What did you test? After the fix, logging in the character causes talents to be reset and a notification "Your talents have been reset"
- On which OS did you test?  Windows 10
- Describe any other tests performed  I checked the database after issuing the command, and observed that the at_login flag of the player was changed to 20 which is the expected value.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. At server console, type reset talents player, for an offline player (with learned talents.)
2. Check in the Character DB the at_login field for that player is now 20.
3. Log in the player.
4. Observe the talents are reset, and a system message saying the talents have been reset.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- This has been confirmed to work properly after the fix with GM ingame command as well, however I'm not sure if it was broken before the fix.
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
