### PR TITLE
fix(DB/creature_addon): Remove deprecated bytes2 flags.

### DIFF
--- a/data/sql/updates/db_world/2023_04_02_09.sql
+++ b/data/sql/updates/db_world/2023_04_02_09.sql
@@ -1,3 +1,4 @@
+-- DB update 2023_04_02_08 -> 2023_04_02_09
 -- Form Rhok'delar and Lok'delar at once
 DELETE FROM `spell_linked_spell` WHERE `spell_trigger`=23192;
 INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES (23192, 24872, 0, 'Form Rhok\'delar and Lok\'delar at once ');

--- a/data/sql/updates/pending_db_world/rev_1680463160388009300.sql
+++ b/data/sql/updates/pending_db_world/rev_1680463160388009300.sql
@@ -1,0 +1,11 @@
+-- Remove old/deprecated bytes2 flags.
+UPDATE `creature_addon` SET `bytes2` = 1 WHERE `bytes2` IN (4092,4096,4097,4098,256,257,301993985,318771201,285216769);
+UPDATE `creature_addon` SET `bytes2` = 0 WHERE `bytes2` IN (733,141313,234885121,251662337);
+UPDATE `creature_addon` SET `bytes2` = 2 WHERE `bytes2` IN (258,4097,4098);
+
+-- Elder Springpaw, Scorpid Bonecrawler & Blackwind Sabercat wrong spawns.
+DELETE FROM `creature_addon` WHERE `guid` IN (75829,77583,77606,77607,82379);
+DELETE FROM `creature` WHERE `guid` IN (75829,77583,82379);
+
+-- Hatecrest Warrior defensive stance, handled by SAI
+UPDATE `creature_addon` SET `auras` = NULL WHERE `guid` = 51476;

--- a/data/sql/updates/pending_db_world/rev_1680463160388009300.sql
+++ b/data/sql/updates/pending_db_world/rev_1680463160388009300.sql
@@ -1,10 +1,11 @@
 -- Remove old/deprecated bytes2 flags.
-UPDATE `creature_addon` SET `bytes2` = 1 WHERE `bytes2` IN (257,733,4092,4097,301993985,318771201,285216769,234885121);
-UPDATE `creature_addon` SET `bytes2` = 0 WHERE `bytes2` IN (256,4096);
+UPDATE `creature_addon` SET `bytes2` = 1 WHERE `bytes2` IN (257,733,4097,301993985,318771201,285216769,234885121);
+UPDATE `creature_addon` SET `bytes2` = 0 WHERE `bytes2` IN (256,4092,4096);
 UPDATE `creature_addon` SET `bytes2` = 2 WHERE `bytes2` IN (258,4098);
 
-UPDATE `creature_template_addon` SET `bytes2` = 1 WHERE `bytes2` IN (133121,10241,2305,2049,69,3);
-UPDATE `creature_template_addon` SET `bytes2` = 0 WHERE `bytes2` = 65536;
+UPDATE `creature_template_addon` SET `bytes2` = 1 WHERE `bytes2` IN (3,69,257,2049,2305,4097,10241,133121,234885121,285216769);
+UPDATE `creature_template_addon` SET `bytes2` = 0 WHERE `bytes2` IN (256,4092,4096,65536);
+UPDATE `creature_template_addon` SET `bytes2` = 2 WHERE `bytes2` IN (258,4098);
 
 -- Creature where neither of the values in creature_addon were used.
 DELETE FROM `creature_addon` WHERE `guid` IN (75829,77583,77606,77607,82379,73192,80419,81738,82004,32943);

--- a/data/sql/updates/pending_db_world/rev_1680463160388009300.sql
+++ b/data/sql/updates/pending_db_world/rev_1680463160388009300.sql
@@ -3,6 +3,9 @@ UPDATE `creature_addon` SET `bytes2` = 1 WHERE `bytes2` IN (257,733,4092,4097,30
 UPDATE `creature_addon` SET `bytes2` = 0 WHERE `bytes2` IN (256,4096);
 UPDATE `creature_addon` SET `bytes2` = 2 WHERE `bytes2` IN (258,4098);
 
+UPDATE `creature_template_addon` SET `bytes2` = 1 WHERE `bytes2` IN (133121,10241,2305,2049,69,3);
+UPDATE `creature_template_addon` SET `bytes2` = 0 WHERE `bytes2` = 65536;
+
 -- Creature where neither of the values in creature_addon were used.
 DELETE FROM `creature_addon` WHERE `guid` IN (75829,77583,77606,77607,82379,73192,80419,81738,82004,32943);
 

--- a/data/sql/updates/pending_db_world/rev_1680463160388009300.sql
+++ b/data/sql/updates/pending_db_world/rev_1680463160388009300.sql
@@ -1,11 +1,23 @@
 -- Remove old/deprecated bytes2 flags.
-UPDATE `creature_addon` SET `bytes2` = 1 WHERE `bytes2` IN (4092,4096,4097,256,257,301993985,318771201,285216769);
-UPDATE `creature_addon` SET `bytes2` = 0 WHERE `bytes2` IN (733,141313,234885121,251662337);
+UPDATE `creature_addon` SET `bytes2` = 1 WHERE `bytes2` IN (257,733,4092,4097,301993985,318771201,285216769,234885121);
+UPDATE `creature_addon` SET `bytes2` = 0 WHERE `bytes2` IN (256,4096);
 UPDATE `creature_addon` SET `bytes2` = 2 WHERE `bytes2` IN (258,4098);
 
--- Elder Springpaw, Scorpid Bonecrawler & Blackwind Sabercat wrong spawns.
-DELETE FROM `creature_addon` WHERE `guid` IN (75829,77583,77606,77607,82379);
-DELETE FROM `creature` WHERE `guid` IN (75829,77583,82379);
+-- Creature where neither of the values in creature_addon were used.
+DELETE FROM `creature_addon` WHERE `guid` IN (75829,77583,77606,77607,82379,73192,80419,81738,82004,32943);
+
+-- Incorrect mob spawns (wrong zone/area/sniffed as a pet (with spirit bond))
+-- Blackwind Sabercat
+DELETE FROM `creature` WHERE (`guid` = 75829 AND `id1` = 21723);
+-- Scorpid Bonecrawler
+DELETE FROM `creature` WHERE (`guid` = 77583 AND `id1` = 22100);
+-- Elder Springpaw
+DELETE FROM `creature` WHERE (`guid` = 82379 AND `id1` = 15652);
+-- Scalewing Serpent
+DELETE FROM `creature` WHERE (`guid` = 73192 AND `id1` = 20749);
+ -- Stunetusk Boar
+DELETE FROM `creature` WHERE (`guid` = 80419 AND `id1` = 113);
+
 
 -- Hatecrest Warrior defensive stance, handled by SAI
-UPDATE `creature_addon` SET `auras` = NULL WHERE `guid` = 51476;
+UPDATE `creature_addon` SET `auras` = '' WHERE `guid` = 51476;

--- a/data/sql/updates/pending_db_world/rev_1680463160388009300.sql
+++ b/data/sql/updates/pending_db_world/rev_1680463160388009300.sql
@@ -19,5 +19,5 @@ DELETE FROM `creature` WHERE (`guid` = 73192 AND `id1` = 20749);
 DELETE FROM `creature` WHERE (`guid` = 80419 AND `id1` = 113);
 
 
--- Hatecrest Warrior defensive stance, handled by SAI
-UPDATE `creature_addon` SET `auras` = '' WHERE `guid` = 51476;
+-- Hatecrest Warrior defensive stance, Grimtotem Raider berserk stance, handled by SAI
+UPDATE `creature_addon` SET `auras` = '' WHERE `guid` IN (51476,50009);

--- a/data/sql/updates/pending_db_world/rev_1680463160388009300.sql
+++ b/data/sql/updates/pending_db_world/rev_1680463160388009300.sql
@@ -1,7 +1,7 @@
 -- Remove old/deprecated bytes2 flags.
-UPDATE `creature_addon` SET `bytes2` = 1 WHERE `bytes2` IN (4092,4096,4097,4098,256,257,301993985,318771201,285216769);
+UPDATE `creature_addon` SET `bytes2` = 1 WHERE `bytes2` IN (4092,4096,4097,256,257,301993985,318771201,285216769);
 UPDATE `creature_addon` SET `bytes2` = 0 WHERE `bytes2` IN (733,141313,234885121,251662337);
-UPDATE `creature_addon` SET `bytes2` = 2 WHERE `bytes2` IN (258,4097,4098);
+UPDATE `creature_addon` SET `bytes2` = 2 WHERE `bytes2` IN (258,4098);
 
 -- Elder Springpaw, Scorpid Bonecrawler & Blackwind Sabercat wrong spawns.
 DELETE FROM `creature_addon` WHERE `guid` IN (75829,77583,77606,77607,82379);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Remove deprecated bytes2 flags.
- Remove couple of wrong creature spawns/addons.


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
(for the deleted creatures)
https://www.wowhead.com/wotlk/npc=21723/blackwind-sabercat
https://www.wowhead.com/wotlk/npc=15652/elder-springpaw
https://www.wowhead.com/wotlk/npc=22100/scorpid-bonecrawler
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

before running sql:
1) go to the 3 GUIDs that are being deleted, confirm they are out of place.
2) Go to random GUIDs and see their SheatheState (bytes2)
```sql
SELECT * FROM `creature_addon` where `bytes2` = XXXXXXXX;
```
Apply SQL
Go to the GUIDs to confirm their SheatheState (bytes2) is correct.


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
