### PR TITLE
Core/GameObjects: Use serverOnly property of GameObjectTemplate for a…

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1252,7 +1252,7 @@ bool GameObject::IsNeverVisible() const
     if (WorldObject::IsNeverVisible())
         return true;
 
-    if (GetGoType()->GetServerOnly())
+    if (GetGOInfo()->GetServerOnly())
         return true;
 
     return false;

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1252,7 +1252,7 @@ bool GameObject::IsNeverVisible() const
     if (WorldObject::IsNeverVisible())
         return true;
 
-    if (GetGoType() == GAMEOBJECT_TYPE_SPELL_FOCUS && GetGOInfo()->spellFocus.serverOnly == 1)
+    if (GetGoType()->GetServerOnly())
         return true;
 
     return false;

--- a/src/server/game/Entities/GameObject/GameObjectData.h
+++ b/src/server/game/Entities/GameObject/GameObjectData.h
@@ -635,6 +635,23 @@ struct GameObjectTemplate
         }
     }
 
+    uint32 GetServerOnly() const
+    {
+        switch (type)
+        {
+        case GAMEOBJECT_TYPE_GENERIC:
+            return _generic.serverOnly;
+        case GAMEOBJECT_TYPE_TRAP:
+            return trap.serverOnly;
+        case GAMEOBJECT_TYPE_SPELL_FOCUS:
+            return spellFocus.serverOnly;
+        case GAMEOBJECT_TYPE_AURA_GENERATOR:
+            return auraGenerator.serverOnly;
+        default:
+            return 0;
+        }
+    }
+
     [[nodiscard]] bool IsGameObjectForQuests() const
     {
         return IsForQuests;


### PR DESCRIPTION
…ll that have it

* cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/4ee64a232ad830255bc6779e595d412c934b6b74)

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  All gobs that use serverSide property should be invisible
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
