### PR TITLE
fix(db/loot): Fix Warp splinter Normal Loot Drops

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1678614761475144800.sql
+++ b/data/sql/updates/pending_db_world/rev_1678614761475144800.sql
@@ -1,6 +1,6 @@
 --
 -- Repair Warp Splinter Loot Table
-UPDATE `reference_loot_template` SET `GroupId`='3' WHERE `Entry`=35006 AND `Item` IN (28370, 28367, 28371, 28348, 28350, 28349);
-UPDATE `creature_loot_template` SET `MaxCount`='1' WHERE `Entry`=17977 AND `Item`=35006 AND `Reference`=35006 AND `GroupId`=2;
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=35006 AND `Item` IN (28370, 28367, 28371, 28348, 28350, 28349);
+UPDATE `creature_loot_template` SET `MaxCount`=1 WHERE `Entry`=17977 AND `Item`=35006 AND `Reference`=35006 AND `GroupId`=2;
 DELETE FROM `creature_loot_template` WHERE  `Entry`=17977 AND `Item`=35006 AND `Reference`=35006 AND `GroupId`=3;
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (17977, 35006, 35006, 100, 0, 1, 3, 1, 1, 'Warp Splinter High Value Table - (ReferenceTable)');

--- a/data/sql/updates/pending_db_world/rev_1678614761475144800.sql
+++ b/data/sql/updates/pending_db_world/rev_1678614761475144800.sql
@@ -1,0 +1,6 @@
+--
+-- Repair Warp Splinter Loot Table
+UPDATE `reference_loot_template` SET `GroupId`='3' WHERE `Entry`=35006 AND `Item` IN (28370, 28367, 28371, 28348, 28350, 28349);
+UPDATE `creature_loot_template` SET `MaxCount`='1' WHERE `Entry`=17977 AND `Item`=35006 AND `Reference`=35006 AND `GroupId`=2;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=17977 AND `Item`=35006 AND `Reference`=35006 AND `GroupId`=3;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (17977, 35006, 35006, 100, 0, 1, 3, 1, 1, 'Warp Splinter High Value Table - (ReferenceTable)');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Solves/corrects Warp Splinter loot in similar manner to Aeonus
- 2 items drop every time now instead of 1-2 items

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
both YT videos/and logical sorting of wowhead drops agree with this sorting

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- spawned and killed it locally since I changed the SQL a bit from last time to take up less lines (though its basically the same, I wanted to be sure)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  .npc add 17977 .damage 43284324 
2.  loot it
3.  .respawn as much as desired

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
