### PR TITLE
chore(Core/ScriptMgr):Add Hook OnBeforeFillQuestLootItem

### DIFF
--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -679,6 +679,8 @@ QuestItemList* Loot::FillQuestLoot(Player* player)
     {
         LootItem& item = quest_items[i];
 
+        sScriptMgr->OnBeforeLootItem(player, item);
+
         // Quest item is not free for all and is already assigned to another player
         // or player doesn't need it
         if (item.is_blocked || !item.AllowedForPlayer(player, sourceWorldObjectGUID))

--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -679,7 +679,7 @@ QuestItemList* Loot::FillQuestLoot(Player* player)
     {
         LootItem& item = quest_items[i];
 
-        sScriptMgr->OnBeforeLootItem(player, item);
+        sScriptMgr->OnBeforeFillQuestLootItem(player, item);
 
         // Quest item is not free for all and is already assigned to another player
         // or player doesn't need it

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -582,11 +582,11 @@ void ScriptMgr::OnLootItem(Player* player, Item* item, uint32 count, ObjectGuid 
     });
 }
 
-void ScriptMgr::OnBeforeLootItem(Player* player, LootItem& item)
+void ScriptMgr::OnBeforeFillQuestLootItem(Player* player, LootItem& item)
 {
     ExecuteScript<PlayerScript>([&](PlayerScript* script)
     {
-        script->OnBeforeLootItem(player, item);
+        script->OnBeforeFillQuestLootItem(player, item);
     });
 }
 

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -582,6 +582,14 @@ void ScriptMgr::OnLootItem(Player* player, Item* item, uint32 count, ObjectGuid 
     });
 }
 
+void ScriptMgr::OnBeforeLootItem(Player* player, LootItem& item)
+{
+    ExecuteScript<PlayerScript>([&](PlayerScript* script)
+    {
+        script->OnBeforeLootItem(player, item);
+    });
+}
+
 void ScriptMgr::OnStoreNewItem(Player* player, Item* item, uint32 count)
 {
     ExecuteScript<PlayerScript>([&](PlayerScript* script)

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -1181,6 +1181,9 @@ public:
     //After looting item
     virtual void OnLootItem(Player* /*player*/, Item* /*item*/, uint32 /*count*/, ObjectGuid /*lootguid*/) { }
 
+    //Before looting item
+    virtual void OnBeforeLootItem(Player* /*player*/, LootItem& /*item*/) { }
+
     //After looting item (includes master loot).
     virtual void OnStoreNewItem(Player* /*player*/, Item* /*item*/, uint32 /*count*/) { }
 
@@ -2290,6 +2293,7 @@ public: /* PlayerScript */
     void GetCustomArenaPersonalRating(Player const* player, uint8 slot, uint32& rating) const;
     void OnGetMaxPersonalArenaRatingRequirement(Player const* player, uint32 minSlot, uint32& maxArenaRating) const;
     void OnLootItem(Player* player, Item* item, uint32 count, ObjectGuid lootguid);
+    void OnBeforeLootItem(Player* player, LootItem& item);
     void OnStoreNewItem(Player* player, Item* item, uint32 count);
     void OnCreateItem(Player* player, Item* item, uint32 count);
     void OnQuestRewardItem(Player* player, Item* item, uint32 count);

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -1182,7 +1182,7 @@ public:
     virtual void OnLootItem(Player* /*player*/, Item* /*item*/, uint32 /*count*/, ObjectGuid /*lootguid*/) { }
 
     //Before looting item
-    virtual void OnBeforeLootItem(Player* /*player*/, LootItem& /*item*/) { }
+    virtual void OnBeforeFillQuestLootItem(Player* /*player*/, LootItem& /*item*/) { }
 
     //After looting item (includes master loot).
     virtual void OnStoreNewItem(Player* /*player*/, Item* /*item*/, uint32 /*count*/) { }
@@ -2293,7 +2293,7 @@ public: /* PlayerScript */
     void GetCustomArenaPersonalRating(Player const* player, uint8 slot, uint32& rating) const;
     void OnGetMaxPersonalArenaRatingRequirement(Player const* player, uint32 minSlot, uint32& maxArenaRating) const;
     void OnLootItem(Player* player, Item* item, uint32 count, ObjectGuid lootguid);
-    void OnBeforeLootItem(Player* player, LootItem& item);
+    void OnBeforeFillQuestLootItem(Player* player, LootItem& item);
     void OnStoreNewItem(Player* player, Item* item, uint32 count);
     void OnCreateItem(Player* player, Item* item, uint32 count);
     void OnQuestRewardItem(Player* player, Item* item, uint32 count);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

- The idea is to add a hook, which is used in a module, to be able to change the condition of the item and to allow all the members of the party to obtain the same item from the quest.
- In other words, if you do a quest, which consists of getting 12 items from an npc, if there are 5 people in the party, they should kill at least 60 npc, as long as the drop is at 100%. Because if the drop is lower, you should kill many more.
- Thanks to this, it is achieved that people do not abandon missions, which involve having to get a lot of items from an npc.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. This change by itself does not work. It has to be accompanied by a module, which I will create once this code is working. Unless, of course, I have to make changes to it. I have tested it, without the module and with the module, and in both cases, the behavior was as expected.
2. Without the module, the behavior is normal. The group eliminates an npc, and at the time of obtaining the quest item (in case it falls), only one of them will be able to obtain it.
3. With the module, however, by modifying the behavior of the variable, all members of the group are able to put the quest item, making the quest less tedious to perform.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

## Related module

https://github.com/pangolp/mod-quest-loot-party

## Screenshots

![WoWScrnShot_061123_103825](https://github.com/azerothcore/azerothcore-wotlk/assets/2810187/6d96f980-e5ba-41c4-8363-502b81ddd34d)

![WoWScrnShot_061123_103840](https://github.com/azerothcore/azerothcore-wotlk/assets/2810187/ec8e3aeb-7a9e-4f60-b88d-854838e2a8b3)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
