### PR TITLE
fix(DB): Against the Legion requirements

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1677781820338823400.sql
+++ b/data/sql/updates/pending_db_world/rev_1677781820338823400.sql
@@ -1,0 +1,11 @@
+--
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(19, 0, 10641, 0, 1, 47, 0, 10640, 64, 0, 0, 0, 0, '', 'Against the Legion - Require Quest 10640 OR 10689'),
+(19, 0, 10669, 0, 1, 47, 0, 10640, 64, 0, 0, 0, 0, '', 'Against All Odds - Require Quest 10640 OR 10689'),
+(19, 0, 10668, 0, 1, 47, 0, 10640, 64, 0, 0, 0, 0, '', 'Against the Illidari - Require Quest 10640 OR 10689'),
+(19, 0, 10641, 0, 2, 47, 0, 10689, 64, 0, 0, 0, 0, '', 'Against the Legion - Require Quest 10640 OR 10689'),
+(19, 0, 10668, 0, 2, 47, 0, 10689, 64, 0, 0, 0, 0, '', 'Against the Illidari - Require Quest 10640 OR 10689'),
+(19, 0, 10669, 0, 2, 47, 0, 10689, 64, 0, 0, 0, 0, '', 'Against All Odds - Require Quest 10640 OR 10689');
+
+UPDATE `quest_template_addon` SET `PrevQuestID` = 0 WHERE `ID` IN (10641, 10668, 10669);
+UPDATE `quest_template_addon` SET `NextQuestID` = 0 WHERE `NextQuestID` IN (10641, 10668, 10669);

--- a/data/sql/updates/pending_db_world/rev_1677781820338823400.sql
+++ b/data/sql/updates/pending_db_world/rev_1677781820338823400.sql
@@ -1,4 +1,5 @@
 --
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 19 AND `SourceEntry` IN (10641, 10669);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (19, 0, 10641, 0, 1, 47, 0, 10640, 64, 0, 0, 0, 0, '', 'Against the Legion - Require Quest 10640 OR 10689'),
 (19, 0, 10669, 0, 1, 47, 0, 10640, 64, 0, 0, 0, 0, '', 'Against All Odds - Require Quest 10640 OR 10689'),

--- a/data/sql/updates/pending_db_world/rev_1677781820338823400.sql
+++ b/data/sql/updates/pending_db_world/rev_1677781820338823400.sql
@@ -1,5 +1,5 @@
 --
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 19 AND `SourceEntry` IN (10641, 10669);
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 19 AND `SourceEntry` IN (10641, 10668, 10669);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (19, 0, 10641, 0, 1, 47, 0, 10640, 64, 0, 0, 0, 0, '', 'Against the Legion - Require Quest 10640 OR 10689'),
 (19, 0, 10669, 0, 1, 47, 0, 10640, 64, 0, 0, 0, 0, '', 'Against All Odds - Require Quest 10640 OR 10689'),


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Fixes Against the Legion and related quests to appear correctly when requirements are met

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15129
- Closes https://github.com/chromiecraft/chromiecraft/issues/5039

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
See original issue

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in game, works


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

See original issue reports.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
