### PR TITLE
fix(Core/Gameobject): Fix lootable chests related to quests but not having quest loot

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1677339915510744100.sql
+++ b/data/sql/updates/pending_db_world/rev_1677339915510744100.sql
@@ -1,0 +1,4 @@
+-- Delete hack fix
+UPDATE `gameobject_template` SET `Data1` = 0 WHERE (`entry` = 182583);
+
+DELETE FROM `gameobject_loot_template` WHERE `Entry` = 19414;

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1343,7 +1343,7 @@ bool GameObject::ActivateToQuest(Player* target) const
         case GAMEOBJECT_TYPE_CHEST:
             {
                 // scan GO chest with loot including quest items
-                if (LootTemplates_Gameobject.HaveQuestLootForPlayer(GetGOInfo()->GetLootId(), target))
+                if (target->GetQuestStatus(GetGOInfo()->chest.questId) == QUEST_STATUS_INCOMPLETE || LootTemplates_Gameobject.HaveQuestLootForPlayer(GetGOInfo()->GetLootId(), target))
                 {
                     //TODO: fix this hack
                     //look for battlegroundAV for some objects which are only activated after mine gots captured by own team


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Authored-By: Shauren <shauren.trinity@gmail.com>

Cherry pick from: https://github.com/TrinityCore/TrinityCore/commit/a26304478d9505713dfadb9b04a3bda4cef57545

## Changes Proposed:
-  Makes chests that have no loot but are quest-related (Rotten Arakkoa Eggs, Draenei Vessel, etc) lootable
-  Removes my old hack fix

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
TC

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.q a 10028`
2. `.tele Tuurem`
3. See that both trapped and lootable Draenei Vessels are available
4. `.go zonexy 44.28 55.78 3932`
5. `.quest add 10547`
6. See that both trapped and lootable Rotten Arakkoa Eggs are available

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
