### PR TITLE
fix(Scripts/Hellfire Ramparts): Nazan should walk on the surface afte…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1673086888979134900.sql
+++ b/data/sql/updates/pending_db_world/rev_1673086888979134900.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `flags_extra`=`flags_extra`|0x00000200 WHERE `entry` IN (17536,18432);

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -196,6 +196,8 @@ public:
             {
                 Talk(EMOTE_NAZAN);
                 events.Reset();
+                me->SetReactState(REACT_PASSIVE);
+                me->InterruptNonMeleeSpells(true);
                 me->GetMotionMaster()->MovePoint(POINT_MIDDLE, -1406.5f, 1746.5f, 81.2f, false);
             }
         }
@@ -206,8 +208,10 @@ public:
             {
                 me->SetCanFly(false);
                 me->SetDisableGravity(false);
-                events.ScheduleEvent(EVENT_RESTORE_COMBAT, 0);
+                me->SetReactState(REACT_AGGRESSIVE);
+                events.ScheduleEvent(EVENT_RESTORE_COMBAT, 1);
                 events.ScheduleEvent(EVENT_SPELL_CONE_OF_FIRE, 5000);
+                events.ScheduleEvent(EVENT_SPELL_FIREBALL, 6000);
                 if (IsHeroic())
                     events.ScheduleEvent(EVENT_SPELL_BELLOWING_ROAR, 10000);
             }


### PR DESCRIPTION
…r descending.

Nazan should keep using Fireball after descending.
Nazan should chase its victims properly after descending.
Fixes #14468

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #14468
- Closes #14279
- Closes https://github.com/chromiecraft/chromiecraft/issues/4426
- Closes https://github.com/chromiecraft/chromiecraft/issues/4427

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go xyz -1383.390015 1711.819946 82.796097 543 5.672320`
kill the hellfire sentries to start the encounter.
kill vazruden
observe Nazan using the flying animation after descending

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
