### PR TITLE
fix(Core/Hook): Fix OnAuraRemove not being called for owned auras.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4575,6 +4575,8 @@ void Unit::_UnapplyAura(AuraApplicationMap::iterator& i, AuraRemoveMode removeMo
     // only way correctly remove all auras from list
     //if (removedAuras != m_removedAurasCount) new aura may be added
     i = m_appliedAuras.begin();
+
+    sScriptMgr->OnAuraRemove(this, aurApp, removeMode);
 }
 
 void Unit::_UnapplyAura(AuraApplication* aurApp, AuraRemoveMode removeMode)
@@ -4655,8 +4657,6 @@ void Unit::RemoveOwnedAura(AuraMap::iterator& i, AuraRemoveMode removeMode)
     aura->_Remove(removeMode);
 
     i = m_ownedAuras.begin();
-
-    sScriptMgr->OnAuraRemove(this, nullptr, removeMode);
 }
 
 void Unit::RemoveOwnedAura(uint32 spellId, ObjectGuid casterGUID, uint8 reqEffMask, AuraRemoveMode removeMode)
@@ -4720,8 +4720,6 @@ void Unit::RemoveAura(AuraApplicationMap::iterator& i, AuraRemoveMode mode)
     // Remove aura - for Area and Target auras
     if (aura->GetOwner() == this)
         aura->Remove(mode);
-
-    sScriptMgr->OnAuraRemove(this, aurApp, mode);
 }
 
 void Unit::RemoveAura(uint32 spellId, ObjectGuid caster, uint8 reqEffMask, AuraRemoveMode removeMode)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4655,6 +4655,8 @@ void Unit::RemoveOwnedAura(AuraMap::iterator& i, AuraRemoveMode removeMode)
     aura->_Remove(removeMode);
 
     i = m_ownedAuras.begin();
+
+    sScriptMgr->OnAuraRemove(this, nullptr, removeMode);
 }
 
 void Unit::RemoveOwnedAura(uint32 spellId, ObjectGuid casterGUID, uint8 reqEffMask, AuraRemoveMode removeMode)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  The OnAuraRemove hook should be called for owned auras.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- OnAuraRemove hook was not being called, you could not detect removed owned auras that were fired by `AURA_REMOVE_BY_EXPIRE` for example.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Subscribed to OnAuraRemove hook and tested spell `67721` to see if it fired.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Attach debugger to worldserver
2. Set breakpoint at `L98` of `UnitScript.cpp`
3. Add weakness aura to self: `.aura 67721`
4. Observe the breakpoint being hit when the aura expires.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- ~~I'm not sure how to get the AuraApplication instance, so I've just passed a nullptr. Any tips here are appreciated.~~

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
