### PR TITLE
fix(DB/WorldEvents): Added missing spawn of Katrina Shimmerstar.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1666530994967113600.sql
+++ b/data/sql/updates/pending_db_world/rev_1666530994967113600.sql
@@ -1,0 +1,8 @@
+--
+DELETE FROM `creature` WHERE `guid`=91799;
+INSERT INTO `creature` (`guid`, `id1`, `map`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(91799,15353,0,1,1,1,-4918.64,-983.141,501.538,2.43867,300,0,0,1,0,0,0,0,0,'',0);
+
+DELETE FROM `game_event_creature` WHERE `guid`=91799;
+INSERT INTO `game_event_creature` VALUES
+(12,91799);


### PR DESCRIPTION
Fixes #13510

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13510
- Closes https://github.com/chromiecraft/chromiecraft/issues/4284

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
try `.go c id 15353`

`.tele ironforge`
`.go xyz -4921 -978 502`

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
