### PR TITLE
fix(DB/Creature): Correct Rep for Heroic Nexus Terror

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1680531018840455000.sql
+++ b/data/sql/updates/pending_db_world/rev_1680531018840455000.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 23 WHERE `creature_id` = 20265;

--- a/data/sql/updates/pending_db_world/rev_1680531018840455000.sql
+++ b/data/sql/updates/pending_db_world/rev_1680531018840455000.sql
@@ -1,2 +1,2 @@
 --
-UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 23 WHERE `creature_id` = 20265;
+UPDATE `creature_onkill_reputation` SET `RewOnKillRepValue1` = 22.5 WHERE `creature_id` = 20265;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fix rep value for Nexus Terror on Heroic

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15799
- Closes https://github.com/chromiecraft/chromiecraft/issues/5328

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
See original issue

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- SQL runs successfully


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Kill Nexus Terror in Heroic difficulty, confirm correct rep

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- We may want to double-check retail values to confirm this is correct rep value.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
