### PR TITLE
refactor(Apps/Docker): Remove Deno as a dependency from Docker Build

### DIFF
--- a/apps/compiler/includes/functions.sh
+++ b/apps/compiler/includes/functions.sh
@@ -1,4 +1,3 @@
-
 function comp_clean() {
   DIRTOCLEAN=${BUILDPATH:-var/build/obj}
   PATTERN="$DIRTOCLEAN/*"
@@ -61,7 +60,7 @@ function comp_configure() {
   #-DAC_WITH_UNIT_TEST=$CAC_UNIT_TEST -DAC_WITH_PLUGINS=$CAC_PLG \
 
   local DCONF=""
-  if [ ! -z "$CONFDIR" ]; then
+  if [ -n "${CONFDIR:-}" ]; then
     DCONF="-DCONF_DIR=$CONFDIR"
   fi
 
@@ -100,7 +99,8 @@ function comp_configure() {
 }
 
 function comp_compile() {
-  [ $MTHREADS == 0 ] && MTHREADS=$(grep -c ^processor /proc/cpuinfo) && MTHREADS=$(($MTHREADS + 2))
+  [[ $MTHREADS == 0 ]] && \
+    MTHREADS=$(grep -c ^processor /proc/cpuinfo) && MTHREADS=$(($MTHREADS + 2))
 
   echo "Using $MTHREADS threads"
 
@@ -138,6 +138,8 @@ function comp_compile() {
 
       popd >> /dev/null || exit 1
 
+      # TODO(michaeldelago) evaluate if setting root ownership and SUID bit is
+      # necessary
       # set all aplications SUID bit
       echo "Setting permissions on binary files"
       find "$AC_BINPATH_FULL"  -mindepth 1 -maxdepth 1 -type f -exec sudo chown root:root -- {} +
@@ -207,7 +209,7 @@ function conf_layer() {
         # if key in base and val not in line
         if grep -qE "^$KEY" "$BASE" && ! grep -qE "^$KEY.*=.*$VAL" "$BASE"; then
           # Replace line
-          # Prevent issues with shell quoting 
+          # Prevent issues with shell quoting
           sed -i \
             's,^'"$KEY"'.*,'"$KEY = $VAL$COMMENT"',g' \
             "$BASE"

--- a/apps/docker/Dockerfile
+++ b/apps/docker/Dockerfile
@@ -105,6 +105,8 @@ USER $DOCKER_USER
 COPY --chown=$DOCKER_USER:$DOCKER_USER . /azerothcore
 
 # Needed if we use the dev image without linking any external folder (e.g. acore-docker)
+# TODO(michaeldelago) This is confusing and isn't really needed. `env/docker`
+# should be removed/merged into `env/dist`
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/authserver.conf.dockerdist /azerothcore/env/dist/etc/authserver.conf.dockerdist
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/worldserver.conf.dockerdist /azerothcore/env/dist/etc/worldserver.conf.dockerdist
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/dbimport.conf.dockerdist /azerothcore/env/dist/etc/dbimport.conf.dockerdist
@@ -233,7 +235,10 @@ COPY --chown=$DOCKER_USER:$DOCKER_USER ./CMakeLists.txt /azerothcore/CMakeLists.
 COPY --chown=$DOCKER_USER:$DOCKER_USER ./deps /azerothcore/deps
 COPY --chown=$DOCKER_USER:$DOCKER_USER ./src /azerothcore/src
 COPY --chown=$DOCKER_USER:$DOCKER_USER ./modules /azerothcore/modules
+# TODO(michaeldelago) Don't copy in cache, mount it in a cache volume instead
 COPY --chown=$DOCKER_USER:$DOCKER_USER var/docker/ccache /azerothcore/var/ccache
+# TODO(michaeldelago) This is confusing and isn't really needed. `env/docker`
+# should be removed/merged into `env/dist`
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/authserver.conf.dockerdist /azerothcore/env/dist/etc/authserver.conf.dockerdist
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/worldserver.conf.dockerdist /azerothcore/env/dist/etc/worldserver.conf.dockerdist
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/dbimport.conf.dockerdist /azerothcore/env/dist/etc/dbimport.conf.dockerdist
@@ -252,11 +257,6 @@ ARG CSCRIPTPCH=OFF
 ARG CCOREPCH=OFF
 ARG CTOOLS_BUILD=all
 ARG CSCRIPTS=static
-ARG DEFAULT_CMAKE_OPTIONS="\
-    -DCTYPE=$CTYPE -DAC_CCACHE=$AC_CCACHE \
-    -DCCACHE_CPP2=$CCACHE_CPP2 -DCSCRIPTPCH=$CCACHE_CPP2 \
-    -DCCOREPCH=$CCOREPCH -DCTOOLS_BUILD=$CTOOLS_BUILD -DCSCRIPTS=$CSCRIPTS"
-ARG EXTRA_CMAKE_OPTIONS
 
 # TODO(michaeldelago) don't copy in cache, mount it to a cache volume instead
 RUN bash /azerothcore/apps/docker/docker-build-prod.sh
@@ -355,6 +355,8 @@ RUN addgroup --gid $GROUP_ID $DOCKER_USER && \
     adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID $DOCKER_USER && \
     passwd -d $DOCKER_USER
 
+# TODO(michaeldelago) is this the only place that `env/client` is used? It might
+# be something that we can remove/merge into `env/dist`
 RUN mkdir -p /azerothcore/env/client/ && \
     chown -R $DOCKER_USER:$DOCKER_USER /azerothcore
 

--- a/apps/docker/Dockerfile
+++ b/apps/docker/Dockerfile
@@ -19,61 +19,68 @@ LABEL description="AC base image for dev containers"
 ENV DOCKER=1
 
 # set timezone environment variable
-ENV TZ=Etc/UTC
+ARG TZ=Etc/UTC
+ENV TZ=$TZ
 
 # set noninteractive mode so tzdata doesn't ask to set timezone on install
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Do not use acore dashboard to install
-# since it's not cacheable by docker
-RUN apt-get update && apt-get install -y gdb gdbserver git dos2unix lsb-core sudo curl unzip \
-  make cmake clang libmysqlclient-dev \
-  libboost-system1.7*-dev libboost-filesystem1.7*-dev libboost-program-options1.7*-dev libboost-iostreams1.7*-dev \
-  build-essential libtool cmake-data openssl libgoogle-perftools-dev google-perftools \
-  libssl-dev libmysql++-dev libreadline6-dev zlib1g-dev libbz2-dev mysql-client \
-  libncurses5-dev ccache \
-  && rm -rf /var/lib/apt/lists/*
+# TODO(michaeldelago) Cache these packages, and remove what we can.
+RUN apt-get update && \
+    apt-get install -y \
+        gdb gdbserver git dos2unix lsb-core curl unzip \
+        make cmake clang libmysqlclient-dev \
+        libboost-system1.7*-dev libboost-filesystem1.7*-dev \
+        libboost-program-options1.7*-dev libboost-iostreams1.7*-dev \
+        build-essential libtool cmake-data openssl libgoogle-perftools-dev google-perftools \
+        libssl-dev libmysql++-dev libreadline6-dev zlib1g-dev libbz2-dev mysql-client \
+        libncurses5-dev ccache && \
+    rm -rf /var/lib/apt/lists/*
 
 # change timezone in container
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo $TZ > /etc/timezone && \
+    dpkg-reconfigure --frontend noninteractive tzdata
 
 # Create a non-root user
-RUN addgroup --gid $GROUP_ID acore && \
-    adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID acore && \
-    passwd -d acore && \
-    echo 'acore ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers
+RUN addgroup --gid $GROUP_ID $DOCKER_USER && \
+    adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID $DOCKER_USER && \
+    passwd -d $DOCKER_USER
 
 # must be created to set the correct permissions on them
-RUN mkdir -p /azerothcore/env/dist/bin
-RUN mkdir -p /azerothcore/env/dist/data/Cameras
-RUN mkdir -p /azerothcore/env/dist/data/dbc
-RUN mkdir -p /azerothcore/env/dist/data/maps
-RUN mkdir -p /azerothcore/env/dist/data/mmaps
-RUN mkdir -p /azerothcore/env/dist/data/vmaps
-RUN mkdir -p /azerothcore/env/dist/logs
-RUN mkdir -p /azerothcore/env/dist/temp
-RUN mkdir -p /azerothcore/env/dist/etc
-RUN mkdir -p /azerothcore/var/build/obj
+RUN mkdir -p \
+        /azerothcore/env/dist/bin \
+        /azerothcore/env/dist/data/Cameras \
+        /azerothcore/env/dist/data/dbc \
+        /azerothcore/env/dist/data/maps \
+        /azerothcore/env/dist/data/mmaps \
+        /azerothcore/env/dist/data/vmaps \
+        /azerothcore/env/dist/logs \
+        /azerothcore/env/dist/temp \
+        /azerothcore/env/dist/etc \
+        /azerothcore/var/build/obj
 
 # Correct permissions for non-root operations
-RUN chown -R $DOCKER_USER:$DOCKER_USER /home/acore
-RUN chown -R $DOCKER_USER:$DOCKER_USER /run
-RUN chown -R $DOCKER_USER:$DOCKER_USER /opt
-RUN chown -R $DOCKER_USER:$DOCKER_USER /azerothcore
+RUN chown -R $DOCKER_USER:$DOCKER_USER \
+        /home/acore \
+        /run \
+        /opt \
+        /azerothcore
 
 USER $DOCKER_USER
 
+# TODO(michaeldelago) evaluate if necessary. The dev container mounts the git repo so it
+# shouldn't really need to copy everything in.
 # copy only necessary files for the acore dashboard
 COPY --chown=$DOCKER_USER:$DOCKER_USER apps /azerothcore/apps
 COPY --chown=$DOCKER_USER:$DOCKER_USER bin /azerothcore/bin
 COPY --chown=$DOCKER_USER:$DOCKER_USER conf /azerothcore/conf
+# TODO(michaeldelago) remove this line especially. This copies in over 600MB of
+# SQL files to the container, which is only necessary at runtime.
 COPY --chown=$DOCKER_USER:$DOCKER_USER data /azerothcore/data
 COPY --chown=$DOCKER_USER:$DOCKER_USER deps /azerothcore/deps
 COPY --chown=$DOCKER_USER:$DOCKER_USER acore.json /azerothcore/acore.json
 COPY --chown=$DOCKER_USER:$DOCKER_USER acore.sh /azerothcore/acore.sh
-
-# Download deno and make sure the dashboard works
-RUN bash /azerothcore/acore.sh quit
 
 WORKDIR /azerothcore
 
@@ -89,6 +96,9 @@ LABEL description="AC dev image for dev containers"
 
 USER $DOCKER_USER
 
+# TODO(michaeldelago) re-evalutate if this is necessary. The dev server mounts it anyway, and
+# despite lower comment this seems redundant
+
 # copy everything so we can work directly within the container
 # using tools such as vscode dev-container
 # NOTE: this folder is different by the /azerothcore (which is binded instead)
@@ -98,6 +108,9 @@ COPY --chown=$DOCKER_USER:$DOCKER_USER . /azerothcore
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/authserver.conf.dockerdist /azerothcore/env/dist/etc/authserver.conf.dockerdist
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/worldserver.conf.dockerdist /azerothcore/env/dist/etc/worldserver.conf.dockerdist
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/dbimport.conf.dockerdist /azerothcore/env/dist/etc/dbimport.conf.dockerdist
+
+# Ensure Git works
+RUN git config --global --add safe.directory /azerothcore
 
 #================================================================
 #
@@ -116,46 +129,56 @@ LABEL description="AC service image for server applications"
 # List of timezones: http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 # set timezone environment variable
-ENV TZ=Etc/UTC
+ARG TZ
 
 # set noninteractive mode so tzdata doesn't ask to set timezone on install
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Create a non-root user
-RUN addgroup --gid $GROUP_ID acore && \
-    adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID acore && \
-    passwd -d acore && \
-    echo 'acore ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers
+RUN addgroup --gid $GROUP_ID $DOCKER_USER && \
+    adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID $DOCKER_USER && \
+    passwd -d $DOCKER_USER
 
+# TODO(michaeldelago) Cache these packages
 # install the required dependencies to run the server
-RUN apt-get update && apt-get install -y dos2unix gdb gdbserver google-perftools libgoogle-perftools-dev net-tools \
-    libboost-system1.7*-dev libboost-filesystem1.7*-dev libboost-program-options1.7*-dev libboost-iostreams1.7*-dev \
-    tzdata libmysqlclient-dev mysql-client curl unzip && rm -rf /var/lib/apt/lists/* ;
+RUN apt-get update && \
+    apt-get install -y \
+        dos2unix gdb gdbserver google-perftools libgoogle-perftools-dev net-tools \
+        libboost-system1.71.0 libboost-filesystem1.71.0 \
+        libboost-program-options1.71.0 libboost-iostreams1.71.0 \
+        libboost-regex1.71.0 \
+        tzdata curl unzip \
+        # Both libmysqlclient and mysql-client are needed since the DB importer uses the
+        # `mysql` binary
+        mysql-client libmysqlclient-dev && \
+    rm -rf /var/lib/apt/lists/* ;
 
 # change timezone in container
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo $TZ > /etc/timezone && \
+    dpkg-reconfigure --frontend noninteractive tzdata
 
 # Correct permissions for non-root operations
-RUN chown -R $DOCKER_USER:$DOCKER_USER /home/acore
-RUN chown -R $DOCKER_USER:$DOCKER_USER /run
-RUN chown -R $DOCKER_USER:$DOCKER_USER /opt
+RUN chown -R $DOCKER_USER:$DOCKER_USER \
+        /home/acore \
+        /run \
+        /opt
 
 COPY --chown=$DOCKER_USER:$DOCKER_USER --from=base /azerothcore /azerothcore
 
 USER $DOCKER_USER
 
 # must be created to avoid permissions errors
-RUN mkdir -p /azerothcore/env/dist/data/Cameras
-RUN mkdir -p /azerothcore/env/dist/data/dbc
-RUN mkdir -p /azerothcore/env/dist/data/maps
-RUN mkdir -p /azerothcore/env/dist/data/mmaps
-RUN mkdir -p /azerothcore/env/dist/data/vmaps
-RUN mkdir -p /azerothcore/env/dist/logs
-RUN mkdir -p /azerothcore/env/dist/etc
-RUN mkdir -p /azerothcore/env/dist/bin
-
-# Download deno and make sure the dashboard works
-RUN bash /azerothcore/acore.sh quit
+RUN mkdir -p \
+        /azerothcore/env/dist/data/Cameras \
+        /azerothcore/env/dist/data/dbc \
+        /azerothcore/env/dist/data/maps \
+        /azerothcore/env/dist/data/mmaps \
+        /azerothcore/env/dist/data/vmaps \
+        /azerothcore/env/dist/logs \
+        /azerothcore/env/dist/etc \
+        /azerothcore/env/dist/bin && \
+    chown -R "$USER_ID:$GROUP_ID" /azerothcore
 
 WORKDIR /azerothcore/
 
@@ -170,7 +193,11 @@ FROM servicebase as authserver-local
 
 LABEL description="AC authserver image for local environment"
 
-CMD ./acore.sh run-authserver
+# TODO(michaeldelago) evaluate if we can use something like tini (widespread
+# usage, built into docker) for service handling. Having a "restarter" such as
+# this doesn't add anything to docker
+CMD /azerothcore/apps/startup-scripts/simple-restarter \
+        /azerothcore/env/dist/bin/authserver
 
 USER $DOCKER_USER
 
@@ -178,7 +205,11 @@ FROM servicebase as worldserver-local
 
 LABEL description="AC worldserver image for local environment"
 
-CMD ./acore.sh run-worldserver
+# TODO(michaeldelago) evaluate if we can use something like tini (widespread
+# usage, built into docker) for service handling. Having a "restarter" such as
+# this doesn't add anything to docker
+CMD /azerothcore/apps/startup-scripts/simple-restarter \
+        /azerothcore/env/dist/bin/workdserver
 
 USER $DOCKER_USER
 
@@ -196,32 +227,39 @@ LABEL description="AC Image used by the build stage to generate production image
 
 RUN mkdir -p /azerothcore/env/etc/
 
-# .git is needed by the compiler
+# .git is needed by the build system
 COPY --chown=$DOCKER_USER:$DOCKER_USER ./.git /azerothcore/.git
 COPY --chown=$DOCKER_USER:$DOCKER_USER ./CMakeLists.txt /azerothcore/CMakeLists.txt
 COPY --chown=$DOCKER_USER:$DOCKER_USER ./deps /azerothcore/deps
 COPY --chown=$DOCKER_USER:$DOCKER_USER ./src /azerothcore/src
 COPY --chown=$DOCKER_USER:$DOCKER_USER ./modules /azerothcore/modules
-# check if we have ccache files available outside
-RUN rm -rf /azerothcore/var/ccache/*
 COPY --chown=$DOCKER_USER:$DOCKER_USER var/docker/ccache /azerothcore/var/ccache
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/authserver.conf.dockerdist /azerothcore/env/dist/etc/authserver.conf.dockerdist
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/worldserver.conf.dockerdist /azerothcore/env/dist/etc/worldserver.conf.dockerdist
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/dbimport.conf.dockerdist /azerothcore/env/dist/etc/dbimport.conf.dockerdist
 
 # install eluna
-RUN git clone --depth=1 --branch=master https://github.com/azerothcore/mod-eluna.git /azerothcore/modules/mod-eluna
+RUN git clone --depth=1 --branch=master \
+    https://github.com/azerothcore/mod-eluna.git \
+    /azerothcore/modules/mod-eluna
 
-ENV USER_CONF_PATH=/azerothcore/apps/docker/config-docker.sh
-ENV CTYPE=RelWithDebInfo
-ENV AC_CCACHE=true
-ENV CCACHE_CPP2=true
-ENV CSCRIPTPCH=OFF
-ENV CCOREPCH=OFF
-ENV CTOOLS_BUILD=all
-# ENV CTOOLS_BUILD=maps-only
-ENV CSCRIPTS=static
-RUN bash apps/docker/docker-build-prod.sh
+ARG BUILD_FORKS
+ARG USER_CONF_PATH=/azerothcore/apps/docker/config-docker.sh
+ARG CTYPE=RelWithDebInfo
+ARG AC_CCACHE=true
+ARG CCACHE_CPP2=true
+ARG CSCRIPTPCH=OFF
+ARG CCOREPCH=OFF
+ARG CTOOLS_BUILD=all
+ARG CSCRIPTS=static
+ARG DEFAULT_CMAKE_OPTIONS="\
+    -DCTYPE=$CTYPE -DAC_CCACHE=$AC_CCACHE \
+    -DCCACHE_CPP2=$CCACHE_CPP2 -DCSCRIPTPCH=$CCACHE_CPP2 \
+    -DCCOREPCH=$CCOREPCH -DCTOOLS_BUILD=$CTOOLS_BUILD -DCSCRIPTS=$CSCRIPTS"
+ARG EXTRA_CMAKE_OPTIONS
+
+# TODO(michaeldelago) don't copy in cache, mount it to a cache volume instead
+RUN bash /azerothcore/apps/docker/docker-build-prod.sh
 
 #================================================================
 #
@@ -236,6 +274,8 @@ LABEL description="AC Production: authserver"
 ARG DOCKER_USER=acore
 USER $DOCKER_USER
 
+# TODO(michaeldelago) Evaluate the need for "production" and "dev" container
+# build
 COPY --chown=$DOCKER_USER:$DOCKER_USER --from=build /azerothcore/env/dist/etc /azerothcore/env/dist/etc
 COPY --chown=$DOCKER_USER:$DOCKER_USER --from=build /azerothcore/env/dist/bin/authserver /azerothcore/env/dist/bin/authserver
 
@@ -252,6 +292,8 @@ LABEL description="AC Production: worldserver"
 ARG DOCKER_USER=acore
 USER $DOCKER_USER
 
+# TODO(michaeldelago) Evaluate the need for "production" and "dev" container
+# build
 RUN mkdir -p /azerothcore/env/dist/bin/lua_scripts
 COPY --chown=$DOCKER_USER:$DOCKER_USER --from=build /azerothcore/env/dist/etc /azerothcore/env/dist/etc
 COPY --chown=$DOCKER_USER:$DOCKER_USER --from=build /azerothcore/env/dist/bin/worldserver /azerothcore/env/dist/bin/worldserver
@@ -265,35 +307,20 @@ COPY --chown=$DOCKER_USER:$DOCKER_USER --from=build /azerothcore/env/dist/bin/db
 #=================================================================
 
 FROM ubuntu:20.04 as client-data
-ARG USER_ID=1000
-ARG GROUP_ID=1000
-ARG DOCKER_USER=acore
 
 LABEL description="AC Production: client-data"
 
-RUN apt-get update && apt-get install -y tzdata curl unzip && rm -rf /var/lib/apt/lists/* ;
+RUN apt-get update && \
+    apt-get install -y curl unzip && \
+    rm -rf /var/lib/apt/lists/*
 
-# set timezone environment variable
-ENV TZ=Etc/UTC
+COPY apps/installer/includes/functions.sh \
+     /azerothcore/installer/includes/functions.sh
 
-# set noninteractive mode so tzdata doesn't ask to set timezone on install
-ENV DEBIAN_FRONTEND=noninteractive
+ENV DATAPATH="/azerothcore/env/dist/data"
 
-RUN addgroup --gid $GROUP_ID acore && \
-    adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID acore && \
-    passwd -d acore && \
-    echo 'acore ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers
-
-# ENV DATAPATH=/azerothcore/env/dist/data-temp
-ENV DATAPATH=/azerothcore/env/dist/data
-ENV DATAPATH_ZIP=/tmp/data.zip
-
-RUN mkdir -p "$DATAPATH"
-ARG CACHEBUST=1
-# RUN --mount=type=bind,target=/azerothcore-temp,readwrite --mount=type=cache,target=/azerothcore/env/dist/data-temp /azerothcore-temp/acore.sh client-data && cp -rT /azerothcore/env/dist/data-temp/ /azerothcore/env/dist/data && chown -R $DOCKER_USER:$DOCKER_USER /azerothcore
-RUN --mount=type=bind,target=/azerothcore-temp,readwrite /azerothcore-temp/acore.sh client-data && chown -R $DOCKER_USER:$DOCKER_USER /azerothcore
-
-USER $DOCKER_USER
+ENTRYPOINT ["/bin/bash"]
+CMD ["-c", "source /azerothcore/installer/includes/functions.sh && inst_download_client_data"]
 
 #================================================================
 #
@@ -311,36 +338,38 @@ LABEL description="AC Production: tools"
 # List of timezones: http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 # set timezone environment variable
-ENV TZ=Etc/UTC
+ARG TZ
 
 # set noninteractive mode so tzdata doesn't ask to set timezone on install
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y libmysqlclient-dev libssl-dev libbz2-dev \
-    libboost-system1.7*-dev libboost-filesystem1.7*-dev libboost-program-options1.7*-dev libboost-iostreams1.7*-dev \
-    sudo && rm -rf /var/lib/apt/lists/* ;
+RUN apt-get update && \
+    apt-get install -y \
+        libmysqlclient-dev libssl-dev libbz2-dev \
+        libboost-system1.7*-dev libboost-filesystem1.7*-dev \
+        libboost-program-options1.7*-dev libboost-iostreams1.7*-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user
-RUN addgroup --gid $GROUP_ID acore && \
-    adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID acore && \
-    passwd -d acore && \
-    echo 'acore ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers
+RUN addgroup --gid $GROUP_ID $DOCKER_USER && \
+    adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID $DOCKER_USER && \
+    passwd -d $DOCKER_USER
 
-RUN mkdir -p /azerothcore/env/client/
-RUN chown -R $DOCKER_USER:$DOCKER_USER /azerothcore
+RUN mkdir -p /azerothcore/env/client/ && \
+    chown -R $DOCKER_USER:$DOCKER_USER /azerothcore
 
 USER $DOCKER_USER
 
 WORKDIR /azerothcore/env/client/
 
-RUN mkdir -p /azerothcore/env/client/Cameras
-RUN mkdir -p /azerothcore/env/client/dbc
-RUN mkdir -p /azerothcore/env/client/maps
-RUN mkdir -p /azerothcore/env/client/mmaps
-RUN mkdir -p /azerothcore/env/client/vmaps
+RUN mkdir -p \
+    /azerothcore/env/client/Cameras \
+    /azerothcore/env/client/dbc     \
+    /azerothcore/env/client/maps    \
+    /azerothcore/env/client/mmaps   \
+    /azerothcore/env/client/vmaps
 
 COPY --chown=$DOCKER_USER:$DOCKER_USER --from=build /azerothcore/env/dist/bin/map_extractor /azerothcore/env/client/map_extractor
 COPY --chown=$DOCKER_USER:$DOCKER_USER --from=build /azerothcore/env/dist/bin/mmaps_generator /azerothcore/env/client/mmaps_generator
 COPY --chown=$DOCKER_USER:$DOCKER_USER --from=build /azerothcore/env/dist/bin/vmap4_assembler /azerothcore/env/client/vmap4_assembler
 COPY --chown=$DOCKER_USER:$DOCKER_USER --from=build /azerothcore/env/dist/bin/vmap4_extractor /azerothcore/env/client/vmap4_extractor
-

--- a/apps/docker/Dockerfile
+++ b/apps/docker/Dockerfile
@@ -111,9 +111,6 @@ COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/authserver.conf.dockerdist
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/worldserver.conf.dockerdist /azerothcore/env/dist/etc/worldserver.conf.dockerdist
 COPY --chown=$DOCKER_USER:$DOCKER_USER env/docker/etc/dbimport.conf.dockerdist /azerothcore/env/dist/etc/dbimport.conf.dockerdist
 
-# Ensure Git works
-RUN git config --global --add safe.directory /azerothcore
-
 #================================================================
 #
 # SERVICE BASE: prepare the OS for the production-ready services
@@ -199,7 +196,7 @@ LABEL description="AC authserver image for local environment"
 # usage, built into docker) for service handling. Having a "restarter" such as
 # this doesn't add anything to docker
 CMD /azerothcore/apps/startup-scripts/simple-restarter \
-        /azerothcore/env/dist/bin/authserver
+        /azerothcore/env/dist/bin authserver
 
 USER $DOCKER_USER
 
@@ -211,7 +208,7 @@ LABEL description="AC worldserver image for local environment"
 # usage, built into docker) for service handling. Having a "restarter" such as
 # this doesn't add anything to docker
 CMD /azerothcore/apps/startup-scripts/simple-restarter \
-        /azerothcore/env/dist/bin/workdserver
+        /azerothcore/env/dist/bin worldserver
 
 USER $DOCKER_USER
 

--- a/apps/docker/config-docker.sh
+++ b/apps/docker/config-docker.sh
@@ -1,8 +1,0 @@
-CUR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-CTOOLS_BUILD=all
-
-# allow the user to override configs
-if [ -f  "$AC_PATH_CONF/config.sh" ]; then
-    source "$AC_PATH_CONF/config.sh" # should overwrite previous
-fi

--- a/apps/docker/docker-build-dev.sh
+++ b/apps/docker/docker-build-dev.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# TODO(michaeldelago) Get as close as we can to running `cmake` and `make`
+# within the Dockerfile. We shouldn't have to jump out to another file to run
+# the build. It's makes it difficult to follow
+
 # The `functions.sh` file assumes that sudo is installed. We don't need to be
 # running builds as root and it creates more problems than it solves.
 function sudo () {
@@ -13,7 +17,8 @@ function sudo () {
 #              left side is where the failure actually occurred
 set -euo pipefail
 # TODO(michaeldelago) Evaluate if these includes are necessary
-# Import Config variables, mainly used in build
+# Import Config variables, mainly used in setting up the build
+# Many of them are essentially passed in as variables to cmake
 
 # Export all variables that get set
 set -a

--- a/apps/docker/docker-build-dev.sh
+++ b/apps/docker/docker-build-dev.sh
@@ -19,7 +19,6 @@ set -euo pipefail
 set -a
 AC_PATH_ROOT=/azerothcore
 CTOOLS_BUILD=all
-# Why do so many environment variables need to exist just to run a build?
 source /azerothcore/apps/bash_shared/includes.sh
 source /azerothcore/apps/bash_shared/defines.sh
 source /azerothcore/conf/dist/config.sh

--- a/apps/docker/docker-build-dev.sh
+++ b/apps/docker/docker-build-dev.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+cd /azerothcore
+
 # TODO(michaeldelago) Get as close as we can to running `cmake` and `make`
 # within the Dockerfile. We shouldn't have to jump out to another file to run
 # the build. It's makes it difficult to follow
@@ -10,7 +12,7 @@ function sudo () {
     $@
 }
 
-# Setting bash options for easier debugging
+# Setting bash options for easier debugging and faster failure
 # e          = exit on error
 # u          = error on unset variable
 # o pipefail = in a pipe, make sure the right side of the pipe is failed if the
@@ -20,18 +22,23 @@ set -euo pipefail
 # Import Config variables, mainly used in setting up the build
 # Many of them are essentially passed in as variables to cmake
 
-# Export all variables that get set
+# Export all variables that need to be set
 set -a
-AC_PATH_ROOT=/azerothcore
-CTOOLS_BUILD=all
-source /azerothcore/apps/bash_shared/includes.sh
+AC_PATH_ROOT="/azerothcore"
+CTOOLS_BUILD="all"
+AC_PATH_APPS="/azerothcore/apps"
+AC_BINPATH_FULL="/azerothcore/env/dist/bin"
 source /azerothcore/apps/bash_shared/defines.sh
+source /azerothcore/deps/acore/bash-lib/src/event/hooks.sh
+source /azerothcore/apps/bash_shared/common.sh
 source /azerothcore/conf/dist/config.sh
 set +a
 
-cd /azerothcore
-
+# This file contains the actual shell function used to build AzerothCore
 source /azerothcore/apps/compiler/includes/functions.sh
+
+# Disable fast failure for the final build, there's some things in `comp_build`
+# that fail
 set +eu
 
 comp_build

--- a/apps/docker/docker-build-dev.sh
+++ b/apps/docker/docker-build-dev.sh
@@ -1,14 +1,33 @@
 #!/usr/bin/env bash
 
-CUR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# The `functions.sh` file assumes that sudo is installed. We don't need to be
+# running builds as root and it creates more problems than it solves.
+function sudo () {
+    $@
+}
 
-source "$CUR_PATH/docker-build-prod.sh"
+# Setting bash options for easier debugging
+# e          = exit on error
+# u          = error on unset variable
+# o pipefail = in a pipe, make sure the right side of the pipe is failed if the
+#              left side is where the failure actually occurred
+set -euo pipefail
+# TODO(michaeldelago) Evaluate if these includes are necessary
+# Import Config variables, mainly used in build
 
-echo "Fixing EOL..."
-# using -n (new file mode) should also fix the issue
-# when the file is created with the default acore user but you
-# set a different user into the docker configurations
-for file in "env/dist/etc/"*
-do
-    dos2unix -n $file $file
-done
+# Export all variables that get set
+set -a
+AC_PATH_ROOT=/azerothcore
+CTOOLS_BUILD=all
+# Why do so many environment variables need to exist just to run a build?
+source /azerothcore/apps/bash_shared/includes.sh
+source /azerothcore/apps/bash_shared/defines.sh
+source /azerothcore/conf/dist/config.sh
+set +a
+
+cd /azerothcore
+
+source /azerothcore/apps/compiler/includes/functions.sh
+set +eu
+
+comp_build

--- a/apps/docker/docker-build-prod.sh
+++ b/apps/docker/docker-build-prod.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-cd /azerothcore
+#TODO(michaeldelago) evaluate if a separate prod/dev build is needed
 
-bash acore.sh compiler build
+exec bash /azerothcore/apps/docker/docker-build-dev.sh

--- a/apps/docker/docker-cmd.ts
+++ b/apps/docker/docker-cmd.ts
@@ -85,13 +85,6 @@ shellCommandFactory(
 );
 
 shellCommandFactory(
-  "client-data",
-  "Download client data inside the ac-data volume",
-  ["docker compose run --rm --no-deps ac-dev-server bash acore.sh client-data"],
-  env
-);
-
-shellCommandFactory(
   "dev:up",
   "Start the dev server container in background",
   ["docker compose up -d ac-dev-server"],

--- a/apps/docker/docker-cmd.ts
+++ b/apps/docker/docker-cmd.ts
@@ -1,3 +1,7 @@
+// TODO(michaeldelago) evaluate if this file/procedure is necessary
+// Using Deno to run shell commands just increases complexity and adds another
+// dependency for no real benefit
+
 import { Command } from "https://cdn.deno.land/cmd/versions/v1.2.0/raw/mod.ts";
 import * as ink from "https://deno.land/x/ink/mod.ts";
 import {
@@ -39,9 +43,11 @@ shellCommandFactory(
   "build",
   "Build the authserver and worldserver",
   [
+    // TODO(michaeldelago) evaluate three-step process for the standard build
+    // process
     "docker compose --profile local --profile dev --profile dev-build build --parallel",
     "docker image prune -f",
-    "docker compose run --rm --no-deps ac-dev-build bash apps/docker/docker-build-dev.sh",
+    "docker compose run --rm --no-deps ac-dev-build /bin/bash apps/docker/docker-build-dev.sh",
   ],
   env
 );

--- a/deps/acore/bash-lib/src/event/hooks.sh
+++ b/deps/acore/bash-lib/src/event/hooks.sh
@@ -1,7 +1,12 @@
+# This function uses Associative arrays (maps) in order to specify a type like
+# this:
+#   hook_name => list(function)
+# each hook is executed when runHooks NAME is called.
+#
 # par 1: hook_name
 function acore_event_runHooks() {
   hook_name="HOOKS_MAP_$1"
-  read -r -a SRCS <<< ${!hook_name}
+  read -r -a SRCS <<< ${!hook_name:-}
   echo "Running hooks: $hook_name"
   for i in "${SRCS[@]}"
   do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,7 +178,6 @@ services:
     tty: true
     cap_add:
       - SYS_NICE  # CAP_SYS_NICE
-    command: ./acore.sh run-worldserver
     image: acore/ac-wotlk-worldserver-local:${DOCKER_IMAGE_TAG:-master} # name of the generated image after built locally
     restart: unless-stopped
     env_file:
@@ -213,7 +212,6 @@ services:
   ac-authserver:
     <<: *ac-service-conf # merge with ac-service-conf
     tty: true
-    command: ./acore.sh run-authserver
     image: acore/ac-wotlk-authserver-local:${DOCKER_IMAGE_TAG:-master} # name of the generated image after built locally
     restart: unless-stopped
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,6 +172,21 @@ services:
 #
 #=======================
 
+  ac-client-data:
+    image: acore/ac-wotlk-client-data:${DOCKER_IMAGE_TAG:-master} # name of the generated image after built locally
+    user: ${DOCKER_USER:-root}
+    build:
+      target: client-data
+      <<: *build-params
+      args:
+        USER_ID: ${DOCKER_USER_ID:-1000}
+        GROUP_ID: ${DOCKER_GROUP_ID:-1000}
+        DOCKER_USER: ${DOCKER_USER:-acore}
+        # BUILDKIT_INLINE_CACHE: 1
+    volumes:
+      - ${DOCKER_VOL_CLIENT_DATA_PROD:-ac-client-data-prod}:/azerothcore/env/dist/data
+    profiles: [local, app, worldserver, clientdata]
+
   ac-worldserver:
     <<: *ac-service-conf # merge with ac-service-conf
     stdin_open: true
@@ -190,23 +205,21 @@ services:
     ports:
       - ${DOCKER_WORLD_EXTERNAL_PORT:-8085}:8085
       - ${DOCKER_SOAP_EXTERNAL_PORT:-7878}:7878
+    volumes_from:
+      - ac-client-data:ro
     volumes:
       # read-only binaries compiled by ac-dev-server
       - ${DOCKER_VOL_BIN:-ac-bin-dev}:/azerothcore/env/dist/bin:ro
       - ${DOCKER_VOL_ETC:-./env/docker/etc}:/azerothcore/env/dist/etc
       # [osxfs optimization]: https://stackoverflow.com/a/63437557/1964544
       - ${DOCKER_VOL_LOGS:-./env/docker/logs}:/azerothcore/env/dist/logs:delegated
-      # client data
-      - ${DOCKER_VOL_DATA_CAMERAS:-./env/docker/data/Cameras}:/azerothcore/env/dist/data/Cameras
-      - ${DOCKER_VOL_DATA_DBC:-./env/docker/data/dbc}:/azerothcore/env/dist/data/dbc
-      - ${DOCKER_VOL_DATA_MAPS:-./env/docker/data/maps}:/azerothcore/env/dist/data/maps
-      - ${DOCKER_VOL_DATA_VMAPS:-./env/docker/data/vmaps}:/azerothcore/env/dist/data/vmaps
-      - ${DOCKER_VOL_DATA_MMAPS:-./env/docker/data/mmaps}:/azerothcore/env/dist/data/mmaps
     profiles: [local, app, worldserver]
     depends_on:
       ac-database:
         condition: service_healthy
       ac-db-import:
+        condition: service_completed_successfully
+      ac-client-data:
         condition: service_completed_successfully
 
   ac-authserver:
@@ -335,7 +348,7 @@ services:
         DOCKER_USER: ${DOCKER_USER:-acore}
         # BUILDKIT_INLINE_CACHE: 1
     volumes:
-      - ${DOCKER_VOL_CLIENT_DATA_PROD:-ac-client-data-prod}:/azerothcore/env/dist/data:ro
+      - ${DOCKER_VOL_CLIENT_DATA_PROD:-ac-client-data-prod}:/azerothcore/env/dist/data
     profiles: [prod, prod-app, clientdata]
 
   ac-tools:


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

I can be contacted on discord as @mynameismeat. I accept DM's, though I strongly prefer a message in one of the channels. #support-general is probably fine (we can open up a thread), but I defer to Discord Admins to proper topic placement. 

## Changes Proposed:
- Remove deno Dependency from Docker build
  - In the context of docker builds, Deno is called from shell, and then it generates shell commands to run. See [`apps/docker/docker-cmd.ts`](https://github.com/michaeldelago/azerothcore-wotlk/blob/prune-docker-deno/apps/docker/docker-cmd.ts#L28-L33)
  - Deno does not have a build for ARM64 Linux or Windows, meaning that the `acore.sh` script can only be run on MacOS (Apple Silicon)
- `./acore.sh docker client-data` has been moved and replaced with a service which downloads the client data in `docker-compose.yml`
- Minor cleanup in the `Dockerfile`
  - blocks of multiple `RUN` commands of the same command (such as `mkdir` and `chown`) have been moved into one `RUN`
  - use of sudo has been wholly removed


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Resolves https://github.com/azerothcore/azerothcore-wotlk/pull/16882 without using an unofficial/unsupported build of Deno
  - In this PR I suggest that we could vendor the deno install script (before I edited my comment that we probably shouldn't be using an unofficial Deno build)
  - Vendoring further dependencies is probably a bad thing
    - We have to maintain/support it
    - It adds to the noise/bloat of the repo
- `sudo` usage has been reduced
  - it's a relatively common issue noted in discord that permissions of the build outputs are owned to `root`, mostly due to liberal use of `sudo`
  - `sudo` is by no means needed. It's easier and cleaner to remove the dependency
  - Resolving relevant problems isn't a goal of this PR, however it's a start on reducing it
- `servicebase` images have had the libboost packages replaced with their non-development versions
  - This saves a bit of disk space
  - Future state, we should just statically compile these into the worldserver/authserver binaries
- Simplified the client-data use in docker
  - This just needs to download and unzip a file, it doesn't need an acore user or anything of the like. 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Built "dev" containers, they come up and work
- Built "prod" containers, though they do not come up because their section of the `docker-compose.yml` file is broken (in regards to database)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Run `./acore.sh docker build`
3. Run `./acore.sh docker start:app`
4. Prune everything 
  a. `docker-compose --profile app --profile dev --profile prod-app --profile prod down --remove-orphans -v`
5. run `./acore.sh docker prod:build`
7. run `./acore.sh docker prod:up`
  a. This will fail due to a bug in the `docker-compose.yml` file
  b. This is "somewhat" fine, since the prod containers are mainly used exclusively for the `acore-docker` repo, which hosts its' own `docker-compose.yml` file

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- The start-to-finish process of building and running the docker containers with the `acore.sh` dashboard is complex and jumps through many hoops.
  - Though it isn't a goal of this PR, I think in the ideal future state documentation tells users to build and run the containers in ways they're familiar with: the `docker` cli, or an incredibly thin wrapper (ie, a single layer of abstraction) around the `docker` cli 
- In this pull request, I was very liberal with TODO comments to audit/review some of the configs for building the docker containers.
  - I intend to work through these comments in order to improve the docker builds by making them simpler and idiomatic
  - Please let me know if I should remove them in order to adhere to style guides

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
