### PR TITLE
Revert "fix(Core/SAI): Set minions in combat with their master's vict…

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -811,20 +811,6 @@ void SmartAI::JustSummoned(Creature* creature)
 {
     GetScript()->ProcessEventsFor(SMART_EVENT_SUMMONED_UNIT, creature);
     GetScript()->AddCreatureSummon(creature->GetGUID());
-
-    if (me->IsEngaged() && !creature->IsInEvadeMode())
-    {
-        if (Unit* victim = me->GetVictim())
-        {
-            creature->SetInCombatWith(victim);
-            victim->SetInCombatWith(creature);
-
-            if (creature->CanHaveThreatList())
-            {
-                creature->AddThreat(victim, 0.0f);
-            }
-        }
-    }
 }
 
 void SmartAI::SummonedCreatureDies(Creature* summon, Unit* /*killer*/)


### PR DESCRIPTION
…im (#14959)"

This reverts commit 1e17eaae0bedc5e03a6b7c5c3792f5c04742b71d.

<!-- First of all, THANK YOU for your contribution. -->

Combat would be handled by script. In several cases it's blizzlike for summons to spawn out of combat even while their summoner is in combat. Other times combat is handled through script, other times solely by detection range.

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
