### PR TITLE
fix(DB/Loot): Junk Loot from Water Barrels removed

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1679482307407253900.sql
+++ b/data/sql/updates/pending_db_world/rev_1679482307407253900.sql
@@ -1,0 +1,3 @@
+--
+-- Remove Pollution from Water Barrels (gameobject 3658)
+DELETE FROM gameobject_loot_template WHERE Entry=2502 AND Item IN(851, 852, 853, 854, 858, 1196, 1197, 1198, 2207, 2455, 4765, 4766, 4777, 4778);

--- a/data/sql/updates/pending_db_world/rev_1679482307407253900.sql
+++ b/data/sql/updates/pending_db_world/rev_1679482307407253900.sql
@@ -1,3 +1,3 @@
 --
 -- Remove Pollution from Water Barrels (gameobject 3658)
-DELETE FROM gameobject_loot_template WHERE Entry=2502 AND Item IN(851, 852, 853, 854, 858, 1196, 1197, 1198, 2207, 2455, 4765, 4766, 4777, 4778);
+DELETE FROM `gameobject_loot_template` WHERE `Entry`=2502 AND `Item` IN (851, 852, 853, 854, 858, 1196, 1197, 1198, 2207, 2455, 4765, 4766, 4777, 4778);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes a bunch of junk loot from water barrels

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
I am the self appointed king of water barrels.

Also classic wotlk, I'm sure I've looted enough water barrels to disprove this by now, wowhead agrees also although it has other pollution that wasn't in ours.

For reference, I have yet to find a normal food/water crate that has anything other than food/water in it so anyone who desires to hunt down every table that has this type of pollution will have my backing, I ran into this while checking another issue so it was just coincidental and I couldn't just ignore it.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check the table, the following will help:
SELECT * FROM gameobject_template WHERE entry=3658;
SELECT * FROM gameobject_loot_template WHERE entry=2502;
3.
4.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
