### PR TITLE
fix(DB/Spells): Drums of War/Battle/Speed/Restorarion should apply Ti…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1668853205841082300.sql
+++ b/data/sql/updates/pending_db_world/rev_1668853205841082300.sql
@@ -1,0 +1,7 @@
+--
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` IN (35475,35476,35477,35478) AND `spell_effect`=51120;
+INSERT INTO `spell_linked_spell` VALUES
+(35475,51120,1,'Drums of War - Tinnitus'),
+(35476,51120,1,'Drums of Battle - Tinnitus'),
+(35477,51120,1,'Drums of Speed - Tinnitus'),
+(35478,51120,1,'Drums of War - Tinnitus');

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4430,9 +4430,15 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Digestive Acid (Temporary)
     ApplySpellFix({ 26476 }, [](SpellInfo* spellInfo)
     {
-            spellInfo->Attributes |= SPELL_ATTR0_NO_IMMUNITIES;
-            spellInfo->AttributesEx2 |= SPELL_ATTR2_IGNORE_LINE_OF_SIGHT;
-            spellInfo->AttributesEx3 |= SPELL_ATTR3_ALWAYS_HIT;
+        spellInfo->Attributes |= SPELL_ATTR0_NO_IMMUNITIES;
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_IGNORE_LINE_OF_SIGHT;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_ALWAYS_HIT;
+    });
+
+    // Drums of War/Battle/Speed/Restoration
+    ApplySpellFix({ 35475, 35476, 35477, 35478 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 51120;
     });
 
     for (uint32 i = 0; i < GetSpellInfoStoreSize(); ++i)


### PR DESCRIPTION
…nnitus debuff.

Fixes #13834

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13834

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.add 29529`
`.learn 51302`
`.setskill 165 450`
Use Drums, see if debuff applies

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
