### PR TITLE
fix(Scripts/Karazhan): Opera Wizard of Oz fight correct start timers for combat as well fixing restart of the event

### DIFF
--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -132,7 +132,6 @@ public:
 
         void Initialize()
         {
-            Talk(SAY_DOROTHEE_AGGRO);
             AggroTimer = 13000;
 
             WaterBoltTimer = 5000;
@@ -197,6 +196,12 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
+            if(!IntroDone)
+            {
+                Talk(SAY_DOROTHEE_AGGRO);
+                IntroDone=true;
+            }
+
             if (AggroTimer)
             {
                 if (AggroTimer <= diff)

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -202,11 +202,7 @@ public:
                 {
                     me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                     me->SetImmuneToPC(false);
-                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 50, true))
-                    {
-                        me->Yell("debug: attack random target", LANG_UNIVERSAL);
-                        me->Attack(target, true);
-                    }
+                    me->SetInCombatWithZone();
                     AggroTimer = 0;
                 }
                 else
@@ -407,11 +403,7 @@ public:
                 {
                     me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                     me->SetImmuneToPC(false);
-                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 50, true))
-                    {
-                        me->Yell("debug: attack random target", LANG_UNIVERSAL);
-                        me->Attack(target, true);
-                    }
+                    me->SetInCombatWithZone();
                     AggroTimer = 0;
                 }
                 else
@@ -525,11 +517,7 @@ public:
                 {
                     me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                     me->SetImmuneToPC(false);
-                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 50, true))
-                    {
-                        me->Yell("debug: attack random target", LANG_UNIVERSAL);
-                        me->Attack(target, true);
-                    }
+                    me->SetInCombatWithZone();
                     AggroTimer = 0;
                 }
                 else
@@ -645,11 +633,7 @@ public:
                 {
                     me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                     me->SetImmuneToPC(false);
-                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 50, true))
-                    {
-                        me->Yell("debug: attack random target", LANG_UNIVERSAL);
-                        me->Attack(target, true);
-                    }
+                    me->SetInCombatWithZone();
                     AggroTimer = 0;
                 }
                 else

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -134,7 +134,7 @@ public:
         {
             AggroTimer = 12000;
 
-            WaterBoltTimer = 1500;
+            WaterBoltTimer = 0;
             FearTimer = 15000;
             SummonTitoTimer = 41000;
 

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -706,6 +706,11 @@ public:
             me->DespawnOrUnsummon();
         }
 
+        void JustSummoned(Creature* summon) override
+        {
+            summons.Summon(summon);
+        }
+
         void KilledUnit(Unit* /*victim*/) override
         {
             Talk(SAY_CRONE_SLAY);

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -201,8 +201,10 @@ public:
             ScriptedAI::EnterEvadeMode(reason);
 
             if(!me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
+            {
                 instance->SetBossState(DATA_OPERA_PERFORMANCE, FAIL);
                 me->DespawnOrUnsummon();
+            }
         }
 
         void UpdateAI(uint32 diff) override
@@ -291,7 +293,6 @@ public:
 
         void JustDied(Unit* /*killer*/) override
         {
-            
             if (DorotheeGUID)
             {
                 Creature* Dorothee = ObjectAccessor::GetCreature(*me, DorotheeGUID);
@@ -380,8 +381,10 @@ public:
             ScriptedAI::EnterEvadeMode(reason);
 
             if(!me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
+            {
                 instance->SetBossState(DATA_OPERA_PERFORMANCE, FAIL);
                 me->DespawnOrUnsummon();
+            }
         }
 
         void AttackStart(Unit* who) override
@@ -513,8 +516,10 @@ public:
             ScriptedAI::EnterEvadeMode(reason);
 
             if(!me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
+            {
                 instance->SetBossState(DATA_OPERA_PERFORMANCE, FAIL);
                 me->DespawnOrUnsummon();
+            }
         }
         void JustEngagedWith(Unit* /*who*/) override
         {
@@ -658,8 +663,10 @@ public:
             ScriptedAI::EnterEvadeMode(reason);
 
             if(!me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
+            {
                 instance->SetBossState(DATA_OPERA_PERFORMANCE, FAIL);
                 me->DespawnOrUnsummon();
+            }
         }
 
         void JustDied(Unit* /*killer*/) override

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -136,7 +136,7 @@ public:
 
             WaterBoltTimer = 5000;
             FearTimer = 15000;
-            SummonTitoTimer = 47500;
+            SummonTitoTimer = 41000;
 
             SummonedTito = false;
             TitoDied = false;
@@ -312,6 +312,125 @@ void boss_dorothee::boss_dorotheeAI::SummonTito()
     }
 }
 
+class boss_roar : public CreatureScript
+{
+public:
+    boss_roar() : CreatureScript("boss_roar") { }
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return GetKarazhanAI<boss_roarAI>(creature);
+    }
+
+    struct boss_roarAI : public ScriptedAI
+    {
+        boss_roarAI(Creature* creature) : ScriptedAI(creature)
+        {
+            instance = creature->GetInstanceScript();
+        }
+
+        InstanceScript* instance;
+
+        uint32 AggroTimer;
+        uint32 MangleTimer;
+        uint32 ShredTimer;
+        uint32 ScreamTimer;
+
+        void Reset() override
+        {
+            AggroTimer = 5170;
+            MangleTimer = 5000;
+            ShredTimer  = 10000;
+            ScreamTimer = 15000;
+        }
+
+        void MoveInLineOfSight(Unit* who) override
+
+        {
+            if (me->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE))
+                return;
+
+            ScriptedAI::MoveInLineOfSight(who);
+        }
+
+        void AttackStart(Unit* who) override
+        {
+            if (me->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE))
+                return;
+
+            ScriptedAI::AttackStart(who);
+        }
+
+        void JustEngagedWith(Unit* /*who*/) override
+        {
+            Talk(SAY_ROAR_AGGRO);
+            DoZoneInCombat();
+        }
+
+        void JustReachedHome() override
+        {
+            me->DespawnOrUnsummon();
+        }
+
+        void JustDied(Unit* /*killer*/) override
+        {
+            Talk(SAY_ROAR_DEATH);
+
+            SummonCroneIfReady(instance, me);
+        }
+
+        void KilledUnit(Unit* /*victim*/) override
+        {
+            Talk(SAY_ROAR_SLAY);
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            if (AggroTimer)
+            {
+                if (AggroTimer <= diff)
+                {
+                    me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+                    me->SetImmuneToPC(false);
+                    me->SetInCombatWithZone();
+                    AggroTimer = 0;
+                }
+                else
+                    AggroTimer -= diff;
+            }
+
+            if (!UpdateVictim())
+                return;
+
+            if (MangleTimer <= diff)
+            {
+                DoCastVictim(SPELL_MANGLE);
+                MangleTimer = urand(5000, 8000);
+            }
+            else
+                MangleTimer -= diff;
+
+            if (ShredTimer <= diff)
+            {
+                DoCastVictim(SPELL_SHRED);
+                ShredTimer = urand(10000, 15000);
+            }
+            else
+                ShredTimer -= diff;
+
+            if (ScreamTimer <= diff)
+            {
+                DoCastVictim(SPELL_FRIGHTENED_SCREAM);
+                ScreamTimer = urand(20000, 30000);
+            }
+            else
+                ScreamTimer -= diff;
+
+            DoMeleeAttackIfReady();
+        }
+    };
+};
+
 class boss_strawman : public CreatureScript
 {
 public:
@@ -337,7 +456,7 @@ public:
 
         void Reset() override
         {
-            AggroTimer = 11000;
+            AggroTimer = 14800;
             BrainBashTimer = 5000;
             BrainWipeTimer = 7000;
         }
@@ -462,7 +581,7 @@ public:
 
         void Reset() override
         {
-            AggroTimer = 15000;
+            AggroTimer = 22970;
             CleaveTimer = 5000;
             RustTimer   = 15000;
 
@@ -547,125 +666,6 @@ public:
                 else
                     RustTimer -= diff;
             }
-
-            DoMeleeAttackIfReady();
-        }
-    };
-};
-
-class boss_roar : public CreatureScript
-{
-public:
-    boss_roar() : CreatureScript("boss_roar") { }
-
-    CreatureAI* GetAI(Creature* creature) const override
-    {
-        return GetKarazhanAI<boss_roarAI>(creature);
-    }
-
-    struct boss_roarAI : public ScriptedAI
-    {
-        boss_roarAI(Creature* creature) : ScriptedAI(creature)
-        {
-            instance = creature->GetInstanceScript();
-        }
-
-        InstanceScript* instance;
-
-        uint32 AggroTimer;
-        uint32 MangleTimer;
-        uint32 ShredTimer;
-        uint32 ScreamTimer;
-
-        void Reset() override
-        {
-            AggroTimer = 20000;
-            MangleTimer = 5000;
-            ShredTimer  = 10000;
-            ScreamTimer = 15000;
-        }
-
-        void MoveInLineOfSight(Unit* who) override
-
-        {
-            if (me->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE))
-                return;
-
-            ScriptedAI::MoveInLineOfSight(who);
-        }
-
-        void AttackStart(Unit* who) override
-        {
-            if (me->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE))
-                return;
-
-            ScriptedAI::AttackStart(who);
-        }
-
-        void JustEngagedWith(Unit* /*who*/) override
-        {
-            Talk(SAY_ROAR_AGGRO);
-            DoZoneInCombat();
-        }
-
-        void JustReachedHome() override
-        {
-            me->DespawnOrUnsummon();
-        }
-
-        void JustDied(Unit* /*killer*/) override
-        {
-            Talk(SAY_ROAR_DEATH);
-
-            SummonCroneIfReady(instance, me);
-        }
-
-        void KilledUnit(Unit* /*victim*/) override
-        {
-            Talk(SAY_ROAR_SLAY);
-        }
-
-        void UpdateAI(uint32 diff) override
-        {
-            if (AggroTimer)
-            {
-                if (AggroTimer <= diff)
-                {
-                    me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
-                    me->SetImmuneToPC(false);
-                    me->SetInCombatWithZone();
-                    AggroTimer = 0;
-                }
-                else
-                    AggroTimer -= diff;
-            }
-
-            if (!UpdateVictim())
-                return;
-
-            if (MangleTimer <= diff)
-            {
-                DoCastVictim(SPELL_MANGLE);
-                MangleTimer = urand(5000, 8000);
-            }
-            else
-                MangleTimer -= diff;
-
-            if (ShredTimer <= diff)
-            {
-                DoCastVictim(SPELL_SHRED);
-                ShredTimer = urand(10000, 15000);
-            }
-            else
-                ShredTimer -= diff;
-
-            if (ScreamTimer <= diff)
-            {
-                DoCastVictim(SPELL_FRIGHTENED_SCREAM);
-                ScreamTimer = urand(20000, 30000);
-            }
-            else
-                ScreamTimer -= diff;
 
             DoMeleeAttackIfReady();
         }

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -140,7 +140,6 @@ public:
 
             SummonedTito = false;
             TitoDied = false;
-            IntroDone = false;
         }
 
         InstanceScript* instance;
@@ -153,7 +152,7 @@ public:
 
         bool SummonedTito;
         bool TitoDied;
-        bool IntroDone;
+        bool IntroDone = false;
 
         void Reset() override
         {
@@ -198,8 +197,12 @@ public:
         {
             if(!IntroDone)
             {
-                Talk(SAY_DOROTHEE_AGGRO);
-                IntroDone=true;
+                if(!me->IsInEvadeMode())
+                {
+                    Talk(SAY_DOROTHEE_AGGRO);
+                    IntroDone = true;
+                }
+                me->Yell("I am evading!", LANG_UNIVERSAL);
             }
 
             if (AggroTimer)

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -193,6 +193,14 @@ public:
             ScriptedAI::MoveInLineOfSight(who);
         }
 
+        void EnterEvadeMode(EvadeReason reason) override
+        {
+            ScriptedAI::EnterEvadeMode(reason);
+
+            if(me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
+                instance->SetBossState(DATA_OPERA_PERFORMANCE, FAIL);
+        }
+
         void UpdateAI(uint32 diff) override
         {
             if(!IntroDone)
@@ -361,6 +369,14 @@ public:
             ScriptedAI::MoveInLineOfSight(who);
         }
 
+        void EnterEvadeMode(EvadeReason reason) override
+        {
+            ScriptedAI::EnterEvadeMode(reason);
+
+            if(!me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
+                instance->SetBossState(DATA_OPERA_PERFORMANCE, FAIL);
+        }
+
         void AttackStart(Unit* who) override
         {
             if (me->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE))
@@ -478,7 +494,6 @@ public:
         }
 
         void MoveInLineOfSight(Unit* who) override
-
         {
             if (me->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE))
                 return;
@@ -486,6 +501,13 @@ public:
             ScriptedAI::MoveInLineOfSight(who);
         }
 
+        void EnterEvadeMode(EvadeReason reason) override
+        {
+            ScriptedAI::EnterEvadeMode(reason);
+
+            if(!me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
+                instance->SetBossState(DATA_OPERA_PERFORMANCE, FAIL);
+        }
         void JustEngagedWith(Unit* /*who*/) override
         {
             Talk(SAY_STRAWMAN_AGGRO);
@@ -616,12 +638,19 @@ public:
         }
 
         void MoveInLineOfSight(Unit* who) override
-
         {
             if (me->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE))
                 return;
 
             ScriptedAI::MoveInLineOfSight(who);
+        }
+
+        void EnterEvadeMode(EvadeReason reason) override
+        {
+            ScriptedAI::EnterEvadeMode(reason);
+
+            if(!me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
+                instance->SetBossState(DATA_OPERA_PERFORMANCE, FAIL);
         }
 
         void JustDied(Unit* /*killer*/) override

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -132,9 +132,9 @@ public:
 
         void Initialize()
         {
-            AggroTimer = 13000;
+            AggroTimer = 12000;
 
-            WaterBoltTimer = 5000;
+            WaterBoltTimer = 1500;
             FearTimer = 15000;
             SummonTitoTimer = 41000;
 
@@ -202,7 +202,6 @@ public:
                     Talk(SAY_DOROTHEE_AGGRO);
                     IntroDone = true;
                 }
-                me->Yell("I am evading!", LANG_UNIVERSAL);
             }
 
             if (AggroTimer)
@@ -224,7 +223,7 @@ public:
             if (WaterBoltTimer <= diff)
             {
                 DoCast(SelectTarget(SelectTargetMethod::Random, 0), SPELL_WATERBOLT);
-                WaterBoltTimer = TitoDied ? 1500 : 5000;
+                WaterBoltTimer = 1500;
             }
             else
                 WaterBoltTimer -= diff;
@@ -347,7 +346,7 @@ public:
 
         void Reset() override
         {
-            AggroTimer = 17670;
+            AggroTimer = 16670;
             MangleTimer = 5000;
             ShredTimer  = 10000;
             ScreamTimer = 15000;
@@ -465,7 +464,7 @@ public:
 
         void Reset() override
         {
-            AggroTimer = 27300;
+            AggroTimer = 26300;
             BrainBashTimer = 5000;
             BrainWipeTimer = 7000;
         }
@@ -590,7 +589,7 @@ public:
 
         void Reset() override
         {
-            AggroTimer = 35470;
+            AggroTimer = 34470;
             CleaveTimer = 5000;
             RustTimer   = 15000;
 

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -202,6 +202,11 @@ public:
                 {
                     me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                     me->SetImmuneToPC(false);
+                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 50, true))
+                    {
+                        me->Yell("debug: attack random target", LANG_UNIVERSAL);
+                        me->Attack(target, true);
+                    }
                     AggroTimer = 0;
                 }
                 else
@@ -402,6 +407,11 @@ public:
                 {
                     me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                     me->SetImmuneToPC(false);
+                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 50, true))
+                    {
+                        me->Yell("debug: attack random target", LANG_UNIVERSAL);
+                        me->Attack(target, true);
+                    }
                     AggroTimer = 0;
                 }
                 else
@@ -515,6 +525,11 @@ public:
                 {
                     me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                     me->SetImmuneToPC(false);
+                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 50, true))
+                    {
+                        me->Yell("debug: attack random target", LANG_UNIVERSAL);
+                        me->Attack(target, true);
+                    }
                     AggroTimer = 0;
                 }
                 else
@@ -630,6 +645,11 @@ public:
                 {
                     me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                     me->SetImmuneToPC(false);
+                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 50, true))
+                    {
+                        me->Yell("debug: attack random target", LANG_UNIVERSAL);
+                        me->Attack(target, true);
+                    }
                     AggroTimer = 0;
                 }
                 else

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -132,7 +132,7 @@ public:
 
         void Initialize()
         {
-            AggroTimer = 500;
+            AggroTimer = 13000;
 
             WaterBoltTimer = 5000;
             FearTimer = 15000;
@@ -338,7 +338,7 @@ public:
 
         void Reset() override
         {
-            AggroTimer = 5170;
+            AggroTimer = 17670;
             MangleTimer = 5000;
             ShredTimer  = 10000;
             ScreamTimer = 15000;
@@ -456,7 +456,7 @@ public:
 
         void Reset() override
         {
-            AggroTimer = 14800;
+            AggroTimer = 27300;
             BrainBashTimer = 5000;
             BrainWipeTimer = 7000;
         }
@@ -581,7 +581,7 @@ public:
 
         void Reset() override
         {
-            AggroTimer = 22970;
+            AggroTimer = 35470;
             CleaveTimer = 5000;
             RustTimer   = 15000;
 

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -706,11 +706,6 @@ public:
             me->DespawnOrUnsummon();
         }
 
-        void JustSummoned(Creature* summon) override
-        {
-            summons.Summon(summon);
-        }
-
         void KilledUnit(Unit* /*victim*/) override
         {
             Talk(SAY_CRONE_SLAY);

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -126,7 +126,8 @@ public:
     {
         boss_dorotheeAI(Creature* creature) : ScriptedAI(creature)
         {
-            SetCombatMovement(false); //this is kinda a big no-no. but it will prevent her from moving to chase targets. she should just cast her spells. in this case, since there is not really something to LOS her with or get out of range this would work. but a more elegant solution would be better
+            SetCombatMovement(false);
+            //this is kinda a big no-no. but it will prevent her from moving to chase targets. she should just cast her spells. in this case, since there is not really something to LOS her with or get out of range this would work. but a more elegant solution would be better
             Initialize();
             instance = creature->GetInstanceScript();
         }
@@ -199,8 +200,9 @@ public:
         {
             ScriptedAI::EnterEvadeMode(reason);
 
-            if(me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
+            if(!me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
                 instance->SetBossState(DATA_OPERA_PERFORMANCE, FAIL);
+                me->DespawnOrUnsummon();
         }
 
         void UpdateAI(uint32 diff) override
@@ -379,6 +381,7 @@ public:
 
             if(!me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
                 instance->SetBossState(DATA_OPERA_PERFORMANCE, FAIL);
+                me->DespawnOrUnsummon();
         }
 
         void AttackStart(Unit* who) override
@@ -511,6 +514,7 @@ public:
 
             if(!me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
                 instance->SetBossState(DATA_OPERA_PERFORMANCE, FAIL);
+                me->DespawnOrUnsummon();
         }
         void JustEngagedWith(Unit* /*who*/) override
         {
@@ -655,6 +659,7 @@ public:
 
             if(!me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
                 instance->SetBossState(DATA_OPERA_PERFORMANCE, FAIL);
+                me->DespawnOrUnsummon();
         }
 
         void JustDied(Unit* /*killer*/) override

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -126,6 +126,7 @@ public:
     {
         boss_dorotheeAI(Creature* creature) : ScriptedAI(creature)
         {
+            SetCombatMovement(false); //this is kinda a big no-no. but it will prevent her from moving to chase targets. she should just cast her spells. in this case, since there is not really something to LOS her with or get out of range this would work. but a more elegant solution would be better
             Initialize();
             instance = creature->GetInstanceScript();
         }
@@ -175,6 +176,7 @@ public:
         {
             Talk(SAY_DOROTHEE_DEATH);
             SummonCroneIfReady(instance, me);
+            me->DespawnOrUnsummon();
         }
 
         void AttackStart(Unit* who) override
@@ -287,6 +289,7 @@ public:
 
         void JustDied(Unit* /*killer*/) override
         {
+            
             if (DorotheeGUID)
             {
                 Creature* Dorothee = ObjectAccessor::GetCreature(*me, DorotheeGUID);
@@ -296,6 +299,7 @@ public:
                     Talk(SAY_DOROTHEE_TITO_DEATH, Dorothee);
                 }
             }
+            me->DespawnOrUnsummon();
         }
 
         void UpdateAI(uint32 diff) override
@@ -399,8 +403,8 @@ public:
         void JustDied(Unit* /*killer*/) override
         {
             Talk(SAY_ROAR_DEATH);
-
             SummonCroneIfReady(instance, me);
+            me->DespawnOrUnsummon();
         }
 
         void KilledUnit(Unit* /*victim*/) override
@@ -535,8 +539,8 @@ public:
         void JustDied(Unit* /*killer*/) override
         {
             Talk(SAY_STRAWMAN_DEATH);
-
             SummonCroneIfReady(instance, me);
+            me->DespawnOrUnsummon();
         }
 
         void KilledUnit(Unit* /*victim*/) override
@@ -656,8 +660,8 @@ public:
         void JustDied(Unit* /*killer*/) override
         {
             Talk(SAY_TINHEAD_DEATH);
-
             SummonCroneIfReady(instance, me);
+            me->DespawnOrUnsummon();
         }
 
         void KilledUnit(Unit* /*victim*/) override

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -132,6 +132,7 @@ public:
 
         void Initialize()
         {
+            Talk(SAY_DOROTHEE_AGGRO);
             AggroTimer = 13000;
 
             WaterBoltTimer = 5000;
@@ -140,6 +141,7 @@ public:
 
             SummonedTito = false;
             TitoDied = false;
+            IntroDone = false;
         }
 
         InstanceScript* instance;
@@ -152,6 +154,7 @@ public:
 
         bool SummonedTito;
         bool TitoDied;
+        bool IntroDone;
 
         void Reset() override
         {
@@ -160,8 +163,7 @@ public:
 
         void JustEngagedWith(Unit* /*who*/) override
         {
-            Talk(SAY_DOROTHEE_AGGRO);
-            DoZoneInCombat();
+            me->SetInCombatWithZone();
         }
 
         void JustReachedHome() override
@@ -186,7 +188,6 @@ public:
         }
 
         void MoveInLineOfSight(Unit* who) override
-
         {
             if (me->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE))
                 return;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- change timers according to evidence gathered from archive footage
- despawn corpses immediately as well, as well as despawning at evade (because they do persist atm)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16283
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16304

- Closes https://github.com/chromiecraft/chromiecraft/issues/5621
- Closes https://github.com/chromiecraft/chromiecraft/issues/5620

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

Used the following videos for the timers:
- links to come

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested by myself. seems to work
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [x] allow Oz fight to reset even when Crone is not summoned yet
- [ ] wowhead and other strategy guides speak of an enrage that happens when Tito is killed and Dorothee still alive. this is easy to implement, but we need sniffs for this because a regular enrage (which they link) would only increase melee damage and since Dorothee only casts spells this does not seem likely
- [ ] get better timers using sniffs as well as the appropriate respawns and such
- [ ] perhaps handle despawning in a different way (either using a scheduler or in another way) NEEDS SNIFFS
- [ ] modernise with scheduler instead of events -> I want to do that in another PR

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
