### PR TITLE
Fix(Core/Spell): Net-o-Matic

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5043,14 +5043,6 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                     if (caster && target->CanHaveThreatList())
                         target->AddThreat(caster, 10.0f);
                     break;
-
-              //  This Script is all wrong, it creates an additional Buff that bugs the characters. it shouldn't be here.
-              //  case 13139:                                     // net-o-matic
-              //      // root to self part of (root_target->charge->root_self sequence
-              //      if (caster)
-              //         caster->CastSpell(caster, 13138, true, nullptr, this);
-              //      break;
-
                 case 34026:   // kill command
                     {
                         Unit* pet = target->GetGuardianPet();

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5050,7 +5050,7 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
               //      if (caster)
               //         caster->CastSpell(caster, 13138, true, nullptr, this);
               //      break;
-				   
+
                 case 34026:   // kill command
                     {
                         Unit* pet = target->GetGuardianPet();

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5051,7 +5051,6 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                  //       caster->CastSpell(caster, 13138, true, nullptr, this);
                    // break;
 				   
-				   
                 case 34026:   // kill command
                     {
                         Unit* pet = target->GetGuardianPet();

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5043,11 +5043,15 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                     if (caster && target->CanHaveThreatList())
                         target->AddThreat(caster, 10.0f);
                     break;
-                case 13139:                                     // net-o-matic
+					
+			//	This Script is all wrong, it creates an additional Buff that bugs the characters. there shouldn't be here.
+             //   case 13139:                                     // net-o-matic
                     // root to self part of (root_target->charge->root_self sequence
-                    if (caster)
-                        caster->CastSpell(caster, 13138, true, nullptr, this);
-                    break;
+               //     if (caster)
+                 //       caster->CastSpell(caster, 13138, true, nullptr, this);
+                   // break;
+				   
+				   
                 case 34026:   // kill command
                     {
                         Unit* pet = target->GetGuardianPet();

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5044,7 +5044,7 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                         target->AddThreat(caster, 10.0f);
                     break;
 
-              //  This Script is all wrong, it creates an additional Buff that bugs the characters. there shouldn't be here.
+              //  This Script is all wrong, it creates an additional Buff that bugs the characters. it shouldn't be here.
               //  case 13139:                                     // net-o-matic
               //      // root to self part of (root_target->charge->root_self sequence
               //      if (caster)

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5043,13 +5043,13 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                     if (caster && target->CanHaveThreatList())
                         target->AddThreat(caster, 10.0f);
                     break;
-					
-			//	This Script is all wrong, it creates an additional Buff that bugs the characters. there shouldn't be here.
-             //   case 13139:                                     // net-o-matic
-                    // root to self part of (root_target->charge->root_self sequence
-               //     if (caster)
-                 //       caster->CastSpell(caster, 13138, true, nullptr, this);
-                   // break;
+
+              //  This Script is all wrong, it creates an additional Buff that bugs the characters. there shouldn't be here.
+              //  case 13139:                                     // net-o-matic
+              //      // root to self part of (root_target->charge->root_self sequence
+              //      if (caster)
+              //         caster->CastSpell(caster, 13138, true, nullptr, this);
+              //      break;
 				   
                 case 34026:   // kill command
                     {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  **Fix Spell:** [Net-o-Matic](https://wowgaming.altervista.org/aowow/?spell=13120) related to the Item: [Gnomish Net-o-Matic Projector](https://wowgaming.altervista.org/aowow/?item=10720) in SpellAuraEffects.cpp which caused an immobilizing Double "Aura", which persisted at each login, leaving the Player motionless until it expired.
- **Spell Removed:** [Net-o-Matic 1 (Duplicate)](https://wowgaming.altervista.org/aowow/?spell=13138)
- **Spell:** [Net-o-Matic 2 (The Right one)](https://wowgaming.altervista.org/aowow/?spell=16566)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes:  https://github.com/chromiecraft/chromiecraft/issues/2889
- Closes:  https://github.com/azerothcore/azerothcore-wotlk/issues/16481

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in game and working
- Tested on Windows 10 (64)
- **Video Test:** [Net-o-Matic](https://youtu.be/7LifmioZR3o)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
