### PR TITLE
chore(DB/Quest): Fix typo in quest reward offer text for ID 9145

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1688730531283365116.sql
+++ b/data/sql/updates/pending_db_world/rev_1688730531283365116.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `quest_offer_reward` SET `RewardText` = 'Good to hear that Lethvalin made it to safety, and that he was smart enough to ask you for help instead of just waiting there.$B$BI hope that Ranger Salissa made it safely to Farstrider Enclave.' WHERE (`ID` = 9145);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16685

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.wowhead.com/wotlk/quest=9145/help-ranger-valanna + grammar
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  Tested, works


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Horde char
2. .npc add 9145
3. .go xyz 7932.62 -7573.54 145.5 530


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
