### PR TITLE
feat(Core/Database): move MySQL handle and HandleMySQLErrno to protected

### DIFF
--- a/src/server/database/Database/MySQLConnection.cpp
+++ b/src/server/database/Database/MySQLConnection.cpp
@@ -51,16 +51,16 @@ MySQLConnectionInfo::MySQLConnectionInfo(std::string_view infoString)
 MySQLConnection::MySQLConnection(MySQLConnectionInfo& connInfo) :
     m_reconnecting(false),
     m_prepareError(false),
-    m_queue(nullptr),
     m_Mysql(nullptr),
+    m_queue(nullptr),
     m_connectionInfo(connInfo),
     m_connectionFlags(CONNECTION_SYNCH) { }
 
 MySQLConnection::MySQLConnection(ProducerConsumerQueue<SQLOperation*>* queue, MySQLConnectionInfo& connInfo) :
     m_reconnecting(false),
     m_prepareError(false),
-    m_queue(queue),
     m_Mysql(nullptr),
+    m_queue(queue),
     m_connectionInfo(connInfo),
     m_connectionFlags(CONNECTION_ASYNC)
 {

--- a/src/server/database/Database/MySQLConnection.h
+++ b/src/server/database/Database/MySQLConnection.h
@@ -98,19 +98,18 @@ protected:
     void PrepareStatement(uint32 index, std::string_view sql, ConnectionFlags flags);
 
     virtual void DoPrepareStatements() = 0;
+    virtual bool _HandleMySQLErrno(uint32 errNo, uint8 attempts = 5);
 
     typedef std::vector<std::unique_ptr<MySQLPreparedStatement>> PreparedStatementContainer;
 
     PreparedStatementContainer m_stmts; //! PreparedStatements storage
     bool m_reconnecting;  //! Are we reconnecting?
     bool m_prepareError;  //! Was there any error while preparing statements?
+    MySQLHandle* m_Mysql; //! MySQL Handle.
 
 private:
-    bool _HandleMySQLErrno(uint32 errNo, uint8 attempts = 5);
-
     ProducerConsumerQueue<SQLOperation*>* m_queue;      //! Queue shared with other asynchronous connections.
     std::unique_ptr<DatabaseWorker> m_worker;           //! Core worker task.
-    MySQLHandle* m_Mysql;                               //! MySQL Handle.
     MySQLConnectionInfo& m_connectionInfo;              //! Connection info (used for logging)
     ConnectionFlags m_connectionFlags;                  //! Connection flags (for preparing relevant statements)
     std::mutex m_Mutex;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Moves `m_Mysql` and `_HandleMySQLErrno` to `protected` in `MySQLConnection`
- Makes `_HandleMySQLErrno` virtual

This allows much more flexibility for child classes.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Compiled and tested on Windows 11

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
