### PR TITLE
fix(DB/SAI): Mosh'Ogg Spellcrafter spmming flamestrike.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1678786830366844800.sql
+++ b/data/sql/updates/pending_db_world/rev_1678786830366844800.sql
@@ -1,0 +1,7 @@
+-- Mosh'Ogg Spellcrafter
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 710;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(710, 0, 0, 0, 4, 0, 15, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Mosh\'Ogg Spellcrafter - On Aggro - Say Line 0'),
+(710, 0, 1, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 11, 12544, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mosh\'Ogg Spellcrafter - On Reset - Cast \'Frost Armor\''),
+(710, 0, 2, 0, 0, 0, 100, 0, 0, 0, 5000, 6000, 0, 11, 9053, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Mosh\'Ogg Spellcrafter - In Combat - Cast \'Fireball\''),
+(710, 0, 3, 0, 0, 0, 100, 0, 7000, 8000, 9000, 12000, 0, 11, 11829, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Mosh\'Ogg Spellcrafter - In Combat - Cast \'Flamestrike\'');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Correct SAI timers

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/4935

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
tc/mangos, same timer for spells
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.go c id 710
Notice they don't use flamestrike after every fireball.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
