### PR TITLE
fix(db/loot): Fix Aeonus Normal Loot Drops

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1678529764517694100.sql
+++ b/data/sql/updates/pending_db_world/rev_1678529764517694100.sql
@@ -1,0 +1,20 @@
+--
+-- Revamp Aeonus Tables
+DELETE FROM `reference_loot_template` WHERE Entry IN (35004);
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
+(35004, 27509, 0, 0, 0, 1, 2, 1, 1, 'Handgrips of Assassination'),
+(35004, 27839, 0, 0, 0, 1, 2, 1, 1, 'Legplates of the Righteous'),
+(35004, 27873, 0, 0, 0, 1, 2, 1, 1, 'Moonglade Pants'),
+(35004, 27977, 0, 0, 0, 1, 2, 1, 1, 'Legplates of the Bold'),
+(35004, 28194, 0, 0, 0, 1, 2, 1, 1, 'Primal Surge Bracers'),
+(35004, 28207, 0, 0, 0, 1, 2, 1, 1, 'Pauldrons of the Crimson Flight'),
+(35004, 28188, 0, 0, 0, 1, 3, 1, 1, 'Bloodfire Greatstaff'),
+(35004, 28189, 0, 0, 0, 1, 3, 1, 1, 'Latro\'s Shifting Sword'),
+(35004, 28190, 0, 0, 0, 1, 3, 1, 1, 'Scarab of the Infinite Cycle'),
+(35004, 28192, 0, 0, 0, 1, 3, 1, 1, 'Helm of Desolation'),
+(35004, 28193, 0, 0, 0, 1, 3, 1, 1, 'Mana-Etched Crown'),
+(35004, 28206, 0, 0, 0, 1, 3, 1, 1, 'Cowl of the Guiltless');
+-- Insert 2nd loot drop
+DELETE FROM `creature_loot_template` WHERE `Entry`=17881 AND `Item`=35007 AND `GroupId`=3;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
+(17881, 35004, 35004, 100, 0, 1, 3, 1, 1, 'Aeonus High Value Table - (ReferenceTable)');


### PR DESCRIPTION
Aeonus should drop two pieces of gear as set

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Splits Aeonus loot into two categories and creates an entry so 1 of each category drops  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5153

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Linked in issue, also I found more videos to establish this as the correct separation in the table 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested locally, works great



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Kill Aeonus (17881):  .npc add 17881  .damage 237482323 or something
2. Loot
3. .respawn and repeat if desired 

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
