### PR TITLE
fix(Scripts/EscapeFromDurnholde): Fix escort mission getting stuck

### DIFF
--- a/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/instance_old_hillsbrad.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/instance_old_hillsbrad.cpp
@@ -66,7 +66,7 @@ public:
 
         void OnPlayerEnter(Player* player) override
         {
-            if (instance->GetPlayersCountExceptGMs() == 1)
+            if (instance->GetPlayersCountExceptGMs() <= 1)
                 CleanupInstance();
 
             EnsureGridLoaded();
@@ -144,8 +144,11 @@ public:
                         Reposition(thrall);
                     return;
                 case DATA_ESCORT_PROGRESS:
-                    _encounterProgress = data;
-                    SaveToDB();
+                    if (_encounterProgress < data)
+                    {
+                        _encounterProgress = data;
+                        SaveToDB();
+                    }
                     break;
                 case DATA_BOMBS_PLACED:
                     {


### PR DESCRIPTION
Fix escort event possibly getting stuck by preventing DATA_ESCORT_PROGRESS from being decreased

<!-- First of all, THANK YOU for your contribution. -->
When all players leave the instance (e.g. corpse walk after wipe) and the first player re-entered the old hillsbrad, CleanupInstance() is called

CleanupInstance() schedules EVENT_FINAL_BARRELS_FLAME which unconditionally sets DATA_ESCORT_PROGRESS, possibly rolling back the instance progress and removing the gossip option from Thrall

Trivia: The way it was previously handled, you could unstuck the instance by leaving _twice_ and re-entering. After the second CleanupInstance() Lieutenant Drake would respawn and could be killed again (exploit alert!).
This would set the escort progress to the correct value again and Thrall's gossip option would reappear. This explains the second comment on the Chromiecraft issue

## Changes Proposed:
-  Enforce only increasing DATA_ESCORT_PROGRESS, preventing any kind of rollback on the instance progress

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5803

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Multiple Runs in the instance, killing Thrall at different point of the escort, leaving the instance at different points in time etc


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Old Hillsbrad Foothills
2. Place 5 bombs in barrels and kill first boss
3. Confirm that Thrall can be talked to and has a gossip option to start the escort
4. Leave the instance, restart the server or something similar
5. Talk to respawned Thrall again and confirm that the gossip option is still available and escort can be restarted / continued

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- A few improvements to the instance are planned but I want to get the fix out. Currently planned:
- Fix Captain Skarloc's horse attacking players
- Fix the armorer RP event
- Check (and possibly fix) the limit for failing the escort (issue #3244)
- Fix Thrall being level 67 on heroic, it is level 71 on official servers

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
