### PR TITLE
fix(DB/Creature): Dustbelcher NPC MovementType

### DIFF
--- a/data/sql/updates/pending_db_world/dustbelchernpcfix
+++ b/data/sql/updates/pending_db_world/dustbelchernpcfix
@@ -1,0 +1,1 @@
+UPDATE `creature` SET `MovementType` = '1' WHERE `creature`.`guid` IN (6974,6989,7210); -- correcting MovementType for creatures Dustbelcher Mauler, Dustbelcher Wyrmhunter, and Dustbelcher Shaman

--- a/data/sql/updates/pending_db_world/dustbelchernpcfix
+++ b/data/sql/updates/pending_db_world/dustbelchernpcfix
@@ -1,1 +1,0 @@
-UPDATE `creature` SET `MovementType` = 1 WHERE `guid` IN (6974,6989,7210); -- correcting MovementType for creatures Dustbelcher Mauler, Dustbelcher Wyrmhunter, and Dustbelcher Shaman

--- a/data/sql/updates/pending_db_world/dustbelchernpcfix
+++ b/data/sql/updates/pending_db_world/dustbelchernpcfix
@@ -1,1 +1,1 @@
-UPDATE `creature` SET `MovementType` = '1' WHERE `creature`.`guid` IN (6974,6989,7210); -- correcting MovementType for creatures Dustbelcher Mauler, Dustbelcher Wyrmhunter, and Dustbelcher Shaman
+UPDATE `creature` SET `MovementType` = 1 WHERE `guid` IN (6974,6989,7210); -- correcting MovementType for creatures Dustbelcher Mauler, Dustbelcher Wyrmhunter, and Dustbelcher Shaman

--- a/data/sql/updates/pending_db_world/dustbelchernpcfix.sql
+++ b/data/sql/updates/pending_db_world/dustbelchernpcfix.sql
@@ -1,1 +1,6 @@
-UPDATE `creature` SET `MovementType` = 1 WHERE `guid` IN (6974,6989,7210) AND `id1` IN (2718,2717,2907);
+UPDATE `creature` SET `MovementType` = 2 WHERE `guid` IN (6974,6989,7210) AND `id1` IN (2718,2717,2907);
+DELETE FROM `creature_addon` WHERE (`guid` IN (6974,6989,7210));
+INSERT INTO `creature_addon` (`guid`, `path_id`, `bytes2`) VALUES
+(6974, 69740, 1),
+(6989, 69890, 1),
+(7210, 72100, 1);

--- a/data/sql/updates/pending_db_world/dustbelchernpcfix.sql
+++ b/data/sql/updates/pending_db_world/dustbelchernpcfix.sql
@@ -1,0 +1,1 @@
+UPDATE `creature` SET `MovementType` = 1 WHERE `guid` IN (6974,6989,7210) AND `id1` IN (2718,2717,2907);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Modified the MovementType values for three Dustbelcher NPCs to resolve WaypointMovementGenerator::LoadPath: creature doesn't have waypoint path id error.
- Specifically, the errors generated in the worldserver console were:  `WaypointMovementGenerator::LoadPath: creature Dustbelcher Mauler (GUID Full: 0xf130000a9d0016b4 Type: Creature Entry: 2717  Low: 5812) doesn't have waypoint path id: 0 WaypointMovementGenerator::LoadPath: creature Dustbelcher Wyrmhunter (GUID Full: 0xf130000a9c0016b7 Type: Creature Entry: 2716  Low: 5815) doesn't have waypoint path id: 0 WaypointMovementGenerator::LoadPath: creature Dustbelcher Shaman (GUID Full: 0xf130000a9e0016b8 Type: Creature Entry: 2718  Low: 5816) doesn't have waypoint path id: 0 WaypointMovementGenerator::LoadPath: creature Dustbelcher Wyrmhunter (GUID Full: 0xf130000a9c0016b9 Type: Creature Entry: 2716  Low: 5817) doesn't have waypoint path id: 0 WaypointMovementGenerator::LoadPath: creature Dustbelcher Mystic (GUID Full: 0xf130000b5b0016ba Type: Creature Entry: 2907  Low: 5818) doesn't have waypoint path id: 0`
- These were due to NPCs having the wrong MovementType set as these NPCs did not have paths supporting MovementType=2.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #16485

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Yes. SQL changes only so build is not affected. Tested to see that NPCs in-game were adhering to new MovementType.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Spawn NPC GUID 6974, 6989, or 7210.
2. Observe movement.
3. Check worldserver console/logs to see that error is no longer present.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ None ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.