### PR TITLE
fix(DB/Conditions): Lok'delar & Rhok'delar should not be mutually exclusive.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1677192762421105200.sql
+++ b/data/sql/updates/pending_db_world/rev_1677192762421105200.sql
@@ -18,7 +18,7 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (15, 30201, 1, 0, 0, 2, 0, 18724, 1, 1, 1, 0, 0, '', '(AND) Require item 18724(Enchanted Black Dragon Sinew) to not be in inventory or bank.');
 
 -- Vartus the Ancient 
-DELETE FROM `gossip_menu_option` WHERE `MenuID`=30201 OR `MenuID`=30201;
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=30201;
 INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`, `BoxBroadcastTextID`, `VerifiedBuild`) VALUES
 (30201, 0, 0, 'Greetings, ancient one. I have done all that has been asked of me. I now ask that you grant me Rhok\'delar.', 10784, 1, 1, 0, 0, 0, 0, '', 0, 0),
 (30201, 1, 0, 'Greetings, ancient one. I have done all that has been asked of me. I now ask that you grant me Lok\'delar.', 10785, 1, 1, 0, 0, 0, 0, '', 0, 0);

--- a/data/sql/updates/pending_db_world/rev_1677192762421105200.sql
+++ b/data/sql/updates/pending_db_world/rev_1677192762421105200.sql
@@ -4,7 +4,7 @@ INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comm
 
 -- Gossip_menu_option (30201) conditions (QUEST_REWARDED & _ITEM)
 -- Require both quests 7636(Stave of the Ancients) & 7635(A Proper String) to be rewarded, to not have either Sinew or Rune and to not have either Bow or Stave.
-DELETE FROM `conditions` WHERE `SourceGroup` = 30201;
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` = 30201;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (15, 30201, 0, 0, 0, 8, 0, 7636, 0, 0, 0, 0, 0, '', '(AND) Require quest 7636(Stave of the Ancients) to be rewarded.'),
 (15, 30201, 0, 0, 0, 8, 0, 7635, 0, 0, 0, 0, 0, '', '(AND) Require quest 7635(A Proper String) to be rewarded.'),

--- a/data/sql/updates/pending_db_world/rev_1677192762421105200.sql
+++ b/data/sql/updates/pending_db_world/rev_1677192762421105200.sql
@@ -1,0 +1,29 @@
+-- Form Rhok'delar and Lok'delar at once
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger`=23192;
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES (23192, 24872, 0, 'Forming Rhok\'delar and Lok\'delar once ');
+
+-- Gossip_menu_option conditions (QUEST_REWARDED & _ITEM)
+-- Require both quests 7636(Stave of the Ancients) & 7635(A Proper String) to be rewarded & the item to not be in inventory or bank (deleted/unobtained).
+DELETE FROM `conditions` WHERE `SourceGroup` = 30201;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 30201, 0, 0, 0, 8, 0, 7636, 0, 0, 0, 0, 0, '', '(AND) Require quest 7636(Stave of the Ancients) to be rewarded to show gossip_menu_option.'),
+(15, 30201, 0, 0, 0, 8, 0, 7635, 0, 0, 0, 0, 0, '', '(AND) Require quest 7635(A Proper String) to be rewarded to show gossip_menu_option.'),
+(15, 30201, 0, 0, 0, 2, 0, 18713, 1, 1, 1, 0, 0, '', '(AND) Require item 18713(Rhok\'delar) to not be in inventory or bank.'),
+(15, 30201, 1, 0, 0, 8, 0, 7636, 0, 0, 0, 0, 0, '', '(AND) Require quest 7636(Stave of the Ancients) to be rewarded to show gossip_menu_option.'),
+(15, 30201, 1, 0, 0, 8, 0, 7635, 0, 0, 0, 0, 0, '', '(AND) Require quest 7635(A Proper String) to be rewarded to show gossip_menu_option.'),
+(15, 30201, 1, 0, 0, 2, 0, 18715, 1, 1, 1, 0, 0, '', '(AND) Require item 18715(Lok\'delar) to not be in inventory or bank.');
+
+-- Vartus the Ancient 
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=30201 OR `MenuID`=30201;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`, `BoxBroadcastTextID`, `VerifiedBuild`) VALUES
+(30201, 0, 0, 'Greetings, ancient one. I have done all that has been asked of me. I now ask that you grant me Rhok\'delar.', 10784, 1, 1, 0, 0, 0, 0, '', 0, 0),
+(30201, 1, 0, 'Greetings, ancient one. I have done all that has been asked of me. I now ask that you grant me Lok\'delar.', 10785, 1, 1, 0, 0, 0, 0, '', 0, 0);
+
+-- SAI
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 14524;
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 14524;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(14524, 0, 0, 2, 62, 0, 100, 0, 30201, 0, 0, 0, 0, 56, 18713, 1, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Vartrus the Ancient - On Gossip Option 0 Selected - Add Item \'Rhok\'delar, Longbow of the Ancient Keepers\' '),
+(14524, 0, 1, 2, 62, 0, 100, 0, 30201, 1, 0, 0, 0, 56, 18715, 1, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Vartrus the Ancient - On Gossip Option 1 Selected - Add Item \'Lok\'delar, Stave of the Ancient Keepers\''),
+(14524, 0, 2, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Vartrus the Ancient - On Gossip Option - Close Gossip');

--- a/data/sql/updates/pending_db_world/rev_1677192762421105200.sql
+++ b/data/sql/updates/pending_db_world/rev_1677192762421105200.sql
@@ -1,17 +1,21 @@
 -- Form Rhok'delar and Lok'delar at once
 DELETE FROM `spell_linked_spell` WHERE `spell_trigger`=23192;
-INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES (23192, 24872, 0, 'Forming Rhok\'delar and Lok\'delar once ');
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES (23192, 24872, 0, 'Form Rhok\'delar and Lok\'delar at once ');
 
--- Gossip_menu_option conditions (QUEST_REWARDED & _ITEM)
--- Require both quests 7636(Stave of the Ancients) & 7635(A Proper String) to be rewarded & the item to not be in inventory or bank (deleted/unobtained).
+-- Gossip_menu_option (30201) conditions (QUEST_REWARDED & _ITEM)
+-- Require both quests 7636(Stave of the Ancients) & 7635(A Proper String) to be rewarded, to not have either Sinew or Rune and to not have either Bow or Stave.
 DELETE FROM `conditions` WHERE `SourceGroup` = 30201;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(15, 30201, 0, 0, 0, 8, 0, 7636, 0, 0, 0, 0, 0, '', '(AND) Require quest 7636(Stave of the Ancients) to be rewarded to show gossip_menu_option.'),
-(15, 30201, 0, 0, 0, 8, 0, 7635, 0, 0, 0, 0, 0, '', '(AND) Require quest 7635(A Proper String) to be rewarded to show gossip_menu_option.'),
+(15, 30201, 0, 0, 0, 8, 0, 7636, 0, 0, 0, 0, 0, '', '(AND) Require quest 7636(Stave of the Ancients) to be rewarded.'),
+(15, 30201, 0, 0, 0, 8, 0, 7635, 0, 0, 0, 0, 0, '', '(AND) Require quest 7635(A Proper String) to be rewarded.'),
 (15, 30201, 0, 0, 0, 2, 0, 18713, 1, 1, 1, 0, 0, '', '(AND) Require item 18713(Rhok\'delar) to not be in inventory or bank.'),
-(15, 30201, 1, 0, 0, 8, 0, 7636, 0, 0, 0, 0, 0, '', '(AND) Require quest 7636(Stave of the Ancients) to be rewarded to show gossip_menu_option.'),
-(15, 30201, 1, 0, 0, 8, 0, 7635, 0, 0, 0, 0, 0, '', '(AND) Require quest 7635(A Proper String) to be rewarded to show gossip_menu_option.'),
-(15, 30201, 1, 0, 0, 2, 0, 18715, 1, 1, 1, 0, 0, '', '(AND) Require item 18715(Lok\'delar) to not be in inventory or bank.');
+(15, 30201, 0, 0, 0, 2, 0, 18707, 1, 1, 1, 0, 0, '', '(AND) Require item 18707(Ancient Rune Etched Stave) to not be in inventory or bank.'),
+(15, 30201, 0, 0, 0, 2, 0, 18724, 1, 1, 1, 0, 0, '', '(AND) Require item 18724(Enchanted Black Dragon Sinew) to not be in inventory or bank.'),
+(15, 30201, 1, 0, 0, 8, 0, 7636, 0, 0, 0, 0, 0, '', '(AND) Require quest 7636(Stave of the Ancients) to be rewarded.'),
+(15, 30201, 1, 0, 0, 8, 0, 7635, 0, 0, 0, 0, 0, '', '(AND) Require quest 7635(A Proper String) to be rewarded.'),
+(15, 30201, 1, 0, 0, 2, 0, 18715, 1, 1, 1, 0, 0, '', '(AND) Require item 18715(Lok\'delar) to not be in inventory or bank.'),
+(15, 30201, 1, 0, 0, 2, 0, 18707, 1, 1, 1, 0, 0, '', '(AND) Require item 18707(Ancient Rune Etched Stave) to not be in inventory or bank.'),
+(15, 30201, 1, 0, 0, 2, 0, 18724, 1, 1, 1, 0, 0, '', '(AND) Require item 18724(Enchanted Black Dragon Sinew) to not be in inventory or bank.');
 
 -- Vartus the Ancient 
 DELETE FROM `gossip_menu_option` WHERE `MenuID`=30201 OR `MenuID`=30201;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
I'm not sure that the option to reclaim either of them if they were deleted should exist, but it acts as a fail safe (and we like those, no?), as neither of them can be disenchanted, sold or interacted in any shape or form outside of just acting as weapons.
## Changes Proposed:
- Create both items at once when using the Ancient Rune Etched Stave
- Fix incorrect gossip (for 3.3.5)
- Changed Vartus the Ancient's SAI to reflect the changes in this PR.
- condition gossip_menu_options (30201) to now require:
1. both quests 7636(Stave of the Ancients) & 7635(A Proper String) to be rewarded
2. to not have either Sinew or Rune
3. to not have either Bow or Stave. 

(This will also show the option to characters that have done the quest before this PR, allowing them to obtain the alternative item.)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11271
- Closes https://github.com/chromiecraft/chromiecraft/issues/3222 (closed by mistake probably)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
In the issue
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

-- Delete cache
-- Create a NEW hunter character
.go c id 14524
Try speaking with Vartrus, notice no gossip options.

-- Stave of the Ancients
.q a 7636
.q c 7636
.q reward 7636
Check for gossip.

-- A Proper String
.q a 7635
.q c 7635
.q reward 7635
Check for gossip.

Use [Ancient Rune Etched Stave]
Notice you get both the Bow and Stave.
Check for gossip.

.learn 227
Equip one or both.
Check for gossip.

.character check bank
Put one or both in the bank.
Check for gossip.

Delete either the Bow or Stave.
Check for gossip, notice the option for the item that you've just deleted. (or both)
Click it, confirm that you get the item and that the gossip option no longer exists, until you've deleted that item again.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
