### PR TITLE
fix(DB/creature_template): Add IGNORE_ASSISTANCE_CALL to Anubisath Sentinel

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1665712907402997300.sql
+++ b/data/sql/updates/pending_db_world/rev_1665712907402997300.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `flags_extra` = 0 WHERE `entry` IN (14882, 14883, 14825, 13996);

--- a/data/sql/updates/pending_db_world/rev_1665712907402997300.sql
+++ b/data/sql/updates/pending_db_world/rev_1665712907402997300.sql
@@ -1,2 +1,3 @@
 --
 UPDATE `creature_template` SET `flags_extra` = 0 WHERE `entry` IN (14882, 14883, 14825, 13996);
+UPDATE `creature_template` SET `flags_extra` = 33554432 WHERE (`entry` = 15264);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add IGNORE_ASSISTANCE_CALL to Anubisath Sentinel
-  And remove that flag from creatures that are not supposed to have it.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Retail

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Zul'Gurub, pull the trash pack in front of Jin'do without pulling Jin'do himself
2. `.go xyz -7455.238281 -893.764771 465.217041 469 5.961959` Attack the warlock, see if Wyrmtalons are pulled
3. Go to AQ40, at the second pack of Anubisath Sentinels, pull an Obsidian Eradicator while it is pathing nearby the Anubisath and see if they assist.
4. Pull the Anubisath Sentinel pack to see if they are still linked

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
