### PR TITLE
feat(Core/SAI): Implement SMART_ACTION_DISABLE 

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1684036819129474700.sql
+++ b/data/sql/updates/pending_db_world/rev_1684036819129474700.sql
@@ -1,0 +1,59 @@
+--
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (-151019,-151020,-151021,-151022,-151023,-151024,-151025,-151026,-151027,-151028,-151029,-151030,-151031,-151032,-151033,-151034,-151019,-151020,-151021,-151022,-151023,-151024,-151025,-151026,-151027,-151028,-151029,-151030,-151031,-151032,-151033,-151034) AND `action_type` = 80 AND `action_param1` IN (1670011, 1670012);
+
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` IN (-151019,-151020,-151021,-151022,-151023,-151024,-151025,-151026,-151027,-151028,-151029,-151030,-151031,-151032,-151033,-151034,-151019,-151020,-151021,-151022,-151023,-151024,-151025,-151026,-151027,-151028,-151029,-151030,-151031,-151032,-151033,-151034) AND `action_type` = 226;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(-151019, 0, 1006, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - On Respawn - Disable'),
+(-151020, 0, 1001, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Reaver - On Respawn - Disable'),
+(-151021, 0, 1001, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Respawn - Disable'),
+(-151022, 0, 1001, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Heathen - On Respawn - Disable'),
+(-151023, 0, 1001, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shadowmoon Darkcaster - On Respawn - Disable'),
+(-151024, 0, 1006, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - On Respawn - Disable'),
+(-151025, 0, 1001, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Reaver - On Respawn - Disable'),
+(-151026, 0, 1001, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Respawn - Disable'),
+(-151027, 0, 1001, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Respawn - Disable'),
+(-151028, 0, 1001, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shadowmoon Darkcaster - On Respawn - Disable'),
+(-151029, 0, 1006, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - On Respawn - Disable'),
+(-151030, 0, 1001, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Reaver - On Respawn - Disable'),
+(-151031, 0, 1001, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Reaver - On Respawn - Disable'),
+(-151032, 0, 1001, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Respawn - Disable'),
+(-151033, 0, 1001, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Respawn - Disable'),
+(-151034, 0, 1001, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Respawn - Disable'),
+(-151019, 0, 1007, 1008, 77, 0, 100, 0, 1, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - On Counter 2/2 - Enable'),
+(-151020, 0, 1002, 1003, 38, 0, 100, 0, 3, 1, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Reaver - On Data Set 3 1 - Enable'),
+(-151021, 0, 1002, 1003, 38, 0, 100, 0, 3, 1, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Data Set 3 1 - Enable'),
+(-151022, 0, 1002, 1003, 38, 0, 100, 0, 3, 1, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Heathen - On Data Set 3 1 - Enable'),
+(-151023, 0, 1002, 1003, 38, 0, 100, 0, 3, 1, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shadowmoon Darkcaster - On Data Set 3 1 - Enable'),
+(-151024, 0, 1007, 1008, 38, 0, 100, 0, 3, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - On Data Set 3 2 - Enable'),
+(-151025, 0, 1002, 1003, 38, 0, 100, 0, 3, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Reaver - On Data Set 3 2 - Enable'),
+(-151026, 0, 1002, 1003, 38, 0, 100, 0, 3, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Data Set 3 2 - Enable'),
+(-151027, 0, 1002, 1003, 38, 0, 100, 0, 3, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Data Set 3 2 - Enable'),
+(-151028, 0, 1002, 1003, 38, 0, 100, 0, 3, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shadowmoon Darkcaster - On Data Set 3 2 - Enable'),
+(-151029, 0, 1008, 1009, 10, 0, 100, 267, 0, 90, 0, 0, 1, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - Within 0-90 Range Out of Combat LoS - Enable'),
+(-151030, 0, 1002, 1003, 38, 0, 100, 0, 3, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Reaver - On Data Set 3 2 - Enable'),
+(-151031, 0, 1002, 1003, 38, 0, 100, 0, 3, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Reaver - On Data Set 3 2 - Enable'),
+(-151032, 0, 1002, 1003, 38, 0, 100, 0, 3, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Data Set 3 2 - Enable'),
+(-151033, 0, 1002, 1003, 38, 0, 100, 0, 3, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Data Set 3 2 - Enable'),
+(-151034, 0, 1002, 1003, 38, 0, 100, 0, 3, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Data Set 3 2 - Enable');
+
+-- Start WP 1670002, say line 5
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = -151019) AND (`source_type` = 0) AND (`id` IN (1009, 1010, 1011));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(-151019, 0, 1009, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 80, 1670011, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - Linked - Run Script'),
+(-151019, 0, 1010, 0, 58, 0, 100, 0, 0, 1670002, 0, 0, 0, 80, 1670013, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - On Waypoint Finished - Run Script');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 1670011);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(1670011, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 53, 0, 1670002, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - Actionlist - Start Waypoint'),
+(1670011, 9, 1, 0, 0, 0, 100, 0, 400, 400, 0, 0, 0, 1, 5, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - Actionlist - Say Line 5');
+
+-- Start WP 1670004, Say Line 8
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = -151024) AND (`source_type` = 0) AND (`id` IN (1008, 1009, 1010));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(-151024, 0, 1008, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 80, 1670012, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - Linked - Run Script'),
+(-151024, 0, 1009, 0, 40, 0, 100, 0, 4, 1670004, 0, 0, 0, 80, 1670014, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - On Waypoint Finished - Run Script');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 1670012);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(1670012, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 53, 0, 1670004, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - Actionlist - Start Waypoint'),
+(1670012, 9, 1, 0, 0, 0, 100, 0, 400, 400, 0, 0, 0, 1, 8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - Actionlist - Say Line 8');

--- a/data/sql/updates/pending_db_world/rev_1684036819129474700.sql
+++ b/data/sql/updates/pending_db_world/rev_1684036819129474700.sql
@@ -36,7 +36,6 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (-151033, 0, 1002, 1003, 38, 0, 100, 0, 3, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Data Set 3 2 - Enable'),
 (-151034, 0, 1002, 1003, 38, 0, 100, 0, 3, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Sharpshooter - On Data Set 3 2 - Enable');
 
--- Start WP 1670002, say line 5
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = -151019) AND (`source_type` = 0) AND (`id` IN (1009, 1010, 1011));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (-151019, 0, 1009, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 80, 1670011, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - Linked - Run Script'),
@@ -47,7 +46,6 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (1670011, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 53, 0, 1670002, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - Actionlist - Start Waypoint'),
 (1670011, 9, 1, 0, 0, 0, 100, 0, 400, 400, 0, 0, 0, 1, 5, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - Actionlist - Say Line 5');
 
--- Start WP 1670004, Say Line 8
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = -151024) AND (`source_type` = 0) AND (`id` IN (1008, 1009, 1010));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (-151024, 0, 1008, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 80, 1670012, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - Linked - Run Script'),
@@ -57,3 +55,5 @@ DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 1670012
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (1670012, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 53, 0, 1670004, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - Actionlist - Start Waypoint'),
 (1670012, 9, 1, 0, 0, 0, 100, 0, 400, 400, 0, 0, 0, 1, 8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Shattered Hand Legionnaire - Actionlist - Say Line 8');
+
+UPDATE `smart_scripts` SET `event_flags`=257 WHERE `entryorguid`=-151029 AND `source_type`=0 AND `id`=1008 AND `link`=1009;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2797,6 +2797,18 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
             break;
         }
+        case SMART_ACTION_DISABLE:
+        {
+            for (WorldObject* target : targets)
+            {
+                if (IsUnit(target))
+                {
+                    target->ToUnit()->SetImmuneToAll(!e.action.disable.state);
+                    target->ToUnit()->SetVisible(e.action.disable.state);
+                }
+            }
+            break;
+        }
         default:
             LOG_ERROR("sql.sql", "SmartScript::ProcessAction: Entry {} SourceType {}, Event {}, Unhandled Action type {}", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType());
             break;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -762,6 +762,7 @@ bool SmartAIMgr::CheckUnusedActionParams(SmartScriptHolder const& e)
             case SMART_ACTION_LOAD_GRID: return NO_PARAMS;
             case SMART_ACTION_MUSIC: return sizeof(SmartAction::music);
             case SMART_ACTION_SET_GUID: return sizeof(SmartAction::setGuid);
+            case SMART_ACTION_DISABLE: return sizeof(SmartAction::disable);
             default:
                 LOG_WARN("sql.sql", "SmartAIMgr: entryorguid {} source_type {} id {} action_type {} is using an action with no unused params specified in SmartAIMgr::CheckUnusedActionParams(), please report this.",
                             e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType());
@@ -1918,6 +1919,7 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         case SMART_ACTION_ATTACK_STOP:
         case SMART_ACTION_PLAY_CINEMATIC:
         case SMART_ACTION_SET_GUID:
+        case SMART_ACTION_DISABLE:
             break;
         default:
             LOG_ERROR("sql.sql", "SmartAIMgr: Not handled action_type({}), event_type({}), Entry {} SourceType {} Event {}, skipped.", e.GetActionType(), e.GetEventType(), e.entryOrGuid, e.GetScriptType(), e.event_id);

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -693,8 +693,9 @@ enum SMART_ACTION
     SMART_ACTION_DO_ACTION                          = 223,    // ActionId
     SMART_ACTION_ATTACK_STOP                        = 224,    //
     SMART_ACTION_SET_GUID                           = 225,    // Sends the invoker's or the base object's own ObjectGuid to target
+    SMART_ACTION_DISABLE                            = 226,    // Disable the targeted creatures, setting them Invisible and Immune to All
 
-    SMART_ACTION_AC_END                             = 226,    // placeholder
+    SMART_ACTION_AC_END                             = 227,    // placeholder
 };
 
 enum class SmartActionSummonCreatureFlags
@@ -1365,6 +1366,11 @@ struct SmartAction
             SAIBool invokerGUID;
             uint32 index;
         } setGuid;
+
+        struct
+        {
+            SAIBool state;
+        } disable;
         //! Note for any new future actions
         //! All parameters must have type uint32
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Adds a new smart action to set creatures invisible and immune to all, effectively disabling them to be re-enabled by scripts later. This allows for a hack of pre-spawns which is a feature that I've argued exists. This just allows us to bypass needless Actionlists and to be able to disable or re-enable several creatures at once with only one row.
- By itself it doesn't do much, as more sophisticated targeting methods would be preferable (targeting all formation members, for example)
- Using this method of pre-spawns is useful due to the large control we have over guid-scripting, especially with the newly added flags_extra. It allows the creation, in DB, of a large amount of creatures that'd otherwise require their spawn positions being handled in a cpp script, such as the Mechanar Bridge event and several Shattered Halls encounters

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

```
DELETE FROM `smart_scripts` WHERE (`entryorguid` = 448) AND (`source_type` = 0) AND (`id` IN (4, 5));
INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
(448, 0, 4, 0, 38, 0, 100, 0, 1, 1, 0, 0, 0, 226, 0, 0, 0, 0, 0, 0, 9, 0, 0, 100, 0, 0, 0, 0, 0, 'Hogger - On Data Set 1 1 - Disable All Creatures in 100y'),
(448, 0, 5, 0, 38, 0, 100, 0, 1, 2, 0, 0, 0, 226, 1, 0, 0, 0, 0, 0, 9, 0, 0, 100, 0, 0, 0, 0, 0, 'Hogger - On Data Set 1 2 - Enable All Creatures in 100y');
```
`.go c id 448`
`.npc set data 1 1`
`.npc set data 1 2`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
