### PR TITLE
fix(DB/SAI): Marshfang Ripper AI

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1669553293045073800.sql
+++ b/data/sql/updates/pending_db_world/rev_1669553293045073800.sql
@@ -1,0 +1,11 @@
+--
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 18130) AND (`source_type` = 0) AND (`id` IN (0, 1, 2, 3));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(18130, 0, 0, 0, 0, 0, 75, 0, 3000, 3000, 9000, 9000, 0, 11, 3604, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Marshfang Ripper - In Combat - Cast \'Tendon Rip\''),
+(18130, 0, 1, 0, 0, 0, 75, 0, 1000, 1000, 10000, 15000, 0, 11, 17008, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Marshfang Ripper - In Combat - Cast \'Drain Mana\''),
+(18130, 0, 2, 0, 0, 0, 100, 0, 3000, 3000, 3000, 6000, 0, 11, 33860, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Marshfang Ripper - In Combat - Cast \'Arcane Explosion\''),
+(18130, 0, 3, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 108, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Marshfang Ripper - On Reset - Set Mana To 0');
+
+UPDATE `creature_template` SET `unit_flags2` = `unit_flags` &~ 2048 WHERE `entry` = 18130;
+
+UPDATE `creature` SET `curmana` = 0 WHERE `id1` = 18130;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add Arcane Explosion spell 
-  Adjust Drain Mana timer after retail research
- Remove mana regeneration
- Set mana to 0 on spawn (creature template current mana is completely ignored)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13926#issuecomment-1328169941


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. pull mob as mana user
2. see drain mana
3. arcane boom
4. gg

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
