### PR TITLE
fix(DB/spell_cooldown_overrides):  Fel Reaver Sentinel spells not having CD.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1681729297995153300.sql
+++ b/data/sql/updates/pending_db_world/rev_1681729297995153300.sql
@@ -1,0 +1,7 @@
+-- Fel Reaver Sentinel
+DELETE FROM `spell_cooldown_overrides` WHERE `Id` IN (38055,38006,38052,37920);
+INSERT INTO `spell_cooldown_overrides` (`Id`, `RecoveryTime`, `CategoryRecoveryTime`, `StartRecoveryTime`, `StartRecoveryCategory`) VALUES 
+(38055, 10000, 10000, 0, 0),
+(38006, 10000, 10000, 0, 0),
+(38052, 15000, 15000, 0, 0),
+(37920, 30000, 30000, 0, 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Add CD to the spells.  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Progress https://github.com/azerothcore/azerothcore-wotlk/issues/15035
- Progress https://github.com/chromiecraft/chromiecraft/issues/5033

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
In the issue(s)
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->


.go zonexy 40.74 21.65 3943
.quest add 10612
Take control of a Fel Reaver Sentinel with one of the consoles in front of you
Use the spells, see if they have cooldown.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
