### PR TITLE
fix(Scripts/Spells): Convert some Druid spells to SpellScript

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1685547548027950300.sql
+++ b/data/sql/updates/pending_db_world/rev_1685547548027950300.sql
@@ -1,6 +1,5 @@
 --
-DELETE FROM `spell_script_names` WHERE `spell_id` IN (-49220, 34246, 60779) AND `ScriptName` IN ('spell_dru_idol_lifebloom', 'spell_dk_impurity');
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (34246, 60779) AND `ScriptName` = 'spell_dru_idol_lifebloom';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
-(-49220, 'spell_dk_impurity'),
 (34246, 'spell_dru_idol_lifebloom'),
 (60779, 'spell_dru_idol_lifebloom');

--- a/data/sql/updates/pending_db_world/rev_1685547548027950300.sql
+++ b/data/sql/updates/pending_db_world/rev_1685547548027950300.sql
@@ -1,0 +1,6 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (-49220, 34246, 60779) AND `ScriptName` IN ('spell_dru_idol_lifebloom', 'spell_dk_impurity');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(-49220, 'spell_dk_impurity'),
+(34246, 'spell_dru_idol_lifebloom'),
+(60779, 'spell_dru_idol_lifebloom');

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12465,32 +12465,6 @@ uint32 Unit::SpellHealingBonusDone(Unit* victim, SpellInfo const* spellProto, ui
 
     switch (spellProto->SpellFamilyName)
     {
-        case SPELLFAMILY_DRUID:
-        {
-            // Nourish vs Idol of the Flourishing Life
-            if (spellProto->SpellFamilyFlags[1] & 0x02000000)
-            {
-                if (AuraEffect const* relicAurEff = GetAuraEffect(64949, EFFECT_0))
-                {
-                    DoneAdvertisedBenefit += relicAurEff->GetAmount();
-                }
-            }
-
-            // Lifebloom vs Idol of Lush Moss/Increased Lifebloom Periodic
-            if (spellProto->SpellFamilyFlags[1] & 00000010)
-            {
-                if (AuraEffect const* relicAurEff = GetAuraEffect(60779, EFFECT_0))
-                {
-                    DoneAdvertisedBenefit += relicAurEff->GetAmount();
-                }
-
-                if (AuraEffect const* relicAurEff = GetAuraEffect(34246, EFFECT_0))
-                {
-                    DoneAdvertisedBenefit += relicAurEff->GetAmount();
-                }
-            }
-            break;
-        }
         case SPELLFAMILY_DEATHKNIGHT:
         {
             // Impurity

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12463,6 +12463,21 @@ uint32 Unit::SpellHealingBonusDone(Unit* victim, SpellInfo const* spellProto, ui
         }
     }
 
+    switch (spellProto->SpellFamilyName)
+    {
+        case SPELLFAMILY_DEATHKNIGHT:
+        {
+            // Impurity
+            if (AuraEffect* aurEff = GetDummyAuraEffect(SPELLFAMILY_DEATHKNIGHT, 1986, 0))
+            {
+                AddPct(ApCoeffMod, aurEff->GetAmount());
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
     // Done fixed damage bonus auras
     DoneAdvertisedBenefit += SpellBaseHealingBonusDone(spellProto->GetSchoolMask());
     float coeff = spellProto->Effects[effIndex].BonusMultiplier;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12463,21 +12463,6 @@ uint32 Unit::SpellHealingBonusDone(Unit* victim, SpellInfo const* spellProto, ui
         }
     }
 
-    switch (spellProto->SpellFamilyName)
-    {
-        case SPELLFAMILY_DEATHKNIGHT:
-        {
-            // Impurity
-            if (AuraEffect* aurEff = GetDummyAuraEffect(SPELLFAMILY_DEATHKNIGHT, 1986, 0))
-            {
-                AddPct(ApCoeffMod, aurEff->GetAmount());
-            }
-            break;
-        }
-        default:
-            break;
-    }
-
     // Done fixed damage bonus auras
     DoneAdvertisedBenefit += SpellBaseHealingBonusDone(spellProto->GetSchoolMask());
     float coeff = spellProto->Effects[effIndex].BonusMultiplier;

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -439,6 +439,13 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x00000040, 0x00000000, 0x00000000);
     });
 
+    // Idol of the Flourishing Life
+    ApplySpellFix({ 64949 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x00000000, 0x02000000, 0x00000000);
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
+    });
+
     ApplySpellFix({
         34231,  // Libram of the Lightbringer
         60792,  // Libram of Tolerance

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -1708,24 +1708,6 @@ class spell_dk_improved_unholy_presence : public AuraScript
     }
 };
 
-// -49220 - Impurity
-class spell_dk_impurity : public AuraScript
-{
-    PrepareAuraScript(spell_dk_impurity);
-
-    void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
-    {
-        if (Unit* caster = GetCaster())
-            if (AuraEffect* aurEff = caster->GetDummyAuraEffect(SPELLFAMILY_DEATHKNIGHT, 1986 /*Impurity IconID*/, EFFECT_0))
-                AddPct(amount, aurEff->GetAmount());
-    }
-
-    void Register() override
-    {
-        DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_dk_impurity::CalculateAmount, EFFECT_0, SPELL_EFFECT_DUMMY);
-    }
-};
-
 // 50842 - Pestilence
 class spell_dk_pestilence : public SpellScript
 {
@@ -2245,7 +2227,6 @@ void AddSC_deathknight_spell_scripts()
     RegisterSpellScript(spell_dk_improved_blood_presence);
     RegisterSpellScript(spell_dk_improved_frost_presence);
     RegisterSpellScript(spell_dk_improved_unholy_presence);
-    RegisterSpellScript(spell_dk_impurity);
     RegisterSpellScript(spell_dk_pestilence);
     RegisterSpellScript(spell_dk_presence);
     RegisterSpellScript(spell_dk_raise_dead);

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -1708,6 +1708,23 @@ class spell_dk_improved_unholy_presence : public AuraScript
     }
 };
 
+// -49220 - Impurity
+class spell_dk_impurity : public AuraScript
+{
+    PrepareAuraScript(spell_dk_impurity);
+
+    void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
+    {
+        if (AuraEffect* aurEff = caster->GetDummyAuraEffect(SPELLFAMILY_DEATHKNIGHT, 1986 /*Impurity IconID*/, EFFECT_0))
+            AddPct(amount, aurEff->GetAmount());
+    }
+
+    void Register() override
+    {
+        DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_dk_impurity::CalculateAmount, EFFECT_0, SPELL_EFFECT_DUMMY);
+    }
+};
+
 // 50842 - Pestilence
 class spell_dk_pestilence : public SpellScript
 {

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -1715,8 +1715,9 @@ class spell_dk_impurity : public AuraScript
 
     void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
     {
-        if (AuraEffect* aurEff = caster->GetDummyAuraEffect(SPELLFAMILY_DEATHKNIGHT, 1986 /*Impurity IconID*/, EFFECT_0))
-            AddPct(amount, aurEff->GetAmount());
+        if (Unit* caster = GetCaster())
+            if (AuraEffect* aurEff = caster->GetDummyAuraEffect(SPELLFAMILY_DEATHKNIGHT, 1986 /*Impurity IconID*/, EFFECT_0))
+                AddPct(amount, aurEff->GetAmount());
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -2245,6 +2245,7 @@ void AddSC_deathknight_spell_scripts()
     RegisterSpellScript(spell_dk_improved_blood_presence);
     RegisterSpellScript(spell_dk_improved_frost_presence);
     RegisterSpellScript(spell_dk_improved_unholy_presence);
+    RegisterSpellScript(spell_dk_impurity);
     RegisterSpellScript(spell_dk_pestilence);
     RegisterSpellScript(spell_dk_presence);
     RegisterSpellScript(spell_dk_raise_dead);

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -1708,23 +1708,6 @@ class spell_dk_improved_unholy_presence : public AuraScript
     }
 };
 
-// -49220 - Impurity
-class spell_dk_impurity : public AuraScript
-{
-    PrepareAuraScript(spell_dk_impurity);
-
-    void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
-    {
-        if (AuraEffect* aurEff = caster->GetDummyAuraEffect(SPELLFAMILY_DEATHKNIGHT, 1986 /*Impurity IconID*/, EFFECT_0))
-            AddPct(amount, aurEff->GetAmount());
-    }
-
-    void Register() override
-    {
-        DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_dk_impurity::CalculateAmount, EFFECT_0, SPELL_EFFECT_DUMMY);
-    }
-};
-
 // 50842 - Pestilence
 class spell_dk_pestilence : public SpellScript
 {

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -500,6 +500,31 @@ class spell_dru_glyph_of_starfire : public SpellScript
     }
 };
 
+// 34246 - Idol of the Emerald Queen
+// 60779 - Idol of Lush Moss
+class spell_dru_idol_lifebloom : public AuraScript
+{
+    PrepareAuraScript(spell_dru_idol_lifebloom);
+
+    void HandleEffectCalcSpellMod(AuraEffect const* aurEff, SpellModifier*& spellMod)
+    {
+        if (!spellMod)
+        {
+            spellMod = new SpellModifier(GetAura());
+            spellMod->op = SPELLMOD_DOT;
+            spellMod->type = SPELLMOD_FLAT;
+            spellMod->spellId = GetId();
+            spellMod->mask = aurEff->GetSpellInfo()->Effects[aurEff->GetEffIndex()].SpellClassMask;
+        }
+        spellMod->value = aurEff->GetAmount() / 7;
+    }
+
+    void Register() override
+    {
+        DoEffectCalcSpellMod += AuraEffectCalcSpellModFn(spell_dru_idol_lifebloom::HandleEffectCalcSpellMod, EFFECT_0, SPELL_AURA_DUMMY);
+    }
+};
+
 // 29166 - Innervate
 class spell_dru_innervate : public AuraScript
 {
@@ -1158,6 +1183,7 @@ void AddSC_druid_spell_scripts()
     RegisterSpellScript(spell_dru_dash);
     RegisterSpellScript(spell_dru_enrage);
     RegisterSpellScript(spell_dru_glyph_of_starfire);
+    RegisterSpellScript(spell_dru_idol_lifebloom);
     RegisterSpellScript(spell_dru_innervate);
     RegisterSpellScript(spell_dru_lifebloom);
     RegisterSpellScript(spell_dru_living_seed);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Convert some spells to SpellScripts

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16403

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Druid

1. .learn 33763
2. .add 27886
3. .add 40711
4. Test Lifebloom with the Idols

DK

1. Learn Impurity talent in Unholy
2. Use ability, see the damge increases with more impurity learned

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
