### PR TITLE
chore(Core/Scripts): Use serverside spell instead of SummonCreature for Nether-wraith Beacon

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1678042235460663800.sql
+++ b/data/sql/updates/pending_db_world/rev_1678042235460663800.sql
@@ -1,0 +1,6 @@
+--
+UPDATE `spell_dbc` SET `Effect_1` = 28, `EffectMiscValueB_1` = 64, `EffectBasePoints_1` = 0 WHERE `ID` = 39111;
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceEntry` = 39105)
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(17, 0, 39105, 0, 0, 47, 0, 10832, 8, 0, 0, 0, 0, '', 'Player can only use Nether-wraith Beacon (31742) while quest Becoming a Spellfire Tailor (10832) is in progress');

--- a/data/sql/updates/pending_db_world/rev_1678042235460663800.sql
+++ b/data/sql/updates/pending_db_world/rev_1678042235460663800.sql
@@ -1,6 +1,6 @@
 --
 UPDATE `spell_dbc` SET `Effect_1` = 28, `EffectMiscValueB_1` = 64, `EffectBasePoints_1` = 0 WHERE `ID` = 39111;
 
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceEntry` = 39105)
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceEntry` = 39105);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (17, 0, 39105, 0, 0, 47, 0, 10832, 8, 0, 0, 0, 0, '', 'Player can only use Nether-wraith Beacon (31742) while quest Becoming a Spellfire Tailor (10832) is in progress');

--- a/data/sql/updates/pending_db_world/rev_1678042235460663800.sql
+++ b/data/sql/updates/pending_db_world/rev_1678042235460663800.sql
@@ -4,3 +4,5 @@ UPDATE `spell_dbc` SET `Effect_1` = 28, `EffectMiscValueB_1` = 64, `EffectBasePo
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceEntry` = 39105);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (17, 0, 39105, 0, 0, 47, 0, 10832, 8, 0, 0, 0, 0, '', 'Player can only use Nether-wraith Beacon (31742) while quest Becoming a Spellfire Tailor (10832) is in progress');
+
+UPDATE `item_template` SET `ScriptName` = '' WHERE (`entry` = 31742);

--- a/src/server/scripts/World/item_scripts.cpp
+++ b/src/server/scripts/World/item_scripts.cpp
@@ -23,7 +23,6 @@ SDCategory: Items
 EndScriptData */
 
 /* ContentData
-item_nether_wraith_beacon(i31742)   Summons creatures for quest Becoming a Spellfire Tailor (q10832)
 item_flying_machine(i34060, i34061)  Engineering crafted flying machines
 item_gor_dreks_ointment(i30175)     Protecting Our Own(q10488)
 item_only_for_flight                Items which should only useable while flying
@@ -77,29 +76,6 @@ public:
         // error
         player->SendEquipError(EQUIP_ERR_CANT_DO_RIGHT_NOW, item, nullptr);
         return true;
-    }
-};
-
-/*#####
-# item_nether_wraith_beacon
-#####*/
-
-class item_nether_wraith_beacon : public ItemScript
-{
-public:
-    item_nether_wraith_beacon() : ItemScript("item_nether_wraith_beacon") { }
-
-    bool OnUse(Player* player, Item* /*item*/, SpellCastTargets const& /*targets*/) override
-    {
-        if (player->GetQuestStatus(10832) == QUEST_STATUS_INCOMPLETE)
-        {
-            if (Creature* nether = player->SummonCreature(22408, player->GetPositionX(), player->GetPositionY() + 20, player->GetPositionZ(), 0, TEMPSUMMON_TIMED_DESPAWN, 180000))
-                nether->AI()->AttackStart(player);
-
-            if (Creature* nether = player->SummonCreature(22408, player->GetPositionX(), player->GetPositionY() - 20, player->GetPositionZ(), 0, TEMPSUMMON_TIMED_DESPAWN, 180000))
-                nether->AI()->AttackStart(player);
-        }
-        return false;
     }
 };
 
@@ -272,7 +248,6 @@ public:
 void AddSC_item_scripts()
 {
     new item_only_for_flight();
-    new item_nether_wraith_beacon();
     new item_gor_dreks_ointment();
     new item_incendiary_explosives();
     new item_mysterious_egg();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Changes from script to serverside spell
-  Attempts to fix exploit around it as well

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.quest add 10832`
2. use item in `.tele Netherstorm`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
