### PR TITLE
fix(DB/Quest) Fix shareable quests

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1686519678664565811.sql
+++ b/data/sql/updates/pending_db_world/rev_1686519678664565811.sql
@@ -1,2 +1,3 @@
 --
 UPDATE `quest_template` SET `AllowableRaces` = 1101 WHERE `ID` IN (9494, 9492);
+UPDATE `quest_template` SET `AllowableRaces` = 690 WHERE `ID` = 9495;

--- a/data/sql/updates/pending_db_world/rev_1686519678664565811.sql
+++ b/data/sql/updates/pending_db_world/rev_1686519678664565811.sql
@@ -1,2 +1,2 @@
 --
-UPDATE `quest_template` SET `AllowableRaces` = 1101 WHERE `ID` = 9494;
+UPDATE `quest_template` SET `AllowableRaces` = 1101 WHERE `ID` IN (9494, 9492);

--- a/data/sql/updates/pending_db_world/rev_1686519678664565811.sql
+++ b/data/sql/updates/pending_db_world/rev_1686519678664565811.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `quest_template` SET `AllowableRaces` = 1101 WHERE `ID` = 9494;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fel Embers now can't be shared with horde
- Turning the Tide can only be shared to Alliance
- The Will of the Warchief can only be shared to Horde

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5683
- Closes https://github.com/chromiecraft/chromiecraft/issues/5697
## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.wowhead.com/wotlk/quest=9494/fel-embers
https://www.wowhead.com/tbc/quest=9495/the-will-of-the-warchief
https://www.wowhead.com/tbc/quest=9492/turning-the-tide
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .quest add 9494
2. .quest add 9492
3. Try sharing to Horde character (67 level +)
1. .quest add 9492
2. Try sharing to Alliance character (67 level +)


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
