### PR TITLE
fix(Spells/TempleOfAhnQiraj): Attempt to partly fix Digestive Acid not being applied

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -51,7 +51,8 @@ void SpellMgr::LoadSpellInfoCorrections()
         53307,  // Thorns (Rank 8)
         53352,  // Explosive Shot (trigger)
         50783,  // Slam (Triggered spell)
-        20647   // Execute (Triggered spell)
+        20647,  // Execute (Triggered spell)
+        26476   // Digestive Acid
         }, [](SpellInfo* spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_ALWAYS_HIT;

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -51,8 +51,7 @@ void SpellMgr::LoadSpellInfoCorrections()
         53307,  // Thorns (Rank 8)
         53352,  // Explosive Shot (trigger)
         50783,  // Slam (Triggered spell)
-        20647,  // Execute (Triggered spell)
-        26476   // Digestive Acid
+        20647  // Execute (Triggered spell)
         }, [](SpellInfo* spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_ALWAYS_HIT;
@@ -4426,6 +4425,14 @@ void SpellMgr::LoadSpellInfoCorrections()
     ApplySpellFix({ 26007 }, [](SpellInfo* spellInfo)
     {
             spellInfo->AttributesEx3 |= SPELL_ATTR3_SUPRESS_CASTER_PROCS;
+    });
+
+    // Digestive Acid
+    ApplySpellFix({ 26476 }, [](SpellInfo* spellInfo)
+    {
+            spellInfo->Attributes |= SPELL_ATTR0_NO_IMMUNITIES;
+            spellInfo->AttributesEx2 |= SPELL_ATTR2_IGNORE_LINE_OF_SIGHT;
+            spellInfo->AttributesEx3 |= SPELL_ATTR3_ALWAYS_HIT;
     });
 
     for (uint32 i = 0; i < GetSpellInfoStoreSize(); ++i)

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -51,7 +51,7 @@ void SpellMgr::LoadSpellInfoCorrections()
         53307,  // Thorns (Rank 8)
         53352,  // Explosive Shot (trigger)
         50783,  // Slam (Triggered spell)
-        20647  // Execute (Triggered spell)
+        20647   // Execute (Triggered spell)
         }, [](SpellInfo* spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_ALWAYS_HIT;

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4427,7 +4427,7 @@ void SpellMgr::LoadSpellInfoCorrections()
             spellInfo->AttributesEx3 |= SPELL_ATTR3_SUPRESS_CASTER_PROCS;
     });
 
-    // Digestive Acid
+    // Digestive Acid (Temporary)
     ApplySpellFix({ 26476 }, [](SpellInfo* spellInfo)
     {
             spellInfo->Attributes |= SPELL_ATTR0_NO_IMMUNITIES;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Digestive Acid still is not applied depending on player's position

## Changes Proposed:
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Does not close https://github.com/azerothcore/azerothcore-wotlk/issues/13733

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame. Using the .gps given in the issue still does not apply Digestive Acid.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 15727
2. .damage 3000000 to enter Phase 2
3. .aura 65961 on self
4. most of the time you'll get Digestive Acid debuff

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
