### PR TITLE
feat(Core/Instance): Implement helpers to easily save/retrieve persist…

### DIFF
--- a/src/server/game/Instances/InstanceScript.cpp
+++ b/src/server/game/Instances/InstanceScript.cpp
@@ -351,6 +351,17 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
     return false;
 }
 
+void InstanceScript::StorePersistentData(uint32 index, uint32 data)
+{
+    if (index > persistentData.size())
+    {
+        LOG_ERROR("scripts", "InstanceScript::StorePersistentData() index larger than storage size. Index: {} Size: {} Data: {}.", index, persistentData.size(), data);
+        return;
+    }
+
+    persistentData[index] = data;
+}
+
 void InstanceScript::Load(const char* data)
 {
     if (!data)
@@ -366,6 +377,7 @@ void InstanceScript::Load(const char* data)
     if (ReadSaveDataHeaders(loadStream))
     {
         ReadSaveDataBossStates(loadStream);
+        ReadSavePersistentData(loadStream);
         ReadSaveDataMore(loadStream);
     }
     else
@@ -403,6 +415,14 @@ void InstanceScript::ReadSaveDataBossStates(std::istringstream& data)
     }
 }
 
+void InstanceScript::ReadSavePersistentData(std::istringstream& data)
+{
+    for (uint32 i = 0; i < persistentData.size(); ++i)
+    {
+        data >> persistentData[i];
+    }
+}
+
 std::string InstanceScript::GetSaveData()
 {
     OUT_SAVE_INST_DATA;
@@ -411,6 +431,7 @@ std::string InstanceScript::GetSaveData()
 
     WriteSaveDataHeaders(saveStream);
     WriteSaveDataBossStates(saveStream);
+    WritePersistentData(saveStream);
     WriteSaveDataMore(saveStream);
 
     OUT_SAVE_INST_DATA_COMPLETE;
@@ -431,6 +452,14 @@ void InstanceScript::WriteSaveDataBossStates(std::ostringstream& data)
     for (BossInfo const& bossInfo : bosses)
     {
         data << uint32(bossInfo.state) << ' ';
+    }
+}
+
+void InstanceScript::WritePersistentData(std::ostringstream& data)
+{
+    for (auto const& entry : persistentData)
+    {
+        data << entry << ' ';
     }
 }
 

--- a/src/server/game/Instances/InstanceScript.h
+++ b/src/server/game/Instances/InstanceScript.h
@@ -229,6 +229,9 @@ public:
     CreatureBoundary const* GetBossBoundary(uint32 id) const { return id < bosses.size() ? &bosses[id].boundary : nullptr; }
     BossInfo const* GetBossInfo(uint32 id) const { return &bosses[id]; }
 
+    uint32 GetPersistentData(uint32 index) const { return index < persistentData.size() ? persistentData[index] : 0; };
+    void StorePersistentData(uint32 index, uint32 data);
+
     // Achievement criteria additional requirements check
     // NOTE: not use this if same can be checked existed requirement types from AchievementCriteriaRequirementType
     virtual bool CheckAchievementCriteriaMeet(uint32 /*criteria_id*/, Player const* /*source*/, Unit const* /*target*/ = nullptr, uint32 /*miscvalue1*/ = 0);
@@ -257,6 +260,7 @@ public:
 protected:
     void SetHeaders(std::string const& dataHeaders);
     void SetBossNumber(uint32 number) { bosses.resize(number); }
+    void SetPersistentDataCount(uint32 number) { persistentData.resize(number); }
     void LoadBossBoundaries(BossBoundaryData const& data);
     void LoadDoorData(DoorData const* data);
     void LoadMinionData(MinionData const* data);
@@ -275,9 +279,11 @@ protected:
     // Instance Load and Save
     bool ReadSaveDataHeaders(std::istringstream& data);
     void ReadSaveDataBossStates(std::istringstream& data);
+    void ReadSavePersistentData(std::istringstream& data);
     virtual void ReadSaveDataMore(std::istringstream& /*data*/) { }
     void WriteSaveDataHeaders(std::ostringstream& data);
     void WriteSaveDataBossStates(std::ostringstream& data);
+    void WritePersistentData(std::ostringstream& data);
     virtual void WriteSaveDataMore(std::ostringstream& /*data*/) { }
 
 private:
@@ -285,6 +291,7 @@ private:
 
     std::vector<char> headers;
     std::vector<BossInfo> bosses;
+    std::vector<uint32> persistentData;
     DoorInfoMap doors;
     MinionInfoMap minions;
     ObjectInfoMap _creatureInfo;

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/instance_mechanar.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/instance_mechanar.cpp
@@ -46,11 +46,6 @@ public:
             _passageGUIDs.clear();
         }
 
-        void Initialize() override
-        {
-            _passageEncounter = GetPersistentData(DATA_INDEX_PASSAGE_ENCOUNTER);
-        }
-
         void OnGameObjectCreate(GameObject* gameObject) override
         {
             switch (gameObject->GetEntry())

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/instance_mechanar.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/instance_mechanar.cpp
@@ -38,11 +38,17 @@ public:
         {
             SetHeaders(DataHeader);
             SetBossNumber(MAX_ENCOUNTER);
+            SetPersistentDataCount(MAX_DATA_INDEXES);
             LoadDoorData(doorData);
 
             _passageEncounter = 0;
             _passageTimer = 0;
             _passageGUIDs.clear();
+        }
+
+        void Initialize() override
+        {
+            _passageEncounter = GetPersistentData(DATA_INDEX_PASSAGE_ENCOUNTER);
         }
 
         void OnGameObjectCreate(GameObject* gameObject) override
@@ -149,7 +155,8 @@ public:
                                     DoSummonAction(creature, player);
                             }
                         }
-                        _passageEncounter++;
+
+                        StorePersistentData(DATA_INDEX_PASSAGE_ENCOUNTER, _passageEncounter++);
                         SaveToDB();
                     }
                 }
@@ -186,26 +193,22 @@ public:
                             if (Creature* creature = instance->GetCreature(_pathaleonGUID))
                                 creature->AI()->DoAction(1);
                         }
-                        _passageEncounter++;
+
+                        StorePersistentData(DATA_INDEX_PASSAGE_ENCOUNTER, _passageEncounter++);
                         SaveToDB();
                     }
                 }
             }
         }
 
-        void ReadSaveDataMore(std::istringstream& data) override
+        void ReadSaveDataMore(std::istringstream& /*data*/) override
         {
-            data >> _passageEncounter;
+            _passageEncounter = GetPersistentData(DATA_INDEX_PASSAGE_ENCOUNTER);
 
             if (_passageEncounter == ENCOUNTER_PASSAGE_DONE)
             {
                 _passageEncounter = ENCOUNTER_PASSAGE_PHASE6;
             }
-        }
-
-        void WriteSaveDataMore(std::ostringstream& data) override
-        {
-            data << _passageEncounter;
         }
 
     private:

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/mechanar.h
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/mechanar.h
@@ -70,6 +70,12 @@ enum SpellIds
     SPELL_TELEPORT_VISUAL               = 35517
 };
 
+enum DataIndex
+{
+    DATA_INDEX_PASSAGE_ENCOUNTER = 0,
+    MAX_DATA_INDEXES
+};
+
 template <class AI, class T>
 inline AI* GetMechanarAI(T* obj)
 {


### PR DESCRIPTION
…ent instance data

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Implement StorePersistentData() & GetPersistentData()
-  Allows saving and retrieving instance variables/data to db with easy

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
