### PR TITLE
add(DB\NPC) NPC Harold Lane is not performing his 'sick/ill' emotes

### DIFF
--- a/data/sql/updates/pending_db_world/18218.sql
+++ b/data/sql/updates/pending_db_world/18218.sql
@@ -1,0 +1,14 @@
+-- Harold Lane
+UPDATE `creature_template` SET `AIName`='SmartAI' WHERE `entry`=18218;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=18218 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(18218,0,0,0,1,0,100,0,1000,15000,150000,180000,1,5,0,0,0,0,0,1,0,0,0,0,0,0,0,'Harold Lane - Out of Combat - Say Line 5');
+
+DELETE FROM `creature_text` WHERE `CreatureID`=18218 AND `GroupID`=5;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(18218,5,0,'Shifting, %s moans from the pain of his thorn scratch.',16,0,100,0,0,0,15157,0,'Harold Lane'),
+(18218,5,1,'%s groans in pain.',16,0,100,0,0,0,15158,0,'Harold Lane'),
+(18218,5,2,'%s looks at his friends and then grunts painfully.',16,0,100,0,0,0,15159,0,'Harold Lane'),
+(18218,5,3,'%s wakes himself up snoring.',16,0,100,0,0,0,15160,0,'Harold Lane'),
+(18218,5,4,'%s winces when he touches the tender area around his scratch.',16,0,100,0,0,0,15161,0,'Harold Lane'),
+(18218,5,5,'%s begins to whistle a tune, but then stops abruptly and moans.',16,0,100,0,0,0,15162,0,'Harold Lane');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  NPC Harold Lane is not performing his 'sick/ill' emotes
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5477
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16204

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowpedia.fandom.com/wiki/Harold_Lane?so=search
https://github.com/TrinityCore/TrinityCore/issues/24987

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Local
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
.go cr 65459
## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
