### PR TITLE
fix(DB/Import) Support multiple styles of sql paths in DBUpdater

### DIFF
--- a/src/server/database/Updater/DBUpdater.h
+++ b/src/server/database/Updater/DBUpdater.h
@@ -79,8 +79,11 @@ public:
     static bool Update(DatabaseWorkerPool<T>& pool, std::vector<std::string> const* setDirectories);
     static bool Populate(DatabaseWorkerPool<T>& pool);
 
-    // module
+    // Get name of databases for module
     static std::string GetDBModuleName();
+
+    // Get search paths for module sql files
+    static std::vector<std::string> GetDBModulePaths();
 
 private:
     static QueryResult Retrieve(DatabaseWorkerPool<T>& pool, std::string const& query);

--- a/src/server/database/Updater/UpdateFetcher.h
+++ b/src/server/database/Updater/UpdateFetcher.h
@@ -47,13 +47,13 @@ public:
     UpdateFetcher(Path const& updateDirectory,
                   std::function<void(std::string const&)> const& apply,
                   std::function<void(Path const& path)> const& applyFile,
-                  std::function<QueryResult(std::string const&)> const& retrieve, std::string const& dbModuleName, std::vector<std::string> const* setDirectories = nullptr);
+                  std::function<QueryResult(std::string const&)> const& retrieve, std::vector<std::string> const& dbModulePaths, std::vector<std::string> const* setDirectories = nullptr);
 
     UpdateFetcher(Path const& updateDirectory,
         std::function<void(std::string const&)> const& apply,
         std::function<void(Path const& path)> const& applyFile,
         std::function<QueryResult(std::string const&)> const& retrieve,
-        std::string const& dbModuleName,
+        std::vector<std::string> const& dbModulePaths,
         std::string_view modulesList = {});
 
     ~UpdateFetcher();
@@ -158,9 +158,11 @@ private:
     std::function<void(Path const& path)> const _applyFile;
     std::function<QueryResult(std::string const&)> const _retrieve;
 
-    // modules
-    std::string const _dbModuleName;
+    // SQL paths for modules
+    std::vector<std::string> const _dbModulePaths;
+    // Existing directories for all modules
     std::vector<std::string> const* _setDirectories;
+    // Modules in ./modules/
     std::string_view _modulesList = {};
 };
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Some modules have sql files in `data/sql/db-world`. Other modules have sql files in `sql/world`. `data/sql/db-world` was referenced in the code, meaning automatic imports would only work with some modules.
- This change puts both paths into consideration
- examples
  - [mod-transmog](https://github.com/azerothcore/mod-transmog) uses `data/sql`
  - [mod-eluna](https://github.com/azerothcore/mod-eluna) uses `sql/`
  - [mod-ah-bot](https://github.com/azerothcore/mod-ah-bot) uses `sql/`
- the [skeleton-module](https://github.com/azerothcore/skeleton-module) use `sql/`

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Issue described in https://github.com/azerothcore/azerothcore-wotlk/pull/16155
    - This change also has fixes to use a proper tmpfile for the "create_table" file. This is probably something that can be used in a few other places.  

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested with docker due to reproducible builds



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Download 2 modules that have sql in the different directories
    ```bash

    git clone https://github.com/azerothcore/mod-transmog.git modules/mod-transmog
    git clone https://github.com/azerothcore/mod-item-level-up.git modules/mod-item-level-up
   ```

 2. make the DBimport a No-op.
   a.  Your yq implementation may need a different command. This is `community/yq` in the arch linux repository
 
    ```bash
    yq -iY '.services."ac-db-import".command |= "/bin/true"' docker-compose.yml
    ```

3. Build and start server
    ```bash
    ./acore.sh docker clean:build && \
    ./acore.sh docker build && \
    ./acore.sh docker start:app
    ```

4. As the container runs, observe SQL from both mod-transmog and mod-item-level-up get imported

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
