### PR TITLE
refactor(Utilities/TaskScheduler): Use randtime instead a custom method

### DIFF
--- a/src/common/Utilities/TaskScheduler.h
+++ b/src/common/Utilities/TaskScheduler.h
@@ -235,7 +235,7 @@ public:
     TaskScheduler& Schedule(std::chrono::duration<_RepLeft, _PeriodLeft> const& min,
                             std::chrono::duration<_RepRight, _PeriodRight> const& max, task_handler_t const& task)
     {
-        return Schedule(RandomDurationBetween(min, max), task);
+        return Schedule(randtime(min, max), task);
     }
 
     /// Schedule an event with a fixed rate.
@@ -245,7 +245,7 @@ public:
                             std::chrono::duration<_RepRight, _PeriodRight> const& max, group_t const group,
                             task_handler_t const& task)
     {
-        return Schedule(RandomDurationBetween(min, max), group, task);
+        return Schedule(randtime(min, max), group, task);
     }
 
     /// Cancels all tasks.
@@ -277,7 +277,7 @@ public:
     TaskScheduler& DelayAll(std::chrono::duration<_RepLeft, _PeriodLeft> const& min,
                             std::chrono::duration<_RepRight, _PeriodRight> const& max)
     {
-        return DelayAll(RandomDurationBetween(min, max));
+        return DelayAll(randtime(min, max));
     }
 
     /// Delays all tasks of a group with the given duration.
@@ -305,7 +305,7 @@ public:
                               std::chrono::duration<_RepLeft, _PeriodLeft> const& min,
                               std::chrono::duration<_RepRight, _PeriodRight> const& max)
     {
-        return DelayGroup(group, RandomDurationBetween(min, max));
+        return DelayGroup(group, randtime(min, max));
     }
 
     /// Reschedule all tasks with a given duration.
@@ -326,7 +326,7 @@ public:
     TaskScheduler& RescheduleAll(std::chrono::duration<_RepLeft, _PeriodLeft> const& min,
                                  std::chrono::duration<_RepRight, _PeriodRight> const& max)
     {
-        return RescheduleAll(RandomDurationBetween(min, max));
+        return RescheduleAll(randtime(min, max));
     }
 
     /// Reschedule all tasks of a group with the given duration.
@@ -355,7 +355,7 @@ public:
                                    std::chrono::duration<_RepLeft, _PeriodLeft> const& min,
                                    std::chrono::duration<_RepRight, _PeriodRight> const& max)
     {
-        return RescheduleGroup(group, RandomDurationBetween(min, max));
+        return RescheduleGroup(group, randtime(min, max));
     }
 
 private:
@@ -378,18 +378,6 @@ private:
     {
         static repeated_t const DEFAULT_REPEATED = 0;
         return InsertTask(TaskContainer(new Task(end + time, time, group, DEFAULT_REPEATED, task)));
-    }
-
-    // Returns a random duration between min and max
-    template<class _RepLeft, class _PeriodLeft, class _RepRight, class _PeriodRight>
-    static std::chrono::milliseconds RandomDurationBetween(std::chrono::duration<_RepLeft, _PeriodLeft> const& min,
-            std::chrono::duration<_RepRight, _PeriodRight> const& max)
-    {
-        auto const milli_min = std::chrono::duration_cast<std::chrono::milliseconds>(min);
-        auto const milli_max = std::chrono::duration_cast<std::chrono::milliseconds>(max);
-
-        // TC specific: use SFMT URandom
-        return std::chrono::milliseconds(urand(uint32(milli_min.count()), uint32(milli_max.count())));
     }
 
     /// Dispatch remaining tasks
@@ -495,7 +483,7 @@ public:
     TaskContext& Repeat(std::chrono::duration<_RepLeft, _PeriodLeft> const& min,
                         std::chrono::duration<_RepRight, _PeriodRight> const& max)
     {
-        return Repeat(TaskScheduler::RandomDurationBetween(min, max));
+        return Repeat(randtime(min, max));
     }
 
     /// Schedule a callable function that is executed at the next update tick from within the context.
@@ -540,7 +528,7 @@ public:
     TaskContext& Schedule(std::chrono::duration<_RepLeft, _PeriodLeft> const& min,
                           std::chrono::duration<_RepRight, _PeriodRight> const& max, TaskScheduler::task_handler_t const& task)
     {
-        return Schedule(TaskScheduler::RandomDurationBetween(min, max), task);
+        return Schedule(randtime(min, max), task);
     }
 
     /// Schedule an event with a randomized rate between min and max rate from within the context.
@@ -552,7 +540,7 @@ public:
                           std::chrono::duration<_RepRight, _PeriodRight> const& max, TaskScheduler::group_t const group,
                           TaskScheduler::task_handler_t const& task)
     {
-        return Schedule(TaskScheduler::RandomDurationBetween(min, max), group, task);
+        return Schedule(randtime(min, max), group, task);
     }
 
     /// Cancels all tasks from within the context.
@@ -577,7 +565,7 @@ public:
     TaskContext& DelayAll(std::chrono::duration<_RepLeft, _PeriodLeft> const& min,
                           std::chrono::duration<_RepRight, _PeriodRight> const& max)
     {
-        return DelayAll(TaskScheduler::RandomDurationBetween(min, max));
+        return DelayAll(randtime(min, max));
     }
 
     /// Delays all tasks of a group with the given duration from within the context.
@@ -593,7 +581,7 @@ public:
                             std::chrono::duration<_RepLeft, _PeriodLeft> const& min,
                             std::chrono::duration<_RepRight, _PeriodRight> const& max)
     {
-        return DelayGroup(group, TaskScheduler::RandomDurationBetween(min, max));
+        return DelayGroup(group, randtime(min, max));
     }
 
     /// Reschedule all tasks with the given duration.
@@ -608,7 +596,7 @@ public:
     TaskContext& RescheduleAll(std::chrono::duration<_RepLeft, _PeriodLeft> const& min,
                                std::chrono::duration<_RepRight, _PeriodRight> const& max)
     {
-        return RescheduleAll(TaskScheduler::RandomDurationBetween(min, max));
+        return RescheduleAll(randtime(min, max));
     }
 
     /// Reschedule all tasks of a group with the given duration.
@@ -624,7 +612,7 @@ public:
                                  std::chrono::duration<_RepLeft, _PeriodLeft> const& min,
                                  std::chrono::duration<_RepRight, _PeriodRight> const& max)
     {
-        return RescheduleGroup(group, TaskScheduler::RandomDurationBetween(min, max));
+        return RescheduleGroup(group, randtime(min, max));
     }
 
 private:


### PR DESCRIPTION


<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change RandomDurationBetween to randtime

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
* Cherry-pick: https://github.com/TrinityCore/TrinityCore/commit/f773bf68e0f96a97b706f366da4071ba28060b04

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- None
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Test with a boss and look if there are no issue
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
