### PR TITLE
fix(DB/loot): Murmur loot count correction

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1681510679512783100.sql
+++ b/data/sql/updates/pending_db_world/rev_1681510679512783100.sql
@@ -1,0 +1,3 @@
+--
+-- Update Murmur Loot Count to always drop 2 items
+UPDATE `creature_loot_template` SET `MinCount`=2 WHERE `Entry`=18708 AND `Item`=35002 AND `Reference`=35002 AND `GroupId`=2;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Update Murmur Loot Count to always drop 2 items


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.youtube.com/watch?v=kXLuDZnJLc0
https://www.youtube.com/watch?v=ht9781OYx6M
https://www.youtube.com/watch?v=axb9b6NkXdM
https://www.youtube.com/watch?v=q1Ms3jSTVsQ
https://www.youtube.com/watch?v=AXsjN_yiu3A
https://www.youtube.com/watch?v=0y8ewSHQ3VE
https://www.youtube.com/watch?v=aKniMhI8HrQ
https://www.youtube.com/watch?v=4VDeFdhTSSQ
https://www.youtube.com/watch?v=DC7LSTgKXng
https://www.youtube.com/watch?v=d7rzDpVEgRM
These videos also show via logical processing why I cannot draw two tables like I normally can

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- Issue:  Due to the way the loot system works, I can not prevent it from dropping 2 of the same item unless I make up a table division
- Table division does seem to exist/is blizzlike to an extent,  but there is more complication than that and there is no "clean" way to divide the table into 6 drops per table without creating an incorrect table.  More information is needed to make that division, but it would not be a complete division, as more importantly another system that prevents duplicate draws is needed to actually get this correctly.  Its very possible that this table is just two (different) draws from the full pool, though I have suspicions that it's slightly more complex than that.  

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
