### PR TITLE
fix(Scripts/TheMechanar): Add missing Enrage event for Pathaleon the Calculator

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1680124416269252400.sql
+++ b/data/sql/updates/pending_db_world/rev_1680124416269252400.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 13) AND (`SourceEntry` = 35301) AND (`ConditionTypeOrReference` = 31) AND (`ConditionValue2` = 21062);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 1, 35301, 0, 0, 31, 0, 3, 21062, 0, 0, 0, 0, '', 'Spell Suicide (35301) only targets Nether Wraith (21062)');

--- a/data/sql/updates/pending_db_world/rev_1680124416269252400.sql
+++ b/data/sql/updates/pending_db_world/rev_1680124416269252400.sql
@@ -5,4 +5,4 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 
 DELETE FROM `creature_equip_template` WHERE (`CreatureID` = 19220 AND `ID` = 2);
 INSERT INTO `creature_equip_template` (`CreatureID`, `ID`, `ItemID1`, `ItemID2`, `ItemID3`, `VerifiedBuild`) VALUES
-(19220, 2, 29455, 0, 0, 0);
+(19220, 2, 29455, 0, 0, 48526);

--- a/data/sql/updates/pending_db_world/rev_1680124416269252400.sql
+++ b/data/sql/updates/pending_db_world/rev_1680124416269252400.sql
@@ -2,3 +2,7 @@
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 13) AND (`SourceEntry` = 35301) AND (`ConditionTypeOrReference` = 31) AND (`ConditionValue2` = 21062);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (13, 1, 35301, 0, 0, 31, 0, 3, 21062, 0, 0, 0, 0, '', 'Spell Suicide (35301) only targets Nether Wraith (21062)');
+
+DELETE FROM `creature_equip_template` WHERE (`CreatureID` = 19220 AND `ID` = 2);
+INSERT INTO `creature_equip_template` (`CreatureID`, `ID`, `ItemID1`, `ItemID2`, `ItemID3`, `VerifiedBuild`) VALUES
+(19220, 2, 29455, 0, 0, 0);

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/boss_pathaleon_the_calculator.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/boss_pathaleon_the_calculator.cpp
@@ -50,12 +50,7 @@ enum Spells
 enum Misc
 {
     ACTION_BRIDGE_MOB_DEATH = 1, // Used by SAI
-    ITEM_WEAPON             = 23382,
-    ITEM_SHIELD             = 24328,
-    ITEM_FRENZY             = 29455,
 };
-
-bool _isEnraged;
 
 struct boss_pathaleon_the_calculator : public BossAI
 {
@@ -67,12 +62,13 @@ struct boss_pathaleon_the_calculator : public BossAI
         });
     }
 
+    bool _isEnraged;
+
     void Reset() override
     {
         _Reset();
-        _isEnraged = 0;
-        me->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID, ITEM_WEAPON);
-        me->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 1, ITEM_SHIELD);
+        _isEnraged = false;
+        me->LoadEquipment(1);
 
         if (instance->GetPersistentData(DATA_BRIDGE_MOB_DEATH_COUNT) < 4)
         {
@@ -94,19 +90,18 @@ struct boss_pathaleon_the_calculator : public BossAI
             DoCastSelf(SPELL_SUICIDE, true);
             DoCastSelf(SPELL_FRENZY, true);
             Talk(SAY_ENRAGE);
-            _isEnraged = 1;
-            me->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID, ITEM_FRENZY);
-            me->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 1, 0);
+            _isEnraged = true;
+            me->LoadEquipment(2);
         });
 
         scheduler.Schedule(20s, 25s, [this](TaskContext context)
         {
             if (!_isEnraged)
             {
-                    for (uint8 i = 0; i < DUNGEON_MODE(3, 4); ++i)
-                        me->CastSpell(me, SPELL_SUMMON_NETHER_WRAITH_1 + i, true);
+                for (uint8 i = 0; i < DUNGEON_MODE(3, 4); ++i)
+                    me->CastSpell(me, SPELL_SUMMON_NETHER_WRAITH_1 + i, true);
 
-                    Talk(SAY_SUMMON);
+                Talk(SAY_SUMMON);
             }
             context.Repeat(45s, 50s);
         }).Schedule(12s, [this](TaskContext context)

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/boss_pathaleon_the_calculator.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/boss_pathaleon_the_calculator.cpp
@@ -124,7 +124,7 @@ struct boss_pathaleon_the_calculator : public BossAI
                 Talk(SAY_DOMINATION);
             }
             context.Repeat(27s, 40s);
-            }).Schedule(25s, [this](TaskContext context)
+        }).Schedule(25s, [this](TaskContext context)
         {
             DoCast(SPELL_DISGRUNTLED_ANGER);
             context.Repeat(40s, 90s);

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/boss_pathaleon_the_calculator.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/boss_pathaleon_the_calculator.cpp
@@ -50,6 +50,8 @@ enum Spells
 enum Misc
 {
     ACTION_BRIDGE_MOB_DEATH = 1, // Used by SAI
+    EQUIPMENT_NORMAL        = 1,
+    EQUIPMENT_FRENZY        = 2,
 };
 
 struct boss_pathaleon_the_calculator : public BossAI
@@ -68,7 +70,7 @@ struct boss_pathaleon_the_calculator : public BossAI
     {
         _Reset();
         _isEnraged = false;
-        me->LoadEquipment(1);
+        me->LoadEquipment(EQUIPMENT_NORMAL);
 
         if (instance->GetPersistentData(DATA_BRIDGE_MOB_DEATH_COUNT) < 4)
         {
@@ -91,7 +93,7 @@ struct boss_pathaleon_the_calculator : public BossAI
             DoCastSelf(SPELL_FRENZY, true);
             Talk(SAY_ENRAGE);
             _isEnraged = true;
-            me->LoadEquipment(2);
+            me->LoadEquipment(EQUIPMENT_FRENZY);
         });
 
         scheduler.Schedule(20s, 25s, [this](TaskContext context)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Use correct spell for Frenzy
- Move Disgruntled Anger to its own event (sniffed)
- Check if boss is Enraged before doing summons
- Add missing spell cast to kill adds
- Changes equipment on Frenzy

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15378
- Closes https://github.com/chromiecraft/chromiecraft/issues/5262

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
