### PR TITLE
fix(Scripts/Achievement: Fixed Flirt With Disaster achievement. Sourc…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1678624060512397500.sql
+++ b/data/sql/updates/pending_db_world/rev_1678624060512397500.sql
@@ -1,0 +1,21 @@
+--
+DELETE FROM `achievement_criteria_data` WHERE `criteria_id` IN (3931,12859,4227,3929);
+INSERT INTO `achievement_criteria_data` (`criteria_id`,`type`,`value1`,`value2`,`ScriptName`) VALUES
+-- aliance
+-- Kissed Sraaz
+(3931,1,9099,0,''),
+(3931,11,0,0,'achievement_flirt_with_disaster_perf_check'),
+(3931,15,3,0,''),
+-- Handful of Rose Petals on Sraaz
+(12859,1,9099,0,''),
+(12859,11,0,0,'achievement_flirt_with_disaster_perf_check'),
+(12859,15,3,0,''),
+-- horde
+-- Kissed Jeremiah Payson
+(3929,1,8403,0,''),
+(3929,11,0,0,'achievement_flirt_with_disaster_perf_check'),
+(3929,15,3,0,''),
+-- Handful of Rose Petals on Jeremiah Payson
+(4227,1,8403,0,''),
+(4227,11,0,0,'achievement_flirt_with_disaster_perf_check'),
+(4227,15,3,0,'');

--- a/src/server/scripts/World/achievement_scripts.cpp
+++ b/src/server/scripts/World/achievement_scripts.cpp
@@ -275,7 +275,6 @@ class achievement_flirt_with_disaster_perf_check : public AchievementCriteriaScr
         }
 };
 
-
 void AddSC_achievement_scripts()
 {
     new achievement_resilient_victory();

--- a/src/server/scripts/World/achievement_scripts.cpp
+++ b/src/server/scripts/World/achievement_scripts.cpp
@@ -263,7 +263,7 @@ class achievement_flirt_with_disaster_perf_check : public AchievementCriteriaScr
     public:
         achievement_flirt_with_disaster_perf_check() : AchievementCriteriaScript("achievement_flirt_with_disaster_perf_check") { }
 
-        bool OnCheck(Player* player, Unit* target, uint32 /*criteria_id*/) override
+        bool OnCheck(Player* player, Unit* /*target*/, uint32 /*criteria_id*/) override
         {
             if (!player)
                 return false;

--- a/src/server/scripts/World/achievement_scripts.cpp
+++ b/src/server/scripts/World/achievement_scripts.cpp
@@ -251,6 +251,31 @@ public:
     }
 };
 
+enum FlirtWithDisaster
+{
+    AURA_PERFUME_FOREVER           = 70235,
+    AURA_PERFUME_ENCHANTRESS       = 70234,
+    AURA_PERFUME_VICTORY           = 70233,
+};
+
+class achievement_flirt_with_disaster_perf_check : public AchievementCriteriaScript
+{
+    public:
+        achievement_flirt_with_disaster_perf_check() : AchievementCriteriaScript("achievement_flirt_with_disaster_perf_check") { }
+
+        bool OnCheck(Player* player, Unit* target, uint32 /*criteria_id*/) override
+        {
+            if (!player)
+                return false;
+
+            if (player->HasAura(AURA_PERFUME_FOREVER) || player->HasAura(AURA_PERFUME_ENCHANTRESS) || player->HasAura(AURA_PERFUME_VICTORY))
+                return true;
+
+            return false;
+        }
+};
+
+
 void AddSC_achievement_scripts()
 {
     new achievement_resilient_victory();
@@ -270,4 +295,5 @@ void AddSC_achievement_scripts()
     new achievement_tilted();
     new achievement_not_even_a_scratch();
     new achievement_killed_exp_or_honor_target();
+    new achievement_flirt_with_disaster_perf_check();
 }


### PR DESCRIPTION
…e: TrinityCore.

Fixes #10585

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #10585
- Closes https://github.com/chromiecraft/chromiecraft/issues/2987

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.event start 8`
`.go creature 31804`
`.mod drunk 100`
Put on [["Enchantress" Perfume]](https://wowgaming.altervista.org/aowow/?item=49857).
Used [[Handful of Rose Petals]](https://wowgaming.altervista.org/aowow/?item=22218) on [Jeremiah Payson](https://wowgaming.altervista.org/aowow/?npc=8403)
/kiss on Jeremiah Payson

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
