### PR TITLE
fix(Core/Scripts): Zort's Protective Elixir

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1671948396193749028.sql
+++ b/data/sql/updates/pending_db_world/rev_1671948396193749028.sql
@@ -1,0 +1,3 @@
+--
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_dragonblight_corrosive_spit';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (47447, 'spell_dragonblight_corrosive_spit');

--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -26,6 +26,7 @@
 #include "ScriptedCreature.h"
 #include "ScriptedGossip.h"
 #include "SpellAuras.h"
+#include "SpellAuraEffects.h"
 #include "SpellScript.h"
 #include "Vehicle.h"
 
@@ -2258,6 +2259,38 @@ public:
     }
 };
 
+// 47447 - Corrosive Spit
+class spell_dragonblight_corrosive_spit : public AuraScript
+{
+    PrepareAuraScript(spell_dragonblight_corrosive_spit);
+
+    bool Validate(SpellInfo const* spellInfo) override
+    {
+        return ValidateSpellInfo({ uint32(spellInfo->GetEffect(EFFECT_0).CalcValue()) });
+    }
+
+    void AfterApply(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
+    {
+        if (GetTarget()->HasAura(aurEff->GetSpellInfo()->GetEffect(EFFECT_0).CalcValue()))
+            GetAura()->Remove();
+    }
+
+    void PeriodicTick(AuraEffect const* aurEff)
+    {
+        if (GetTarget()->HasAura(aurEff->GetSpellInfo()->GetEffect(EFFECT_0).CalcValue()))
+        {
+            PreventDefaultAction();
+            GetAura()->Remove();
+        }
+    }
+
+    void Register() override
+    {
+        AfterEffectApply += AuraEffectApplyFn(spell_dragonblight_corrosive_spit::AfterApply, EFFECT_1, SPELL_AURA_PERIODIC_DAMAGE, AURA_EFFECT_HANDLE_REAL_OR_REAPPLY_MASK);
+        OnEffectPeriodic += AuraEffectPeriodicFn(spell_dragonblight_corrosive_spit::PeriodicTick, EFFECT_1, SPELL_AURA_PERIODIC_DAMAGE);
+    }
+};
+
 void AddSC_dragonblight()
 {
     // Ours
@@ -2287,4 +2320,6 @@ void AddSC_dragonblight()
     new spell_q12096_q12092_dummy();
     new spell_q12096_q12092_bark();
     new npc_torturer_lecraft();
+
+    RegisterSpellScript(spell_dragonblight_corrosive_spit);
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

Co-authored-by: @r4d1sh

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://github.com/TrinityCore/TrinityCore/pull/28372

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .aura 47447
2. .add 36770
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
