### PR TITLE
fix(DB/BlackrockSpire): Add teleport trigger for crater

### DIFF
--- a/data/sql/updates/pending_db_world/add_teleport_to_brs_are_trigger.sql
+++ b/data/sql/updates/pending_db_world/add_teleport_to_brs_are_trigger.sql
@@ -1,2 +1,3 @@
 --
+DELETE FROM `areatrigger_teleport` WHERE ID = 2068;
 INSERT INTO `areatrigger_teleport` (`ID`, `Name`, `target_map`, `target_position_x`, `target_position_y`, `target_position_z`, `target_orientation`) VALUES (2068, 'Blackrock Spire - Jump Exit', 0, -7558.39, -1309.43, 248.454, 1.5708);

--- a/data/sql/updates/pending_db_world/add_teleport_to_brs_are_trigger.sql
+++ b/data/sql/updates/pending_db_world/add_teleport_to_brs_are_trigger.sql
@@ -1,0 +1,2 @@
+--
+INSERT INTO `areatrigger_teleport` (`ID`, `Name`, `target_map`, `target_position_x`, `target_position_y`, `target_position_z`, `target_orientation`) VALUES (2068, 'Blackrock Spire - Jump Exit', 0, -7558.39, -1309.43, 248.454, 1.5708);

--- a/data/sql/updates/pending_db_world/add_teleport_to_brs_are_trigger.sql
+++ b/data/sql/updates/pending_db_world/add_teleport_to_brs_are_trigger.sql
@@ -1,3 +1,3 @@
 --
-DELETE FROM `areatrigger_teleport` WHERE ID = 2068;
+DELETE FROM `areatrigger_teleport` WHERE `ID` = 2068;
 INSERT INTO `areatrigger_teleport` (`ID`, `Name`, `target_map`, `target_position_x`, `target_position_y`, `target_position_z`, `target_orientation`) VALUES (2068, 'Blackrock Spire - Jump Exit', 0, -7558.39, -1309.43, 248.454, 1.5708);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Area trigger entry 2068 is missing from  areatrigger_teleport
-  Jumping in the crater in BRS should teleport to Blackrock Mountain
- Current behavior:

https://github.com/azerothcore/azerothcore-wotlk/assets/19265585/6374cf93-62da-490f-b2ea-cfbe33081fd0


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Mangos
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. go trigger 2068
2.
3.
## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
