### PR TITLE
fix(DB/SAI): Kaliri Nest should despawn on use

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1668744480410104200.sql
+++ b/data/sql/updates/pending_db_world/rev_1668744480410104200.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 181582) AND (`source_type` = 1) AND (`id` IN (0, 1));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(181582, 1, 0, 1, 70, 0, 100, 0, 2, 0, 0, 0, 0, 12, 19656, 1, 30000, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Kaliri Nest - On Gameobject State Changed - Summon Creature \'Invisible Location Trigger\''),
+(181582, 1, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Kaliri Nest - On Gameobject State Changed - Despawn Instant');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add a despawn event and remove a useless one.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13587
- Closes https://github.com/chromiecraft/chromiecraft/issues/4335

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .quest add 9397
2. .go xyz -1072.6 4171.5 38.1 (or nearby if not spawned)
3. Use Kaliri Nest, it should despawn.

