### PR TITLE
fix(scripts/TempleOfAhnQiraj): Giant Claw Tentacle - FarHit/AbilityCycle

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -15,13 +15,6 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* ScriptData
-SDName: Boss_Cthun
-SD%Complete: 95
-SDComment: Darkglare tracking issue
-SDCategory: Temple of Ahn'Qiraj
-EndScriptData */
-
 #include "Player.h"
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
@@ -778,7 +771,8 @@ struct npc_giant_claw_tentacle : public ScriptedAI
                 context.Repeat(10s);
         }).Schedule(5s, [this](TaskContext context)
         {
-            DoCastSelf(SPELL_THRASH);
+            if (me->GetVictim()->IsWithinMeleeRange(me))
+                DoCastSelf(SPELL_THRASH);
             context.Repeat(10s);
         }).Schedule(3s, [this](TaskContext /*context*/)
         {
@@ -857,12 +851,8 @@ struct npc_giant_claw_tentacle : public ScriptedAI
             me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_NON_ATTACKABLE);
 
             ScheduleMeleeCheck();
+            EnterCombat(target);
         }
-
-        _scheduler.Schedule(3s, [this](TaskContext /*context*/)
-        {
-            _canAttack = true;
-        });
     }
 
     void UpdateAI(uint32 diff) override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Fixes Proposed:
- The cast of SPELL_THRASH will result in two instant hits on the current target at any range, including a meleeCheck has resolved it for good. (attached images as proof of this in the linked-ac issue)
- An additional issue I found: When GCT where submerging 'cause no target within melee range, the _scheduler.CancelAll(); within void Submerge() would also remove its abilities, it ends up in a dummy tentacle after emerge, this gets solved with another EnterCombat, no issues found so far, I ran a 30min cthun attempt to be sure.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13669
- Closes https://github.com/chromiecraft/chromiecraft/issues/4379



## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested both fixes

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
