### PR TITLE
fix (db): EOTS BG StartMaxDist

### DIFF
--- a/data/sql/updates/pending_db_world/eots-maxdist.sql
+++ b/data/sql/updates/pending_db_world/eots-maxdist.sql
@@ -1,0 +1,3 @@
+DELETE FROM `battleground_template` WHERE `ID`=7;
+INSERT INTO `battleground_template` (`ID`, `MinPlayersPerTeam`, `MaxPlayersPerTeam`, `MinLvl`, `MaxLvl`, `AllianceStartLoc`, `AllianceStartO`, `HordeStartLoc`, `HordeStartO`, `StartMaxDist`, `Weight`, `ScriptName`, `Comment`) VALUES 
+(7, 8, 15, 61, 80, 1103, 3.03123, 1104, 0.055761, 10, 1, '', 'Eye of The Storm (battleground)');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  this fixes the StartMaxDist to the appropiate size of 10 instead of default which will never flag the player for being outside the start spot before the bg starts (exploit) and there fore will never tele them back into place after 9 seconds.
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported EOTS StartMaxDist is incorrect and allows exploiters to be outside of the start spot without penalty.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds
- Self Tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Enter etos bg
2. teleport out of the start bubble before it begins
3. observe player being auto tele back after the 9 second count down

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
