### PR TITLE
fix(DB/quest_template_locale): Add missing zhCN localization to quest 349.

### DIFF
--- a/data/sql/updates/pending_db_world/zhcn-quest-template-locale.sql
+++ b/data/sql/updates/pending_db_world/zhcn-quest-template-locale.sql
@@ -1,0 +1,1 @@
+UPDATE `quest_template_locale` SET `Details` = 'temp text 02 - description', `Objectives` = 'temp text 02 - log' WHERE `ID` = 349 AND `locale` = 'zhCN';


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Adds QuestDescription and LogDescription to missing zhCN quest_template_locale entry.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Makes progress towards #14209 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Wrath Classic live sniffs.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Untested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Run the query.
2. Start a client with zhCN locale.
3. `.quest add 349`
4. Observe no missing localization.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- Sniffed every other quest entry that was "missing" localization from the original issue. No other quest was actually missing localization, they either don't exist on live servers or they don't have any text in the applicable fields.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
