### PR TITLE
fix(Scripts/Creature): Add 5 second timer for Raliq the Drunk to animate drinking

### DIFF
--- a/src/server/scripts/Outland/zone_shattrath_city.cpp
+++ b/src/server/scripts/Outland/zone_shattrath_city.cpp
@@ -86,18 +86,26 @@ public:
         {
             m_uiNormFaction = creature->GetFaction();
         }
-
+        uint32 Drink_Timer = 5000;
         uint32 m_uiNormFaction;
         uint32 Uppercut_Timer;
 
         void Reset() override
         {
+            Drink_Timer = 5000;
             Uppercut_Timer = 5000;
             me->RestoreFaction();
         }
 
         void UpdateAI(uint32 diff) override
         {
+            if (!me->IsInCombat() && Drink_Timer <= diff)
+            {
+                me->HandleEmoteCommand(7);
+                Drink_Timer = 5000;
+            }
+            else Drink_Timer -= diff;
+
             if (!UpdateVictim())
                 return;
 

--- a/src/server/scripts/Outland/zone_shattrath_city.cpp
+++ b/src/server/scripts/Outland/zone_shattrath_city.cpp
@@ -115,7 +115,7 @@ public:
         void UpdateAI(uint32 diff) override
         {
 
-            _scheduler.Update(diff, [this] { });
+            _scheduler.Update(diff);
 
             if (!UpdateVictim())
                 return;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add a 5 second timer for Raliq the Drunk to animate drinking.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/14916

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- Checked time on retail, consistently 5 seconds.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Observed 5 second time between drink animations.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .tele Shattrath
2. Go to Worlds End Tavern
3. Observe Raliq the Drunk and use /timer to time his drinks

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
