### PR TITLE
fix(DB/Trainer): Add TBC Goggles and Frost Grenades to proper reference

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1686957483376943500.sql
+++ b/data/sql/updates/pending_db_world/rev_1686957483376943500.sql
@@ -1,0 +1,27 @@
+--
+DELETE FROM `npc_trainer` WHERE `SpellID` IN (
+39973, -- Frost Grenades
+40274, -- Furious Gizmatic Goggles
+41311, -- Justicebringer 2000 Specs
+41312, -- Tankatronic Goggles
+41314, -- Surestrike Goggles v2.0
+41315, -- Gadgetstorm Goggles
+41316, -- Living Replicator Specs
+41317, -- Deathblow X11 Goggles
+41318, -- Wonderheal XT40 Shades
+41319, -- Magnified Moon Specs
+41320, -- Destruction Holo-gogs
+41321  -- Powerheal 4000 Lens
+);
+INSERT INTO `npc_trainer` (`ID`, `SpellID`, `MoneyCost`, `ReqSkillLine`, `ReqSkillRank`, `ReqLevel`, `ReqSpell`) VALUES
+(201013, 39973, 50000, 202, 335, 0, 0),
+(201013, 40274, 50000, 202, 350, 0, 0),
+(201013, 41311, 50000, 202, 350, 0, 0),
+(201013, 41312, 50000, 202, 350, 0, 0),
+(201013, 41314, 50000, 202, 350, 0, 0),
+(201013, 41315, 50000, 202, 350, 0, 0),
+(201013, 41316, 50000, 202, 350, 0, 0),
+(201013, 41317, 50000, 202, 350, 0, 0),
+(201013, 41318, 50000, 202, 350, 0, 0),
+(201013, 41319, 50000, 202, 350, 0, 0),
+(201013, 41320, 50000, 202, 350, 0, 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- TBC Epic goggles obtained from trainers were all over the place, some only having one trainer, WoWhead lists them all as part of a reference containing 14 trainers, all of which use reference 201013

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
WoWhead Wotlk Classic

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
```
SELECT * FROM `npc_trainer` WHERE `SpellID` IN (-201013)
```
- Also tested ingame

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
