### PR TITLE
fix(DB/npc_vendor): Improve a few TBC Vendor Recipe Rates

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1672683380617865400.sql
+++ b/data/sql/updates/pending_db_world/rev_1672683380617865400.sql
@@ -1,7 +1,7 @@
 --
 -- Recipe: Elixir of Major Frost Power 
 UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=18017 AND `item`=22902 AND `ExtendedCost`=0;
-UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=19837 AND `item`=22902 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=18005 AND `item`=22902 AND `ExtendedCost`=0;
 
 -- Tailoring Recipes off Aarond
 UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=19521 AND `item`=21900 AND `ExtendedCost`=0;

--- a/data/sql/updates/pending_db_world/rev_1672683380617865400.sql
+++ b/data/sql/updates/pending_db_world/rev_1672683380617865400.sql
@@ -1,8 +1,6 @@
 --
 -- Recipe: Elixir of Major Frost Power 
-UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=18017 AND `item`=22902 AND `ExtendedCost`=0;
-UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=18005 AND `item`=22902 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry` IN (18005, 18017) AND `item`=22902 AND `ExtendedCost`=0;
 
 -- Tailoring Recipes off Aarond
-UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=19521 AND `item`=21900 AND `ExtendedCost`=0;
-UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=19521 AND `item`=21901 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=19521 AND `item` IN (21900, 21901) AND `ExtendedCost`=0;

--- a/data/sql/updates/pending_db_world/rev_1672683380617865400.sql
+++ b/data/sql/updates/pending_db_world/rev_1672683380617865400.sql
@@ -1,0 +1,8 @@
+--
+-- Recipe: Elixir of Major Frost Power 
+UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=18017 AND `item`=22902 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=19837 AND `item`=22902 AND `ExtendedCost`=0;
+
+-- Tailoring Recipes off Aarond
+UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=19521 AND `item`=21900 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=1800 WHERE `entry`=19521 AND `item`=21901 AND `ExtendedCost`=0;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Improves a few TBC Recipe Rates
-  (Uses this wotlk sourced rate for a previously touched recipe as well, since wotlk classic rates can not be trusted sadly)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- Research, unfortunately classic can not be used as a source for this (else all the timers would be 5/10 mins, and we'd actually need to edit some recipes to be BoP and unlimited) but general research concludes that no recipes were in the multi-hour respawn rate by wotlk and at least one TBC recipe was reported at 30mins respawn during the wotlk era.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- There might still be more recipes like this that need reported

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
