### PR TITLE
fix(DB) Deadmines Cleaver should only drop from Defias Henchman

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1675140644244916700.sql
+++ b/data/sql/updates/pending_db_world/rev_1675140644244916700.sql
@@ -1,7 +1,6 @@
 --
-
 DELETE FROM `reference_loot_template` WHERE `Entry` = 24076 AND `Item` = 1927;
 
 DELETE FROM `creature_loot_template` WHERE `Entry` = 594 AND `Item` = 1927;
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(594,1927,0,6,0,1,1,1,1,"Defias Henchman - Deadmines Cleaver");
+(594,1927,0,6,0,1,1,1,1,'Defias Henchman - Deadmines Cleaver');

--- a/data/sql/updates/pending_db_world/rev_1675140644244916700.sql
+++ b/data/sql/updates/pending_db_world/rev_1675140644244916700.sql
@@ -2,6 +2,6 @@
 
 DELETE FROM `reference_loot_template` WHERE `Entry` = 24076 AND `Item` = 1927;
 
-DELETE FROM `reference_loot_template` WHERE `Entry` = 594 AND `Item` = 1927;
+DELETE FROM `creature_loot_template` WHERE `Entry` = 594 AND `Item` = 1927;
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (594,1927,0,6,0,1,1,1,1,"Defias Henchman - Deadmines Cleaver");

--- a/data/sql/updates/pending_db_world/rev_1675140644244916700.sql
+++ b/data/sql/updates/pending_db_world/rev_1675140644244916700.sql
@@ -1,0 +1,5 @@
+--
+
+DELETE FROM `creature_loot_template` WHERE `Reference` = 24076;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(594,24076,24076,5,0,1,1,1,1,"Defias Henchman - (ReferenceTable)");

--- a/data/sql/updates/pending_db_world/rev_1675140644244916700.sql
+++ b/data/sql/updates/pending_db_world/rev_1675140644244916700.sql
@@ -2,4 +2,4 @@
 
 DELETE FROM `creature_loot_template` WHERE `Reference` = 24076;
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(594,24076,24076,5,0,1,1,1,1,"Defias Henchman - (ReferenceTable)");
+(594,24076,24076,6,0,1,1,1,1,"Defias Henchman - (ReferenceTable)");

--- a/data/sql/updates/pending_db_world/rev_1675140644244916700.sql
+++ b/data/sql/updates/pending_db_world/rev_1675140644244916700.sql
@@ -1,5 +1,7 @@
 --
 
-DELETE FROM `creature_loot_template` WHERE `Reference` = 24076;
+DELETE FROM `reference_loot_template` WHERE `Entry` = 24076 AND `Item` = 1927;
+
+DELETE FROM `reference_loot_template` WHERE `Entry` = 594 AND `Item` = 1927;
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(594,24076,24076,6,0,1,1,1,1,"Defias Henchman - (ReferenceTable)");
+(594,1927,0,6,0,1,1,1,1,"Defias Henchman - Deadmines Cleaver");


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Removes the Deadmines Cleaver drop from entry 24076 of `reference_loot_template` and creates a new independent loot for the Defias Henchman.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- https://github.com/chromiecraft/chromiecraft/issues/2220
- https://github.com/azerothcore/azerothcore-wotlk/issues/8844

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.wowhead.com/wotlk/item=1927/deadmines-cleaver
https://www.wowhead.com/wotlk/npc=594/defias-henchman

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
![Defias](https://user-images.githubusercontent.com/111697701/215672892-71fc37dd-9525-479d-8a16-0bc47f636d47.PNG)





## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Insert the new statment in your world database and execute the statement SELECT * FROM `creature_loot_template` WHERE `Entry` = 594 AND `Item` = 1927;

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
