### PR TITLE
(DB/creature_text) Adding missing BroadcastTextId in Pit of Saron

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1675021295162850400.sql
+++ b/data/sql/updates/pending_db_world/rev_1675021295162850400.sql
@@ -1,0 +1,66 @@
+--
+UPDATE `creature_text` SET `BroadcastTextId`=37088 WHERE `CreatureID`=36993 AND `GroupID`=6 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37089 WHERE `CreatureID`=36993 AND `GroupID`=9 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37090 WHERE `CreatureID`=36993 AND `GroupID`=10 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37091 WHERE `CreatureID`=36993 AND `GroupID`=12 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36854 WHERE `CreatureID`=36993 AND `GroupID`=36 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36856 WHERE `CreatureID`=36993 AND `GroupID`=39 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36855 WHERE `CreatureID`=36993 AND `GroupID`=45 AND `ID`=0;
+
+UPDATE `creature_text` SET `BroadcastTextId`=37094 WHERE `CreatureID`=36794 AND `GroupID`=4 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37095 WHERE `CreatureID`=36794 AND `GroupID`=5 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37096 WHERE `CreatureID`=36794 AND `GroupID`=8 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36852 WHERE `CreatureID`=36794 AND `GroupID`=42 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36853 WHERE `CreatureID`=36794 AND `GroupID`=44 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36708 WHERE `CreatureID`=36794 AND `GroupID`=47 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36709 WHERE `CreatureID`=36794 AND `GroupID`=48 AND `ID`=0;
+
+UPDATE `creature_text` SET `BroadcastTextId`=36531 WHERE `CreatureID`=36476 AND `GroupID`=33 AND `ID`=0;
+
+UPDATE `creature_text` SET `BroadcastTextId`=37321 WHERE `CreatureID`=37580 AND `GroupID`=62 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37320 WHERE `CreatureID`=37580 AND `GroupID`=68 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37232 WHERE `CreatureID`=37580 AND `GroupID`=69 AND `ID`=0;
+
+UPDATE `creature_text` SET `BroadcastTextId`=37479 WHERE `CreatureID`=38188 AND `GroupID`=63 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37478 WHERE `CreatureID`=38188 AND `GroupID`=65 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37480 WHERE `CreatureID`=38188 AND `GroupID`=66 AND `ID`=0;
+
+UPDATE `creature_text` SET `BroadcastTextId`=37222 WHERE `CreatureID`=36477 AND `GroupID`=24 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37223 WHERE `CreatureID`=36477 AND `GroupID`=25 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37224 WHERE `CreatureID`=36477 AND `GroupID`=26 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36538 WHERE `CreatureID`=36477 AND `GroupID`=27 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36537 WHERE `CreatureID`=36477 AND `GroupID`=28 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36536 WHERE `CreatureID`=36477 AND `GroupID`=29 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37225 WHERE `CreatureID`=36477 AND `GroupID`=30 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37226 WHERE `CreatureID`=36477 AND `GroupID`=31 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36550 WHERE `CreatureID`=36477 AND `GroupID`=32 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36841 WHERE `CreatureID`=36477 AND `GroupID`=35 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36842 WHERE `CreatureID`=36477 AND `GroupID`=38 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36843 WHERE `CreatureID`=36477 AND `GroupID`=41 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36844 WHERE `CreatureID`=36477 AND `GroupID`=43 AND `ID`=0;
+
+UPDATE `creature_text` SET `BroadcastTextId`=37178 WHERE `CreatureID`=37591 AND `GroupID`=21 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37178 WHERE `CreatureID`=37592 AND `GroupID`=21 AND `ID`=0;
+
+UPDATE `creature_text` SET `BroadcastTextId`=37218 WHERE `CreatureID`=36494 AND `GroupID`=14 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37219 WHERE `CreatureID`=36494 AND `GroupID`=15 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37220 WHERE `CreatureID`=36494 AND `GroupID`=16 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37221 WHERE `CreatureID`=36494 AND `GroupID`=17 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36445 WHERE `CreatureID`=36494 AND `GroupID`=18 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36444 WHERE `CreatureID`=36494 AND `GroupID`=19 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37260 WHERE `CreatureID`=36494 AND `GroupID`=23 AND `ID`=0;
+
+UPDATE `creature_text` SET `BroadcastTextId`=37233 WHERE `CreatureID`=36658 AND `GroupID`=50 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=37234 WHERE `CreatureID`=36658 AND `GroupID`=52 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=38718 WHERE `CreatureID`=36658 AND `GroupID`=53 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=38715 WHERE `CreatureID`=36658 AND `GroupID`=54 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=38716 WHERE `CreatureID`=36658 AND `GroupID`=55 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=38714 WHERE `CreatureID`=36658 AND `GroupID`=56 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36648 WHERE `CreatureID`=36658 AND `GroupID`=57 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=38717 WHERE `CreatureID`=36658 AND `GroupID`=58 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36628 WHERE `CreatureID`=36658 AND `GroupID`=60 AND `ID`=0;
+
+UPDATE `creature_text` SET `BroadcastTextId`=36765 WHERE `CreatureID`=36795 AND `GroupID`=20 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36714 WHERE `CreatureID`=36795 AND `GroupID`=49 AND `ID`=0;
+
+UPDATE `creature_text` SET `BroadcastTextId`=36718 WHERE `CreatureID`=36888 AND `GroupID`=0 AND `ID`=0;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Link the broadcast_text IDs, so that the dialogs are displayed in different languages, since the translations are in the database, but are not assigned.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- Inside the game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Apply the SQL, and perform the dungeon Pit of Saron
2. Depending on the game client, and if the dialogs are added (at least in Spanish they are), they should be displayed in different languages.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

## Screenshots

![WoWScrnShot_012923_162749](https://user-images.githubusercontent.com/2810187/215352054-8dedab6c-130f-4af7-a70f-3cf876c7f951.jpg)

![WoWScrnShot_012923_162910](https://user-images.githubusercontent.com/2810187/215352056-d104ff83-66eb-407a-93d2-6b13f4e6879d.jpg)

![WoWScrnShot_012923_163227](https://user-images.githubusercontent.com/2810187/215352057-4f4a3e9e-cb34-434b-b91e-d3deeba8e3b4.jpg)

![WoWScrnShot_012923_163242](https://user-images.githubusercontent.com/2810187/215352058-ebba7b6e-4c9c-4a1c-a7b7-2262a21c3e55.jpg)

![WoWScrnShot_012923_163311](https://user-images.githubusercontent.com/2810187/215352060-32c93a71-e68e-434f-ad32-57b6afc6e603.jpg)

![WoWScrnShot_012923_163602](https://user-images.githubusercontent.com/2810187/215352061-4dcab07c-e0e4-40f1-9349-25d7d6398b09.jpg)

![WoWScrnShot_012923_163618](https://user-images.githubusercontent.com/2810187/215352063-92286d9b-93a7-4067-975b-a19a233c2d3a.jpg)

![WoWScrnShot_012923_163646](https://user-images.githubusercontent.com/2810187/215352064-d5dce14e-1135-4f4f-8eca-96c5b63e4716.jpg)

![WoWScrnShot_012923_163730](https://user-images.githubusercontent.com/2810187/215352065-407b53f9-9394-4cf4-9a62-2422984a9480.jpg)


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
