### PR TITLE
fix(Scripts/TempleOfAhnQiraj): make C'thun Dark Glare face location of last eyebeam before cast, instead of random target

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -231,18 +231,18 @@ struct boss_eye_of_cthun : public BossAI
             {
                 if (task.GetRepeatCounter() < 3 && onEngage)
                 {
-                    if (Unit* target = ObjectAccessor::GetUnit(*me, _beamTarget))
-                    {
-                        DoCast(target, SPELL_GREEN_BEAM);
-                    }
-
+                    DoCastRandomTarget(SPELL_GREEN_BEAM);
                     task.Repeat();
                 }
                 else
                 {
                     scheduler.Schedule(5s, [this](TaskContext task)
                     {
-                        DoCastRandomTarget(SPELL_GREEN_BEAM);
+                        if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true))
+                        {
+                            DoCast(target, SPELL_GREEN_BEAM);
+                            DarkGlareAngle = me->GetAngle(target); //keep as the location dark glare will be at
+                        }
 
                         task.SetGroup(GROUP_BEAM_PHASE);
                         task.Repeat(3s);
@@ -284,21 +284,18 @@ struct boss_eye_of_cthun : public BossAI
 
                 scheduler.Schedule(1s, [this](TaskContext /*task*/)
                 {
-                    //Select random target for dark beam to start on
-                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true))
-                    {
-                        //Face our target
-                        DarkGlareAngle = me->GetAngle(target);
-                        DarkGlareTick = 0;
-                        ClockWise = RAND(true, false);
+                    //Select last target that had a beam cast on it
+                    //Face our target
+                    
+                    DarkGlareTick = 0;
+                    ClockWise = RAND(true, false);
 
-                        //Add red coloration to C'thun
-                        DoCast(me, SPELL_RED_COLORATION, true);
+                    //Add red coloration to C'thun
+                    DoCast(me, SPELL_RED_COLORATION, true);
 
-                        me->StopMoving();
-                        me->SetFacingToObject(target);
-                        me->SetOrientation(DarkGlareAngle);
-                    }
+                    me->StopMoving();
+                    me->SetOrientation(DarkGlareAngle);
+                    me->SetFacingTo(DarkGlareAngle);
 
                     scheduler.Schedule(3s, [this](TaskContext tasker)
                     {

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -231,7 +231,11 @@ struct boss_eye_of_cthun : public BossAI
             {
                 if (task.GetRepeatCounter() < 3 && onEngage)
                 {
-                    DoCastRandomTarget(SPELL_GREEN_BEAM);
+                    if (Unit* target = ObjectAccessor::GetUnit(*me, _beamTarget))
+                    {
+                        DoCast(target, SPELL_GREEN_BEAM);
+                    }
+                    
                     task.Repeat();
                 }
                 else

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -235,7 +235,7 @@ struct boss_eye_of_cthun : public BossAI
                     {
                         DoCast(target, SPELL_GREEN_BEAM);
                     }
-                    
+
                     task.Repeat();
                 }
                 else
@@ -290,7 +290,7 @@ struct boss_eye_of_cthun : public BossAI
                 {
                     //Select last target that had a beam cast on it
                     //Face our target
-                    
+
                     DarkGlareTick = 0;
                     ClockWise = RAND(true, false);
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  uses the angle it faces when casting the last eye beam now instead of random player
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/4442

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

Videos in linked issue

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested, should work
- not extenstively tested with multiple characters. but it does seem to work with the little testing I did


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. go to c'thun
2. wait for dark glare
3. preferably with multiple characters

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
