### PR TITLE
fix(Core/Scripts): Ghaz'an acid spit should hit just one target

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4534,6 +4534,12 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->MaxAffectedTargets = 1;
     });
 
+    // Acid Spit
+    ApplySpellFix({ 34290 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->MaxAffectedTargets = 1;
+    });
+
     for (uint32 i = 0; i < GetSpellInfoStoreSize(); ++i)
     {
         SpellInfo* spellInfo = mSpellInfoMap[i];


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Make the spell just hit one target instead of all.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5101

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
issue

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to The Underbog
2. Engage Ghaz'an with more than 2 players.
3. It shouldn't hit anyone now.


