### PR TITLE
fix(DB/creature): Remove 1.X-era mobs from Mirror Lake Orchid

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1677639790735595900.sql
+++ b/data/sql/updates/pending_db_world/rev_1677639790735595900.sql
@@ -1,0 +1,3 @@
+--
+-- Remove 1.X mobs that are not in wotlk
+DELETE FROM creature where guid IN (80391, 80392, 80393, 80394, 80396, 80397, 80399, 80400, 80401, 80402, 80403, 80404, 80405) AND id1 IN(116, 94);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove 1.X-era mobs from Mirror Lake Orchid

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
They exist in 1.12 classic, but not wotlk classic.  The rare mob is still there when it's up.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested locally.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Goto Mirror Lake Orchid (north west of Goldshire)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
