### PR TITLE
fix(DB/Loot): Remove Bloodforged Guard and Gold-Trimmed Cuffs from reference loot

### DIFF
--- a/data/sql/updates/pending_db_world/remove-bop-quest-loot.sql
+++ b/data/sql/updates/pending_db_world/remove-bop-quest-loot.sql
@@ -1,2 +1,1 @@
-DELETE FROM reference_loot_template WHERE (`Entry` = 4110) AND (`Item` = 30520); --remove row with Gold-Trimmed Cuffs
-DELETE FROM reference_loot_template WHERE (`Entry` = 4110) AND (`Item` = 30986); --remove row with Bloodforged Guard
+DELETE FROM reference_loot_template WHERE (`Entry` = 4110) AND (`Item` IN (30520, 30986));

--- a/data/sql/updates/pending_db_world/remove-bop-quest-loot.sql
+++ b/data/sql/updates/pending_db_world/remove-bop-quest-loot.sql
@@ -1,0 +1,2 @@
+DELETE FROM reference_loot_template WHERE (`Entry` = 4110) AND (`Item` = 30520); --remove row with Gold-Trimmed Cuffs
+DELETE FROM reference_loot_template WHERE (`Entry` = 4110) AND (`Item` = 30986); --remove row with Bloodforged Guard


### PR DESCRIPTION
removes two quest items (Gold-Trimmed Cuffs and Bloodforged Guard) from a reference loot table used by a few mobs in Hellfire Peninsula.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15586

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

If you check the old database before these two deletes you will see reference 6002 from e.g. Fel Reaver loot points to Entry 4110 in reference_loot_template. The last two entries for 4110 are Gold-Trimmed Cuffs and Bloodforged Guard, which don't belong here.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- runs using HeidiSQL
- no syntax error
- rows are removed


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. run sql queries
2. see results


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
