### PR TITLE
Fix module related cmake error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ FOREACH(subdir ${sub_DIRS})
         continue()
     endif()
 
-    STRING(REGEX REPLACE "^${CMAKE_SOURCE_DIR}/" "" subdir_rel ${subdir})
+    STRING(REPLACE "${CMAKE_SOURCE_DIR}/" "" subdir_rel ${subdir})
     if(EXISTS "${subdir}/CMakeLists.txt")
         add_subdirectory("${subdir_rel}")
     endif()


### PR DESCRIPTION


<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove unnecessary regex check and use simple string replace instead

## Issues Addressed:
- The original code can cause errors depending on the absolute path to your source directory. This fixes that.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://stackoverflow.com/questions/75045135/cmake-regex-replace-fails-to-compile

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested and working

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Put your source directory in a subdirectory named C++, then try to generate.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
