### PR TITLE
fix(Scripts/UBRS): Update UBRS/Pyroguard Emberseer script to fix issues and increase accuracy

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_pyroguard_emberseer.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_pyroguard_emberseer.cpp
@@ -101,7 +101,7 @@ public:
             switch (data)
             {
                 case 1:
-                    events.ScheduleEvent(EVENT_PRE_FIGHT_1, 5s);
+                    events.ScheduleEvent(EVENT_PRE_FIGHT_1, 2s);
                     instance->SetBossState(DATA_PYROGAURD_EMBERSEER, IN_PROGRESS);
                     break;
                 case 2:
@@ -149,9 +149,8 @@ public:
 
             if (spell->Id == SPELL_EMBERSEER_GROWING_TRIGGER)
             {
-                if (me->GetAuraCount(SPELL_EMBERSEER_GROWING_TRIGGER) == 10) {
+                if (me->GetAuraCount(SPELL_EMBERSEER_GROWING_TRIGGER) == 10)
                     Talk(EMOTE_TEN_STACK);
-                }
 
                 if (me->GetAuraCount(SPELL_EMBERSEER_GROWING_TRIGGER) == 20)
                 {

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_pyroguard_emberseer.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_pyroguard_emberseer.cpp
@@ -63,9 +63,9 @@ enum Events
     EVENT_PYROBLAST                 = 6,
     // Hack due to trigger spell not in dbc
     EVENT_FIRE_SHIELD               = 7,
-    // Make sure all players have aura from altar
-    EVENT_PLAYER_CHECK              = 8,
-    EVENT_ENTER_COMBAT              = 9
+    EVENT_PRE_ENTER_COMBAT_1        = 8,
+    EVENT_PRE_ENTER_COMBAT_2        = 9,
+    EVENT_ENTER_COMBAT              = 10
 };
 
 class boss_pyroguard_emberseer : public CreatureScript
@@ -101,7 +101,8 @@ public:
             switch (data)
             {
                 case 1:
-                    events.ScheduleEvent(EVENT_PLAYER_CHECK, 5s);
+                    events.ScheduleEvent(EVENT_PRE_FIGHT_1, 5s);
+                    instance->SetBossState(DATA_PYROGAURD_EMBERSEER, IN_PROGRESS);
                     break;
                 case 2:
                     // Close these two doors on Blackhand Incarcerators aggro
@@ -148,19 +149,18 @@ public:
 
             if (spell->Id == SPELL_EMBERSEER_GROWING_TRIGGER)
             {
-                if (me->GetAuraCount(SPELL_EMBERSEER_GROWING_TRIGGER) == 10)
+                if (me->GetAuraCount(SPELL_EMBERSEER_GROWING_TRIGGER) == 10) {
                     Talk(EMOTE_TEN_STACK);
+                }
 
                 if (me->GetAuraCount(SPELL_EMBERSEER_GROWING_TRIGGER) == 20)
                 {
-                    me->RemoveAura(SPELL_ENCAGED_EMBERSEER);
-                    me->RemoveAura(SPELL_FREEZE_ANIM);
-                    me->CastSpell(me, SPELL_EMBERSEER_FULL_STRENGTH);
-                    Talk(EMOTE_FREE_OF_BONDS);
-                    Talk(YELL_FREE_OF_BONDS);
-                    me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
-                    me->SetImmuneToPC(false);
-                    events.ScheduleEvent(EVENT_ENTER_COMBAT, 2s);
+                    events.CancelEvent(EVENT_FIRE_SHIELD); // temporarily cancel fire shield to keep it from interrupting combat start
+
+                    // Schedule out the pre-combat scene
+                    events.ScheduleEvent(EVENT_PRE_ENTER_COMBAT_1, 0s);
+                    events.ScheduleEvent(EVENT_PRE_ENTER_COMBAT_2, 2s);
+                    events.ScheduleEvent(EVENT_ENTER_COMBAT, 5s);
                 }
             }
         }
@@ -235,7 +235,7 @@ public:
                                     if (Creature* creature = *itr)
                                         creature->AI()->SetData(1, 1);
                                 }
-                                events.ScheduleEvent(EVENT_PRE_FIGHT_2, 32s);
+                                events.ScheduleEvent(EVENT_PRE_FIGHT_2, 2s);
                                 break;
                             }
                         case EVENT_PRE_FIGHT_2:
@@ -248,25 +248,21 @@ public:
                             DoCast(me, SPELL_FIRE_SHIELD);
                             events.ScheduleEvent(EVENT_FIRE_SHIELD, 3s);
                             break;
-                        case EVENT_PLAYER_CHECK:
-                            {
-                                // Check to see if all players in instance have aura SPELL_EMBERSEER_START before starting event
-                                bool _hasAura = false;
-                                Map::PlayerList const& players = me->GetMap()->GetPlayers();
-                                for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
-                                    if (Player* player = itr->GetSource()->ToPlayer())
-                                        if (player->HasAura(SPELL_EMBERSEER_OBJECT_VISUAL))
-                                            _hasAura = true;
-
-                                if (_hasAura)
-                                {
-                                    events.ScheduleEvent(EVENT_PRE_FIGHT_1, 1s);
-                                    instance->SetBossState(DATA_PYROGAURD_EMBERSEER, IN_PROGRESS);
-                                }
-                                break;
-                            }
+                        case EVENT_PRE_ENTER_COMBAT_1:
+                            me->RemoveAura(SPELL_ENCAGED_EMBERSEER);
+                            me->RemoveAura(SPELL_FREEZE_ANIM);
+                            me->CastSpell(me, SPELL_EMBERSEER_FULL_STRENGTH);
+                            Talk(EMOTE_FREE_OF_BONDS);
+                            break;
+                        case EVENT_PRE_ENTER_COMBAT_2:
+                            Talk(YELL_FREE_OF_BONDS);
+                            break;
                         case EVENT_ENTER_COMBAT:
+                            me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+                            me->SetImmuneToPC(false);
                             DoZoneInCombat();
+                            // re-enable fire shield
+                            events.ScheduleEvent(EVENT_FIRE_SHIELD, 0s);
                             break;
                         default:
                             break;
@@ -347,11 +343,6 @@ public:
             _fleedForAssistance = false;
         }
 
-        void JustDied(Unit* /*killer*/) override
-        {
-            me->DespawnOrUnsummon(10000);
-        }
-
         void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*type*/, SpellSchoolMask /*school*/) override
         {
             if (!_fleedForAssistance && me->HealthBelowPctDamaged(30, damage))
@@ -392,7 +383,6 @@ public:
             }
 
             _events.ScheduleEvent(EVENT_STRIKE, 8s, 16s);
-            _events.ScheduleEvent(EVENT_ENCAGE, 10s, 20s);
         }
 
         void UpdateAI(uint32 diff) override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Remove EVENT_PLAYER_CHECK which was causing triggering the fight to work only sporadically and does not exist in the WotLK Classic version
- Break out pre-enter-combat phase to better match actual timing
- Pre-enter-combat sequence starts 2s after the adds are engaged (instead of 32s) to better match actual timing
- timing now matches DBM and multiple videos
- disable fire shield hack during pre-enter-combat to keep the fight from resetting
- remove faster add despawn which doesn't appear to be in the WotLK Classic version
- remove adds doing EVENT_ENCAGE every 10-20s, which was unnecessary and caused them to glitch move around the player

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- None

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Used these two videos as reference:
- https://youtu.be/roNyUYbM0JE?t=507 (Season of Mastery, good to watch timing of emotes and boss actions)
- https://www.youtube.com/watch?v=H0F02urENz0&t=283s (fight activated by only one player summoning)
- https://youtu.be/1tGdVHw9HME?t=227 (final version on live before rework, shows single player summoning and same timing)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- start/restart the fight multiple times, checking timing with stopwatch app


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go gameobject 87838` (Blackrock Alter)
2. channel ritual for 5 seconds
3. 5 seconds later the fight should start and proceed as normal
4. note that the boss starts growing immediately, and becomes attackable 65 seconds later

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- would be great to figure out why channeling the Blackrock Alter cancels after 5s instead of continuing (Uldaman altar for the final boss does the same thing)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
