### PR TITLE
fix (DB/Loot) Add Tailoring condition for the Battlecast Hood Recipe

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1680525460717061700.sql
+++ b/data/sql/updates/pending_db_world/rev_1680525460717061700.sql
@@ -1,3 +1,3 @@
-DELETE FROM `conditions` WHERE `SourceGroup` = 17798 AND `SourceEntry` = 24313;
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 1 AND `SourceGroup` = 17798 AND `SourceEntry` = 24313 AND `ConditionTypeOrReference` = 7;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`,`ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`) VALUES
 (1, 17798, 24313, 7, 197, 1);

--- a/data/sql/updates/pending_db_world/rev_1680525460717061700.sql
+++ b/data/sql/updates/pending_db_world/rev_1680525460717061700.sql
@@ -1,3 +1,4 @@
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 1 AND `SourceGroup` = 17798 AND `SourceEntry` = 24313 AND `ConditionTypeOrReference` = 7;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`,`ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
 (1, 17798, 24313, 7, 197, 1, 'Pattern: Battlecast Hood requires Tailoring to drop');
+UPDATE `conditions` SET `Comment` = 'Pattern: Battlecast Hood requires Tailoring to drop' WHERE `SourceTypeOrReferenceId` = 1 AND `SourceGroup` = 20633 AND `SourceEntry` = 24313 AND `ConditionTypeOrReference` = 7;

--- a/data/sql/updates/pending_db_world/rev_1680525460717061700.sql
+++ b/data/sql/updates/pending_db_world/rev_1680525460717061700.sql
@@ -1,3 +1,3 @@
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 1 AND `SourceGroup` = 17798 AND `SourceEntry` = 24313 AND `ConditionTypeOrReference` = 7;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`,`ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`) VALUES
-(1, 17798, 24313, 7, 197, 1);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`,`ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(1, 17798, 24313, 7, 197, 1, 'Pattern: Battlecast Hood requires Tailoring to drop');

--- a/data/sql/updates/pending_db_world/rev_1680525460717061700.sql
+++ b/data/sql/updates/pending_db_world/rev_1680525460717061700.sql
@@ -1,2 +1,3 @@
+DELETE FROM `conditions` WHERE `SourceGroup` = 17798 AND `SourceEntry` = 24313;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`,`ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`) VALUES
 (1, 17798, 24313, 7, 197, 1);

--- a/data/sql/updates/pending_db_world/rev_1680525460717061700.sql
+++ b/data/sql/updates/pending_db_world/rev_1680525460717061700.sql
@@ -1,0 +1,2 @@
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`,`ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`) VALUES
+(1, 17798, 24313, 7, 197, 1);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add missing condition to require tailoring for the [battlecast hood recipe](https://wowgaming.altervista.org/aowow/?item=24313) from Warlord Kalithresh
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Common knowledge that the bop recipes in TBC require the profession
Comments: https://www.wowhead.com/wotlk/item=24313/pattern-battlecast-hood#comments

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Did test as described below
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

```UPDATE `creature_loot_template` SET `Chance`=100 WHERE `Item`=24313;```
Killed Warlord Kalithresh with and without tailoring

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
