### PR TITLE
fix(Scripts/HellfireRamparts): Nazan should descend when Vazruden rea…

### DIFF
--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -265,6 +265,7 @@ public:
         void Reset() override
         {
             events.Reset();
+            _nazanCalled = false;
         }
 
         void EnterEvadeMode(EvadeReason /*why*/) override
@@ -288,9 +289,17 @@ public:
             }
         }
 
+        void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*type*/, SpellSchoolMask /*school*/) override
+        {
+            if (!_nazanCalled && me->HealthBelowPctDamaged(35, damage))
+            {
+                _nazanCalled = true;
+                me->CastSpell(me, SPELL_CALL_NAZAN, true);
+            }
+        }
+
         void JustDied(Unit*) override
         {
-            me->CastSpell(me, SPELL_CALL_NAZAN, true);
             Talk(SAY_DIE);
         }
 
@@ -316,6 +325,7 @@ public:
 
     private:
         EventMap events;
+        bool _nazanCalled;
     };
 
     CreatureAI* GetAI(Creature* creature) const override


### PR DESCRIPTION
…ches 35%.

Fixes #13741

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13741
- Closes https://github.com/chromiecraft/chromiecraft/issues/4425

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go xyz -1383.390015 1711.819946 82.796097 543 5.672320`
`.go c id 17307`
damage Vazruden to 30% hp.
observe nazan descending

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
