### PR TITLE
fix(DB/Quest): Fixed rep requirements for some Darkmoon quests.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1677339050428804700.sql
+++ b/data/sql/updates/pending_db_world/rev_1677339050428804700.sql
@@ -1,0 +1,3 @@
+--
+UPDATE `quest_template_addon` SET `RequiredMaxRepValue`=5000 WHERE `ID` IN (7893,8222,7903,7898,7885);
+UPDATE `quest_template_addon` SET `RequiredMinRepValue`=5000 WHERE `ID` IN (7939,8223,7943,7942,7941);


### PR DESCRIPTION
Fixes #14727

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #14727
- Closes https://github.com/chromiecraft/chromiecraft/issues/3875

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.go c 52416`
`.mod rep 909 4999`
Look at quest, still available as it should be
`.mod rep 909 5001`
Look at quests - the old (the rep) ones are replaced by the new (the non-rep) ones

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
