### PR TITLE
fix(DB/creature) add missing stealth detection to mobs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1684589406305000945.sql
+++ b/data/sql/updates/pending_db_world/rev_1684589406305000945.sql
@@ -1,8 +1,8 @@
 --
 
 UPDATE `creature_addon` SET `auras` = '18950' WHERE `guid` IN (135170, 135171, 135172, 135173, 135174, 135175, 135345, 135346, 135347, 135348, 135349, 135350, 135351, 135352, 135353, 135354, 135355, 135356, 135357, 135358, 135359, 135360, 135361, 135362);
-INSERT INTO `creature_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
-(16408, 0, 0, 0, 0, 0, 0, '18950');
+
+DELETE FROM `creature_template_addon` WHERE `entry` = 16408;
 INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
 (16408, 0, 0, 0, 0, 0, 0, '18950');
 

--- a/data/sql/updates/pending_db_world/rev_1684589406305000945.sql
+++ b/data/sql/updates/pending_db_world/rev_1684589406305000945.sql
@@ -1,6 +1,6 @@
 --
 
-UPDATE `creature_addon` SET `auras` = '18950' WHERE `guid` IN (135170, 135171, 135172, 135173, 135174, 135175, 135345, 135346, 135347, 135348, 135349, 135350, 135351, 135352, 135353, 135354, 135355, 135356, 135357, 135358, 135359, 135360, 135361, 135362);
+UPDATE `creature_addon` SET `auras` = '18950' WHERE `guid` IN (135170, 135171, 135174, 135175, 135345, 135346, 135347, 135348, 135349, 135350, 135351, 135352, 135353, 135354, 135355, 135356, 135357, 135358, 135359, 135360, 135361, 135362);
 
 DELETE FROM `creature_template_addon` WHERE `entry` = 16408;
 INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1684589406305000945.sql
+++ b/data/sql/updates/pending_db_world/rev_1684589406305000945.sql
@@ -1,0 +1,10 @@
+--
+
+UPDATE `creature_addon` SET `auras` = '18950' WHERE `guid` IN (135170, 135171, 135172, 135173, 135174, 135175, 135345, 135346, 135347, 135348, 135349, 135350, 135351, 135352, 135353, 135354, 135355, 135356, 135357, 135358, 135359, 135360, 135361, 135362);
+INSERT INTO `creature_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(16408, 0, 0, 0, 0, 0, 0, '18950');
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(16408, 0, 0, 0, 0, 0, 0, '18950');
+
+UPDATE `creature_addon` SET `auras` = 18950  WHERE `guid` in (20058, 16424)
+UPDATE `creature_template_addon` SET `auras` = '18950' WHERE `entry` IN (20058, 16424);

--- a/data/sql/updates/pending_db_world/rev_1684589406305000945.sql
+++ b/data/sql/updates/pending_db_world/rev_1684589406305000945.sql
@@ -6,5 +6,4 @@ INSERT INTO `creature_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `
 INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
 (16408, 0, 0, 0, 0, 0, 0, '18950');
 
-UPDATE `creature_addon` SET `auras` = 18950  WHERE `guid` in (20058, 16424)
 UPDATE `creature_template_addon` SET `auras` = '18950' WHERE `entry` IN (20058, 16424);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  add missing stealth detection to mobs

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16221
- Closes https://github.com/chromiecraft/chromiecraft/issues/5645
- Closes https://github.com/chromiecraft/chromiecraft/issues/5580

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
While stealthed (.aura 1784)

1. .go cr 71514  

1. .tele kara 
2. Walk next to the sentries/valets.
3. Observe they do see you.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
