### PR TITLE
fix(DB/Creature): Some immunities in Arcatraz

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1680294116991836000.sql
+++ b/data/sql/updates/pending_db_world/rev_1680294116991836000.sql
@@ -1,8 +1,6 @@
 --
-UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|46284631 WHERE (`entry` IN (20866, 21614));
-UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|652689279 WHERE (`entry` IN (20870, 21626));
-UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|46284631 WHERE (`entry` IN (20898, 21598));
+UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|46284631 WHERE (`entry` IN (20866, 21614, 20898, 21598));
+UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|652689279 WHERE (`entry` IN (20870, 21626, 20912, 21601));
 UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|37882897 WHERE (`entry` IN (20875, 21604));
-UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|652689279 WHERE (`entry` IN (20912, 21601));
 UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|3089, `flags_extra`=`flags_extra`|256 WHERE (`entry` IN (20883, 21615));
 UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|16405, `flags_extra`=`flags_extra`|256 WHERE (`entry` IN (20869, 21586));

--- a/data/sql/updates/pending_db_world/rev_1680294116991836000.sql
+++ b/data/sql/updates/pending_db_world/rev_1680294116991836000.sql
@@ -1,7 +1,8 @@
 --
 UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|46284631 WHERE (`entry` IN (20866, 21614));
-UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|652689407 WHERE (`entry` IN (20870, 21626));
+UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|652689279 WHERE (`entry` IN (20870, 21626));
 UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|46284631 WHERE (`entry` IN (20898, 21598));
 UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|37882897 WHERE (`entry` IN (20875, 21604));
+UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|652689279 WHERE (`entry` IN (20912, 21601));
 UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|3089, `flags_extra`=`flags_extra`|256 WHERE (`entry` IN (20883, 21615));
 UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|16405, `flags_extra`=`flags_extra`|256 WHERE (`entry` IN (20869, 21586));

--- a/data/sql/updates/pending_db_world/rev_1680294116991836000.sql
+++ b/data/sql/updates/pending_db_world/rev_1680294116991836000.sql
@@ -1,0 +1,7 @@
+--
+UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|46284631 WHERE (`entry` IN (20866, 21614));
+UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|652689407 WHERE (`entry` IN (20870, 21626));
+UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|46284631 WHERE (`entry` IN (20898, 21598));
+UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|37882897 WHERE (`entry` IN (20875, 21604));
+UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|3089, `flags_extra`=`flags_extra`|256 WHERE (`entry` IN (20883, 21615));
+UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`|16405, `flags_extra`=`flags_extra`|256 WHERE (`entry` IN (20869, 21586));


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5306
- Closes https://github.com/chromiecraft/chromiecraft/issues/5307
- Closes https://github.com/chromiecraft/chromiecraft/issues/5305
- Closes https://github.com/chromiecraft/chromiecraft/issues/5303
- Progress https://github.com/chromiecraft/chromiecraft/issues/5302

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Mangos

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
