### PR TITLE
fix(DB/Dungeons): Caverns of Time: Old Hilsbrad should be available u…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1668951316420712600.sql
+++ b/data/sql/updates/pending_db_world/rev_1668951316420712600.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `dungeon_access_requirements` WHERE `dungeon_access_id` IN (62,63) AND `requirement_type`=1 AND `requirement_id`=10277;
+INSERT INTO `dungeon_access_requirements` VALUES
+(62,1,10277,'You must complete the quest "The Caverns of Time" before entering the Old Hillsbrad.',2,0,0,''),
+(63,1,10277,'You must complete the quest "The Caverns of Time" before entering the Old Hillsbrad (Heroic).',2,0,0,'');


### PR DESCRIPTION
…pon "Caverns of Time" completion.

Fixes #13837

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13837
- Closes https://github.com/chromiecraft/chromiecraft/issues/4466

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.level 64`
See if CoT: Old Hilsbrad is enabled  in RDF tool.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
