### PR TITLE
fix(DB/Creature): Immunity mask for Rift Lord/Keeper

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1685492458809465300.sql
+++ b/data/sql/updates/pending_db_world/rev_1685492458809465300.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `mechanic_immune_mask` = 663699067 WHERE `entry` IN (17839, 20744, 21140, 22172, 21104, 21148, 22170, 22171);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Add immunity mask for every Rift Lord/Keeper.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16242
- Closes https://github.com/chromiecraft/chromiecraft/issues/5159

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Mangos -> tweaked some weird ones.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check every one of them are immunity to interrupts, stuns, etc.
