### PR TITLE
fix(DB/Teldrassil): Gnarlpine Mystic uses the right 'Wrath'

### DIFF
--- a/data/sql/updates/pending_db_world/gnarlpine-mystic-wrath.sql
+++ b/data/sql/updates/pending_db_world/gnarlpine-mystic-wrath.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `smart_scripts` SET `action_param1` = 9739 WHERE `entryorguid` = 7235 AND `source_type` = 0; -- action_param1 was 5177 AKA wrong Wrath


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  change spell from 5177 to 9739
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16678
- Closes https://github.com/chromiecraft/chromiecraft/issues/5682

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

Classic sniffs (see AC issue)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game. Damage seems accurate
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Find Gnarlpine mystics.
2. See correct damage and hopefully other things mentioned in original issue
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

None I know off (maybe timers?)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
