### PR TITLE
fix(Scripts/Temple of AhnQiraj): Cthun's Eye should always focus on b…

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -202,9 +202,13 @@ struct boss_eye_of_cthun : public BossAI
             // Z checks are necessary here because AQ maps do funky stuff.
             if (me->IsWithinLOSInMap(who) && me->IsWithinDist2d(who, 90.0f) && who->GetPositionZ() > 100.0f)
             {
-                AttackStart(who);
+                me->Attack(who, false);
             }
         }
+    }
+
+    void AttackStart(Unit* /*victim*/) override
+    {
     }
 
     void DoAction(int32 action) override
@@ -241,6 +245,7 @@ struct boss_eye_of_cthun : public BossAI
                     if (Unit* target = ObjectAccessor::GetUnit(*me, _beamTarget))
                     {
                         DoCast(target, SPELL_GREEN_BEAM);
+                        me->Attack(target, false);
                     }
 
                     task.Repeat();
@@ -249,7 +254,11 @@ struct boss_eye_of_cthun : public BossAI
                 {
                     _scheduler.Schedule(5s, [this](TaskContext task)
                     {
-                        DoCastRandomTarget(SPELL_GREEN_BEAM);
+                        if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.f, 0))
+                        {
+                            DoCast(target, SPELL_GREEN_BEAM);
+                            me->Attack(target, false);
+                        }
 
                         task.SetGroup(GROUP_BEAM_PHASE);
                         task.Repeat(3s);


### PR DESCRIPTION
…eam target.

Fixes #13673

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13673
- Closes https://github.com/chromiecraft/chromiecraft/issues/4376

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go xyz -8670.49 1953.46 108.9 531 0.363`
Start C'thun fight with at least two players
Have one player get the aggro on the Eye

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
