### PR TITLE
fix:(DB/loot): Put Item 1219 onto the correct loot table

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1681296870508704800.sql
+++ b/data/sql/updates/pending_db_world/rev_1681296870508704800.sql
@@ -1,0 +1,6 @@
+--
+-- Put Item 1219 Redridge Machete loot on right mob
+DELETE FROM `reference_loot_template` WHERE  `Entry`=24077 AND `Item`=1219;
+DELETE FROM `creature_loot_template` WHERE  `Entry`=424 AND `Item`=1219 AND `Reference`=0 AND `GroupId`=0;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES 
+(424, 1219, 0, 2, 0, 1, 0, 1, 1, 'Redridge Poacher - Redridge Machete');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes https://wowgaming.altervista.org/aowow/?item=1219 from the current creatures it drops from
-  Places it on creature [Redridge Poacher](https://www.wowhead.com/wotlk/npc=424/redridge-poacher)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.wowhead.com/wotlk/item=1219/redridge-machete

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
