### PR TITLE
fix(Core/Totem): Implement casting delay for the Fire Totem used by c…

### DIFF
--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -146,7 +146,7 @@ void Totem::UnSummon(uint32 msTime)
 
         // Remove Sentry Totem Aura
         if (GetEntry() == SENTRY_TOTEM_ENTRY)
-            owner->RemoveAurasDueToSpell((uint32)TotemSpellIds::SentryTotemSpell);
+            owner->RemoveAurasDueToSpell(static_cast<uint32>(TotemSpellIds::SentryTotemSpell));
 
         //remove aura all party members too
         if (Player* player = owner->ToPlayer())

--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -83,7 +83,7 @@ void Totem::InitSummon()
 
     if (m_type == TOTEM_PASSIVE && GetSpell())
     {
-        if (GetUInt32Value(UNIT_CREATED_BY_SPELL) == TotemSpellIds::FireTotemSpell)
+        if (TotemSpellIds(GetUInt32Value(UNIT_CREATED_BY_SPELL)) == TotemSpellIds::FireTotemSpell)
         {
             m_Events.AddEventAtOffset([this]()
             {
@@ -146,7 +146,7 @@ void Totem::UnSummon(uint32 msTime)
 
         // Remove Sentry Totem Aura
         if (GetEntry() == SENTRY_TOTEM_ENTRY)
-            owner->RemoveAurasDueToSpell(TotemSpellIds::SentryTotemSpell);
+            owner->RemoveAurasDueToSpell((uint32)TotemSpellIds::SentryTotemSpell);
 
         //remove aura all party members too
         if (Player* player = owner->ToPlayer())

--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -82,14 +82,29 @@ void Totem::InitSummon()
     Minion::InitSummon();
 
     if (m_type == TOTEM_PASSIVE && GetSpell())
-        CastSpell(this, GetSpell(), true);
+    {
+        if (GetUInt32Value(UNIT_CREATED_BY_SPELL) == TotemSpellIds::FireTotemSpell)
+        {
+            m_Events.AddEventAtOffset([this]()
+            {
+                CastSpell(this, GetSpell(), true);
+            }, 4s);
+        }
+        else
+        {
+            CastSpell(this, GetSpell(), true);
+        }
+    }
 
     // Some totems can have both instant effect and passive spell
-    if(GetSpell(1))
+    if (GetSpell(1))
+    {
+        LOG_ERROR("sql.sql", "casting spell {}", GetSpell(1));
         CastSpell(this, GetSpell(1), true);
+    }
 
     // xinef: this is better than the script, 100% sure to work
-    if(GetEntry() == SENTRY_TOTEM_ENTRY)
+    if (GetEntry() == SENTRY_TOTEM_ENTRY)
     {
         SetReactState(REACT_AGGRESSIVE);
         GetOwner()->CastSpell(this, 6277, true);
@@ -132,7 +147,7 @@ void Totem::UnSummon(uint32 msTime)
 
         // Remove Sentry Totem Aura
         if (GetEntry() == SENTRY_TOTEM_ENTRY)
-            owner->RemoveAurasDueToSpell(SENTRY_TOTEM_SPELLID);
+            owner->RemoveAurasDueToSpell(TotemSpellIds::SentryTotemSpell);
 
         //remove aura all party members too
         if (Player* player = owner->ToPlayer())

--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -99,7 +99,6 @@ void Totem::InitSummon()
     // Some totems can have both instant effect and passive spell
     if (GetSpell(1))
     {
-        LOG_ERROR("sql.sql", "casting spell {}", GetSpell(1));
         CastSpell(this, GetSpell(1), true);
     }
 

--- a/src/server/game/Entities/Totem/Totem.h
+++ b/src/server/game/Entities/Totem/Totem.h
@@ -27,7 +27,12 @@ enum TotemType
     TOTEM_STATUE     = 2 // copied straight from moongose, may need more implementation to work
 };
 // Some Totems cast spells that are not in creature DB
-#define SENTRY_TOTEM_SPELLID  6495
+
+enum TotemSpellIds : uint32
+{
+    SentryTotemSpell = 6495,
+    FireTotemSpell   = 32062
+};
 
 #define SENTRY_TOTEM_ENTRY    3968
 #define EARTHBIND_TOTEM_ENTRY 2630

--- a/src/server/game/Entities/Totem/Totem.h
+++ b/src/server/game/Entities/Totem/Totem.h
@@ -28,7 +28,7 @@ enum TotemType
 };
 // Some Totems cast spells that are not in creature DB
 
-enum TotemSpellIds : uint32
+enum class TotemSpellIds : uint32
 {
     SentryTotemSpell = 6495,
     FireTotemSpell   = 32062


### PR DESCRIPTION
…reatures

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/14262
- Closes https://github.com/chromiecraft/chromiecraft/issues/4579

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Cast 32062
2. fire nova happens after 4s instead of on spawn
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
