### PR TITLE
feat(Core/DB): add support range loop for mysql result

### DIFF
--- a/src/server/apps/authserver/Server/AuthSession.cpp
+++ b/src/server/apps/authserver/Server/AuthSession.cpp
@@ -195,13 +195,11 @@ void AuthSession::CheckIpCallback(PreparedQueryResult result)
     {
         bool banned = false;
 
-        do
+        for (auto const& fields : *result)
         {
-            Field* fields = result->Fetch();
             if (fields[0].Get<uint64>() != 0)
                 banned = true;
-
-        } while (result->NextRow());
+        }
 
         if (banned)
         {

--- a/src/server/apps/authserver/Server/AuthSession.cpp
+++ b/src/server/apps/authserver/Server/AuthSession.cpp
@@ -198,7 +198,10 @@ void AuthSession::CheckIpCallback(PreparedQueryResult result)
         for (auto const& fields : *result)
         {
             if (fields[0].Get<uint64>() != 0)
+            {
                 banned = true;
+                break;
+            }
         }
 
         if (banned)

--- a/src/server/database/Database/QueryResult.h
+++ b/src/server/database/Database/QueryResult.h
@@ -24,6 +24,27 @@
 #include <tuple>
 #include <vector>
 
+template<typename T>
+struct ResultIterator
+{
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type   = std::ptrdiff_t;
+    using value_type        = T;
+    using pointer           = T*;
+    using reference         = T&;
+
+    explicit ResultIterator(pointer ptr) : _ptr(ptr) { }
+
+    reference operator*() const { return *_ptr; }
+    pointer operator->() { return _ptr; }
+    ResultIterator& operator++() { if (!_ptr->NextRow()) _ptr = nullptr; return *this; }
+
+    bool operator!=(const ResultIterator& right) { return _ptr != right._ptr; }
+
+private:
+    pointer _ptr;
+};
+
 class AC_DATABASE_API ResultSet
 {
 public:
@@ -53,6 +74,9 @@ public:
 
         return theTuple;
     }
+
+    auto begin()      { return ResultIterator<ResultSet>(this); }
+    static auto end() { return ResultIterator<ResultSet>(nullptr); }
 
 protected:
     std::vector<QueryResultFieldMetadata> _fieldMetadata;
@@ -99,6 +123,9 @@ public:
 
         return theTuple;
     }
+
+    auto begin()        { return ResultIterator<PreparedResultSet>(this); }
+    static auto end()   { return ResultIterator<PreparedResultSet>(nullptr); }
 
 protected:
     std::vector<QueryResultFieldMetadata> m_fieldMetadata;

--- a/src/server/shared/Realms/RealmList.cpp
+++ b/src/server/shared/Realms/RealmList.cpp
@@ -53,11 +53,10 @@ void RealmList::Close()
 void RealmList::LoadBuildInfo()
 {
     //                                                              0             1              2              3      4                5                6
-    if (QueryResult result = LoginDatabase.Query("SELECT majorVersion, minorVersion, bugfixVersion, hotfixVersion, build, winChecksumSeed, macChecksumSeed FROM build_info ORDER BY build ASC"))
+    if (auto result = LoginDatabase.Query("SELECT majorVersion, minorVersion, bugfixVersion, hotfixVersion, build, winChecksumSeed, macChecksumSeed FROM build_info ORDER BY build ASC"))
     {
-        do
+        for (auto const& fields : *result)
         {
-            Field* fields = result->Fetch();
             RealmBuildInfo& build = _builds.emplace_back();
             build.MajorVersion = fields[0].Get<uint32>();
             build.MinorVersion = fields[1].Get<uint32>();
@@ -87,7 +86,7 @@ void RealmList::LoadBuildInfo()
             {
                 HexStrToByteArray(macHash, build.MacHash);
             }
-        } while (result->NextRow());
+        }
     }
 }
 
@@ -149,11 +148,10 @@ void RealmList::UpdateRealms(boost::system::error_code const& error)
     // Circle through results and add them to the realm map
     if (result)
     {
-        do
+        for (auto const& fields : *result)
         {
             try
             {
-                Field* fields = result->Fetch();
                 uint32 realmId = fields[0].Get<uint32>();
                 std::string name = fields[1].Get<std::string>();
                 std::string externalAddressString = fields[2].Get<std::string>();
@@ -221,7 +219,7 @@ void RealmList::UpdateRealms(boost::system::error_code const& error)
                 LOG_ERROR("server.authserver", "Realmlist::UpdateRealms has thrown an exception: {}", ex.what());
                 ABORT();
             }
-        } while (result->NextRow());
+        }
     }
 
     for (auto itr = existingRealms.begin(); itr != existingRealms.end(); ++itr)


### PR DESCRIPTION
## Changes Proposed:
- Add support range loop for `ResultSet` and `PreparedResultSet`

## SOURCE:
- https://github.com/WarheadCore/WarheadBand/commit/ea5f2b1538cc39d551a4fadc8ce9f8fa04c37b37

## Tests Performed:
- Tested in-game

### Examples:

```cpp
auto result = WorldDatabase.Query("SELECT racemask, classmask, Spell FROM playercreateinfo_spell_custom");

for (auto const& fields : *result)
{

    uint32 raceMask = fields[0].Get<uint32>();
    uint32 classMask = fields[1].Get<uint32>();
    uint32 spellId = fields[2].Get<uint32>();

    // ...
}
````