### PR TITLE
fix(db/creature_template): Remove creature 138

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1678062827982837200.sql
+++ b/data/sql/updates/pending_db_world/rev_1678062827982837200.sql
@@ -1,0 +1,3 @@
+--
+-- This entry should not exist and appears to serve no purpose
+DELETE FROM `creature_template` WHERE `entry`=138;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes creature 138
-  Just look at this thing, what's it doing?  be gone.
 https://wowgaming.altervista.org/aowow/?npc=138

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
This doesn't exist anywhere, nor should it.  If you can prove me wrong I'd be very interested to see it.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
