### PR TITLE
fix(Scripts/HellfireRamparts): Removed invalid spells from Omor the U…

### DIFF
--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_omor_the_unscarred.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_omor_the_unscarred.cpp
@@ -35,8 +35,6 @@ enum Spells
     SPELL_SUMMON_FIENDISH_HOUND = 30707,
     SPELL_TREACHEROUS_AURA      = 30695,
     SPELL_DEMONIC_SHIELD        = 31901,
-    SPELL_ORBITAL_STRIKE        = 30637,
-    SPELL_SHADOW_WHIP           = 30638
 };
 
 enum Misc
@@ -45,9 +43,7 @@ enum Misc
     EVENT_SUMMON2               = 2,
     EVENT_TREACHEROUS_AURA      = 3,
     EVENT_DEMONIC_SHIELD        = 4,
-    EVENT_KILL_TALK             = 5,
-    EVENT_ORBITAL_STRIKE        = 6,
-    EVENT_SHADOW_WHIP           = 7
+    EVENT_KILL_TALK             = 5
 };
 
 class boss_omor_the_unscarred : public CreatureScript
@@ -77,7 +73,6 @@ public:
             events.ScheduleEvent(EVENT_SUMMON2, 25000);
             events.ScheduleEvent(EVENT_TREACHEROUS_AURA, 6000);
             events.ScheduleEvent(EVENT_DEMONIC_SHIELD, 1000);
-            events.ScheduleEvent(EVENT_ORBITAL_STRIKE, 20000);
         }
 
         void KilledUnit(Unit*) override
@@ -136,23 +131,6 @@ public:
                     }
                     else
                         events.ScheduleEvent(EVENT_DEMONIC_SHIELD, 1000);
-                    break;
-                case EVENT_ORBITAL_STRIKE:
-                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 15.0f, true))
-                    {
-                        _targetGUID = target->GetGUID();
-                        me->CastSpell(target, SPELL_ORBITAL_STRIKE, false);
-                        events.DelayEvents(5000);
-                        events.ScheduleEvent(EVENT_SHADOW_WHIP, 4000);
-                        me->GetMotionMaster()->Clear();
-                    }
-                    events.ScheduleEvent(EVENT_ORBITAL_STRIKE, 20000);
-                    break;
-                case EVENT_SHADOW_WHIP:
-                    me->GetMotionMaster()->MoveChase(me->GetVictim());
-                    if (Unit* target = ObjectAccessor::GetUnit(*me, _targetGUID))
-                        me->CastSpell(target, SPELL_SHADOW_WHIP, false);
-                    _targetGUID.Clear();
                     break;
             }
 


### PR DESCRIPTION
…nscarred script.

Fixes #14471

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #14471
- Closes https://github.com/chromiecraft/chromiecraft/issues/4429

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go xyz -1197.796997 1678.449707 91.886002 543 0.456575`
engage Omor The Unscarred and move to melee
See the Orbital Strike is not used anymore

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
