### PR TITLE
fix(Core/Combat): Pets should put their owners in combat only on init…

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13585,13 +13585,13 @@ void Unit::CombatStart(Unit* victim, bool initialAggro)
             }
         }
 
-        bool alreadyInCombat = HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IN_COMBAT);
+        bool alreadyInCombat = IsInCombat();
 
         SetInCombatWith(victim);
         victim->SetInCombatWith(this);
 
         // Xinef: If pet started combat - put owner in combat
-        if (!alreadyInCombat && HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IN_COMBAT))
+        if (!alreadyInCombat && IsInCombat())
         {
             if (Unit* owner = GetOwner())
             {

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1064,7 +1064,7 @@ uint32 Unit::DealDamage(Unit* attacker, Unit* victim, uint32 damage, CleanDamage
 
             if (attacker)
             {
-                if (spellProto && !victim->IsInCombatWith(attacker))
+                if (spellProto && victim->CanHaveThreatList() && !victim->HasUnitState(UNIT_STATE_EVADE) && !victim->IsInCombatWith(attacker))
                 {
                     victim->CombatStart(attacker, !(spellProto->AttributesEx3 & SPELL_ATTR3_SUPRESS_TARGET_PROCS));
                 }
@@ -13585,14 +13585,19 @@ void Unit::CombatStart(Unit* victim, bool initialAggro)
             }
         }
 
+        bool alreadyInCombat = HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IN_COMBAT);
+
         SetInCombatWith(victim);
         victim->SetInCombatWith(this);
 
         // Xinef: If pet started combat - put owner in combat
-        if (Unit* owner = GetOwner())
+        if (!alreadyInCombat && HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IN_COMBAT))
         {
-            owner->SetInCombatWith(victim);
-            victim->SetInCombatWith(owner);
+            if (Unit* owner = GetOwner())
+            {
+                owner->SetInCombatWith(victim);
+                victim->SetInCombatWith(owner);
+            }
         }
     }
 


### PR DESCRIPTION
…ial attack.

Fixes #14498

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #14498
- Closes https://github.com/chromiecraft/chromiecraft/issues/2928
- Closes https://github.com/chromiecraft/chromiecraft/issues/2934
- Closes https://github.com/chromiecraft/chromiecraft/issues/4490

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Enter a PvP state of combat with another player.
Attack said target with attacks and the pet.
Have the opponent dot the pet and or player.
after killing opponent, attempt to Feign Death or Shadowmeld.
Notice that combat drops properly

Create a hunter and summon your pet
Engage higher level mob (I tested in Blasted Lands) with hunter and pet
After mob is dead, count the seconds it takes to leave combat

Create a hunter with pet
Enter BG
Attack a player with both pet and your character
Call pet back and Feign Death

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
