### PR TITLE
fix(DB/SAI): Unliving adds summoned by Auchenai Soulpriest/Monk/Vindi…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1668948769786286200.sql
+++ b/data/sql/updates/pending_db_world/rev_1668948769786286200.sql
@@ -1,0 +1,8 @@
+--
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (18498,18499,18500,18501,18503) AND `source_type`=0 AND `id`=12;
+INSERT INTO `smart_scripts` VALUES
+(18498,0,12,0,54,0,100,0,0,0,0,0,0,11,33422,2,0,0,0,0,1,0,0,0,0,0,0,0,0,'Unliving Soldier - on just summoned - cast Phase In'),
+(18499,0,12,0,54,0,100,0,0,0,0,0,0,11,33422,2,0,0,0,0,1,0,0,0,0,0,0,0,0,'Unliving Sorcerer - on just summoned - cast Phase In'),
+(18500,0,12,0,54,0,100,0,0,0,0,0,0,11,33422,2,0,0,0,0,1,0,0,0,0,0,0,0,0,'Unliving Cleric - on just summoned - cast Phase In'),
+(18501,0,12,0,54,0,100,0,0,0,0,0,0,11,33422,2,0,0,0,0,1,0,0,0,0,0,0,0,0,'Unliving Stalker - on just summoned - cast Phase In'),
+(18503,0,12,0,54,0,100,0,0,0,0,0,0,11,33422,2,0,0,0,0,1,0,0,0,0,0,0,0,0,'Phantasmal Possessor - on just summoned - cast Phase In');


### PR DESCRIPTION
…cator should cast Phase In on summon.

Fixes #13814

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13814
- Closes [#4460](https://github.com/chromiecraft/chromiecraft/issues/4460)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.tele ac`
Attack any Auchenai Soulpriest/Monk/Vindicator (they are at the very beginning of the dungeon) and watch him

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
