### PR TITLE
chore(CI): fix `ci-pending.sh` script for linting SQL

### DIFF
--- a/apps/ci/ci-pending.sh
+++ b/apps/ci/ci-pending.sh
@@ -4,16 +4,6 @@ set -e
 echo "Pending SQL check script:"
 echo
 
-# Updates shouldn't contain PROCEDURE or FUNCTION statements
-find data/sql/updates/pending* -name "*.sql" -type f | while read -r file; do
-    if sed "s/'.*'\(.*\)/\1/g" "$file" | grep -q -i -E "(PROCEDURE|FUNCTION)"; then
-        echo "> PROCEDURE check - Failed"
-        exit 1
-    else
-        echo "> PROCEDURE check - OK"
-    fi
-done
-
 # We want to ensure the end of file has a semicolon and doesn't have extra
 # newlines
 find data/sql/updates/pending* -name "*.sql" -type f | while read -r file; do

--- a/apps/ci/ci-pending.sh
+++ b/apps/ci/ci-pending.sh
@@ -17,7 +17,12 @@ done
 # We want to ensure the end of file has a semicolon and doesn't have extra
 # newlines
 find data/sql/updates/pending* -name "*.sql" -type f | while read -r file; do
-    ERR_AT_EOF="$(sed 's/ --[^-'\''"]*$//' "$file" | tr -d '\n ' | tail -c 1)"
+    # The first sed script collapses all strings into an empty string. The
+    # contents of strings aren't necessary for this check and its still valid
+    # sql.
+    #
+    # The second rule removes sql comments.
+    ERR_AT_EOF="$(sed -e "s/'.*'/''/g" -e 's/ --([^-])*$//' "$file" | tr -d '\n ' | tail -c 1)"
     if [[ "$ERR_AT_EOF" != ";"  ]]; then
         echo "Missing Semicolon (;) or multiple newlines at the end of the file."
         exit 1


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- This fixes an issue in the `ci-pending.sh` script, which performs a few checks on incoming SQL changes.
  - If there was a "--" that was supposed to be in a string, the `sed` command would see it as a comment.
  - This PR updates the `sed` command used to remove strings (which may contain "--") and replace them with an empty string

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Addresses issue experienced in review of PR https://github.com/azerothcore/azerothcore-wotlk/pull/16850

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested on the file that was having issues in the PR

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- Download file that was throwing errors 
  - `cd data/sql/updates/pending_db_world`
  - `curl -O curl -O https://raw.githubusercontent.com/azerothcore/azerothcore-wotlk/f258a496a47fbe5d778fe1457b1ffcabe6444889/data/sql/updates/pending_db_world/reaching.sql`
  - `cd - # get back to where you started`

- Test the `ci-pending.sh` script
  - `bash apps/ci/ci-pending.sh`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- Regex in general can start getting shakey and completely unmaintainable 
  - If this continues to be an issue (see Overkill testing), it may be desirable to switch mechanism with which we are linting SQL.
- Overkill testing
  - We should back-test this against PR's where this issue has happened in the past
  - We should back-test this against PR's that _were successful_ in the past

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
