### PR TITLE
fix(DB/Loot): Mote of Shadow dropping from wrong creatures.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1679851493822859000.sql
+++ b/data/sql/updates/pending_db_world/rev_1679851493822859000.sql
@@ -1,6 +1,6 @@
 -- Mote of Shadow
 DELETE FROM `creature_loot_template` WHERE `Item` = 22577;
-INSERT INTO `creature_loot_template` VALUES
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (16974, 22577, 0, 20, 0, 1, 0, 1, 1, 'Rogue Voidwalker - Mote of Shadow'),
 (16975, 22577, 0, 20, 0, 1, 0, 1, 1, 'Uncontrolled Voidwalker - Mote of Shadow'),
 (17014, 22577, 0, 20, 0, 1, 0, 1, 2, 'Collapsing Voidwalker - Mote of Shadow'),

--- a/data/sql/updates/pending_db_world/rev_1679851493822859000.sql
+++ b/data/sql/updates/pending_db_world/rev_1679851493822859000.sql
@@ -1,0 +1,23 @@
+-- Mote of Shadow
+DELETE FROM `creature_loot_template` WHERE `Item` = 22577;
+INSERT INTO `creature_loot_template` VALUES
+(16974, 22577, 0, 20, 0, 1, 0, 1, 1, 'Rogue Voidwalker - Mote of Shadow'),
+(16975, 22577, 0, 20, 0, 1, 0, 1, 1, 'Uncontrolled Voidwalker - Mote of Shadow'),
+(17014, 22577, 0, 20, 0, 1, 0, 1, 2, 'Collapsing Voidwalker - Mote of Shadow'),
+(17981, 22577, 0, 18.6912, 0, 1, 0, 1, 2, 'Voidspawn - Mote of Shadow'),
+(18683, 22577, 0, 25, 0, 1, 0, 1, 2, 'Voidhunter Yar - Mote of Shadow'),
+(18869, 22577, 0, 1.0615, 0, 1, 0, 1, 2, 'Unstable Voidwraith - Mote of Shadow'),
+(18870, 22577, 0, 1.0194, 0, 1, 0, 1, 2, 'Voidshrieker - Mote of Shadow'),
+(19307, 22577, 0, 17.8397, 0, 1, 0, 1, 4, 'Nexus Terror - Mote of Shadow'),
+(19527, 22577, 0, 20, 0, 1, 0, 1, 2, 'Vacillating Voidcaller - Mote of Shadow'),
+(19554, 22577, 0, 60, 0, 1, 0, 2, 4, 'Dimensius the All-Devouring - Mote of Shadow'),
+(20554, 22577, 0, 26.6608, 0, 1, 0, 1, 2, 'Arconus the Insatiable - Mote of Shadow'),
+(20873, 22577, 0, 31.15, 0, 1, 0, 2, 4, 'Negaton Warp-Master - Mote of Shadow'),
+(20875, 22577, 0, 30.59, 0, 1, 0, 2, 4, 'Negaton Screamer - Mote of Shadow'),
+(22295, 22577, 0, 27.0833, 0, 1, 0, 2, 4, 'Deathforge Automaton - Mote of Shadow'),
+(22301, 22577, 0, 37.8378, 0, 1, 0, 1, 2, 'Throne-Guard Sentinel - Mote of Shadow'),
+-- Previously missing, from TrinityCore
+(19299, 22577, 0, 42.4242, 0, 1, 0, 2, 4,'Deathwhisperer - Mote of Shadow'),
+(20870, 22577, 0, 15, 0, 1, 0,  2, 4, 'Zereketh the Unbound - Mote of Shadow'),
+(18341, 22577, 0, 15, 0, 1, 0, 2, 4, 'Pandemonius - Mote of Shadow'),
+(19354, 22577, 0, 19.0751, 0, 1, 0, 2, 4, 'Arzeth the Merciless - Mote of Shadow');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Correct Mote of Shadow dropping from wrong mobs for 3.3.5
- Add the 4 missing entries, from TrinityCore

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/14760
- Closes https://github.com/chromiecraft/chromiecraft/issues/4732

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.wowhead.com/wotlk/item=22577/mote-of-shadow#dropped-by
https://wowpedia.fandom.com/wiki/Mote_of_Shadow
TrinityCore dropchance for the missing 4

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- sql runs

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

run sql
```sql
SELECT * FROM `creature_loot_template` WHERE `Entry` IN (16974,16975,17014,17981,18341,18683,18869,18870,19299,19307,19354,19527,19554,20554,20870,20873,20875,22295,22301) and `Item` = 22577;
```
<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
