### PR TITLE
fix(Scripts/Pets): Force of Nature's Treants should inherit haste fro…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1668370395482260000.sql
+++ b/data/sql/updates/pending_db_world/rev_1668370395482260000.sql
@@ -1,2 +1,2 @@
 --
-UPDATE `spell_dbc` SET `EffectAura_2`=193 WHERE `ID`=35672;
+UPDATE `spell_dbc` SET `Effect_2`=6, `EffectAura_2`=193, `ImplicitTargetA_2`=1 WHERE `ID`=35672;;

--- a/data/sql/updates/pending_db_world/rev_1668370395482260000.sql
+++ b/data/sql/updates/pending_db_world/rev_1668370395482260000.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `spell_dbc` SET `EffectAura_2`=193 WHERE `ID`=35672;

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -316,6 +316,17 @@ class spell_dru_treant_scaling : public AuraScript
         }
     }
 
+    void CalculateHasteAmount(AuraEffect const*  /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
+    {
+        if (Unit* owner = GetUnitOwner()->GetOwner())
+        {
+            if (owner->GetFloatValue(UNIT_MOD_CAST_SPEED) < 1.0f)
+            {
+                amount = std::min<int32>(100, int32(((1.0f / owner->GetFloatValue(UNIT_MOD_CAST_SPEED)) - 1.0f) * 100.0f));
+            }
+        }
+    }
+
     void CalculateAPAmount(AuraEffect const*  /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
     {
         // xinef: treant inherits 105% of SP as AP - 15% of damage increase per hit
@@ -366,6 +377,9 @@ class spell_dru_treant_scaling : public AuraScript
             DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_dru_treant_scaling::CalculateAPAmount, EFFECT_ALL, SPELL_AURA_MOD_ATTACK_POWER);
             DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_dru_treant_scaling::CalculateSPAmount, EFFECT_ALL, SPELL_AURA_MOD_DAMAGE_DONE);
         }
+
+        if (m_scriptSpellId == 35672)
+            DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_dru_treant_scaling::CalculateHasteAmount, EFFECT_1, SPELL_AURA_MELEE_SLOW);
 
         OnEffectApply += AuraEffectApplyFn(spell_dru_treant_scaling::HandleEffectApply, EFFECT_ALL, SPELL_AURA_ANY, AURA_EFFECT_HANDLE_REAL);
     }


### PR DESCRIPTION
…m owner.

Fixes #13531

<!-- First of all, THANK YOU for your contribution. --> 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13531
- Closes https://github.com/chromiecraft/chromiecraft/issues/4288

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Create a druid
`.learn 33831`
`.level 59`
`.setskill 160 300 300`
`.additem 22838 & 9449`
Use MCP ( https://wowgaming.altervista.org/aowow/?item=9449 ) + Haste potion ( https://wowgaming.altervista.org/aowow/?item=22838 ) in order to have massive haste, making the difference more noticeable.
See the difference between 0 haste and 900 haste rating.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
