### PR TITLE
Revert(conditions): Gordok Shackle Key should not be seen if you already have one.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1683957297429455600.sql
+++ b/data/sql/updates/pending_db_world/rev_1683957297429455600.sql
@@ -1,0 +1,1 @@
+DELETE FROM `conditions` WHERE `SourceEntry` = 18250 AND `SourceTypeOrReferenceId` = 1 AND `ConditionTypeOrReference` = 2;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Revert https://github.com/azerothcore/azerothcore-wotlk/pull/12792

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Player gets a key drop that he cannot loot because he already has one
https://youtu.be/U2OEhkvjZaE?t=163
![image](https://github.com/azerothcore/azerothcore-wotlk/assets/50233983/7630eb66-0875-4bcf-a715-0c5b5000db5d)
Numerous comments like that on [wowhead](https://www.wowhead.com/wotlk/item=18250/gordok-shackle-key#comments)


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

```UPDATE `creature_loot_template` SET `Chance` = 100 WHERE `Entry` = 14321 AND `Item` = 18250;```
.add 18250
.go c id 14321
.damage 1000000
Loot

To revert this test drop chance:
```UPDATE `creature_loot_template` SET `Chance` = 13 WHERE `Entry` = 14321 AND `Item` = 18250;```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
https://github.com/azerothcore/azerothcore-wotlk/issues/12786
Being able to roll on already owned unique items possibly is a general bug with group loot

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
