### PR TITLE
correct worn troll dice

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3910,7 +3910,13 @@ void Spell::EffectScriptEffect(SpellEffIndex effIndex)
                             const char* gender = "his";
                             if (m_caster->getGender() > 0)
                                 gender = "her";
-                            sprintf(buf, "%s causually tosses %s [Worn Troll Dice]. One %u and one %u.", m_caster->GetName().c_str(), gender, urand(1, 6), urand(1, 6));
+                            sprintf(buf, "casually tosses %s [Worn Troll Dice].", gender);
+                            m_caster->TextEmote(buf);
+
+                            sprintf(buf, "rolls %u (1-6)", urand(1, 6));
+                            m_caster->TextEmote(buf);
+
+                            sprintf(buf, "rolls %u (1-6)", urand(1, 6));
                             m_caster->TextEmote(buf);
                             break;
                         }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

Correct worn troll dice - don't double up name, don't include gratuitous typo, match patch 3.2+ behaviour with /rolls.

## Issues Addressed:
- Closes #14357

## SOURCE:
https://wowpedia.fandom.com/wiki/Worn_Troll_Dice#Patch_changes

## Tests Performed:
- Build and use


## How to Test the Changes:
Create item 36862, right click it

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

nothing

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
