### PR TITLE
fix(DB/SAI): Shadowmoon Summoner should not interrupt its spells.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1673180342307668400.sql
+++ b/data/sql/updates/pending_db_world/rev_1673180342307668400.sql
@@ -1,0 +1,11 @@
+--
+DELETE FROM `smart_scripts` WHERE `entryorguid`=17395 AND `source_type`=0 AND `id`=3;
+UPDATE `smart_scripts` SET `event_type`=0, `event_param1`=500, `event_param2`=500 WHERE `entryorguid`=17395 AND `source_type`=0 AND `id` IN (0,1);
+
+UPDATE `smart_scripts` SET `action_param2`=0 WHERE `entryorguid`=17395 AND `source_type`=0 AND `id` IN (4,5);
+UPDATE `smart_scripts` SET `event_flags`=0, `event_type`=4, `event_param1`=0, `event_param2`=0, `action_type`=87, `action_param1`=1739500, `action_param2`=1739501, `Comment`='Shadowmoon Summoner - In Combat - Call Random Actionlist' WHERE `entryorguid`=17395 AND `source_type`=0 AND `id`=2;
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (1739500,1739501) AND `source_type`=9;
+INSERT INTO `smart_scripts` VALUES
+(1739500,9,0,0,0,0,100,0,0,0,0,0,0,11,30853,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Shadowmoon Summoner - Actionlist - Cast Summon Seductress'),
+(1739501,9,0,0,0,0,100,0,0,0,0,0,0,11,30851,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Shadowmoon Summoner - Actionlist - Cast Summon Felhound Manastalker');


### PR DESCRIPTION
Fixes #13820

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #13820

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go creature 138175`
engage npc

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
