### PR TITLE
fix(DB/SmartScript) Sundered Rumblers wrong use of Summon Sundered Shard

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1675207681546911800.sql
+++ b/data/sql/updates/pending_db_world/rev_1675207681546911800.sql
@@ -2,7 +2,7 @@
 
 DELETE FROM `creature_text` WHERE `CreatureID` = 18881;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
-(18881,0,0,"Sundered Rumbler shatters into shards.",16,0,100,0,0,0,0,0,"Sundered Rumbler - Emote");
+(18881,0,0,"Sundered Rumbler shatters into shards.",16,0,100,0,0,0,19115,0,"Sundered Rumbler - Emote");
 
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 18881) AND (`source_type` = 0) AND (`id` IN (2, 3));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1675207681546911800.sql
+++ b/data/sql/updates/pending_db_world/rev_1675207681546911800.sql
@@ -2,9 +2,9 @@
 
 DELETE FROM `creature_text` WHERE `CreatureID` = 18881;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
-(18881,0,0,"Sundered Rumbler shatters into shards.",16,0,100,0,0,0,0,0,'Sundered Rumbler - Emote');
+(18881,0,0,"Sundered Rumbler shatters into shards.",16,0,100,0,0,0,0,0,"Sundered Rumbler - Emote");
 
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 18881) AND (`source_type` = 0) AND (`id` IN (2, 3));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(18881, 0, 2, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 11, 35310, 3, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Sundered Rumbler - On Just Died - Cast \'Summon Sundered Shard\''),
-(18881, 0, 3, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Sundered Rumbler - On Just Died - Say Line 0');
+(18881, 0, 2, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 11, 35310, 3, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, "Sundered Rumbler - On Just Died - Cast \'Summon Sundered Shard\'"),
+(18881, 0, 3, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, "Sundered Rumbler - On Just Died - Say Line 0");

--- a/data/sql/updates/pending_db_world/rev_1675207681546911800.sql
+++ b/data/sql/updates/pending_db_world/rev_1675207681546911800.sql
@@ -2,7 +2,7 @@
 
 DELETE FROM `creature_text` WHERE `CreatureID` = 18881;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
-(18881,0,0,"Sundered Rumbler shatters into shards.",16,0,100,0,0,0,19115,0,"Sundered Rumbler - Emote");
+(18881,0,0,"%s shatters into shards.",16,0,100,0,0,0,19115,0,"Sundered Rumbler - Emote");
 
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 18881) AND (`source_type` = 0) AND (`id` IN (2, 3));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1675207681546911800.sql
+++ b/data/sql/updates/pending_db_world/rev_1675207681546911800.sql
@@ -1,0 +1,10 @@
+--
+
+DELETE FROM `creature_text` WHERE `CreatureID` = 18881;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(18881,0,0,"Sundered Rumbler shatters into shards.",16,0,100,0,0,0,0,0,'Sundered Rumbler - Emote');
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 18881) AND (`source_type` = 0) AND (`id` IN (2, 3));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(18881, 0, 2, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 11, 35310, 3, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Sundered Rumbler - On Just Died - Cast \'Summon Sundered Shard\''),
+(18881, 0, 3, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Sundered Rumbler - On Just Died - Say Line 0');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Casts Summon Sundered Shard on death
-  Says text "Sundered Rumbler shatters into shards."

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- https://github.com/azerothcore/azerothcore-wotlk/issues/14818
- https://github.com/chromiecraft/chromiecraft/issues/4908

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://youtu.be/HX8haCDIVT0?t=165

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
![WoWScrnShot_013123_181633](https://user-images.githubusercontent.com/111697701/215908430-81755f8c-4a02-482a-9588-baa53475bbfd.jpg)



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Insert the changes in your world database
2. .go c 67708
3. .damage 50000


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
