### PR TITLE
fix(DB/SAI): Remove wrong spell from Fiendling Flesh Beast.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1681829644195320500.sql
+++ b/data/sql/updates/pending_db_world/rev_1681829644195320500.sql
@@ -1,0 +1,3 @@
+-- 20668 (Fiendling Flesh Beast)
+UPDATE `creature_template` SET `AIName` = '' WHERE `entry` = 20668;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 20668 AND `source_type` = 0;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
They already have Shadowform (37816) as a template_addon.
## Changes Proposed:
- Remove https://www.wowhead.com/wotlk/spell=36471/rapid-pummel from SAI.  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5250

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.wowhead.com/wotlk/npc=20668 / Mangos & Trinity
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.go c id 20668
They should not cast any spells.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
