### PR TITLE
fix(Core/Loot): Fix quest items looting system

### DIFF
--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -404,7 +404,7 @@ LootItem::LootItem(LootStoreItem const& li)
 }
 
 // Basic checks for player/item compatibility - if false no chance to see the item in the loot
-bool LootItem::AllowedForPlayer(Player const *player, ObjectGuid source) const
+bool LootItem::AllowedForPlayer(Player const* player, ObjectGuid source) const
 {
     ItemTemplate const* pProto = sObjectMgr->GetItemTemplate(itemid);
     if (!pProto)
@@ -658,9 +658,9 @@ QuestItemList* Loot::FillQuestLoot(Player* player)
     if (items.size() == MAX_NR_LOOT_ITEMS)
         return nullptr;
 
-    auto* ql = new QuestItemList();
+    QuestItemList* ql = new QuestItemList();
 
-    Player *lootOwner = (roundRobinPlayer) ? ObjectAccessor::FindPlayer(roundRobinPlayer) : player;
+    Player* lootOwner = (roundRobinPlayer) ? ObjectAccessor::FindPlayer(roundRobinPlayer) : player;
 
     for (uint8 i = 0; i < quest_items.size(); ++i)
     {
@@ -682,7 +682,8 @@ QuestItemList* Loot::FillQuestLoot(Player* player)
         ql->push_back(QuestItem(i));
         ++unlootedCount;
 
-        if (!item.freeforall) {
+        if (!item.freeforall)
+        {
             item.is_blocked = true;
         }
 
@@ -701,7 +702,7 @@ QuestItemList* Loot::FillQuestLoot(Player* player)
 
 QuestItemList* Loot::FillNonQuestNonFFAConditionalLoot(Player* player)
 {
-    auto* ql = new QuestItemList();
+    QuestItemList* ql = new QuestItemList();
 
     for (uint8 i = 0; i < items.size(); ++i)
     {

--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -404,7 +404,7 @@ LootItem::LootItem(LootStoreItem const& li)
 }
 
 // Basic checks for player/item compatibility - if false no chance to see the item in the loot
-bool LootItem::AllowedForPlayer(Player const* player, bool isGivenByMasterLooter /*= false*/, bool allowQuestLoot /*= true*/, ObjectGuid source) const
+bool LootItem::AllowedForPlayer(Player const *player, ObjectGuid source) const
 {
     ItemTemplate const* pProto = sObjectMgr->GetItemTemplate(itemid);
     if (!pProto)
@@ -418,7 +418,7 @@ bool LootItem::AllowedForPlayer(Player const* player, bool isGivenByMasterLooter
     if (!sConditionMgr->IsObjectMeetToConditions(const_cast<Player*>(player), conditions))
     {
         // Master Looter can see conditioned recipes
-        if (!isGivenByMasterLooter && isMasterLooter)
+        if (isMasterLooter && follow_loot_rules && !is_underthreshold)
         {
             if ((pProto->Flags & ITEM_FLAG_HIDE_UNUSABLE_RECIPE) || (pProto->Class == ITEM_CLASS_RECIPE && pProto->Bonding == BIND_WHEN_PICKED_UP && pProto->Spells[1].SpellId != 0))
             {
@@ -441,7 +441,7 @@ bool LootItem::AllowedForPlayer(Player const* player, bool isGivenByMasterLooter
     }
 
     // Master looter can see all items even if the character can't loot them
-    if (!isGivenByMasterLooter && isMasterLooter && allowQuestLoot)
+    if (isMasterLooter && follow_loot_rules && !is_underthreshold)
     {
         return true;
     }
@@ -658,28 +658,36 @@ QuestItemList* Loot::FillQuestLoot(Player* player)
     if (items.size() == MAX_NR_LOOT_ITEMS)
         return nullptr;
 
-    QuestItemList* ql = new QuestItemList();
+    auto* ql = new QuestItemList();
+
+    Player *lootOwner = (roundRobinPlayer) ? ObjectAccessor::FindPlayer(roundRobinPlayer) : player;
 
     for (uint8 i = 0; i < quest_items.size(); ++i)
     {
         LootItem& item = quest_items[i];
 
-        if (!item.is_looted && (item.AllowedForPlayer(player, false, false) || (item.follow_loot_rules && player->GetGroup() && ((player->GetGroup()->GetLootMethod() == MASTER_LOOT && player->GetGroup()->GetMasterLooterGuid() == player->GetGUID()) || player->GetGroup()->GetLootMethod() != MASTER_LOOT ))))
+        // Quest item is not free for all and is already assigned to another player
+        // or player doesn't need it
+        if (item.is_blocked || !item.AllowedForPlayer(player, sourceWorldObjectGUID))
         {
-            ql->push_back(QuestItem(i));
-
-            // quest items get blocked when they first appear in a
-            // player's quest vector
-            //
-            // increase once if one looter only, looter-times if free for all
-            if (item.freeforall || !item.is_blocked)
-                ++unlootedCount;
-            if (!player->GetGroup() || (player->GetGroup()->GetLootMethod() != GROUP_LOOT && player->GetGroup()->GetLootMethod() != ROUND_ROBIN))
-                item.is_blocked = true;
-
-            if (items.size() + ql->size() == MAX_NR_LOOT_ITEMS)
-                break;
+            continue;
         }
+
+        // Player is not the loot owner, and loot owner still needs this quest item
+        if (!item.freeforall && lootOwner != player && item.AllowedForPlayer(lootOwner, sourceWorldObjectGUID))
+        {
+            continue;
+        }
+
+        ql->push_back(QuestItem(i));
+        ++unlootedCount;
+
+        if (!item.freeforall) {
+            item.is_blocked = true;
+        }
+
+        if (items.size() + ql->size() == MAX_NR_LOOT_ITEMS)
+            break;
     }
     if (ql->empty())
     {
@@ -693,12 +701,13 @@ QuestItemList* Loot::FillQuestLoot(Player* player)
 
 QuestItemList* Loot::FillNonQuestNonFFAConditionalLoot(Player* player)
 {
-    QuestItemList* ql = new QuestItemList();
+    auto* ql = new QuestItemList();
 
     for (uint8 i = 0; i < items.size(); ++i)
     {
         LootItem& item = items[i];
-        if (!item.is_looted && !item.freeforall && (item.AllowedForPlayer(player, sourceWorldObjectGUID) || (item.follow_loot_rules && player->GetGroup() && ((player->GetGroup()->GetLootMethod() == MASTER_LOOT && player->GetGroup()->GetMasterLooterGuid() == player->GetGUID()) || player->GetGroup()->GetLootMethod() != MASTER_LOOT ))))
+
+        if (!item.is_looted && !item.freeforall && item.AllowedForPlayer(player, sourceWorldObjectGUID))
         {
             item.AddAllowedLooter(player);
 

--- a/src/server/game/Loot/LootMgr.h
+++ b/src/server/game/Loot/LootMgr.h
@@ -176,7 +176,7 @@ struct LootItem
     LootItem() = default;
 
     // Basic checks for player/item compatibility - if false no chance to see the item in the loot
-    bool AllowedForPlayer(Player const *player, ObjectGuid source) const;
+    bool AllowedForPlayer(Player const* player, ObjectGuid source) const;
     void AddAllowedLooter(Player const* player);
     [[nodiscard]] const AllowedLooterSet& GetAllowedLooters() const { return allowedGUIDs; }
 };

--- a/src/server/game/Loot/LootMgr.h
+++ b/src/server/game/Loot/LootMgr.h
@@ -176,8 +176,7 @@ struct LootItem
     LootItem() = default;
 
     // Basic checks for player/item compatibility - if false no chance to see the item in the loot
-    bool AllowedForPlayer(Player const* player, bool isGivenByMasterLooter = false, bool allowQuestLoot = true, ObjectGuid source = ObjectGuid::Empty) const;
-    bool AllowedForPlayer(Player const* player, ObjectGuid source) { return AllowedForPlayer(player, false, true, source); };
+    bool AllowedForPlayer(Player const *player, ObjectGuid source) const;
     void AddAllowedLooter(Player const* player);
     [[nodiscard]] const AllowedLooterSet& GetAllowedLooters() const { return allowedGUIDs; }
 };


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Fixes quest items distribution as described in this [issue](https://github.com/TrinityCore/TrinityCore/issues/22829). Problem applies to AC aswell.

Currently, quest items are seen by everyone, even in round robin or group mode. The first player who click on corpse get the item. This is frustrating for ranged players, and comes problematic for pickup groups (hello ninja looters).

The new rules are:
- in every mode, "non free for all" quest items are round robin
- if the round robin player can't loot quest item (he has not the quest or he has completed it), it will find the first available player in the group (can be changed to something else if someone got Blizz rules for this)
- "free for all" quest items won't change, everybody is able to see and loot it.

On a side effect, it will fix master loot by letting grey and white items round robin (green items is the minimum threshold for master loot).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
I didn't find any issue on this in AC or CC.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

> Quest loot is on a separate loot distribution and there are two common modes for this to occur. 1) In quests where the party is to collect one of a specific item from a specific mob (Collect the head of (mob name here)) then regardless of loot setting, the mob will indicate lootable by every party member with the quest (and without the object). Each member may loot the quest item off the corpse. The other loot on the corpse is subject to the party loot setting. 2) In other quests which require collecting several items of a type (harpy feathers for example), the quest items will drop on some mobs and be looted in the normal way, except that if the current looter can't collect the items (not on quest, already has full set) then the quest loot is FFA for those members who can still pick up the quest items. Other items on the corpse are governed by the party loot setting. On some quests the quest loot is always free-for-all and this may be the above mechanic gone haywire. Some quests where the party is collecting one item will use the named mob mechanism (1) (the [Shaman Voodoo Charm](https://wowwiki-archive.fandom.com/wiki/Shaman_Voodoo_Charm) from [The Sleeping Druid](https://wowwiki-archive.fandom.com/wiki/Quest:The_Sleeping_Druid) quest, for example, where all party members can get the charm off the same shaman.)

[Source](https://wowwiki-archive.fandom.com/wiki/Loot)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
A lot of combinations of group looting parameters, and quest with ffa and non ffa items.
Some tests around master loot and also case like [this](https://github.com/TrinityCore/TrinityCore/issues/24230).

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

See tests performed. Test different combinations.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

If you kill multiple monsters and aoe, you can have more quest items that you need when you start looting them (because calculation is done on monster kill). Your extra quest items won't go to the group. Again if someone knows the rules for this in order to be more "blizzlike", I would be happy to improve this PR.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
