### PR TITLE
fix(DB/SAI): Bogblossom trap - knockback and despawn.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1681824132109329700.sql
+++ b/data/sql/updates/pending_db_world/rev_1681824132109329700.sql
@@ -2,8 +2,8 @@
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 23104;
 DELETE FROM `smart_scripts` WHERE `entryorguid` = 23104 AND `source_type` = 0;
 INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
-(23104,0,0,1,54,0,100,0,0,0,0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,"Bogblossom Bunny - On Just Summoned - Say Line 0"),
-(23104,0,1,0,61,0,100,0,0,0,0,0,0,11,40532,0,0,0,0,0,1,0,0,0,0,0,0,0,0,"Bogblossom Bunny - On Link - Cast 'Bogblossom Knockback'");
+(23104,0,0,1,54,0,100,0,0,0,0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Bogblossom Bunny - On Just Summoned - Say Line 0'),
+(23104,0,1,0,61,0,100,0,0,0,0,0,0,11,40532,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Bogblossom Bunny - On Link - Cast \'Bogblossom Knockback\'');
 
 DELETE FROM `creature_text` WHERE `CreatureID` = 23104;
 INSERT INTO `creature_text` (`CreatureID`,`GroupID`,`ID`,`Text`,`Type`,`Language`,`Probability`,`Emote`,`Duration`,`Sound`,`BroadcastTextId`,`TextRange`,`comment`) VALUES 

--- a/data/sql/updates/pending_db_world/rev_1681824132109329700.sql
+++ b/data/sql/updates/pending_db_world/rev_1681824132109329700.sql
@@ -1,5 +1,5 @@
 -- Bogblossom Bunny SAI (Source: https://www.youtube.com/watch?v=EIFhKHtvOe0) 
-UPDATE `creature_template` SET `AIName` = "SmartAI" WHERE `entry` = 23104;
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 23104;
 DELETE FROM `smart_scripts` WHERE `entryorguid` = 23104 AND `source_type` = 0;
 INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
 (23104,0,0,1,54,0,100,0,0,0,0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,"Bogblossom Bunny - On Just Summoned - Say Line 0"),

--- a/data/sql/updates/pending_db_world/rev_1681824132109329700.sql
+++ b/data/sql/updates/pending_db_world/rev_1681824132109329700.sql
@@ -1,0 +1,17 @@
+-- Bogblossom Bunny SAI (Source: https://www.youtube.com/watch?v=EIFhKHtvOe0) 
+UPDATE `creature_template` SET `AIName` = "SmartAI" WHERE `entry` = 23104;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 23104 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(23104,0,0,1,54,0,100,0,0,0,0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,"Bogblossom Bunny - On Just Summoned - Say Line 0"),
+(23104,0,1,0,61,0,100,0,0,0,0,0,0,11,40532,0,0,0,0,0,1,0,0,0,0,0,0,0,0,"Bogblossom Bunny - On Link - Cast 'Bogblossom Knockback'");
+
+DELETE FROM `creature_text` WHERE `CreatureID` = 23104;
+INSERT INTO `creature_text` (`CreatureID`,`GroupID`,`ID`,`Text`,`Type`,`Language`,`Probability`,`Emote`,`Duration`,`Sound`,`BroadcastTextId`,`TextRange`,`comment`) VALUES 
+(23104,0,0,"The bogblossom explodes, spraying pollen wildly.",16,0,100,0,0,0,20932,0,'Bogblossom Bunny');
+
+-- 185500 (Bogblossom)
+UPDATE `gameobject_template` SET `AIName` = 'SmartGameObjectAI' WHERE `entry` = 185500 ;
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 1 AND `entryorguid` = 185500 );
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(185500 , 1, 0, 0, 70, 0, 100, 0, 2, 0, 0, 0, 0, 41, 1000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Bogblossom - On Gameobject State Changed - Despawn In 1000 ms');


### PR DESCRIPTION
Shouldn't the trapped and non trapped object be pooled?
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Add knockback and emote SAI for Bogblossom Bunny.
- Add despawn SAI for Bogblossom (Goober, that spawns the actual trap).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5163

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://github.com/TrinityCore/TrinityCore/commit/6fc2c62883b18be58201608848dadf348d1d91fe
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Be a druid
.q a 10961
.go gameobject 20375
See if it knocksback and despawn after.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
