### PR TITLE
fix(Scripts/Commands): Fix assertion error on mmaps path command

### DIFF
--- a/src/server/scripts/Commands/cs_mmaps.cpp
+++ b/src/server/scripts/Commands/cs_mmaps.cpp
@@ -61,7 +61,7 @@ public:
         return commandTable;
     }
 
-    static bool HandleMmapPathCommand(ChatHandler* handler, Optional<std::string> para)
+    static bool HandleMmapPathCommand(ChatHandler* handler, Optional<std::string> param)
     {
         if (!MMAP::MMapFactory::createOrGetMMapMgr()->GetNavMesh(handler->GetSession()->GetPlayer()->GetMapId()))
         {
@@ -81,13 +81,19 @@ public:
         }
 
         bool useStraightPath = false;
-        if (StringStartsWith("true", *para))
-            useStraightPath = true;
-
         bool useRaycast = false;
-        if (StringStartsWith("line", *para) || StringStartsWith("ray", *para) || StringStartsWith("raycast", *para))
+        if (param)
         {
-            useRaycast = true;
+            auto paramValue = param.value();
+            if (paramValue.starts_with("true"))
+            {
+                useStraightPath = true;
+            }
+
+            if (paramValue.starts_with("line") || paramValue.starts_with("ray") || paramValue.starts_with("raycast"))
+            {
+                useRaycast = true;
+            }
         }
 
         // unit locations


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Fixes this error when using `.mmap path` with server running on debug mode (maybe that's just a specific combination of MSVC version and Windows).
```
C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\optional(359) : Asserti
on failed: Cannot access value of empty optional
```

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
