### PR TITLE
fix(DB/Karazhan): Update mech_immune_mask to make Spectral Performers immune to CC

### DIFF
--- a/data/sql/updates/pending_db_world/fixmechimmunemaskspectperf.sql
+++ b/data/sql/updates/pending_db_world/fixmechimmunemaskspectperf.sql
@@ -1,4 +1,2 @@
 --
-UPDATE `creature_template`
-SET `mechanic_immune_mask` = 650854267, `flags_extra` = 256
-WHERE `entry` = 16473 AND `name` = 'Spectral Performer';
+UPDATE `creature_template` SET `mechanic_immune_mask` = `mechanic_immune_mask`|2|16|64|256|512|1024|2048|4096|8192|131072|524288|4194304|8388608|33554432, `flags_extra` = `flags_extra`|256 WHERE `entry` = 16473;

--- a/data/sql/updates/pending_db_world/fixmechimmunemaskspectperf.sql
+++ b/data/sql/updates/pending_db_world/fixmechimmunemaskspectperf.sql
@@ -1,2 +1,4 @@
 --
-UPDATE `creature_template` SET `mechanic_immune_mask` = 650854267 WHERE `entry` = 16473;
+UPDATE `creature_template`
+SET `mechanic_immune_mask` = 650854267, `flags_extra` = 256
+WHERE `entry` = 16473 AND `name` = 'Spectral Performer';

--- a/data/sql/updates/pending_db_world/fixmechimmunemaskspectperf.sql
+++ b/data/sql/updates/pending_db_world/fixmechimmunemaskspectperf.sql
@@ -1,0 +1,1 @@
+UPDATE `creature_template` SET `mechanic_immune_mask` = 650854267 WHERE `entry` = 16473;

--- a/data/sql/updates/pending_db_world/fixmechimmunemaskspectperf.sql
+++ b/data/sql/updates/pending_db_world/fixmechimmunemaskspectperf.sql
@@ -1,1 +1,2 @@
+--
 UPDATE `creature_template` SET `mechanic_immune_mask` = 650854267 WHERE `entry` = 16473;


### PR DESCRIPTION
adds mechanic immunities to spectral performer that should make it immune to CC

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  change mech mask
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15972

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tests by me. seems to work
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. `.tele gmisland`
2. add a bunch of CC spells to your character (.learn (20989, 37369, 39176))
3. `.npc add 16473`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
