### PR TITLE
fix(Core/Pets) Pet scaling only being applied to pets with DB Entry

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1108,7 +1108,7 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
             SetCreateMana(pInfo->mana);
             SetModifierValue(UNIT_MOD_MANA, BASE_VALUE, (float)pInfo->mana);
         }
-
+        
         if (pInfo->armor > 0)
             SetModifierValue(UNIT_MOD_ARMOR, BASE_VALUE, float(pInfo->armor));
 

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1100,7 +1100,7 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
         {
             factorHealth *= _GetHealthMod(cinfo->rank);
         }
-        
+
         SetCreateHealth(pInfo->health*factorHealth);
         SetModifierValue(UNIT_MOD_HEALTH, BASE_VALUE, (float)pInfo->health);
         if (petType != HUNTER_PET) //hunter pet use focus
@@ -1108,7 +1108,7 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
             SetCreateMana(pInfo->mana);
             SetModifierValue(UNIT_MOD_MANA, BASE_VALUE, (float)pInfo->mana);
         }
-        
+
         if (pInfo->armor > 0)
             SetModifierValue(UNIT_MOD_ARMOR, BASE_VALUE, float(pInfo->armor));
 

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1095,7 +1095,7 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
         float factorHealth = 1;
         // If config is set to allow pets to use health modifiers, apply it to creatures with a DB entry
         // Pet.RankMod.Health = 1 use the factor value based on the rank of the pet, most pets have a rank of 0 and so use
-        // the Elite rank which is set as the default in Creature.cpp >> Creature::_GetHealthMod(int32 Rank) 
+        // the Elite rank which is set as the default in Creature.cpp >> Creature::_GetHealthMod(int32 Rank)
         if (sWorld->getBoolConfig(CONFIG_ALLOWS_RANK_MOD_FOR_PET_HEALTH))
         {
             factorHealth *= _GetHealthMod(cinfo->rank);

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1091,7 +1091,17 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
     PetLevelInfo const* pInfo = sObjectMgr->GetPetLevelInfo(creature_ID, petlevel);
     if (pInfo)                                      // exist in DB
     {
-        SetCreateHealth(pInfo->health);
+        // Default scale value of 1 to use if Pet.RankMod.Health = 0
+        float factorHealth = 1;
+        // If config is set to allow pets to use health modifiers, apply it to creatures with a DB entry
+        // Pet.RankMod.Health = 1 use the factor value based on the rank of the pet, most pets have a rank of 0 and so use
+        // the Elite rank which is set as the default in Creature.cpp >> Creature::_GetHealthMod(int32 Rank) 
+        if (sWorld->getBoolConfig(CONFIG_ALLOWS_RANK_MOD_FOR_PET_HEALTH))
+        {
+            factorHealth *= _GetHealthMod(cinfo->rank);
+        }
+        
+        SetCreateHealth(pInfo->health*factorHealth);
         SetModifierValue(UNIT_MOD_HEALTH, BASE_VALUE, (float)pInfo->health);
         if (petType != HUNTER_PET) //hunter pet use focus
         {

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1095,7 +1095,7 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
         float factorHealth = 1;
         // If config is set to allow pets to use health modifiers, apply it to creatures with a DB entry
         // Pet.RankMod.Health = 1 use the factor value based on the rank of the pet, most pets have a rank of 0 and so use
-        // the Elite rank which is set as the default in Creature.cpp >> Creature::_GetHealthMod(int32 Rank)
+        // the Elite rank which is set as the default in Creature::_GetHealthMod(int32 Rank)
         if (sWorld->getBoolConfig(CONFIG_ALLOWS_RANK_MOD_FOR_PET_HEALTH))
         {
             factorHealth *= _GetHealthMod(cinfo->rank);


### PR DESCRIPTION
Original script was only applying the config option `CONFIG_ALLOWS_RANK_MOD_FOR_PET_HEALTH` (Pet.RankMod.Health)
to pets who did *not* have a DB entry. It was part of the else statement.

This PR creates a new if statement above the else statement where the scaling value will be applied appropriately if this bool is true.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Apply this change to core core to allow all pets to be scaled appropriately to config options if they have a DB entry and also without a DB entry.


## Issues Addressed:
- Further improves https://github.com/azerothcore/azerothcore-wotlk/issues/11480

## SOURCE:
- After testing noticed that pets without a DB entry would not scale regardless of the config option `Pet.RankMod.Health` being set to true or false.

## Tests Performed:
- Rebuilt without errors. 
- Tested locally on entity 8996 (Voidwalker Minion)
- Tested locally on entity 416 (Imp)


## How to Test the Changes:
1. go to orgrimmar burning blade cave
2. observe caster minion (voidwalker) hp with `Pet.RankMod.Health` = 0 and `Pet.RankMod.Health = 1`

## Known Issues and TODO List:
- There may be some outlier summons I have not thought about for this change, but it should not be a breaking change, it will merely scale the HP values to the global modifiers in the `worldconf` if they are changed and if the `Pet.RankMod.Health` is true.