### PR TITLE
fix(Scripts/TempleOfAhnQiraj): let small Eye Tentacles attack the raid

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -620,6 +620,7 @@ struct npc_eye_tentacle : public ScriptedAI
 
     void Reset() override
     {
+        DoZoneInCombat();
         _scheduler.Schedule(500ms, [this](TaskContext /*task*/)
         {
             DoCastAOE(SPELL_GROUND_RUPTURE);
@@ -630,20 +631,8 @@ struct npc_eye_tentacle : public ScriptedAI
         });
     }
 
-    void MoveInLineOfSight(Unit* who) override
-    {
-        //necessary because the grouped summons dont instantly order the eye tentacles
-        if(who->IsPlayer())
-        {
-            DoZoneInCombat();
-            me->Attack(who, false);
-        }
-    }
-
     void JustEngagedWith(Unit* /*who*/) override
     {
-        DoZoneInCombat();
-
         _scheduler.Schedule(1s, 5s, [this](TaskContext context)
         {
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, NotInStomachSelector()))

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -621,19 +621,20 @@ struct npc_eye_tentacle : public ScriptedAI
     void Reset() override
     {
         _scheduler.Schedule(500ms, [this](TaskContext /*task*/)
-            {
-                DoCastAOE(SPELL_GROUND_RUPTURE);
-            })
-            .Schedule(5min, [this](TaskContext /*task*/)
-            {
-                me->DespawnOrUnsummon();
-            });
+        {
+            DoCastAOE(SPELL_GROUND_RUPTURE);
+        })
+        .Schedule(5min, [this](TaskContext /*task*/)
+        {
+            me->DespawnOrUnsummon();
+        });
     }
 
     void MoveInLineOfSight(Unit* who) override
     {
         //necessary because the grouped summons dont instantly order the eye tentacles
-        if(who->IsPlayer()) {
+        if(who->IsPlayer())
+        {
             DoZoneInCombat();
             me->Attack(who, false);
         }
@@ -644,14 +645,14 @@ struct npc_eye_tentacle : public ScriptedAI
         DoZoneInCombat();
 
         _scheduler.Schedule(1s, 5s, [this](TaskContext context)
+        {
+            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, NotInStomachSelector()))
             {
-                if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, NotInStomachSelector()))
-                {
-                    DoCast(target, SPELL_MIND_FLAY);
-                }
+                DoCast(target, SPELL_MIND_FLAY);
+            }
 
-                context.Repeat(10s, 15s);
-            });
+            context.Repeat(10s, 15s);
+        });
     }
 
     void UpdateAI(uint32 diff) override

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -620,7 +620,6 @@ struct npc_eye_tentacle : public ScriptedAI
 
     void Reset() override
     {
-        
         _scheduler.Schedule(500ms, [this](TaskContext /*task*/)
             {
                 DoCastAOE(SPELL_GROUND_RUPTURE);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- make them attack people
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16782
- Closes https://github.com/chromiecraft/chromiecraft/issues/4251

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

See issue

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested with 1 char
- needs group testing to see if mind flay still works as intended


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.list creature <cthuneyeid>`
2. `.go creature <guid>`
3. engage

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

None I know of rn

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
