### PR TITLE
fix(Core/Magtheridon): Fix double schedule

### DIFF
--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
@@ -218,9 +218,9 @@ struct boss_magtheridon : public BossAI
                 Talk(SAY_EMOTE_FREE);
                 Talk(SAY_FREE);
                 scheduler.CancelGroup(GROUP_EARLY_RELEASE_CHECK); //cancel regular countdown
+                _magReleased = true;
                 scheduler.Schedule(3s, [this](TaskContext)
                 {
-                    _magReleased = true; //redundancy
                     ScheduleCombatEvents();
                 });
             }
@@ -239,6 +239,7 @@ struct boss_magtheridon : public BossAI
         {
             Talk(SAY_EMOTE_FREE);
             Talk(SAY_FREE);
+            _magReleased = true;
         }).Schedule(123s, GROUP_EARLY_RELEASE_CHECK, [this](TaskContext /*context*/)
         {
             ScheduleCombatEvents();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Co-authored-by: Balleny <balleny@users.noreply.github.com>

## Changes Proposed:
-  Move the boolean flag out the last schedule.
-  Credits to balleny, practically solved it on the issue.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/5975


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go to Magtheridon, kil 4 channelers and leave 1 alive, then wait until Mag free himself.
2. Kill the last channeler.
3. Shouldn't be double scheduled abilities anymore.

