### PR TITLE
fix(DB/Creature): Burning Abyssal immune mask

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1689021460555110200.sql
+++ b/data/sql/updates/pending_db_world/rev_1689021460555110200.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `mechanic_immune_mask` = `mechanic_immune_mask`&~(64|2048|536870912) WHERE `entry` = 17454;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Remove Root, Stun and Sapped MIM

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16119
- Closes https://github.com/chromiecraft/chromiecraft/issues/5349

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Engage channelers and wait until they summon a Burning Abyssal.
2. Try to root/stun/banish it.

