### PR TITLE
fix(DB/SAI) Zul'Farrak: make Antu'sul (8127) despawn his summoned adds (8156) when reset

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1684908860029011348.sql
+++ b/data/sql/updates/pending_db_world/rev_1684908860029011348.sql
@@ -1,0 +1,4 @@
+--
+-- Antu'Sul (Zul'Farrak)
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(8127, 0, 12, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 9, 8156, 0, 500, 1, 0, 0, 0, 0, 'Antu\'sul - On Reset - Despawn Summons');

--- a/data/sql/updates/pending_db_world/rev_1684908860029011348.sql
+++ b/data/sql/updates/pending_db_world/rev_1684908860029011348.sql
@@ -1,4 +1,17 @@
 --
 -- Antu'Sul (Zul'Farrak)
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 8127);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(8127, 0, 0, 0, 0, 0, 75, 0, 5000, 5000, 17000, 17000, 0, 11, 8376, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Antu\'sul - In Combat - Cast Earthgrab Totem'),
+(8127, 0, 1, 0, 0, 0, 75, 0, 13000, 13000, 17000, 17000, 0, 11, 11899, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Antu\'sul - In Combat - Cast Healing Ward'),
+(8127, 0, 2, 3, 4, 0, 100, 0, 0, 0, 0, 0, 0, 11, 11894, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Antu\'sul - On Aggro - Cast Antu\'sul\'s Minion'),
+(8127, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Antu\'sul - On Aggro - Say Line 1'),
+(8127, 0, 4, 0, 0, 0, 100, 0, 5000, 5000, 12000, 14000, 0, 11, 16006, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 'Antu\'sul - In Combat - Cast Chain Lightning'),
+(8127, 0, 5, 0, 0, 0, 100, 0, 3000, 3000, 9000, 11000, 0, 11, 15501, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Antu\'sul - In Combat - Cast Earth Shock'),
+(8127, 0, 6, 0, 38, 0, 100, 0, 1, 1, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 21, 100, 0, 0, 0, 0, 0, 0, 0, 'Antu\'sul - On Data Set 1 1 - Start Attacking'),
+(8127, 0, 7, 8, 2, 0, 100, 1, 0, 75, 0, 0, 0, 11, 11894, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Antu\'sul - Between 0-75% Health - Cast Antu\'sul\'s Minion'),
+(8127, 0, 8, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Antu\'sul - Between 0-75% Health - Say Line 2'),
+(8127, 0, 9, 10, 2, 0, 100, 1, 0, 25, 0, 0, 0, 11, 11894, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Antu\'sul - Between 0-25% Health - Cast Antu\'sul\'s Minion'),
+(8127, 0, 10, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Antu\'sul - Between 0-25% Health - Say Line 0'),
+(8127, 0, 11, 0, 2, 0, 100, 1, 0, 20, 0, 0, 0, 11, 11895, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Antu\'sul - Between 0-20% Health - Cast Healing Wave of Antu\'sul'),
 (8127, 0, 12, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 9, 8156, 0, 500, 1, 0, 0, 0, 0, 'Antu\'sul - On Reset - Despawn Summons');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  adds a SAI entry to cause Antu'sul (8127) to despawn his own summoned adds (8156) when reset

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- summoned creatures created by Antu'sul's SAI during a first attempt are not despawned for subsequent attempts

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- personal experience


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Engaged boss and reset to observe one or more adds being despawned


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. `.list creature 8127`
2. `.go creature <entry from above>`
3. target self and `.die`
4. observe that Antu'sul despawns the add he created upon returning to his spawn point

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
