### PR TITLE
fix(Scripts/BloodFurnace): The Maker should cast Domination instead o…

### DIFF
--- a/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/boss_the_maker.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/boss_the_maker.cpp
@@ -28,7 +28,7 @@ enum eEnums
     SPELL_ACID_SPRAY            = 38153,
     SPELL_EXPLODING_BREAKER     = 30925,
     SPELL_KNOCKDOWN             = 20276,
-    SPELL_DOMINATION            = 25772,
+    SPELL_DOMINATION            = 30923,
 
     EVENT_SPELL_ACID                = 1,
     EVENT_SPELL_EXPLODING           = 2,

--- a/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/boss_the_maker.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/boss_the_maker.cpp
@@ -25,15 +25,11 @@ enum eEnums
     SAY_KILL                    = 1,
     SAY_DIE                     = 2,
 
-    SPELL_ACID_SPRAY            = 38153,
     SPELL_EXPLODING_BREAKER     = 30925,
-    SPELL_KNOCKDOWN             = 20276,
     SPELL_DOMINATION            = 30923,
 
-    EVENT_SPELL_ACID                = 1,
-    EVENT_SPELL_EXPLODING           = 2,
-    EVENT_SPELL_DOMINATION          = 3,
-    EVENT_SPELL_KNOCKDOWN           = 4,
+    EVENT_SPELL_EXPLODING       = 1,
+    EVENT_SPELL_DOMINATION      = 2
 };
 
 class boss_the_maker : public CreatureScript
@@ -66,10 +62,8 @@ public:
         void EnterCombat(Unit* /*who*/) override
         {
             Talk(SAY_AGGRO);
-            events.ScheduleEvent(EVENT_SPELL_ACID, 15000);
             events.ScheduleEvent(EVENT_SPELL_EXPLODING, 6000);
             events.ScheduleEvent(EVENT_SPELL_DOMINATION, 120000);
-            events.ScheduleEvent(EVENT_SPELL_KNOCKDOWN, 10000);
 
             if (!instance)
                 return;
@@ -107,10 +101,6 @@ public:
 
             switch (events.ExecuteEvent())
             {
-                case EVENT_SPELL_ACID:
-                    me->CastSpell(me->GetVictim(), SPELL_ACID_SPRAY, false);
-                    events.RepeatEvent(urand(15000, 23000));
-                    break;
                 case EVENT_SPELL_EXPLODING:
                     if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                         me->CastSpell(target, SPELL_EXPLODING_BREAKER, false);
@@ -120,10 +110,6 @@ public:
                     if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                         me->CastSpell(target, SPELL_DOMINATION, false);
                     events.RepeatEvent(120000);
-                    break;
-                case EVENT_SPELL_KNOCKDOWN:
-                    me->CastSpell(me->GetVictim(), SPELL_KNOCKDOWN, false);
-                    events.RepeatEvent(urand(4000, 12000));
                     break;
             }
 


### PR DESCRIPTION
…f Mental Domination.
Removed invalid spells from the script.

Fixes #13822

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13822
- Closes #13823
- Closes #13824

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go creature 138123`
wait for him to cast domination

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
