### PR TITLE
fix(DB/Loot): HC ramparts chest should drop a badge of justice

### DIFF
--- a/data/sql/updates/pending_db_world/rampartshcbadge.sql
+++ b/data/sql/updates/pending_db_world/rampartshcbadge.sql
@@ -1,4 +1,4 @@
 --
 DELETE FROM `gameobject_loot_template` WHERE (`Entry` = 21764) AND (`Item` IN (29434));
 INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(21764, 29434, 0, 100, 0, 1, 0, 1, 1, '');]
+(21764, 29434, 0, 100, 0, 1, 0, 1, 1, '');

--- a/data/sql/updates/pending_db_world/rampartshcbadge.sql
+++ b/data/sql/updates/pending_db_world/rampartshcbadge.sql
@@ -1,4 +1,4 @@
---
+    --
 DELETE FROM `gameobject_loot_template` WHERE (`Entry` = 21764) AND (`Item` IN (29434));
 INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(21764, 29434, 0, 100, 0, 1, 0, 1, 1, '');
+(21764, 29434, 0, 100, 0, 1, 0, 1, 1, 'Badge of Justice');

--- a/data/sql/updates/pending_db_world/rampartshcbadge.sql
+++ b/data/sql/updates/pending_db_world/rampartshcbadge.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `gameobject_loot_template` WHERE (`Entry` = 21764) AND (`Item` IN (29434));
+INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(21764, 29434, 0, 100, 0, 1, 0, 1, 1, '');]


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  adds badge of justice to hc ramparts chest

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5558

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested both normal and hc (normal has different chest id)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. see linked issue

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
