### PR TITLE
fix(Scripts/Pet): hunter snake trap creatures base damage

### DIFF
--- a/src/server/scripts/Pet/pet_hunter.cpp
+++ b/src/server/scripts/Pet/pet_hunter.cpp
@@ -32,6 +32,11 @@ enum HunterSpells
     SPELL_HUNTER_PET_SCALING            = 62915
 };
 
+enum CreatureTemplateEntry {
+    CREATURE_VENOMOUS_SNAKE             = 19833,
+    CREATURE_VIPER                      = 19921
+};
+
 struct npc_pet_hunter_snake_trap : public ScriptedAI
 {
     npc_pet_hunter_snake_trap(Creature* creature) : ScriptedAI(creature) { _init = false; }
@@ -113,6 +118,15 @@ struct npc_pet_hunter_snake_trap : public ScriptedAI
             uint32 delta = urand(0, 700);
             me->SetAttackTime(BASE_ATTACK, Info->BaseAttackTime + delta);
             me->SetStatFloatValue(UNIT_FIELD_RANGED_ATTACK_POWER, float(stats->AttackPower));
+
+            if (Info->Entry == CREATURE_VIPER) {
+                me->SetFloatValue(UNIT_FIELD_MINDAMAGE, 38);
+                me->SetFloatValue(UNIT_FIELD_MAXDAMAGE, 53);
+            } else if (Info->Entry == CREATURE_VENOMOUS_SNAKE) {
+                me->SetFloatValue(UNIT_FIELD_MINDAMAGE, 16);
+                me->SetFloatValue(UNIT_FIELD_MAXDAMAGE, 24);
+            }
+
             me->CastSpell(me, SPELL_HUNTER_DEADLY_POISON_PASSIVE, true);
 
             // Glyph of Snake Trap


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Set base damage for hunter trap's snakes, accordingly with the report.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15910

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
* https://wowpedia.fandom.com/wiki/Snake_Trap?oldid=2341652
> [...]
> The Vipers hit for 38-53. 4 of these appear.
> 
> The Venomous Snakes hit for 16-24. 4 of these appear. 

* https://github.com/azerothcore/azerothcore-wotlk/issues/15910

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested on modified server, with hunter (lev 80).
- Inserted/enabled additional logs on core (i.e., `entities.unit`); the base damage is congruent with the expected report.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Set `snake trap` on enemy.
2. Check logs/damage before and after the patch.


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
