### PR TITLE
fix(DB/creature) Lisaile Fireweaver

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1667492399768442000.sql
+++ b/data/sql/updates/pending_db_world/rev_1667492399768442000.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `creature` WHERE `guid` =84701;
+INSERT INTO `creature` (`guid`, `id1`, `id2`, `id3`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
+(84701, 18583, 0, 0, 530, 0, 0, 1, 1, 0, -2918.13, 3419.44, 1.95939, 1.8675, 120, 0, 0, 4572, 2705, 0, 0, 0, 0, '', 0);
+

--- a/data/sql/updates/pending_db_world/rev_1667492399768442000.sql
+++ b/data/sql/updates/pending_db_world/rev_1667492399768442000.sql
@@ -1,5 +1,3 @@
 --
-DELETE FROM `creature` WHERE `guid` =84701;
-INSERT INTO `creature` (`guid`, `id1`, `id2`, `id3`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
-(84701, 18583, 0, 0, 530, 0, 0, 1, 1, 0, -2918.13, 3419.44, 1.95939, 1.8675, 120, 0, 0, 4572, 2705, 0, 0, 0, 0, '', 0);
+UPDATE `creature` SET `spawntimesecs`=120 WHERE `guid`=84701 AND `id1`=18583;
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Decreases spawn timer to 120 seconds
-  with despawn time, this brings the respawn time to between 2:30 and 3:00 mins as expected

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13677
- Closes https://github.com/chromiecraft/chromiecraft/issues/4364
-
## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- killed Lisaile Fireweaver and looted
- killed Lisaile Fireweaver and not looted 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  .go cr 84701
2.  kill Lisaile Fireweaver
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
