### PR TITLE
fix(DB/Conditions): Pint-Sized Pink Pachyderm and Wolpertinger should…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1669454417149643100.sql
+++ b/data/sql/updates/pending_db_world/rev_1669454417149643100.sql
@@ -1,0 +1,8 @@
+--
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=30 AND `SourceEntry` IN (24753,22943);
+INSERT INTO `conditions` VALUES
+(30,0,24753,0,0,33,0,1,2,0,0,0,0,'','Pint-Sized Pink Pachyderm visible only if target is in party with its owner'),
+(30,0,24753,0,1,10,0,2,0,0,0,0,0,'','Pint-Sized Pink Pachyderm visible only if target is drunk'),
+
+(30,0,22943,0,0,33,0,1,2,0,0,0,0,'','Pint-Sized Pink Pachyderm visible only if target is in party with its owner'),
+(30,0,22943,0,1,10,0,2,0,0,0,0,0,'','Pint-Sized Pink Pachyderm visible only if target is drunk');

--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -768,21 +768,24 @@ uint32 Condition::GetMaxAvailableConditionTargets()
     // returns number of targets which are available for given source type
     switch (SourceType)
     {
-    case CONDITION_SOURCE_TYPE_SMART_EVENT:
-        return 3;
-    case CONDITION_SOURCE_TYPE_SPELL:
-    case CONDITION_SOURCE_TYPE_SPELL_IMPLICIT_TARGET:
-    case CONDITION_SOURCE_TYPE_CREATURE_TEMPLATE_VEHICLE:
-    case CONDITION_SOURCE_TYPE_VEHICLE_SPELL:
-    case CONDITION_SOURCE_TYPE_SPELL_CLICK_EVENT:
-    case CONDITION_SOURCE_TYPE_GOSSIP_MENU:
-    case CONDITION_SOURCE_TYPE_GOSSIP_MENU_OPTION:
-    case CONDITION_SOURCE_TYPE_NPC_VENDOR:
-    case CONDITION_SOURCE_TYPE_SPELL_PROC:
-        return 2;
-    default:
-        return 1;
+        case CONDITION_SOURCE_TYPE_SMART_EVENT:
+            return 3;
+        case CONDITION_SOURCE_TYPE_SPELL:
+        case CONDITION_SOURCE_TYPE_SPELL_IMPLICIT_TARGET:
+        case CONDITION_SOURCE_TYPE_CREATURE_TEMPLATE_VEHICLE:
+        case CONDITION_SOURCE_TYPE_VEHICLE_SPELL:
+        case CONDITION_SOURCE_TYPE_SPELL_CLICK_EVENT:
+        case CONDITION_SOURCE_TYPE_GOSSIP_MENU:
+        case CONDITION_SOURCE_TYPE_GOSSIP_MENU_OPTION:
+        case CONDITION_SOURCE_TYPE_NPC_VENDOR:
+        case CONDITION_SOURCE_TYPE_SPELL_PROC:
+        case CONDITION_SOURCE_TYPE_CREATURE_VISIBILITY:
+            return 2;
+        default:
+            break;
     }
+
+    return 1;
 }
 
 ConditionMgr::ConditionMgr() {}

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1737,7 +1737,7 @@ bool WorldObject::CanSeeOrDetect(WorldObject const* obj, bool ignoreStealth, boo
     // Creature scripts
     if (Creature const* cObj = obj->ToCreature())
     {
-        if (Player const* player = this->ToPlayer())
+        if (Player const* player = ToPlayer())
         {
             if (cObj->IsAIEnabled && !cObj->AI()->CanBeSeen(player))
             {
@@ -1745,8 +1745,7 @@ bool WorldObject::CanSeeOrDetect(WorldObject const* obj, bool ignoreStealth, boo
             }
 
             ConditionList conditions = sConditionMgr->GetConditionsForNotGroupedEntry(CONDITION_SOURCE_TYPE_CREATURE_VISIBILITY, cObj->GetEntry());
-
-            if (!sConditionMgr->IsObjectMeetToConditions((WorldObject*)this, conditions))
+            if (!sConditionMgr->IsObjectMeetToConditions((WorldObject*)this, (WorldObject*)obj, conditions))
             {
                 return false;
             }
@@ -1755,8 +1754,12 @@ bool WorldObject::CanSeeOrDetect(WorldObject const* obj, bool ignoreStealth, boo
 
     // Gameobject scripts
     if (GameObject const* goObj = obj->ToGameObject())
-        if (this->ToPlayer() && !goObj->AI()->CanBeSeen(this->ToPlayer()))
+    {
+        if (ToPlayer() && !goObj->AI()->CanBeSeen(ToPlayer()))
+        {
             return false;
+        }
+    }
 
     // pussywizard: arena spectator
     if (obj->GetTypeId() == TYPEID_PLAYER)


### PR DESCRIPTION
… be visible only to party members or drunk players.

Fixes #13900

<!-- First of all, THANK YOU for your contribution. --> 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13900
- Closes https://github.com/chromiecraft/chromiecraft/issues/4486

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.additem 46707`
`.additem 32233`
summon
on second character check if you can see

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
