### PR TITLE
Fix compiling with gcc 12

### DIFF
--- a/src/common/Cryptography/OpenSSLCrypto.h
+++ b/src/common/Cryptography/OpenSSLCrypto.h
@@ -15,8 +15,8 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OPENSSL_CRYPTO_H
-#define OPENSSL_CRYPTO_H
+#ifndef OPENSSL_CRYPTO_H_
+#define OPENSSL_CRYPTO_H_
 
 #include "Define.h"
 #include <openssl/opensslv.h>

--- a/src/common/Threading/PCQueue.h
+++ b/src/common/Threading/PCQueue.h
@@ -34,7 +34,7 @@ private:
     std::atomic<bool> _shutdown;
 
 public:
-    ProducerConsumerQueue<T>() : _shutdown(false) { }
+    ProducerConsumerQueue() : _shutdown(false) { }
 
     void Push(const T& value)
     {


### PR DESCRIPTION
I noticed that compiling with gcc 12.1 fails.

## Changes Proposed:
-  remove `<T>`from a constructor
-  rename header guard because in conflicts with openssl header guard

## Tests Performed:
-  compile with gcc 12


## How to Test the Changes:

1. compile with gcc 12

I saw that in the openssl 3.0 PRs the header is also renamed. I was not sure if I should keep it in the PR or not. I kept it for now, because without it can not compile on gcc 12.