### PR TITLE
fix(DB/Spells): Fiery Payback should have 1min internal cooldown.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1666457333873760600.sql
+++ b/data/sql/updates/pending_db_world/rev_1666457333873760600.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `spell_proc_event` WHERE `entry` IN (64349,64350);
+INSERT INTO `spell_proc_event` VALUES
+(64349,0,0,0,0,0,0,0,0,0,0,60000),
+(64350,0,0,0,0,0,0,0,0,0,0,60000);


### PR DESCRIPTION
Fixes #13345

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13345
- Closes https://github.com/chromiecraft/chromiecraft/issues/3770

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.aura 64349` (Fiery Payback) on target
`.mod hp 1000000000` `.damage 800000000` on target
`.additem 5551` or any other .lookup item fast test on self
Attack the target that is below <35% HP
See how often Fiery Payback procs. Remember that diminishing effects still apply.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
