### PR TITLE
fix (DB/SAI): Lupine Delusion (5097) and Illusionary Phantasm (6493) properly despawn when hit

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1685233623001496914.sql
+++ b/data/sql/updates/pending_db_world/rev_1685233623001496914.sql
@@ -1,0 +1,11 @@
+-- 5097: Lupine Delusion (Shadowfang Keep)
+-- 6493: Illusionary Phantasm (Scarlet Monastery Graveyard)
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` in (5097, 6493);
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` in (5097, 6493));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(5097, 0, 0, 0, 2, 0, 100, 0, 0, 99, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lupine Delusion - Between 0-99% Health - Despawn Instant'),
+(5097, 0, 1, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lupine Delusion - On Just Died - Despawn Instant'),
+(6493, 0, 0, 0, 2, 0, 100, 0, 0, 99, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Illusionary Phantasm - Between 0-99% Health - Despawn Instant'),
+(6493, 0, 1, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Illusionary Phantasm - On Just Died - Despawn Instant');
+

--- a/data/sql/updates/pending_db_world/rev_1685233623001496914.sql
+++ b/data/sql/updates/pending_db_world/rev_1685233623001496914.sql
@@ -1,11 +1,10 @@
 -- 5097: Lupine Delusion (Shadowfang Keep)
 -- 6493: Illusionary Phantasm (Scarlet Monastery Graveyard)
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` in (5097, 6493);
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (5097, 6493);
 
-DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` in (5097, 6493));
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` IN (5097, 6493));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (5097, 0, 0, 0, 2, 0, 100, 0, 0, 99, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lupine Delusion - Between 0-99% Health - Despawn Instant'),
 (5097, 0, 1, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Lupine Delusion - On Just Died - Despawn Instant'),
 (6493, 0, 0, 0, 2, 0, 100, 0, 0, 99, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Illusionary Phantasm - Between 0-99% Health - Despawn Instant'),
 (6493, 0, 1, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Illusionary Phantasm - On Just Died - Despawn Instant');
-


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Updates two creatures to have more Blizz-like behaviors
- Lupine Delusion (5097, Shadowfang Keep)
- Illusionary Phantasm (6493, Scarlet Monastery Graveyard)

These creatures have been assigned as AI of "SmartAI" and have SAI actions to despawn immediately when hit.   

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
Creatures previously would be killed like normal enemies, with the entire health bar needing to be DPS'd through. This change fixes that incorrect behavior.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Personal testing on WotLK Classic live. Both creatures act identically - any damage (AoE or single-target) of any amount will cause them to immediately despawn without a death animation and without rewarding XP.

Worked with @Gultask to refine the SAI and ensure both small damage (taking a % of health away) and massive damage (killed in one hit) properly result in the same effect.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- SQL imported into my live database successfully
- enemies exhibit the desired behavior

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
- Lupine Delusion (5097) is spawned by any Lupine Horror (3863) enemy in Shadowfang Keep
- Illusionary Phantasm (6493) is spawned by any Haunting Phantasm (6427) in Scarlet Monastery: Graveyard

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- I'm sure there are other summoned enemies who could use this same treatment

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
