### PR TITLE
fix(DB/creature_template): Remove bleed immunity from Escape from Durnholde bosses.

### DIFF
--- a/data/sql/updates/pending_db_world/durnholde-immunity.sql
+++ b/data/sql/updates/pending_db_world/durnholde-immunity.sql
@@ -1,0 +1,1 @@
+UPDATE `creature_template` SET `mechanic_immune_mask` = `mechanic_immune_mask` &~ 16384 WHERE `entry` IN (17848, 17862, 18096);

--- a/data/sql/updates/pending_db_world/durnholde-immunity.sql
+++ b/data/sql/updates/pending_db_world/durnholde-immunity.sql
@@ -1,1 +1,1 @@
-UPDATE `creature_template` SET `mechanic_immune_mask` = `mechanic_immune_mask` &~ 16384 WHERE `entry` IN (17848, 17862, 18096);
+UPDATE `creature_template` SET `mechanic_immune_mask` = `mechanic_immune_mask` &~ 16384 WHERE `entry` IN (17848, 17862, 18096, 20521, 20531, 20535);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Removes the bleed immunity mask from [Lieutenant Drake](https://www.wowhead.com/wotlk/npc=17848), [Captain Skarloc](https://www.wowhead.com/wotlk/npc=17862), and [Epoch Hunter](https://www.wowhead.com/wotlk/npc=18096), including their heroic variants.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/4944.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Original issue, as well as Wrath Classic.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game, works as observed on Wrath Classic.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. `.tele oldhillsbrad`
2. `.quest add 10277`
3. `.quest reward 10277`
4. Enter the dungeon.
5. Try to cast a bleeding spell (such as [Rend](https://www.wowhead.com/wotlk/spell=47465)) on the three bosses.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
