### PR TITLE
fix(scripts/ZulGurub) fix timing regression for Venoxis cobras

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_venoxis.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_venoxis.cpp
@@ -301,7 +301,7 @@ public:
 
         void JustEngagedWith(Unit*)
         {
-            events.ScheduleEvent(EVENT_POISON, 8ms);
+            events.ScheduleEvent(EVENT_POISON, 8s);
 
             if (Creature* Venoxis = GetVenoxis())
             {
@@ -331,7 +331,7 @@ public:
                 case EVENT_POISON:
                 {
                     me->CastSpell(me->GetVictim(), SPELL_POISON);
-                    events.ScheduleEvent(EVENT_POISON, 15ms);
+                    events.ScheduleEvent(EVENT_POISON, 15s);
                     break;
                 }
                 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Corrects the poison event on Venoxis' cobras to be in seconds instead of milliseconds

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Issue introduced in #14876

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- works in latest AzerothCore


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Pull Venoxis
2. Don't get insta-gibbed by poison (or audibly killed by repeating poison sound effects)
3. Rejoice

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
