### PR TITLE
fix(DB/creature_loot): fix two quest rates in EK

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1672995772284756600.sql
+++ b/data/sql/updates/pending_db_world/rev_1672995772284756600.sql
@@ -1,0 +1,7 @@
+--
+-- Worn Stone Tokens are 100%
+UPDATE `creature_loot_template` SET `Chance`=100 WHERE `Item`=3714 AND `entry` IN (2271, 2272, 2358, 2415, 2628);
+
+-- Encrusted Tail Fins should be 100% and only off Saltscale Murlocs
+UPDATE `creature_loot_template` SET `Chance`=100 WHERE `Item`=5796 AND `entry` IN (871, 873, 875, 877, 879);
+DELETE FROM `creature_loot_template` WHERE  `Entry` IN (4457, 4458, 4459, 4460, 4461) AND `Item`=5796 AND `Reference`=0 AND `GroupId`=0;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Worn Stone Tokens are 100%
-  Encrusted Tail Fins should be 100% and only off Saltscale Murlocs

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Sniffed/classic


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
