### PR TITLE
feat(apps/scripts): set a logging file for gdb using starter app

### DIFF
--- a/apps/startup-scripts/run-engine
+++ b/apps/startup-scripts/run-engine
@@ -61,9 +61,9 @@ function run() {
 
         echo "> Starting with screen ( screen $OPTIONS )"
 
-        screen $OPTIONS $1 "$RUN_ENGINE_PATH/starter" $2 $3 "$4" "$5" "$6" $7
+        screen $OPTIONS $1 "$RUN_ENGINE_PATH/starter" $2 $3 "$4" "$5" "$6" $7 "$BINPATH/crashes"
     else
-        $RUN_ENGINE_PATH/starter $2 $3 "$4" "$5" "$6" $7
+        $RUN_ENGINE_PATH/starter $2 $3 "$4" "$5" "$6" $7 "$BINPATH/crashes"
     fi
 }
 
@@ -71,6 +71,7 @@ function starter() {
     cd $BINPATH
 
     mkdir -p "$LOGS_PATH"
+    mkdir -p "$BINPATH"/crashes
 
     configureFiles
 
@@ -82,6 +83,7 @@ function restarter() {
     cd $BINPATH
 
     mkdir -p "$LOGS_PATH"
+    mkdir -p "$BINPATH"/crashes
 
     configureFiles
 

--- a/apps/startup-scripts/starter
+++ b/apps/startup-scripts/starter
@@ -5,9 +5,11 @@ CONFIG="$3"
 SYSLOG="$4"
 SYSERR="$5"
 GDB_ENABLED="$6"
+CRASHES_PATH="$7"
 
 if [ $GDB_ENABLED -eq 1 ]; then
-    echo "set logging on" > "$GDB_FILE"
+    echo "set logging file "$CRASHES_PATH"/gdb-$(date +%Y-%m-%d-%H-%M-%S).txt" > "$GDB_FILE"
+    echo "set logging on" >> "$GDB_FILE"
     echo "set debug timestamp" >> "$GDB_FILE"
     echo "run -c $3" >> "$GDB_FILE"
     echo "bt" >> "$GDB_FILE"

--- a/apps/startup-scripts/starter
+++ b/apps/startup-scripts/starter
@@ -8,7 +8,7 @@ GDB_ENABLED="$6"
 CRASHES_PATH="$7"
 
 if [ $GDB_ENABLED -eq 1 ]; then
-    echo "set logging file "$CRASHES_PATH"/gdb-$(date +%Y-%m-%d-%H-%M-%S).txt" > "$GDB_FILE"
+    echo "set logging file "$CRASHES_PATH/gdb-$(date +%Y-%m-%d-%H-%M-%S).txt" > "$GDB_FILE"
     echo "set logging on" >> "$GDB_FILE"
     echo "set debug timestamp" >> "$GDB_FILE"
     echo "run -c $3" >> "$GDB_FILE"

--- a/apps/startup-scripts/starter
+++ b/apps/startup-scripts/starter
@@ -8,7 +8,7 @@ GDB_ENABLED="$6"
 CRASHES_PATH="$7"
 
 if [ $GDB_ENABLED -eq 1 ]; then
-    echo "set logging file "$CRASHES_PATH/gdb-$(date +%Y-%m-%d-%H-%M-%S).txt" > "$GDB_FILE"
+    echo "set logging file "$CRASHES_PATH"/gdb-$(date +%Y-%m-%d-%H-%M-%S).txt" > "$GDB_FILE"
     echo "set logging on" >> "$GDB_FILE"
     echo "set debug timestamp" >> "$GDB_FILE"
     echo "run -c $3" >> "$GDB_FILE"


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Use a different file for each execution to avoid keeping all the crashes in one file.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- None for now.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Have a linux server.
2. Use the acore.sh dashboard.
3. Use the advanced restarter from [AC wiki](https://www.azerothcore.org/wiki/how-to-restart-and-debug)
4. On execution, check if the gdb is created inside the folder with the current datetime. Also, if you restart the server it should create a gdb file.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] More configurable?
