### PR TITLE
fix(DB/creature) Add Magnetic Pull to Living Cyclone and remove wrong…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1684961632752120124.sql
+++ b/data/sql/updates/pending_db_world/rev_1684961632752120124.sql
@@ -1,0 +1,7 @@
+--
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 17160);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(17160, 0, 0, 0, 23, 0, 100, 1, 12550, 0, 10000, 10000, 0, 11, 12550, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Living Cyclone - On Missing Aura - Cast Lightning Shield'),
+(17160, 0, 1, 0, 9, 0, 100, 1, 8, 40, 10000, 15000, 0, 11, 31705, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Living Cyclone - On Range - Cast Magnetic Pull');
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 19996) AND (`source_type` = 0) AND (`id` IN (1));

--- a/data/sql/updates/pending_db_world/rev_1684961632752120124.sql
+++ b/data/sql/updates/pending_db_world/rev_1684961632752120124.sql
@@ -1,7 +1,7 @@
 --
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 17160);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(17160, 0, 0, 0, 23, 0, 100, 1, 12550, 0, 10000, 10000, 0, 11, 12550, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Living Cyclone - On Missing Aura - Cast Lightning Shield'),
-(17160, 0, 1, 0, 9, 0, 100, 1, 8, 40, 10000, 15000, 0, 11, 31705, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Living Cyclone - On Range - Cast Magnetic Pull');
+(17160, 0, 0, 0, 23, 0, 100, 0, 12550, 0, 10000, 10000, 0, 11, 12550, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Living Cyclone - On Missing Aura - Cast Lightning Shield'),
+(17160, 0, 1, 0, 9, 0, 100, 0, 8, 40, 10000, 15000, 0, 11, 31705, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Living Cyclone - On Range - Cast Magnetic Pull');
 
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 19996) AND (`source_type` = 0) AND (`id` IN (1));

--- a/rev_1684961632752120124.sql
+++ b/rev_1684961632752120124.sql
@@ -1,7 +1,0 @@
---
-DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 17160);
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(17160, 0, 0, 0, 23, 0, 100, 1, 12550, 0, 10000, 10000, 0, 11, 12550, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Living Cyclone - On Missing Aura - Cast Lightning Shield'),
-(17160, 0, 1, 0, 9, 0, 100, 1, 8, 40, 10000, 15000, 0, 11, 31705, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Living Cyclone - On Range - Cast Magnetic Pull');
-
-DELETE FROM `smart_scripts` WHERE (`entryorguid` = 19996) AND (`source_type` = 0) AND (`id` IN (1));

--- a/rev_1684961632752120124.sql
+++ b/rev_1684961632752120124.sql
@@ -1,0 +1,6 @@
+--
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 17160) AND (`source_type` = 0) AND (`id` IN (1));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(17160, 0, 1, 0, 4, 0, 100, 1, 0, 0, 0, 0, 0, 11, 31705, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Living Cyclone - On Aggro - Cast Magnetic Pull (No Repeat)')
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 19996) AND (`source_type` = 0) AND (`id` IN (1));

--- a/rev_1684961632752120124.sql
+++ b/rev_1684961632752120124.sql
@@ -1,6 +1,7 @@
 --
-DELETE FROM `smart_scripts` WHERE (`entryorguid` = 17160) AND (`source_type` = 0) AND (`id` IN (1));
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 17160);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(17160, 0, 1, 0, 4, 0, 100, 1, 0, 0, 0, 0, 0, 11, 31705, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Living Cyclone - On Aggro - Cast Magnetic Pull (No Repeat)')
+(17160, 0, 0, 0, 23, 0, 100, 1, 12550, 0, 10000, 10000, 0, 11, 12550, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Living Cyclone - On Missing Aura - Cast Lightning Shield'),
+(17160, 0, 1, 0, 9, 0, 100, 1, 8, 40, 10000, 15000, 0, 11, 31705, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Living Cyclone - On Range - Cast Magnetic Pull');
 
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 19996) AND (`source_type` = 0) AND (`id` IN (1));


### PR DESCRIPTION
… spell from Bladespire Battlemage

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add Magnetic Pull to Living Cyclone, adjusts Lightning Shield
-  Removes wrong spell (Lightning Shield) from Bladespire Battlemage

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5623
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16282

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.wowhead.com/wotlk/npc=17160/living-cyclone
https://www.wowhead.com/wotlk/npc=19996/bladespire-battlemage
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Works


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .npc add 17160, aggro

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
