### PR TITLE
fix(DB/onkill_reputation) Venture Co. mobs in stv

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1667348648920858600.sql
+++ b/data/sql/updates/pending_db_world/rev_1667348648920858600.sql
@@ -3,5 +3,5 @@ DELETE FROM `creature_onkill_reputation` WHERE (`creature_id` = 676);
 INSERT INTO `creature_onkill_reputation` (`creature_id`, `RewOnKillRepFaction1`, `RewOnKillRepFaction2`, `MaxStanding1`, `IsTeamAward1`, `RewOnKillRepValue1`, `MaxStanding2`, `IsTeamAward2`, `RewOnKillRepValue2`, `TeamDependent`) VALUES
 (676, 21, 0, 5, 0, 5, 0, 0, 0, 0);
 UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 5 WHERE `creature_id` IN (674, 675, 677, 1094, 1095, 1096, 1097, 4260, 4723);
-UPDATE `creature_onkill_reputation` SET `MaxStanding1` = 5 WHERE `creature_id` IN  (921);
+UPDATE `creature_onkill_reputation` SET `MaxStanding1` = 5 WHERE `creature_id` IN (921);
 

--- a/data/sql/updates/pending_db_world/rev_1667348648920858600.sql
+++ b/data/sql/updates/pending_db_world/rev_1667348648920858600.sql
@@ -1,0 +1,4 @@
+--
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 5 WHERE (`creature_id` = 674, 675, 676, 677, 1094, 1095, 1096, 1097, 4260, 4723);
+UPDATE `creature_onkill_reputation` SET `MaxStanding1` = 5 WHERE (`creature_id` = 921);
+

--- a/data/sql/updates/pending_db_world/rev_1667348648920858600.sql
+++ b/data/sql/updates/pending_db_world/rev_1667348648920858600.sql
@@ -1,4 +1,4 @@
 --
-UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 5 WHERE (`creature_id` = 674, 675, 676, 677, 1094, 1095, 1096, 1097, 4260, 4723);
-UPDATE `creature_onkill_reputation` SET `MaxStanding1` = 5 WHERE (`creature_id` = 921);
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 5 WHERE `creature_id` IN (674, 675, 676, 677, 1094, 1095, 1096, 1097, 4260, 4723);
+UPDATE `creature_onkill_reputation` SET `MaxStanding1` = 5 WHERE `creature_id` IN  (921);
 

--- a/data/sql/updates/pending_db_world/rev_1667348648920858600.sql
+++ b/data/sql/updates/pending_db_world/rev_1667348648920858600.sql
@@ -1,4 +1,7 @@
 --
-UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 5 WHERE `creature_id` IN (674, 675, 676, 677, 1094, 1095, 1096, 1097, 4260, 4723);
+DELETE FROM `creature_onkill_reputation` WHERE (`creature_id` = 676);
+INSERT INTO `creature_onkill_reputation` (`creature_id`, `RewOnKillRepFaction1`, `RewOnKillRepFaction2`, `MaxStanding1`, `IsTeamAward1`, `RewOnKillRepValue1`, `MaxStanding2`, `IsTeamAward2`, `RewOnKillRepValue2`, `TeamDependent`) VALUES
+(676, 21, 0, 5, 0, 5, 0, 0, 0, 0);
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 5 WHERE `creature_id` IN (674, 675, 677, 1094, 1095, 1096, 1097, 4260, 4723);
 UPDATE `creature_onkill_reputation` SET `MaxStanding1` = 5 WHERE `creature_id` IN  (921);
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Updates on kill rep for several Venture Co. mobs in stv
-  Sets Venture Co. Lumberjack to not give rep after honored

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes [Venture Co. mobs in stv give too much reputation #13586 ](https://github.com/azerothcore/azerothcore-wotlk/issues/13586)
- Closes [Venture Co. mobs in stv give too much reputation #4324 ](https://github.com/chromiecraft/chromiecraft/issues/4324)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- killed mobs on local
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id ( 675, 1096, 1097, 1094, 4260, 674, 676, 677, 1095, 4723)
2. kill them
3. note xp gain (account for human bonus)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
