### PR TITLE
fix(DB/Loot): Fenclaw Hide

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1669589041819811900.sql
+++ b/data/sql/updates/pending_db_world/rev_1669589041819811900.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_loot_template` SET `Chance` = 100 WHERE `Entry` = 18214 AND `Item` = 24486;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Set 100% chance to Fenclaw Thrashers' loot.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13921

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  Executed the query, no issues. No further tests needed.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .quest add 9834
2. .go c 65442
3. Kill the npcs, you should always get 1 item.

