### PR TITLE
fix(DB/Quest): Zandalari Tribe missing rogue quest and race restrictions.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1677597663131840800.sql
+++ b/data/sql/updates/pending_db_world/rev_1677597663131840800.sql
@@ -1,0 +1,11 @@
+-- Falthir the Sightless, add 8143 (Rogue revered neck quest)
+DELETE FROM `creature_queststarter` WHERE `id` = 14905 AND `quest` = 8143;
+INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES (14905, 8143);
+
+DELETE FROM `creature_questender` WHERE `id` = 14905 AND `quest` = 8143;
+INSERT INTO `creature_questender` (`id`, `quest`) VALUES (14905, 8143);
+-- Remove race restrictions. (Rogue exalted neck quest)
+UPDATE `quest_template` SET `AllowableRaces` = 0 WHERE `ID` = 8144;
+
+-- Remove race restrictions. (Paladin exalted neck quest)
+UPDATE `quest_template` SET `AllowableRaces` = 0 WHERE `ID` = 8048;


### PR DESCRIPTION
In the issues, warrior class is mentioned, but It didn't have any issues.
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Add rogue's revered quest and remove race restrictions. 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/12668
- Closes https://github.com/chromiecraft/chromiecraft/issues/3896

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
In wotlk these quests are restricted by class, not race.
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Make a NON Night Elf, Undead or Troll rogue
.level 79
.go c id 14905
.modify rep 270 exalted
Confirm that you can get every neck, starting from friendly, all the way to exalted.
Friendly 19614-> Honored 19615-> Revered19616-> Exalted 19617

Make a NON Blood Elf or Human paladin
.level 79
.go c id 14902
.modify rep 270 exalted
Confirm that you can complete the last quest and receive the exalted neck.


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
