### PR TITLE
fix(DB/SmartAI): Laughing Skull Warden stealth detection buff

### DIFF
--- a/data/sql/updates/pending_db_world/stealthdetect.sql
+++ b/data/sql/updates/pending_db_world/stealthdetect.sql
@@ -1,0 +1,2 @@
+-- Set Correct stealh detection spell
+Update `smart_scripts` set `action_param1`=41634 WHERE (`entryorguid` = 17624) AND (`source_type` = 0) AND (`id` IN (1));


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Swaps Laughing Skull Warden from [38551](https://wowgaming.altervista.org/aowow/?spell=38551) to [41634](https://wowgaming.altervista.org/aowow/?spell=%2041634) (same id as officer jaxon given in report)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13821

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- teleported to on local


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  .go creature 138187
2. exit combat

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
