### PR TITLE
fix(db/npc_vendor): Improve two Alch Recipe Timers (Super Mana Pot Recipe, Frost Power Potion Recipe)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1671645973738924500.sql
+++ b/data/sql/updates/pending_db_world/rev_1671645973738924500.sql
@@ -1,0 +1,7 @@
+--
+-- Recipe: Super Mana Potion 30m
+UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=18005 AND `item`=22907 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=19837 AND `item`=22907 AND `ExtendedCost`=0;
+-- Recipe: Elixir of Major Frost Power 10m
+UPDATE `npc_vendor` SET `incrtime`=600 WHERE `entry`=18005 AND `item`=22902 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=600 WHERE `entry`=19837 AND `item`=22902 AND `ExtendedCost`=0;

--- a/data/sql/updates/pending_db_world/rev_1671645973738924500.sql
+++ b/data/sql/updates/pending_db_world/rev_1671645973738924500.sql
@@ -1,7 +1,6 @@
 --
 -- Recipe: Super Mana Potion 30m
-UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=18005 AND `item`=22907 AND `ExtendedCost`=0;
-UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=19837 AND `item`=22907 AND `ExtendedCost`=0;
--- Recipe: Elixir of Major Frost Power 10m
-UPDATE `npc_vendor` SET `incrtime`=600 WHERE `entry`=18005 AND `item`=22902 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry` IN (18005, 19837) AND `item`=22907 AND `ExtendedCost`=0;
+-- Recipe: Elixir of Major Frost Power 
+UPDATE `npc_vendor` SET `incrtime`=600 WHERE `entry`=18017 AND `item`=22902 AND `ExtendedCost`=0;
 UPDATE `npc_vendor` SET `incrtime`=600 WHERE `entry`=19837 AND `item`=22902 AND `ExtendedCost`=0;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Sets Super Mana Pot Recipe to 30m based on wowhead comments and Frost Power Potion to 10m based on testing

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Testing for Frost power pot (variable timer)
The only source on the timer I could really get for this was comments on wowhead from 2010, as super mana potion recipe was changed in classic but intuitively this should not be 12hrs, not ever, but definitely not in wotlk.  Even at 30m in heavy population this will get pretty absurdly camped, at 12hr you get people camping the vendors on small servers >_> 