### PR TITLE
fix(DB/creature_loot_template): Darkwood Fishing Pole

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1680024512309807300.sql
+++ b/data/sql/updates/pending_db_world/rev_1680024512309807300.sql
@@ -1,0 +1,30 @@
+--
+
+/* Does not drop from any other creatures */
+DELETE FROM `creature_loot_template` WHERE `Item` = 6366;
+/*
+By Managos (2,236 – 5·11) on 2021/03/18 (Classic)
+After killing over 3,769 worgs in Tirisfal Glades, with stringy wolf meat x2000,
+discolored worg hearts x2946, and many useless greens... I got my DARKWOOD POLE.
+Now to say that its better than the quest pole for horde would be a lie, however..
+Its pretty neat to see. Good luck to those still grinding it out!
+*/
+/*
+By Karasukami on 2005/01/21 (Patch 1.2.1)
+Subject: "hmm"
+I have read that Bloodsnout Worgs in silverpine drop this..
+I guess I'll try and see if that is so. :\
+*/
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Chance`, `GroupId`, `MinCount`, `MaxCount`) VALUES
+(1765, 6366, 0.005, 0, 1, 1), -- Worg
+(1766, 6366, 0.005, 0, 1, 1), -- Mottled Worg
+(1923, 6366, 0.005, 0, 1, 1); -- Bloodsnout Worg
+
+/*
+By bilcosby on 2006/08/11 (Patch 1.11.2)
+Subject: "i got one"
+i got one from a random mob in duskwood was a worg i was just running thro to get to ZG and i killed for fun and it droped
+*/
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Chance`, `GroupId`, `MinCount`, `MaxCount`) VALUES
+(628, 6366, 0.005, 0, 1, 1), -- Black Ravager
+(923, 6366, 0.005, 0, 1, 1); -- Young Black Ravager


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  In addition to being able to fished, Darkwood Fishing Pole should be a rare drop from some worg mobs
- Cherrypicked from Vmangos: https://github.com/vmangos/core/commit/620def0c321e4acf11f8544db126b0d2a30cdfee

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Vmangos: https://github.com/vmangos/core/commit/620def0c321e4acf11f8544db126b0d2a30cdfee

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- SQL runs without error


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Ensure item drops (it is a rare drop - feel free to increase drop rate to test)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
