### PR TITLE
fix(DB/ShadowLabyrinth): Apply 'Incite Chaos' as debuff

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1681793209169080500.sql
+++ b/data/sql/updates/pending_db_world/rev_1681793209169080500.sql
@@ -1,4 +1,4 @@
 --
 DELETE FROM `spell_custom_attr` WHERE `spell_id`=33684;
-INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (33684,12288);
+INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (33684,4096);
 

--- a/data/sql/updates/pending_db_world/rev_1681793209169080500.sql
+++ b/data/sql/updates/pending_db_world/rev_1681793209169080500.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_custom_attr` WHERE `spell_id`=33684;
+INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (33684,12288);
+


### PR DESCRIPTION
## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #15996

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://youtu.be/8OEHi3WldNg?t=1686

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- ### Before
![image](https://user-images.githubusercontent.com/61223313/232674327-22578d7b-882b-48f7-b90d-3fc5900b6da5.png)


- ### After
![image](https://user-images.githubusercontent.com/61223313/232674340-5c947e17-0c03-4e8d-a707-ed8868067f34.png)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
