### PR TITLE
Revert "fix(Core/Spells): Seal of Command, Seal of Vengeance and Seal…

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3439,10 +3439,10 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
                         spell_bonus += int32(0.08f * m_caster->GetTotalAttackPowerValue(BASE_ATTACK));
                         spell_bonus += int32(0.13f * m_caster->SpellBaseDamageBonusDone(m_spellInfo->GetSchoolMask()));
                         break;
-                     case 53385:  // Divine Storm deals normalized damage
+                    case 53385:  // Divine Storm deals normalized damage
                         normalized = true;
                         break;
-                     default:
+                    default:
                         break;
                 }
                 break;

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3352,6 +3352,7 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
     // some spell specific modifiers
     float totalDamagePercentMod  = 100.0f;                  // applied to final bonus+weapon damage
     int32 spell_bonus = 0;                                  // bonus specific for spell
+    bool normalized = false;
 
     switch (m_spellInfo->SpellFamilyName)
     {
@@ -3432,11 +3433,17 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
             }
         case SPELLFAMILY_PALADIN:
             {
-                // Seal of Command Unleashed
-                if (m_spellInfo->Id == 20467)
+                switch (m_spellInfo->Id)
                 {
-                    spell_bonus += int32(0.08f * m_caster->GetTotalAttackPowerValue(BASE_ATTACK));
-                    spell_bonus += int32(0.13f * m_caster->SpellBaseDamageBonusDone(m_spellInfo->GetSchoolMask()));
+                    case 20467: // Seal of Command Unleashed
+                        spell_bonus += int32(0.08f * m_caster->GetTotalAttackPowerValue(BASE_ATTACK));
+                        spell_bonus += int32(0.13f * m_caster->SpellBaseDamageBonusDone(m_spellInfo->GetSchoolMask()));
+                        break;
+                     case 53385:  // Divine Storm deals normalized damage
+                        normalized = true;
+                        break;
+                     default:
+                        break;
                 }
                 break;
             }
@@ -3557,13 +3564,8 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
             }
     }
 
-    bool normalized = false;
     float weaponDamagePercentMod = 100.0f;
     int32 fixed_bonus = 0;
-
-    // xinef: Divine Storm deals normalized damage
-    if (m_spellInfo->Id == 53385)
-        normalized = true;
 
     for (int j = 0; j < MAX_SPELL_EFFECTS; ++j)
     {

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3352,7 +3352,6 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
     // some spell specific modifiers
     float totalDamagePercentMod  = 100.0f;                  // applied to final bonus+weapon damage
     int32 spell_bonus = 0;                                  // bonus specific for spell
-    bool normalized = false;
 
     switch (m_spellInfo->SpellFamilyName)
     {
@@ -3438,18 +3437,6 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
                 {
                     spell_bonus += int32(0.08f * m_caster->GetTotalAttackPowerValue(BASE_ATTACK));
                     spell_bonus += int32(0.13f * m_caster->SpellBaseDamageBonusDone(m_spellInfo->GetSchoolMask()));
-                }
-
-                switch (m_spellInfo->Id)
-                {
-                    case 20424: // Seal of Command
-                    case 42463: // Seal of Vengeance
-                    case 53739: // Seal of Corruption
-                    case 53385: // Divine Storm
-                        normalized = true;
-                        break;
-                    default:
-                        break;
                 }
                 break;
             }
@@ -3570,8 +3557,13 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
             }
     }
 
+    bool normalized = false;
     float weaponDamagePercentMod = 100.0f;
     int32 fixed_bonus = 0;
+
+    // xinef: Divine Storm deals normalized damage
+    if (m_spellInfo->Id == 53385)
+        normalized = true;
 
     for (int j = 0; j < MAX_SPELL_EFFECTS; ++j)
     {


### PR DESCRIPTION
… of Corr… (#15193)"

This reverts commit 88401360ab94d9d1704c928b0ed5edc8cef8caf9.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Revert https://github.com/azerothcore/azerothcore-wotlk/pull/15193
The change made these spells normalized, aka somewhat weaponspeed independent, Seals happen on hit
It is left to the reader to find out what might be wrong with fast weapons

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15925

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Actually tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.learn 20375
.learn 53736
Unequip your weapon for low variance in the damage
Use the Seal, attack a dummy

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
