### PR TITLE
improve(DB/npc_vendor): Address vendor exploit

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1675903993952928700.sql
+++ b/data/sql/updates/pending_db_world/rev_1675903993952928700.sql
@@ -1,0 +1,7 @@
+--
+UPDATE `npc_vendor` SET `incrtime`=3600 WHERE `entry`=19575 AND `item`=23771 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=3600 WHERE `entry`=19575 AND `item`=23783 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=32400 WHERE `entry`=19575 AND `item`=23781 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=7200 WHERE `entry`=19575 AND `item`=23782 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=180000 WHERE `entry`=19575 AND `item`=23787 AND `ExtendedCost`=0;
+UPDATE `npc_vendor` SET `incrtime`=150000 WHERE `entry`=19575 AND `item`=23786 AND `ExtendedCost`=0;


### PR DESCRIPTION
changes Qiff's limited supply frequency

## Changes Proposed:
-  Changes timers on Qiff, to best reflect what I was able to datamine, see TODO at bottom  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- There is a high value exploit currently possible, see TODO for more info

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Classic WotLK

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- The correct functionality for this vendor (and prolly others like this) is as followed:
Every approximately hour a spawn group will spawn only if the vendor is empty of the spawned group
This spawned group will contain up to 6 items at their randomly selected quantities (1 to max)
There is different rarity levels of each item, and some items are quite rare while other ones seem to spawn every time.

In this PR I simply adjust the timers based on their frequency to throttle an exploit (also makes it hard for a single person to camp reasonably as the timer should drift and not occur at the same exact times every day), this is incorrect but the best I can do in the current system.   Since AC's goal is a playable server this will at least address the severity of the exploit.  It's still easier to get the item than it should be, but the economy isn't going to be as polluted.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
