### PR TITLE
Fix typo in `wp show` command description.

### DIFF
--- a/data/sql/updates/pending_db_world/command_typo_fix.sql
+++ b/data/sql/updates/pending_db_world/command_typo_fix.sql
@@ -1,5 +1,3 @@
 
-UPDATE command 
-SET help = 'Syntax: .wp show $option\nOptions:\non $pathid (or selected creature with loaded path) - Show path\noff - Hide path\ninfo $selected_waypoint - Show info for selected waypoint.'
-WHERE 
-  name = 'wp show';
+SET @HELP_TEXT := 'Syntax: .wp show $option\nOptions:\non $pathid (or selected creature with loaded path) - Show path\noff - Hide path\ninfo $selected_waypoint - Show info for selected waypoint.';
+UPDATE `command` SET `help` = @HELP_TEXT WHERE `name` = 'wp show';

--- a/data/sql/updates/pending_db_world/command_typo_fix.sql
+++ b/data/sql/updates/pending_db_world/command_typo_fix.sql
@@ -1,0 +1,5 @@
+
+UPDATE command 
+SET help = 'Syntax: .wp show $option\nOptions:\non $pathid (or selected creature with loaded path) - Show path\noff - Hide path\ninfo $selected_waypoint - Show info for selected waypoint.'
+WHERE 
+  name = 'wp show';


### PR DESCRIPTION
`s/$slected_waypoint/$selected_waypoint`

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fix a typo in a command description/example.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- N/A

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- It builds.
- It changes a string.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run the .wp show command, and observe that the help text no longer contains a typo.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
