### PR TITLE
fix(DB/SAI): Brazen & Erozion having wrong gossips.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1679350928099099300.sql
+++ b/data/sql/updates/pending_db_world/rev_1679350928099099300.sql
@@ -1,0 +1,27 @@
+-- Brazen (18725)
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 18725;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(18725, 0, 0, 1, 62, 0, 100, 0, 7959, 0, 0, 0, 0, 11, 32892, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Brazen - On Gossip Option 0 Selected - Cast \'Brazen Taxi\''),
+(18725, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Brazen - On Linked Actions - Close Gossip'),
+(18725, 0, 2, 0, 38, 0, 100, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 12, 1, 0, 0, 0, 0, 0, 0, 0, 'Brazen - On Data Set - Talk (Invoker)');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` IN (14,15) AND `SourceGroup`=7959;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 7959, 9779, 0, 0, 2, 0, 25853, 1, 0, 0, 0, 0, '', 'Brazen - Show gossip menu text if player has item 25853'),
+(14, 7959, 9780, 0, 0, 2, 0, 25853, 1, 0, 1, 0, 0, '', 'Brazen - Show gossip menu text if player does not have item 25853'),
+(15, 7959, 0, 0, 0, 2, 0, 25853, 1, 0, 0, 0, 0, '', 'Brazen - Show gossip option 0 if player has item 25853');
+
+-- Erozion (18723)
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 18723;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(18723, 0, 0, 1, 62, 0, 100, 512, 7769, 0, 0, 0, 0, 56, 25853, 1, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Erozion - On Gossip Option 0 Selected - Add Item \'Pack of Incendiary Bombs\''),
+(18723, 0, 1, 2, 61, 0, 100, 512, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Erozion - On Gossip Option 0 Selected - Close Gossip'),
+(18723, 0, 2, 4, 61, 0, 100, 512, 0, 0, 0, 0, 0, 64, 1, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Erozion - On Gossip Option 0 Selected - Store Targetlist'),
+(18723, 0, 3, 4, 19, 0, 100, 512, 10283, 0, 0, 0, 0, 64, 1, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Erozion - On Quest \'Taretha\'s Diversion\' Taken - Store Targetlist'),
+(18723, 0, 4, 5, 61, 0, 100, 512, 0, 0, 0, 0, 0, 100, 1, 0, 0, 0, 0, 0, 19, 18725, 20, 0, 0, 0, 0, 0, 0, 'Erozion - On Gossip Option 0 Selected - Send Target 1'),
+(18723, 0, 5, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 45, 1, 1, 0, 0, 0, 0, 19, 18725, 20, 0, 0, 0, 0, 0, 0, 'Erozion - On Gossip Option 0 Selected - Set Data 1 1');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup`=7769;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 7769, 0, 0, 0, 2, 0, 25853, 1, 0, 1, 0, 0, '', '(AND) Erozion - Show gossip menu option if player doesn\'t have item 25853'),
+(15, 7769, 0, 0, 0, 47, 0, 10283, 74, 0, 0, 0, 0, '', '(AND) Erozion - Show gossip menu option if quest 10283 has been rewarded or incomplete.');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Fix SAI and conditions  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.go c id 18725
Check for gossip, should be none
Check Brazen for gossip, should be none, should have npc_text "You should receive a pack of..."
.q a 10282 -> Turn it in
Check Erozion for gossip, should be none
Delete the [Pack of Incendiary Bombs]
Check Erozion for gossip, should have "I need a pack of ..."
Speak with Brazen, should have gossip "I'm ready..." with npc_text "I can take you to..."
.q c 10283
.q reward 10283
Check if you can still get bombs from Erozion

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
