### PR TITLE
fix(DB/Quest): The Stone Watcher

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1676741293045096600.sql
+++ b/data/sql/updates/pending_db_world/rev_1676741293045096600.sql
@@ -1,0 +1,16 @@
+-- 
+DELETE FROM `gameobject_queststarter` WHERE (`quest` = 2954) AND (`id` IN (142343));
+INSERT INTO `gameobject_queststarter` (`id`, `quest`) VALUES
+(142343, 2954);
+
+DELETE FROM `creature_queststarter` WHERE `quest` = 2954;
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 142343) AND (`source_type` = 1) AND (`id` IN (2));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(142343, 1, 2, 0, 19, 0, 100, 0, 2954, 0, 0, 0, 0, 80, 14234300, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Uldum Pedestal - On Quest \'The Stone Watcher\' Taken - Run Script');
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 22) AND (`SourceEntry` = 142343);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(22, 1, 142343, 1, 0, 29, 1, 7918, 10, 0, 1, 0, 0, '', 'Only summon Stone Watcher of Norgannon if there isn\'t one already spawned'),
+(22, 2, 142343, 1, 0, 29, 1, 7918, 10, 0, 1, 0, 0, '', 'Only summon Stone Watcher of Norgannon if there isn\'t one already spawned'),
+(22, 3, 142343, 1, 0, 29, 1, 7918, 10, 0, 1, 0, 0, '', 'Only summon Stone Watcher of Norgannon if there isn\'t one already spawned');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fixes being able to spawn The Stone Watcher several times
-  Fixes wrong creature queststarter
- Makes quest re-obtainable if Stone Watcher despawns

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11700
- Closes https://github.com/chromiecraft/chromiecraft/issues/3483

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
