### PR TITLE
fix(DB/Spells): Improved Stormstrike should proc only once per cast.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1673692538921177900.sql
+++ b/data/sql/updates/pending_db_world/rev_1673692538921177900.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `spell_proc_event` SET `SpellFamilyMask1`=16777216 WHERE `entry`=-51521;


### PR DESCRIPTION
Fixes #14282

<!-- First of all, THANK YOU for your contribution. --> 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #14282
- Closes https://github.com/chromiecraft/chromiecraft/issues/4033

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.cheat cooldown`
`.learn 17364`
`.learn 51522`
`.mod mana 10000`
Spam with Stormstrike (while wielding both melee weapons) and see only one proc of Improved Stormstrike per cast.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
