### PR TITLE
fix(Core/LFG): Fixed showing dungeon access requirements only for lea…

### DIFF
--- a/src/server/game/DungeonFinding/LFGMgr.h
+++ b/src/server/game/DungeonFinding/LFGMgr.h
@@ -491,7 +491,7 @@ namespace lfg
         /// Get leader of the group (using internal data)
         ObjectGuid GetLeader(ObjectGuid guid);
         /// Initializes locked dungeons for given player (called at login or level change)
-        void InitializeLockedDungeons(Player* player, uint8 level = 0);
+        void InitializeLockedDungeons(Player* player, Group const* group = nullptr);
         /// Sets player team
         void SetTeam(ObjectGuid guid, TeamId teamId);
         /// Sets player group

--- a/src/server/game/DungeonFinding/LFGScripts.cpp
+++ b/src/server/game/DungeonFinding/LFGScripts.cpp
@@ -36,7 +36,7 @@ namespace lfg
         if (!sLFGMgr->isOptionEnabled(LFG_OPTION_ENABLE_DUNGEON_FINDER | LFG_OPTION_ENABLE_RAID_BROWSER | LFG_OPTION_ENABLE_SEASONAL_BOSSES))
             return;
 
-        sLFGMgr->InitializeLockedDungeons(player);
+        sLFGMgr->InitializeLockedDungeons(player, player->GetGroup());
     }
 
     void LFGPlayerScript::OnLogout(Player* player)
@@ -68,7 +68,8 @@ namespace lfg
         ObjectGuid guid = player->GetGUID();
         ObjectGuid gguid = sLFGMgr->GetGroup(guid);
 
-        if (Group const* group = player->GetGroup())
+        Group const* group = player->GetGroup();
+        if (group)
         {
             ObjectGuid gguid2 = group->GetGUID();
             if (gguid != gguid2)
@@ -77,7 +78,7 @@ namespace lfg
             }
         }
 
-        sLFGMgr->InitializeLockedDungeons(player);
+        sLFGMgr->InitializeLockedDungeons(player, group);
         sLFGMgr->SetTeam(player->GetGUID(), player->GetTeamId());
         // TODO - Restore LfgPlayerData and send proper status to player if it was in a group
     }
@@ -86,7 +87,7 @@ namespace lfg
     {
         MapEntry const* mapEntry = sMapStore.LookupEntry(mapId);
         if (mapEntry->IsDungeon() && difficulty > DUNGEON_DIFFICULTY_NORMAL)
-            sLFGMgr->InitializeLockedDungeons(player);
+            sLFGMgr->InitializeLockedDungeons(player, player->GetGroup());
     }
 
     void LFGPlayerScript::OnMapChanged(Player* player)

--- a/src/server/game/Handlers/LFGHandler.cpp
+++ b/src/server/game/Handlers/LFGHandler.cpp
@@ -157,7 +157,7 @@ void WorldSession::HandleLfgPlayerLockInfoRequestOpcode(WorldPacket& /*recvData*
         sLFGMgr->GetRandomAndSeasonalDungeons(level, GetPlayer()->GetSession()->Expansion());
 
     // Get player locked Dungeons
-    sLFGMgr->InitializeLockedDungeons(GetPlayer()); // pussywizard
+    sLFGMgr->InitializeLockedDungeons(GetPlayer(), GetPlayer()->GetGroup()); // pussywizard
     lfg::LfgLockMap const& lock = sLFGMgr->GetLockedDungeons(guid);
     uint32 rsize = uint32(randomDungeons.size());
     uint32 lsize = uint32(lock.size());
@@ -239,7 +239,7 @@ void WorldSession::HandleLfgPartyLockInfoRequestOpcode(WorldPacket&  /*recvData*
         if (pguid == guid)
             continue;
 
-        sLFGMgr->InitializeLockedDungeons(plrg); // pussywizard
+        sLFGMgr->InitializeLockedDungeons(plrg, group); // pussywizard
         lockMap[pguid] = sLFGMgr->GetLockedDungeons(pguid);
     }
 


### PR DESCRIPTION
…ders in LFG.

Fixes #14070

<!-- First of all, THANK YOU for your contribution. -->  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #14070

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.quest add 10285` `.quest reward 10285` on one character
rest of the group does not complete quest
attempt to enter Opening the Dark Portal using LFD

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
