### PR TITLE
fix(Core/ShadowLabyrinth): Murmur's Touch

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1687388954869141000.sql
+++ b/data/sql/updates/pending_db_world/rev_1687388954869141000.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_murmur_touch', 'spell_shockwave_knockback');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(33686, 'spell_shockwave_knockback');

--- a/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_murmur.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_murmur.cpp
@@ -208,25 +208,27 @@ class spell_murmur_thundering_storm : public SpellScript
     }
 };
 
-// 33711/38794 - Murmur's Touch
-class spell_murmur_touch : public AuraScript
+// 33686 - Shockwave (Murmur's Touch final explosion)
+class spell_shockwave_knockback : public SpellScript
 {
-    PrepareAuraScript(spell_murmur_touch);
+    PrepareSpellScript(spell_shockwave_knockback);
 
-    void HandleAfterRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    bool Validate(SpellInfo const* /*spellInfo*/) override
     {
-        if (GetTargetApplication()->GetRemoveMode() == AURA_REMOVE_BY_EXPIRE)
+        return ValidateSpellInfo({ SPELL_SHOCKWAVE_SERVERSIDE });
+    }
+
+    void HandleOnHit()
+    {
+        if (Unit* target = GetHitUnit())
         {
-            if (GetTarget())
-            {
-                GetTarget()->CastSpell(GetTarget(), SPELL_SHOCKWAVE_SERVERSIDE, true);
-            }
+            target->CastSpell(target, SPELL_SHOCKWAVE_SERVERSIDE, true);
         }
     }
 
     void Register() override
     {
-        AfterEffectRemove += AuraEffectRemoveFn(spell_murmur_touch::HandleAfterRemove, EFFECT_0, SPELL_AURA_PERIODIC_TRIGGER_SPELL, AURA_EFFECT_HANDLE_REAL);
+        OnHit += SpellHitFn(spell_shockwave_knockback::HandleOnHit);
     }
 };
 
@@ -252,6 +254,6 @@ void AddSC_boss_murmur()
 {
     RegisterShadowLabyrinthCreatureAI(boss_murmur);
     RegisterSpellScript(spell_murmur_thundering_storm);
-    RegisterSpellScript(spell_murmur_touch);
+    RegisterSpellScript(spell_shockwave_knockback);
     RegisterSpellScript(spell_murmur_sonic_boom_effect);
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove not-working AuraScript.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Partially closes https://github.com/chromiecraft/chromiecraft/issues/5797

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  Tested in-game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Shadow Labyrinth and engage Murmur.
2. Wait for it to cast Murmur's Touch, stay close to the target of it.
3. It should knockback and silence the player and all the players within 20yds (also dmg)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Couldn't find the right spell for the pull towards player. It must be a serverside spell because it doesn't show anything on sniffs.

