### PR TITLE
fix(Scripts/Mechanar): Fix Mechano-Lord Nether Charges not spawning

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1679709753237572800.sql
+++ b/data/sql/updates/pending_db_world/rev_1679709753237572800.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `spell_dbc` SET `Effect_1` = 28, `EffectMiscValueB_1` = 64, `EffectBasePoints_1` = 0 WHERE `ID` IN (35153, 35904, 35905, 35906);

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/boss_mechano_lord_capacitus.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/boss_mechano_lord_capacitus.cpp
@@ -77,7 +77,7 @@ struct boss_mechano_lord_capacitus : public BossAI
                 SPELL_SUMMON_NETHER_CHARGE_SE,
                 SPELL_SUMMON_NETHER_CHARGE_SW);
             DoCastAOE(spellId);
-            IsHeroic() ? context.Repeat(2s, 5s) : context.Repeat(9s, 11s);
+            context.Repeat(2400ms, 3600ms);
         }).Schedule(3min, [this](TaskContext /*context*/)
         {
             DoCastSelf(SPELL_BERSERK, true);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Lower Timer according to Retail sniffs
-  Fix some spell_dbc pollution

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5264

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Retail

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
