### PR TITLE
Fix adduser/addgroup commands in dockerfile

### DIFF
--- a/apps/docker/Dockerfile
+++ b/apps/docker/Dockerfile
@@ -38,10 +38,10 @@ RUN apt-get update && apt-get install -y gdb gdbserver git dos2unix lsb-core sud
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
 
 # Create a non-root user
-RUN addgroup --gid $GROUP_ID acore && \
-    adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID acore && \
-    passwd -d acore && \
-    echo 'acore ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers
+RUN addgroup --gid "$GROUP_ID" "$DOCKER_USER" && \
+    adduser --disabled-password --gecos '' --uid "$USER_ID" --gid "$GROUP_ID" "$DOCKER_USER" && \
+    passwd -d "$DOCKER_USER" && \
+    echo "$DOCKER_USER ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # must be created to set the correct permissions on them
 RUN mkdir -p /azerothcore/env/dist/bin
@@ -122,10 +122,10 @@ ENV TZ=Etc/UTC
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Create a non-root user
-RUN addgroup --gid $GROUP_ID acore && \
-    adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID acore && \
-    passwd -d acore && \
-    echo 'acore ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers
+RUN addgroup --gid "$GROUP_ID" "$DOCKER_USER" && \
+    adduser --disabled-password --gecos '' --uid "$USER_ID" --gid "$GROUP_ID" "$DOCKER_USER" && \
+    passwd -d "$DOCKER_USER" && \
+    echo "$DOCKER_USER ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # install the required dependencies to run the server
 RUN apt-get update && apt-get install -y dos2unix gdb gdbserver google-perftools libgoogle-perftools-dev net-tools \
@@ -279,10 +279,10 @@ ENV TZ=Etc/UTC
 # set noninteractive mode so tzdata doesn't ask to set timezone on install
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN addgroup --gid $GROUP_ID acore && \
-    adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID acore && \
-    passwd -d acore && \
-    echo 'acore ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers
+RUN addgroup --gid "$GROUP_ID" "$DOCKER_USER" && \
+    adduser --disabled-password --gecos '' --uid "$USER_ID" --gid "$GROUP_ID" "$DOCKER_USER" && \
+    passwd -d "$DOCKER_USER" && \
+    echo "$DOCKER_USER ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # ENV DATAPATH=/azerothcore/env/dist/data-temp
 ENV DATAPATH=/azerothcore/env/dist/data
@@ -321,10 +321,10 @@ RUN apt-get update && apt-get install -y libmysqlclient-dev libssl-dev libbz2-de
     sudo && rm -rf /var/lib/apt/lists/* ;
 
 # Create a non-root user
-RUN addgroup --gid $GROUP_ID acore && \
-    adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID acore && \
-    passwd -d acore && \
-    echo 'acore ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers
+RUN addgroup --gid "$GROUP_ID" "$DOCKER_USER" && \
+    adduser --disabled-password --gecos '' --uid "$USER_ID" --gid "$GROUP_ID" "$DOCKER_USER" && \
+    passwd -d "$DOCKER_USER" && \
+    echo "$DOCKER_USER ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 RUN mkdir -p /azerothcore/env/client/
 RUN chown -R $DOCKER_USER:$DOCKER_USER /azerothcore


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  adduser and addgroup commands in Dockerfile have `acore` hardcoded

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- No issue found, but this was discussed in discord 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- I haven't performed any tests

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run command that should fail in previous setup
    ```bash
    $ docker compose --profile app build --build-arg DOCKER_USER=foobar
    ```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- I need to test this change. I can't because I'm working right now. 

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
