### PR TITLE
fix(DB/SAI): Shaleskin Flayer should cast Shaleskin out of combat

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1680197775441354500.sql
+++ b/data/sql/updates/pending_db_world/rev_1680197775441354500.sql
@@ -1,0 +1,6 @@
+--
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 20210;
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 20210);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(20210, 0, 0, 0, 1, 0, 100, 1, 0, 0, 0, 0, 0, 11, 36576, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shaleskin Flayer - Out Of Combat - Cast \'Shaleskin\' (No Repeat)');

--- a/data/sql/updates/pending_db_world/rev_1680197775441354500.sql
+++ b/data/sql/updates/pending_db_world/rev_1680197775441354500.sql
@@ -1,6 +1,4 @@
 --
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 20210;
-
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 20210);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (20210, 0, 0, 0, 1, 0, 100, 0, 0, 0, 600000, 600000, 0, 11, 36576, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shaleskin Flayer - Out Of Combat - Cast \'Shaleskin\'');

--- a/data/sql/updates/pending_db_world/rev_1680197775441354500.sql
+++ b/data/sql/updates/pending_db_world/rev_1680197775441354500.sql
@@ -3,4 +3,4 @@ UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 20210;
 
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 20210);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(20210, 0, 0, 0, 1, 0, 100, 1, 0, 0, 0, 0, 0, 11, 36576, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shaleskin Flayer - Out Of Combat - Cast \'Shaleskin\' (No Repeat)');
+(20210, 0, 0, 0, 1, 0, 100, 0, 0, 0, 600000, 600000, 0, 11, 36576, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shaleskin Flayer - Out Of Combat - Cast \'Shaleskin\'');


### PR DESCRIPTION
## Changes Proposed:
-  Shaleskin Flayer casts Shaleskin spell out of combat

## Issues Addressed:
- Closes #15010 
- Closes https://github.com/chromiecraft/chromiecraft/issues/5000

## SOURCE:
https://youtu.be/dwi2HSu5A4A?t=19

## Tests Performed:
- Tested in game. They cast the spell while out of combat.

## How to Test the Changes:
1. .go c 71848
2. check if they have cast the spell

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
