### PR TITLE
Revert "fix(Core/Spells): Fixed calculating LoS for dynamic objects. …

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -2923,18 +2923,15 @@ void DynObjAura::FillTargetMap(std::map<Unit*, uint8>& targets, Unit* /*caster*/
 
         for (UnitList::iterator itr = targetList.begin(); itr != targetList.end(); ++itr)
         {
+            // xinef: check z level and los dependence
             Unit* target = *itr;
-
-            Optional<float> collisionHeight = { };
-            if (Unit* dynObjCaster = GetDynobjOwner()->GetCaster())
+            float zLevel = GetDynobjOwner()->GetPositionZ();
+            if (target->GetPositionZ() + 3.0f < zLevel || target->GetPositionZ() - 5.0f > zLevel)
             {
-                collisionHeight = dynObjCaster->GetCollisionHeight();
-            }
-
-            if (!spellInfo->HasAttribute(SPELL_ATTR2_IGNORE_LINE_OF_SIGHT) && !spellInfo->HasAttribute(SPELL_ATTR5_ALWAYS_AOE_LINE_OF_SIGHT) &&
-                !target->IsWithinLOSInMap(GetDynobjOwner(), VMAP::ModelIgnoreFlags::Nothing, LINEOFSIGHT_ALL_CHECKS, collisionHeight))
-            {
-                continue;
+                if (!spellInfo->HasAttribute(SPELL_ATTR2_IGNORE_LINE_OF_SIGHT) && !spellInfo->HasAttribute(SPELL_ATTR5_ALWAYS_AOE_LINE_OF_SIGHT) && !target->IsWithinLOSInMap(GetDynobjOwner()))
+                {
+                    continue;
+                }
             }
 
             std::map<Unit*, uint8>::iterator existing = targets.find(*itr);


### PR DESCRIPTION
…(#13521)"

This reverts commit 0cd6319cfc13fe14e06f11a5d31242884718ac8f.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  The PR caused a regression seen here: https://github.com/azerothcore/azerothcore-wotlk/issues/12080
-  See: https://github.com/azerothcore/azerothcore-wotlk/pull/12090

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go xyz -9797.036133 722.195251 35.278992 0 5.542893`
2. cast Flamestrike (2120) right in front of your character
3. cast Consecration (26573)
4. cast Explosive Trap (13813)
5. both targets will be hit

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
