### PR TITLE
fix: correct the parameter order

### DIFF
--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -1009,7 +1009,7 @@ void ScriptMgr::OnGetMaxSkillValue(Player* player, uint32 skill, int32& result, 
 void ScriptMgr::OnUpdateGatheringSkill(Player *player, uint32 skillId, uint32 currentLevel, uint32 gray, uint32 green, uint32 yellow, uint32 &gain) {
     ExecuteScript<PlayerScript>([&](PlayerScript* script)
     {
-        script->OnUpdateGatheringSkill(player, skillId, gray, green, yellow, currentLevel, gain);
+        script->OnUpdateGatheringSkill(player, skillId, currentLevel, gray, green, yellow, gain);
     });
 }
 


### PR DESCRIPTION
## Changes Proposed:
-  Update parameter order to match naming in docs

## Issues Addressed:
- No issue created, noticed while using

## SOURCE:
The function is specified as follows:
```c++
OnUpdateGatheringSkill(Player* /*player*/, uint32 /*skill_id*/, uint32 /*current*/, uint32 /*gray*/, uint32 /*green*/, uint32 /*yellow*/, uint32& /*gain*/)
```
However the use site used:
```c++
script->OnUpdateGatheringSkill(player, skillId, gray, green, yellow, currentLevel, gain);
```
Instead of:
```c++
script->OnUpdateGatheringSkill(player, skillId, currentLevel, gray, green, yellow, gain);
```

## Tests Performed:
Created a module as following:
```c++
class CraftingGainScript : public PlayerScript {
public:
    CraftingGainScript() : PlayerScript("CraftingGainScript_PlayerScript") {
    }

    void
    OnUpdateGatheringSkill(Player *player, uint32 skill, uint32 skill_level, uint32 gray, uint32 green, uint32 yellow,
                           uint32 &gain) override {
        if (skill_level <= yellow) {
            gain *= 2;
        }
    }

    void OnUpdateCraftingSkill(Player *player, const SkillLineAbilityEntry *entry, uint32 skill_level,
                               uint32 &gain) override {
        if (skill_level <= entry->TrivialSkillLineRankLow) {
            gain *= 2;
        }
    }
};
```
Expected result: crafting orange difficulty would grant 2 skillups instead of one, but 1 for other levels (if triggered)


## How to Test the Changes:
See script above. Try gathering plants with orange difficulty, observe that 2 skill levels are awarded.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
