### PR TITLE
fix(Scripts/Creature): Fel Guard Hound not despawning.

### DIFF
--- a/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
+++ b/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
@@ -329,7 +329,8 @@ public:
 enum FelGuard
 {
     SPELL_SUMMON_POO            = 37688,
-    NPC_DERANGED_HELBOAR        = 16863
+    NPC_DERANGED_HELBOAR        = 16863,
+    QUEST_SHIZZ_WORK            = 10629,
 };
 
 class npc_fel_guard_hound : public CreatureScript
@@ -358,7 +359,7 @@ public:
                 DoCast(SPELL_SUMMON_POO);
 
                 if (Player* owner = me->GetCharmerOrOwnerPlayerOrPlayerItself())
-                    me->GetMotionMaster()->MoveFollow(owner, 0.0f, 0.0f);
+                    me->GetMotionMaster()->MoveFollow(owner, 1.0f, 90.0f);
             }
         }
 
@@ -372,6 +373,13 @@ public:
                     {
                         helboarGUID = helboar->GetGUID();
                         me->GetMotionMaster()->MovePoint(1, helboar->GetPositionX(), helboar->GetPositionY(), helboar->GetPositionZ());
+                    }
+                }
+                if (Player* owner = me->GetCharmerOrOwnerPlayerOrPlayerItself())
+                {
+                    if (!owner->HasQuest(QUEST_SHIZZ_WORK))
+                    {
+                        me->DespawnOrUnsummon();
                     }
                 }
                 checkTimer = 5000;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Fix MoveFollow distance and angle
- (On the same check as search for boars) - Despawn if owner doesn't have the quest.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/14294
- Closes https://github.com/chromiecraft/chromiecraft/issues/4595

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.go c 58690
.quest add 10629
Use item
Notice the hound following you like a pet.
Kill some boars, abandon quest or finish it, hound should despawn within 5s.


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
