### PR TITLE
fix(DB/SAI): Swamplord Musel'ek should yell when Claw is enraged.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1672568748762669000.sql
+++ b/data/sql/updates/pending_db_world/rev_1672568748762669000.sql
@@ -1,0 +1,5 @@
+--
+UPDATE `smart_scripts` SET `link`=9 WHERE `entryorguid`=17827 AND `source_type`=0 AND `id`=2;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=17827 AND `source_type`=0 AND `id`=9;
+INSERT INTO `smart_scripts` VALUES
+(17827,0,9,0,61,0,100,0,0,0,0,0,0,1,0,0,0,0,0,0,19,17826,100,0,0,0,0,0,0,'Claw - Combat - Swamplord Musel\'ek Say 0');


### PR DESCRIPTION
Fixes #13996

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13996

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go cr 138500`
Wait until Claw is enraged

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
