### PR TITLE
fix(DB/Conditions):  Add missing gossip text for Rathis Tomber.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1681835987102434300.sql
+++ b/data/sql/updates/pending_db_world/rev_1681835987102434300.sql
@@ -1,0 +1,10 @@
+-- Rathis Tomber (16224)
+DELETE FROM `gossip_menu` WHERE `MenuID` = 7162 AND `TextID` = 8432;
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES
+(7162, 8432);
+
+UPDATE `conditions` SET `Comment` = 'Rathis Tomber - Show Option 0 (Vendor) if quest 9152 has been rewarded.' WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` = 7162 AND `SourceEntry` = 0;
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 14 AND `SourceGroup` = 7162;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 7162, 8432, 0, 0, 8, 0, 9152, 0, 0, 0, 0, 0, '', 'Rathis Tomber - Show gossip text 8432 if quest 9152 has been rewarded.');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Add missing gossip text and condition it to show if quest 9152 has been rewarded.
- Update comment for previously existing condition.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowpedia.fandom.com/wiki/Rathis_Tomber
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

.go c id 16224
Check gossip, should be `Ah, hello there, <race>`
accept the quest
.q c 9152
turn in the quest
check gossip again, should be `Such a delight to see you again, <class>`

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
