### PR TITLE
fix(DB/spell_custom_attr): Warchief's Blessing - add NO_PVP_FLAG.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1677428934650582700.sql
+++ b/data/sql/updates/pending_db_world/rev_1677428934650582700.sql
@@ -1,0 +1,3 @@
+-- Warchief's blessing - Add NO_PVP_FLAG
+DELETE FROM `spell_custom_attr` WHERE `spell_id`=16609;
+INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (16609, 128);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12130
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

be horde
.tele orgri
.learn 16609
find it in your spell book and click it
Confirm that it doesn't pvp flag you


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
