### PR TITLE
fix(CORE/Player): Book of the Dead unequip fix

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7008,8 +7008,8 @@ void Player::ApplyItemEquipSpell(Item* item, bool apply, bool form_change)
         // Spells that should stay on the caster after removing the item.
         constexpr std::array<int32, 2> spellExceptions =
         {
-            /*Electromagnetic Gigaflux Reactivator*/ 11826,
-            /*Book of the Dead - Summon Skeleton*/ 17490
+            11826,  //Electromagnetic Gigaflux Reactivator
+            17490   //Book of the Dead - Summon Skeleton
         };
         const auto found = std::find(std::begin(spellExceptions), std::end(spellExceptions), spellData.SpellId);
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7009,7 +7009,7 @@ void Player::ApplyItemEquipSpell(Item* item, bool apply, bool form_change)
         constexpr std::array<int32, 2> spellExceptions =
         {
             /*Electromagnetic Gigaflux Reactivator*/ 11826,
-            /*Book of the Damned - Summon Skeleton*/ 17490
+            /*Book of the Dead - Summon Skeleton*/ 17490
         };
         const auto found = std::find(std::begin(spellExceptions), std::end(spellExceptions), spellData.SpellId);
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7006,7 +7006,11 @@ void Player::ApplyItemEquipSpell(Item* item, bool apply, bool form_change)
             continue;
 
         // Spells that should stay on the caster after removing the item.
-        constexpr std::array<int32, 1> spellExceptions = { /*Electromagnetic Gigaflux Reactivator*/ 11826 };
+        constexpr std::array<int32, 2> spellExceptions =
+        {
+            /*Electromagnetic Gigaflux Reactivator*/ 11826,
+            /*Book of the Damned - Summon Skeleton*/ 17490
+        };
         const auto found = std::find(std::begin(spellExceptions), std::end(spellExceptions), spellData.SpellId);
 
         // wrong triggering type


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Adds the Summon Skeleton effect of Book of the Dead to unequip exceptions list
-  Allows player to unequip Book of the Dead and have the summoned skeleton remain for its duration

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11691
- Closes https://github.com/chromiecraft/chromiecraft/issues/3480
- Also fixes Ancient Cornerstone Grimoire

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Additional source material in the above issue links.
https://www.wowhead.com/item=13353/book-of-the-dead#comments:id=239392

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Used active ability of Book of the Dead, swapped to a different offhand equip, confirmed summoned skeleton remained active.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create/Select character level 58+
2. .additem 17067
3. Equip Book of the Dead, wait until active ability is ready
4. Use active ability
5. Swap to any other offhand item or otherwise unequip Book of  the Dead
6. Observe summoned skeleton remains active
7. Observe summoned skeleton correctly disappears after its full 1minute duration

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
