### PR TITLE
fix(Core/Battlefield): Wintergrasp Workshops SW/SE to Attacker

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -64,10 +64,10 @@ Battlefield::Battlefield()
 Battlefield::~Battlefield()
 {
     for (BfCapturePointVector::iterator itr = m_capturePoints.begin(); itr != m_capturePoints.end(); ++itr)
-        delete *itr;
+        delete* itr;
 
     for (GraveyardVect::const_iterator itr = m_GraveyardList.begin(); itr != m_GraveyardList.end(); ++itr)
-        delete *itr;
+        delete* itr;
 
     m_capturePoints.clear();
 }
@@ -911,7 +911,7 @@ void BfCapturePoint::SendChangePhase()
                 // send this too, sometimes the slider disappears, dunno why :(
                 player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldState1, 1);
                 // send these updates to only the ones in this objective
-                player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate2, (uint32) std::ceil((m_value + m_maxValue) / (2 * m_maxValue) * 100.0f));
+                player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate2, (uint32)std::ceil((m_value + m_maxValue) / (2 * m_maxValue) * 100.0f));
                 // send this too, sometimes it resets :S
                 player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate3, m_neutralValuePct);
             }
@@ -921,7 +921,7 @@ bool BfCapturePoint::SetCapturePointData(GameObject* capturePoint, TeamId team)
 {
     ASSERT(capturePoint);
 
-	//At first call using TEAM_NEUTRAL as a checker but never using it, after first call we reset the capturepoints to the new winner of the last WG war
+    //At first call using TEAM_NEUTRAL as a checker but never using it, after first call we reset the capturepoints to the new winner of the last WG war
     if (team == TEAM_NEUTRAL)
         team = m_team;
     LOG_DEBUG("bg.battlefield", "Creating capture point {}", capturePoint->GetEntry());
@@ -1012,7 +1012,7 @@ bool BfCapturePoint::Update(uint32 diff)
                 HandlePlayerEnter(*itr);
 
     // get the difference of numbers
-    float fact_diff = ((float) m_activePlayers[0].size() - (float) m_activePlayers[1].size()) * diff / BATTLEFIELD_OBJECTIVE_UPDATE_INTERVAL;
+    float fact_diff = ((float)m_activePlayers[0].size() - (float)m_activePlayers[1].size()) * diff / BATTLEFIELD_OBJECTIVE_UPDATE_INTERVAL;
     if (G3D::fuzzyEq(fact_diff, 0.0f))
         return false;
 
@@ -1110,14 +1110,14 @@ void BfCapturePoint::SendObjectiveComplete(uint32 id, ObjectGuid guid)
     uint8 team;
     switch (m_State)
     {
-        case BF_CAPTUREPOINT_OBJECTIVESTATE_ALLIANCE:
-            team = 0;
-            break;
-        case BF_CAPTUREPOINT_OBJECTIVESTATE_HORDE:
-            team = 1;
-            break;
-        default:
-            return;
+    case BF_CAPTUREPOINT_OBJECTIVESTATE_ALLIANCE:
+        team = 0;
+        break;
+    case BF_CAPTUREPOINT_OBJECTIVESTATE_HORDE:
+        team = 1;
+        break;
+    default:
+        return;
     }
 
     // send to all players present in the area

--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -510,17 +510,6 @@ void Battlefield::ShowNpc(Creature* creature, bool aggressive)
     }
 }
 
-void Battlefield::HidePortal(GameObject* go)
-{
-    go->SetPhaseMask(2, false);
-    //TODO
-}
-
-void Battlefield::ShowPortal(GameObject* go)
-{
-    go->SetPhaseMask(1, false);
-    //TODO
-}
 // ****************************************************
 // ******************* Group System *******************
 // ****************************************************
@@ -932,7 +921,8 @@ bool BfCapturePoint::SetCapturePointData(GameObject* capturePoint, TeamId team)
 {
     ASSERT(capturePoint);
 
-    if (team == TEAM_NEUTRAL)//At first call we change team neutral, after first call we reset the capturepoints to the new winner of WG
+	//At first call using TEAM_NEUTRAL as a checker but never using it, after first call we reset the capturepoints to the new winner of the last WG war
+    if (team == TEAM_NEUTRAL)
         team = m_team;
     LOG_DEBUG("bg.battlefield", "Creating capture point {}", capturePoint->GetEntry());
 

--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -510,6 +510,17 @@ void Battlefield::ShowNpc(Creature* creature, bool aggressive)
     }
 }
 
+void Battlefield::HidePortal(GameObject* go)
+{
+    go->SetPhaseMask(2, false);
+    //TODO
+}
+
+void Battlefield::ShowPortal(GameObject* go)
+{
+    go->SetPhaseMask(1, false);
+    //TODO
+}
 // ****************************************************
 // ******************* Group System *******************
 // ****************************************************
@@ -917,10 +928,12 @@ void BfCapturePoint::SendChangePhase()
             }
 }
 
-bool BfCapturePoint::SetCapturePointData(GameObject* capturePoint)
+bool BfCapturePoint::SetCapturePointData(GameObject* capturePoint, TeamId team)
 {
     ASSERT(capturePoint);
 
+    if (team == TEAM_NEUTRAL)//At first call we change team neutral, after first call we reset the capturepoints to the new winner of WG
+        team = m_team;
     LOG_DEBUG("bg.battlefield", "Creating capture point {}", capturePoint->GetEntry());
 
     m_capturePoint = capturePoint->GetGUID();
@@ -939,7 +952,7 @@ bool BfCapturePoint::SetCapturePointData(GameObject* capturePoint)
     m_neutralValuePct = goinfo->capturePoint.neutralPercent;
     m_minValue = m_maxValue * goinfo->capturePoint.neutralPercent / 100;
     m_capturePointEntry = capturePoint->GetEntry();
-    if (m_team == TEAM_ALLIANCE)
+    if (team == TEAM_ALLIANCE)
     {
         m_value = m_maxValue;
         m_State = BF_CAPTUREPOINT_OBJECTIVESTATE_ALLIANCE;

--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -64,10 +64,10 @@ Battlefield::Battlefield()
 Battlefield::~Battlefield()
 {
     for (BfCapturePointVector::iterator itr = m_capturePoints.begin(); itr != m_capturePoints.end(); ++itr)
-        delete* itr;
+        delete *itr;
 
     for (GraveyardVect::const_iterator itr = m_GraveyardList.begin(); itr != m_GraveyardList.end(); ++itr)
-        delete* itr;
+        delete *itr;
 
     m_capturePoints.clear();
 }
@@ -911,7 +911,7 @@ void BfCapturePoint::SendChangePhase()
                 // send this too, sometimes the slider disappears, dunno why :(
                 player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldState1, 1);
                 // send these updates to only the ones in this objective
-                player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate2, (uint32)std::ceil((m_value + m_maxValue) / (2 * m_maxValue) * 100.0f));
+                player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate2, (uint32) std::ceil((m_value + m_maxValue) / (2 * m_maxValue) * 100.0f));
                 // send this too, sometimes it resets :S
                 player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate3, m_neutralValuePct);
             }
@@ -1012,7 +1012,7 @@ bool BfCapturePoint::Update(uint32 diff)
                 HandlePlayerEnter(*itr);
 
     // get the difference of numbers
-    float fact_diff = ((float)m_activePlayers[0].size() - (float)m_activePlayers[1].size()) * diff / BATTLEFIELD_OBJECTIVE_UPDATE_INTERVAL;
+    float fact_diff = ((float) m_activePlayers[0].size() - (float) m_activePlayers[1].size()) * diff / BATTLEFIELD_OBJECTIVE_UPDATE_INTERVAL;
     if (G3D::fuzzyEq(fact_diff, 0.0f))
         return false;
 
@@ -1110,14 +1110,14 @@ void BfCapturePoint::SendObjectiveComplete(uint32 id, ObjectGuid guid)
     uint8 team;
     switch (m_State)
     {
-    case BF_CAPTUREPOINT_OBJECTIVESTATE_ALLIANCE:
-        team = 0;
-        break;
-    case BF_CAPTUREPOINT_OBJECTIVESTATE_HORDE:
-        team = 1;
-        break;
-    default:
-        return;
+        case BF_CAPTUREPOINT_OBJECTIVESTATE_ALLIANCE:
+            team = 0;
+            break;
+        case BF_CAPTUREPOINT_OBJECTIVESTATE_HORDE:
+            team = 1;
+            break;
+        default:
+            return;
     }
 
     // send to all players present in the area

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -348,6 +348,9 @@ public:
 
     void HideNpc(Creature* creature);
     void ShowNpc(Creature* creature, bool aggressive);
+    //Hide|Show Dalaran portals from wintergrasp
+    void HidePortal(GameObject* go);
+    void ShowPortal(GameObject* go);
 
     GraveyardVect GetGraveyardVector() { return m_GraveyardList; }
 
@@ -420,6 +423,7 @@ protected:
 
     // CapturePoint system
     void AddCapturePoint(BfCapturePoint* cp) { m_capturePoints.push_back(cp); }
+    void ClearCapturePoint() { m_capturePoints.clear(); }
 
     void RegisterZone(uint32 zoneid);
     bool HasPlayer(Player* player) const;

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -104,7 +104,8 @@ public:
     virtual void ChangeTeam(TeamId /*oldTeam*/) {}
     virtual void SendChangePhase();
 
-    bool SetCapturePointData(GameObject* capturePoint);
+    //Added team to reset capturepoints on sliders after warTime
+    bool SetCapturePointData(GameObject* capturePoint, TeamId team);
     GameObject* GetCapturePointGo();
     GameObject* GetCapturePointGo(WorldObject* obj);
 
@@ -347,6 +348,9 @@ public:
 
     void HideNpc(Creature* creature);
     void ShowNpc(Creature* creature, bool aggressive);
+    //Hide|Show Dalaran portals from wintergrasp
+    void HidePortal(GameObject* go);
+    void ShowPortal(GameObject* go);
 
     GraveyardVect GetGraveyardVector() { return m_GraveyardList; }
 
@@ -419,6 +423,7 @@ protected:
 
     // CapturePoint system
     void AddCapturePoint(BfCapturePoint* cp) { m_capturePoints.push_back(cp); }
+    void ClearCapturePoint() { m_capturePoints.clear(); }
 
     void RegisterZone(uint32 zoneid);
     bool HasPlayer(Player* player) const;

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -348,9 +348,6 @@ public:
 
     void HideNpc(Creature* creature);
     void ShowNpc(Creature* creature, bool aggressive);
-    //Hide|Show Dalaran portals from wintergrasp
-    void HidePortal(GameObject* go);
-    void ShowPortal(GameObject* go);
 
     GraveyardVect GetGraveyardVector() { return m_GraveyardList; }
 
@@ -423,7 +420,6 @@ protected:
 
     // CapturePoint system
     void AddCapturePoint(BfCapturePoint* cp) { m_capturePoints.push_back(cp); }
-    void ClearCapturePoint() { m_capturePoints.clear(); }
 
     void RegisterZone(uint32 zoneid);
     bool HasPlayer(Player* player) const;

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -406,7 +406,6 @@ void BattlefieldWG::OnBattleEnd(bool endByTimer)
         (*itr)->Save();
     }
 
-
     for (uint8 team = 0; team < 2; ++team)
     {
         for (GuidUnorderedSet::const_iterator itr = m_vehicles[team].begin(); itr != m_vehicles[team].end(); ++itr)

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -102,7 +102,7 @@ bool BattlefieldWG::SetupBattlefield()
 
         // When between games, the graveyard is controlled by the defending team
         if (WGGraveYard[i].startcontrol == TEAM_NEUTRAL)
-            graveyard->Initialize(m_DefenderTeam, WGGraveYard[i].gyid);
+            graveyard->Initialize(m_DefenderTeam == TEAM_ALLIANCE && (WGGraveYard[i].gyid == BATTLEFIELD_WG_GY_WORKSHOP_SE || WGGraveYard[i].gyid == BATTLEFIELD_WG_GY_WORKSHOP_SW) ? TEAM_HORDE : m_DefenderTeam, WGGraveYard[i].gyid);
         else
             graveyard->Initialize(WGGraveYard[i].startcontrol, WGGraveYard[i].gyid);
 
@@ -114,7 +114,7 @@ bool BattlefieldWG::SetupBattlefield()
     for (uint8 i = 0; i < WG_MAX_WORKSHOP; i++)
     {
         WGWorkshop* workshop = new WGWorkshop(this, i);
-        if (i < BATTLEFIELD_WG_WORKSHOP_KEEP_WEST)
+        if ((i == BATTLEFIELD_WG_WORKSHOP_SE || i == BATTLEFIELD_WG_WORKSHOP_SW) && i < BATTLEFIELD_WG_WORKSHOP_KEEP_WEST)
             workshop->GiveControlTo(GetAttackerTeam(), true);
         else
             workshop->GiveControlTo(GetDefenderTeam(), true);
@@ -262,6 +262,11 @@ void BattlefieldWG::OnBattleStart()
         if (*itr)
             (*itr)->UpdateGraveyardAndWorkshop();
 
+    // Set Sliders capture points data to his owners when battle start
+    for (BfCapturePointVector::const_iterator itr = m_capturePoints.begin(); itr != m_capturePoints.end(); ++itr)
+        (*itr)->SetCapturePointData((*itr)->GetCapturePointGo(),
+            (*itr)->GetCapturePointGo()->GetEntry() == GO_WINTERGRASP_FACTORY_BANNER_SE || (*itr)->GetCapturePointGo()->GetEntry() == GO_WINTERGRASP_FACTORY_BANNER_SW ? GetAttackerTeam() : GetDefenderTeam());
+
     for (uint8 team = 0; team < 2; ++team)
         for (GuidUnorderedSet::const_iterator itr = m_players[team].begin(); itr != m_players[team].end(); ++itr)
         {
@@ -375,7 +380,7 @@ void BattlefieldWG::OnBattleEnd(bool endByTimer)
     // Update all graveyard, control is to defender when no wartime
     for (uint8 i = 0; i < BATTLEFIELD_WG_GY_HORDE; i++)
         if (BfGraveyard* graveyard = GetGraveyardById(i))
-            graveyard->GiveControlTo(GetDefenderTeam());
+                graveyard->GiveControlTo(i == BATTLEFIELD_WG_GY_WORKSHOP_SE || i == BATTLEFIELD_WG_GY_WORKSHOP_SW ? GetAttackerTeam() : GetDefenderTeam());
 
     for (GameObjectSet::const_iterator itr = m_KeepGameObject[GetDefenderTeam()].begin(); itr != m_KeepGameObject[GetDefenderTeam()].end(); ++itr)
         (*itr)->SetRespawnTime(RESPAWN_IMMEDIATELY);
@@ -396,7 +401,11 @@ void BattlefieldWG::OnBattleEnd(bool endByTimer)
     }
 
     for (Workshop::const_iterator itr = WorkshopsList.begin(); itr != WorkshopsList.end(); ++itr)
-        (*itr)->Save();
+    {
+        (*itr)->GiveControlTo((*itr)->workshopId == BATTLEFIELD_WG_WORKSHOP_SE || (*itr)->workshopId == BATTLEFIELD_WG_WORKSHOP_SW ? GetAttackerTeam() : GetDefenderTeam(), true);
+        (*itr)->Save();   
+    }
+
 
     for (uint8 team = 0; team < 2; ++team)
     {
@@ -689,9 +698,9 @@ void BattlefieldWG::OnGameObjectCreate(GameObject* go)
         {
             if (workshop->workshopId == workshopId)
             {
-                WintergraspCapturePoint* capturePoint = new WintergraspCapturePoint(this, GetAttackerTeam());
-
-                capturePoint->SetCapturePointData(go);
+                WintergraspCapturePoint* capturePoint = new WintergraspCapturePoint(this, workshop->teamControl);
+                //Sending neutral team at start to set normal capture points by workshop->teamControl, TEAM_NEUTRAL is ignored at first call
+                capturePoint->SetCapturePointData(go, TEAM_NEUTRAL);
                 capturePoint->LinkToWorkshop(workshop);
                 AddCapturePoint(capturePoint);
                 break;
@@ -846,7 +855,7 @@ void BattlefieldWG::OnPlayerJoinWar(Player* player)
         if (player->GetTeamId() == TEAM_HORDE)
             player->TeleportTo(571, 5025.857422f, 3674.628906f, 362.737122f, 4.135169f);
         else
-            player->TeleportTo(571, 5101.284f, 2186.564f, 373.549f, 3.812f);
+            player->TeleportTo(571, 5101.284f, 2186.564f, 365.549f, 3.812f);
     }
 
     if (player->GetTeamId() == GetAttackerTeam())

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -102,7 +102,7 @@ bool BattlefieldWG::SetupBattlefield()
 
         // When between games, the graveyard is controlled by the defending team
         if (WGGraveYard[i].startcontrol == TEAM_NEUTRAL)
-            graveyard->Initialize(m_DefenderTeam == TEAM_ALLIANCE && (WGGraveYard[i].gyid == BATTLEFIELD_WG_GY_WORKSHOP_SE || WGGraveYard[i].gyid == BATTLEFIELD_WG_GY_WORKSHOP_SW) ? TEAM_HORDE : m_DefenderTeam, WGGraveYard[i].gyid);
+            graveyard->Initialize(WGGraveYard[i].gyid == BATTLEFIELD_WG_GY_WORKSHOP_SE || WGGraveYard[i].gyid == BATTLEFIELD_WG_GY_WORKSHOP_SW ? GetAttackerTeam() : m_DefenderTeam, WGGraveYard[i].gyid);
         else
             graveyard->Initialize(WGGraveYard[i].startcontrol, WGGraveYard[i].gyid);
 
@@ -114,7 +114,7 @@ bool BattlefieldWG::SetupBattlefield()
     for (uint8 i = 0; i < WG_MAX_WORKSHOP; i++)
     {
         WGWorkshop* workshop = new WGWorkshop(this, i);
-        if ((i == BATTLEFIELD_WG_WORKSHOP_SE || i == BATTLEFIELD_WG_WORKSHOP_SW) && i < BATTLEFIELD_WG_WORKSHOP_KEEP_WEST)
+        if (i == BATTLEFIELD_WG_WORKSHOP_SE || i == BATTLEFIELD_WG_WORKSHOP_SW)
             workshop->GiveControlTo(GetAttackerTeam(), true);
         else
             workshop->GiveControlTo(GetDefenderTeam(), true);
@@ -380,7 +380,7 @@ void BattlefieldWG::OnBattleEnd(bool endByTimer)
     // Update all graveyard, control is to defender when no wartime
     for (uint8 i = 0; i < BATTLEFIELD_WG_GY_HORDE; i++)
         if (BfGraveyard* graveyard = GetGraveyardById(i))
-                graveyard->GiveControlTo(i == BATTLEFIELD_WG_GY_WORKSHOP_SE || i == BATTLEFIELD_WG_GY_WORKSHOP_SW ? GetAttackerTeam() : GetDefenderTeam());
+            graveyard->GiveControlTo(i == BATTLEFIELD_WG_GY_WORKSHOP_SE || i == BATTLEFIELD_WG_GY_WORKSHOP_SW ? GetAttackerTeam() : GetDefenderTeam());
 
     for (GameObjectSet::const_iterator itr = m_KeepGameObject[GetDefenderTeam()].begin(); itr != m_KeepGameObject[GetDefenderTeam()].end(); ++itr)
         (*itr)->SetRespawnTime(RESPAWN_IMMEDIATELY);
@@ -403,7 +403,7 @@ void BattlefieldWG::OnBattleEnd(bool endByTimer)
     for (Workshop::const_iterator itr = WorkshopsList.begin(); itr != WorkshopsList.end(); ++itr)
     {
         (*itr)->GiveControlTo((*itr)->workshopId == BATTLEFIELD_WG_WORKSHOP_SE || (*itr)->workshopId == BATTLEFIELD_WG_WORKSHOP_SW ? GetAttackerTeam() : GetDefenderTeam(), true);
-        (*itr)->Save();   
+        (*itr)->Save();
     }
 
 


### PR DESCRIPTION
At the setup|Battlestart|Battleend of wintergrasp all WS were owned to attacker team, now only SW and SE are owned by Attacker, the rest are for Defender team

https://github.com/azerothcore/azerothcore-wotlk/issues/603

Valdifer

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Set WS/GY from SW/SE to Attacker and the rest to Defender
-  Relocate alliance players when attacking WG to not appear in the air

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/603

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Build without error
- Capturing wintergrasp and wait until next battle to capture again with the contrary faction
- Restartint the server to see the owner of WG


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Join WG war
2. Check workshops capturepoints sliders are correct
3. Win wintergrasp (Alliance or Horde)
4. Wait until the next war (You can change the timer in worldconfig.dist or editing the values in acore_characters.worldstates)
5. Join WG war
6. Check workshops capturepoints sliders are correct
7. Win wintergrasp (Alliance or Horde)
8. Restart the server
9. Starting again on Step1

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
