### PR TITLE
fix(Scripts/ShatteredHalls): hack fix to prevent pets from pulling the non-attackable peons in Nethekurse room

### DIFF
--- a/data/sql/updates/pending_db_world/update-peon-unit-flag.sql
+++ b/data/sql/updates/pending_db_world/update-peon-unit-flag.sql
@@ -1,2 +1,2 @@
 --
-UPDATE `smart_scripts` SET `action_param1` = 768 WHERE `entryorguid` IN (-151090, -151091, -151092, -151093);
+UPDATE `smart_scripts` SET `action_param1` = 768 WHERE `entryorguid` IN (-151090, -151091, -151092, -151093) AND `source_type` = 0;

--- a/data/sql/updates/pending_db_world/update-peon-unit-flag.sql
+++ b/data/sql/updates/pending_db_world/update-peon-unit-flag.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `smart_scripts` SET `action_param1` = 768 WHERE `entryorguid` IN (-151090, -151091, -151092, -151093);

--- a/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_nethekurse.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_nethekurse.cpp
@@ -235,11 +235,13 @@ struct boss_grand_warlock_nethekurse : public BossAI
             me->SetInCombatWithZone();
             return;
         }
-        else if (action == ACTION_START_INTRO)
+        else if (action == ACTION_START_INTRO && !_introStarted)
         {
             // Hack: Prevent from pulling from behind door
             me->SetImmuneToAll(false);
             _canAggro = true;
+            // Bit of a hack to make sure it can't be started with the areatrigger AND the door opening
+            _introStarted = true;
 
             std::list<Creature*> creatureList;
             GetCreatureListWithEntryInGrid(creatureList, me, NPC_PEON, 60.0f);
@@ -258,6 +260,21 @@ struct boss_grand_warlock_nethekurse : public BossAI
     {
         scheduler.Update(diff);
 
+        // this should never be called if the action to start intro has been called
+        if (!_introStarted)
+        {
+            // find the door that is nearest to the entrance
+            if (GameObject* nethekursedoor = GetClosestGameObjectWithEntry(me, GO_GRAND_WARLOCK_CHAMBER_DOOR_1, 100.0f))
+            {
+                // check if door is openened
+                //this should only happen before the intro, if the door is picked by someone
+                if(nethekursedoor->GetGoState() == 0)
+                {
+                    DoAction(ACTION_START_INTRO);
+                }
+            }
+        }
+
         if (!UpdateVictim())
             return;
 
@@ -272,6 +289,7 @@ private:
     uint8 PeonEngagedCount = 0;
     uint8 PeonKilledCount = 0;
     bool _canAggro = false;
+    bool _introStarted = false;
 };
 
 class spell_tsh_shadow_bolt : public SpellScript

--- a/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_nethekurse.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_nethekurse.cpp
@@ -238,7 +238,6 @@ struct boss_grand_warlock_nethekurse : public BossAI
         else if (action == ACTION_START_INTRO)
         {
             // Hack: Prevent from pulling from behind door
-            // Additional hack: prevent them from attacking pets that run by when jumping down the sewer
             me->SetImmuneToAll(false);
             _canAggro = true;
 

--- a/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_nethekurse.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_nethekurse.cpp
@@ -115,6 +115,7 @@ struct boss_grand_warlock_nethekurse : public BossAI
         if (!_canAggro)
         {
             me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+            me->SetUnitFlag(UNIT_FLAG_PACIFIED);
         }
     }
 
@@ -238,7 +239,9 @@ struct boss_grand_warlock_nethekurse : public BossAI
         else if (action == ACTION_START_INTRO)
         {
             // Hack: Prevent from pulling from behind door
+            // Additional hack: prevent them from attacking pets that run by when jumping down the sewer
             me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+            me->RemoveUnitFlag(UNIT_FLAG_PACIFIED);
             _canAggro = true;
 
             std::list<Creature*> creatureList;
@@ -248,6 +251,7 @@ struct boss_grand_warlock_nethekurse : public BossAI
                 if (creature)
                 {
                     creature->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+                    creature->RemoveUnitFlag(UNIT_FLAG_PACIFIED);
                 }
             }
             IntroRP();

--- a/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_nethekurse.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_nethekurse.cpp
@@ -114,8 +114,7 @@ struct boss_grand_warlock_nethekurse : public BossAI
 
         if (!_canAggro)
         {
-            me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
-            me->SetUnitFlag(UNIT_FLAG_PACIFIED);
+            me->SetImmuneToAll(true);
         }
     }
 
@@ -240,8 +239,7 @@ struct boss_grand_warlock_nethekurse : public BossAI
         {
             // Hack: Prevent from pulling from behind door
             // Additional hack: prevent them from attacking pets that run by when jumping down the sewer
-            me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
-            me->RemoveUnitFlag(UNIT_FLAG_PACIFIED);
+            me->SetImmuneToAll(false);
             _canAggro = true;
 
             std::list<Creature*> creatureList;
@@ -250,8 +248,7 @@ struct boss_grand_warlock_nethekurse : public BossAI
             {
                 if (creature)
                 {
-                    creature->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
-                    creature->RemoveUnitFlag(UNIT_FLAG_PACIFIED);
+                    creature->SetImmuneToAll(false);
                 }
             }
             IntroRP();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  intro now starts on lockpick
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5692

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->


See issue

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested the immunity part
- the lockpick part has to be thoroughly tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [x] make a better way to solve this problem also removing the non-attackable hack fix that was created in the first place
- [x] make it so door can be picked and the intro starts as well

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
