### PR TITLE
fix(Scripts/HellfireRamparts): Fix Nazan getting stuck in middle air

### DIFF
--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -171,6 +171,14 @@ public:
             events.Reset();
         }
 
+        void JustDied(Unit* killer) override
+        {
+            me->SetCanFly(false);
+            me->SetDisableGravity(false);
+
+            ScriptedAI::JustDied(killer);
+        }
+
         void EnterEvadeMode(EvadeReason /*why*/) override
         {
             me->DespawnOrUnsummon(1);
@@ -196,6 +204,7 @@ public:
             {
                 Talk(EMOTE_NAZAN);
                 events.Reset();
+                me->SetReactState(REACT_PASSIVE);
                 me->GetMotionMaster()->MovePoint(POINT_MIDDLE, -1406.5f, 1746.5f, 81.2f, false);
             }
         }
@@ -206,6 +215,9 @@ public:
             {
                 me->SetCanFly(false);
                 me->SetDisableGravity(false);
+                Position land = me->GetPosition();
+                me->GetMotionMaster()->MoveLand(0, land, 8.5f);
+                me->SetReactState(REACT_AGGRESSIVE);
                 events.ScheduleEvent(EVENT_RESTORE_COMBAT, 0);
                 events.ScheduleEvent(EVENT_SPELL_CONE_OF_FIRE, 5000);
                 if (IsHeroic())


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Make the creature passive during the flypath.
-  It should perform a move land when it reaches the waypoint.
-  In all cases, set disable gravity and fly to off on death.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Hellfire Ramparts, engage Vazruden and get it to 30% so Nazan descends.
2. Make sure it does the full path and it lands correctly (it shouldn't make flying movements when it is on ground)
3. ??
