### PR TITLE
fix(DB/Creature): Avatar of Sathal missing text.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1678173710393604400.sql
+++ b/data/sql/updates/pending_db_world/rev_1678173710393604400.sql
@@ -1,0 +1,11 @@
+-- Avatar of Sathal
+DELETE FROM `creature_text` WHERE `CreatureID`=21925;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(21925, 0, 0, 'Feel my wrath, $r scum!  You will not get away with this!', 14, 0, 100, 0, 0, 0, 19598, 0, 'Avatar of Sathal SAY_AGGRO');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 21925);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(21925, 0, 0, 1, 54, 0, 100, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - On Just Summoned - Start Attacking'),
+(21925, 0, 1, 0, 61, 0, 100, 257, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - On Just Summoned - Say Line 0'),
+(21925, 0, 2, 0, 0, 0, 100, 0, 2300, 3000, 8700, 9000, 0, 11, 12471, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - In Combat - Cast \'Shadow Bolt\''),
+(21925, 0, 3, 0, 2, 0, 100, 1, 20, 80, 0, 0, 0, 11, 34017, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - Between 20-80% Health - Cast \'Rain of Chaos\' (No Repeat)');

--- a/data/sql/updates/pending_db_world/rev_1678173710393604400.sql
+++ b/data/sql/updates/pending_db_world/rev_1678173710393604400.sql
@@ -6,6 +6,6 @@ INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Lan
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 21925);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (21925, 0, 0, 1, 54, 0, 100, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - On Just Summoned - Start Attacking'),
-(21925, 0, 1, 0, 61, 0, 100, 257, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - On Just Summoned - Say Line 0'),
+(21925, 0, 1, 0, 61, 0, 100, 257, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - On Just Summoned - Say Line 0 (No Repeat/Reset)'),
 (21925, 0, 2, 0, 0, 0, 100, 0, 2300, 3000, 8700, 9000, 0, 11, 12471, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - In Combat - Cast \'Shadow Bolt\''),
 (21925, 0, 3, 0, 2, 0, 100, 1, 20, 80, 0, 0, 0, 11, 34017, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - Between 20-80% Health - Cast \'Rain of Chaos\' (No Repeat)');

--- a/data/sql/updates/pending_db_world/rev_1678173710393604400.sql
+++ b/data/sql/updates/pending_db_world/rev_1678173710393604400.sql
@@ -8,4 +8,4 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (21925, 0, 0, 1, 54, 0, 100, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - On Just Summoned - Start Attacking'),
 (21925, 0, 1, 0, 61, 0, 100, 257, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - On Just Summoned - Say Line 0 (No Repeat/Reset)'),
 (21925, 0, 2, 0, 0, 0, 100, 0, 2300, 3000, 8700, 9000, 0, 11, 12471, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - In Combat - Cast \'Shadow Bolt\''),
-(21925, 0, 3, 0, 2, 0, 100, 1, 20, 80, 0, 0, 0, 11, 34017, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - Between 20-80% Health - Cast \'Rain of Chaos\' (No Repeat)');
+(21925, 0, 3, 0, 0, 0, 100, 0, 6000, 12000, 12000, 17000, 0, 11, 34017, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Avatar of Sathal - In Combat - Cast \'Rain of Chaos\'');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Added aggro on spawn and missing text (said only once, on spawn)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13917

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://youtu.be/U3wXnt4YS2w?t=204
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.additem 30850
.go xyz 4716.976074 3336.434326 191.614655 530
Use the item, mob will aggro on spawn and say the line.
Leave combat without killing the npc, aggro again, will not say the line again.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
