### PR TITLE
fix(DB/creature_template): Make "Ambient Minion of Terokk" not selectable

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1687016239956745200.sql
+++ b/data/sql/updates/pending_db_world/rev_1687016239956745200.sql
@@ -1,0 +1,3 @@
+--
+UPDATE `creature_template` SET `unit_flags` = `unit_flags`|33554432 WHERE `entry`=22380;
+


### PR DESCRIPTION

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5634

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Linked issue

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

### Before
![image](https://github.com/azerothcore/azerothcore-wotlk/assets/61223313/6898e403-f725-4f00-a1a7-1516292595b9)


### After
![image](https://github.com/azerothcore/azerothcore-wotlk/assets/61223313/2073740c-03ec-4cba-8ea7-baf21381f857)



<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
