### PR TITLE
fix(Scripts/TempleOfAhnQiraj): Use correct Ids for Drain Mana

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/temple_of_ahnqiraj.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/temple_of_ahnqiraj.cpp
@@ -59,7 +59,7 @@ enum Spells
 
     // Obsidian Nullifier
     SPELL_NULLIFY                       = 26552,
-	SPELL_DRAIN_MANA_NULLIFIER          = 25671,
+    SPELL_DRAIN_MANA_NULLIFIER          = 25671,
     SPELL_CLEAVE                        = 40504,
 
     // Qiraji Scorpion

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/temple_of_ahnqiraj.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/temple_of_ahnqiraj.cpp
@@ -47,7 +47,7 @@ enum Spells
 
     // Obsidian Eradicator
     SPELL_SHOCK_BLAST                   = 26458,
-    SPELL_DRAIN_MANA                    = 25671,
+    SPELL_DRAIN_MANA_ERADICATOR         = 25755,
     SPELL_DRAIN_MANA_VISUAL             = 26639,
 
     // Anubisath Warder
@@ -59,6 +59,7 @@ enum Spells
 
     // Obsidian Nullifier
     SPELL_NULLIFY                       = 26552,
+	SPELL_DRAIN_MANA_NULLIFIER          = 25671,
     SPELL_CLEAVE                        = 40504,
 
     // Qiraji Scorpion
@@ -268,7 +269,7 @@ struct npc_obsidian_eradicator : public ScriptedAI
 
             for (Unit* target : _targets)
             {
-                DoCast(target, SPELL_DRAIN_MANA, true);
+                DoCast(target, SPELL_DRAIN_MANA_ERADICATOR, true);
             }
 
             if (me->GetPowerPct(POWER_MANA) >= 100.f)
@@ -401,7 +402,7 @@ struct npc_obsidian_nullifier : public ScriptedAI
 
             for (Unit* target : _targets)
             {
-                DoCast(target, SPELL_DRAIN_MANA, true);
+                DoCast(target, SPELL_DRAIN_MANA_NULLIFIER, true);
             }
 
             if (me->GetPowerPct(POWER_MANA) >= 100.f)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/4227

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Drain Mana is still cast for both creatures
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
