### PR TITLE
fix(DB/Loot) Use Condition for Quest Drop "Two Halves Become One"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1680620959783505058.sql
+++ b/data/sql/updates/pending_db_world/rev_1680620959783505058.sql
@@ -1,0 +1,4 @@
+UPDATE `creature_loot_template` SET `QuestRequired` = 0 WHERE `Item` = 12722;
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 1 AND `SourceGroup` = 10801 AND `SourceEntry` = 12722 AND `ConditionTypeOrReference` = 9;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
+(1, 10801, 12722, 0, 0, 9, 0, 5051, 0, 0, 0, 0, 0, '', 'Jabbering Ghoul - Good Luck Other-Half-Charm');


### PR DESCRIPTION
In quest Two Halves Become One, the Jabbering Ghoul drops an item (good luck other half charm) which is used to create the quest reward item (good luck charm). Because it is an indirect quest item drop, we must add a condition instead of relying on QuestRequired from creature_loot_template.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Use conditions table to reward good luck other-half-charm only if player has the requisite quest (5051)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  In game, enter command `.q add 5051` to add quest
2. Go to Jabbering ghoul, `.go c id 10801` 
3. Kill npc and confirm you can loot good luck other-half-charm (item id 12722)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
