### PR TITLE
fix(Core/Scripts): Sepethrea should prioritize players that don't hav…

### DIFF
--- a/src/server/scripts/Outland/TempestKeep/Mechanar/boss_nethermancer_sepethrea.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/boss_nethermancer_sepethrea.cpp
@@ -68,6 +68,8 @@ struct boss_nethermancer_sepethrea : public BossAI
                 }
             }
         }
+
+        return true;
     }
 
     void JustEngagedWith(Unit*  /*who*/) override

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/boss_nethermancer_sepethrea.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/boss_nethermancer_sepethrea.cpp
@@ -54,6 +54,22 @@ struct boss_nethermancer_sepethrea : public BossAI
         });
     }
 
+    bool CanAIAttack(Unit const* target) const override
+    {
+        if (me->GetThreatMgr().GetThreatListSize() > 1)
+        {
+            ThreatContainer::StorageType::const_iterator lastRef = me->GetThreatMgr().GetOnlineContainer().GetThreatList().end();
+            --lastRef;
+            if (Unit* lastTarget = (*lastRef)->getTarget())
+            {
+                if (lastTarget != target)
+                {
+                    return !target->HasAura(SPELL_DRAGONS_BREATH);
+                }
+            }
+        }
+    }
+
     void JustEngagedWith(Unit*  /*who*/) override
     {
         _JustEngagedWith();


### PR DESCRIPTION
…e Dragon's breath aura

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Implement CanAIAttack with Dragon's breath aura condition 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5259

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
issue

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- NOT TESTED.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Engage Sepethrea with 2 or more players.
2. If the tank is hit by Dragon's Breath, it should ignore him.

