### PR TITLE
Core/Movement fix shallow water dismount

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -1963,12 +1963,12 @@ inline LiquidData const GridMap::GetLiquidData(float x, float y, float z, float 
 
                     if (delta > collisionHeight)
                         liquidData.Status = LIQUID_MAP_UNDER_WATER;
+                    else if (delta > 0.0f && delta - collisionHeight / 2.0f < 0.0f)
+                        liquidData.Status = LIQUID_MAP_ABOVE_WATER;
                     else if (delta > 0.0f)
                         liquidData.Status = LIQUID_MAP_IN_WATER;
                     else if (delta > -0.1f)
                         liquidData.Status = LIQUID_MAP_WATER_WALK;
-                    else
-                        liquidData.Status = LIQUID_MAP_ABOVE_WATER;
                 }
             }
         }

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -1969,6 +1969,8 @@ inline LiquidData const GridMap::GetLiquidData(float x, float y, float z, float 
                         liquidData.Status = LIQUID_MAP_IN_WATER;
                     else if (delta > -0.1f)
                         liquidData.Status = LIQUID_MAP_WATER_WALK;
+                    else
+                        liquidData.Status = LIQUID_MAP_ABOVE_WATER;
                 }
             }
         }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
https://github.com/SunstriderEmu/BugTracker/commit/086883018a46a6cf7a66ad91e8d973cd01f8acc2
## Changes Proposed:
-  Stops dismount at the "edge" of the water

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5657

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  Tested seems to work 

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .go xyz -191.9 5726 19.9 530
2. Notice before and after

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
