### PR TITLE
fix(DB/Smart Scripts) Quest 437: The Dead Fields

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1686872651542486500.sql
+++ b/data/sql/updates/pending_db_world/rev_1686872651542486500.sql
@@ -2,4 +2,4 @@
 DELETE FROM `smart_scripts` WHERE `entryorguid`=173 AND `source_type`=2;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (173, 2, 0, 1, 46, 0, 100, 0, 0, 0, 0, 0, 0, 12, 2056, 3, 300000, 0, 0, 0, 8, 0, 0, 0, 0, 1077, 1539, 28.89, 0, 'Areatrigger - On Trigger - Summon Creature \'Ravenclaw Apparition\' (The Dead Fields)'),
-(173, 2, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 15, 437, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Areatrigger - On Link - Call Area explored or event happens');
+(173, 2, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 15, 437, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 'Areatrigger - On Link - Call Area explored or event happens');

--- a/data/sql/updates/pending_db_world/rev_1686872651542486500.sql
+++ b/data/sql/updates/pending_db_world/rev_1686872651542486500.sql
@@ -2,4 +2,4 @@
 DELETE FROM `smart_scripts` WHERE `entryorguid`=173 AND `source_type`=2;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (173, 2, 0, 1, 46, 0, 100, 0, 0, 0, 0, 0, 0, 12, 2056, 3, 300000, 0, 0, 0, 8, 0, 0, 0, 0, 1077, 1539, 28.89, 0, 'Areatrigger - On Trigger - Summon Creature \'Ravenclaw Apparition\' (The Dead Fields)'),
-(173, 2, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 15, 437, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 'Areatrigger - On Link - Call Area explored or event happens');
+(173, 2, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 15, 437, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 'Areatrigger - Linked - Quest Credit \'The Dead Fields\'');

--- a/data/sql/updates/pending_db_world/rev_1686872651542486500.sql
+++ b/data/sql/updates/pending_db_world/rev_1686872651542486500.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `smart_scripts` WHERE `entryorguid`=173 AND `source_type`=2 AND `id`=1;
+UPDATE `smart_scripts` SET `link`=1 WHERE `entryorguid`=173 AND `source_type`=2 AND `id`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(173, 2, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 15, 437, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Areatrigger - On Link - Call Area explored or event happens');

--- a/data/sql/updates/pending_db_world/rev_1686872651542486500.sql
+++ b/data/sql/updates/pending_db_world/rev_1686872651542486500.sql
@@ -1,5 +1,5 @@
 --
-DELETE FROM `smart_scripts` WHERE `entryorguid`=173 AND `source_type`=2 AND `id`=1;
-UPDATE `smart_scripts` SET `link`=1 WHERE `entryorguid`=173 AND `source_type`=2 AND `id`=0;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=173 AND `source_type`=2;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(173, 2, 0, 1, 46, 0, 100, 0, 0, 0, 0, 0, 0, 12, 2056, 3, 300000, 0, 0, 0, 8, 0, 0, 0, 0, 1077, 1539, 28.89, 0, 'Areatrigger - On Trigger - Summon Creature \'Ravenclaw Apparition\' (The Dead Fields)'),
 (173, 2, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 15, 437, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Areatrigger - On Link - Call Area explored or event happens');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  The mission lacks credits upon arrival at the site, so it cannot be completed.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16210
- Closes https://github.com/chromiecraft/chromiecraft/issues/5771
- Closes https://github.com/chromiecraft/chromiecraft/issues/5472
- Closes https://github.com/chromiecraft/chromiecraft/issues/5650

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
I cannot provide any source. Because there is no sniff.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.quest add 437`
2. `.go c 17611`
3. When you enter the area, it should give you the exploration credits and then, when you kill the npc, the mission is completed.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

## Screenshot

![WoWScrnShot_061523_212237](https://github.com/azerothcore/azerothcore-wotlk/assets/2810187/c4ed45bb-3527-4071-b571-ba5fdca3161e)

![WoWScrnShot_061523_212300](https://github.com/azerothcore/azerothcore-wotlk/assets/2810187/2e6437d5-a2ed-460a-b40c-ffc590081712)

![WoWScrnShot_061523_215124](https://github.com/azerothcore/azerothcore-wotlk/assets/2810187/17b9660e-7ed8-4ab3-a272-cf07f5a094d6)


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
