### PR TITLE
fix(Scripts/Spells): Nether Portal - Perseverence should not increase…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1669543104429416500.sql
+++ b/data/sql/updates/pending_db_world/rev_1669543104429416500.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id`=30421;
+INSERT INTO `spell_script_names` VALUES
+(30421,'spell_nether_portal_perseverence');

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -334,12 +334,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Attributes &= ~SPELL_ATTR0_NOT_SHAPESHIFTED;   // with this spell atrribute aura can be stacked several times
     });
 
-    // Nether Portal - Perseverence
-    ApplySpellFix({ 30421 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->Effects[EFFECT_2].BasePoints += 30000;
-    });
-
     // Natural shapeshifter
     ApplySpellFix({ 16834, 16835 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
@@ -27,6 +27,7 @@ EndScriptData */
 #include "ScriptedCreature.h"
 #include "karazhan.h"
 #include "SpellAuras.h"
+#include "SpellScript.h"
 
 enum Netherspite
 {

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
@@ -26,6 +26,7 @@ EndScriptData */
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
 #include "karazhan.h"
+#include "SpellAuras.h"
 
 enum Netherspite
 {

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
@@ -347,7 +347,23 @@ public:
     };
 };
 
+class spell_nether_portal_perseverence : public AuraScript
+{
+    PrepareAuraScript(spell_nether_portal_perseverence);
+
+    void HandleApply(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
+    {
+        const_cast<AuraEffect*>(aurEff)->SetAmount(aurEff->GetAmount() + 30000);
+    }
+
+    void Register() override
+    {
+        OnEffectApply += AuraEffectApplyFn(spell_nether_portal_perseverence::HandleApply, EFFECT_2, SPELL_AURA_MOD_INCREASE_HEALTH, AURA_EFFECT_HANDLE_REAL_OR_REAPPLY_MASK);
+    }
+};
+
 void AddSC_boss_netherspite()
 {
     new boss_netherspite();
+    RegisterSpellScript(spell_nether_portal_perseverence);
 }

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
@@ -26,7 +26,7 @@ EndScriptData */
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
 #include "karazhan.h"
-#include "SpellAuras.h"
+#include "SpellAuraEffects.h"
 #include "SpellScript.h"
 
 enum Netherspite


### PR DESCRIPTION
… player's health infinitely.

Fixes #1107

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #1107

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Go to Netherspite in Karazhan
Begin combat
Stand in the path of the Red Portal's beam
Watch player HP

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
