### PR TITLE
fix(Scripts/Steamvault): Correct Timers for Thespia and add missing line

### DIFF
--- a/data/sql/updates/pending_db_world/thespia.sql
+++ b/data/sql/updates/pending_db_world/thespia.sql
@@ -1,0 +1,4 @@
+-- 
+DELETE FROM `creature_text` WHERE `CreatureID`=17797 AND `GroupID`=4 AND `ID`=0;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(17797, 4, 0, 'Enjoy the storm warm bloods!', 14, 0, 100, 0, 0, 0, 19456, 0, 'thespia SAY_SPELL');

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_hydromancer_thespia.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_hydromancer_thespia.cpp
@@ -71,16 +71,21 @@ struct boss_hydromancer_thespia : public BossAI
         {
         case EVENT_SPELL_LIGHTNING:
             Talk(SAY_SPELL);
-            me->CastSpell(target, SPELL_LIGHTNING_CLOUD, false);
+            DoCastVictim(SPELL_LIGHTNING_CLOUD);
             events.RepeatEvent(urand(12100, 14500));
             break;
         case EVENT_SPELL_LUNG:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
+            {
                 DoCast(target, SPELL_LUNG_BURST);
+            }
             events.RepeatEvent(urand(21800, 25400));
             break;
         case EVENT_SPELL_ENVELOPING:
-            me->CastSpell(target, SPELL_ENVELOPING_WINDS, false);
+            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
+            {
+                me->CastSpell(target, SPELL_ENVELOPING_WINDS, false);
+            }
             events.RepeatEvent(urand(30000, 40000));
             break;
         }

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_hydromancer_thespia.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_hydromancer_thespia.cpp
@@ -71,7 +71,10 @@ struct boss_hydromancer_thespia : public BossAI
         {
         case EVENT_SPELL_LIGHTNING:
             Talk(SAY_SPELL);
-            DoCastVictim(SPELL_LIGHTNING_CLOUD);
+            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
+            {
+                DoCastVictim(SPELL_LIGHTNING_CLOUD);
+            }
             events.RepeatEvent(urand(12100, 14500));
             break;
         case EVENT_SPELL_LUNG:

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_hydromancer_thespia.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_hydromancer_thespia.cpp
@@ -21,10 +21,11 @@
 
 enum HydromancerThespia
 {
-    SAY_SUMMON                  = 0,
+    SAY_SUMMON                  = 0, // Unused or Unknown Use
     SAY_AGGRO                   = 1,
     SAY_SLAY                    = 2,
     SAY_DEAD                    = 3,
+    SAY_SPELL                   = 4,
 
     SPELL_LIGHTNING_CLOUD       = 25033,
     SPELL_LUNG_BURST            = 31481,
@@ -55,9 +56,9 @@ struct boss_hydromancer_thespia : public BossAI
     {
         Talk(SAY_AGGRO);
         _JustEngagedWith();
-        events.ScheduleEvent(EVENT_SPELL_LIGHTNING, 15000);
-        events.ScheduleEvent(EVENT_SPELL_LUNG, 7000);
-        events.ScheduleEvent(EVENT_SPELL_ENVELOPING, 9000);
+        events.ScheduleEvent(EVENT_SPELL_LIGHTNING, 9800);
+        events.ScheduleEvent(EVENT_SPELL_LUNG, 13300);
+        events.ScheduleEvent(EVENT_SPELL_ENVELOPING, 14500);
     }
 
     void UpdateAI(uint32 diff) override
@@ -69,21 +70,18 @@ struct boss_hydromancer_thespia : public BossAI
         switch (events.ExecuteEvent())
         {
         case EVENT_SPELL_LIGHTNING:
-            for (uint8 i = 0; i < DUNGEON_MODE(1, 2); ++i)
-                if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
-                    me->CastSpell(target, SPELL_LIGHTNING_CLOUD, false);
-            events.RepeatEvent(urand(15000, 25000));
+            Talk(SAY_SPELL);
+            me->CastSpell(target, SPELL_LIGHTNING_CLOUD, false);
+            events.RepeatEvent(urand(12100, 14500));
             break;
         case EVENT_SPELL_LUNG:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                 DoCast(target, SPELL_LUNG_BURST);
-            events.RepeatEvent(urand(7000, 12000));
+            events.RepeatEvent(urand(21800, 25400));
             break;
         case EVENT_SPELL_ENVELOPING:
-            for (uint8 i = 0; i < DUNGEON_MODE(1, 2); ++i)
-                if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
-                    me->CastSpell(target, SPELL_ENVELOPING_WINDS, false);
-            events.RepeatEvent(urand(10000, 15000));
+            me->CastSpell(target, SPELL_ENVELOPING_WINDS, false);
+            events.RepeatEvent(urand(30000, 40000));
             break;
         }
 

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_hydromancer_thespia.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_hydromancer_thespia.cpp
@@ -71,24 +71,15 @@ struct boss_hydromancer_thespia : public BossAI
         {
         case EVENT_SPELL_LIGHTNING:
             Talk(SAY_SPELL);
-            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
-            {
-                DoCastVictim(SPELL_LIGHTNING_CLOUD);
-            }
+            DoCastRandomTarget(SPELL_LIGHTNING_CLOUD);
             events.RepeatEvent(urand(12100, 14500));
             break;
         case EVENT_SPELL_LUNG:
-            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
-            {
-                DoCast(target, SPELL_LUNG_BURST);
-            }
+            DoCastRandomTarget(SPELL_LUNG_BURST);
             events.RepeatEvent(urand(21800, 25400));
             break;
         case EVENT_SPELL_ENVELOPING:
-            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
-            {
-                me->CastSpell(target, SPELL_ENVELOPING_WINDS, false);
-            }
+            DoCastRandomTarget(SPELL_ENVELOPING_WINDS);
             events.RepeatEvent(urand(30000, 40000));
             break;
         }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add line 'Enjoy the storm warm bloods!' when casting Lightning Cloud
-  Correct the timers using sniffs
-  Remove incorrect double-cast mechanic

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
