### PR TITLE
fix(DB/creature_onkill_reputation): Correct reputation gains in Blood Furnace Normal Mode

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1670029407665884500.sql
+++ b/data/sql/updates/pending_db_world/rev_1670029407665884500.sql
@@ -1,0 +1,20 @@
+-- Normal Mode regular creatures award 5 rep. Heroic awards 15
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 5, `RewOnKillRepValue2` = 5 WHERE `creature_id` IN (
+17370, -- Laughing Skull Enforcer
+17626, -- Laughing Skull Legionnaire
+17624, -- Laughing Skull Warden
+17397, -- Shadowmoon Adept
+17491, -- Laughing Skull Rogue
+17371, -- Shadowmoon Warlock
+17395, -- Shadowmoon Summoner
+17414, -- Shadowmoon Technician
+17398, -- Nascent Fel Orc
+17429, -- Fel Orc Neophyte
+18894, -- Fel Guard Brute
+17653  -- Shadowmoon Channeler
+);
+-- One of these heroic creatures awarded 1 instead of 3 and I forgot to check which
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 3, `RewOnKillRepValue2` = 3 WHERE `creature_id` IN (
+18606, -- Hellfire Imp
+21646  -- Hellfire Familiar
+);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changes 13 creatures onkill_rep
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/14015

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
