### PR TITLE
fix(DB/creature_template): Update AQ40 detection ranges

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1665166481073025800.sql
+++ b/data/sql/updates/pending_db_world/rev_1665166481073025800.sql
@@ -1,0 +1,5 @@
+UPDATE `creature_template` SET `detection_range` = 37.5 WHERE (`entry` IN (15262, 15312));
+UPDATE `creature_template` SET `detection_range` = 38.5 WHERE (`entry` = 15263);
+UPDATE `creature_template` SET `detection_range` = 15 WHERE (`entry` = 15300);
+UPDATE `creature_template` SET `detection_range` = 35 WHERE (`entry` IN (15240, 15230, 15264, 15311));
+UPDATE `creature_template` SET `detection_range` = 40 WHERE (`entry` IN (15235, 15236, 15249, 15509, 15277, 15229, 15544, 15543, 15511, 15233, 15247, 15275, 15276, 15252, 15246, 15250));

--- a/data/sql/updates/pending_db_world/rev_1665166481073025800.sql
+++ b/data/sql/updates/pending_db_world/rev_1665166481073025800.sql
@@ -2,4 +2,4 @@ UPDATE `creature_template` SET `detection_range` = 37.5 WHERE (`entry` IN (15262
 UPDATE `creature_template` SET `detection_range` = 38.5 WHERE (`entry` = 15263);
 UPDATE `creature_template` SET `detection_range` = 15 WHERE (`entry` = 15300);
 UPDATE `creature_template` SET `detection_range` = 35 WHERE (`entry` IN (15240, 15230, 15264, 15311));
-UPDATE `creature_template` SET `detection_range` = 40 WHERE (`entry` IN (15235, 15236, 15249, 15509, 15277, 15229, 15544, 15543, 15511, 15233, 15247, 15275, 15276, 15252, 15246, 15250));
+UPDATE `creature_template` SET `detection_range` = 40 WHERE (`entry` IN (15235, 15236, 15249, 15509, 15277, 15229, 15544, 15543, 15511, 15233, 15247, 15275, 15276, 15252, 15246, 15250, 15299));


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Increases detection ranges for AQ40 creatures

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unopened issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Retail

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. See if the creatures now pull at ranges higher than 20y

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
