### PR TITLE
Removed cooking requirement for Beer Basted Boar Ribs quest

### DIFF
--- a/data/sql/updates/pending_db_world/fix-14033.sql
+++ b/data/sql/updates/pending_db_world/fix-14033.sql
@@ -1,2 +1,3 @@
 UPDATE `quest_template` SET `QuestSortID` = 0 WHERE `ID` = 384;
 UPDATE `quest_template_addon` SET `RequiredSkillID` = 0, `RequiredSkillPoints` = 0 WHERE `ID` = 384;
+

--- a/data/sql/updates/pending_db_world/fix-14033.sql
+++ b/data/sql/updates/pending_db_world/fix-14033.sql
@@ -1,0 +1,2 @@
+UPDATE `quest_template` SET `QuestSortID` = 0 WHERE `ID` = 384;
+UPDATE `quest_template_addon` SET `RequiredSkillID` = 0, `RequiredSkillPoints` = 0 WHERE `ID` = 384;


### PR DESCRIPTION
## Changes Proposed:
Remove Cooking requirement for quest

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/14033
- Closes https://github.com/chromiecraft/chromiecraft/issues/4524

## SOURCE:
see issue

## Tests Performed:
- Created dwarf character, went to quest giver, verified quest giver is available without the cooking skill trained

## How to Test the Changes:
1. Create dwarf char
2. .levelup 4
3. .go c id 1267
4. Verify quest is available for pick up
5. Pick up quest from quest giver

## Known Issues and TODO List:

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
