### PR TITLE
fix(DB/Creature): Tamed Kodo - Remove gosisp flag.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1677147108487825000.sql
+++ b/data/sql/updates/pending_db_world/rev_1677147108487825000.sql
@@ -1,2 +1,2 @@
--- Tamed Kodo - Remove GOSSIP flag, set via CreatureScript.
-UPDATE `creature_template` SET `unit_flags` = 0 WHERE `entry` = 11627;
+-- Tamed Kodo - Remove gossip flag & gosip menu.
+UPDATE `creature_template` SET `npcflag` = 0,`gossip_menu_id` = 0  WHERE `entry` = 11627;

--- a/data/sql/updates/pending_db_world/rev_1677147108487825000.sql
+++ b/data/sql/updates/pending_db_world/rev_1677147108487825000.sql
@@ -1,0 +1,2 @@
+-- Tamed Kodo - Remove GOSSIP flag, set via CreatureScript.
+UPDATE `creature_template` SET `unit_flags` = 0 WHERE `entry` = 11627;

--- a/data/sql/updates/pending_db_world/rev_1677147108487825000.sql
+++ b/data/sql/updates/pending_db_world/rev_1677147108487825000.sql
@@ -1,2 +1,2 @@
 -- Tamed Kodo - Remove gossip flag & gosip menu.
-UPDATE `creature_template` SET `npcflag` = 0,`gossip_menu_id` = 0  WHERE `entry` = 11627;
+UPDATE `creature_template` SET `npcflag` = `npcflag`&~(1),`gossip_menu_id` = 0  WHERE `entry` = 11627;

--- a/src/server/scripts/Kalimdor/zone_desolace.cpp
+++ b/src/server/scripts/Kalimdor/zone_desolace.cpp
@@ -427,6 +427,8 @@ enum DyingKodo
 
     QUEST_KODO                      = 5561,
 
+    NPC_TEXT_KODO                   = 4449, // MenuID 3650
+
     NPC_SMEED                       = 11596,
     NPC_AGED_KODO                   = 4700,
     NPC_DYING_KODO                  = 4701,
@@ -498,7 +500,7 @@ public:
             player->RemoveAurasDueToSpell(SPELL_KODO_KOMBO_PLAYER_BUFF);
         }
 
-        SendGossipMenuFor(player, player->GetGossipTextId(creature), creature->GetGUID());
+        SendGossipMenuFor(player, NPC_TEXT_KODO, creature->GetGUID());
         return true;
     }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12893
- Closes https://github.com/chromiecraft/chromiecraft/issues/3984
## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.youtube.com/watch?v=NS-oEeZhm9o

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.tele desolace
.go xyz -1467 1743 61
.quest add 5561
Use Kodo Kombobulator on nearby kodos.
Try to interact (speak) with them, see that you can't, unless you get them close to Smeed.
## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
