### PR TITLE
fix(Core/Taxi): Correct cleanup for when the final destination is hit

### DIFF
--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -248,12 +248,10 @@ void WorldSession::HandleMoveWorldportAck()
     GetPlayer()->GetZoneAndAreaId(newzone, newarea);
     GetPlayer()->UpdateZone(newzone, newarea);
 
-    // honorless target
-    if (GetPlayer()->pvpInfo.IsHostile)
-        GetPlayer()->CastSpell(GetPlayer(), 2479, true);
+    GetPlayer()->CastSpell(GetPlayer(), 2479 /*Honorless Target*/, true);
 
     // in friendly area
-    else if (GetPlayer()->IsPvP() && !GetPlayer()->HasPlayerFlag(PLAYER_FLAGS_IN_PVP))
+    if (GetPlayer()->IsPvP() && !GetPlayer()->HasPlayerFlag(PLAYER_FLAGS_IN_PVP))
         GetPlayer()->UpdatePvP(false, false);
 
     // resummon pet
@@ -308,12 +306,10 @@ void WorldSession::HandleMoveTeleportAck(WorldPacket& recvData)
         // new zone
         if (old_zone != newzone)
         {
-            // honorless target
-            if (plMover->pvpInfo.IsHostile)
-                plMover->CastSpell(plMover, 2479, true);
+            plMover->CastSpell(plMover, 2479 /*Honorless Target*/, true);
 
             // in friendly area
-            else if (plMover->IsPvP() && !plMover->HasPlayerFlag(PLAYER_FLAGS_IN_PVP))
+            if (plMover->IsPvP() && !plMover->HasPlayerFlag(PLAYER_FLAGS_IN_PVP))
                 plMover->UpdatePvP(false, false);
         }
     }

--- a/src/server/game/Handlers/TaxiHandler.cpp
+++ b/src/server/game/Handlers/TaxiHandler.cpp
@@ -253,7 +253,7 @@ void WorldSession::HandleMoveSplineDoneOpcode(WorldPacket& recvData)
     {
         GetPlayer()->CleanupAfterTaxiFlight();
         GetPlayer()->SetFallInformation(GameTime::GetGameTime().count(), GetPlayer()->GetPositionZ());
-        GetPlayer()->CastSpell(GetPlayer(), 2479, true);
+        GetPlayer()->CastSpell(GetPlayer(), 2479 /*Honorless Target*/, true);
         return;
     }
 }

--- a/src/server/game/Handlers/TaxiHandler.cpp
+++ b/src/server/game/Handlers/TaxiHandler.cpp
@@ -95,7 +95,8 @@ void WorldSession::SendTaxiMenu(Creature* unit)
         return;
 
     bool lastTaxiCheaterState = GetPlayer()->isTaxiCheater();
-    if (unit->GetEntry() == 29480) GetPlayer()->SetTaxiCheater(true); // Grimwing in Ebon Hold, special case. NOTE: Not perfect, Zul'Aman should not be included according to WoWhead, and I think taxicheat includes it.
+    if (unit->GetEntry() == 29480)
+        GetPlayer()->SetTaxiCheater(true); // Grimwing in Ebon Hold, special case. NOTE: Not perfect, Zul'Aman should not be included according to WoWhead, and I think taxicheat includes it.
 
     LOG_DEBUG("network", "WORLD: CMSG_TAXINODE_STATUS_QUERY {} ", curloc);
 
@@ -250,14 +251,10 @@ void WorldSession::HandleMoveSplineDoneOpcode(WorldPacket& recvData)
     // at this point only 1 node is expected (final destination)
     if (GetPlayer()->m_taxi.GetPath().size() != 1)
     {
-        return;
-    }
-
-    GetPlayer()->CleanupAfterTaxiFlight();
-    GetPlayer()->SetFallInformation(GameTime::GetGameTime().count(), GetPlayer()->GetPositionZ());
-    if (GetPlayer()->pvpInfo.IsHostile)
-    {
+        GetPlayer()->CleanupAfterTaxiFlight();
+        GetPlayer()->SetFallInformation(GameTime::GetGameTime().count(), GetPlayer()->GetPositionZ());
         GetPlayer()->CastSpell(GetPlayer(), 2479, true);
+        return;
     }
 }
 

--- a/src/server/game/Handlers/TaxiHandler.cpp
+++ b/src/server/game/Handlers/TaxiHandler.cpp
@@ -249,7 +249,7 @@ void WorldSession::HandleMoveSplineDoneOpcode(WorldPacket& recvData)
     }
 
     // at this point only 1 node is expected (final destination)
-    if (GetPlayer()->m_taxi.GetPath().size() != 1)
+    if (!GetPlayer()->GetVehicle() && GetPlayer()->m_taxi.GetPath().size() != 1)
     {
         GetPlayer()->CleanupAfterTaxiFlight();
         GetPlayer()->SetFallInformation(GameTime::GetGameTime().count(), GetPlayer()->GetPositionZ());


### PR DESCRIPTION
* closes https://github.com/azerothcore/azerothcore-wotlk/issues/14728
* closes chromiecraft/chromiecraft#4844

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Actually call the Cleanup CleanupAfterTaxiFlight() when the taxi is done
- Sneak in a correction for Honorless Target aura when teleporting or finishing taxi.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
