### PR TITLE
fix(Scripts/BlackMorass): Don't pick the same rift spot in succession

### DIFF
--- a/src/server/scripts/Kalimdor/CavernsOfTime/TheBlackMorass/instance_the_black_morass.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/TheBlackMorass/instance_the_black_morass.cpp
@@ -150,7 +150,7 @@ public:
                             _canSpawnPortal = true;
                         });
 
-                        ScheduleNextPortal(2min + 30s);
+                        ScheduleNextPortal(2min + 30s, Position(0.0f, 0.0f, 0.0f, 0.0f));
                         break;
                     }
                     default:
@@ -173,11 +173,11 @@ public:
             player->SendUpdateWorldState(WORLD_STATE_BM_RIFT, _currentRift);
         }
 
-        void ScheduleNextPortal(Milliseconds time)
+        void ScheduleNextPortal(Milliseconds time, Position lastPosition)
         {
             _scheduler.CancelGroup(CONTEXT_GROUP_RIFTS);
 
-            _scheduler.Schedule(time, [this](TaskContext context)
+            _scheduler.Schedule(time, [this, lastPosition](TaskContext context)
             {
                 if (GetCreature(DATA_MEDIVH))
                 {
@@ -190,7 +190,18 @@ public:
                     Position spawnPos;
                     if (!_availableRiftPositions.empty())
                     {
-                        spawnPos = Acore::Containers::SelectRandomContainerElement(_availableRiftPositions);
+                        if (_availableRiftPositions.size() > 1)
+                        {
+                            spawnPos = Acore::Containers::SelectRandomContainerElementIf(_availableRiftPositions, [&](Position pos) -> bool
+                            {
+                                return pos != lastPosition;
+                            });
+                        }
+                        else
+                        {
+                            spawnPos = Acore::Containers::SelectRandomContainerElement(_availableRiftPositions);
+                        }
+
                         _availableRiftPositions.remove(spawnPos);
 
                         DoUpdateWorldState(WORLD_STATE_BM_RIFT, ++_currentRift);
@@ -254,13 +265,13 @@ public:
                 case NPC_TIME_RIFT:
                     if (_currentRift < 18)
                     {
-                        if (!_availableRiftPositions.empty() && _availableRiftPositions.size() < 3)
+                        if (_availableRiftPositions.size() < 3)
                         {
-                            ScheduleNextPortal((_currentRift >= 13 ? 2min : 90s));
+                            ScheduleNextPortal((_currentRift >= 13 ? 2min : 90s), creature->GetHomePosition());
                         }
                         else
                         {
-                            ScheduleNextPortal(4s);
+                            ScheduleNextPortal(1s, creature->GetHomePosition());
                         }
                     }
 
@@ -301,7 +312,7 @@ public:
                     DoUpdateWorldState(WORLD_STATE_BM_SHIELD, _shieldPercent);
                     DoUpdateWorldState(WORLD_STATE_BM_RIFT, _currentRift);
 
-                    ScheduleNextPortal(3s);
+                    ScheduleNextPortal(3s, Position(0.0f, 0.0f, 0.0f, 0.0f));
 
                     for (ObjectGuid const& guid : _encounterNPCs)
                     {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5156

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
