### PR TITLE
fix(DB/Conditions): Costume Scraps not having quest status requirements.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1681332432499578800.sql
+++ b/data/sql/updates/pending_db_world/rev_1681332432499578800.sql
@@ -1,5 +1,5 @@
 -- Costume Scraps
-DELETE FROM `conditions` WHERE `SourceGroup` IN (21383,21382,21492,21810,22308,21809,21637) AND `SourceEntry` = 31121;
+DELETE FROM `conditions` WHERE `SourceGroup` IN (21383,21382,21492,21810,22308,21809,21637) AND `SourceEntry` = 31121 AND `SourceTypeOrReferenceId` = 1;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (1, 21383, 31121, 0, 0, 47, 0, 10722, 74, 0, 0, 0, 0, '', 'Allow obtaining Costume Scraps only if quest \'Meeting at the Blackwing Coven\' is complete, in progress or have been rewarded.'),
 (1, 21382, 31121, 0, 0, 47, 0, 10722, 74, 0, 0, 0, 0, '', 'Allow obtaining Costume Scraps only if quest \'Meeting at the Blackwing Coven\' is complete, in progress or have been rewarded.'),

--- a/data/sql/updates/pending_db_world/rev_1681332432499578800.sql
+++ b/data/sql/updates/pending_db_world/rev_1681332432499578800.sql
@@ -1,0 +1,10 @@
+-- Costume Scraps
+DELETE FROM `conditions` WHERE `SourceGroup` IN (21383,21382,21492,21810,22308,21809,21637) AND `SourceEntry` = 31121;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(1, 21383, 31121, 0, 0, 47, 0, 10722, 74, 0, 0, 0, 0, '', 'Allow obtaining Costume Scraps only if quest \'Meeting at the Blackwing Coven\' is complete, in progress or have been rewarded.'),
+(1, 21382, 31121, 0, 0, 47, 0, 10722, 74, 0, 0, 0, 0, '', 'Allow obtaining Costume Scraps only if quest \'Meeting at the Blackwing Coven\' is complete, in progress or have been rewarded.'),
+(1, 21492, 31121, 0, 0, 47, 0, 10722, 74, 0, 0, 0, 0, '', 'Allow obtaining Costume Scraps only if quest \'Meeting at the Blackwing Coven\' is complete, in progress or have been rewarded.'),
+(1, 21810, 31121, 0, 0, 47, 0, 10722, 74, 0, 0, 0, 0, '', 'Allow obtaining Costume Scraps only if quest \'Meeting at the Blackwing Coven\' is complete, in progress or have been rewarded.'),
+(1, 22308, 31121, 0, 0, 47, 0, 10722, 74, 0, 0, 0, 0, '', 'Allow obtaining Costume Scraps only if quest \'Meeting at the Blackwing Coven\' is complete, in progress or have been rewarded.'),
+(1, 21809, 31121, 0, 0, 47, 0, 10722, 74, 0, 0, 0, 0, '', 'Allow obtaining Costume Scraps only if quest \'Meeting at the Blackwing Coven\' is complete, in progress or have been rewarded.'),
+(1, 21637, 31121, 0, 0, 47, 0, 10722, 74, 0, 0, 0, 0, '', 'Allow obtaining Costume Scraps only if quest \'Meeting at the Blackwing Coven\' is complete, in progress or have been rewarded.');


### PR DESCRIPTION
Scraps drop during the next quest (10748) as well, unknown if they stop dropping after those 2 quests or not (10722 and 10748)
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Require quest 10722 (Meeting at the Blackwing Coven) to be complete, in progress or have been rewarded in order to see Costume Scraps.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/4993
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15004

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.wowhead.com/wotlk/item=31121/costume-scraps#comments

Scraps drop during the next quest as well, unknown if they stop dropping after those 2 quests or not (10722 and 10748)
https://www.wowhead.com/wotlk/quest=10748/maxnar-must-die#comments:id=200654
> By Nevoron (271 – 3) on 2007/12/13 (Patch 2.3.0)		
Those costume scraps from the previous quest still drop, i'm collecting them right now, so i guess thats easier than a corpse run.
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.go xyz 3239 7112 173 530
Kill Wyrmcults, notice no Scraps dropping
.q add 10722
Kill Wyrmcults, notice you get Scraps if you have the quest complete, in progress or have been rewarded.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
