### PR TITLE
fix(db/npc_vendor): Improve Xerintha Ravenoak vendor timers

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1671639583415891400.sql
+++ b/data/sql/updates/pending_db_world/rev_1671639583415891400.sql
@@ -1,0 +1,4 @@
+--
+-- Xerintha Ravenoak vendor timers repaired
+UPDATE `npc_vendor` SET `incrtime`=300 WHERE `entry`=20916 AND `item`=31674 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=600 WHERE `entry`=20916 AND `item`=31675 AND `ExtendedCost`=0;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changes timers from 12hr to 5/10m  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
First timers pulled from classic wotlk PTR (note:  this, like all timers are not actually supposed to be static)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Should run fine (just a timer change) but https://www.wowhead.com/wotlk/npc=20916/xerintha-ravenoak is the NPC in question, just buy the items and wait

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- More of these vendors exist, this is just important as a barrier for cooking for Horde side on CC so it's annoying (recipe is also available via quest)
