### PR TITLE
fix(Scripts/Instance): Utgarde Keep - Prince Keleseth not aggroing

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1679382605948942700.sql
+++ b/data/sql/updates/pending_db_world/rev_1679382605948942700.sql
@@ -1,6 +1,4 @@
 -- Prince Keleseth (Utgarde Keep)
-UPDATE `broadcast_text` SET`SoundEntriesId`=13223 WHERE `ID`=29591 AND `LanguageID`=0;
-
 DELETE FROM `creature_text` WHERE `CreatureID`=23953 AND `GroupID`=6;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
 (23953, 6, 0, 'Darkness waits.', 14, 0, 0, 0, 0, 13223, 29591, 0, 'Prince Keleseth - SAY_KILL');

--- a/data/sql/updates/pending_db_world/rev_1679382605948942700.sql
+++ b/data/sql/updates/pending_db_world/rev_1679382605948942700.sql
@@ -1,0 +1,10 @@
+-- Prince Keleseth (Utgarde Keep)
+UPDATE `broadcast_text` SET`SoundEntriesId`=13223 WHERE `ID`=29591 AND `LanguageID`=0;
+
+DELETE FROM `creature_text` WHERE `CreatureID`=23953 AND `GroupID`=6;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(23953, 6, 0, 'Darkness waits.', 14, 0, 0, 0, 0, 13223, 29591, 0, 'Prince Keleseth - SAY_KILL');
+
+DELETE FROM `creature_text_locale` WHERE `CreatureID`=23953 AND `GroupID`=6 AND `Locale`='zhCN';
+INSERT INTO `creature_text_locale` (`CreatureID`, `GroupID`, `ID`, `Locale`, `Text`) VALUES
+(23953, 6, 0, 'zhCN', '黑暗在等着你呢。');

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
@@ -29,6 +29,7 @@ enum eTexts
     SAY_SUMMON_SKELETONS                = 2,
     SAY_FROST_TOMB_EMOTE                = 4,
     SAY_DEATH                           = 5,
+    SAY_KILL                            = 6,
 };
 
 enum eNPCs
@@ -138,6 +139,14 @@ public:
             events.Reset();
             if (pInstance)
                 pInstance->SetData(DATA_KELESETH, NOT_STARTED);
+        }
+
+        void KilledUnit(Unit * victim)
+        {
+            if (victim->IsPlayer())
+            {
+                Talk(SAY_KILL);
+            }
         }
 
         void JustDied(Unit* /*killer*/) override

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
@@ -141,7 +141,7 @@ public:
                 pInstance->SetData(DATA_KELESETH, NOT_STARTED);
         }
 
-        void KilledUnit(Unit * victim)
+        void KilledUnit(Unit * victim) override
         {
             if (victim->IsPlayer())
             {

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
@@ -140,15 +140,6 @@ public:
                 pInstance->SetData(DATA_KELESETH, NOT_STARTED);
         }
 
-        void MoveInLineOfSight(Unit* /*who*/) override {}
-
-        /*void KilledUnit(Unit * victim)
-        {
-            if (victim == me)
-                return;
-            DoScriptText(SAY_KILL, me);
-        }*/
-
         void JustDied(Unit* /*killer*/) override
         {
             Talk(SAY_DEATH);

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
@@ -141,7 +141,7 @@ public:
                 pInstance->SetData(DATA_KELESETH, NOT_STARTED);
         }
 
-        void KilledUnit(Unit * victim) override
+        void KilledUnit(Unit* victim) override
         {
             if (victim->IsPlayer())
             {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Remove MoveInLineOfSight overrride (Source below)
- Add previously missing SAY_KILL creature_text and sound

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15514

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://youtu.be/Kuw6AqYrbGM?t=219
https://www.wowhead.com/npc=23953/prince-keleseth#comments:id=1097379
https://www.wowhead.com/wotlk/sound=13223/a-kelesethkill
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested

## How to Test the Changes:
.go c id 23953
Should aggro from proximity

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
