### PR TITLE
fix(Scripts/TempleOfAhnQiraj): Anubisath Sentinel Mortal Strike and M…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1665949856612609200.sql
+++ b/data/sql/updates/pending_db_world/rev_1665949856612609200.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_anubisath_mortal_strike', 'spell_mana_burn_area');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(9347, 'spell_anubisath_mortal_strike'),
+(26626, 'spell_mana_burn_area');

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/mob_anubisath_sentinel.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/mob_anubisath_sentinel.cpp
@@ -30,6 +30,7 @@ EndScriptData */
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
 #include "Spell.h"
+#include "SpellScript.h"
 #include "WorldPacket.h"
 
 enum Spells

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/mob_anubisath_sentinel.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/mob_anubisath_sentinel.cpp
@@ -316,7 +316,46 @@ public:
     };
 };
 
+// 9347: Mortal Strike
+class spell_anubisath_mortal_strike : public AuraScript
+{
+    PrepareAuraScript(spell_anubisath_mortal_strike);
+
+    void OnPeriodic(AuraEffect const* /*aurEff*/)
+    {
+        PreventDefaultAction();
+
+        if (Unit* target = GetUnitOwner()->GetVictim())
+            if (target->IsWithinDist(GetUnitOwner(), 5.f))
+                GetUnitOwner()->CastSpell(target, GetSpellInfo()->Effects[EFFECT_0].TriggerSpell, true);
+    }
+
+    void Register() override
+    {
+        OnEffectPeriodic += AuraEffectPeriodicFn(spell_anubisath_mortal_strike::OnPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_TRIGGER_SPELL);
+    }
+};
+
+// 26626 (Server-side): Mana Burn Area
+class spell_mana_burn_area : public SpellScript
+{
+    PrepareSpellScript(spell_mana_burn_area);
+
+    void HandleDummy(SpellEffIndex /*effIndex*/)
+    {
+        if (Unit* target = GetHitUnit())
+            GetCaster()->CastSpell(target, SPELL_MANAB, true);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_mana_burn_area::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+    }
+};
+
 void AddSC_npc_anubisath_sentinel()
 {
     new npc_anubisath_sentinel();
+    RegisterSpellScript(spell_anubisath_mortal_strike);
+    RegisterSpellScript(spell_mana_burn_area);
 }

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/mob_anubisath_sentinel.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/mob_anubisath_sentinel.cpp
@@ -15,23 +15,11 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* ScriptData
-SDName: npc_anubisath_sentinel
-SD%Complete: 95
-SDComment: Shadow storm is not properly implemented in core it should only target ppl outside of melee range.
-SDCategory: Temple of Ahn'Qiraj
-EndScriptData */
-
-#include "Cell.h"
-#include "CellImpl.h"
-#include "GridNotifiers.h"
-#include "GridNotifiersImpl.h"
 #include "Player.h"
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
-#include "Spell.h"
 #include "SpellScript.h"
-#include "WorldPacket.h"
+#include "temple_of_ahnqiraj.h"
 
 enum Spells
 {


### PR DESCRIPTION
…ana Burn

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added scripts for the spells.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13434
- Closes https://github.com/chromiecraft/chromiecraft/issues/4230
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13432
- Closes https://github.com/chromiecraft/chromiecraft/issues/4229

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Temple of Ahn Qiraj and engage Anubisath Sentinels with mortal strike and mana burn buffs.
2. Mortal Strike should be casted on victim and the sentinel should mana burn within a fixed radius (40yds).

