### PR TITLE
fix(DB/SmartScript): Boulderfirst Mage / Warrior smartscript

### DIFF
--- a/data/sql/updates/pending_db_world/bouldermagic.sql
+++ b/data/sql/updates/pending_db_world/bouldermagic.sql
@@ -1,0 +1,13 @@
+-- 
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 17136;
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 17136) AND (`source_type` = 0) AND (`id` IN (0, 1));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(17136, 0, 0, 0, 11, 0, 100, 1, 0, 0, 0, 0, 0, 11, 30798, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Boulderfist Warrior - On Respawn - Cast \'Dual Wield\' (No Repeat)'),
+(17136, 0, 1, 0, 9, 0, 100, 0, 8, 25, 18000, 24000, 0, 11, 31994, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Boulderfist Warrior - Within 8-25 Range - Cast \'Shoulder Charge\'');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 17137;
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 17137) AND (`source_type` = 0) AND (`id` IN (0, 1, 2));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(17137, 0, 0, 0, 16, 0, 100, 0, 6742, 30, 15000, 45000, 0, 11, 6742, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Boulderfist Mage - On Friendly Unit Missing Buff \'Bloodlust\' - Cast \'Bloodlust\''),
+(17137, 0, 1, 0, 0, 0, 100, 0, 5000, 9000, 9000, 12000, 0, 11, 20795, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Boulderfist Mage - In Combat - Cast \'Fire Blast\''),
+(17137, 0, 2, 0, 0, 0, 100, 0, 5000, 9000, 3800, 5200, 0, 11, 9672, 0, 256, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Boulderfist Mage - In Combat - Cast \'Frostbolt\'');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  add smartscript to boulderfist mage and warrior

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes no reported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

Based on MANGOS WOTLK 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
