### PR TITLE
fix(DB/Creature): Njorndar Proto-Drake vehicle unable to fly in “Vile Like Fire”

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1688557801143854400.sql
+++ b/data/sql/updates/pending_db_world/rev_1688557801143854400.sql
@@ -1,9 +1,9 @@
 -- Vile Like Fire! (13071)
 -- fix Njorndar Proto-Drake vehicle unable to fly
 DELETE FROM `creature_template_spell` WHERE `CreatureID` = 30564;
-INSERT INTO `creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES (30564, 0, 57493, 12340);
-INSERT INTO `creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES (30564, 2, 7769, 12340);
-INSERT INTO `creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES (30564, 6, 57403, 12340);
-
+INSERT INTO `creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES
+(30564, 0, 57493, 12340),
+(30564, 2, 7769, 12340),
+(30564, 6, 57403, 12340);
 -- fix Njorndar Proto-Drake display status on the ground
 UPDATE `creature_template_movement` SET `Flight`=2 WHERE  `CreatureId`=30272;

--- a/data/sql/updates/pending_db_world/rev_1688557801143854400.sql
+++ b/data/sql/updates/pending_db_world/rev_1688557801143854400.sql
@@ -1,6 +1,8 @@
 -- Vile Like Fire! (13071)
 -- fix Njorndar Proto-Drake vehicle unable to fly
 DELETE FROM `creature_template_spell` WHERE `CreatureID` = 30564;
+INSERT INTO `creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES (30564, 0, 57493, 12340);
+INSERT INTO `creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES (30564, 2, 7769, 12340);
 INSERT INTO `creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES (30564, 6, 57403, 12340);
 
 -- fix Njorndar Proto-Drake display status on the ground

--- a/data/sql/updates/pending_db_world/rev_1688557801143854400.sql
+++ b/data/sql/updates/pending_db_world/rev_1688557801143854400.sql
@@ -1,0 +1,6 @@
+-- Vile Like Fire! (13071)
+-- fix Njorndar Proto-Drake vehicle unable to fly
+INSERT INTO `acore_world`.`creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES (30564, 6, 57403, 12340);
+
+-- fix Njorndar Proto-Drake display status on the ground
+UPDATE `acore_world`.`creature_template_movement` SET `Flight`=2 WHERE  `CreatureId`=30272;

--- a/data/sql/updates/pending_db_world/rev_1688557801143854400.sql
+++ b/data/sql/updates/pending_db_world/rev_1688557801143854400.sql
@@ -1,6 +1,7 @@
 -- Vile Like Fire! (13071)
 -- fix Njorndar Proto-Drake vehicle unable to fly
-INSERT INTO `acore_world`.`creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES (30564, 6, 57403, 12340);
+DELETE FROM `creature_template_spell` WHERE `CreatureID` = 30564;
+INSERT INTO `creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES (30564, 6, 57403, 12340);
 
 -- fix Njorndar Proto-Drake display status on the ground
-UPDATE `acore_world`.`creature_template_movement` SET `Flight`=2 WHERE  `CreatureId`=30272;
+UPDATE `creature_template_movement` SET `Flight`=2 WHERE  `CreatureId`=30272;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  add spell 57403 (flight) to Njorndar Proto-Drake vehicle
-  adjust Njorndar Proto-Drake display status on the ground

## Issues Addressed:
-  fix Quest "Vile Like Fire" vehicle unable to fly

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

Vile Like Fire! https://www.wowhead.com/wotlk/quest=13071/vile-like-fire
spell 57403 https://www.wowhead.com/wotlk/spell=57403/flight

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- It builds without errors
- Tested in-game

- Server:
AzerothCore rev. 893a9beeacc4+
Debian 11 x64
MySQL 8.0.33

- Client:
3.3.5a.12340 enUS
Windows 10 x64 LTSC

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- .go xyz 7872.494 3695.697 653.3371 571
- observe the Njorndar Proto-Drake on the ground
- .q a 13071
- right click the Proto-Drake
- press space try flying
- fly to the "Vrykul buildings" press 4 use "Strafe Jotunheim Building"
