### PR TITLE
fix(DB/loot): Improve Mazthoril recipe drop rates

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1669870365832502100.sql
+++ b/data/sql/updates/pending_db_world/rev_1669870365832502100.sql
@@ -1,5 +1,5 @@
 --
 -- Improve Mazthoril Recipe Drop Rates
-UPDATE `world`.`creature_loot_template` SET `Chance`=6 WHERE  `Entry`=7437 AND `Item`=14493 AND `Reference`=0 AND `GroupId`=0;
-UPDATE `world`.`creature_loot_template` SET `Chance`=2 WHERE  `Entry`=7437 AND `Item`=16054 AND `Reference`=0 AND `GroupId`=0;
-UPDATE `world`.`creature_loot_template` SET `Chance`=10 WHERE  `Entry`=7437 AND `Item`=13497 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `creature_loot_template` SET `Chance`=6 WHERE  `Entry`=7437 AND `Item`=14493 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `creature_loot_template` SET `Chance`=2 WHERE  `Entry`=7437 AND `Item`=16054 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `creature_loot_template` SET `Chance`=10 WHERE  `Entry`=7437 AND `Item`=13497 AND `Reference`=0 AND `GroupId`=0;

--- a/data/sql/updates/pending_db_world/rev_1669870365832502100.sql
+++ b/data/sql/updates/pending_db_world/rev_1669870365832502100.sql
@@ -1,5 +1,5 @@
 --
 -- Improve Mazthoril Recipe Drop Rates
-UPDATE `creature_loot_template` SET `Chance`=6 WHERE  `Entry`=7437 AND `Item`=14493 AND `Reference`=0 AND `GroupId`=0;
-UPDATE `creature_loot_template` SET `Chance`=2 WHERE  `Entry`=7437 AND `Item`=16054 AND `Reference`=0 AND `GroupId`=0;
-UPDATE `creature_loot_template` SET `Chance`=10 WHERE  `Entry`=7437 AND `Item`=13497 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `creature_loot_template` SET `Chance`=6 WHERE `Entry`=7437 AND `Item`=14493 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `creature_loot_template` SET `Chance`=2 WHERE `Entry`=7437 AND `Item`=16054 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `creature_loot_template` SET `Chance`=10 WHERE `Entry`=7437 AND `Item`=13497 AND `Reference`=0 AND `GroupId`=0;

--- a/data/sql/updates/pending_db_world/rev_1669870365832502100.sql
+++ b/data/sql/updates/pending_db_world/rev_1669870365832502100.sql
@@ -1,5 +1,5 @@
 --
 -- Improve Mazthoril Recipe Drop Rates
-UPDATE `world`.`creature_loot_template` SET `Chance`='6' WHERE  `Entry`=7437 AND `Item`=14493 AND `Reference`=0 AND `GroupId`=0;
-UPDATE `world`.`creature_loot_template` SET `Chance`='2' WHERE  `Entry`=7437 AND `Item`=16054 AND `Reference`=0 AND `GroupId`=0;
-UPDATE `world`.`creature_loot_template` SET `Chance`='10' WHERE  `Entry`=7437 AND `Item`=13497 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `world`.`creature_loot_template` SET `Chance`=6 WHERE  `Entry`=7437 AND `Item`=14493 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `world`.`creature_loot_template` SET `Chance`=2 WHERE  `Entry`=7437 AND `Item`=16054 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `world`.`creature_loot_template` SET `Chance`=10 WHERE  `Entry`=7437 AND `Item`=13497 AND `Reference`=0 AND `GroupId`=0;

--- a/data/sql/updates/pending_db_world/rev_1669870365832502100.sql
+++ b/data/sql/updates/pending_db_world/rev_1669870365832502100.sql
@@ -1,0 +1,5 @@
+--
+-- Improve Mazthoril Recipe Drop Rates
+UPDATE `world`.`creature_loot_template` SET `Chance`='6' WHERE  `Entry`=7437 AND `Item`=14493 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `world`.`creature_loot_template` SET `Chance`='2' WHERE  `Entry`=7437 AND `Item`=16054 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `world`.`creature_loot_template` SET `Chance`='10' WHERE  `Entry`=7437 AND `Item`=13497 AND `Reference`=0 AND `GroupId`=0;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Increases the drop rate chance of 2 recipes, lowers the drop rate chance of 1 recipe to match wowhead's* values


## SOURCE:
*I used Wowhead values to save time, I also as always sniffed the loot manually and got every item to drop, usually multiple times, but it would take me at least 10hours to come up with better numbers and their numbers seemed "pretty close enough" for this and our numbers seemed wildly inaccurate

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Untested but I don't see why it wouldn't work as is, its just a loot change and the SQL is written by HeidiSQL
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
