### PR TITLE
fix(Scripts/Spells): Omen of Clarity should not proc from Revitalize.

### DIFF
--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -63,6 +63,11 @@ enum DruidSpells
     SPELL_DRUID_ITEM_T10_FERAL_4P_BONUS     = 70726,
 };
 
+enum DruidIcons
+{
+    SPELL_ICON_REVITALIZE                   = 2862
+};
+
 // 1178 - Bear Form (Passive)
 // 9635 - Dire Bear Form (Passive)
 class spell_dru_bear_form_passive : public AuraScript
@@ -216,6 +221,12 @@ class spell_dru_omen_of_clarity : public AuraScript
                 return !spellInfo->HasAura(SPELL_AURA_MOD_SHAPESHIFT);
             }
 
+            return false;
+        }
+
+        // Revitalize
+        if (spellInfo->SpellIconID == SPELL_ICON_REVITALIZE)
+        {
             return false;
         }
 


### PR DESCRIPTION
Fixes #13829

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13829
- Closes https://github.com/chromiecraft/chromiecraft/issues/4072

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Take Omen of Clarity talent
Take Revitalize talent
Cast Rejuvenation/Wild Growth
Watch Clearcasting not procing on a hot tick

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
