### PR TITLE
fix(Core/Unit): Fix creatures not being able to cast spells during Ju…

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -17852,6 +17852,13 @@ void Unit::Kill(Unit* killer, Unit* victim, bool durabilityLoss, WeaponAttackTyp
         isRewardAllowed = creature->IsDamageEnoughForLootingAndReward();
         if (!isRewardAllowed)
             creature->SetLootRecipient(nullptr);
+
+        // Call creature just died function
+        if (CreatureAI* ai = creature->AI())
+        {
+            ai->JustDied(killer);
+            sScriptMgr->OnUnitDeath(creature, killer);
+        }
     }
 
     // pussywizard: remade this if section (player is on the same map
@@ -18073,13 +18080,6 @@ void Unit::Kill(Unit* killer, Unit* victim, bool durabilityLoss, WeaponAttackTyp
         // Call KilledUnit for creatures, this needs to be called after the lootable flag is set
         if (killer && killer->GetTypeId() == TYPEID_UNIT && killer->IsAIEnabled)
             killer->ToCreature()->AI()->KilledUnit(victim);
-
-        // Call creature just died function
-        if (CreatureAI* ai = creature->AI())
-        {
-            ai->JustDied(killer);
-            sScriptMgr->OnUnitDeath(creature, killer);
-        }
 
         if (TempSummon* summon = creature->ToTempSummon())
         {


### PR DESCRIPTION
…stDied()

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Move the call earlier so spell casts and such have a chance to execute 
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Apply the SQL below 
```sql
UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 20478;

DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 20478);
INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
(20478, 0, 0, 0, 25, 0, 100, 1, 0, 0, 0, 0, 0, 11, 35259, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Arcane Servant - On Reset - Cast \'Spotlight\' (No Repeat)'),
(20478, 0, 1, 0, 0, 0, 100, 0, 20000, 25000, 20000, 25000, 0, 11, 35255, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Arcane Servant - In Combat - Cast \'Arcane Volley\''),
(20478, 0, 2, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 11, 22271, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Arcane Servant - On Just Died - Cast \'Arcane Explosion\'');
```

And cast 35260, check if the minion explodes on death

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
