### PR TITLE
fix:(DB/loot): Improve Flesh Eater Loot

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1681499033422961200.sql
+++ b/data/sql/updates/pending_db_world/rev_1681499033422961200.sql
@@ -1,0 +1,3 @@
+--
+-- Removes Jade and Citrine (wrong level mob), Mining, and Herbing loot from Flesh Eater
+DELETE FROM `creature_loot_template` WHERE `entry`=3 AND `item` IN (1529, 2453, 2770, 2775, 2835, 2838, 3369, 3864, 5504, 2772);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes Jade and Citrine (wrong level mob), Mining, and Herbing loot from Flesh Eater


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- Ref table work still needs done, and a lot of drops need adjusted to logical numbers.  This is gonna be the case in a lot of my incoming touchups as I am going to attempt to get them in a "ready" state for that.
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
