### PR TITLE
fix(DB/Quest): Our Boy Wants To Be A Skyguard Ranger prerequisite

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1669590774563293200.sql
+++ b/data/sql/updates/pending_db_world/rev_1669590774563293200.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `quest_template_addon` SET `PrevQuestID` = 11025 WHERE (`ID` = 11030);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add 11025 as prerequisite.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13949

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. . go c 91763
2. It shouldn't give any quests.
3. .quest add 11025
4. .quest complete 11025
5. .quest reward 11025
6. And now Torkus should give you the quest 11030 (Our Boy Wants To Be A Skyguard Ranger)


