### PR TITLE
fix(Scripts/Spells): Bladestorm vs Sweeping Strikes.

### DIFF
--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -59,6 +59,7 @@ enum WarriorSpells
     SPELL_WARRIOR_UNRELENTING_ASSAULT_TRIGGER_2     = 64850,
     SPELL_WARRIOR_VIGILANCE_PROC                    = 50725,
     SPELL_WARRIOR_VIGILANCE_REDIRECT_THREAT         = 59665,
+    SPELL_WARRIOR_WHIRLWIND_MAIN                    = 50622,
     SPELL_WARRIOR_WHIRLWIND_OFF                     = 44949
 };
 
@@ -646,12 +647,18 @@ class spell_warr_sweeping_strikes : public AuraScript
                 case SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_2:
                 case SPELL_WARRIOR_WHIRLWIND_OFF:
                     return false;
+                case SPELL_WARRIOR_WHIRLWIND_MAIN:
+                    if (actor->HasSpellCooldown(SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_1))
+                    {
+                        return false;
+                    }
+                    break;
                 default:
                     break;
             }
         }
 
-        _procTarget = eventInfo.GetActor()->SelectNearbyNoTotemTarget(eventInfo.GetProcTarget());
+        _procTarget = actor->SelectNearbyNoTotemTarget(eventInfo.GetProcTarget());
         return _procTarget != nullptr;
     }
 
@@ -668,6 +675,11 @@ class spell_warr_sweeping_strikes : public AuraScript
             }
             else
             {
+                if (spellInfo && spellInfo->Id == SPELL_WARRIOR_WHIRLWIND_MAIN)
+                {
+                    eventInfo.GetActor()->AddSpellCooldown(SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_1, 0, 500);
+                }
+
                 int32 damage = damageInfo->GetUnmitigatedDamage();
                 GetTarget()->CastCustomSpell(_procTarget, SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_1, &damage, 0, 0, true, nullptr, aurEff);
             }


### PR DESCRIPTION
Fixes #15464

<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #15464
- Closes https://github.com/chromiecraft/chromiecraft/issues/5196

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
`.learn 46924`
`.learn 12328`
`.go xyz 2113.94 -4670.22 44.58 1`
Cast Sweeping Strikes and then Bladestorm

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
