### PR TITLE
fix(DB/Spell): Correct Essence of Wintergrasp zones

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1682809085520081000.sql
+++ b/data/sql/updates/pending_db_world/rev_1682809085520081000.sql
@@ -1,0 +1,13 @@
+--
+DELETE FROM `spell_area` WHERE `spell` = 57940 AND `area` IN (495,4277);
+INSERT INTO `spell_area` (`spell`, `area`, `quest_start`, `quest_end`, `aura_spell`, `racemask`, `gender`, `autocast`, `quest_start_status`, `quest_end_status`) VALUES
+(57940, 495, 0, 0, 0, 0, 2, 1, 0, 0),  -- Howling Fjord
+(57940, 4277, 0, 0, 0, 0, 2, 1, 0, 0); -- Azjol-Nerub (Dungeon)
+
+-- Remove Essence of Wintergrasp in Instances (must be obtained only in Northrend map and Dungeons)
+DELETE FROM `spell_area` WHERE `spell` = 57940 AND `area` IN (
+3456, -- Naxxramas
+4493, -- The Obsidian Sanctum
+4603, -- Vault of Archavon
+4273  -- Ulduar
+);


### PR DESCRIPTION
* Cherry-pick commit (https://github.com/TrinityCore/TrinityCore/commit/2d5afb36c7b3908e47bc3ea3ed27a85ed5cebb07)

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

> Essence of Wintergrasp is a buff that is available for every player in Northrend, as long as the faction controls Wintergrasp. Players under the effect of the buff receive 5% more experience and are able to collect [Stone Keeper's Shards](https://www.wowhead.com/item=43228) from dungeon bosses in Northrend.

Howling Fjord area and Azjol-Nerub (Dungeon) area are missing.
Instances should be removed from spell_area (Naxxramas, The Obsidian Sanctum, Vault of Archavon and Ulduar) because only in dungeons should gain the buff.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
