### PR TITLE
fix(Core/Quest): Fixed implementation of `CONFIG_QUEST_IGNORE_AUTO_ACCEPT` and `CONFIG_QUEST_IGNORE_AUTO_COMPLETE` configs.

### DIFF
--- a/src/server/game/Quests/QuestDef.cpp
+++ b/src/server/game/Quests/QuestDef.cpp
@@ -131,6 +131,16 @@ Quest::Quest(Field* questRecord)
     }
 
     _eventIdForQuest = 0;
+
+    if (sWorld->getBoolConfig(CONFIG_QUEST_IGNORE_AUTO_ACCEPT))
+    {
+        Flags &= ~QUEST_FLAGS_AUTO_ACCEPT;
+    }
+
+    if (sWorld->getBoolConfig(CONFIG_QUEST_IGNORE_AUTO_COMPLETE))
+    {
+        Flags &= ~QUEST_FLAGS_AUTOCOMPLETE;
+    }
 }
 
 void Quest::LoadQuestDetails(Field* fields)
@@ -180,8 +190,10 @@ void Quest::LoadQuestTemplateAddon(Field* fields)
     RewardMailSenderEntry = fields[16].Get<uint32>();
     SpecialFlags = fields[17].Get<uint8>();
 
-    if (SpecialFlags & QUEST_SPECIAL_FLAGS_AUTO_ACCEPT)
+    if ((SpecialFlags & QUEST_SPECIAL_FLAGS_AUTO_ACCEPT) && !sWorld->getBoolConfig(CONFIG_QUEST_IGNORE_AUTO_ACCEPT))
+    {
         Flags |= QUEST_FLAGS_AUTO_ACCEPT;
+    }
 }
 
 uint32 Quest::XPValue(uint8 playerLevel) const
@@ -253,12 +265,12 @@ uint32 Quest::GetRewMoneyMaxLevel() const
 
 bool Quest::IsAutoAccept() const
 {
-    return sWorld->getBoolConfig(CONFIG_QUEST_IGNORE_AUTO_ACCEPT) ? false : (Flags & QUEST_FLAGS_AUTO_ACCEPT);
+    return HasFlag(QUEST_FLAGS_AUTO_ACCEPT);
 }
 
 bool Quest::IsAutoComplete() const
 {
-    return sWorld->getBoolConfig(CONFIG_QUEST_IGNORE_AUTO_COMPLETE) ? false : HasFlag(QUEST_FLAGS_AUTOCOMPLETE);
+    return HasFlag(QUEST_FLAGS_AUTOCOMPLETE);
 }
 
 bool Quest::IsRaidQuest(Difficulty difficulty) const


### PR DESCRIPTION
Fixes #3503

<!-- First of all, THANK YOU for your contribution. --> 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #3503

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Set `Quests.IgnoreAutoAccept=1` in worldconfig
Clear `Cache` folder inside WoW directory
Create human char
Accept the quest from the nearby NPC

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
