### PR TITLE
fix(Scripts/Temple of AhnQiraj): Anubisath Sentinels should emote af…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1668338070824615600.sql
+++ b/data/sql/updates/pending_db_world/rev_1668338070824615600.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `creature_text` WHERE `CreatureID`=15264 AND `groupid`=1;
+INSERT INTO `creature_text` VALUES
+(15264,1,0,'%s shares his powers with his brethren.',16,0,100,0,0,0,11692,0,'Anubisath Sentinel Emote');

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/mob_anubisath_sentinel.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/mob_anubisath_sentinel.cpp
@@ -49,7 +49,8 @@ enum Spells
     SPELL_HEAL_BRETHEN                  = 26565,
     SPELL_ENRAGE                        = 8599,
 
-    TALK_ENRAGE                         = 0
+    TALK_ENRAGE                         = 0,
+    TALK_SHARE_BUFFS                    = 1
 };
 
 class npc_anubisath_sentinel : public CreatureScript
@@ -275,6 +276,7 @@ public:
 
         void JustDied(Unit* /*killer*/) override
         {
+            bool cast = false;
             for (int ni = 0; ni < 3; ++ni)
             {
                 Creature* sent = ObjectAccessor::GetCreature(*me, NearbyGUID[ni]);
@@ -282,8 +284,14 @@ public:
                     continue;
                 if (sent->isDead())
                     continue;
+                cast = true;
                 DoCast(sent, SPELL_HEAL_BRETHEN, true);
                 DoCast(sent, SPELL_TRANSFER_POWER, true);
+            }
+
+            if (cast)
+            {
+                Talk(TALK_SHARE_BUFFS);
             }
 
             DoCastSelf(SPELL_SUMMON_SMALL_OBSIDIAN_CHUNK, true);


### PR DESCRIPTION
…ter sharing buffs.

Fixes #13544

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13544

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go c id 15264`
kill them, see if their emote plays
kill the last one, see if the last emote is not played

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
