### PR TITLE
fix(Core/BattlefieldWG): Workshops/Graveyard not changing to neutral

### DIFF
--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -1474,7 +1474,7 @@ struct WGWorkshop
                     // Send warning message to all player to inform a faction attack to a workshop
                     // alliance / horde attacking a workshop
                     bf->SendWarning(teamControl ? WorkshopsData[workshopId].attackText : (WorkshopsData[workshopId].attackText + 2));
-                    
+
                     // Updating worldstate, update icon to neutral
                     state = BATTLEFIELD_WG_OBJECTSTATE_NEUTRAL_INTACT;
                     bf->SendUpdateWorldState(WorkshopsData[workshopId].worldstate, state);

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -1474,6 +1474,17 @@ struct WGWorkshop
                     // Send warning message to all player to inform a faction attack to a workshop
                     // alliance / horde attacking a workshop
                     bf->SendWarning(teamControl ? WorkshopsData[workshopId].attackText : (WorkshopsData[workshopId].attackText + 2));
+                    
+                    // Updating worldstate, update icon to neutral
+                    state = BATTLEFIELD_WG_OBJECTSTATE_NEUTRAL_INTACT;
+                    bf->SendUpdateWorldState(WorkshopsData[workshopId].worldstate, state);
+
+                    // Found associate graveyard and update it
+                    if (workshopId < BATTLEFIELD_WG_WORKSHOP_KEEP_WEST)
+                        if (bf->GetGraveyardById(workshopId))
+                            bf->GetGraveyardById(workshopId)->GiveControlTo(team);
+
+                    teamControl = team;
                     break;
                 }
             case TEAM_ALLIANCE:

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -1193,6 +1193,8 @@ bool SpellArea::IsFitToRequirements(Player const* player, uint32 newZone, uint32
                     return spellId == 56618;
                 else if (team == TEAM_ALLIANCE)
                     return spellId == 56617;
+                else
+                    return false;
                 break;
             }
         // Hellscream's Warsong


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  When you were capturing a workshop, when the bar was at gray (neutral), the workshops weren't updating to neutral team and the team who was owning the workshop still had more vehicles while it was neutral
-  Change workshop/GY to neutral

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Build without error
- 
![WoWScrnShot_113022_130125](https://user-images.githubusercontent.com/37176834/204793629-73a088f8-27b2-4f7c-9114-0075003f6594.jpg)



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .tele wintergrasp
2. start wintergrasp
3. go to some graveyard/workshop and cap it

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
