### PR TITLE
fix(DB/gameobject): instant spawn on 61-64 quest interactables

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1667666190202265500.sql
+++ b/data/sql/updates/pending_db_world/rev_1667666190202265500.sql
@@ -1,0 +1,8 @@
+-- Quest: A Pilgrim's Plight
+UPDATE `gameobject` SET `spawntimesecs`=0 WHERE `guid`=25340 AND `id`=184478;
+-- Quest: The Dread Relic
+UPDATE `gameobject` SET `spawntimesecs`=0 WHERE `guid`=26109 AND `id`=185220;
+-- Quest: The Shadow Tomb
+UPDATE `gameobject` SET `spawntimesecs`=0 WHERE `id` IN (185224, 185225, 185226) AND `guid` IN (26110, 26111, 47565);
+-- Quest: A Damp Dark Place
+UPDATE `gameobject` SET `spawntimesecs`=0 WHERE `guid`=22527 AND `id`=182122;

--- a/data/sql/updates/pending_db_world/rev_1667666190202265500.sql
+++ b/data/sql/updates/pending_db_world/rev_1667666190202265500.sql
@@ -1,5 +1,5 @@
 -- Quest: A Pilgrim's Plight
-UPDATE `gameobject` SET `spawntimesecs`=0 WHERE `guid`=25340 AND `id`=184478;
+UPDATE `gameobject` SET `spawntimesecs`=1 WHERE `guid`=25340 AND `id`=184478;
 -- Quest: The Dread Relic
 UPDATE `gameobject` SET `spawntimesecs`=0 WHERE `guid`=26109 AND `id`=185220;
 -- Quest: The Shadow Tomb


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  fixes a bunch of quest interactables that shouldnt dissapear on looting
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13588
- Closes https://github.com/chromiecraft/chromiecraft/issues/4336

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13672
- Closes https://github.com/chromiecraft/chromiecraft/issues/4387

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13667
- Closes https://github.com/chromiecraft/chromiecraft/issues/4384

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13621
- Closes https://github.com/chromiecraft/chromiecraft/issues/4354
 
## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- used gm commandts to test on my local
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. 
.quest add 9376
.go xyz -870 4397 72
2.
.quest add 10877
.tele terok
.go xyz -3750.310059 4711.770020 -17.320499
3.
.quest add 10881
.tele terok
.go xyz -2843.110107 5350.000000 -30.438601
.go xyz -2860.850098 5482.500000 -30.189301
.go xyz -2679.229980 5403.160156 **-36.469002**
4.
.quest add 9788
.tele funggorcavern
.go xyz -1345 5931 12

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
