### PR TITLE
fix(Core/OPvP): Hellfire PvP Objective Flag and Progress bar not in sync

### DIFF
--- a/src/server/scripts/OutdoorPvP/OutdoorPvPHP.cpp
+++ b/src/server/scripts/OutdoorPvP/OutdoorPvPHP.cpp
@@ -238,20 +238,10 @@ void OPvPCapturePointHP::ChangeState()
                 break;
             }
         case OBJECTIVESTATE_NEUTRAL_ALLIANCE_CHALLENGE:
-            field = HP_MAP_N[m_TowerType];
-            break;
         case OBJECTIVESTATE_NEUTRAL_HORDE_CHALLENGE:
-            field = HP_MAP_N[m_TowerType];
-            break;
         case OBJECTIVESTATE_ALLIANCE_HORDE_CHALLENGE:
-            field = HP_MAP_A[m_TowerType];
-            artkit = 2;
-            artkit2 = HP_TowerArtKit_A[m_TowerType];
-            break;
         case OBJECTIVESTATE_HORDE_ALLIANCE_CHALLENGE:
-            field = HP_MAP_H[m_TowerType];
-            artkit = 1;
-            artkit2 = HP_TowerArtKit_H[m_TowerType];
+            field = HP_MAP_N[m_TowerType];
             break;
     }
 


### PR DESCRIPTION
Progress bar shows the objective to be neutral but it still is horde/alliance controlled.

https://github.com/azerothcore/azerothcore-wotlk/issues/14300

Valdifer

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Progress bar sync when slider is on neutral zone
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/14300

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested (Capped horde and turn back to neutral, not tested alliance side to normal and alliance to horde)
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go xyz -450 3470 40 530
2. Cap it with Horde/Alliance
3. Change to opposite faction and move it to neutral

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
