### PR TITLE
fix some spells benefit from both SPELL_EFFECT_WEAPON_PERCENT_DAMAGE …

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13121,21 +13121,27 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     // mods for SPELL_SCHOOL_MASK_NORMAL are already factored in base melee damage calculation
     if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
     {
-        // Some spells don't benefit from pct done mods
-        AuraEffectList const& mModDamagePercentDone = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
-        for (AuraEffectList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
+        if (spellProto
+            && spellProto->Effects[0].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE
+            && spellProto->Effects[1].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE
+            && spellProto->Effects[2].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE)
         {
-            if (!spellProto || (spellProto->ValidateAttribute6SpellDamageMods(this, *i, false) &&
-                sScriptMgr->IsNeedModMeleeDamagePercent(this, *i, DoneTotalMod, spellProto)))
+            // Some spells don't benefit from pct done mods
+            AuraEffectList const& mModDamagePercentDone = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
+            for (AuraEffectList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
             {
-                if (((*i)->GetMiscValue() & damageSchoolMask))
+                if (!spellProto || (spellProto->ValidateAttribute6SpellDamageMods(this, *i, false) &&
+                    sScriptMgr->IsNeedModMeleeDamagePercent(this, *i, DoneTotalMod, spellProto)))
                 {
-                    if ((*i)->GetSpellInfo()->EquippedItemClass == -1)
-                        AddPct(DoneTotalMod, (*i)->GetAmount());
-                    else if (!(*i)->GetSpellInfo()->HasAttribute(SPELL_ATTR5_AURA_AFFECTS_NOT_JUST_REQ_EQUIPED_ITEM) && ((*i)->GetSpellInfo()->EquippedItemSubClassMask == 0))
-                        AddPct(DoneTotalMod, (*i)->GetAmount());
-                    else if (ToPlayer() && ToPlayer()->HasItemFitToSpellRequirements((*i)->GetSpellInfo()))
-                        AddPct(DoneTotalMod, (*i)->GetAmount());
+                    if (((*i)->GetMiscValue() & damageSchoolMask))
+                    {
+                        if ((*i)->GetSpellInfo()->EquippedItemClass == -1)
+                            AddPct(DoneTotalMod, (*i)->GetAmount());
+                        else if (!(*i)->GetSpellInfo()->HasAttribute(SPELL_ATTR5_AURA_AFFECTS_NOT_JUST_REQ_EQUIPED_ITEM) && ((*i)->GetSpellInfo()->EquippedItemSubClassMask == 0))
+                            AddPct(DoneTotalMod, (*i)->GetAmount());
+                        else if (ToPlayer() && ToPlayer()->HasItemFitToSpellRequirements((*i)->GetSpellInfo()))
+                            AddPct(DoneTotalMod, (*i)->GetAmount());
+                    }
                 }
             }
         }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13121,30 +13121,30 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     // mods for SPELL_SCHOOL_MASK_NORMAL are already factored in base melee damage calculation
     if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
     {
-        if (spellProto
-            && spellProto->Effects[0].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE
+		if (spellProto
+			&& spellProto->Effects[0].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE
             && spellProto->Effects[1].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE
             && spellProto->Effects[2].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE)
-            {
-            // Some spells don't benefit from pct done mods
-            AuraEffectList const& mModDamagePercentDone = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
-            for (AuraEffectList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
-            {
-                if (!spellProto || (spellProto->ValidateAttribute6SpellDamageMods(this, *i, false) &&
-                    sScriptMgr->IsNeedModMeleeDamagePercent(this, *i, DoneTotalMod, spellProto)))
-                {
-                    if (((*i)->GetMiscValue() & damageSchoolMask))
-                    {
-                        if ((*i)->GetSpellInfo()->EquippedItemClass == -1)
-                            AddPct(DoneTotalMod, (*i)->GetAmount());
-                        else if (!(*i)->GetSpellInfo()->HasAttribute(SPELL_ATTR5_AURA_AFFECTS_NOT_JUST_REQ_EQUIPED_ITEM) && ((*i)->GetSpellInfo()->EquippedItemSubClassMask == 0))
-                            AddPct(DoneTotalMod, (*i)->GetAmount());
-                        else if (ToPlayer() && ToPlayer()->HasItemFitToSpellRequirements((*i)->GetSpellInfo()))
-                            AddPct(DoneTotalMod, (*i)->GetAmount());
-                    }
-                }
-            }
-        }
+			{
+			// Some spells don't benefit from pct done mods
+			AuraEffectList const& mModDamagePercentDone = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
+			for (AuraEffectList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
+			{
+				if (!spellProto || (spellProto->ValidateAttribute6SpellDamageMods(this, *i, false) &&
+					sScriptMgr->IsNeedModMeleeDamagePercent(this, *i, DoneTotalMod, spellProto)))
+				{
+					if (((*i)->GetMiscValue() & damageSchoolMask))
+					{
+						if ((*i)->GetSpellInfo()->EquippedItemClass == -1)
+							AddPct(DoneTotalMod, (*i)->GetAmount());
+						else if (!(*i)->GetSpellInfo()->HasAttribute(SPELL_ATTR5_AURA_AFFECTS_NOT_JUST_REQ_EQUIPED_ITEM) && ((*i)->GetSpellInfo()->EquippedItemSubClassMask == 0))
+							AddPct(DoneTotalMod, (*i)->GetAmount());
+						else if (ToPlayer() && ToPlayer()->HasItemFitToSpellRequirements((*i)->GetSpellInfo()))
+							AddPct(DoneTotalMod, (*i)->GetAmount());
+					}
+				}
+			}
+		}
     }
 
     AuraEffectList const& mDamageDoneVersus = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_DONE_VERSUS);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13121,30 +13121,24 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     // mods for SPELL_SCHOOL_MASK_NORMAL are already factored in base melee damage calculation
     if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
     {
-		if (spellProto
-			&& spellProto->Effects[0].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE
-            && spellProto->Effects[1].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE
-            && spellProto->Effects[2].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE)
-			{
-			// Some spells don't benefit from pct done mods
-			AuraEffectList const& mModDamagePercentDone = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
-			for (AuraEffectList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
-			{
-				if (!spellProto || (spellProto->ValidateAttribute6SpellDamageMods(this, *i, false) &&
-					sScriptMgr->IsNeedModMeleeDamagePercent(this, *i, DoneTotalMod, spellProto)))
-				{
-					if (((*i)->GetMiscValue() & damageSchoolMask))
-					{
-						if ((*i)->GetSpellInfo()->EquippedItemClass == -1)
-							AddPct(DoneTotalMod, (*i)->GetAmount());
-						else if (!(*i)->GetSpellInfo()->HasAttribute(SPELL_ATTR5_AURA_AFFECTS_NOT_JUST_REQ_EQUIPED_ITEM) && ((*i)->GetSpellInfo()->EquippedItemSubClassMask == 0))
-							AddPct(DoneTotalMod, (*i)->GetAmount());
-						else if (ToPlayer() && ToPlayer()->HasItemFitToSpellRequirements((*i)->GetSpellInfo()))
-							AddPct(DoneTotalMod, (*i)->GetAmount());
-					}
-				}
-			}
-		}
+        // Some spells don't benefit from pct done mods
+        AuraEffectList const& mModDamagePercentDone = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
+        for (AuraEffectList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
+        {
+            if (!spellProto || (spellProto->ValidateAttribute6SpellDamageMods(this, *i, false) &&
+                sScriptMgr->IsNeedModMeleeDamagePercent(this, *i, DoneTotalMod, spellProto)))
+            {
+                if (((*i)->GetMiscValue() & damageSchoolMask))
+                {
+                    if ((*i)->GetSpellInfo()->EquippedItemClass == -1)
+                        AddPct(DoneTotalMod, (*i)->GetAmount());
+                    else if (!(*i)->GetSpellInfo()->HasAttribute(SPELL_ATTR5_AURA_AFFECTS_NOT_JUST_REQ_EQUIPED_ITEM) && ((*i)->GetSpellInfo()->EquippedItemSubClassMask == 0))
+                        AddPct(DoneTotalMod, (*i)->GetAmount());
+                    else if (ToPlayer() && ToPlayer()->HasItemFitToSpellRequirements((*i)->GetSpellInfo()))
+                        AddPct(DoneTotalMod, (*i)->GetAmount());
+                }
+            }
+        }
     }
 
     AuraEffectList const& mDamageDoneVersus = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_DONE_VERSUS);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13121,30 +13121,30 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     // mods for SPELL_SCHOOL_MASK_NORMAL are already factored in base melee damage calculation
     if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
     {
-		if (spellProto
-			&& spellProto->Effects[0].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE
+        if (spellProto
+            && spellProto->Effects[0].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE
             && spellProto->Effects[1].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE
             && spellProto->Effects[2].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE)
-			{
-			// Some spells don't benefit from pct done mods
-			AuraEffectList const& mModDamagePercentDone = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
-			for (AuraEffectList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
-			{
-				if (!spellProto || (spellProto->ValidateAttribute6SpellDamageMods(this, *i, false) &&
-					sScriptMgr->IsNeedModMeleeDamagePercent(this, *i, DoneTotalMod, spellProto)))
-				{
-					if (((*i)->GetMiscValue() & damageSchoolMask))
-					{
-						if ((*i)->GetSpellInfo()->EquippedItemClass == -1)
-							AddPct(DoneTotalMod, (*i)->GetAmount());
-						else if (!(*i)->GetSpellInfo()->HasAttribute(SPELL_ATTR5_AURA_AFFECTS_NOT_JUST_REQ_EQUIPED_ITEM) && ((*i)->GetSpellInfo()->EquippedItemSubClassMask == 0))
-							AddPct(DoneTotalMod, (*i)->GetAmount());
-						else if (ToPlayer() && ToPlayer()->HasItemFitToSpellRequirements((*i)->GetSpellInfo()))
-							AddPct(DoneTotalMod, (*i)->GetAmount());
-					}
-				}
-			}
-		}
+            {
+            // Some spells don't benefit from pct done mods
+            AuraEffectList const& mModDamagePercentDone = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
+            for (AuraEffectList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
+            {
+                if (!spellProto || (spellProto->ValidateAttribute6SpellDamageMods(this, *i, false) &&
+                    sScriptMgr->IsNeedModMeleeDamagePercent(this, *i, DoneTotalMod, spellProto)))
+                {
+                    if (((*i)->GetMiscValue() & damageSchoolMask))
+                    {
+                        if ((*i)->GetSpellInfo()->EquippedItemClass == -1)
+                            AddPct(DoneTotalMod, (*i)->GetAmount());
+                        else if (!(*i)->GetSpellInfo()->HasAttribute(SPELL_ATTR5_AURA_AFFECTS_NOT_JUST_REQ_EQUIPED_ITEM) && ((*i)->GetSpellInfo()->EquippedItemSubClassMask == 0))
+                            AddPct(DoneTotalMod, (*i)->GetAmount());
+                        else if (ToPlayer() && ToPlayer()->HasItemFitToSpellRequirements((*i)->GetSpellInfo()))
+                            AddPct(DoneTotalMod, (*i)->GetAmount());
+                    }
+                }
+            }
+        }
     }
 
     AuraEffectList const& mDamageDoneVersus = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_DONE_VERSUS);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13121,24 +13121,30 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     // mods for SPELL_SCHOOL_MASK_NORMAL are already factored in base melee damage calculation
     if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
     {
-        // Some spells don't benefit from pct done mods
-        AuraEffectList const& mModDamagePercentDone = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
-        for (AuraEffectList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
-        {
-            if (!spellProto || (spellProto->ValidateAttribute6SpellDamageMods(this, *i, false) &&
-                sScriptMgr->IsNeedModMeleeDamagePercent(this, *i, DoneTotalMod, spellProto)))
-            {
-                if (((*i)->GetMiscValue() & damageSchoolMask))
-                {
-                    if ((*i)->GetSpellInfo()->EquippedItemClass == -1)
-                        AddPct(DoneTotalMod, (*i)->GetAmount());
-                    else if (!(*i)->GetSpellInfo()->HasAttribute(SPELL_ATTR5_AURA_AFFECTS_NOT_JUST_REQ_EQUIPED_ITEM) && ((*i)->GetSpellInfo()->EquippedItemSubClassMask == 0))
-                        AddPct(DoneTotalMod, (*i)->GetAmount());
-                    else if (ToPlayer() && ToPlayer()->HasItemFitToSpellRequirements((*i)->GetSpellInfo()))
-                        AddPct(DoneTotalMod, (*i)->GetAmount());
-                }
-            }
-        }
+		if (spellProto
+			&& spellProto->Effects[0].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE
+            && spellProto->Effects[1].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE
+            && spellProto->Effects[2].Effect != SPELL_EFFECT_WEAPON_PERCENT_DAMAGE)
+			{
+			// Some spells don't benefit from pct done mods
+			AuraEffectList const& mModDamagePercentDone = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
+			for (AuraEffectList::const_iterator i = mModDamagePercentDone.begin(); i != mModDamagePercentDone.end(); ++i)
+			{
+				if (!spellProto || (spellProto->ValidateAttribute6SpellDamageMods(this, *i, false) &&
+					sScriptMgr->IsNeedModMeleeDamagePercent(this, *i, DoneTotalMod, spellProto)))
+				{
+					if (((*i)->GetMiscValue() & damageSchoolMask))
+					{
+						if ((*i)->GetSpellInfo()->EquippedItemClass == -1)
+							AddPct(DoneTotalMod, (*i)->GetAmount());
+						else if (!(*i)->GetSpellInfo()->HasAttribute(SPELL_ATTR5_AURA_AFFECTS_NOT_JUST_REQ_EQUIPED_ITEM) && ((*i)->GetSpellInfo()->EquippedItemSubClassMask == 0))
+							AddPct(DoneTotalMod, (*i)->GetAmount());
+						else if (ToPlayer() && ToPlayer()->HasItemFitToSpellRequirements((*i)->GetSpellInfo()))
+							AddPct(DoneTotalMod, (*i)->GetAmount());
+					}
+				}
+			}
+		}
     }
 
     AuraEffectList const& mDamageDoneVersus = GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_DONE_VERSUS);


### PR DESCRIPTION
fix some spells benefit from both SPELL_EFFECT_WEAPON_PERCENT_DAMAGE and SPELL_AURA_MOD_DAMAGE_PERCENT_DONE

eg: Hunter's Chimera Shot with "Essence of the Blood Queen"(ID:70867) debuff, the final damage is double calculated before that is wrong.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  bug fix

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- no yet

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
SpellEffects.cpp, line 3641 around, here is the first time applyDamagePercent
```
            case SPELL_EFFECT_WEAPON_PERCENT_DAMAGE:
                ApplyPct(weaponDamage, weaponDamagePercentMod);
```

Unit.cpp, line 13135 around, here is the second time applyDamagePercent for some spells like: Hunter's Chimera Shot
```
                    if (((*i)->GetMiscValue() & damageSchoolMask))
                    {
                        if ((*i)->GetSpellInfo()->EquippedItemClass == -1)
                            AddPct(DoneTotalMod, (*i)->GetAmount());
                        else if (!(*i)->GetSpellInfo()->HasAttribute(SPELL_ATTR5_AURA_AFFECTS_NOT_JUST_REQ_EQUIPED_ITEM) && ((*i)->GetSpellInfo()->EquippedItemSubClassMask == 0))
                            AddPct(DoneTotalMod, (*i)->GetAmount());
                        else if (ToPlayer() && ToPlayer()->HasItemFitToSpellRequirements((*i)->GetSpellInfo()))
                            AddPct(DoneTotalMod, (*i)->GetAmount());
                    }
```
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- build pass
- tested in game
- test the damage of Hunter's Chimera Shot  with "Essence of the Blood Queen"(ID:70867) debuff
- os: ubuntu


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
before apply this code:
1.cast Hunter's Chimera Shot
2.see the damage
3.use gm command: .learn 70867
4.use "Essence of the Blood Queen"(ID:70867) to self
5.cast Hunter's Chimera Shot
6.see the damage again, the value is base_damage * 2 * 2, and it's wrong.

after apply this code:
1.use gm command: .learn 70867
2.use "Essence of the Blood Queen"(ID:70867) to self
3.cast Hunter's Chimera Shot
4.see the damage, it will be correct.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- some spells like Hunter's Chimera Shot have the same problem too, like spell_id:53217, they are fixed on this PR too, you can test these kind of spells, I tested some of these kind of spells, and no problem.
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
