### PR TITLE
fix(Core/Creature): Adjust IGNORE ASSISTANCE CALL flag to prevent assistance on initial aggro only

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1682017480991526700.sql
+++ b/data/sql/updates/pending_db_world/rev_1682017480991526700.sql
@@ -1,0 +1,7 @@
+--
+UPDATE `creature_template` SET `flags_extra` = `flags_extra`|33554432 WHERE `entry` IN (16523, 16594, 17083, 17420, 17694, 16507, 17462, 18404, 17993, 18421, 19486, 18422, 19557, 19505); -- Botanica & SHH
+UPDATE `creature_template` SET `flags_extra` = `flags_extra`|33554432 WHERE `entry` IN (20567, 20576, 20577, 20587, 20591, 20593, 20595, 21548, 21549, 21555, 21570, 21571, 21572, 21577); -- Botanica & SHH Heroics
+UPDATE `creature_template` SET `flags_extra` = `flags_extra`|33554432 WHERE `entry` = 13996; -- Blackwing Technician
+UPDATE `creature_template` SET `flags_extra` = `flags_extra`&~33554432 WHERE `entry` = 12460; -- Blackwing Adds
+UPDATE `creature_template` SET `flags_extra` = `flags_extra`&~33554432 WHERE `entry` = 11380; -- Jin'do the Hexxer
+UPDATE `creature_template` SET `flags_extra` = `flags_extra`|33554432 WHERE `entry` IN (14825, 14882, 14883); -- Jin'do the Hexxer Adds

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2445,12 +2445,6 @@ bool Creature::CanAssistTo(Unit const* u, Unit const* enemy, bool checkfaction /
     if (GetCharmerOrOwnerGUID())
         return false;
 
-    // Check for ignore assistance extra flag
-    if (m_creatureInfo->HasFlagsExtra(CREATURE_FLAG_EXTRA_IGNORE_ASSISTANCE_CALL))
-    {
-        return false;
-    }
-
     // only from same creature faction
     if (checkfaction)
     {

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -71,7 +71,7 @@ enum CreatureFlagsExtra : uint32
     CREATURE_FLAG_EXTRA_AVOID_AOE                       = 0x00400000,   // pussywizard: ignored by aoe attacks (for icc blood prince council npc - Dark Nucleus)
     CREATURE_FLAG_EXTRA_NO_DODGE                        = 0x00800000,   // xinef: target cannot dodge
     CREATURE_FLAG_EXTRA_MODULE                          = 0x01000000,
-    CREATURE_FLAG_EXTRA_IGNORE_ASSISTANCE_CALL          = 0x02000000,   // Creatures are not aggroed by other mobs assistance functions
+    CREATURE_FLAG_EXTRA_DONT_CALL_ASSISTANCE            = 0x02000000,   // Prevent creatures from calling for assistance on initial aggro
     CREATURE_FLAG_DONT_OVERRIDE_ENTRY_SAI               = 0x04000000,   // Load both ENTRY and GUID specific SAI
     CREATURE_FLAG_EXTRA_UNUSED_28                       = 0x08000000,
     CREATURE_FLAG_EXTRA_DUNGEON_BOSS                    = 0x10000000,   // creature is a dungeon boss (SET DYNAMICALLY, DO NOT ADD IN DB)

--- a/src/server/game/Entities/Creature/enuminfo_CreatureData.cpp
+++ b/src/server/game/Entities/Creature/enuminfo_CreatureData.cpp
@@ -56,7 +56,7 @@ AC_API_EXPORT EnumText EnumUtils<CreatureFlagsExtra>::ToString(CreatureFlagsExtr
         case CREATURE_FLAG_EXTRA_AVOID_AOE: return { "CREATURE_FLAG_EXTRA_AVOID_AOE", "CREATURE_FLAG_EXTRA_AVOID_AOE", "pussywizard: ignored by aoe attacks (for icc blood prince council npc - Dark Nucleus)" };
         case CREATURE_FLAG_EXTRA_NO_DODGE: return { "CREATURE_FLAG_EXTRA_NO_DODGE", "CREATURE_FLAG_EXTRA_NO_DODGE", "xinef: target cannot dodge" };
         case CREATURE_FLAG_EXTRA_MODULE: return { "CREATURE_FLAG_EXTRA_MODULE", "CREATURE_FLAG_EXTRA_MODULE", "Used by module creatures to avoid blizzlike checks." };
-        case CREATURE_FLAG_EXTRA_IGNORE_ASSISTANCE_CALL: return { "CREATURE_FLAG_EXTRA_IGNORE_ASSISTANCE_CALL", "Creatures are not aggroed by other mobs assistance functions", "" };
+        case CREATURE_FLAG_EXTRA_DONT_CALL_ASSISTANCE: return { "CREATURE_FLAG_EXTRA_DONT_CALL_ASSISTANCE", "Creature does not call for assistance on initial aggro", "" };
         case CREATURE_FLAG_DONT_OVERRIDE_ENTRY_SAI: return { "CREATURE_FLAG_DONT_OVERRIDE_ENTRY_SAI", "Creature entry SAI won't be overriden by GUID SAI", "" };
         case CREATURE_FLAG_EXTRA_UNUSED_28: return { "CREATURE_FLAG_EXTRA_UNUSED_28", "CREATURE_FLAG_EXTRA_UNUSED_28", "" };
         case CREATURE_FLAG_EXTRA_DUNGEON_BOSS: return { "CREATURE_FLAG_EXTRA_DUNGEON_BOSS", "CREATURE_FLAG_EXTRA_DUNGEON_BOSS", "creature is a dungeon boss (SET DYNAMICALLY, DO NOT ADD IN DB)" };
@@ -100,7 +100,7 @@ AC_API_EXPORT CreatureFlagsExtra EnumUtils<CreatureFlagsExtra>::FromIndex(size_t
         case 22: return CREATURE_FLAG_EXTRA_AVOID_AOE;
         case 23: return CREATURE_FLAG_EXTRA_NO_DODGE;
         case 24: return CREATURE_FLAG_EXTRA_MODULE;
-        case 25: return CREATURE_FLAG_EXTRA_IGNORE_ASSISTANCE_CALL;
+        case 25: return CREATURE_FLAG_EXTRA_DONT_CALL_ASSISTANCE;
         case 26: return CREATURE_FLAG_DONT_OVERRIDE_ENTRY_SAI;
         case 27: return CREATURE_FLAG_EXTRA_UNUSED_28;
         case 28: return CREATURE_FLAG_EXTRA_DUNGEON_BOSS;
@@ -141,7 +141,7 @@ AC_API_EXPORT size_t EnumUtils<CreatureFlagsExtra>::ToIndex(CreatureFlagsExtra v
         case CREATURE_FLAG_EXTRA_AVOID_AOE: return 22;
         case CREATURE_FLAG_EXTRA_NO_DODGE: return 23;
         case CREATURE_FLAG_EXTRA_MODULE: return 24;
-        case CREATURE_FLAG_EXTRA_IGNORE_ASSISTANCE_CALL: return 25;
+        case CREATURE_FLAG_EXTRA_DONT_CALL_ASSISTANCE: return 25;
         case CREATURE_FLAG_DONT_OVERRIDE_ENTRY_SAI: return 26;
         case CREATURE_FLAG_EXTRA_UNUSED_28: return 27;
         case CREATURE_FLAG_EXTRA_DUNGEON_BOSS: return 28;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10368,7 +10368,11 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
 
         creature->SendAIReaction(AI_REACTION_HOSTILE);
 
-        creature->CallAssistance();
+        /// @todo: Implement aggro range, detection range and assistance range templates
+        if (!(creature->ToCreature()->GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_DONT_CALL_ASSISTANCE))
+        {
+            creature->CallAssistance();
+        }
         creature->SetAssistanceTimer(sWorld->getIntConfig(CONFIG_CREATURE_FAMILY_ASSISTANCE_PERIOD));
 
         SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Instead of ignoring all assistance, the flag will now only not call the initial assistance call sent on aggro and not subsequent ones

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15460
- Closes https://github.com/chromiecraft/chromiecraft/issues/5203

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go xyz 118 283 -5.5 553 0`
2. See if you can pull each trio separately
3. Fly overhead and herd the aggroed trio to another group, see if assistance is called

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
