### PR TITLE
fix(DB/SAI): Fingrom Blast Wave

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1689094675369155000.sql
+++ b/data/sql/updates/pending_db_world/rev_1689094675369155000.sql
@@ -1,0 +1,6 @@
+--
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 20757 AND `source_type` = 0 AND `id` IN (0, 1, 2);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(20757, 0, 0, 0, 4, 0, 100, 1, 0, 0, 0, 0, 0, 11, 33245, 32, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Fingrom - On Aggro - Cast \'Ice Barrier\' (No Repeat)'),
+(20757, 0, 1, 0, 2, 0, 100, 1, 20, 80, 0, 0, 0, 11, 17145, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Fingrom - Between 20-80% Health - Cast \'Blast Wave\' (No Repeat)'),
+(20757, 0, 2, 0, 0, 0, 100, 0, 2500, 3000, 7500, 8000, 0, 11, 15242, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Fingrom - In Combat - Cast \'Fireball\'');

--- a/data/sql/updates/pending_db_world/rev_1689094675369155000.sql
+++ b/data/sql/updates/pending_db_world/rev_1689094675369155000.sql
@@ -1,6 +1,6 @@
 --
-DELETE FROM `smart_scripts` WHERE `entryorguid` = 20757 AND `source_type` = 0 AND `id` IN (0, 1, 2);
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 20757);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(20757, 0, 0, 0, 4, 0, 100, 1, 0, 0, 0, 0, 0, 11, 33245, 32, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Fingrom - On Aggro - Cast \'Ice Barrier\' (No Repeat)'),
-(20757, 0, 1, 0, 2, 0, 100, 1, 20, 80, 0, 0, 0, 11, 17145, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Fingrom - Between 20-80% Health - Cast \'Blast Wave\' (No Repeat)'),
-(20757, 0, 2, 0, 0, 0, 100, 0, 2500, 3000, 7500, 8000, 0, 11, 15242, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Fingrom - In Combat - Cast \'Fireball\'');
+(20757, 0, 0, 0, 0, 0, 100, 0, 3000, 4800, 12000, 16000, 0, 11, 33245, 32, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Fingrom - In Combat - Cast \'Ice Barrier\''),
+(20757, 0, 1, 0, 9, 0, 100, 0, 0, 10, 5000, 11000, 1, 11, 33061, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Fingrom - Within 0-10 Range - Cast \'Blast Wave\''),
+(20757, 0, 2, 0, 0, 0, 100, 0, 0, 0, 3400, 4800, 0, 11, 15242, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Fingrom - In Combat - Cast \'Fireball\'');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change Blast Wave from 33061 (used by Krosh Firehand) to 17145.
-  Change comments on SAI (that's why I didn't use an UPDATE statement)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16736
- Closes https://github.com/chromiecraft/chromiecraft/issues/5911

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.wowhead.com/wotlk/spell=17145/blast-wave

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Do the quest and engage the mob.
2. Wait until it casts Blast Wave, it shouldn't hit for 7k anymore.



