### PR TITLE
enforceDBCAttributes set to false bypass code block

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -2865,47 +2865,43 @@ void ObjectMgr::LoadItemTemplates()
 
         if (dbcitem)
         {
-            if (itemTemplate.Class != dbcitem->ClassID)
+            if (enforceDBCAttributes)
             {
-                LOG_ERROR("sql.sql", "Item (Entry: {}) has wrong Class value ({}), must be ({}).", entry, itemTemplate.Class, dbcitem->ClassID);
-                if (enforceDBCAttributes)
+                if (itemTemplate.Class != dbcitem->ClassID)
+                {
+                    LOG_ERROR("sql.sql", "Item (Entry: {}) has wrong Class value ({}), must be ({}).", entry, itemTemplate.Class, dbcitem->ClassID);
                     itemTemplate.Class = dbcitem->ClassID;
-            }
-            if (itemTemplate.SubClass != dbcitem->SubclassID)
-            {
-                LOG_ERROR("sql.sql", "Item (Entry: {}) has wrong Subclass value ({}) for class {}, must be ({}).", entry, itemTemplate.SubClass, itemTemplate.Class, dbcitem->SubclassID);
-                if (enforceDBCAttributes)
+                }
+                if (itemTemplate.SubClass != dbcitem->SubclassID)
+                {
+                    LOG_ERROR("sql.sql", "Item (Entry: {}) has wrong Subclass value ({}) for class {}, must be ({}).", entry, itemTemplate.SubClass, itemTemplate.Class, dbcitem->SubclassID);
                     itemTemplate.SubClass = dbcitem->SubclassID;
-            }
-            if (itemTemplate.SoundOverrideSubclass != dbcitem->SoundOverrideSubclassID)
-            {
-                LOG_ERROR("sql.sql", "Item (Entry: {}) does not have a correct SoundOverrideSubclass ({}), must be {}.", entry, itemTemplate.SoundOverrideSubclass);
-                if (enforceDBCAttributes)
+                }
+                if (itemTemplate.SoundOverrideSubclass != dbcitem->SoundOverrideSubclassID)
+                {
+                    LOG_ERROR("sql.sql", "Item (Entry: {}) does not have a correct SoundOverrideSubclass ({}), must be {}.", entry, itemTemplate.SoundOverrideSubclass, dbcitem->SoundOverrideSubclassID);
                     itemTemplate.SoundOverrideSubclass = dbcitem->SoundOverrideSubclassID;
-            }
-            if (itemTemplate.Material != dbcitem->Material)
-            {
-                LOG_ERROR("sql.sql", "Item (Entry: {}) does not have a correct material ({}), must be {}.", entry, itemTemplate.Material, dbcitem->Material);
-                if (enforceDBCAttributes)
+                }
+                if (itemTemplate.Material != dbcitem->Material)
+                {
+                    LOG_ERROR("sql.sql", "Item (Entry: {}) does not have a correct material ({}), must be {}.", entry, itemTemplate.Material, dbcitem->Material);
                     itemTemplate.Material = dbcitem->Material;
-            }
-            if (itemTemplate.InventoryType != dbcitem->InventoryType)
-            {
-                LOG_ERROR("sql.sql", "Item (Entry: {}) has wrong InventoryType value ({}), must be {}.", entry, itemTemplate.InventoryType, dbcitem->InventoryType);
-                if (enforceDBCAttributes)
+                }
+                if (itemTemplate.InventoryType != dbcitem->InventoryType)
+                {
+                    LOG_ERROR("sql.sql", "Item (Entry: {}) has wrong InventoryType value ({}), must be {}.", entry, itemTemplate.InventoryType, dbcitem->InventoryType);
                     itemTemplate.InventoryType = dbcitem->InventoryType;
-            }
-            if (itemTemplate.DisplayInfoID != dbcitem->DisplayInfoID)
-            {
-                LOG_ERROR("sql.sql", "Item (Entry: {}) does not have a correct display id ({}), must be {}.", entry, itemTemplate.DisplayInfoID, dbcitem->DisplayInfoID);
-                if (enforceDBCAttributes)
+                }
+                if (itemTemplate.DisplayInfoID != dbcitem->DisplayInfoID)
+                {
+                    LOG_ERROR("sql.sql", "Item (Entry: {}) does not have a correct display id ({}), must be {}.", entry, itemTemplate.DisplayInfoID, dbcitem->DisplayInfoID);
                     itemTemplate.DisplayInfoID = dbcitem->DisplayInfoID;
-            }
-            if (itemTemplate.Sheath != dbcitem->SheatheType)
-            {
-                LOG_ERROR("sql.sql", "Item (Entry: {}) has wrong Sheath ({}), must be {}.", entry, itemTemplate.Sheath, dbcitem->SheatheType);
-                if (enforceDBCAttributes)
+                }
+                if (itemTemplate.Sheath != dbcitem->SheatheType)
+                {
+                    LOG_ERROR("sql.sql", "Item (Entry: {}) has wrong Sheath ({}), must be {}.", entry, itemTemplate.Sheath, dbcitem->SheatheType);
                     itemTemplate.Sheath = dbcitem->SheatheType;
+                }
             }
         }
         else


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Code block is bypassed if enforceDBCAttributes is false reducing unnecessary logging and checks

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- DBC.EnforceItemAttributes = 1 produces logging errors verifying enforcement
- DBC.EnforceItemAttributes = 0 produces no errors therefore db overrides is successful


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Change item types in db and modify  DBC.EnforceItemAttribute
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
