### PR TITLE
fix(CORE/Player): Apply equip effect auras with -1 duration

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7056,7 +7056,8 @@ void Player::ApplyEquipSpell(SpellInfo const* spellInfo, Item* item, bool apply,
 
         LOG_DEBUG("entities.player", "WORLD: cast {} Equip spellId - {}", (item ? "item" : "itemset"), spellInfo->Id);
 
-        CastSpell(this, spellInfo, true, item);
+        //Ignore spellInfo->DurationEntry, cast with -1 duration
+        CastCustomSpell(spellInfo->Id, SPELLVALUE_AURA_DURATION, -1, this, true, item);
     }
     else
     {


### PR DESCRIPTION
Enforces a -1 duration value to auras applied from equip effects. 
Current reliance on the DurationEntry of the auras causes at least one aura to incorrectly expire.


<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Enforces a -1 duration value to auras applied from equip effects, rather than using the value from spellinfo->DurationEntry

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes AzerothCore issue #5649
- Closes https://github.com/chromiecraft/chromiecraft/issues/531
- May close other open or unreported issues

## SOURCE:
To my knowledge, there exists no concise documentation that proves this behavior was previously Blizzlike, or that the proposed behavior is Blizzlike. Please read my writeup in the comments for the supporting argument for this change.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested item "The Green Tower" is now correctly applying an aura with -1 duration, and not expiring before unequip.
- Regression tested several other known working auras from "Equip:" and "Set" effects to ensure they still worked as intended.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create/Select a character level 36+
2. .additem 1204
3. Equip item "The Green Tower"
4. .list auras 
5. Observe that the aura for The Green Tower has a duration and maxduration of -1
6. Enter combat and allow yourself to be damaged by melee until the aura correctly procs

Regression:
1. Repeat steps 2-5 above with any item which has an "Equip:" or "Set" effect
2. Perform the necessary steps to test that each regression item's aura is still correctly functioning in combat or as otherwise relevant.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- This change would create new issues IF: any item exists with an "Equip:" effect that is meant to expire a set duration after initially equipping the item.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
