### PR TITLE
fix(Scripts/Spells): Hallow's End Candy punpkin treat should turn pla…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1668360561748791400.sql
+++ b/data/sql/updates/pending_db_world/rev_1668360561748791400.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id`=24926;
+INSERT INTO `spell_script_names` VALUES
+(24926,'spell_hallows_end_candy_pirate_costume');

--- a/src/server/scripts/Events/hallows_end.cpp
+++ b/src/server/scripts/Events/hallows_end.cpp
@@ -156,7 +156,9 @@ enum eHallowsEndCandy
     SPELL_HALLOWS_END_CANDY_1               = 24924,
     SPELL_HALLOWS_END_CANDY_2               = 24925,
     SPELL_HALLOWS_END_CANDY_3               = 24926,
-    SPELL_HALLOWS_END_CANDY_4               = 24927,
+    SPELL_HALLOWS_END_CANDY_3_FEMALE        = 44742,
+    SPELL_HALLOWS_END_CANDY_3_MALE          = 44743,
+    SPELL_HALLOWS_END_CANDY_4               = 24927
 };
 
 class spell_hallows_end_candy : public SpellScript
@@ -168,13 +170,41 @@ class spell_hallows_end_candy : public SpellScript
         if (Player* target = GetHitPlayer())
         {
             uint32 spellId = SPELL_HALLOWS_END_CANDY_1 + urand(0, 3);
-            GetCaster()->CastSpell(target, spellId, true, nullptr);
+            GetCaster()->CastSpell(target, spellId, true);
         }
     }
 
     void Register() override
     {
         OnEffectHitTarget += SpellEffectFn(spell_hallows_end_candy::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+    }
+};
+
+class spell_hallows_end_candy_pirate_costume : public AuraScript
+{
+    PrepareAuraScript(spell_hallows_end_candy_pirate_costume);
+
+    void HandleEffectApply(AuraEffect const*  /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        if (Unit* target = GetTarget())
+        {
+            target->CastSpell(target, target->getGender() == GENDER_MALE ? SPELL_HALLOWS_END_CANDY_3_MALE : SPELL_HALLOWS_END_CANDY_3_FEMALE, true);
+        }
+    }
+
+    void HandleEffectRemove(AuraEffect const*  /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        if (Unit* target = GetTarget())
+        {
+            target->RemoveAurasDueToSpell(SPELL_HALLOWS_END_CANDY_3_MALE);
+            target->RemoveAurasDueToSpell(SPELL_HALLOWS_END_CANDY_3_FEMALE);
+        }
+    }
+
+    void Register() override
+    {
+        OnEffectApply += AuraEffectApplyFn(spell_hallows_end_candy_pirate_costume::HandleEffectApply, EFFECT_0, SPELL_AURA_MOD_INCREASE_SWIM_SPEED, AURA_EFFECT_HANDLE_REAL);
+        OnEffectRemove += AuraEffectRemoveFn(spell_hallows_end_candy_pirate_costume::HandleEffectRemove, EFFECT_0, SPELL_AURA_MOD_INCREASE_SWIM_SPEED, AURA_EFFECT_HANDLE_REAL);
     }
 };
 
@@ -1426,6 +1456,7 @@ void AddSC_event_hallows_end_scripts()
     RegisterSpellScript(spell_hallows_end_trick);
     RegisterSpellScript(spell_hallows_end_trick_or_treat);
     RegisterSpellScript(spell_hallows_end_candy);
+    RegisterSpellScript(spell_hallows_end_candy_pirate_costume);
     RegisterSpellScript(spell_hallows_end_tricky_treat);
     RegisterSpellScriptWithArgs(spell_hallows_end_put_costume, "spell_hallows_end_pirate_costume", SPELL_PIRATE_COSTUME_MALE, SPELL_PIRATE_COSTUME_FEMALE);
     RegisterSpellScriptWithArgs(spell_hallows_end_put_costume, "spell_hallows_end_leper_costume", SPELL_LEPER_GNOME_COSTUME_MALE, SPELL_LEPER_GNOME_COSTUME_FEMALE);


### PR DESCRIPTION
…yer into a pirate.

Fixes #13540

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13540
- Closes https://github.com/chromiecraft/chromiecraft/issues/4253

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.additem 20557`
get buff called "Yeargh..." - you changed into pirate

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
