### PR TITLE
fix(DB/HellfirePeninsula): remove very strange resistance from Kaliri Swooper, Matriarch and the Hatchlings

### DIFF
--- a/data/sql/updates/pending_db_world/fix-kaliri-resist.sql
+++ b/data/sql/updates/pending_db_world/fix-kaliri-resist.sql
@@ -1,2 +1,3 @@
 --
 UPDATE `creature_template_resistance` SET `Resistance` = 0 WHERE `CreatureID` IN (17034, 17035, 17039, 17053);
+UPDATE `creature_template_resistance` SET `VerifiedBuild` = 0 WHERE `CreatureID` IN (17034, 17035, 17039, 17053);

--- a/data/sql/updates/pending_db_world/fix-kaliri-resist.sql
+++ b/data/sql/updates/pending_db_world/fix-kaliri-resist.sql
@@ -1,3 +1,3 @@
 --
 UPDATE `creature_template_resistance` SET `Resistance` = 0 WHERE `CreatureID` IN (17034, 17035, 17039, 17053);
-UPDATE `creature_template_resistance` SET `VerifiedBuild` = 0 WHERE `CreatureID` IN (17034, 17035, 17039, 17053);
+UPDATE `creature_template_resistance` SET `VerifiedBuild` = 49705 WHERE `CreatureID` IN (17034, 17035, 17039, 17053);

--- a/data/sql/updates/pending_db_world/fix-kaliri-resist.sql
+++ b/data/sql/updates/pending_db_world/fix-kaliri-resist.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template_resistance` SET `Resistance` = 0 WHERE `CreatureID` IN (17034, 17035, 17039, 17053);

--- a/data/sql/updates/pending_db_world/fix-kaliri-resist.sql
+++ b/data/sql/updates/pending_db_world/fix-kaliri-resist.sql
@@ -1,3 +1,2 @@
 --
-UPDATE `creature_template_resistance` SET `Resistance` = 0 WHERE `CreatureID` IN (17034, 17035, 17039, 17053);
-UPDATE `creature_template_resistance` SET `VerifiedBuild` = 49705 WHERE `CreatureID` IN (17034, 17035, 17039, 17053);
+DELETE FROM `creature_template_resistance` WHERE `CreatureID` IN (17034, 17035, 17039, 17053);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16368
- Closes https://github.com/chromiecraft/chromiecraft/issues/5639

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

The video shows that this resistance that it is rn (see AC issue) just cannot be right. The arcane shot we see [here](https://www.youtube.com/watch?v=8LrraqpLa1M&t=150s) would likely be totally resisted.

checking thanks to @heyitsbench 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- not tested in game
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [x] <s>set verified build to 0</s>delete entries
- [x] this is very likely not needed, but to be absolutely sure we would need sniffs


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
