### PR TITLE
fix(Scripts/MagtheridonsLair): Fixed Blast Nova timers.

### DIFF
--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
@@ -24,19 +24,18 @@ enum Yells
 {
     SAY_TAUNT                       = 0,
     SAY_FREE                        = 1,
-    SAY_AGGRO                       = 2,
-    SAY_SLAY                        = 3,
-    SAY_BANISH                      = 4,
-    SAY_PHASE3                      = 5,
-    SAY_DEATH                       = 6,
+    SAY_SLAY                        = 2,
+    SAY_BANISH                      = 3,
+    SAY_PHASE3                      = 4,
+    SAY_DEATH                       = 5,
 };
 
 enum Emotes
 {
-    SAY_EMOTE_BEGIN                 = 7,
-    SAY_EMOTE_NEARLY                = 8,
-    SAY_EMOTE_FREE                  = 9,
-    SAY_EMOTE_NOVA                  = 10
+    SAY_EMOTE_BEGIN                 = 6,
+    SAY_EMOTE_NEARLY                = 7,
+    SAY_EMOTE_FREE                  = 8,
+    SAY_EMOTE_NOVA                  = 9
 };
 
 enum Spells
@@ -189,7 +188,6 @@ public:
                     me->SetImmuneToPC(false);
                     me->SetReactState(REACT_AGGRESSIVE);
                     events.ScheduleEvent(EVENT_CLEAVE, 9000);
-                    events.ScheduleEvent(EVENT_BLAST_NOVA, 60000);
                     events.ScheduleEvent(EVENT_BLAZE, 10000);
                     events.ScheduleEvent(EVENT_QUAKE, 40000);
                     events.ScheduleEvent(EVENT_CHECK_HEALTH, 500);
@@ -204,7 +202,6 @@ public:
                     break;
                 case EVENT_BLAST_NOVA:
                     me->CastSpell(me, SPELL_BLAST_NOVA, false);
-                    events.ScheduleEvent(EVENT_BLAST_NOVA, 60000);
                     events.ScheduleEvent(EVENT_CANCEL_GRASP_CHECK, 12000);
                     events2.ScheduleEvent(EVENT_CHECK_GRASP, 0);
                     break;
@@ -220,6 +217,7 @@ public:
                     break;
                 case EVENT_QUAKE:
                     me->CastSpell(me, SPELL_QUAKE, false);
+                    events.ScheduleEvent(EVENT_BLAST_NOVA, 7000);
                     events.ScheduleEvent(EVENT_QUAKE, 50000);
                     break;
                 case EVENT_CHECK_HEALTH:


### PR DESCRIPTION
Fixed emotes.
Fixes #14721

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #14721
- Closes https://github.com/chromiecraft/chromiecraft/issues/4814

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Engage https://wotlkdb.com/?npc=17257
Kill all 5 https://wotlkdb.com/?npc=18829
Survive for 120 seconds and wait until Magtheridons aggro and start casting Quake.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
