### PR TITLE
fix(Core/Formations): Implemented new creature formation flag: GROUP_…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1673079889836910900.sql
+++ b/data/sql/updates/pending_db_world/rev_1673079889836910900.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_formations` SET `groupAI`=`groupAI`|0x020 WHERE `leaderGUID` IN (84634,84648);

--- a/src/server/game/Entities/Creature/CreatureGroups.h
+++ b/src/server/game/Entities/Creature/CreatureGroups.h
@@ -28,22 +28,23 @@ class CreatureGroup;
 
 enum class GroupAIFlags : uint16
 {
-    GROUP_AI_FLAG_MEMBER_ASSIST_LEADER         = 0x001,
-    GROUP_AI_FLAG_LEADER_ASSIST_MEMBER         = 0x002,
-    GROUP_AI_FLAG_EVADE_TOGETHER               = 0x004,
-    GROUP_AI_FLAG_RESPAWN_ON_EVADE             = 0x008,
-    GROUP_AI_FLAG_DONT_RESPAWN_LEADER_ON_EVADE = 0x010,
-    //GROUP_AI_FLAG_UNK3                = 0x010,
-    //GROUP_AI_FLAG_UNK4                = 0x020,
-    //GROUP_AI_FLAG_UNK5                = 0x040,
-    //GROUP_AI_FLAG_UNK6                = 0x080,
-    //GROUP_AI_FLAG_UNK7                = 0x100,
-    GROUP_AI_FLAG_FOLLOW_LEADER         = 0x200,
+    GROUP_AI_FLAG_MEMBER_ASSIST_LEADER          = 0x001,
+    GROUP_AI_FLAG_LEADER_ASSIST_MEMBER          = 0x002,
+    GROUP_AI_FLAG_EVADE_TOGETHER                = 0x004,
+    GROUP_AI_FLAG_RESPAWN_ON_EVADE              = 0x008,
+    GROUP_AI_FLAG_DONT_RESPAWN_LEADER_ON_EVADE  = 0x010,
+    GROUP_AI_FLAG_ACQUIRE_NEW_TARGET_ON_EVADE   = 0x020,
+    //GROUP_AI_FLAG_UNK5                        = 0x040,
+    //GROUP_AI_FLAG_UNK6                        = 0x080,
+    //GROUP_AI_FLAG_UNK7                        = 0x100,
+    GROUP_AI_FLAG_FOLLOW_LEADER                 = 0x200,
 
-    GROUP_AI_FLAG_EVADE_MASK = GROUP_AI_FLAG_EVADE_TOGETHER | GROUP_AI_FLAG_RESPAWN_ON_EVADE,
+    GROUP_AI_FLAG_ASSIST_MASK                   = GROUP_AI_FLAG_MEMBER_ASSIST_LEADER | GROUP_AI_FLAG_LEADER_ASSIST_MEMBER,
+    GROUP_AI_FLAG_EVADE_MASK                    = GROUP_AI_FLAG_EVADE_TOGETHER | GROUP_AI_FLAG_RESPAWN_ON_EVADE,
 
     // Used to verify valid and usable flags
-    GROUP_AI_FLAG_SUPPORTED = GROUP_AI_FLAG_MEMBER_ASSIST_LEADER | GROUP_AI_FLAG_LEADER_ASSIST_MEMBER | GROUP_AI_FLAG_EVADE_MASK | GROUP_AI_FLAG_FOLLOW_LEADER
+    GROUP_AI_FLAG_SUPPORTED                     = GROUP_AI_FLAG_ASSIST_MASK | GROUP_AI_FLAG_EVADE_MASK | GROUP_AI_FLAG_DONT_RESPAWN_LEADER_ON_EVADE |
+                                                  GROUP_AI_FLAG_FOLLOW_LEADER | GROUP_AI_FLAG_ACQUIRE_NEW_TARGET_ON_EVADE
 };
 
 struct FormationInfo
@@ -108,6 +109,7 @@ public:
 
     void LeaderMoveTo(float x, float y, float z, bool run);
     void MemberEngagingTarget(Creature* member, Unit* target);
+    Unit* GetNewTargetForMember(Creature* member);
     void MemberEvaded(Creature* member);
     void RespawnFormation(bool force = false);
     [[nodiscard]] bool IsFormationInCombat();

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -14676,6 +14676,16 @@ Unit* Creature::SelectVictim()
         return nullptr;
     }
 
+    // Last chance: creature group
+    if (CreatureGroup* group = GetFormation())
+    {
+        if (Unit* groupTarget = group->GetNewTargetForMember(this))
+        {
+            SetInFront(groupTarget);
+            return groupTarget;
+        }
+    }
+
     // enter in evade mode in other case
     AI()->EnterEvadeMode();
 


### PR DESCRIPTION
…AI_FLAG_ACQUIRE_NEW_TARGET_ON_EVADE.

Fixes #14494

Corrected version, with https://github.com/azerothcore/azerothcore-wotlk/pull/14494#issuecomment-1370484583 fixed.

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #14494

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go c id 15277`, see if only one is aggroed
`.tele BRD`
`.GO XYZ 1379 -723 -92` see if aggroing a creature won't pull the entire room

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
