### PR TITLE
fix(DB/Conditions): Allow gossip with Ethereal Teleport Pad after quest 10270.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1681758967243313800.sql
+++ b/data/sql/updates/pending_db_world/rev_1681758967243313800.sql
@@ -1,0 +1,5 @@
+-- 184073 (Ethereal Teleport Pad)
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` = 8062;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 8062, 0, 0, 0, 29, 1, 20518, 10, 0, 1, 0, 0, '', '(AND) Ethereal Teleport Pad - Show Gossip option 0 only if no Image of Wind Trader Marid is within 10y.'),
+(15, 8062, 0, 0, 0, 47, 0, 10270, 66, 0, 0, 0, 0, '', '(AND) Ethereal Teleport Pad - Show Gossip option 0 only if quest A Not-So-Modest Proposal has been completed or rewarded.');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
You should be able to interact with the Pad after completing 10270, since you've "repaired" it. (the entire point of the quest)
## Changes Proposed:
- Remove the previous mess of conditions and add COMPLETE and REWARDED condition for quest 10270. 
- Reduce range check for Image of Wind Trader Marid to 10y, from 200.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5074

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowpedia.fandom.com/wiki/Ethereal_Teleport_Pad + Possibility of being locked out of the quest chain.
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.go gameobject id 184073
.q a 10270 
Interact with the pad, no gossip.
.q c 10270
Interact with the pad, gossip should be there.
Turn in the quest without accepting the follow up.
Wait for Image of Wind Trader to despawn and interact with the pad again, gossip should be present.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
