### PR TITLE
fix(Core/Spells): Seal of Command, Seal of Vengeance and Seal of Corruption do not benefit from percentage damage increases

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -212,6 +212,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     {
         spellInfo->MaxAffectedTargets = 4;
     });
+
     ApplySpellFix({
         20424,  // Seal of Command
         42463,  // Seal of Vengeance

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -212,6 +212,14 @@ void SpellMgr::LoadSpellInfoCorrections()
     {
         spellInfo->MaxAffectedTargets = 4;
     });
+    ApplySpellFix({
+        20424,  // Seal of Command
+        42463,  // Seal of Vengeance
+        53739   // Seal of Corruption
+        }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_CASTER_MODIFIERS;
+    });
 
     // Spitfire Totem
     ApplySpellFix({ 38296 }, [](SpellInfo* spellInfo)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/14988

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Necrosis ([Wowhead](https://www.wowhead.com/wotlk/spell=51460/necrosis)) should have the SPELL_ATTR3_IGNORE_CASTER_MODIFIERS flag and works as expected


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested as described below


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.learn 20375
.learn 31884
Unequip your weapon for low variance in the damage
Use Seal of Command, attack a dummy
Use Avenging Wrath and attack more

With avenging wrath deals ~20% damage more than without

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Holy only damage increases/decreases do not affect the seals anymore ( I do not know if that is correct or not, there are like 2 of those in the game total)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
