### PR TITLE
fix(DB/Movement): Unpopulated rows from previous PRs.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1678084806976383500.sql
+++ b/data/sql/updates/pending_db_world/rev_1678084806976383500.sql
@@ -1,0 +1,9 @@
+-- Sindragosa (NullCreature)
+DELETE FROM `creature_template_movement` WHERE `CreatureId` = 37755;
+INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES
+(37755, 0, 0, 2, 0, 0, 0, 0);
+
+-- Column Ornament
+DELETE FROM `creature_template_movement` WHERE `CreatureId` = 29754;
+INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES
+(29754, 0, 0, 1, 0, 0, 0, 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

Didn't even notice they were empty . . . (Was updating empty rows)
https://github.com/azerothcore/azerothcore-wotlk/pull/15160/files#diff-932bbc99b527b7ea8aa199559d97615d26286f877a2e0b4a20f3ef9c170768bdR135
https://github.com/azerothcore/azerothcore-wotlk/pull/15087/files#diff-b4a6ffc3678affd0f162d0c946212920a31b9da6f455cca754d7519aad465a10R8

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
