### PR TITLE
fix(DB/SAI): Port Wickerman Guardian from Mangos.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1680771211065684700.sql
+++ b/data/sql/updates/pending_db_world/rev_1680771211065684700.sql
@@ -1,0 +1,27 @@
+-- Wickerman Guardian 15195
+DELETE FROM `creature_template_addon` WHERE (`entry` = 15195);
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(15195, 0, 0, 0, 0, 0, 0, '12187');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 15195;
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 15195);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(15195, 0, 0, 0, 0, 0, 100, 0, 4000, 12000, 8000, 12000, 0, 11, 18368, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Wickerman Guardian - In Combat - Cast \'Strike\''),
+(15195, 0, 1, 0, 0, 0, 100, 0, 8000, 14000, 9000, 15000, 0, 11, 19128, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 'Wickerman Guardian - In Combat - Cast \'Knockdown\''),
+(15195, 0, 2, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 11, 25007, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Wickerman Guardian - On Just Died - Cast \'Wickerman Guardian Ember\'');
+
+-- Wickerman Guardian Ember 180574
+DELETE FROM `gameobject_template` WHERE (`entry` = 180574);
+INSERT INTO `gameobject_template` (`entry`, `type`, `displayId`, `name`, `IconName`, `castBarCaption`, `unk1`, `size`, `Data0`, `Data1`, `Data2`, `Data3`, `Data4`, `Data5`, `Data6`, `Data7`, `Data8`, `Data9`, `Data10`, `Data11`, `Data12`, `Data13`, `Data14`, `Data15`, `Data16`, `Data17`, `Data18`, `Data19`, `Data20`, `Data21`, `Data22`, `Data23`, `AIName`, `ScriptName`, `VerifiedBuild`) VALUES
+(180574, 2, 6421, 'Wickerman Guardian Ember', '', 'Using', '', 5, 43, 0, 0, 6535, 0, 0, 19700, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'SmartGameObjectAI', '', 0);
+
+-- Unsure/unknown if it can only be opened by Alliance (Same way as the horde ones can be opened only by horde)
+DELETE FROM `gameobject_template_addon` WHERE (`entry` = 180574);
+INSERT INTO `gameobject_template_addon` (`entry`, `faction`, `flags`, `mingold`, `maxgold`, `artkit0`, `artkit1`, `artkit2`, `artkit3`) VALUES
+(180574, 84, 0, 0, 0, 0, 0, 0, 0);
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 1 AND `entryorguid` = 180574);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(180574, 1, 0, 1, 62, 0, 100, 0, 6535, 0, 0, 0, 0, 85, 24705, 34, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Wickerman Guardian Ember - On Gossip Option 0 Selected - Invoker Cast \'Invocation of the Wickerman\''),
+(180574, 1, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Wickerman Guardian Ember - On Gossip Option 0 Selected - Close Gossip');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
It's unknown if the gameobject can only interact with alliance players (same way how the Horde one can only be opened by horde players).
## Changes Proposed:
- Port SAI and the gameobject they spawn from Mangos

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/4254
## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowpedia.fandom.com/wiki/Wickerman_Guardian
https://www.wowhead.com/wotlk/npc=15195/wickerman-guardian
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Be Alliance
.event start 12
.go c id 15195
Check if they have Disease Cloud, cast strike and knockdown and on death should spawn a gameobject that works the same as the Horde version.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
