### PR TITLE
fix(Core/Spells): Improve Feign Death scripts

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1679268639264716700.sql
+++ b/data/sql/updates/pending_db_world/rev_1679268639264716700.sql
@@ -1,0 +1,41 @@
+--
+-- spell_gen_feign_death_no_dyn_flag
+-- UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT, UNIT_FLAG2_FEIGN_DEATH
+UPDATE `spell_script_names` SET `ScriptName` = 'spell_gen_feign_death_no_dyn_flag' WHERE `spell_id` = 35357 AND `ScriptName` = 'spell_gen_creature_permanent_feign_death';
+
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (51329) AND `ScriptName` = 'spell_gen_feign_death_no_dyn_flag';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(51329,'spell_gen_feign_death_no_dyn_flag');
+
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` &~ 536870912 WHERE `entry` IN (31786); -- 35357
+DELETE FROM `creature_template_addon` WHERE `entry` IN (29811);
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(29811,0,0,0,1,0,0,'51329');
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` &~ (262144|536870912) WHERE `entry` IN (29811); -- 51329
+
+
+-- spell_gen_feign_death_no_prevent_emotes
+-- UNIT_FLAG2_FEIGN_DEATH, UNIT_DYNFLAG_DEAD, used by 31281
+UPDATE `spell_script_names` SET `ScriptName` = 'spell_gen_feign_death_no_prevent_emotes' WHERE `spell_id` = 58951 AND `ScriptName` = 'spell_gen_creature_permanent_feign_death';
+
+
+-- spell_gen_feign_death_all_flags
+-- All flags
+UPDATE `spell_script_names` SET `ScriptName` = 'spell_gen_feign_death_all_flags' WHERE `ScriptName` = 'spell_gen_creature_permanent_feign_death';
+
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` &~ 536870912 WHERE `entry` IN (37970,37972,37973,38399,38400,38401,38769,38770,38771,38772,38784,38785); -- 71598
+
+
+-- spell_gen_prevent_emotes
+-- UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (33569,58540,70904,58806,58768) AND `ScriptName` = 'spell_gen_prevent_emotes';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(33569,'spell_gen_prevent_emotes'),
+(58540,'spell_gen_prevent_emotes'),
+(70904,'spell_gen_prevent_emotes'),
+(58806,'spell_gen_prevent_emotes'),
+(58768,'spell_gen_prevent_emotes');
+
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` &~ 536870912 WHERE `entry` IN (18035,19224,20663); -- 33569
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` &~ (262144|536870912) WHERE `entry` IN (30947); -- 58540
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` &~ 536870912 WHERE `entry` IN (36789,38174); -- 70904

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -1785,19 +1785,29 @@ class spell_gen_elune_candle : public SpellScript
     }
 };
 
-/* 29266, 57685, 58951, 70592, 70628, 74490 - Permanent Feign Death
-   31261 - Permanent Feign Death (Root)
-   35356, 35357 - Spawn Feign Death */
-class spell_gen_creature_permanent_feign_death : public AuraScript
+/*
+There are only 3 possible flags Feign Death auras can apply: UNIT_DYNFLAG_DEAD, UNIT_FLAG2_FEIGN_DEATH
+and UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT. Some auras can apply only 2 flags
+
+spell_gen_feign_death_all_flags applies all 3 flags
+spell_gen_feign_death_no_dyn_flag applies no UNIT_DYNFLAG_DEAD (does not make the creature appear dead)
+spell_gen_feign_death_no_prevent_emotes applies no UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT
+
+REACT_PASSIVE should be handled directly in scripts since not all creatures should be passive. Otherwise
+creature will be not able to aggro or execute MoveInLineOfSight events. Removing may cause more issues
+than already exists
+*/
+
+class spell_gen_feign_death_all_flags : public AuraScript
 {
-    PrepareAuraScript(spell_gen_creature_permanent_feign_death);
+    PrepareAuraScript(spell_gen_feign_death_all_flags);
 
     void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         Unit* target = GetTarget();
         target->SetDynamicFlag(UNIT_DYNFLAG_DEAD);
         target->SetUnitFlag2(UNIT_FLAG2_FEIGN_DEATH);
-        target->SetImmuneToAll(true);
+        target->SetUnitFlag(UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT);
 
         if (target->GetTypeId() == TYPEID_UNIT)
             target->ToCreature()->SetReactState(REACT_PASSIVE);
@@ -1808,16 +1818,83 @@ class spell_gen_creature_permanent_feign_death : public AuraScript
         Unit* target = GetTarget();
         target->RemoveDynamicFlag(UNIT_DYNFLAG_DEAD);
         target->RemoveUnitFlag2(UNIT_FLAG2_FEIGN_DEATH);
-        target->SetImmuneToAll(false);
+        target->RemoveUnitFlag(UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT);
 
         if (target->GetTypeId() == TYPEID_UNIT)
-            target->ToCreature()->SetReactState(REACT_AGGRESSIVE);
+            target->ToCreature()->InitializeReactState();
     }
 
     void Register() override
     {
-        OnEffectApply += AuraEffectApplyFn(spell_gen_creature_permanent_feign_death::HandleEffectApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
-        OnEffectRemove += AuraEffectApplyFn(spell_gen_creature_permanent_feign_death::HandleEffectRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+        OnEffectApply += AuraEffectApplyFn(spell_gen_feign_death_all_flags::HandleEffectApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+        OnEffectRemove += AuraEffectApplyFn(spell_gen_feign_death_all_flags::HandleEffectRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
+// 35357 - Spawn Feign Death
+// 51329 - Feign Death
+
+class spell_gen_feign_death_no_dyn_flag : public AuraScript
+{
+    PrepareAuraScript(spell_gen_feign_death_no_dyn_flag);
+
+    void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* target = GetTarget();
+        target->SetUnitFlag2(UNIT_FLAG2_FEIGN_DEATH);
+        target->SetUnitFlag(UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT);
+
+        if (target->GetTypeId() == TYPEID_UNIT)
+            target->ToCreature()->SetReactState(REACT_PASSIVE);
+    }
+
+    void HandleEffectRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* target = GetTarget();
+        target->RemoveUnitFlag2(UNIT_FLAG2_FEIGN_DEATH);
+        target->RemoveUnitFlag(UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT);
+
+        if (target->GetTypeId() == TYPEID_UNIT)
+            target->ToCreature()->InitializeReactState();
+    }
+
+    void Register() override
+    {
+        OnEffectApply += AuraEffectApplyFn(spell_gen_feign_death_no_dyn_flag::HandleEffectApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+        OnEffectRemove += AuraEffectApplyFn(spell_gen_feign_death_no_dyn_flag::HandleEffectRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
+// 58951 - Permanent Feign Death
+
+class spell_gen_feign_death_no_prevent_emotes : public AuraScript
+{
+    PrepareAuraScript(spell_gen_feign_death_no_prevent_emotes);
+
+    void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* target = GetTarget();
+        target->SetUnitFlag2(UNIT_FLAG2_FEIGN_DEATH);
+        target->SetUnitFlag(UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT);
+
+        if (target->GetTypeId() == TYPEID_UNIT)
+            target->ToCreature()->SetReactState(REACT_PASSIVE);
+    }
+
+    void HandleEffectRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* target = GetTarget();
+        target->RemoveUnitFlag2(UNIT_FLAG2_FEIGN_DEATH);
+        target->RemoveUnitFlag(UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT);
+
+        if (target->GetTypeId() == TYPEID_UNIT)
+            target->ToCreature()->InitializeReactState();
+    }
+
+    void Register() override
+    {
+        OnEffectApply += AuraEffectApplyFn(spell_gen_feign_death_no_prevent_emotes::HandleEffectApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+        OnEffectRemove += AuraEffectApplyFn(spell_gen_feign_death_no_prevent_emotes::HandleEffectRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
     }
 };
 
@@ -3689,6 +3766,29 @@ class spell_gen_paralytic_poison : public AuraScript
     }
 };
 
+class spell_gen_prevent_emotes : public AuraScript
+{
+    PrepareAuraScript(spell_gen_prevent_emotes);
+
+    void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* target = GetTarget();
+        target->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT);
+    }
+
+    void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* target = GetTarget();
+        target->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT);
+    }
+
+    void Register() override
+    {
+        OnEffectApply += AuraEffectApplyFn(spell_gen_prevent_emotes::HandleEffectApply, EFFECT_FIRST_FOUND, SPELL_AURA_ANY, AURA_EFFECT_HANDLE_REAL);
+        OnEffectRemove += AuraEffectRemoveFn(spell_gen_prevent_emotes::OnRemove, EFFECT_FIRST_FOUND, SPELL_AURA_ANY, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
 enum BladeWarding
 {
     SPELL_GEN_BLADE_WARDING_TRIGGERED = 64442
@@ -4753,7 +4853,9 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_parachute);
     RegisterSpellScript(spell_gen_pet_summoned);
     RegisterSpellScript(spell_gen_remove_flight_auras);
-    RegisterSpellScript(spell_gen_creature_permanent_feign_death);
+    RegisterSpellScript(spell_gen_feign_death_all_flags);
+    RegisterSpellScript(spell_gen_feign_death_no_dyn_flag);
+    RegisterSpellScript(spell_gen_feign_death_no_prevent_emotes);
     RegisterSpellScript(spell_pvp_trinket_wotf_shared_cd);
     RegisterSpellScript(spell_gen_animal_blood);
     RegisterSpellScript(spell_gen_divine_storm_cd_reset);
@@ -4795,6 +4897,7 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_despawn_self);
     RegisterSpellScript(spell_gen_bandage);
     RegisterSpellScript(spell_gen_paralytic_poison);
+    RegisterSpellScript(spell_gen_prevent_emotes);
     RegisterSpellScript(spell_gen_blade_warding);
     RegisterSpellScriptWithArgs(spell_gen_lifebloom, "spell_hexlord_lifebloom", SPELL_HEXLORD_MALACRASS_LIFEBLOOM_FINAL_HEAL);
     RegisterSpellScriptWithArgs(spell_gen_lifebloom, "spell_tur_ragepaw_lifebloom", SPELL_TUR_RAGEPAW_LIFEBLOOM_FINAL_HEAL);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Authored-By: offl <11556157+offl@users.noreply.github.com>

ImmuneToAll is provably and demonstrably false. Removal might cause issues down the line but **These are fixed by sniffed unit_flags that are not changed by these auras**

ReactStates can be modified by script. Agressive ReactStates are able to aggro, it seems

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Cherry-Pick from: https://github.com/TrinityCore/TrinityCore/commit/43f63d76315ec251cc04d70ec6ee811aef9d1176

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
