### PR TITLE
fix(DB/skinning_loot_template): Create new skinning entries for different mobs in TBC

### DIFF
--- a/data/sql/updates/pending_db_world/skinning.sql
+++ b/data/sql/updates/pending_db_world/skinning.sql
@@ -1,0 +1,16 @@
+-- Making Domesticated Felboar skinnable
+UPDATE `creature_template` SET `skinloot` = 70068 WHERE (`entry` = 21195);
+
+-- Create a new skinning loot with right percentage
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Chance`) VALUES (70068, 21887, 80);
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Chance`, `MaxCount`) VALUES (70068, 25649, 20, 3);
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Chance`) VALUES (70068, 35229, 25);
+
+-- Creature with 80% Knothide Leather and 20% Knothide Leather Scraps
+UPDATE `creature_template` SET `skinloot`= 70068 WHERE (`entry` IN (21879, 21408, 21864, 21901, 21462, 21878, 21195, 20610, 20773, 18879, 20671, 20634, 18880, 20777));
+
+-- Create a new skinning loot with right percentage
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Chance`) VALUES (70069, 21887, 100);
+
+-- Creature with 100% Knothide Leather
+UPDATE `creature_template` SET `skinloot`= 70069 WHERE (`entry` IN (23501, 22181));

--- a/data/sql/updates/pending_db_world/skinning.sql
+++ b/data/sql/updates/pending_db_world/skinning.sql
@@ -2,7 +2,7 @@
 DELETE FROM `skinning_loot_template` WHERE (`Entry` = 70068) AND (`Item` IN (21887, 25649, 35229));
 INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (70068, 21887, 0, 80, 0, 1, 1, 1, 1, 'Knothide Leather'),
-(70068, 25649, 0, 0, 0, 1, 1, 1, 3, 'Knothide Leather Scraps'),
+(70068, 25649, 0, 0, 0, 1, 1, 2, 3, 'Knothide Leather Scraps'),
 (70068, 35229, 0, 25, 1, 1, 0, 1, 1, 'Nether Residue');
 
 -- Creature with 80% Knothide Leather and 20% Knothide Leather Scraps

--- a/data/sql/updates/pending_db_world/skinning.sql
+++ b/data/sql/updates/pending_db_world/skinning.sql
@@ -2,7 +2,7 @@
 DELETE FROM `skinning_loot_template` WHERE (`Entry` = 70068) AND (`Item` IN (21887, 25649, 35229));
 INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (70068, 21887, 0, 80, 0, 1, 1, 1, 1, 'Knothide Leather'),
-(70068, 25649, 0, 0, 0, 1, 1, 1, 3, 'Knothide Leather Scraps');
+(70068, 25649, 0, 0, 0, 1, 1, 1, 3, 'Knothide Leather Scraps'),
 (70068, 35229, 0, 25, 1, 1, 0, 1, 1, 'Nether Residue');
 
 -- Creature with 80% Knothide Leather and 20% Knothide Leather Scraps

--- a/data/sql/updates/pending_db_world/skinning.sql
+++ b/data/sql/updates/pending_db_world/skinning.sql
@@ -7,7 +7,10 @@ INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Chance`) VALUES (70068, 
 UPDATE `creature_template` SET `skinloot`= 70068 WHERE (`entry` IN (21879, 21408, 21864, 21901, 21462, 21878, 21195, 20610, 20773, 18879, 20671, 20634, 18880, 20777));
 
 -- Create a new skinning loot with right percentage
-INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Chance`) VALUES (70069, 21887, 100);
+DELETE FROM `skinning_loot_template` WHERE (`Entry` = 70069) AND `Item` IN (21887, 35229);
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(70069, 21887, 0, 0, 0, 1, 1, 1, 1, 'Knothide Leather'),
+(70069, 35229, 0, 25, 1, 1, 0, 1, 1, 'Nether Residue');
 
 -- Creature with 100% Knothide Leather
 UPDATE `creature_template` SET `skinloot`= 70069 WHERE (`entry` IN (23501, 22181));

--- a/data/sql/updates/pending_db_world/skinning.sql
+++ b/data/sql/updates/pending_db_world/skinning.sql
@@ -1,6 +1,3 @@
--- Making Domesticated Felboar skinnable
-UPDATE `creature_template` SET `skinloot` = 70068 WHERE (`entry` = 21195);
-
 -- Create a new skinning loot with right percentage
 INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Chance`) VALUES (70068, 21887, 80);
 INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Chance`, `MaxCount`) VALUES (70068, 25649, 20, 3);

--- a/data/sql/updates/pending_db_world/skinning.sql
+++ b/data/sql/updates/pending_db_world/skinning.sql
@@ -1,7 +1,9 @@
 -- Create a new skinning loot with right percentage
-INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Chance`) VALUES (70068, 21887, 80);
-INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Chance`, `MaxCount`) VALUES (70068, 25649, 20, 3);
-INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Chance`) VALUES (70068, 35229, 25);
+DELETE FROM `skinning_loot_template` WHERE (`Entry` = 70068) AND (`Item` IN (21887, 25649, 35229));
+INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(70068, 21887, 0, 80, 0, 1, 1, 1, 1, 'Knothide Leather'),
+(70068, 25649, 0, 0, 0, 1, 1, 1, 3, 'Knothide Leather Scraps');
+(70068, 35229, 0, 25, 1, 1, 0, 1, 1, 'Nether Residue');
 
 -- Creature with 80% Knothide Leather and 20% Knothide Leather Scraps
 UPDATE `creature_template` SET `skinloot`= 70068 WHERE (`entry` IN (21879, 21408, 21864, 21901, 21462, 21878, 21195, 20610, 20773, 18879, 20671, 20634, 18880, 20777));


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Create a new skinning loot entry with 80% chance (Knothide Leather) and 20% chance (Knothide Leather Scraps)
-  Create a new skinning loot entry with 100% chance (Knothide Leather)
-  Updated different mobs (see Source) with the right skinning loot percentage

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/14486

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://github.com/azerothcore/azerothcore-wotlk/issues/14486

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- I checked the updated values in the DB


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. learn Skinning
2. `.additem 7005` (skinning knife)
3. `.go c 74891`
4. Skin the creature

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
