### PR TITLE
fix(DB/QuestGreeting): Krelding Ungor missing locale

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1669303320334648300.sql
+++ b/data/sql/updates/pending_db_world/rev_1669303320334648300.sql
@@ -1,3 +1,5 @@
 -- Fix issue 13914
 DELETE FROM `quest_greeting_locale` WHERE `locale` IN ('esES', 'esMX') AND ID = 5638;
-INSERT INTO `quest_greeting_locale` (`ID`, `type`, `locale`, `Greeting`) VALUES (5638, 0, 'esES', 'Tengo muchas cosas que hacer por aquí en Desolace, $N. Roetten quiere que recojamos algunos componentes para uno de nuestros clientes y buscar alguno de esos objetos perdidos.$b$bViéndote que estás aquí para ayudar. ¿Por qué no empezamos?');
+INSERT INTO `quest_greeting_locale` (`ID`, `type`, `locale`, `Greeting`) VALUES 
+(5638, 0, 'esES', 'Tengo muchas cosas que hacer por aquí en Desolace, $N. Roetten quiere que recojamos algunos componentes para uno de nuestros clientes y buscar alguno de esos objetos perdidos.$b$bViéndote que estás aquí para ayudar. ¿Por qué no empezamos?'),
+(5638, 0, 'esMX', 'Tengo muchas cosas que hacer por aquí en Desolace, $N. Roetten quiere que recojamos algunos componentes para uno de nuestros clientes y buscar alguno de esos objetos perdidos.$b$bViéndote que estás aquí para ayudar. ¿Por qué no empezamos?');

--- a/data/sql/updates/pending_db_world/rev_1669303320334648300.sql
+++ b/data/sql/updates/pending_db_world/rev_1669303320334648300.sql
@@ -1,3 +1,3 @@
 -- Fix issue 13914
 DELETE FROM `quest_greeting_locale` WHERE `locale` IN ('esES', 'esMX') AND ID = 5638;
-INSERT INTO `quest_greeting_locale` (`ID`, `type`, `locale`, `Greeting`) VALUES (5638, 0, 'esES', 'Tengo muchas cosas que hacer por aquí en Desolace, $N. Roetten quiere que recojamos algunos componentes para uno de nuestros clientes y buscar alguno de esos objetos perdidos.$b$bViéndote que estás aquí para ayudar. ¿Por qué no empezamos?')
+INSERT INTO `quest_greeting_locale` (`ID`, `type`, `locale`, `Greeting`) VALUES (5638, 0, 'esES', 'Tengo muchas cosas que hacer por aquí en Desolace, $N. Roetten quiere que recojamos algunos componentes para uno de nuestros clientes y buscar alguno de esos objetos perdidos.$b$bViéndote que estás aquí para ayudar. ¿Por qué no empezamos?');

--- a/data/sql/updates/pending_db_world/rev_1669303320334648300.sql
+++ b/data/sql/updates/pending_db_world/rev_1669303320334648300.sql
@@ -1,0 +1,3 @@
+-- Fix issue 13914
+DELETE FROM quest_greeting_locale WHERE `locale` IN ('esES', 'esMX') AND ID = 5638;
+INSERT INTO quest_greeting_locale (`ID`, `type`, `locale`, `Greeting`) VALUES (5638, 0, 'esES', 'Tengo muchas cosas que hacer por aquí en Desolace, $N. Roetten quiere que recojamos algunos componentes para uno de nuestros clientes y buscar alguno de esos objetos perdidos.$b$bViéndote que estás aquí para ayudar. ¿Por qué no empezamos?')

--- a/data/sql/updates/pending_db_world/rev_1669303320334648300.sql
+++ b/data/sql/updates/pending_db_world/rev_1669303320334648300.sql
@@ -1,5 +1,5 @@
 -- Fix issue 13914
-DELETE FROM `quest_greeting_locale` WHERE `locale` IN ('esES', 'esMX') AND ID = 5638;
+DELETE FROM `quest_greeting_locale` WHERE `locale` IN ('esES', 'esMX') AND `ID` = 5638;
 INSERT INTO `quest_greeting_locale` (`ID`, `type`, `locale`, `Greeting`) VALUES 
 (5638, 0, 'esES', 'Tengo muchas cosas que hacer por aquí en Desolace, $N. Roetten quiere que recojamos algunos componentes para uno de nuestros clientes y buscar alguno de esos objetos perdidos.$b$bViéndote que estás aquí para ayudar. ¿Por qué no empezamos?'),
 (5638, 0, 'esMX', 'Tengo muchas cosas que hacer por aquí en Desolace, $N. Roetten quiere que recojamos algunos componentes para uno de nuestros clientes y buscar alguno de esos objetos perdidos.$b$bViéndote que estás aquí para ayudar. ¿Por qué no empezamos?');

--- a/data/sql/updates/pending_db_world/rev_1669303320334648300.sql
+++ b/data/sql/updates/pending_db_world/rev_1669303320334648300.sql
@@ -1,3 +1,3 @@
 -- Fix issue 13914
-DELETE FROM quest_greeting_locale WHERE `locale` IN ('esES', 'esMX') AND ID = 5638;
-INSERT INTO quest_greeting_locale (`ID`, `type`, `locale`, `Greeting`) VALUES (5638, 0, 'esES', 'Tengo muchas cosas que hacer por aquí en Desolace, $N. Roetten quiere que recojamos algunos componentes para uno de nuestros clientes y buscar alguno de esos objetos perdidos.$b$bViéndote que estás aquí para ayudar. ¿Por qué no empezamos?')
+DELETE FROM `quest_greeting_locale` WHERE `locale` IN ('esES', 'esMX') AND ID = 5638;
+INSERT INTO `quest_greeting_locale` (`ID`, `type`, `locale`, `Greeting`) VALUES (5638, 0, 'esES', 'Tengo muchas cosas que hacer por aquí en Desolace, $N. Roetten quiere que recojamos algunos componentes para uno de nuestros clientes y buscar alguno de esos objetos perdidos.$b$bViéndote que estás aquí para ayudar. ¿Por qué no empezamos?')


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fix missing esES Kreldig ungor

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Close AC issue #13914 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://github.com/azerothcore/azerothcore-wotlk/issues/13914

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Executed without errors, not tested
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go c id 5638
2. Speak to NPC

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [Seems quest_greeting_locale only have one row in rusian so all languages miss those locales]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
