### PR TITLE
fix(Scripts/HellfireRamparts): Fix Gargolmar Retalliation procs with …

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1687098356342753500.sql
+++ b/data/sql/updates/pending_db_world/rev_1687098356342753500.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_gargolmar_retalliation' AND `spell_id` = 22857;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(22857, 'spell_gargolmar_retalliation');

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_watchkeeper_gargolmar.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_watchkeeper_gargolmar.cpp
@@ -144,7 +144,28 @@ private:
 
 };
 
+class spell_gargolmar_retalliation : public AuraScript
+{
+    PrepareAuraScript(spell_gargolmar_retalliation);
+
+    bool CheckProc(ProcEventInfo& eventInfo)
+    {
+        if (!eventInfo.GetActor() || !eventInfo.GetProcTarget())
+        {
+            return false;
+        }
+
+        return GetTarget()->isInFront(eventInfo.GetActor(), M_PI);
+    }
+
+    void Register() override
+    {
+        DoCheckProc += AuraCheckProcFn(spell_gargolmar_retalliation::CheckProc);
+    }
+};
+
 void AddSC_boss_watchkeeper_gargolmar()
 {
     RegisterHellfireRampartsCreatureAI(boss_watchkeeper_gargolmar);
+    RegisterSpellScript(spell_gargolmar_retalliation);
 }


### PR DESCRIPTION
…targets behind him

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Check the target position before firing the proc in the spell script so it no longer procs with targets behind him
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16548
- Closes https://github.com/chromiecraft/chromiecraft/issues/5741

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  learn 22857
2. pull a mob
3. move your back to the mob

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
