### PR TITLE
fix(CORE): another attempt to fix the dbimport command line warning

### DIFF
--- a/apps/docker/Dockerfile
+++ b/apps/docker/Dockerfile
@@ -47,6 +47,7 @@ RUN addgroup --gid $GROUP_ID acore && \
 RUN mkdir -p /azerothcore/env/dist/bin
 RUN mkdir -p /azerothcore/env/dist/data
 RUN mkdir -p /azerothcore/env/dist/logs
+RUN mkdir -p /azerothcore/env/dist/temp
 RUN mkdir -p /azerothcore/env/dist/etc
 RUN mkdir -p /azerothcore/var/build/obj
 

--- a/env/docker/etc/authserver.conf.dockerdist
+++ b/env/docker/etc/authserver.conf.dockerdist
@@ -6,6 +6,8 @@
 # Do not change this
 # Files in LogsDir will reflect on your host directory: docker/authserver/logs
 LogsDir = "/azerothcore/env/dist/logs"
+# Files in TempDir will reflect on your host directory: docker/authserver/temp
+TempDir = "/azerothcore/env/dist/temp"
 
 # Change this configuration accordingly with your docker setup
 # The format is "hostname;port;username;password;database":

--- a/env/docker/etc/dbimport.conf.dockerdist
+++ b/env/docker/etc/dbimport.conf.dockerdist
@@ -1,6 +1,8 @@
 # Do NOT change those Dir configs
 # Files in LogsDir will reflect on your host directory: docker/worldserver/logs
 LogsDir = "/azerothcore/env/dist/logs"
+# Files in TempDir will reflect on your host directory: docker/authserver/temp
+TempDir = "/azerothcore/env/dist/temp"
 DataDir = "/azerothcore/env/dist/data"
 
 # Change this configuration accordingly with your docker setup

--- a/env/docker/etc/worldserver.conf.dockerdist
+++ b/env/docker/etc/worldserver.conf.dockerdist
@@ -6,6 +6,8 @@
 # Do NOT change those Dir configs
 # Files in LogsDir will reflect on your host directory: docker/worldserver/logs
 LogsDir = "/azerothcore/env/dist/logs"
+# Files in TempDir will reflect on your host directory: docker/authserver/temp
+TempDir = "/azerothcore/env/dist/temp"
 DataDir = "/azerothcore/env/dist/data"
 
 # Change this configuration accordingly with your docker setup

--- a/mysql_ac.conf
+++ b/mysql_ac.conf
@@ -1,0 +1,2 @@
+[client]
+password = "password"

--- a/mysql_ac.conf
+++ b/mysql_ac.conf
@@ -1,2 +1,0 @@
-[client]
-password = "password"

--- a/src/common/Utilities/StringFormat.cpp
+++ b/src/common/Utilities/StringFormat.cpp
@@ -67,9 +67,9 @@ std::string Acore::String::TrimRightInPlace(std::string& str)
 /**
  * @brief Util function to add a suffix char. Can be used to add a slash at the end of a path
  * 
- * @param str 
- * @param suffix 
- * @return std::string 
+ * @param str String where to apply the suffix
+ * @param suffix Character to add at the end of the str
+ * @return std::string Suffixed string
  */
 std::string Acore::String::AddSuffixIfNotExists(std::string str, const char suffix) {
     if (str.empty() || (str.at(str.length() - 1) != suffix))

--- a/src/common/Utilities/StringFormat.cpp
+++ b/src/common/Utilities/StringFormat.cpp
@@ -66,7 +66,7 @@ std::string Acore::String::TrimRightInPlace(std::string& str)
 
 /**
  * @brief Util function to add a suffix char. Can be used to add a slash at the end of a path
- * 
+ *
  * @param str String where to apply the suffix
  * @param suffix Character to add at the end of the str
  * @return std::string Suffixed string

--- a/src/common/Utilities/StringFormat.cpp
+++ b/src/common/Utilities/StringFormat.cpp
@@ -64,5 +64,19 @@ std::string Acore::String::TrimRightInPlace(std::string& str)
     return str;
 }
 
+/**
+ * @brief Util function to add a suffix char. Can be used to add a slash at the end of a path
+ * 
+ * @param str 
+ * @param suffix 
+ * @return std::string 
+ */
+std::string Acore::String::AddSuffixIfNotExists(std::string str, const char suffix) {
+    if (str.empty() || (str.at(str.length() - 1) != suffix))
+        str.push_back(suffix);
+
+    return str;
+}
+
 // Template Trim
 template AC_COMMON_API std::string Acore::String::Trim<std::string>(const std::string& s, const std::locale& loc /*= std::locale()*/);

--- a/src/common/Utilities/StringFormat.h
+++ b/src/common/Utilities/StringFormat.h
@@ -72,6 +72,8 @@ namespace Acore::String
     AC_COMMON_API Str Trim(const Str& s, const std::locale& loc = std::locale());
 
     AC_COMMON_API std::string TrimRightInPlace(std::string& str);
+
+    AC_COMMON_API std::string AddSuffixIfNotExists(std::string str, const char suffix);
 }
 
 #endif

--- a/src/server/apps/authserver/authserver.conf.dist
+++ b/src/server/apps/authserver/authserver.conf.dist
@@ -167,13 +167,23 @@ SourceDirectory = ""
 #        Description: The path to your MySQL CLI binary.
 #                     If the path is left empty, built-in path from cmake is used.
 #        Example:     "C:/Program Files/MariaDB 10.5/bin/mysql.exe"
-#                     "C:/Program Files/MySQL/MySQL Server 5.6/bin/mysql.exe"
+#                     "C:/Program Files/MySQL/MySQL Server 8.0/bin/mysql.exe"
 #                     "mysql.exe"
 #                     "/usr/bin/mysql"
 #        Default:     ""
 #
 
 MySQLExecutable = ""
+
+#
+#    TempDir
+#        Description: Temp directory setting.
+#        Important:   TempDir needs to be quoted, as the string might contain space characters.
+#                     TempDir directory must exists, or the server can't work properly
+#        Example:     "/home/youruser/azerothcore/temp"
+#        Default:     "" - (Temp files will be stored in the current path)
+
+TempDir = ""
 
 #
 #    IPLocationFile

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -211,17 +211,6 @@ SourceDirectory = ""
 MySQLExecutable = ""
 
 #
-#    MySQLConfigEditorExecutable
-#        Description: The path to your MySQL CLI binary.
-#                     If the path is left empty, built-in path from cmake is used.
-#        Example:     "C:/Program Files/MySQL/MySQL Server 8.0/bin/mysql_config_editor.exe"
-#                     "mysql.exe"
-#                     "/usr/bin/mysql_config_editor"
-#        Default:     ""
-
-MySQLConfigEditorExecutable = ""
-
-#
 #    ThreadPool
 #        Description: Number of threads to be used for the global thread pool
 #                     The thread pool is currently used for:

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -82,6 +82,16 @@ DataDir = "."
 LogsDir = ""
 
 #
+#    TempDir
+#        Description: Temp directory setting.
+#        Important:   TempDir needs to be quoted, as the string might contain space characters.
+#                     TempDir directory must exists, or the server can't work properly
+#        Example:     "/home/youruser/azerothcore/temp"
+#        Default:     "" - (Temp files will be stored in the current path)
+
+TempDir = ""
+
+#
 #    LoginDatabaseInfo
 #    WorldDatabaseInfo
 #    CharacterDatabaseInfo
@@ -193,12 +203,23 @@ SourceDirectory = ""
 #    MySQLExecutable
 #        Description: The path to your MySQL CLI binary.
 #                     If the path is left empty, built-in path from cmake is used.
-#        Example:     "C:/Program Files/MySQL/MySQL Server 5.7/bin/mysql.exe"
+#        Example:     "C:/Program Files/MySQL/MySQL Server 8.0/bin/mysql.exe"
 #                     "mysql.exe"
 #                     "/usr/bin/mysql"
 #        Default:     ""
 
 MySQLExecutable = ""
+
+#
+#    MySQLConfigEditorExecutable
+#        Description: The path to your MySQL CLI binary.
+#                     If the path is left empty, built-in path from cmake is used.
+#        Example:     "C:/Program Files/MySQL/MySQL Server 8.0/bin/mysql_config_editor.exe"
+#                     "mysql.exe"
+#                     "/usr/bin/mysql_config_editor"
+#        Default:     ""
+
+MySQLConfigEditorExecutable = ""
 
 #
 #    ThreadPool

--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -440,15 +440,27 @@ template<class T>
 void DBUpdater<T>::ApplyFile(DatabaseWorkerPool<T>& pool, std::string const& host, std::string const& user,
                              std::string const& password, std::string const& port_or_socket, std::string const& database, std::string const& ssl, Path const& path)
 {
+    std::string tempDir = sConfigMgr->GetOption<std::string>("TempDir", "");
+
+    if (!tempDir.empty())
+        tempDir = Acore::String::AddSuffixIfNotExists(tempDir, '/');
+
+    std::string confFileName = "mysql_ac.conf";
+
+    std::ofstream outfile (tempDir + confFileName);
+
+    outfile << "[client]\npassword = \"" << password << '"' << std::endl;
+
+    outfile.close();
+
     std::vector<std::string> args;
     args.reserve(9);
+
+    args.emplace_back("--defaults-extra-file="+tempDir + confFileName+"");
 
     // CLI Client connection info
     args.emplace_back("-h" + host);
     args.emplace_back("-u" + user);
-
-    if (!password.empty())
-        args.emplace_back("-p" + password);
 
     // Check if we want to connect through ip or socket (Unix only)
 #ifdef _WIN32

--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -440,10 +440,9 @@ template<class T>
 void DBUpdater<T>::ApplyFile(DatabaseWorkerPool<T>& pool, std::string const& host, std::string const& user,
                              std::string const& password, std::string const& port_or_socket, std::string const& database, std::string const& ssl, Path const& path)
 {
-    std::string tempDir = sConfigMgr->GetOption<std::string>("TempDir", "");
+    std::string configTempDir = sConfigMgr->GetOption<std::string>("TempDir", "");
 
-    if (tempDir.empty())
-        tempDir = std::filesystem::temp_directory_path().filename().string();;
+    auto tempDir = configTempDir.empty() ? std::filesystem::temp_directory_path().generic_string() : configTempDir;
 
     tempDir = Acore::String::AddSuffixIfNotExists(tempDir, '/');
     std::string confFileName = "mysql_ac.conf";

--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -442,9 +442,10 @@ void DBUpdater<T>::ApplyFile(DatabaseWorkerPool<T>& pool, std::string const& hos
 {
     std::string tempDir = sConfigMgr->GetOption<std::string>("TempDir", "");
 
-    if (!tempDir.empty())
-        tempDir = Acore::String::AddSuffixIfNotExists(tempDir, '/');
+    if (tempDir.empty())
+        tempDir = std::filesystem::temp_directory_path();
 
+    tempDir = Acore::String::AddSuffixIfNotExists(tempDir, '/');
     std::string confFileName = "mysql_ac.conf";
 
     std::ofstream outfile (tempDir + confFileName);

--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -442,9 +442,10 @@ void DBUpdater<T>::ApplyFile(DatabaseWorkerPool<T>& pool, std::string const& hos
 {
     std::string configTempDir = sConfigMgr->GetOption<std::string>("TempDir", "");
 
-    auto tempDir = configTempDir.empty() ? std::filesystem::temp_directory_path().generic_string() : configTempDir;
+    auto tempDir = configTempDir.empty() ? std::filesystem::temp_directory_path().string() : configTempDir;
 
-    tempDir = Acore::String::AddSuffixIfNotExists(tempDir, '/');
+    tempDir = Acore::String::AddSuffixIfNotExists(tempDir, std::filesystem::path::preferred_separator);
+
     std::string confFileName = "mysql_ac.conf";
 
     std::ofstream outfile (tempDir + confFileName);

--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -443,7 +443,7 @@ void DBUpdater<T>::ApplyFile(DatabaseWorkerPool<T>& pool, std::string const& hos
     std::string tempDir = sConfigMgr->GetOption<std::string>("TempDir", "");
 
     if (tempDir.empty())
-        tempDir = std::filesystem::temp_directory_path();
+        tempDir = std::filesystem::temp_directory_path().filename().string();;
 
     tempDir = Acore::String::AddSuffixIfNotExists(tempDir, '/');
     std::string confFileName = "mysql_ac.conf";

--- a/src/tools/dbimport/dbimport.conf.dist
+++ b/src/tools/dbimport/dbimport.conf.dist
@@ -61,6 +61,17 @@ SourceDirectory = ""
 #
 
 MySQLExecutable = ""
+
+#
+#    TempDir
+#        Description: Temp directory setting.
+#        Important:   TempDir needs to be quoted, as the string might contain space characters.
+#                     TempDir directory must exists, or the server can't work properly
+#        Example:     "/home/youruser/azerothcore/temp"
+#        Default:     "" - (Temp files will be stored in the current path)
+
+TempDir = ""
+
 ###################################################################################################
 
 ###################################################################################################


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  This new approach uses the defaults-extra-file strategy mysql argument to provide a password through a config file that is created by the server on the fly
- Implemented the TempDir config that can be used to store temporary files (including the generated mysql conf)

Related: https://github.com/azerothcore/azerothcore-wotlk/pull/13404

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Running on a linux and windows environment. No errors


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run the worldserver preferably on a new database 
2. check if you have any error
