### PR TITLE
fix(Scripts/Instances): Old Hillsbrad Foothills - Captain Skarloc casting wrong spell

### DIFF
--- a/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/boss_captain_skarloc.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/boss_captain_skarloc.cpp
@@ -203,7 +203,7 @@ public:
                     events.ScheduleEvent(EVENT_SPELL_HAMMER, 30000);
                     break;
                 case EVENT_SPELL_HOLY_SHIELD:
-                    me->CastSpell(me, SPELL_CLEANSE, false);
+                    me->CastSpell(me, SPELL_HOLY_SHIELD, false);
                     events.ScheduleEvent(SPELL_HOLY_SHIELD, 30000);
                     break;
                 case EVENT_SPELL_CONSECRATION:


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Quick fix, also timers are way off.
## Changes Proposed:
- Fix wrong spell for the event (cleanse duplicate) 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.go xyz 2055 235 64 560
.npc add temp 17862

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
