### PR TITLE
feat(Core/AI): Implement ScheduleHealthCheckEvent() for events that fire …

### DIFF
--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -686,7 +686,7 @@ void BossAI::DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*
  * @param healthPct The health percent at which the code will be executed.
  * @param exec The fuction to be executed.
  */
-void BossAI::SetHealthCheckEvent(uint32 healthPct, std::function<void()> exec)
+void BossAI::ScheduleHealthCheckEvent(uint32 healthPct, std::function<void()> exec)
 {
     _healthCheckEvents.push_back(HealthCheckEventData(healthPct, exec));
 };

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -577,6 +577,7 @@ void BossAI::_Reset()
     events.Reset();
     scheduler.CancelAll();
     summons.DespawnAll();
+    _healthCheckEvents.clear();
     if (instance)
         instance->SetBossState(_bossId, NOT_STARTED);
 }
@@ -586,6 +587,7 @@ void BossAI::_JustDied()
     events.Reset();
     scheduler.CancelAll();
     summons.DespawnAll();
+    _healthCheckEvents.clear();
     if (instance)
     {
         instance->SetBossState(_bossId, DONE);
@@ -665,6 +667,39 @@ void BossAI::UpdateAI(uint32 diff)
     }
 
     DoMeleeAttackIfReady();
+}
+
+void BossAI::DamageTaken(Unit* attacker, uint32& damage, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask)
+{
+    if (!_healthCheckEvents.empty())
+    {
+        _healthCheckEvents.remove_if([&](HealthCheckEventData data) -> bool
+        {
+            return _ProccessHealthCheckEvent(data.healthPct, damage, data.exec);
+        });
+    }
+}
+
+/**
+ * @brief Executes a function once the creature reaches the defined health point percent.
+ *
+ * @param healthPct The health percent at which the code will be executed.
+ * @param exec The fuction to be executed.
+ */
+void BossAI::SetHealthCheckEvent(uint32 healthPct, std::function<void()> exec)
+{
+    _healthCheckEvents.push_back(HealthCheckEventData(healthPct, exec));
+};
+
+bool BossAI::_ProccessHealthCheckEvent(uint8 healthPct, uint32 damage, std::function<void()> exec) const
+{
+    if (me->HealthBelowPctDamaged(healthPct, damage))
+    {
+        exec();
+        return true;
+    }
+
+    return false;
 }
 
 // WorldBossAI - for non-instanced bosses

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -669,7 +669,7 @@ void BossAI::UpdateAI(uint32 diff)
     DoMeleeAttackIfReady();
 }
 
-void BossAI::DamageTaken(Unit* attacker, uint32& damage, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask)
+void BossAI::DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*damagetype*/, SpellSchoolMask /*damageSchoolMask*/)
 {
     if (!_healthCheckEvents.empty())
     {

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -675,7 +675,7 @@ void BossAI::DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*
     {
         _healthCheckEvents.remove_if([&](HealthCheckEventData data) -> bool
         {
-            return _ProccessHealthCheckEvent(data.healthPct, damage, data.exec);
+            return _ProccessHealthCheckEvent(data._healthPct, damage, data._exec);
         });
     }
 }

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -432,7 +432,7 @@ private:
 
 struct HealthCheckEventData
 {
-    HealthCheckEventData(uint8 healthPct, std::function<void()> exec) : _healthPct(_healthPct), _exec(_exec) { };
+    HealthCheckEventData(uint8 healthPct, std::function<void()> exec) : _healthPct(healthPct), _exec(exec) { };
 
     uint8 _healthPct;
     std::function<void()> _exec;

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -432,8 +432,10 @@ private:
 
 struct HealthCheckEventData
 {
-    uint8 healthPct;
-    std::function<void()> exec;
+    HealthCheckEventData(uint8 healthPct, std::function<void()> exec) : _healthPct(_healthPct), _exec(_exec) { };
+
+    uint8 _healthPct;
+    std::function<void()> _exec;
 };
 
 class BossAI : public ScriptedAI

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -430,6 +430,12 @@ private:
     bool _isHeroic;
 };
 
+struct HealthCheckEventData
+{
+    uint8 healthPct;
+    std::function<void()> exec;
+};
+
 class BossAI : public ScriptedAI
 {
 public:
@@ -440,11 +446,14 @@ public:
 
     bool CanRespawn() override;
 
+    void DamageTaken(Unit* attacker, uint32& damage, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask) override;
     void JustSummoned(Creature* summon) override;
     void SummonedCreatureDespawn(Creature* summon) override;
     void SummonedCreatureDespawnAll() override;
 
     void UpdateAI(uint32 diff) override;
+
+    void SetHealthCheckEvent(uint32 healthPct, std::function<void()> exec);
 
     // Hook used to execute events scheduled into EventMap without the need
     // to override UpdateAI
@@ -464,6 +473,7 @@ protected:
     void _JustEngagedWith();
     void _JustDied();
     void _JustReachedHome() { me->setActive(false); }
+    [[nodiscard]] bool _ProccessHealthCheckEvent(uint8 healthPct, uint32 damage, std::function<void()> exec) const;
 
     void TeleportCheaters();
 
@@ -473,6 +483,7 @@ protected:
 
 private:
     uint32 const _bossId;
+    std::list<HealthCheckEventData> _healthCheckEvents;
 };
 
 class WorldBossAI : public ScriptedAI

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -453,7 +453,7 @@ public:
 
     void UpdateAI(uint32 diff) override;
 
-    void SetHealthCheckEvent(uint32 healthPct, std::function<void()> exec);
+    void ScheduleHealthCheckEvent(uint32 healthPct, std::function<void()> exec);
 
     // Hook used to execute events scheduled into EventMap without the need
     // to override UpdateAI

--- a/src/server/scripts/Outland/TempestKeep/botanica/boss_thorngrin_the_tender.cpp
+++ b/src/server/scripts/Outland/TempestKeep/botanica/boss_thorngrin_the_tender.cpp
@@ -44,8 +44,6 @@ enum Events
     EVENT_SACRIFICE             = 1,
     EVENT_HELLFIRE              = 2,
     EVENT_ENRAGE                = 3,
-    EVENT_HEALTH_CHECK_50       = 4,
-    EVENT_HEALTH_CHECK_20       = 5
 };
 
 class boss_thorngrin_the_tender : public CreatureScript
@@ -64,6 +62,12 @@ public:
         void Reset() override
         {
             _Reset();
+            SetHealthCheckEvent(20, [&]() {
+                Talk(SAY_20_PERCENT_HP);
+            });
+            SetHealthCheckEvent(50, [&]() {
+                Talk(SAY_50_PERCENT_HP);
+            });
         }
 
         void MoveInLineOfSight(Unit* who) override
@@ -83,8 +87,6 @@ public:
             events.ScheduleEvent(EVENT_SACRIFICE, 6000);
             events.ScheduleEvent(EVENT_HELLFIRE, 18000);
             events.ScheduleEvent(EVENT_ENRAGE, 15000);
-            events.ScheduleEvent(EVENT_HEALTH_CHECK_50, 500);
-            events.ScheduleEvent(EVENT_HEALTH_CHECK_20, 500);
         }
 
         void KilledUnit(Unit* victim) override
@@ -128,22 +130,6 @@ public:
                     Talk(EMOTE_ENRAGE);
                     me->CastSpell(me, SPELL_ENRAGE, false);
                     events.ScheduleEvent(EVENT_ENRAGE, 30000);
-                    break;
-                case EVENT_HEALTH_CHECK_50:
-                    if (me->HealthBelowPct(50))
-                    {
-                        Talk(SAY_50_PERCENT_HP);
-                        break;
-                    }
-                    events.ScheduleEvent(EVENT_HEALTH_CHECK_50, 500);
-                    break;
-                case EVENT_HEALTH_CHECK_20:
-                    if (me->HealthBelowPct(20))
-                    {
-                        Talk(SAY_20_PERCENT_HP);
-                        break;
-                    }
-                    events.ScheduleEvent(EVENT_HEALTH_CHECK_20, 500);
                     break;
             }
 

--- a/src/server/scripts/Outland/TempestKeep/botanica/boss_thorngrin_the_tender.cpp
+++ b/src/server/scripts/Outland/TempestKeep/botanica/boss_thorngrin_the_tender.cpp
@@ -62,10 +62,10 @@ public:
         void Reset() override
         {
             _Reset();
-            SetHealthCheckEvent(20, [&]() {
+            ScheduleHealthCheckEvent(20, [&]() {
                 Talk(SAY_20_PERCENT_HP);
             });
-            SetHealthCheckEvent(50, [&]() {
+            ScheduleHealthCheckEvent(50, [&]() {
                 Talk(SAY_50_PERCENT_HP);
             });
         }


### PR DESCRIPTION
…upon being damaged past a certain health percent

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Implement SetHealthCheckEvents() for events that fire upon being damaged past a certain health percent
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame with the script provided (the botanica, thorngrin)
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. pull boss
2. damage to 50%
3. damage to 20%
4. notice nothing bad happens and still says his text

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
