### PR TITLE
feat(CORE): implemented AC_DISABLE_INTERACTIVE for DBUpdater

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ x-cache-from: &cache-from
 x-ac-shared-conf: &ac-shared-conf
   <<: *networks
   working_dir: /azerothcore
+  environment:
+    AC_DISABLE_INTERACTIVE: "1"
   depends_on:
     ac-database:
       condition: service_healthy

--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -170,11 +170,15 @@ BaseLocation DBUpdater<T>::GetBaseLocationType()
 template<class T>
 bool DBUpdater<T>::Create(DatabaseWorkerPool<T>& pool)
 {
-    LOG_WARN("sql.updates", "Database \"{}\" does not exist, do you want to create it? [yes (default) / no]: ",
+    LOG_WARN("sql.updates", "Database \"{}\" does not exist",
              pool.GetConnectionInfo()->database);
 
-    if (!sConfigMgr->isDryRun())
+    const char* interactiveOpt = std::getenv("AC_DISABLE_INTERACTIVE");
+
+    if (!sConfigMgr->isDryRun() && std::strcmp(interactiveOpt, "1") != 0)
     {
+        std::cout << "Do you want to create it? [yes (default) / no]:" << interactiveOpt << std::endl;
+
         std::string answer;
         std::getline(std::cin, answer);
         if (!answer.empty() && !(answer.substr(0, 1) == "y"))

--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -170,15 +170,13 @@ BaseLocation DBUpdater<T>::GetBaseLocationType()
 template<class T>
 bool DBUpdater<T>::Create(DatabaseWorkerPool<T>& pool)
 {
-    LOG_WARN("sql.updates", "Database \"{}\" does not exist",
-             pool.GetConnectionInfo()->database);
+    LOG_WARN("sql.updates", "Database \"{}\" does not exist", pool.GetConnectionInfo()->database);
 
     const char* interactiveOpt = std::getenv("AC_DISABLE_INTERACTIVE");
 
     if (!sConfigMgr->isDryRun() && std::strcmp(interactiveOpt, "1") != 0)
     {
-        std::cout << "Do you want to create it? [yes (default) / no]:" << interactiveOpt << std::endl;
-
+        std::cout << "Do you want to create it? [yes (default) / no]:" << std::endl;
         std::string answer;
         std::getline(std::cin, answer);
         if (!answer.empty() && !(answer.substr(0, 1) == "y"))


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Implement AC_DISABLE_INTERACTIVE that allow us to skip the question when the db doesn't exit

It can be useful for other purposes

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
