### PR TITLE
feat(Core/Config): add "include" statement to config parser

### DIFF
--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -164,7 +164,7 @@ namespace
                 if (match.size() == 2)
                 {
                     std::string includeFile = std::ssub_match(match[1]).str();
-                    // Save include statesments to be parsed after all the keys
+                    // Save include statements to be parsed after all the keys
                     // are added for this file.
                     includesToParse.push_back(includeFile);
                 }

--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -93,9 +93,9 @@ namespace
         // Values are taken until there's a # or end of line
         const std::regex parameter_regex("^\\s*([a-zA-Z0-9\\.]+)\\s*=\\s*([^#\\n]+)(?:#[^\\n]*)?$");
         // include will parse values from another file
-        const std::regex include_regex("^\\s*include\\s+([^#\\n]+)(?:#[\\h\\S]*)?$");
+        const std::regex include_regex("^\\s*include\\s+\"?([^#\\n\"]+)\"?(?:#[\\h\\S]*)?$");
         // includeDir will include values from files in a directory
-        const std::regex include_dir_regex("^\\s*includeDir\\s+([^#\\n]+)(?:#[\\h\\S]*)?$");
+        const std::regex include_dir_regex("^\\s*includeDir\\s+\"?([^#\\n\"]+)\"?(?:#[\\h\\S]*)?$");
 
         std::smatch match;
 

--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -87,8 +87,6 @@ namespace
             return false;
         }
 
-
-
         std::ifstream in(file);
 
         // Values are taken until there's a # or end of line

--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -94,8 +94,8 @@ namespace
         const std::regex parameter_regex("^\\s*([a-zA-Z0-9\\.]+)\\s*=\\s*([^#\\n]+)(?:#[^\\n]*)?$");
         // include will parse values from another file
         const std::regex include_regex("^\\s*include\\s+([^#\\n]+)(?:#[\\h\\S]*)?$");
-        // includedir will include values from files in a directory
-        const std::regex include_dir_regex("^\\s*includedir\\s+([^#\\n]+)(?:#[\\h\\S]*)?$");
+        // includeDir will include values from files in a directory
+        const std::regex include_dir_regex("^\\s*includeDir\\s+([^#\\n]+)(?:#[\\h\\S]*)?$");
 
         std::smatch match;
 

--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -128,18 +128,6 @@ namespace
         uint32 count = 0;
         uint32 lineNumber = 0;
 
-        // return true if duplicate found for this file
-        // does not find duplicates across include statements
-        auto IsDuplicateOption = [&](std::string const& confOption)
-        {
-            auto const& itr = fileConfigs.find(confOption);
-            if (itr != fileConfigs.end())
-            {
-                PrintError(file, "> Config::LoadFile: Duplicate key name '{}' in config file '{}'", confOption, file);
-            }
-            return itr != fileConfigs.end();
-        };
-
         // Used for include statements
         // If path is absolute, return path
         // else, return path relative to filePath (the current file)

--- a/src/common/Configuration/Config.h
+++ b/src/common/Configuration/Config.h
@@ -48,7 +48,7 @@ public:
     T GetOption(std::string const& name, T const& def, bool showLogs = true) const;
 
     /*
-     * Deprecated geters. This geters will be deleted
+     * Deprecatted geters. This getters will be deleted
      */
 
     [[deprecated("Use GetOption<std::string> instead")]]

--- a/src/server/apps/authserver/authserver.conf.dist
+++ b/src/server/apps/authserver/authserver.conf.dist
@@ -31,6 +31,19 @@
 ###################################################################################################
 
 ###################################################################################################
+# INCLUDING OTHER CONFIGURATION FILES
+#
+#    include ...
+#    includeDir ...
+#       Description: Include another configuration file. The paramaters from
+#                    that file will override conflicting configs occurring before it. Configs
+#                    after an include will override conflicting configs defined in the include
+#
+# include /etc/azerothcore/authserver.conf
+# includeDir /etc/azerothcore/common.d/
+###################################################################################################
+
+###################################################################################################
 # AUTH SERVER SETTINGS
 #
 #    LogsDir
@@ -431,14 +444,3 @@ Logger.root=4,Console Auth
 
 #
 ###################################################################################################
-#
-#    include ...
-#       Description: Include another configuration file. The paramaters from
-#                    that file will overwrite any conflicting parameters in this
-#                    file.
-#
-#include /etc/azerothcore/authserver.conf
-#
-## To include a directory (and all files under it), make sure there's a slash at the end of the path
-#
-#include /etc/azerothcore/common.d/

--- a/src/server/apps/authserver/authserver.conf.dist
+++ b/src/server/apps/authserver/authserver.conf.dist
@@ -431,3 +431,14 @@ Logger.root=4,Console Auth
 
 #
 ###################################################################################################
+#
+#    include ...
+#       Description: Include another configuration file. The paramaters from
+#                    that file will overwrite any conflicting parameters in this
+#                    file.
+#
+#include /etc/azerothcore/authserver.conf
+#
+## To include a directory (and all files under it), make sure there's a slash at the end of the path
+#
+#include /etc/azerothcore/common.d/

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -4153,3 +4153,14 @@ Metric.OverallStatusInterval = 1
 
 #
 ###################################################################################################
+#
+#    include ...
+#       Description: Include another configuration file. The paramaters from
+#                    that file will overwrite any conflicting parameters in this
+#                    file.
+#
+#include /etc/azerothcore/worldserver.conf
+#
+## To include a directory (and all files under it), make sure there's a slash at the end of the path
+#
+#include /etc/azerothcore/common.d/

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -53,6 +53,19 @@
 ###################################################################################################
 
 ###################################################################################################
+# INCLUDING OTHER CONFIGURATION FILES
+#
+#    include ...
+#    includeDir ...
+#       Description: Include another configuration file. The paramaters from
+#                    that file will override conflicting configs occurring before it. Configs
+#                    after an include will override conflicting configs defined in the include
+#
+# include /etc/azerothcore/worldserver.conf
+# includeDir /etc/azerothcore/common.d/
+###################################################################################################
+
+###################################################################################################
 # CONNECTIONS AND DIRECTORIES
 #
 #    RealmID
@@ -4153,14 +4166,3 @@ Metric.OverallStatusInterval = 1
 
 #
 ###################################################################################################
-#
-#    include ...
-#       Description: Include another configuration file. The paramaters from
-#                    that file will overwrite any conflicting parameters in this
-#                    file.
-#
-#include /etc/azerothcore/worldserver.conf
-#
-## To include a directory (and all files under it), make sure there's a slash at the end of the path
-#
-#include /etc/azerothcore/common.d/

--- a/src/tools/dbimport/dbimport.conf.dist
+++ b/src/tools/dbimport/dbimport.conf.dist
@@ -29,6 +29,19 @@
 ###################################################################################################
 
 ###################################################################################################
+# INCLUDING OTHER CONFIGURATION FILES
+#
+#    include ...
+#    includeDir ...
+#       Description: Include another configuration file. The paramaters from
+#                    that file will override conflicting configs occurring before it. Configs
+#                    after an include will override conflicting configs defined in the include
+#
+# include /etc/azerothcore/dbimport.conf
+# includeDir /etc/azerothcore/common.d/
+###################################################################################################
+
+###################################################################################################
 # DB IMPORT CONFIG
 #
 #    LogsDir
@@ -294,15 +307,6 @@ Appender.DBImport=2,5,0,DBImport.log,w
 #
 
 Logger.root=4,Console DBImport
+
+#
 ###################################################################################################
-#
-#    include ...
-#       Description: Include another configuration file. The paramaters from
-#                    that file will overwrite any conflicting parameters in this
-#                    file.
-#
-#include /etc/azerothcore/dbimport.conf
-#
-## To include a directory (and all files under it), make sure there's a slash at the end of the path
-#
-#include /etc/azerothcore/common.d/

--- a/src/tools/dbimport/dbimport.conf.dist
+++ b/src/tools/dbimport/dbimport.conf.dist
@@ -295,3 +295,14 @@ Appender.DBImport=2,5,0,DBImport.log,w
 
 Logger.root=4,Console DBImport
 ###################################################################################################
+#
+#    include ...
+#       Description: Include another configuration file. The paramaters from
+#                    that file will overwrite any conflicting parameters in this
+#                    file.
+#
+#include /etc/azerothcore/dbimport.conf
+#
+## To include a directory (and all files under it), make sure there's a slash at the end of the path
+#
+#include /etc/azerothcore/common.d/


### PR DESCRIPTION
Please feel free to mention me (@mynamismeat) in discord. I prefer communication in a channel of the AC discord rather than as a DM.  

## Changes Proposed:
- Add an "include" statement to the configuration parser
  - This allows users to logically group configuration parameters with each other, based on the file they're in. 
  - the `include` statement works with either files or directories
  - `include` files are parsed _after_ the base file has completed parsing
  - included files are in-line with the root file. This means that a parameter after an include will supersede the include, and if the include is after the parameter, it will supersede the root file.
  - Cyclical `include` statements will cause a failure
- Configuration parser has been rewritten to use regex rather than reformatting the lines of the file. 
  - This can make it easier to expand the config file format in the future
- Empty files do not halt execution of the worldserver

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- It builds without issues
- It starts without issues
- It appears to parse all debug options without issues


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. run an initial build with `./acore.sh docker build`
2. start the container with `docker compose --profile app up ac-worldserver`. hit CTRL+C after everything seems satisfactory
3. change the worldserver config (`env/docker/etc/worldserver.conf`). I adding this line to the bottom:

    ```ini
    include /azerothcore/env/dist/etc/worldserver.conf.dockerdist
    ```

4. Run the build and start the new container
5. Test the worldserver config with a directory. First, run this command:

    ```console
    $ mkdir env/docker/etc/worldserver.d
    $ mv env/docker/etc/worldserver.conf.dockerdist env/docker/etc/worldserver.d/dockerdist.conf
    ```

    Change the include statement at the bottom of the worldserver config:

    ```ini
    include /azerothcore/env/dist/etc/worldserver.d/
    ```

6. Again, build and start the container to ensure that the worldserver starts
7. To test a cyclical include, add `include /azerothcore/env/dist/etc/worldserver.conf` to the end of `env/docker/etc/worldserver.d/dockerdist.conf`. The worldserver should fail.


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- With this change, I'd like to deprecate [the conf layering](https://github.com/azerothcore/azerothcore-wotlk/blob/master/apps/compiler/includes/functions.sh#L189-L220) that happens as a part of the compiler shell scripts
  - The whole section can be reduced to `echo "include /path/to/dockerdist" >> /path/to/main/conf`
  - Overall, I think a more featured configuration system should be favored over extra steps that happen right after compile time. 
- I'd also like to implement configuration sourcing from environment variables. I intended to do that with this PR, though I wasn't happy in the way it turned out so I removed it
  - it's probably better to keep this as small as possible, anyways.
- I removed erroring on duplicate parameters because I don't think that this is an issue. If this isn't shared by other contributors, an alternative I have in mind is  to prevent duplicate parameters in the same file, and then emitting an `info` log when a parameter gets overwritten between one file and another.  

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
