### PR TITLE
fix(DB/Conditions): Show correct Zorbin Fandazzle gossip on quests rewarded.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1677450429923552400.sql
+++ b/data/sql/updates/pending_db_world/rev_1677450429923552400.sql
@@ -1,0 +1,5 @@
+-- Zorbin Fandazzle - show gossip menu if Quests Zapped Giants (7003) and  Fuel for the Zapping (7721) are rewarded
+DELETE FROM `conditions` WHERE `SourceGroup` = 11361 AND `ConditionValue1` IN (7003, 7721);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 11361, 7116, 0, 0, 8, 0, 7003, 0, 0, 0, 0, 0, '', '(AND) Zorbin Fandazzle - Show gossip menu if Quests Zapped Giants is rewarded'),
+(14, 11361, 7116, 0, 0, 8, 0, 7721, 0, 0, 0, 0, 0, '', '(AND) Zorbin Fandazzle - Show gossip menu if Fuel for the Zapping is rewarded');

--- a/data/sql/updates/pending_db_world/rev_1677450429923552400.sql
+++ b/data/sql/updates/pending_db_world/rev_1677450429923552400.sql
@@ -1,5 +1,5 @@
 -- Zorbin Fandazzle - show gossip menu if Quests Zapped Giants (7003) and  Fuel for the Zapping (7721) are rewarded
-DELETE FROM `conditions` WHERE `SourceGroup` = 11361 AND `ConditionValue1` IN (7003, 7721);
+DELETE FROM `conditions` WHERE `SourceGroup` = 11361 AND `SourceTypeOrReferenceId` = 14 AND `ConditionValue1` IN (7003, 7721);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (14, 11361, 7116, 0, 0, 8, 0, 7003, 0, 0, 0, 0, 0, '', '(AND) Zorbin Fandazzle - Show gossip menu if Quests Zapped Giants is rewarded'),
 (14, 11361, 7116, 0, 0, 8, 0, 7721, 0, 0, 0, 0, 0, '', '(AND) Zorbin Fandazzle - Show gossip menu if Fuel for the Zapping is rewarded');


### PR DESCRIPTION

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add show gossip menu condition upon quests Zapped Giants (7003) and Fuel for the Zapping (7721) have been rewarded.
## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12263
- Closes https://github.com/chromiecraft/chromiecraft/issues/3699

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.go c id 14637
check gossip, see if it says "Maybe it wasn't the best place for a shop after all..."
.quest a 7721
.quest c 7721
.quest a 7003
.quest c 7003
turn in both quests and check gossip, should be "Well hello again..."



<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
