### PR TITLE
Fix XP disable NPC script

### DIFF
--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -2033,8 +2033,19 @@ public:
 
     bool OnGossipSelect(Player* player, Creature* /*creature*/, uint32 /*sender*/, uint32 action) override
     {
+        auto toggleXpCost = sWorld->getIntConfig(CONFIG_TOGGLE_XP_COST);
+        
         ClearGossipMenuFor(player);
-
+        
+        if (!player->HasEnoughMoney(toggleXpCost))
+        {
+            player->SendBuyError(BUY_ERR_NOT_ENOUGHT_MONEY, 0, 0, 0);
+            player->PlayerTalkClass->SendCloseGossip();
+            return true;
+        }
+        
+        player->ModifyMoney(-toggleXpCost);
+        
         switch (action)
         {
             case GOSSIP_ACTION_INFO_DEF + 1://xp off
@@ -2044,7 +2055,7 @@ public:
                 player->RemovePlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
                 break;
         }
-
+        
         player->PlayerTalkClass->SendCloseGossip();
         return true;
     }

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -2034,18 +2034,18 @@ public:
     bool OnGossipSelect(Player* player, Creature* /*creature*/, uint32 /*sender*/, uint32 action) override
     {
         auto toggleXpCost = sWorld->getIntConfig(CONFIG_TOGGLE_XP_COST);
-        
+
         ClearGossipMenuFor(player);
-        
+
         if (!player->HasEnoughMoney(toggleXpCost))
         {
             player->SendBuyError(BUY_ERR_NOT_ENOUGHT_MONEY, 0, 0, 0);
             player->PlayerTalkClass->SendCloseGossip();
             return true;
         }
-        
+
         player->ModifyMoney(-toggleXpCost);
-        
+
         switch (action)
         {
             case GOSSIP_ACTION_INFO_DEF + 1://xp off
@@ -2055,7 +2055,7 @@ public:
                 player->RemovePlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
                 break;
         }
-        
+
         player->PlayerTalkClass->SendCloseGossip();
         return true;
     }

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -2016,13 +2016,15 @@ public:
 
     bool OnGossipHello(Player* player, Creature* creature) override
     {
+        auto toggleXpCost = sWorld->getIntConfig(CONFIG_TOGGLE_XP_COST);
+
         if (!player->HasPlayerFlag(PLAYER_FLAGS_NO_XP_GAIN))
         {
-            AddGossipItemFor(player, GOSSIP_MENU_EXP_NPC, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1); // "I no longer wish to gain experience."
+            AddGossipItemFor(player, GOSSIP_MENU_EXP_NPC, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1, toggleXpCost); // "I no longer wish to gain experience."
         }
         else
         {
-            AddGossipItemFor(player, GOSSIP_MENU_EXP_NPC, 1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2); // "I wish to start gaining experience again."
+            AddGossipItemFor(player, GOSSIP_MENU_EXP_NPC, 1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2, toggleXpCost); // "I wish to start gaining experience again."
         }
 
         SendGossipMenuFor(player, player->GetGossipTextId(creature), creature);
@@ -2032,42 +2034,17 @@ public:
     bool OnGossipSelect(Player* player, Creature* /*creature*/, uint32 /*sender*/, uint32 action) override
     {
         ClearGossipMenuFor(player);
-        bool noXPGain = player->HasPlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
-        bool doSwitch = false;
-        auto toggleXpCost = sWorld->getIntConfig(CONFIG_TOGGLE_XP_COST);
 
         switch (action)
         {
             case GOSSIP_ACTION_INFO_DEF + 1://xp off
-                {
-                    if (!noXPGain)//does gain xp
-                        doSwitch = true;//switch to don't gain xp
-                }
+                player->SetPlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
                 break;
             case GOSSIP_ACTION_INFO_DEF + 2://xp on
-                {
-                    if (noXPGain)//doesn't gain xp
-                        doSwitch = true;//switch to gain xp
-                }
+                player->RemovePlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
                 break;
         }
-        if (doSwitch)
-        {
-            if (!player->HasEnoughMoney(toggleXpCost))
-            {
-                player->SendBuyError(BUY_ERR_NOT_ENOUGHT_MONEY, 0, 0, 0);
-            }
-            else if (noXPGain)
-            {
-                player->ModifyMoney(-toggleXpCost);
-                player->RemovePlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
-            }
-            else if (!noXPGain)
-            {
-                player->ModifyMoney(-toggleXpCost);
-                player->SetPlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
-            }
-        }
+
         player->PlayerTalkClass->SendCloseGossip();
         return true;
     }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Fixes the script to use the xp toggle cost config option properly.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Previously this config variable did not work, as the cost defined in the db would override this config option.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- It builds, logic should be fine. Feel free to test ingame.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
- Set the config option to something else than 10g, it should now reflect properly ingame.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
