### PR TITLE
fix(DB/Creature): Garrick Padfoot Rage generation

### DIFF
--- a/data/sql/updates/pending_db_world/angermanagementcourse.sql
+++ b/data/sql/updates/pending_db_world/angermanagementcourse.sql
@@ -1,0 +1,2 @@
+-- Remove Garrick Padfoot rage generation
+UPDATE `creature_template` SET `ManaModifier` = 0 WHERE (`entry` = 103);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Sets Rage modifier to zero so they cant gain any

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/3026

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.youtube.com/watch?v=X00FCqp3s_I&t=67s

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- teleported to npc on local


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. go c 103 (wont aggro so downlevel to not insta kill / taunt)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
