### PR TITLE
fix(docker): missing config file in dev image

### DIFF
--- a/apps/docker/Dockerfile
+++ b/apps/docker/Dockerfile
@@ -94,6 +94,11 @@ USER $DOCKER_USER
 # NOTE: this folder is different by the /azerothcore (which is binded instead)
 COPY --chown=$DOCKER_USER:$DOCKER_USER . /azerothcore
 
+# Needed if we use the dev image without linking any external folder (e.g. acore-docker)
+COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/authserver.conf.dockerdist /azerothcore/env/dist/etc/authserver.conf.dockerdist
+COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/worldserver.conf.dockerdist /azerothcore/env/dist/etc/worldserver.conf.dockerdist
+COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/dbimport.conf.dockerdist /azerothcore/env/dist/etc/dbimport.conf.dockerdist
+
 #================================================================
 #
 # SERVICE BASE: prepare the OS for the production-ready services


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
When we create the dev image we do not have the .dockerdist file under the etc folder. The ac-dev-server included in the azerothcore-wotlk repository bind the /env/docker/etc folder inside the container, but the acore-docker repository doesn't. That's why we are having the error in that project. 

This happened after the latest changes:

* https://github.com/azerothcore/azerothcore-wotlk/pull/14707
* https://github.com/azerothcore/azerothcore-wotlk/pull/14747

Closes https://github.com/azerothcore/acore-docker/issues/12
