### PR TITLE
fix(DB/Spells): Missing bonus data for paladin judgements

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1665082821255363600.sql
+++ b/data/sql/updates/pending_db_world/rev_1665082821255363600.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_bonus_data` WHERE `entry` = 54158;
+INSERT INTO `spell_bonus_data` (`entry`, `direct_bonus`, `dot_bonus`, `ap_bonus`, `ap_dot_bonus`, `comments`) VALUES
+(54158, 0.25, 0, 0.16, 0, 'Paladin - Judgement (Seal of Light, Seal of Wisdom, Seal of Justice)');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Re-add missing spell_bonus_data (not ideal but until we fix this shit out)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13331
- Closes https://github.com/chromiecraft/chromiecraft/issues/4159

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. See the issue.
2.
3.

