### PR TITLE
fix(DB/creature_onkill_rep): Add AQ40 missing onkill reputation gains

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1671225346039183900.sql
+++ b/data/sql/updates/pending_db_world/rev_1671225346039183900.sql
@@ -1,0 +1,10 @@
+--
+DELETE FROM `creature_onkill_reputation` WHERE `creature_id` IN (15233,15246,15247,15250,15252,15311,15312);
+INSERT INTO `creature_onkill_reputation` (`creature_id`, `RewOnKillRepFaction1`, `RewOnKillRepFaction2`, `MaxStanding1`, `IsTeamAward1`, `RewOnKillRepValue1`, `MaxStanding2`, `IsTeamAward2`, `RewOnKillRepValue2`, `TeamDependent`) VALUES
+(15233, 910, 0, 0, 0, 100, 0, 0, 0, 0),
+(15246, 910, 0, 3, 0, 100, 0, 0, 0, 0), 
+(15247, 910, 0, 3, 0, 100, 0, 0, 0, 0), 
+(15250, 910, 0, 3, 0, 100, 0, 0, 0, 0), 
+(15252, 910, 0, 3, 0, 100, 0, 0, 0, 0), 
+(15311, 910, 0, 3, 0, 100, 0, 0, 0, 0), 
+(15312, 910, 0, 3, 0, 100, 0, 0, 0, 0); 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Title
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/4517

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
