### PR TITLE
fix(DB) Heartswood drop

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1675142910827405300.sql
+++ b/data/sql/updates/pending_db_world/rev_1675142910827405300.sql
@@ -1,0 +1,3 @@
+--
+
+DELETE FROM `creature_loot_template` WHERE `Entry` = 3730 AND `Item` = 6912;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes Heartswood drop from excavators

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- https://github.com/azerothcore/azerothcore-wotlk/issues/14676
- https://github.com/chromiecraft/chromiecraft/issues/4819

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.wowhead.com/wotlk/item=6912/heartswood

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
![WoWScrnShot_013023_231857](https://user-images.githubusercontent.com/111697701/215674896-45ea6855-094d-4780-932a-7dd5eae05fbf.jpg)

-
![WoWScrnShot_013023_231924](https://user-images.githubusercontent.com/111697701/215674925-5add255c-28f7-49f5-b63a-b194b137ce9d.jpg)



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Insert the changes in your world database
2. .go zonexy 31 31 412
3. .quest add 1738
4. Kill an excavator

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
