### PR TITLE
fix(DB/Spell) Fix WOTLK trinket procs

### DIFF
--- a/data/sql/updates/pending_db_world/wotlktrinkets.sql
+++ b/data/sql/updates/pending_db_world/wotlktrinkets.sql
@@ -1,0 +1,46 @@
+--
+UPDATE `item_template` SET `spellcooldown_1` = -1 WHERE (`entry` = 37111);
+UPDATE `item_template` SET `spellcooldown_1` = -1, `spellcategorycooldown_1` = 2000 WHERE (`entry` = 47477);
+UPDATE `item_template` SET `spellcooldown_1` = -1, `spellcategorycooldown_1` = 2000 WHERE (`entry` = 47316);
+UPDATE `item_template` SET `spellcooldown_1` = -1, `spellcooldown_2` = -1, `spellcooldown_3` = -1 WHERE (`entry` = 45507);
+UPDATE `item_template` SET `spellcooldown_2` = -1, `spellcooldown_3` = -1 WHERE (`entry` = 45522);
+UPDATE `item_template` SET `spellcooldown_2` = -1, `spellcooldown_3` = -1 WHERE (`entry` = 45929);
+UPDATE `item_template` SET `spellcooldown_2` = -1, `spellcooldown_3` = -1 WHERE (`entry` = 45931);
+UPDATE `item_template` SET `spelltrigger_2` = 0, `spellcooldown_2` = -1, `spellcooldown_3` = -1 WHERE (`entry` = 45866);
+UPDATE `item_template` SET `spellcooldown_1` = -1, `spellcategorycooldown_1` = 45000 WHERE (`entry` = 40255);
+UPDATE `item_template` SET `spellcooldown_1` = -1 WHERE (`entry` = 40373);
+UPDATE `item_template` SET `spellcooldown_1` = 0, `spellcategorycooldown_1` = -1 WHERE (`entry` = 37835);
+UPDATE `item_template` SET `spellcooldown_1` = 0, `spellcategorycooldown_1` = -1 WHERE (`entry` = 39229);
+UPDATE `item_template` SET `spellcooldown_1` = 0 WHERE (`entry` = 37390);
+UPDATE `item_template` SET `spellcooldown_1` = 0 WHERE (`entry` = 37657);
+UPDATE `item_template` SET `spellcooldown_1` = 0 WHERE (`entry` = 37660);
+
+UPDATE `item_template` SET `spellppmRate_1` = 0 WHERE (`entry` = 50348);
+UPDATE `item_template` SET `spellppmRate_1` = 0 WHERE (`entry` = 50353);
+UPDATE `item_template` SET `spellppmRate_1` = 0 WHERE (`entry` = 54588);
+
+UPDATE `spell_proc_event` SET `CustomChance` = '35' WHERE `entry` = 71562;
+UPDATE `spell_proc_event` SET `CustomChance` = '45' WHERE `entry` = 71545;  
+
+
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 71585;
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 64738;
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 64792;
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 62114;
+UPDATE `spell_proc_event` SET `Cooldown` = '45000' WHERE `entry` = 58901;
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 33648;
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 49622;
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 65013;
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 65002;
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 62115;
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 67672;
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 33648;
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 60221;
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 60519;
+UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 63251;
+
+DELETE FROM `spell_proc_event` WHERE `entry` IN (75474, 71602, 64764);
+INSERT INTO `spell_proc_event` (`entry`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `procFlags`, `procEx`, `procPhase`, `ppmRate`, `CustomChance`, `Cooldown`) VALUES
+(75474,0,0,0,0,0,0,0,0,0,0,50000),
+(64764,0,0,0,0,0,0,0,0,0,0,50000),
+(71602,0,0,0,0,0,0,0,0,0,0,45000);

--- a/data/sql/updates/pending_db_world/wotlktrinkets.sql
+++ b/data/sql/updates/pending_db_world/wotlktrinkets.sql
@@ -19,25 +19,24 @@ UPDATE `item_template` SET `spellppmRate_1` = 0 WHERE (`entry` = 50348);
 UPDATE `item_template` SET `spellppmRate_1` = 0 WHERE (`entry` = 50353);
 UPDATE `item_template` SET `spellppmRate_1` = 0 WHERE (`entry` = 54588);
 
-UPDATE `spell_proc_event` SET `CustomChance` = '35' WHERE `entry` = 71562;
-UPDATE `spell_proc_event` SET `CustomChance` = '45' WHERE `entry` = 71545;  
+UPDATE `spell_proc_event` SET `CustomChance` = 45 WHERE `entry` = 71545;  
+UPDATE `spell_proc_event` SET `CustomChance` = 35 WHERE `entry` = 71562;
 
-
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 71585;
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 64738;
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 64792;
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 62114;
-UPDATE `spell_proc_event` SET `Cooldown` = '45000' WHERE `entry` = 58901;
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 33648;
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 49622;
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 65013;
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 65002;
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 62115;
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 67672;
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 33648;
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 60221;
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 60519;
-UPDATE `spell_proc_event` SET `Cooldown` = '50000' WHERE `entry` = 63251;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 71585;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 64738;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 64792;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 62114;
+UPDATE `spell_proc_event` SET `Cooldown` = 45000 WHERE `entry` = 58901;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 33648;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 49622;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 65013;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 65002;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 62115;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 67672;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 33648;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 60221;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 60519;
+UPDATE `spell_proc_event` SET `Cooldown` = 50000 WHERE `entry` = 63251;
 
 DELETE FROM `spell_proc_event` WHERE `entry` IN (75474, 71602, 64764);
 INSERT INTO `spell_proc_event` (`entry`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `procFlags`, `procEx`, `procPhase`, `ppmRate`, `CustomChance`, `Cooldown`) VALUES


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

Charred Twilight Scale - Removed unused PPM rate and set ICD of 50s.
Soul Preserver - Removed incorrect and unused cooldown
Dislodged Foreign Object - Removed unused PPM rate
Deathbringer's Will - Set correct proc chance
Tiny Abomination in a Jar - Set proc rate to 45%, down from 50%
Dislodged Foreign Object (normal) - Removed unused PPM rate, set correct ICD of 45s
Purified Lunar Dust - Set ICD to 50s, up from 45s
Reign of the Dead (Heroic) - removed incorrect cooldown from item template
Reign of the Dead (Normal) - removed incorrect cooldown from item template
Show of Faith - Set ICD to 50s, up from 45s
The General's Heart - removed incorrect cooldowns and unused  from item template, set correct ICD of 50s
Blood of the Old God - removed incorrect and unused  cooldowns from the item template, set ICD to 50s, up from 45s
Sif's Remembranec - removed incorrect and unused  cooldowns from the item template, set ICD to 50s, up from 45s
Mjolnir Runestone - removed incorrect and unused cooldowns from the item template
Pyrite Infuser - Set ICD to 50s, up from 45s
Elemental Focus Stone - removed incorrect and unused cooldowns from the item template
Dying Curse - removed incorrect and unused cooldowns from the item template
Extract of Necromantic Power - removed incorrect cooldown from the item template
Je'Tze's Bell - removed incorrect cooldowns from the item template and set ICD to 50s, down from 60s
Embrace of the Spider - removed incorrect cooldowns and PPM from the item template
Mirror of Truth - set ICD to 50s, up from 45s
Tears of Bitter Anguish - set ICD to 50s, up from 45s
Flow of Knowledge - set ICD to 50s, up from 45s
Anvil of Titans - set ICD to 50s, up from 45s
Banner of Victory - set ICD to 50s, up from 45s
Coren's Chromium Coaster - set ICD to 50s, up from 45s
Essence of Gossamer - set ICD to 50s, up from 45s
Meteorite Whetstone - removed incorrect cooldown from item template 
Spark of Life - removed incorrect cooldown from the item template and set ICD to 50s, up from 45s
Forge Ember - removed incorrect cooldown from the item template 
Jouster's Fury (Alliance and Horde) - set ICD to 50s, up from 45s

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes no reported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
wowhead wotlk + comments

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

See above what items changed

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Possibly still wrong flags, this requires more testing and will be adressed on a case by case basis

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
