### PR TITLE
fix(DB/Event): (Mulgore) DMF Building event GOs in Brewfest.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1679241095722302100.sql
+++ b/data/sql/updates/pending_db_world/rev_1679241095722302100.sql
@@ -1,2 +1,2 @@
 -- Remove (71) Darkmoon Faire Building (Mulgore) gameobjects from (24) Brewfest
-DELETE FROM `game_event_gameobject` WHERE `eventEntry` = 24 and `guid` IN (31919,31918,31916,31915,31914,31913,31912,31879,31878,31877,31876,31875,31874,31872);
+DELETE FROM `game_event_gameobject` WHERE `eventEntry` = 24 AND `guid` IN (31919,31918,31916,31915,31914,31913,31912,31879,31878,31877,31876,31875,31874,31872);

--- a/data/sql/updates/pending_db_world/rev_1679241095722302100.sql
+++ b/data/sql/updates/pending_db_world/rev_1679241095722302100.sql
@@ -1,0 +1,2 @@
+-- Remove (71) Darkmoon Faire Building (Mulgore) gameobjects from (24) Brewfest
+DELETE FROM `game_event_gameobject` WHERE `eventEntry` = 24 and `guid` IN (31919,31918,31916,31915,31914,31913,31912,31879,31878,31877,31876,31875,31874,31872);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Remove DMF (Mulgore) Building event (71) gameobjects from Brewfest (24)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/4153

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.go xyz -1572 162 -8 1
.event start 24 (Brewfest)
There should be nothing spawning.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
