### PR TITLE
fix(Instance/Script): Fix Factory Door in Deadmines being closable

### DIFF
--- a/data/sql/updates/pending_db_world/DM_FactoryDoor_Fix.sql
+++ b/data/sql/updates/pending_db_world/DM_FactoryDoor_Fix.sql
@@ -1,1 +1,1 @@
-UPDATE `acore_world`.`smart_scripts` SET `action_type`=9, `comment`='Rhahk\'Zor - On Just Died - Activate Gameobject' WHERE  `entryorguid`=644 AND `source_type`=0 AND `id`=2 AND `link`=3;
+UPDATE `smart_scripts` SET `action_type`=9, `comment`='Rhahk\'Zor - On Just Died - Activate Gameobject' WHERE `entryorguid`=644 AND `source_type`=0 AND `id`=2 AND `link`=3;

--- a/data/sql/updates/pending_db_world/DM_FactoryDoor_Fix.sql
+++ b/data/sql/updates/pending_db_world/DM_FactoryDoor_Fix.sql
@@ -1,0 +1,1 @@
+UPDATE `acore_world`.`smart_scripts` SET `action_type`=9, `comment`='Rhahk\'Zor - On Just Died - Activate Gameobject' WHERE  `entryorguid`=644 AND `source_type`=0 AND `id`=2 AND `link`=3;

--- a/src/server/scripts/EasternKingdoms/Deadmines/instance_deadmines.cpp
+++ b/src/server/scripts/EasternKingdoms/Deadmines/instance_deadmines.cpp
@@ -50,8 +50,9 @@ public:
                     break;
                 case GO_FACTORY_DOOR:
                     gameobject->UpdateSaveToDb(true);
+                    // GoState (Door opened) is restored during GO creation, but we need to set LootState to prevent Lever from closing it again
                     if (_encounters[TYPE_RHAHK_ZOR] == DONE)
-                        gameobject->SetGoState(GO_STATE_ACTIVE);
+                        gameobject->SetLootState(GO_ACTIVATED);
                     break;
                 case GO_IRON_CLAD_DOOR:
                     gameobject->UpdateSaveToDb(true);


### PR DESCRIPTION
## Changes Proposed:
-  The boss (Rhahk'Zor) activates the door in his room instead of only changing gameobject state
-  The lever behind the door then won't be able to close the door again when players click on it
- Change Instance script

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes [10340](https://github.com/azerothcore/azerothcore-wotlk/issues/10340)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
In this WoW Classic video you see the door open as soon as the boss is killed:
https://youtu.be/71UPdm30VrI?t=448

Shortly after, the player clicks the door lever and nothing happens:
https://youtu.be/71UPdm30VrI?t=471

This is also the only logic way a group cannot be softlocked in the instance. If the lever would close _and_ open the door, the following could happen:
1) All players go through the door, a player closes the door behind the group.
2) The group progresses through the instance and wipes at some point
3) Everyone has to run in and stands in front of the closed door. Even though the lever would be able to open it again, nobody can reach it, locking any further progress
(This would be even more annoying because you might wipe at the last boss and would fail the instance much later.)
The only way to prevent that is to make the door static and players can't close it to begin with.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Killed the boss, go through the now open door. Click the lever and watch nothing happen
- Restarted server, entered DM again and confirmed that the correct state was preserved


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Enter Deadmines, progress to first boss and defeat it (Door must open)
2. Click on the lever in the door way (Door must not close)
3. Restart server
4. After server restart and entering the saved DM instance, the door must still be open and the lever must not close the door when clicked

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
While researching this issue, I found more issues with DM (will create separate issues and PRs later)

- [ ] Fix DM Instance script (currently, after server restart other doors could be closed by players)
- [ ] Cleanup all DM door scripts (most are scripted twice with only one way of activation required)
- [ ] Possibly overhaul the core logic for saving and restoring Gameobjects in instances

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
