### PR TITLE
feat(Core/PacketIO): Implement STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT

### DIFF
--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -481,6 +481,12 @@ void WorldSession::HandlePlayerLogoutOpcode(WorldPackets::Character::PlayerLogou
 
 void WorldSession::HandleLogoutCancelOpcode(WorldPackets::Character::LogoutCancel& /*logoutCancel*/)
 {
+    LOG_ERROR("sql", "Recieved opcode HandleLogoutCancelOpcode");
+
+    // Player have already logged out serverside, too late to cancel
+    if (!GetPlayer())
+        return;
+
     SetLogoutStartTime(0);
 
     SendPacket(WorldPackets::Character::LogoutCancelAck().Write());

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -481,8 +481,6 @@ void WorldSession::HandlePlayerLogoutOpcode(WorldPackets::Character::PlayerLogou
 
 void WorldSession::HandleLogoutCancelOpcode(WorldPackets::Character::LogoutCancel& /*logoutCancel*/)
 {
-    LOG_ERROR("sql", "Recieved opcode HandleLogoutCancelOpcode");
-
     // Player have already logged out serverside, too late to cancel
     if (!GetPlayer())
         return;

--- a/src/server/game/Handlers/TradeHandler.cpp
+++ b/src/server/game/Handlers/TradeHandler.cpp
@@ -527,7 +527,7 @@ void WorldSession::HandleBeginTradeOpcode(WorldPacket& /*recvPacket*/)
 
 void WorldSession::SendCancelTrade()
 {
-    if (PlayerLogout())
+    if (PlayerRecentlyLoggedOut() || PlayerLogout())
         return;
 
     SendTradeStatus(TRADE_STATUS_TRADE_CANCELED);
@@ -535,7 +535,10 @@ void WorldSession::SendCancelTrade()
 
 void WorldSession::HandleCancelTradeOpcode(WorldPacket& /*recvPacket*/)
 {
-    _player->TradeCancel(true);
+    LOG_ERROR("sql", "RECIEVED OPCODE HandleCancelTradeOpcode");
+    // sended also after LOGOUT COMPLETE
+    if (_player)                                             // needed because STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT
+        _player->TradeCancel(true);
 }
 
 void WorldSession::HandleInitiateTradeOpcode(WorldPacket& recvPacket)

--- a/src/server/game/Handlers/TradeHandler.cpp
+++ b/src/server/game/Handlers/TradeHandler.cpp
@@ -535,7 +535,6 @@ void WorldSession::SendCancelTrade()
 
 void WorldSession::HandleCancelTradeOpcode(WorldPacket& /*recvPacket*/)
 {
-    LOG_ERROR("sql", "RECIEVED OPCODE HandleCancelTradeOpcode");
     // sended also after LOGOUT COMPLETE
     if (_player)                                             // needed because STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT
         _player->TradeCancel(true);

--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -206,7 +206,7 @@ void OpcodeTable::Initialize()
     /*0x04B*/ DEFINE_HANDLER(CMSG_LOGOUT_REQUEST,                                                   STATUS_LOGGEDIN,   PROCESS_THREADUNSAFE,   &WorldSession::HandleLogoutRequestOpcode                );
     /*0x04C*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_LOGOUT_RESPONSE,                                    STATUS_NEVER);
     /*0x04D*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_LOGOUT_COMPLETE,                                    STATUS_NEVER);
-    /*0x04E*/ DEFINE_HANDLER(CMSG_LOGOUT_CANCEL,                                                    STATUS_LOGGEDIN,   PROCESS_THREADUNSAFE,   &WorldSession::HandleLogoutCancelOpcode                 );
+    /*0x04E*/ DEFINE_HANDLER(CMSG_LOGOUT_CANCEL,                                                    STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT,   PROCESS_THREADUNSAFE,   &WorldSession::HandleLogoutCancelOpcode);
     /*0x04F*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_LOGOUT_CANCEL_ACK,                                  STATUS_NEVER);
     /*0x050*/ DEFINE_HANDLER(CMSG_NAME_QUERY,                                                       STATUS_LOGGEDIN,   PROCESS_INPLACE,        &WorldSession::HandleNameQueryOpcode                    );
     /*0x051*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_NAME_QUERY_RESPONSE,                                STATUS_NEVER);
@@ -412,7 +412,7 @@ void OpcodeTable::Initialize()
     /*0x119*/ DEFINE_HANDLER(CMSG_IGNORE_TRADE,                                                     STATUS_LOGGEDIN,   PROCESS_THREADUNSAFE,   &WorldSession::HandleIgnoreTradeOpcode                  );
     /*0x11A*/ DEFINE_HANDLER(CMSG_ACCEPT_TRADE,                                                     STATUS_LOGGEDIN,   PROCESS_THREADUNSAFE,   &WorldSession::HandleAcceptTradeOpcode                  );
     /*0x11B*/ DEFINE_HANDLER(CMSG_UNACCEPT_TRADE,                                                   STATUS_LOGGEDIN,   PROCESS_THREADUNSAFE,   &WorldSession::HandleUnacceptTradeOpcode                );
-    /*0x11C*/ DEFINE_HANDLER(CMSG_CANCEL_TRADE,                                                     STATUS_LOGGEDIN,   PROCESS_THREADUNSAFE,   &WorldSession::HandleCancelTradeOpcode                  );
+    /*0x11C*/ DEFINE_HANDLER(CMSG_CANCEL_TRADE,                                                     STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT,   PROCESS_THREADUNSAFE,   &WorldSession::HandleCancelTradeOpcode);
     /*0x11D*/ DEFINE_HANDLER(CMSG_SET_TRADE_ITEM,                                                   STATUS_LOGGEDIN,   PROCESS_THREADUNSAFE,   &WorldSession::HandleSetTradeItemOpcode                 );
     /*0x11E*/ DEFINE_HANDLER(CMSG_CLEAR_TRADE_ITEM,                                                 STATUS_LOGGEDIN,   PROCESS_THREADUNSAFE,   &WorldSession::HandleClearTradeItemOpcode               );
     /*0x11F*/ DEFINE_HANDLER(CMSG_SET_TRADE_GOLD,                                                   STATUS_LOGGEDIN,   PROCESS_THREADUNSAFE,   &WorldSession::HandleSetTradeGoldOpcode                 );

--- a/src/server/game/Server/Protocol/Opcodes.h
+++ b/src/server/game/Server/Protocol/Opcodes.h
@@ -1353,9 +1353,10 @@ typedef Opcodes OpcodeServer;
 /// Player state
 enum SessionStatus
 {
-    STATUS_AUTHED = 0,                                      // Player authenticated (_player == nullptr, m_GUID has garbage)
+    STATUS_AUTHED = 0,                                      // Player authenticated (_player == NULL, m_playerRecentlyLogout = false or will be reset before handler call, m_GUID have garbage)
     STATUS_LOGGEDIN,                                        // Player in game (_player != nullptr, m_GUID == _player->GetGUID(), inWorld())
     STATUS_TRANSFER,                                        // Player transferring to another map (_player != nullptr, m_GUID == _player->GetGUID(), !inWorld())
+    STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT,                    // _player != NULL or _player == NULL && m_playerRecentlyLogout && m_playerLogout, m_GUID store last _player guid)
     STATUS_NEVER,                                           // Opcode not accepted from client (deprecated or server side only)
     STATUS_UNHANDLED,                                       // Opcode not handled yet
 };

--- a/src/server/game/Server/Protocol/Opcodes.h
+++ b/src/server/game/Server/Protocol/Opcodes.h
@@ -1353,10 +1353,10 @@ typedef Opcodes OpcodeServer;
 /// Player state
 enum SessionStatus
 {
-    STATUS_AUTHED = 0,                                      // Player authenticated (_player == NULL, m_playerRecentlyLogout = false or will be reset before handler call, m_GUID have garbage)
+    STATUS_AUTHED = 0,                                      // Player authenticated (_player == nullptr, m_playerRecentlyLogout = false or will be reset before handler call, m_GUID have garbage)
     STATUS_LOGGEDIN,                                        // Player in game (_player != nullptr, m_GUID == _player->GetGUID(), inWorld())
     STATUS_TRANSFER,                                        // Player transferring to another map (_player != nullptr, m_GUID == _player->GetGUID(), !inWorld())
-    STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT,                    // _player != NULL or _player == NULL && m_playerRecentlyLogout && m_playerLogout, m_GUID store last _player guid)
+    STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT,                    // _player != nullptr or _player == nullptr && m_playerRecentlyLogout && m_playerLogout, m_GUID store last _player guid)
     STATUS_NEVER,                                           // Opcode not accepted from client (deprecated or server side only)
     STATUS_UNHANDLED,                                       // Opcode not handled yet
 };

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -340,18 +340,22 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
                                     "Player {} is currently not in world yet.", GetOpcodeNameForLogging(static_cast<OpcodeClient>(packet->GetOpcode())), GetPlayerInfo());
                     }
                 }
-                else if (_player->IsInWorld() && AntiDOS.EvaluateOpcode(*packet, currentTime))
+                else if (_player->IsInWorld())
                 {
-                    if (!sScriptMgr->CanPacketReceive(this, *packet))
+                    if (AntiDOS.EvaluateOpcode(*packet, currentTime))
                     {
-                        break;
-                    }
+                        if (!sScriptMgr->CanPacketReceive(this, *packet))
+                        {
+                            break;
+                        }
 
-                    opHandle->Call(this, *packet);
-                    LogUnprocessedTail(packet);
-                }
-                else
+                        opHandle->Call(this, *packet);
+                        LogUnprocessedTail(packet);
+                    }
+                    else
                     processedPackets = MAX_PROCESSED_PACKETS_IN_SAME_WORLDSESSION_UPDATE;   // break out of packet processing loop
+                }
+
 
                 // lag can cause STATUS_LOGGEDIN opcodes to arrive after the player started a transfer
                 break;

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -353,9 +353,8 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
                         LogUnprocessedTail(packet);
                     }
                     else
-                    processedPackets = MAX_PROCESSED_PACKETS_IN_SAME_WORLDSESSION_UPDATE;   // break out of packet processing loop
+                        processedPackets = MAX_PROCESSED_PACKETS_IN_SAME_WORLDSESSION_UPDATE;   // break out of packet processing loop
                 }
-
 
                 // lag can cause STATUS_LOGGEDIN opcodes to arrive after the player started a transfer
                 break;

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -121,6 +121,7 @@ WorldSession::WorldSession(uint32 id, std::string&& name, std::shared_ptr<WorldS
     m_inQueue(false),
     m_playerLoading(false),
     m_playerLogout(false),
+    m_playerRecentlyLogout(false),
     m_playerSave(false),
     m_sessionDbcLocale(sWorld->GetDefaultDbcLocale()),
     m_sessionDbLocaleIndex(locale),
@@ -326,21 +327,18 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
             case STATUS_LOGGEDIN:
                 if (!_player)
                 {
-                    // pussywizard: such packets were sent to do something for a character that has already logged out, skip them
-                }
-                else if (!_player->IsInWorld())
-                {
-                    // pussywizard: such packets may do something important and the player is just being teleported, move to the end of the queue
-                    // pussywizard: previously such were skipped, so leave it as it is xD proper code below if we wish to change that
-
-                    // pussywizard: requeue only important packets not related to maps (PROCESS_THREADUNSAFE)
-                    /*if (opHandle.packetProcessing == PROCESS_THREADUNSAFE)
+                    // skip STATUS_LOGGEDIN opcode unexpected errors if player logout sometime ago - this can be network lag delayed packets
+                    //! If player didn't log out a while ago, it means packets are being sent while the server does not recognize
+                    //! the client to be in world yet. We will re-add the packets to the bottom of the queue and process them later.
+                    if (!m_playerRecentlyLogout)
                     {
-                        if (!firstDelayedPacket)
-                            firstDelayedPacket = packet;
+                        requeuePackets.push_back(packet);
                         deletePacket = false;
                         QueuePacket(packet);
-                    }*/
+
+                        LOG_DEBUG("network", "Re-enqueueing packet with opcode %s with with status STATUS_LOGGEDIN. "
+                                    "Player {} is currently not in world yet.", GetOpcodeNameForLogging(static_cast<OpcodeClient>(packet->GetOpcode())), GetPlayerInfo());
+                    }
                 }
                 else if (_player->IsInWorld() && AntiDOS.EvaluateOpcode(*packet, currentTime))
                 {
@@ -348,6 +346,26 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
                     {
                         break;
                     }
+
+                    opHandle->Call(this, *packet);
+                    LogUnprocessedTail(packet);
+                }
+                else
+                    processedPackets = MAX_PROCESSED_PACKETS_IN_SAME_WORLDSESSION_UPDATE;   // break out of packet processing loop
+
+                // lag can cause STATUS_LOGGEDIN opcodes to arrive after the player started a transfer
+                break;
+            case STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT:
+                if (!_player && !m_playerRecentlyLogout) // There's a short delay between _player = null and m_playerRecentlyLogout = true during logout
+                {
+                    LogUnexpectedOpcode(packet, "STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT",
+                            "the player has not logged in yet and not recently logout");
+                }
+                else if (AntiDOS.EvaluateOpcode(*packet, currentTime))
+                {
+                    // not expected _player or must checked in packet hanlder
+                    if (!sScriptMgr->CanPacketReceive(this, *packet))
+                        break;
 
                     opHandle->Call(this, *packet);
                     LogUnprocessedTail(packet);
@@ -372,6 +390,11 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
             case STATUS_AUTHED:
                 if (m_inQueue) // prevent cheating
                     break;
+
+                // some auth opcodes can be recieved before STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT opcodes
+                // however when we recieve CMSG_CHAR_ENUM we are surely no longer during the logout process.
+                if (packet->GetOpcode() == CMSG_CHAR_ENUM)
+                    m_playerRecentlyLogout = false;
 
                 if (AntiDOS.EvaluateOpcode(*packet, currentTime))
                 {
@@ -714,6 +737,7 @@ void WorldSession::LogoutPlayer(bool save)
 
     m_playerLogout = false;
     m_playerSave = false;
+    m_playerRecentlyLogout = true;
     SetLogoutStartTime(0);
 }
 
@@ -1261,6 +1285,8 @@ void WorldSession::SendAddonsInfo()
 void WorldSession::SetPlayer(Player* player)
 {
     _player = player;
+
+    // set m_GUID that can be used while player loggined and later until m_playerRecentlyLogout not reset
     if (_player)
         m_GUIDLow = _player->GetGUID().GetCounter();
 }

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -334,6 +334,7 @@ public:
 
     bool PlayerLoading() const { return m_playerLoading; }
     bool PlayerLogout() const { return m_playerLogout; }
+    bool PlayerRecentlyLoggedOut() const { return m_playerRecentlyLogout; }
     bool PlayerLogoutWithSave() const { return m_playerLogout && m_playerSave; }
 
     void ReadAddonsInfo(ByteBuffer& data);
@@ -1139,7 +1140,7 @@ private:
     // characters who failed on Player::BuildEnumData shouldn't login
     GuidSet _legitCharacters;
 
-    ObjectGuid::LowType m_GUIDLow;
+    ObjectGuid::LowType m_GUIDLow;                     // set logined or recently logout player (while m_playerRecentlyLogout set)
     Player* _player;
     std::shared_ptr<WorldSocket> m_Socket;
     std::string m_Address;
@@ -1160,6 +1161,7 @@ private:
     bool m_inQueue;                                     // session wait in auth.queue
     bool m_playerLoading;                               // code processed in LoginPlayer
     bool m_playerLogout;                                // code processed in LogoutPlayer
+    bool m_playerRecentlyLogout;
     bool m_playerSave;
     LocaleConstant m_sessionDbcLocale;
     LocaleConstant m_sessionDbLocaleIndex;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

* Cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/dc68c2b269fdd401e2f0f6e1e372292b74c66bb8)
* Cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/9fc5c4bc41b2738836ce99eb42ddbb88fb398884)
* cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/f1e6601032ba4077e1d1c6070c4cb20812289f7a)
* cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/aee4f0350ea5610b663cb07fb097f2fad256809e)

Funny that someone have cherry-picked 90% of these commits already, but forgot about the important things x)

## Changes Proposed:
- Implement m_playerRecentlyLogout & STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT

- make use of requeuePackets

* For client packets that can be send in loggined state or just after logout but assocualted with recently logout character add new login status STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT

* Requeue packets handled with STATUS_LOGGEDIN received before player is fully loaded in one step after packet processing loop - reduces used locks from 3 per packet to 1 per packet

* Allow CMSG_LOGOUT_CANCEL to be recieved during serverside logout process (ignore it however, it's too late to abort)

* Fix STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT opcodes because of m_playerRecentlyLogout being set false too early in some cases

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Test cancel trade
- Test cancel logout


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Tested opcodes in-game with LOG_ERROR to know that we recieve the opcodes

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
