### PR TITLE
fix(Core/Unit): petrified lichen guard DoT effect

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9278,8 +9278,13 @@ bool Unit::HandleProcTriggerSpell(Unit* victim, uint32 damage, AuraEffect* trigg
                 }
             case SPELLFAMILY_SHAMAN:
                 {
+                    // Spore Cloud (from Petrified Lichen Guard)
+                    if (auraSpellInfo->Id == 32642)
+                    {
+                        trigger_spell_id = sSpellMgr->GetSpellWithRank(32643, auraSpellInfo->GetRank());
+                    }
                     // Lightning Shield (overwrite non existing triggered spell call in spell.dbc
-                    if (auraSpellInfo->SpellFamilyFlags[0] & 0x400)
+                    else if (auraSpellInfo->SpellFamilyFlags[0] & 0x400)
                     {
                         // Do not proc off from self-casted items
                         if (Spell const* spell = eventInfo.GetProcSpell())


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Added handling of Spore Cloud (32642) aura from Petrified Lichen Guard
-  Now correctly procs Spore Cloud (32643) DoT instead of Lightning Shield (26364)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
Previously unreported issue: Petrified Lichen Guard incorrectly proccing Lightning Shield instead of Spore Cloud (32643)
## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.wowhead.com/wotlk/spell=32642/spore-cloud
spell.dbc

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Built without errors
- Tested on Windows 10 x86_64
- Tested correct application of DoT effect
- Regression tested actual Lightning Shield spell to ensure this change did not break it


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create/Select a character able to equip a shield
2. Give item 25828
3. Set Sporeggar rep to honored or above if not already set
4. Equip Petrified Lichen Guard and enter combat
5. Observe that each block correctly applies the DoT effect to the blocked enemy

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] The Spore Cloud (32642) aura still overrides the actual Lightning Shield (324) aura, and vice versa, unsure if blizzlike.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
