### PR TITLE
fix(DB/HallowsEnd): Fixed "Trick or Treat" gossip option for Innkeepe…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1666432426153540900.sql
+++ b/data/sql/updates/pending_db_world/rev_1666432426153540900.sql
@@ -1,0 +1,7 @@
+--
+DELETE FROM `smart_scripts` WHERE `entryorguid`=6740 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(6740,0,0,1,62,0,100,0,342,0,0,0,0,72,0,0,0,0,0,0,7,0,0,0,0,0,0,0,0,'Innkeeper Allison - On Gossip Option 0 Selected - Close Gossip'),
+(6740,0,1,0,61,0,100,0,0,0,0,0,0,85,24751,0,0,0,0,0,7,0,0,0,0,0,0,0,0,'Innkeeper Allison - On Gossip Option 0 Selected - Invoker Cast Trick or Treat'),
+(6740,0,2,3,22,0,100,0,41,0,0,0,0,33,6740,0,0,0,0,0,7,0,0,0,0,0,0,0,0,'Innkeeper Allison - Received Emote 41 - Quest Credit Flexing for Nougat'),
+(6740,0,3,0,61,0,100,0,0,0,0,0,0,1,0,0,0,0,0,0,7,0,0,0,0,0,0,0,0,'Innkeeper Allison - Received Emote 41 - Talk 0');


### PR DESCRIPTION
…r Allison. Source: TrinityCore.

Fixed #13462

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13462
- Closes #13463
- Closes https://github.com/chromiecraft/chromiecraft/issues/4245
- Closes https://github.com/chromiecraft/chromiecraft/issues/4250

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go c 79841` while in the event "hallow's end".
Interact with the innkeeper and see the dialog options.
Click the option "trick or treat".

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
