### PR TITLE
fix(Scripts/TempleOfAhnQiraj): Skeram copies shouldn't save raid cd

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1665863988336160100.sql
+++ b/data/sql/updates/pending_db_world/rev_1665863988336160100.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `flags_extra` = `flags_extra`&~1 WHERE `entry` = 15263;

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
@@ -134,6 +134,8 @@ struct boss_skeram : public BossAI
         {
             _JustDied();
             Talk(SAY_DEATH);
+            if (me->GetMap() && me->GetMap()->ToInstanceMap())
+                me->GetMap()->ToInstanceMap()->PermBindAllPlayers();
         }
         else
             me->RemoveCorpse();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove instance bind flag_extra and force bind on death.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13417
- Closes https://github.com/chromiecraft/chromiecraft/issues/4214

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to skeram and kill copies, they shouldn't give raid cd unless you kill the original one.

