### PR TITLE
fix(Scripts/Quest): Improved Varedis Must Be Stopped

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1689813586760998100.sql
+++ b/data/sql/updates/pending_db_world/rev_1689813586760998100.sql
@@ -5,4 +5,4 @@ INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceGroup` = 0) AND (`SourceEntry` = 37906) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 1) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 21178) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(17, 0, 37906, 0, 0, 31, 1, 3, 21178, 0, 0, 0, 0, '', 'Rip the pages from this book when Varedis uses Metamorphosis to deprive him of his power.');
+(17, 0, 37906, 0, 0, 31, 1, 3, 21178, 0, 0, 0, 0, '', 'Book of Fel Names can only target Varedis');

--- a/data/sql/updates/pending_db_world/rev_1689813586760998100.sql
+++ b/data/sql/updates/pending_db_world/rev_1689813586760998100.sql
@@ -1,0 +1,8 @@
+--
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_q10651_q10692_book_of_fel_names';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(36298, 'spell_q10651_q10692_book_of_fel_names');
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceGroup` = 0) AND (`SourceEntry` = 37906) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 1) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 21178) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(17, 0, 37906, 0, 0, 31, 1, 3, 21178, 0, 0, 0, 0, '', 'Rip the pages from this book when Varedis uses Metamorphosis to deprive him of his power.');

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -2448,6 +2448,26 @@ class spell_q4735_collect_rookery_egg : public SpellScript
     }
 };
 
+enum book
+{
+    SPELL_METAMORPHOSIS   = 36298
+};
+
+class spell_q10651_q10692_book_of_fel_names : public SpellScript
+{
+    PrepareSpellScript(spell_q10651_q10692_book_of_fel_names)
+
+    void HandleScript(SpellEffIndex /*effIndex*/)
+    {
+        GetHitUnit()->RemoveAurasDueToSpell(SPELL_METAMORPHOSIS);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_q10651_q10692_book_of_fel_names::HandleScript, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+    }
+};
+
 void AddSC_quest_spell_scripts()
 {
     RegisterSpellAndAuraScriptPair(spell_q11065_wrangle_some_aether_rays, spell_q11065_wrangle_some_aether_rays_aura);
@@ -2519,4 +2539,5 @@ void AddSC_quest_spell_scripts()
     RegisterSpellScript(spell_q12919_gymers_throw);
     RegisterSpellScript(spell_q5056_summon_shy_rotam);
     RegisterSpellScript(spell_q4735_collect_rookery_egg);
+    RegisterSpellScript(spell_q10651_q10692_book_of_fel_names);
 }

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -2455,7 +2455,7 @@ enum book
 
 class spell_q10651_q10692_book_of_fel_names : public SpellScript
 {
-    PrepareSpellScript(spell_q10651_q10692_book_of_fel_names)
+    PrepareSpellScript(spell_q10651_q10692_book_of_fel_names);
 
     void HandleScript(SpellEffIndex /*effIndex*/)
     {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  added the book and used only in Varedis
-  added remove metamorphosis


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.youtube.com/watch?v=D0GecU9-gUE (58:25 minutos de vídeo)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  .quest add 10651 (Altar of Sha'tar)
2.  .quest add 10692 (Sanctum of the Stars)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
