### PR TITLE
Update SpellEffects.cpp

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -425,7 +425,8 @@ void Spell::EffectSchoolDMG(SpellEffIndex effIndex)
                             damage += int32(CalculatePct(pdamage * baseTotalTicks, pct_dir));
 
                             uint32 pct_dot = m_caster->CalculateSpellDamage(unitTarget, m_spellInfo, (effIndex + 2)) / 3;
-                            m_spellValue->EffectBasePoints[1] = m_spellInfo->Effects[EFFECT_1].CalcBaseValue(int32(CalculatePct(pdamage * baseTotalTicks, pct_dot)));
+                            uint32 oldPdamage = uint32(std::max(aura->GetOldAmount(), 0));
+                            m_spellValue->EffectBasePoints[1] = m_spellInfo->Effects[EFFECT_1].CalcBaseValue(int32(CalculatePct(oldPdamage * baseTotalTicks, pct_dot)));
 
                             apply_direct_bonus = false;
                             // Glyph of Conflagrate


### PR DESCRIPTION
fix warlock's spell Conflagrate(ID:17962) double benifit from some "add percent damage" buff like  "Essence of the Blood Queen"(ID:70867)

## Changes Proposed:
-  bug fix
-  

## Issues Addressed:
- not yet

## SOURCE:
SpellEffects.cpp
around line 428, here, the spell(ID:XX) dot value is based on the final spell damage(ID:XX), this should be the final damage value for spell(ID:XX)
`
m_spellValue->EffectBasePoints[1] = m_spellInfo->Effects[EFFECT_1].CalcBaseValue(int32(CalculatePct(pdamage * baseTotalTicks, pct_dot)));
`

Unit.cpp
around line 11875,here, is the second time, spell's(ID:XX) dot damage take percent modify;
`
float tmpDamage = (float(pdamage) + TakenTotal) * TakenTotalMod;
`

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- build pass
- test in game pass


## How to Test the Changes:
before apply this code:
1.cast Warlock's Conflagrate
2.see the DOT damage
3.use gm command: .learn 70867
4.use "Essence of the Blood Queen"(ID:70867) to self
5.cast Warlock's Conflagrate
6.see the damage again, the value is base_damage * 2 * 2, and it's wrong.

after apply this code:
1.use gm command: .learn 70867
2.use "Essence of the Blood Queen"(ID:70867) to self
3.cast Warlock's Conflagrate
4.see the DOT damage, it will be correct.

## Known Issues and TODO List:
- I think there are still some spells have this problem, consume A buff, product B buff, this thought of solution can be helpful
- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
