### PR TITLE
fix(DB/Spell) Fix trinkets procs TBC and Vanilla

### DIFF
--- a/data/sql/updates/pending_db_world/trinkets.sql
+++ b/data/sql/updates/pending_db_world/trinkets.sql
@@ -1,8 +1,8 @@
 --
-update `spell_proc_event` set `Cooldown` = '50000' where `entry` = 37655;
-update `spell_proc_event` set `Cooldown` = '40000' where `entry` = 37247;
-update `spell_proc_event` set `Cooldown` = '50000' where `entry` = 60066;
-update `spell_proc_event` set `Cooldown` = '2000' where `entry` = 15600;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 37655;
+UPDATE `spell_proc_event` SET `Cooldown` = 40000 WHERE `entry` = 37247;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 60066;
+UPDATE `spell_proc_event` SET `Cooldown` = 2000  WHERE `entry` = 15600;
 
-update `spell_proc_event` set `procEx` = '262144' where `entry` = 37655;
+UPDATE `spell_proc_event` SET `procEx` = 262144 WHERE `entry` = 37655;
 UPDATE `item_template` SET `spellcooldown_2` = -1 WHERE (`entry` = 28823);

--- a/data/sql/updates/pending_db_world/trinkets.sql
+++ b/data/sql/updates/pending_db_world/trinkets.sql
@@ -2,5 +2,6 @@
 update `spell_proc_event` set `Cooldown` = '50000' where `entry` = 37655;
 update `spell_proc_event` set `Cooldown` = '40000' where `entry` = 37247;
 update `spell_proc_event` set `Cooldown` = '50000' where `entry` = 60066;
+update `spell_proc_event` set `Cooldown` = '2000' where `entry` = 15600;
 
 update `spell_proc_event` set `procEx` = '262144' where `entry` = 37655;

--- a/data/sql/updates/pending_db_world/trinkets.sql
+++ b/data/sql/updates/pending_db_world/trinkets.sql
@@ -5,3 +5,4 @@ update `spell_proc_event` set `Cooldown` = '50000' where `entry` = 60066;
 update `spell_proc_event` set `Cooldown` = '2000' where `entry` = 15600;
 
 update `spell_proc_event` set `procEx` = '262144' where `entry` = 37655;
+UPDATE `item_template` SET `spellcooldown_2` = -1 WHERE (`entry` = 28823);

--- a/data/sql/updates/pending_db_world/trinkets.sql
+++ b/data/sql/updates/pending_db_world/trinkets.sql
@@ -1,0 +1,6 @@
+--
+update `spell_proc_event` set `Cooldown` = '50000' where `entry` = 37655;
+update `spell_proc_event` set `Cooldown` = '40000' where `entry` = 37247;
+update `spell_proc_event` set `Cooldown` = '50000' where `entry` = 60066;
+
+update `spell_proc_event` set `procEx` = '262144' where `entry` = 37655;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

Memento of Tyrande - Set ICD from 60s to 50s
Memento of Tyrande - Make it only proc on spellcast
Fathom-Brooch of the Tidewalker - Set ICD from 45s to 40s
Hourglass of the Unraveller - Set ICD from 45s to 50s
Hand of Justice - Set ICD from 0s to 2s
Eye of Gruul - removed wrong cooldown from template

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes no reported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
WOTLK Wowhead + comments

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
