### PR TITLE
fix(Scripts/Spells): Fixed level requirements for Blade Ward and Bloo…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1670666174473143000.sql
+++ b/data/sql/updates/pending_db_world/rev_1670666174473143000.sql
@@ -1,0 +1,3 @@
+--
+UPDATE `spell_script_names` SET `spell_id`=64579 WHERE `spell_id`=64568 AND `ScriptName`='spell_gen_proc_above_75';
+UPDATE `spell_script_names` SET `spell_id`=64441 WHERE `spell_id`=64440 AND `ScriptName`='spell_gen_proc_above_75';

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -850,18 +850,24 @@ class spell_gen_fixate_aura : public AuraScript
 
 /* 64440 - Blade Warding
    64568 - Blood Reserve */
-class spell_gen_proc_above_75 : public AuraScript
+class spell_gen_proc_above_75 : public SpellScript
 {
-    PrepareAuraScript(spell_gen_proc_above_75);
+    PrepareSpellScript(spell_gen_proc_above_75);
 
-    bool CheckProc(ProcEventInfo& eventInfo)
+    SpellCastResult CheckLevel()
     {
-        return eventInfo.GetActor() && eventInfo.GetActor()->getLevel() >= 75;
+        Unit* caster = GetCaster();
+        if (caster->getLevel() < 75)
+        {
+            return SPELL_FAILED_LOWLEVEL;
+        }
+
+        return SPELL_CAST_OK;
     }
 
     void Register() override
     {
-        DoCheckProc += AuraCheckProcFn(spell_gen_proc_above_75::CheckProc);
+        OnCheckCast += SpellCheckCastFn(spell_gen_proc_above_75::CheckLevel);
     }
 };
 


### PR DESCRIPTION
…d Draining enchants.

Fixed Blood Draining proc.
Fixes #12131

<!-- First of all, THANK YOU for your contribution. -->  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12131
- Closes https://github.com/chromiecraft/chromiecraft/issues/3643

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Enchant a barman shanker (item id 12791) with Blood Draining (item id 46098) and melee at lvl 60.
Enchant any weapon with Blade Ward (item id 46026) and melee at lvl 60.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
