### PR TITLE
fix(Scripts/TempleOfAhnQiraj): Don't submerge Ouro if it's already en…

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_ouro.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_ouro.cpp
@@ -129,6 +129,9 @@ struct boss_ouro : public BossAI
 
     void Submerge()
     {
+        if (_enraged)
+            return;
+
         me->AttackStop();
         me->SetReactState(REACT_PASSIVE);
         me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_NON_ATTACKABLE);


### PR DESCRIPTION
…raged

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add an enrage check for its third phase.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes -

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Ouro, engage and damage it until 20%
2. It should never submerge after that.

