### PR TITLE
fix(DB/Conditions): Baron Revilgaz - correct gossip for Pirates' Day

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1677266850243629600.sql
+++ b/data/sql/updates/pending_db_world/rev_1677266850243629600.sql
@@ -1,0 +1,4 @@
+-- Baron Revilgaz - On Pirates' Day - Show appropriate gossip
+DELETE FROM `conditions` WHERE  `SourceGroup`=6685 AND `SourceEntry`=13062;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 6685, 13062, 0, 0, 12, 0, 50, 0, 0, 0, 0, 0, '', 'Baron Revilgaz - On Pirates\' Day event - Show appropriate gossip');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
The same menuID contains the npc_text for both active and inactive status.
## Changes Proposed:
- Require Pirates' Day (event 50) to be active in order to show the appropriate text.


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/11327
- Closes https://github.com/chromiecraft/chromiecraft/issues/3307

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.go c id 2496
Check gossip
If not Pirates' Day = "... I hope your stay in my town ..."
.event start 50
If Pirates' Day = "... Don't mind DeMeza ..."

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
