### PR TITLE
fix(Core/Position): Normalize Position.GetRelativeAngle

### DIFF
--- a/src/server/game/Entities/Object/Position.h
+++ b/src/server/game/Entities/Object/Position.h
@@ -196,10 +196,10 @@ struct Position
 
     float GetRelativeAngle(const Position* pos) const
     {
-        return GetAngle(pos) - m_orientation;
+        return NormalizeOrientation(GetAngle(pos) - m_orientation);
     }
 
-    [[nodiscard]] float GetRelativeAngle(float x, float y) const { return GetAngle(x, y) - m_orientation; }
+    [[nodiscard]] float GetRelativeAngle(float x, float y) const { return NormalizeOrientation(GetAngle(x, y) - m_orientation); }
     [[nodiscard]] float ToAbsoluteAngle(float relAngle) const { return NormalizeOrientation(relAngle + m_orientation); }
 
     void GetSinCos(float x, float y, float& vsin, float& vcos) const;


### PR DESCRIPTION

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Normalize angle returned by both Position.GetRelativeAngle functions.
-  Currently GetRelativeAngle can return angles values which will later cause issues in ChaseMovementGenerator.PositionOkay. For example if it returns a relative angle -4.9 it is then passed onto ChaseAngle.IsAngleOkay function. For desired RelativeAngle value of 3.2 we will get a diff value of 8.1 which is larger than 2pi and will make the 2nd argument to std::min negative, returning said argument. Given that Tolerance for most sane applications should be positive this will cause the function to sometimes return incorrect result.


https://github.com/azerothcore/azerothcore-wotlk/assets/54774532/7e15fe71-a06c-4084-8d11-b25f627a19b2

From PetAI.cpp, PetAI::DoAttack:
```cpp
float angle = combatRange == 0.f && target->GetTypeId() != TYPEID_PLAYER && !target->IsPet() ? float(M_PI) : 0.f;
float tolerance = combatRange == 0.f ? float(M_PI_4) : float(M_PI * 2);
me->GetMotionMaster()->MoveChase(target, ChaseRange(0.f, combatRange), ChaseAngle(angle, tolerance));
```
From this, melee pets should stand right behind the target with pi/4 tolerance. combatRange is set based on if its gonna cast ranged spells, for melees should be 0.

I tested this in Naxxramas with warlock's Felhunter pet. Isolate any single enemy with lots of health, ensure you have a massive threat lead on your pet and start slowly going around in circles.
In my case I moved until my pet was somewhere about 1.5 radians absolute angle to the target. (target:GetAngle(pet) ~ 1.5 radians) and target's orientation was ~5.9 radians. After this I changed the direction of my rotation and as you can first see at roughly 10 seconds in the video and again at the end pet does not move behind it despite actual relative angle diff being approx double the tolerance (pi/4). For some combinations of absolute angle, orientation, and chase angle it works as expected, for others not at all. Also note how small of an angle change it reacts to at the beginnig of the video.

It should not be possible to replicate this with this PR.

There really aren't any other times where ChaseAngle is used that I found.
GetRelativeAngle is used only in a couple of other places but they were passing angle to cos/sin so were never affected.

tldr; this same funciton is normalized in trinity core if you don't trust my math/footage.
https://github.com/TrinityCore/TrinityCore/blob/f9033a5dbd559fde3030a21d83d664983d95f39f/src/server/game/Entities/Object/Position.h#L139C5-L139C5.


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
