### PR TITLE
fix(Core/Spells): Casting Basaic Campfire should give cooking skill.

### DIFF
--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -4577,6 +4577,26 @@ private:
     uint32 _aura;
 };
 
+inline int32 SkillGainChance(uint32 SkillValue, uint32 GrayLevel, uint32 GreenLevel, uint32 YellowLevel)
+{
+    if (SkillValue >= GrayLevel)
+    {
+        return sWorld->getIntConfig(CONFIG_SKILL_CHANCE_GREY) * 10;
+    }
+
+    if (SkillValue >= GreenLevel)
+    {
+        return sWorld->getIntConfig(CONFIG_SKILL_CHANCE_GREEN) * 10;
+    }
+
+    if (SkillValue >= YellowLevel)
+    {
+        return sWorld->getIntConfig(CONFIG_SKILL_CHANCE_YELLOW) * 10;
+    }
+
+    return sWorld->getIntConfig(CONFIG_SKILL_CHANCE_ORANGE) * 10;
+}
+
 // 818 Basic Campfire
 class spell_gen_basic_campfire : public SpellScript
 {
@@ -4594,9 +4614,20 @@ class spell_gen_basic_campfire : public SpellScript
         }
     }
 
+    void ModifyCookingSkill(SpellEffIndex effIndex)
+    {
+        if (Player* player = GetCaster()->ToPlayer())
+        {
+            uint32 SkillValue = player->GetPureSkillValue(SKILL_COOKING);
+            int32 chance = SkillGainChance(SkillValue, 75, 50, 25);
+            player->UpdateSkillPro(SKILL_COOKING, chance, 1);
+        }
+    }
+
     void Register() override
     {
         OnDestinationTargetSelect += SpellDestinationTargetSelectFn(spell_gen_basic_campfire::ModDest, EFFECT_0, TARGET_DEST_CASTER_SUMMON);
+        OnEffectHit += SpellEffectFn(spell_gen_basic_campfire::ModifyCookingSkill, EFFECT_0, SPELL_EFFECT_TRANS_DOOR);
     }
 };
 


### PR DESCRIPTION
Fixes #14900

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #14900

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.learn 2550`
`.cheat cooldown on`, `.cheat casttime on`
Bring ruin to the Basic Campfire spell using an autoclicker.
Observe your cooking skill.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
