### PR TITLE
fix(Core): Fix PlayerSettingVectors

### DIFF
--- a/src/server/game/Entities/Player/PlayerSettings.cpp
+++ b/src/server/game/Entities/Player/PlayerSettings.cpp
@@ -78,6 +78,13 @@ PlayerSetting Player::GetPlayerSetting(std::string source, uint8 index)
         return GetPlayerSetting(source, index);
     }
 
+    PlayerSettingVector settingVector = itr->second;
+    if (settingVector.size() < index+1)
+    {
+        UpdatePlayerSetting(source, index, 0);
+        return GetPlayerSetting(source, index);
+    }
+
     return itr->second[index];
 }
 

--- a/src/server/game/Entities/Player/PlayerSettings.cpp
+++ b/src/server/game/Entities/Player/PlayerSettings.cpp
@@ -79,7 +79,7 @@ PlayerSetting Player::GetPlayerSetting(std::string source, uint8 index)
     }
 
     PlayerSettingVector settingVector = itr->second;
-    if (settingVector.size() < index+1)
+    if (settingVector.size() < (uint8)(index + 1))
     {
         UpdatePlayerSetting(source, index, 0);
         return GetPlayerSetting(source, index);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fix PlayerSettingVectors returning garbage values when requesting an existing source with a non-existing index

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game, works


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Call GetPlayerSetting for any source with a low index on a new character to create the vector
2. Call GetPlayerSetting a second time with the same source and a higher index
3. Ensure returned value is 0

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
