### PR TITLE
fix(DB/loot): Deathknell unique drops rate improvements

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1670381120624981200.sql
+++ b/data/sql/updates/pending_db_world/rev_1670381120624981200.sql
@@ -1,0 +1,16 @@
+--
+-- Deathknell Zone Drops
+-- Night Web Matriarch should drop Webbed Cloak most of the time (~80%  Wowhead estimate, seems fair based off testing)
+UPDATE `creature_loot_template` SET `Chance`=80, `Comment`='Night Web Matriarch - Webbed Cloak' WHERE `Entry`=1688 AND `Item`=3261 AND `Reference`=0 AND `GroupId`=0;
+-- Night Web Crawlers should drop Webbed Pants (sniff 5/~410, wowhead estimate 1% based on robust error adjusted wowhead data
+UPDATE `creature_loot_template` SET `Chance`=1, `Comment`='Night Web Spider - Webbed Pants' WHERE `Entry`=1505 AND `Item`=3263 AND `Reference`=0 AND `GroupId`=0;
+-- Putrid Wooden Hammer 3/369 off Rattlecage Skeleton, but 2% is in line with robust error adjusted wowhead data, leaving unchanged from AC
+-- Deadman Cleaver off Daniel Ulfman (~3/300 sniff, wowhead 10/567 1.5% seems fair)
+UPDATE `creature_loot_template` SET `Chance`=1.5 WHERE `Entry`=1917 AND `Item`=3293 AND `Reference`=0 AND `GroupId`=0;
+-- Deadman Dagger off Stephan Bartec (~7/300 sniff, wowhead 9/518 2% seems fair, leaving unchanged from AC)
+-- 1 Deadman Blade off Samuel Flipps (~1/300 sniff, wowhead 48/5208 0.9% seems fair)
+UPDATE `creature_loot_template` SET `Chance`=0.9 WHERE `Entry`=1919 AND `Item`=3295 AND `Reference`=0 AND `GroupId`=0;
+-- 1 Deadman Club off Karrel Grayves (~1/300 sniff, wowhead 22/664 2% seems fair, leaving unchanged from AC)
+-- 3 Tarnished Bastard Sword off 850 Scarlet Converts, 2 Scarlet Initiate Robes off ~250 Scarlet Initiates, 1.25% brings it in line with robust error adjusted wowhead data
+UPDATE `creature_loot_template` SET `Chance`=1.25 WHERE `Entry`=1506 AND `Item`=2754 AND `Reference`=0 AND `GroupId`=0;
+UPDATE `creature_loot_template` SET `Chance`=1.25 WHERE `Entry`=1507 AND `Item`=3260 AND `Reference`=0 AND `GroupId`=0;

--- a/data/sql/updates/pending_db_world/rev_1670381120624981200.sql
+++ b/data/sql/updates/pending_db_world/rev_1670381120624981200.sql
@@ -1,7 +1,7 @@
 --
 -- Deathknell Zone Drops
 UPDATE `creature_loot_template` SET `Chance`=80, `Comment`='Night Web Matriarch - Webbed Cloak' WHERE `Entry`=1688 AND `Item`=3261 AND `Reference`=0 AND `GroupId`=0;
-UPDATE `creature_loot_template` SET `Chance`=1, `Comment`='Night Web Spider - Webbed Pants' WHERE `Entry`=1505 AND `It
+UPDATE `creature_loot_template` SET `Chance`=1, `Comment`='Night Web Spider - Webbed Pants' WHERE `Entry`=1505 AND `Item`=3263 AND `Reference`=0 AND `GroupId`=0;
 UPDATE `creature_loot_template` SET `Chance`=1.5 WHERE `Entry`=1917 AND `Item`=3293 AND `Reference`=0 AND `GroupId`=0;
 UPDATE `creature_loot_template` SET `Chance`=0.9 WHERE `Entry`=1919 AND `Item`=3295 AND `Reference`=0 AND `GroupId`=0;
 UPDATE `creature_loot_template` SET `Chance`=1.25 WHERE `Entry`=1506 AND `Item`=2754 AND `Reference`=0 AND `GroupId`=0;

--- a/data/sql/updates/pending_db_world/rev_1670381120624981200.sql
+++ b/data/sql/updates/pending_db_world/rev_1670381120624981200.sql
@@ -1,16 +1,8 @@
 --
 -- Deathknell Zone Drops
--- Night Web Matriarch should drop Webbed Cloak most of the time (~80%  Wowhead estimate, seems fair based off testing)
 UPDATE `creature_loot_template` SET `Chance`=80, `Comment`='Night Web Matriarch - Webbed Cloak' WHERE `Entry`=1688 AND `Item`=3261 AND `Reference`=0 AND `GroupId`=0;
--- Night Web Crawlers should drop Webbed Pants (sniff 5/~410, wowhead estimate 1% based on robust error adjusted wowhead data
-UPDATE `creature_loot_template` SET `Chance`=1, `Comment`='Night Web Spider - Webbed Pants' WHERE `Entry`=1505 AND `Item`=3263 AND `Reference`=0 AND `GroupId`=0;
--- Putrid Wooden Hammer 3/369 off Rattlecage Skeleton, but 2% is in line with robust error adjusted wowhead data, leaving unchanged from AC
--- Deadman Cleaver off Daniel Ulfman (~3/300 sniff, wowhead 10/567 1.5% seems fair)
+UPDATE `creature_loot_template` SET `Chance`=1, `Comment`='Night Web Spider - Webbed Pants' WHERE `Entry`=1505 AND `It
 UPDATE `creature_loot_template` SET `Chance`=1.5 WHERE `Entry`=1917 AND `Item`=3293 AND `Reference`=0 AND `GroupId`=0;
--- Deadman Dagger off Stephan Bartec (~7/300 sniff, wowhead 9/518 2% seems fair, leaving unchanged from AC)
--- 1 Deadman Blade off Samuel Flipps (~1/300 sniff, wowhead 48/5208 0.9% seems fair)
 UPDATE `creature_loot_template` SET `Chance`=0.9 WHERE `Entry`=1919 AND `Item`=3295 AND `Reference`=0 AND `GroupId`=0;
--- 1 Deadman Club off Karrel Grayves (~1/300 sniff, wowhead 22/664 2% seems fair, leaving unchanged from AC)
--- 3 Tarnished Bastard Sword off 850 Scarlet Converts, 2 Scarlet Initiate Robes off ~250 Scarlet Initiates, 1.25% brings it in line with robust error adjusted wowhead data
 UPDATE `creature_loot_template` SET `Chance`=1.25 WHERE `Entry`=1506 AND `Item`=2754 AND `Reference`=0 AND `GroupId`=0;
 UPDATE `creature_loot_template` SET `Chance`=1.25 WHERE `Entry`=1507 AND `Item`=3260 AND `Reference`=0 AND `GroupId`=0;


### PR DESCRIPTION
ALL unique drops in Deathknell have been looked at. Improvements made based on a mix of available data and research.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Improves loot as followed:
-- Deathknell Zone Drops (DONE)
-- Night Web Matriarch should drop Webbed Cloak most of the time (~80%  Wowhead estimate, seems fair based off testing)
-- Night Web Crawlers should drop Webbed Pants (sniff 5/~410, wowhead estimate 1% based on robust error adjusted wowhead data
-- Putrid Wooden Hammer 3/369 off Rattlecage Skeleton, but 2% is in line with robust error adjusted wowhead data, leaving unchanged from AC
-- Deadman Cleaver off Daniel Ulfman (~3/300 sniff, wowhead 10/567 1.5% seems fair)
-- Deadman Dagger off Stephan Bartec (~7/300 sniff, wowhead 9/518 2% seems fair, leaving unchanged from AC)
-- 1 Deadman Blade off Samuel Flipps (~1/300 sniff, wowhead 48/5208 0.9% seems fair)
-- 1 Deadman Club off Karrel Grayves (~1/300 sniff, wowhead 22/664 2% seems fair, leaving unchanged from AC)
-- 3 Tarnished Bastard Sword off 850 Scarlet Converts, 2 Scarlet Initiate Robes off ~250 Scarlet Initiates, 1.25% brings it in line with robust error adjusted wowhead data

Finalized my rounding system, On drops 10-100% single percentiles are used, 1-10% quarter percentiles, at 1% and lower tenths are used.  If I ever address ultra-rare loot I will use hundreths or thousandths as necessary for things below 0.1/0.01% (not in this PR).


## SOURCE:
Combination of sniffed research and wowhead data.  In some cases wowhead had tens of thousands of iterations and I was able to parse the bad loot out and adjust the number to a good approximation (in most cases this didn't change rates).  In cases where I had a comparable amount of iterations I would combine results to come up with a better approximation 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- SQL runs


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  Should just need looked at in SQL,  I use this query to make sure the item is correct and also to make sure the item/s does not show up in other location:
```
SELECT * FROM creature_loot_template
WHERE item IN (3263, 3261, 3260, 2754, 3262, 3293, 3294, 3295, 3296);
SELECT * FROM reference_loot_template
WHERE item IN (3263, 3261, 3260, 2754, 3262, 3293, 3294, 3295, 3296);
SELECT * FROM gameobject_loot_template
WHERE item IN (3263, 3261, 3260, 2754, 3262, 3293, 3294, 3295, 3296); 
```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- Honestly these numbers are prolly as close as anyone will ever get, who else is gonna spend 12 hours farming low level mobs on timers to make sure wowhead numbers are sane and to add meaningfully to the less robust data?  :P  
- There is an off-chance that my personal experience was not a fluke and that they did something to loot tables in wotlk, in which case these drop rates are actually too high still.  I doubt anyone is gonna argue for lowering these tho, and I made the assumption that I was having some bad luck streaks as a few of the numbers lined up nearly perfect while others didn't like dropping.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
