### PR TITLE
fix(Scripts/Steamvault): Correct timers and add missing events

### DIFF
--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_mekgineer_steamrigger.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_mekgineer_steamrigger.cpp
@@ -29,6 +29,7 @@ enum MekgineerSteamrigger
     SPELL_SUPER_SHRINK_RAY      = 31485,
     SPELL_SAW_BLADE             = 31486,
     SPELL_ELECTRIFIED_NET       = 35107,
+    SPELL_ENRAGE                = 26662,
     SPELL_REPAIR_N              = 31532,
     SPELL_REPAIR_H              = 37936,
 
@@ -39,7 +40,8 @@ enum MekgineerSteamrigger
     EVENT_CHECK_HP75            = 3,
     EVENT_SPELL_SHRINK          = 4,
     EVENT_SPELL_SAW             = 5,
-    EVENT_SPELL_NET             = 6
+    EVENT_SPELL_NET             = 6,
+    EVENT_ENRAGE                = 7
 };
 
 struct boss_mekgineer_steamrigger : public BossAI
@@ -62,9 +64,10 @@ struct boss_mekgineer_steamrigger : public BossAI
     {
         Talk(SAY_AGGRO);
         _JustEngagedWith();
-        events.ScheduleEvent(EVENT_SPELL_SHRINK, 20000);
-        events.ScheduleEvent(EVENT_SPELL_SAW, 15000);
-        events.ScheduleEvent(EVENT_SPELL_NET, 10000);
+        events.ScheduleEvent(EVENT_SPELL_SHRINK, 26550);
+        events.ScheduleEvent(EVENT_SPELL_SAW, urand(6050, 17650));
+        events.ScheduleEvent(EVENT_SPELL_NET, 14400);
+        events.ScheduleEvent(EVENT_ENRAGE, 300000);
         events.ScheduleEvent(EVENT_CHECK_HP75, 5000);
         events.ScheduleEvent(EVENT_CHECK_HP50, 5000);
         events.ScheduleEvent(EVENT_CHECK_HP25, 5000);
@@ -96,19 +99,22 @@ struct boss_mekgineer_steamrigger : public BossAI
         {
         case EVENT_SPELL_SHRINK:
             me->CastSpell(me->GetVictim(), SPELL_SUPER_SHRINK_RAY, false);
-            events.RepeatEvent(20000);
+            events.RepeatEvent(urand(35100, 54100));
             break;
         case EVENT_SPELL_SAW:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1))
                 me->CastSpell(target, SPELL_SAW_BLADE, false);
             else
                 me->CastSpell(me->GetVictim(), SPELL_SAW_BLADE, false);
-            events.RepeatEvent(15000);
+            events.RepeatEvent(urand(6050, 17650));
             break;
         case EVENT_SPELL_NET:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                 me->CastSpell(target, SPELL_ELECTRIFIED_NET, false);
-            events.RepeatEvent(10000);
+            events.RepeatEvent(urand(21800, 34200));
+            break;
+        case EVENT_ENRAGE:
+            DoCastSelf(SPELL_ENRAGE, true);
             break;
         case EVENT_CHECK_HP25:
         case EVENT_CHECK_HP50:

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_mekgineer_steamrigger.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_mekgineer_steamrigger.cpp
@@ -65,7 +65,7 @@ struct boss_mekgineer_steamrigger : public BossAI
         Talk(SAY_AGGRO);
         _JustEngagedWith();
         events.ScheduleEvent(EVENT_SPELL_SHRINK, 26550);
-        events.ScheduleEvent(EVENT_SPELL_SAW, urand(6050, 17650));
+        events.ScheduleEvent(EVENT_SPELL_SAW, 6050, 17650);
         events.ScheduleEvent(EVENT_SPELL_NET, 14400);
         events.ScheduleEvent(EVENT_ENRAGE, 300000);
         events.ScheduleEvent(EVENT_CHECK_HP75, 5000);
@@ -99,19 +99,19 @@ struct boss_mekgineer_steamrigger : public BossAI
         {
         case EVENT_SPELL_SHRINK:
             me->CastSpell(me->GetVictim(), SPELL_SUPER_SHRINK_RAY, false);
-            events.RepeatEvent(urand(35100, 54100));
+            events.RepeatEvent(35100, 54100);
             break;
         case EVENT_SPELL_SAW:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1))
                 me->CastSpell(target, SPELL_SAW_BLADE, false);
             else
                 me->CastSpell(me->GetVictim(), SPELL_SAW_BLADE, false);
-            events.RepeatEvent(urand(6050, 17650));
+            events.RepeatEvent(6050, 17650);
             break;
         case EVENT_SPELL_NET:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                 me->CastSpell(target, SPELL_ELECTRIFIED_NET, false);
-            events.RepeatEvent(urand(21800, 34200));
+            events.RepeatEvent(21800, 34200);
             break;
         case EVENT_ENRAGE:
             DoCastSelf(SPELL_ENRAGE, true);

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_mekgineer_steamrigger.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_mekgineer_steamrigger.cpp
@@ -99,19 +99,19 @@ struct boss_mekgineer_steamrigger : public BossAI
         {
         case EVENT_SPELL_SHRINK:
             me->CastSpell(me->GetVictim(), SPELL_SUPER_SHRINK_RAY, false);
-            events.Repeat(35100, 54100);
+            events.Repeat(35100ms, 54100ms);
             break;
         case EVENT_SPELL_SAW:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1))
                 me->CastSpell(target, SPELL_SAW_BLADE, false);
             else
                 me->CastSpell(me->GetVictim(), SPELL_SAW_BLADE, false);
-            events.Repeat(6050, 17650);
+            events.Repeat(6050ms, 17650ms);
             break;
         case EVENT_SPELL_NET:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                 me->CastSpell(target, SPELL_ELECTRIFIED_NET, false);
-            events.Repeat(21800, 34200);
+            events.Repeat(21800ms, 34200ms);
             break;
         case EVENT_ENRAGE:
             DoCastSelf(SPELL_ENRAGE, true);

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_mekgineer_steamrigger.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_mekgineer_steamrigger.cpp
@@ -99,19 +99,19 @@ struct boss_mekgineer_steamrigger : public BossAI
         {
         case EVENT_SPELL_SHRINK:
             me->CastSpell(me->GetVictim(), SPELL_SUPER_SHRINK_RAY, false);
-            events.RepeatEvent(35100, 54100);
+            events.Repeat(35100, 54100);
             break;
         case EVENT_SPELL_SAW:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1))
                 me->CastSpell(target, SPELL_SAW_BLADE, false);
             else
                 me->CastSpell(me->GetVictim(), SPELL_SAW_BLADE, false);
-            events.RepeatEvent(6050, 17650);
+            events.Repeat(6050, 17650);
             break;
         case EVENT_SPELL_NET:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                 me->CastSpell(target, SPELL_ELECTRIFIED_NET, false);
-            events.RepeatEvent(21800, 34200);
+            events.Repeat(21800, 34200);
             break;
         case EVENT_ENRAGE:
             DoCastSelf(SPELL_ENRAGE, true);

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
@@ -30,6 +30,7 @@ enum NagaDistiller
 
     SPELL_SPELL_REFLECTION      = 31534,
     SPELL_IMPALE                = 39061,
+    SPELL_HEAD_CRACK            = 16172,
     SPELL_WARLORDS_RAGE         = 37081,
     SPELL_WARLORDS_RAGE_NAGA    = 31543,
     SPELL_WARLORDS_RAGE_PROC    = 36453,
@@ -38,7 +39,8 @@ enum NagaDistiller
 
     EVENT_SPELL_REFLECTION      = 1,
     EVENT_SPELL_IMPALE          = 2,
-    EVENT_SPELL_RAGE            = 3
+    EVENT_SPELL_HEAD_CRACK      = 3,
+    EVENT_SPELL_RAGE            = 4
 };
 
 struct boss_warlord_kalithresh : public BossAI
@@ -49,8 +51,9 @@ struct boss_warlord_kalithresh : public BossAI
     {
         Talk(SAY_AGGRO);
         _JustEngagedWith();
-        events.ScheduleEvent(EVENT_SPELL_REFLECTION, 10000);
+        events.ScheduleEvent(EVENT_SPELL_REFLECTION, urand(20000, 36000));
         events.ScheduleEvent(EVENT_SPELL_IMPALE, urand(7000, 14000));
+        events.ScheduleEvent(EVENT_SPELL_HEAD_CRACK, 15000);
         events.ScheduleEvent(EVENT_SPELL_RAGE, 20000);
     }
 
@@ -78,12 +81,16 @@ struct boss_warlord_kalithresh : public BossAI
         {
         case EVENT_SPELL_REFLECTION:
             me->CastSpell(me, SPELL_SPELL_REFLECTION, false);
-            events.RepeatEvent(urand(15000, 20000));
+            events.RepeatEvent(urand(20000, 36000));
             break;
         case EVENT_SPELL_IMPALE:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 10.0f, true))
                 me->CastSpell(target, SPELL_IMPALE, false);
             events.RepeatEvent(urand(7500, 12500));
+            break;
+        case EVENT_SPELL_HEAD_CRACK:
+            DoCastVictim(SPELL_HEAD_CRACK);
+            events.RepeatEvent(urand(45000, 55000));
             break;
         case EVENT_SPELL_RAGE:
             if (Creature* distiller = me->FindNearestCreature(NPC_NAGA_DISTILLER, 100.0f))

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
@@ -51,8 +51,8 @@ struct boss_warlord_kalithresh : public BossAI
     {
         Talk(SAY_AGGRO);
         _JustEngagedWith();
-        events.ScheduleEvent(EVENT_SPELL_REFLECTION, urand(20000, 36000));
-        events.ScheduleEvent(EVENT_SPELL_IMPALE, urand(7000, 14000));
+        events.ScheduleEvent(EVENT_SPELL_REFLECTION, 20000, 36000);
+        events.ScheduleEvent(EVENT_SPELL_IMPALE, 7000, 14000);
         events.ScheduleEvent(EVENT_SPELL_HEAD_CRACK, 15000);
         events.ScheduleEvent(EVENT_SPELL_RAGE, 20000);
     }
@@ -81,16 +81,16 @@ struct boss_warlord_kalithresh : public BossAI
         {
         case EVENT_SPELL_REFLECTION:
             me->CastSpell(me, SPELL_SPELL_REFLECTION, false);
-            events.RepeatEvent(urand(20000, 36000));
+            events.RepeatEvent(20000, 36000);
             break;
         case EVENT_SPELL_IMPALE:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 10.0f, true))
                 me->CastSpell(target, SPELL_IMPALE, false);
-            events.RepeatEvent(urand(7500, 12500));
+            events.RepeatEvent(7500, 12500);
             break;
         case EVENT_SPELL_HEAD_CRACK:
             DoCastVictim(SPELL_HEAD_CRACK);
-            events.RepeatEvent(urand(45000, 55000));
+            events.RepeatEvent(45000, 55000);
             break;
         case EVENT_SPELL_RAGE:
             if (Creature* distiller = me->FindNearestCreature(NPC_NAGA_DISTILLER, 100.0f))

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
@@ -81,16 +81,16 @@ struct boss_warlord_kalithresh : public BossAI
         {
         case EVENT_SPELL_REFLECTION:
             me->CastSpell(me, SPELL_SPELL_REFLECTION, false);
-            events.Repeat(20000, 36000);
+            events.Repeat(20s, 36s);
             break;
         case EVENT_SPELL_IMPALE:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 10.0f, true))
                 me->CastSpell(target, SPELL_IMPALE, false);
-            events.RepeatEvent(7500, 12500);
+            events.RepeatEvent(7500ms, 12500ms);
             break;
         case EVENT_SPELL_HEAD_CRACK:
             DoCastVictim(SPELL_HEAD_CRACK);
-            events.Repeat(45000, 55000);
+            events.Repeat(45s, 55s);
             break;
         case EVENT_SPELL_RAGE:
             if (Creature* distiller = me->FindNearestCreature(NPC_NAGA_DISTILLER, 100.0f))

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
@@ -86,7 +86,7 @@ struct boss_warlord_kalithresh : public BossAI
         case EVENT_SPELL_IMPALE:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 10.0f, true))
                 me->CastSpell(target, SPELL_IMPALE, false);
-            events.RepeatEvent(7500ms, 12500ms);
+            events.Repeat(7500ms, 12500ms);
             break;
         case EVENT_SPELL_HEAD_CRACK:
             DoCastVictim(SPELL_HEAD_CRACK);

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
@@ -81,7 +81,7 @@ struct boss_warlord_kalithresh : public BossAI
         {
         case EVENT_SPELL_REFLECTION:
             me->CastSpell(me, SPELL_SPELL_REFLECTION, false);
-            events.RepeatEvent(20000, 36000);
+            events.Repeat(20000, 36000);
             break;
         case EVENT_SPELL_IMPALE:
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 10.0f, true))
@@ -90,7 +90,7 @@ struct boss_warlord_kalithresh : public BossAI
             break;
         case EVENT_SPELL_HEAD_CRACK:
             DoCastVictim(SPELL_HEAD_CRACK);
-            events.RepeatEvent(45000, 55000);
+            events.Repeat(45000, 55000);
             break;
         case EVENT_SPELL_RAGE:
             if (Creature* distiller = me->FindNearestCreature(NPC_NAGA_DISTILLER, 100.0f))


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Adds spells Head Crack to Kalithresh and Enrage to Steamrigger
-  Corrects timers

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Retail Sniffs

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
