### PR TITLE
fix (scripts/cs) Fix '.send items' command to no longer require an itemId count

### DIFF
--- a/src/server/scripts/Commands/cs_send.cpp
+++ b/src/server/scripts/Commands/cs_send.cpp
@@ -70,14 +70,22 @@ public:
         {
             auto itemTokens = Acore::Tokenize(itemString, ':', false);
 
-            if (itemTokens.size() != 2)
+            uint32 itemCount;
+            handler->SendSysMessage(Acore::StringFormatFmt("> '{}' contains {} token.", itemString, itemTokens.size()));
+            switch (itemTokens.size())
             {
-                handler->SendSysMessage(Acore::StringFormatFmt("> Incorrect item list format for '{}'", itemString));
-                continue;
+                case 1:
+                    itemCount = 1; // Default to sending 1 item
+                    break;
+                case 2:
+                    itemCount = *Acore::StringTo<uint32>(itemTokens.at(1));
+                    break;
+                default:
+                    handler->SendSysMessage(Acore::StringFormatFmt("> Incorrect item list format for '{}'", itemString));
+                    continue;
             }
 
             uint32 itemID = *Acore::StringTo<uint32>(itemTokens.at(0));
-            uint32 itemCount = *Acore::StringTo<uint32>(itemTokens.at(1));
 
             ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(itemID);
             if (!itemTemplate)

--- a/src/server/scripts/Commands/cs_send.cpp
+++ b/src/server/scripts/Commands/cs_send.cpp
@@ -71,7 +71,6 @@ public:
             auto itemTokens = Acore::Tokenize(itemString, ':', false);
 
             uint32 itemCount;
-            handler->SendSysMessage(Acore::StringFormatFmt("> '{}' contains {} token.", itemString, itemTokens.size()));
             switch (itemTokens.size())
             {
                 case 1:


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  makes item count optional again
- defaults the count of items sent to 1, as indicated by the help text

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- None I could find

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- personal experience and testing

## Tests Performed:
- Sent items with and without a count attached to the itemId


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. `.send items CharacterName "Test1" "Test1" 11284`
2. `.send items CharacterName "Test2" "Test2" 11284:5`
3. `.send items CharacterName "Test3" "Test3" 11284:5 23768`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
