### PR TITLE
fix(Core/Socket): `CMSG_WARDEN_DATA` should not reset idle connections.

### DIFF
--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -385,7 +385,10 @@ WorldSocket::ReadDataHandlerResult WorldSocket::ReadDataHandler()
     }
 
     // Our Idle timer will reset on any non PING opcodes on login screen, allowing us to catch people idling.
-    _worldSession->ResetTimeOutTime(false);
+    if (packetToQueue->GetOpcode() != CMSG_WARDEN_DATA)
+    {
+        _worldSession->ResetTimeOutTime(false);
+    }
 
     // Copy the packet to the heap before enqueuing
     _worldSession->QueuePacket(packetToQueue);


### PR DESCRIPTION
Fixes #14790

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #14790

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Set `SocketTimeOutTime` and `SocketTimeOutTimeActive` to `60000` in `worldserver.conf`
Login with your username and password, but do not login into the game (stay at character selection screen)
Wait 1 minute until got disconnected

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
