### PR TITLE
fix(DB/creature): Correct Mok'rash respawn timer

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1673609818458819900.sql
+++ b/data/sql/updates/pending_db_world/rev_1673609818458819900.sql
@@ -1,0 +1,3 @@
+--
+-- Mok'rash respawn timer 3hr
+UPDATE `creature` SET `spawntimesecs`=10800 WHERE `guid`=1672;


### PR DESCRIPTION
## Changes Proposed:
-  Increase respawn timer from 30m to 3hr

## SOURCE:
Tested on Wotlk Classic, confirmed an approximate 3hr timer with frequent visitation and npctime's / GUID derived server timestamps, and confirmed not a 30m timer the most manual hard way.  Sniffed over several packets.


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
