### PR TITLE
fix (Core/Spells) Correct Life Tap mana gain and cleanup

### DIFF
--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -773,7 +773,7 @@ class spell_warl_life_tap : public SpellScript
         if (Unit* target = GetHitUnit())
         {
             int32 spellEffect = GetEffectValue();
-            int32 damage = spellEffect + (caster->GetStat(STAT_SPIRIT) * 1.5f);
+            int32 damage = spellEffect;
             int32 mana = int32(spellEffect + (caster->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_SHADOW) * 0.5f));
             
             // Shouldn't Appear in Combat Log
@@ -800,7 +800,7 @@ class spell_warl_life_tap : public SpellScript
 
     SpellCastResult CheckCast()
     {
-        if ((int32(GetCaster()->GetHealth()) > int32(GetSpellInfo()->Effects[EFFECT_0].CalcValue() + (GetCaster()->GetStat(STAT_SPIRIT) * 1.5f))))
+        if ((int32(GetCaster()->GetHealth()) > int32(GetSpellInfo()->Effects[EFFECT_0].CalcValue())))
             return SPELL_CAST_OK;
         return SPELL_FAILED_FIZZLE;
     }

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -753,7 +753,6 @@ class spell_warl_siphon_life : public AuraScript
 };
 
 // -1454 - Life Tap
-#define LIFE_TAP_COEFFICIENT 0.9F
 class spell_warl_life_tap : public SpellScript
 {
     PrepareSpellScript(spell_warl_life_tap);
@@ -773,10 +772,10 @@ class spell_warl_life_tap : public SpellScript
         Player* caster = GetCaster()->ToPlayer();
         if (Unit* target = GetHitUnit())
         {
-            int32 damage = GetEffectValue() + LIFE_TAP_COEFFICIENT;
-            int32 damage2Mana = GetEffectValue();
-            int32 mana = int32(damage2Mana + (caster->GetInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + static_cast<uint8>(SPELL_SCHOOL_SHADOW)) * 0.5f));
-
+            int32 spellEffect = GetEffectValue();
+            int32 damage = spellEffect + (caster->GetStat(STAT_SPIRIT) * 1.5f);
+            int32 mana = int32(spellEffect + (caster->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_SHADOW) * 0.5f));
+            
             // Shouldn't Appear in Combat Log
             target->ModifyHealth(-damage);
 
@@ -801,10 +800,11 @@ class spell_warl_life_tap : public SpellScript
 
     SpellCastResult CheckCast()
     {
-        if ((int32(GetCaster()->GetHealth()) > int32(GetSpellInfo()->Effects[EFFECT_0].CalcValue() + (3.1 * GetSpellInfo()->BaseLevel) + LIFE_TAP_COEFFICIENT )))
+        if ((int32(GetCaster()->GetHealth()) > int32(GetSpellInfo()->Effects[EFFECT_0].CalcValue() + (GetCaster()->GetStat(STAT_SPIRIT) * 1.5f))))
             return SPELL_CAST_OK;
         return SPELL_FAILED_FIZZLE;
     }
+
 
     void Register() override
     {

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -805,7 +805,6 @@ class spell_warl_life_tap : public SpellScript
         return SPELL_FAILED_FIZZLE;
     }
 
-
     void Register() override
     {
         OnEffectHitTarget += SpellEffectFn(spell_warl_life_tap::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -773,11 +773,10 @@ class spell_warl_life_tap : public SpellScript
         if (Unit* target = GetHitUnit())
         {
             int32 spellEffect = GetEffectValue();
-            int32 damage = spellEffect;
             int32 mana = int32(spellEffect + (caster->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_SHADOW) * 0.5f));
 
             // Shouldn't Appear in Combat Log
-            target->ModifyHealth(-damage);
+            target->ModifyHealth(-spellEffect);
 
             // Improved Life Tap mod
             if (AuraEffect const* aurEff = caster->GetDummyAuraEffect(SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_IMPROVED_LIFE_TAP, 0))

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -775,7 +775,7 @@ class spell_warl_life_tap : public SpellScript
             int32 spellEffect = GetEffectValue();
             int32 damage = spellEffect;
             int32 mana = int32(spellEffect + (caster->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_SHADOW) * 0.5f));
-            
+
             // Shouldn't Appear in Combat Log
             target->ModifyHealth(-damage);
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove extra 0.9f added to health cost
-  Adjusted fizzle calculation to be the same as health cost
- Use SpellBaseDamageBonusDone() to get the casters shadow spellpower

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Used various ranks of life tap at hp cost and hp cost +1 to test the fizzle
- Used various ranks of life tap with different amounts of (shadow)spellpower to see that restores the correct amount of mana


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
.learn 27222
.mod hp 1124
cast Life Tap -> Fizzle
.mod hp 1125
cast Life Tap -> Works

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
