### PR TITLE
fix(DB/HallsOfStone): Triggers in Tribunal of Ages

### DIFF
--- a/data/sql/updates/pending_db_world/update.sql
+++ b/data/sql/updates/pending_db_world/update.sql
@@ -1,0 +1,4 @@
+--
+UPDATE `creature_template` SET `flags_extra`=130 WHERE `entry`=31874;
+UPDATE `creature_template` SET `modelid1`=17200, `modelid2`=0 WHERE `entry` IN (31874,28235);
+

--- a/data/sql/updates/pending_db_world/update.sql
+++ b/data/sql/updates/pending_db_world/update.sql
@@ -1,4 +1,3 @@
 --
-UPDATE `creature_template` SET `flags_extra`=130 WHERE `entry`=31874;
-UPDATE `creature_template` SET `modelid1`=17200, `modelid2`=0 WHERE `entry` IN (31874,28235);
+UPDATE `creature_template` SET ``flags_extra`=`flags_extra`|130 WHERE `entry`=31874;
 

--- a/data/sql/updates/pending_db_world/update.sql
+++ b/data/sql/updates/pending_db_world/update.sql
@@ -1,3 +1,3 @@
 --
-UPDATE `creature_template` SET ``flags_extra`=`flags_extra`|130 WHERE `entry`=31874;
+UPDATE `creature_template` SET `flags_extra`=`flags_extra`|130 WHERE `entry`=31874;
 


### PR DESCRIPTION
Tested in live server with ~130 players
No negative script/side-effects found.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
* Trigger attacking players - Fix trigger aggro (updates flags)
![image](https://user-images.githubusercontent.com/61223313/206923945-2bc3ac93-2278-41fe-8516-38bb739f3ff1.png)


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
