### PR TITLE
fix(DB/SAI) Cabal Spellbinder adjustment to Spell Shock

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1688085865524921702.sql
+++ b/data/sql/updates/pending_db_world/rev_1688085865524921702.sql
@@ -1,3 +1,6 @@
 --
 -- Change event UPDATE_IC to VICTIM_CASTING
-UPDATE `smart_scripts` SET `event_type` = 13 WHERE `entryorguid` = 18639 AND `id` = 1;
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 18639 AND `id`=1);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(18639, 0, 1, 0, 13, 0, 100, 0, 16300, 16900, 0, 0, 0, 11, 32691, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Cabal Spellbinder - In Combat - Cast \'Spell Shock\'')
+

--- a/data/sql/updates/pending_db_world/rev_1688085865524921702.sql
+++ b/data/sql/updates/pending_db_world/rev_1688085865524921702.sql
@@ -1,5 +1,4 @@
 --
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 18639 AND `id`=1);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(18639, 0, 1, 0, 13, 0, 100, 0, 16300, 16900, 0, 0, 0, 11, 32691, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Cabal Spellbinder - In Combat - Cast \'Spell Shock\'');
-
+(18639, 0, 1, 0, 13, 0, 100, 0, 9600, 16900, 0, 0, 0, 11, 32691, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Cabal Spellbinder - On Victim Casting - Cast \'Spell Shock\'');

--- a/data/sql/updates/pending_db_world/rev_1688085865524921702.sql
+++ b/data/sql/updates/pending_db_world/rev_1688085865524921702.sql
@@ -1,0 +1,3 @@
+--
+-- Change event UPDATE_IC to VICTIM_CASTING
+UPDATE `smart_scripts` SET `event_type` = 13 WHERE `entryorguid` = 18639 AND `id` = 1;

--- a/data/sql/updates/pending_db_world/rev_1688085865524921702.sql
+++ b/data/sql/updates/pending_db_world/rev_1688085865524921702.sql
@@ -1,5 +1,4 @@
 --
--- Change event UPDATE_IC to VICTIM_CASTING
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 18639 AND `id`=1);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (18639, 0, 1, 0, 13, 0, 100, 0, 16300, 16900, 0, 0, 0, 11, 32691, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Cabal Spellbinder - In Combat - Cast \'Spell Shock\'')

--- a/data/sql/updates/pending_db_world/rev_1688085865524921702.sql
+++ b/data/sql/updates/pending_db_world/rev_1688085865524921702.sql
@@ -1,5 +1,5 @@
 --
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 18639 AND `id`=1);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(18639, 0, 1, 0, 13, 0, 100, 0, 16300, 16900, 0, 0, 0, 11, 32691, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Cabal Spellbinder - In Combat - Cast \'Spell Shock\'')
+(18639, 0, 1, 0, 13, 0, 100, 0, 16300, 16900, 0, 0, 0, 11, 32691, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Cabal Spellbinder - In Combat - Cast \'Spell Shock\'');
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change event type to VICTIM_CASTING

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5513

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  Works

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. .npc add 18639
2. spam abilities


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
