### PR TITLE
fix(Core/Unit): Exclude Sword Specialization and Hack and Slash from …

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -469,8 +469,8 @@ void Unit::Update(uint32 p_time)
             extraAttacksTargets.erase(itr);
             if (Unit* victim = ObjectAccessor::GetUnit(*this, targetGuid))
             {
-                if ((_lastExtraAttackSpell != SPELL_SWORD_SPECIALIZATION && _lastExtraAttackSpell != SPELL_HACK_AND_SLASH)
-                    && victim->IsWithinMeleeRange(this))
+                if (_lastExtraAttackSpell == SPELL_SWORD_SPECIALIZATION || _lastExtraAttackSpell == SPELL_HACK_AND_SLASH
+                    || victim->IsWithinMeleeRange(this))
                 {
                     HandleProcExtraAttackFor(victim, count);
                 }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -469,7 +469,8 @@ void Unit::Update(uint32 p_time)
             extraAttacksTargets.erase(itr);
             if (Unit* victim = ObjectAccessor::GetUnit(*this, targetGuid))
             {
-                if (victim->IsWithinMeleeRange(this))
+                if ((_lastExtraAttackSpell != SPELL_SWORD_SPECIALIZATION && _lastExtraAttackSpell != SPELL_HACK_AND_SLASH)
+                    && victim->IsWithinMeleeRange(this))
                 {
                     HandleProcExtraAttackFor(victim, count);
                 }
@@ -9376,7 +9377,7 @@ bool Unit::HandleProcTriggerSpell(Unit* victim, uint32 damage, AuraEffect* trigg
 
         // Patch 2.2.0 Sword Specialization (Warrior, Rogue) extra attack can no longer proc additional extra attacks
         // 3.3.5 Sword Specialization (Warrior), Hack and Slash (Rogue)
-        if (lastExtraAttackSpell == 16459 || lastExtraAttackSpell == 66923)
+        if (lastExtraAttackSpell == SPELL_SWORD_SPECIALIZATION || lastExtraAttackSpell == SPELL_HACK_AND_SLASH)
         {
             return false;
         }

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -717,6 +717,12 @@ enum MeleeHitOutcome
     MELEE_HIT_GLANCING, MELEE_HIT_CRIT, MELEE_HIT_CRUSHING, MELEE_HIT_NORMAL
 };
 
+enum ExtraAttackSpells
+{
+    SPELL_SWORD_SPECIALIZATION   = 16459,
+    SPELL_HACK_AND_SLASH         = 66923
+};
+
 class DispelInfo
 {
 public:


### PR DESCRIPTION
…the extra attack range check

<!-- First of all, THANK YOU for your contribution. -->

- Exclude Hack and Slash (Rogue) and Sword Specialization (Warrior) from the extra attack (thrash) distance check
- This allows spells such as Whirlwind to proc it

How to test:
- .cheat power
- .cheat cooldown
- learn the sword spec talent (warrior)
- spam whirlwind, check you get white hits (easy to miss so pay attention)

Tested ingame
