### PR TITLE
fix(scripts/Steamvault): Switch Mekgineer Steamrigger's enrage to Heroic mode only

### DIFF
--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_mekgineer_steamrigger.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_mekgineer_steamrigger.cpp
@@ -30,8 +30,6 @@ enum MekgineerSteamrigger
     SPELL_SAW_BLADE             = 31486,
     SPELL_ELECTRIFIED_NET       = 35107,
     SPELL_ENRAGE                = 26662,
-    SPELL_REPAIR_N              = 31532,
-    SPELL_REPAIR_H              = 37936,
 
     SPELL_SUMMON_MECHANICS_1    = 31528,
     SPELL_SUMMON_MECHANICS_2    = 31529,
@@ -85,23 +83,17 @@ struct boss_mekgineer_steamrigger : public BossAI
         {
             DoCastRandomTarget(SPELL_ELECTRIFIED_NET);
             context.Repeat(21800ms, 34200ms);
-        }).Schedule(5min, [this](TaskContext /*context*/)
-        {
-            DoCastSelf(SPELL_ENRAGE, true);
         });
 
-        if (!IsHeroic())
+        ScheduleHealthCheckEvent({ 75, 50, 25 }, [&] {
+        Talk(SAY_MECHANICS);
+        for (auto const& spell : { SPELL_SUMMON_MECHANICS_1, SPELL_SUMMON_MECHANICS_2, SPELL_SUMMON_MECHANICS_3 })
         {
-            ScheduleHealthCheckEvent({ 75, 50, 25 }, [&] {
-                Talk(SAY_MECHANICS);
-
-                for (auto const& spell : { SPELL_SUMMON_MECHANICS_1, SPELL_SUMMON_MECHANICS_2, SPELL_SUMMON_MECHANICS_3 })
-                {
-                    DoCastAOE(spell, true);
-                }
-            });
+            DoCastAOE(spell, true);
         }
-        else
+        });
+
+        if (IsHeroic())
         {
             scheduler.Schedule(15600ms, [this](TaskContext context)
             {
@@ -109,9 +101,11 @@ struct boss_mekgineer_steamrigger : public BossAI
                 {
                     Talk(SAY_MECHANICS);
                 }
-
                 DoCastAOE(RAND(SPELL_SUMMON_MECHANICS_1, SPELL_SUMMON_MECHANICS_2, SPELL_SUMMON_MECHANICS_3), true);
                 context.Repeat(15600ms, 25400ms);
+            }).Schedule(5min, [this](TaskContext /*context*/)
+            {
+                DoCastSelf(SPELL_ENRAGE, true);
             });
         }
     }

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_mekgineer_steamrigger.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_mekgineer_steamrigger.cpp
@@ -30,6 +30,8 @@ enum MekgineerSteamrigger
     SPELL_SAW_BLADE             = 31486,
     SPELL_ELECTRIFIED_NET       = 35107,
     SPELL_ENRAGE                = 26662,
+    SPELL_REPAIR_N              = 31532,
+    SPELL_REPAIR_H              = 37936,
 
     SPELL_SUMMON_MECHANICS_1    = 31528,
     SPELL_SUMMON_MECHANICS_2    = 31529,
@@ -85,15 +87,18 @@ struct boss_mekgineer_steamrigger : public BossAI
             context.Repeat(21800ms, 34200ms);
         });
 
-        ScheduleHealthCheckEvent({ 75, 50, 25 }, [&] {
-        Talk(SAY_MECHANICS);
-        for (auto const& spell : { SPELL_SUMMON_MECHANICS_1, SPELL_SUMMON_MECHANICS_2, SPELL_SUMMON_MECHANICS_3 })
+        if (!IsHeroic())
         {
-            DoCastAOE(spell, true);
-        }
-        });
+            ScheduleHealthCheckEvent({ 75, 50, 25 }, [&] {
+                Talk(SAY_MECHANICS);
 
-        if (IsHeroic())
+                for (auto const& spell : { SPELL_SUMMON_MECHANICS_1, SPELL_SUMMON_MECHANICS_2, SPELL_SUMMON_MECHANICS_3 })
+                {
+                    DoCastAOE(spell, true);
+                }
+            });
+        }
+        else
         {
             scheduler.Schedule(15600ms, [this](TaskContext context)
             {
@@ -101,6 +106,7 @@ struct boss_mekgineer_steamrigger : public BossAI
                 {
                     Talk(SAY_MECHANICS);
                 }
+
                 DoCastAOE(RAND(SPELL_SUMMON_MECHANICS_1, SPELL_SUMMON_MECHANICS_2, SPELL_SUMMON_MECHANICS_3), true);
                 context.Repeat(15600ms, 25400ms);
             }).Schedule(5min, [this](TaskContext /*context*/)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Change (5min) enrage timer to Heroic only (see source)

(The difficulty increment in heroic for summons is that besides de HP checks, there's an additional summon every 15s-24s)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5790

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowwiki-archive.fandom.com/wiki/Mekgineer_Steamrigger
&
![image](https://github.com/azerothcore/azerothcore-wotlk/assets/61223313/dea41b58-c39d-484e-9539-6d60ad35899c)
&
![image](https://github.com/azerothcore/azerothcore-wotlk/assets/61223313/40952be7-6819-4db5-89b2-8b7d4c028ccc)


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
