### PR TITLE
fix(Core/Battlegrounds): When team loses the base in EotS, dead playe…

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundEY.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundEY.cpp
@@ -472,6 +472,12 @@ void BattlegroundEY::EventTeamLostPoint(Player* player, uint32 point)
     UpdatePointsIcons(point);
     UpdatePointsCount();
     DelCreature(BG_EY_TRIGGER_FEL_REAVER + point);
+
+    _reviveEvents.AddEventAtOffset([this, point]()
+    {
+        RelocateDeadPlayers(BgCreatures[point]);
+        DelCreature(point);
+    }, 500ms);
 }
 
 void BattlegroundEY::EventTeamCapturedPoint(Player* player, TeamId teamId, uint32 point)
@@ -498,8 +504,6 @@ void BattlegroundEY::EventTeamCapturedPoint(Player* player, TeamId teamId, uint3
     }
 
     _capturePointInfo[point]._ownerTeamId = teamId;
-    if (BgCreatures[point])
-        DelCreature(point);
 
     GraveyardStruct const* sg = sGraveyard->GetGraveyard(m_CapturingPointTypes[point].GraveYardId);
     AddSpiritGuide(point, sg->x, sg->y, sg->z, 3.124139f, teamId);


### PR DESCRIPTION
…rs should be teleported to nearest controled graveyard.

Fixes #14620

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #14620
- Closes https://github.com/chromiecraft/chromiecraft/issues/4621

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Go in Eots
Capture a base with team A
Team B kill team A and make the base "uncapped" (grey part of the bar when it's not alliance nor horde controled)
Watch the team A dead players are being teleport to other base (or start)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
