### PR TITLE
fix(DB/Loot): Blood of the Mountain dropping from wrong mobs.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1680371174965612100.sql
+++ b/data/sql/updates/pending_db_world/rev_1680371174965612100.sql
@@ -1,0 +1,4 @@
+-- Blood of the Mountain
+DELETE FROM `creature_loot_template` WHERE `Item` = 11382;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(11659, 11382, 0, 13, 0, 1, 0, 1, 1, 'Molten Destroyer - Blood of the Mountain');

--- a/data/sql/updates/pending_db_world/rev_1680371174965612100.sql
+++ b/data/sql/updates/pending_db_world/rev_1680371174965612100.sql
@@ -1,4 +1,4 @@
 -- Blood of the Mountain
 DELETE FROM `creature_loot_template` WHERE `Item` = 11382;
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(11659, 11382, 0, 13, 0, 1, 0, 1, 1, 'Molten Destroyer - Blood of the Mountain');
+(11659, 11382, 0, 7.1259, 0, 1, 0, 1, 1, 'Molten Destroyer - Blood of the Mountain');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Remove Blood of the Mountain from all creatures, except Molten Destroyer and change to 13%

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/2090
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8530

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.wowhead.com/wotlk/item=11382/blood-of-the-mountain#dropped-by
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- sql


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

```sql
SELECT * FROM creature_loot_template WHERE item=11382
```



<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
