### PR TITLE
fix(DB/Worldboss): Lower Doom Lord Kazzak's damage

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1686083132284151700.sql
+++ b/data/sql/updates/pending_db_world/rev_1686083132284151700.sql
@@ -1,2 +1,2 @@
 --
-UPDATE `creature_template` SET `DamageModifier` = 35 WHERE `entry` = 18728;
+UPDATE `creature_template` SET `DamageModifier` = 65 WHERE `entry` = 18728;

--- a/data/sql/updates/pending_db_world/rev_1686083132284151700.sql
+++ b/data/sql/updates/pending_db_world/rev_1686083132284151700.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `DamageModifier` = 35 WHERE `entry` = 18728;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Lower DamageModifier from 90 to 35.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5708

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
TC db

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- None.
