### PR TITLE
fix(DB/Loot): Syndicate emblems in junkboxes

### DIFF
--- a/data/sql/updates/pending_db_world/removeloot.sql
+++ b/data/sql/updates/pending_db_world/removeloot.sql
@@ -1,2 +1,2 @@
 -- Remove Syndicate emblems from Battered Junkbox and Worn Junkbox
-DELETE FROM `item_loot_template` WHERE (`Entry` = 16882 or `Entry` = 16883) AND (`Item` IN (17124));
+DELETE FROM `item_loot_template` WHERE `Entry` in (16882, 16883) AND (`Item` IN (17124));

--- a/data/sql/updates/pending_db_world/removeloot.sql
+++ b/data/sql/updates/pending_db_world/removeloot.sql
@@ -1,2 +1,2 @@
 -- Remove Syndicate emblems from Battered Junkbox and Worn Junkbox
-DELETE FROM `item_loot_template` WHERE `Entry` in (16882, 16883) AND (`Item` IN (17124));
+DELETE FROM `item_loot_template` WHERE `Entry` IN (16882, 16883) AND (`Item` IN (17124));

--- a/data/sql/updates/pending_db_world/removeloot.sql
+++ b/data/sql/updates/pending_db_world/removeloot.sql
@@ -1,0 +1,2 @@
+-- Remove Syndicate emblems from Battered Junkbox and Worn Junkbox
+DELETE FROM `item_loot_template` WHERE (`Entry` = 16882 or `Entry` = 16883) AND (`Item` IN (17124));


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove Syndicate emblems from Battered Junkbox and Worn Junkbox

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11360

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Checked Kiera loot table after running SQL query
- opened a few boxes and no obvious issues, but low sample size


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .setskill 633 300 300
2. .additem 16882
3. .additem 16883

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
