### PR TITLE
feat(Core/Unit): Add KillSelf overload

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1059,7 +1059,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         {
             if (me && !me->isDead())
             {
-                Unit::Kill(me, me);
+                me->KillSelf();
                 LOG_DEBUG("sql.sql", "SmartScript::ProcessAction: SMART_ACTION_DIE: Creature {}", me->GetGUID().ToString());
             }
             break;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1548,6 +1548,7 @@ public:
     static void DealDamageMods(Unit const* victim, uint32& damage, uint32* absorb);
     static uint32 DealDamage(Unit* attacker, Unit* victim, uint32 damage, CleanDamage const* cleanDamage = nullptr, DamageEffectType damagetype = DIRECT_DAMAGE, SpellSchoolMask damageSchoolMask = SPELL_SCHOOL_MASK_NORMAL, SpellInfo const* spellProto = nullptr, bool durabilityLoss = true, bool allowGM = false, Spell const* spell = nullptr);
     static void Kill(Unit* killer, Unit* victim, bool durabilityLoss = true, WeaponAttackType attackType = BASE_ATTACK, SpellInfo const* spellProto = nullptr, Spell const* spell = nullptr);
+    void KillSelf(bool durabilityLoss = true, WeaponAttackType attackType = BASE_ATTACK, SpellInfo const* spellProto = nullptr, Spell const* spell = nullptr) { Kill(this, this, durabilityLoss, attackType, spellProto, spell); };
     static int32 DealHeal(Unit* healer, Unit* victim, uint32 addhealth);
 
     static void ProcDamageAndSpell(Unit* actor, Unit* victim, uint32 procAttacker, uint32 procVictim, uint32 procEx, uint32 amount, WeaponAttackType attType = BASE_ATTACK, SpellInfo const* procSpellInfo = nullptr, SpellInfo const* procAura = nullptr, int8 procAuraEffectIndex = -1, Spell const* procSpell = nullptr, DamageInfo* damageInfo = nullptr, HealInfo* healInfo = nullptr, uint32 procPhase = 2 /*PROC_SPELL_PHASE_HIT*/);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
@@ -306,7 +306,7 @@ public:
             {
                 summons.DespawnEntry(_nefarianLeftTunnel);
                 summons.DespawnEntry(_nefarianRightTunnel);
-                Unit::Kill(me, me);
+                me->KillSelf();
             }
         }
 

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_midnight.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_midnight.cpp
@@ -134,7 +134,7 @@ public:
             if (summon->GetEntry() == NPC_ATTUMEN_THE_HUNTSMAN_MOUNTED)
             {
                 summons.clear();
-                Unit::Kill(me, me);
+                me->KillSelf();
             }
         }
 

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
@@ -206,7 +206,7 @@ public:
                         AttackStart(target);
                     return;
                 case EVENT_FINISH_TALK:
-                    Unit::Kill(me, me);
+                    me->KillSelf();
                     return;
             }
 

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kalecgos.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kalecgos.cpp
@@ -263,7 +263,7 @@ public:
                     break;
                 case EVENT_TALK_GOOD_5:
                     me->SetVisible(false);
-                    Unit::Kill(me, me);
+                    me->KillSelf();
                     break;
                 case EVENT_TALK_BAD_1:
                     me->SetReactState(REACT_PASSIVE);

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kiljaeden.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kiljaeden.cpp
@@ -398,7 +398,7 @@ public:
             switch (events2.ExecuteEvent())
             {
                 case EVENT_KILL_SELF:
-                    Unit::Kill(me, me);
+                    me->KillSelf();
                     break;
                 case EVENT_REBIRTH:
                     me->SetVisible(true);

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -299,7 +299,7 @@ public:
             switch (events.ExecuteEvent())
             {
                 case EVENT_SINGULARITY_DEATH:
-                    Unit::Kill(me, me);
+                    me->KillSelf();
                     break;
                 case EVENT_START_BLACK_HOLE:
                     me->RemoveAurasDueToSpell(SPELL_BLACK_HOLE_SUMMON_VISUAL2);

--- a/src/server/scripts/Events/brewfest.cpp
+++ b/src/server/scripts/Events/brewfest.cpp
@@ -733,7 +733,7 @@ struct npc_dark_iron_guzzler : public ScriptedAI
         if (me->IsAlive() && spellInfo->Id == SPELL_PLAYER_MUG)
         {
             me->CastSpell(me, SPELL_MUG_BOUNCE_BACK, true);
-            Unit::Kill(me, me);
+            me->KillSelf();
             me->CastSpell(me, SPELL_REPORT_DEATH, true);
         }
     }
@@ -795,7 +795,7 @@ struct npc_brewfest_super_brew_trigger : public ScriptedAI
             {
                 player->CastSpell(player, SPELL_DRUNKEN_MASTER, true);
                 me->RemoveAllGameObjects();
-                Unit::Kill(me, me);
+                me->KillSelf();
             }
         }
     }

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_viscidus.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_viscidus.cpp
@@ -362,7 +362,7 @@ struct boss_glob_of_viscidus : public ScriptedAI
         if (id == ROOM_CENTER)
         {
             DoCastSelf(SPELL_REJOIN_VISCIDUS);
-            Unit::Kill(me, me);
+            me->KillSelf();
         }
     }
 

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/trial_of_the_champion.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/trial_of_the_champion.cpp
@@ -128,7 +128,7 @@ public:
             if (pInstance->GetData(DATA_INSTANCE_PROGRESS) < INSTANCE_PROGRESS_ARGENT_CHALLENGE_DIED)
                 return;
 
-            Unit::Kill(me, me); // for bk scene, die after knockback
+            me->KillSelf(); // for bk scene, die after knockback
         }
 
         void UpdateAI(uint32 /*diff*/) override { }

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
@@ -450,7 +450,7 @@ public:
                         }
                     }
                     me->setActive(false);
-                    Unit::Kill(me, me);
+                    me->KillSelf();
 
                     break;
             }

--- a/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
@@ -170,7 +170,7 @@ public:
         {
             summons.Despawn(summon);
             if (summon->GetEntry() == NPC_DRAKKARI_ELEMENTAL)
-                Unit::Kill(me, me);
+                me->KillSelf();
         }
 
         void SummonedCreatureDespawn(Creature* summon) override

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
@@ -3566,7 +3566,7 @@ public:
                     events.ScheduleEvent(EVENT_GAUNTLET_PHASE3, 0);
                 }
                 else
-                    Unit::Kill(me, me);
+                    me->KillSelf();
             }
         }
 

--- a/src/server/scripts/Northrend/Ulduar/HallsOfStone/boss_sjonnir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfStone/boss_sjonnir.cpp
@@ -502,7 +502,7 @@ public:
                             if ((*itr)->GetGUID() != me->GetGUID() && (*itr)->IsAlive() && me->IsAlive())
                                 if (Creature* is = me->SummonCreature(NPC_IRON_SLUDGE, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), 0, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 20000))
                                 {
-                                    Unit::Kill(me, me);
+                                    me->KillSelf();
                                     Unit::Kill(*itr, *itr);
                                     is->SetInCombatWithZone();
                                     break;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -760,7 +760,7 @@ public:
             data << uint32(SPELL_BOOM);
             me->SendMessageToSet(&data, false);
 
-            Unit::Kill(me, me);
+            me->KillSelf();
 
             // Visual only seems to work if the instant kill event is delayed or the spell itself is delayed
             // Casting done from player and caster source has the same targetinfo flags,

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -666,7 +666,7 @@ public:
                 summons.DespawnEntry(NPC_FREYA_KEEPER);
                 summons.DespawnEntry(NPC_THORIM_KEEPER);
                 summons.DespawnEntry(NPC_SANITY_WELL);
-                Unit::Kill(me, me);
+                me->KillSelf();
                 return;
             }
 

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
@@ -104,10 +104,10 @@ public:
                 if (Unit* p = ObjectAccessor::GetUnit(*me, PrisonerGUID))
                 {
                     if( !p->HasAura(SPELL_FROST_TOMB_AURA) )
-                        Unit::Kill(me, me);
+                        me->KillSelf();
                 }
                 else
-                    Unit::Kill(me, me);
+                    me->KillSelf();
             }
         }
     };
@@ -294,7 +294,7 @@ public:
             if( pInstance && pInstance->GetData(DATA_KELESETH) != IN_PROGRESS )
             {
                 if( me->IsAlive() )
-                    Unit::Kill(me, me);
+                    me->KillSelf();
                 return;
             }
 

--- a/src/server/scripts/Northrend/VioletHold/boss_zuramat.cpp
+++ b/src/server/scripts/Northrend/VioletHold/boss_zuramat.cpp
@@ -246,7 +246,7 @@ public:
                         if (s->IsAlive())
                             good = true;
                 if (!good)
-                    Unit::Kill(me, me);
+                    me->KillSelf();
             }
             else
                 checkTimer -= diff;

--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -1435,7 +1435,7 @@ public:
             else if (a == -2)
             {
                 me->CastSpell(me, SPELL_SAC_GHOUL_EXPLODE, true);
-                Unit::Kill(me, me);
+                me->KillSelf();
                 me->m_Events.KillAllEvents(true);
                 Deactivate();
             }

--- a/src/server/scripts/Northrend/zone_storm_peaks.cpp
+++ b/src/server/scripts/Northrend/zone_storm_peaks.cpp
@@ -391,7 +391,7 @@ public:
             else if (type == ESCORT_MOTION_TYPE && me->movespline->Finalized())
                 startPath = true;
             else if (type == EFFECT_MOTION_TYPE && pointId == me->GetEntry())
-                Unit::Kill(me, me);
+                me->KillSelf();
         }
 
         void DamageTaken(Unit* who, uint32& damage, DamageEffectType, SpellSchoolMask) override

--- a/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_grandmaster_vorpil.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_grandmaster_vorpil.cpp
@@ -253,7 +253,7 @@ public:
                     me->AddAura(DUNGEON_MODE(SPELL_EMPOWERING_SHADOWS_N, SPELL_EMPOWERING_SHADOWS_H), Vorpil);
                     Vorpil->ModifyHealth(int32(Vorpil->CountPctFromMaxHealth(4)));
                     me->CastSpell(me, SPELL_SHADOW_NOVA, true);
-                    Unit::Kill(me, me);
+                    me->KillSelf();
                     return;
                 }
 

--- a/src/server/scripts/Outland/BlackTemple/illidari_council.cpp
+++ b/src/server/scripts/Outland/BlackTemple/illidari_council.cpp
@@ -205,7 +205,7 @@ public:
                     if ((member = ObjectAccessor::GetCreature(*me, councilGUIDs[i])))
                         if (member->IsAlive())
                             Unit::Kill(me, member);
-                Unit::Kill(me, me);
+                me->KillSelf();
             }
         }
 

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
@@ -172,7 +172,7 @@ public:
                 {
                     if (Creature* kali = me->FindNearestCreature(NPC_WARLORD_KALITHRESH, 100.0f))
                         kali->CastSpell(kali, SPELL_WARLORDS_RAGE_PROC, true);
-                    Unit::Kill(me, me);
+                    me->KillSelf();
                 }
             }
         }

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -121,7 +121,7 @@ public:
             }
             else if (summons.size() == 0)
             {
-                Unit::Kill(me, me);
+                me->KillSelf();
             }
         }
 

--- a/src/server/scripts/Outland/TempestKeep/arcatraz/arcatraz.cpp
+++ b/src/server/scripts/Outland/TempestKeep/arcatraz/arcatraz.cpp
@@ -340,7 +340,7 @@ public:
         {
             if (summon->GetEntry() == NPC_HARBINGER_SKYRISS)
             {
-                Unit::Kill(me, me);
+                me->KillSelf();
                 me->setActive(false);
                 instance->SetBossState(DATA_WARDEN_MELLICHAR, DONE);
                 if (Creature* creature = summons.GetCreatureWithEntry(NPC_MILLHOUSE))

--- a/src/server/scripts/Pet/pet_generic.cpp
+++ b/src/server/scripts/Pet/pet_generic.cpp
@@ -640,7 +640,7 @@ struct npc_pet_gen_plump_turkey : public PassiveAI
     {
         if (type == EFFECT_MOTION_TYPE && id == 1)
         {
-            Unit::Kill(me, me);
+            me->KillSelf();
             me->AddAura(SPELL_TURKEY_STARTS_TO_BURN, me);
         }
     }

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -444,7 +444,7 @@ public:
             {
                 me->SetLootRecipient(me->GetOwner());
                 me->LowerPlayerDamageReq(me->GetMaxHealth());
-                Unit::Kill(me, me);
+                me->KillSelf();
                 deathTimer = 600000;
             }
             else


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- 
Add Unit::KillSelf() function as overload of Unit::Kill(this) . Use KillSelf() whenever the killer and the victim are the same to clearly state the Unit is going to kill itself.
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
