### PR TITLE
fix(Scripts/TempleOfAhnQiraj): Make sure Sartura adds respawn on evade

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1666648043812780000.sql
+++ b/data/sql/updates/pending_db_world/rev_1666648043812780000.sql
@@ -1,2 +1,2 @@
 --
-UPDATE `creature_formations` SET `groupAI` = 523 WHERE `leaderGUID` = 87648 AND `memberGUID` IN (87649, 87650, 87651);
+UPDATE `creature_formations` SET `groupAI` = 539 WHERE `leaderGUID` = 87648 AND `memberGUID` IN (87648, 87649, 87650, 87651);

--- a/data/sql/updates/pending_db_world/rev_1666648043812780000.sql
+++ b/data/sql/updates/pending_db_world/rev_1666648043812780000.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_formations` SET `groupAI` = 523 WHERE `leaderGUID` = 87648 AND `memberGUID` IN (87649, 87650, 87651);

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_sartura.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_sartura.cpp
@@ -70,19 +70,8 @@ struct boss_sartura : public BossAI
         _Reset();
         enraged = false;
         berserked = false;
-        MinionReset();
 
         me->SetReactState(REACT_AGGRESSIVE);
-    }
-
-    void MinionReset()
-    {
-        std::list<Creature*> royalGuards;
-        me->GetCreaturesWithEntryInRange(royalGuards, 200.0f, NPC_SARTURA_ROYAL_GUARD);
-        for (Creature* minion : royalGuards)
-        {
-            minion->Respawn();
-        }
     }
 
     void EnterCombat(Unit* who) override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Moves mechanic from .cpp to DB
-  Makes use of flag GROUP_AI_FLAG_DONT_RESPAWN_LEADER_ON_EVADE implemented by Nyeriah

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame by killing 2 of 3 adds then resetting. Killing all adds and resetting, killing the boss and resetting, killing 2/3 adds, moving far away and resetting and waiting for the corpses to despawn and then resetting.
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 15516
2. Kill a couple of the adds, move boss away from them (>200y) and then .combatstop OR wait for the corpses to despawn and then .combatstop
3. See if adds reset

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
