### PR TITLE
fix(Core/Creatures): Critters should start fleeing upon entering comb…

### DIFF
--- a/src/server/game/AI/CoreAI/PassiveAI.cpp
+++ b/src/server/game/AI/CoreAI/PassiveAI.cpp
@@ -69,30 +69,30 @@ void PossessedAI::KilledUnit(Unit*  /*victim*/)
     //    victim->RemoveDynamicFlag(UNIT_DYNFLAG_LOOTABLE);
 }
 
-void CritterAI::DamageTaken(Unit*, uint32&, DamageEffectType, SpellSchoolMask)
+void CritterAI::EnterCombat(Unit* who)
 {
     if (!me->HasUnitState(UNIT_STATE_FLEEING))
-        me->SetControlled(true, UNIT_STATE_FLEEING);
+    {
+        me->SetControlled(true, UNIT_STATE_FLEEING, who);
+    }
+}
 
-    _combatTimer = 1;
+void CritterAI::MovementInform(uint32 type, uint32 /*id*/)
+{
+    if (type == TIMED_FLEEING_MOTION_TYPE)
+    {
+        EnterEvadeMode(EVADE_REASON_OTHER);
+    }
 }
 
 void CritterAI::EnterEvadeMode(EvadeReason why)
 {
     if (me->HasUnitState(UNIT_STATE_FLEEING))
-        me->SetControlled(false, UNIT_STATE_FLEEING);
-    CreatureAI::EnterEvadeMode(why);
-    _combatTimer = 0;
-}
-
-void CritterAI::UpdateAI(uint32 diff)
-{
-    if (me->IsInCombat())
     {
-        _combatTimer += diff;
-        if (_combatTimer >= 5000)
-            EnterEvadeMode(EVADE_REASON_OTHER);
+        me->SetControlled(false, UNIT_STATE_FLEEING);
     }
+
+    CreatureAI::EnterEvadeMode(why);
 }
 
 int32 CritterAI::Permissible(Creature const* creature)

--- a/src/server/game/AI/CoreAI/PassiveAI.h
+++ b/src/server/game/AI/CoreAI/PassiveAI.h
@@ -66,16 +66,14 @@ public:
 class CritterAI : public PassiveAI
 {
 public:
-    explicit CritterAI(Creature* c) : PassiveAI(c) { _combatTimer = 0; }
+    explicit CritterAI(Creature* c) : PassiveAI(c) { }
 
-    void DamageTaken(Unit* /*done_by*/, uint32& /*damage*/, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask) override;
+    void EnterCombat(Unit* /*who*/) override;
     void EnterEvadeMode(EvadeReason why) override;
-    void UpdateAI(uint32) override;
+    void MovementInform(uint32 type, uint32 id) override;
+    void UpdateAI(uint32 /*diff*/) override { }
 
     static int32 Permissible(Creature const* creature);
-    // Xinef: Added
-private:
-    uint32 _combatTimer;
 };
 
 class TriggerAI : public NullCreatureAI

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1036,7 +1036,7 @@ void Creature::DoFleeToGetAssistance()
         if (!creature)
             //SetFeared(true, GetVictim()->GetGUID(), 0, sWorld->getIntConfig(CONFIG_CREATURE_FAMILY_FLEE_DELAY));
             //TODO: use 31365
-            SetControlled(true, UNIT_STATE_FLEEING);
+            SetControlled(true, UNIT_STATE_FLEEING, GetVictim());
         else
             GetMotionMaster()->MoveSeekAssistance(creature->GetPositionX(), creature->GetPositionY(), creature->GetPositionZ());
     }

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2276,7 +2276,7 @@ public:
     [[nodiscard]] uint16 GetExtraUnitMovementFlags() const { return m_movementInfo.flags2; }
     void SetExtraUnitMovementFlags(uint16 f) { m_movementInfo.flags2 = f; }
 
-    void SetControlled(bool apply, UnitState state);
+    void SetControlled(bool apply, UnitState state, Unit* source = nullptr, bool isFear = false);
     void DisableRotate(bool apply);
     void DisableSpline();
 
@@ -2553,7 +2553,7 @@ private:
     [[nodiscard]] uint32 GetCombatRatingDamageReduction(CombatRating cr, float rate, float cap, uint32 damage) const;
 
 protected:
-    void SetFeared(bool apply);
+    void SetFeared(bool apply, Unit* fearedBy = nullptr, bool isFear = false);
     void SetConfused(bool apply);
     void SetStunned(bool apply);
     void SetRooted(bool apply, bool isStun = false);

--- a/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
@@ -36,6 +36,7 @@ void FleeingMovementGenerator<T>::DoInitialize(T* owner)
         return;
     }
 
+    owner->StopMoving();
     _path = nullptr;
     owner->SetUnitFlag(UNIT_FLAG_FLEEING);
     owner->AddUnitState(UNIT_STATE_FLEEING);

--- a/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
@@ -233,8 +233,19 @@ void TimedFleeingMovementGenerator::Finalize(Unit* owner)
 {
     owner->RemoveUnitFlag(UNIT_FLAG_FLEEING);
     owner->ClearUnitState(UNIT_STATE_FLEEING | UNIT_STATE_FLEEING_MOVE);
-    if (owner->GetVictim())
-        owner->SetTarget(owner->GetVictim()->GetGUID());
+
+    if (Unit* victim = owner->GetVictim())
+    {
+        owner->SetTarget(victim->GetGUID());
+    }
+
+    if (Creature* ownerCreature = owner->ToCreature())
+    {
+        if (CreatureAI* AI = ownerCreature->AI())
+        {
+            AI->MovementInform(TIMED_FLEEING_MOTION_TYPE, 0);
+        }
+    }
 }
 
 bool TimedFleeingMovementGenerator::Update(Unit* owner, uint32 time_diff)

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -3087,7 +3087,7 @@ void AuraEffect::HandleModFear(AuraApplication const* aurApp, uint8 mode, bool a
 
     Unit* target = aurApp->GetTarget();
 
-    target->SetControlled(apply, UNIT_STATE_FLEEING);
+    target->SetControlled(apply, UNIT_STATE_FLEEING, GetCaster(), true);
 }
 
 void AuraEffect::HandleAuraModStun(AuraApplication const* aurApp, uint8 mode, bool apply) const


### PR DESCRIPTION
…at rather than taking damage.

Cleaned up fleeing code.
Original source: TrinityCore.
Fixes #14218

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #14218
- Closes https://github.com/chromiecraft/chromiecraft/issues/4543

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.learn 5487`, `.learn 99`/`.learn 5209`, `.learn 5229`
`.tele stormwind`
Leave Stormwind through the southeast gates and go to the critters in the area surrounding area.
Either cast enrage or use .modify rage (sufficiently high number)
Cast roar of your choice while in range of critters.
Observe the issue.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
