### PR TITLE
fix(DB/Creature): Infected Wildkin uses Infected Wound

### DIFF
--- a/data/sql/updates/pending_db_world/infectedwildkinfix.sql
+++ b/data/sql/updates/pending_db_world/infectedwildkinfix.sql
@@ -3,6 +3,6 @@ SET @ENTRY := 17322;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryOrGuid` = @ENTRY;
 UPDATE `creature_template` SET `AIName` = 'SmartAI', `ScriptName` = '' WHERE `entry` = @ENTRY;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
-(@ENTRY, 0, 0, 0, 0, 0, 100, 0, 10000, 15000, 0, 0, 11, 31282, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Time between 10 - 15 seconds (IC) - Self: Cast spell Infected Wound (31282) on Victim');
+(@ENTRY, 0, 0, 0, 0, 0, 100, 0, 10000, 15000, 0, 0, 11, 31282, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Infected Wildkin - In Combat - Cast \'Infected Wound\'');
 
 

--- a/data/sql/updates/pending_db_world/infectedwildkinfix.sql
+++ b/data/sql/updates/pending_db_world/infectedwildkinfix.sql
@@ -5,5 +5,3 @@ UPDATE `creature_template` SET `AIName` = 'SmartAI', `ScriptName` = '' WHERE `en
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
 (@ENTRY, 0, 0, 0, 0, 0, 100, 0, 10000, 15000, 0, 0, 11, 31282, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Time between 10 - 15 seconds (IC) - Self: Cast spell Infected Wound (31282) on Victim');
 
-
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 17322 AND `SourceId` = 0;

--- a/data/sql/updates/pending_db_world/infectedwildkinfix.sql
+++ b/data/sql/updates/pending_db_world/infectedwildkinfix.sql
@@ -5,3 +5,4 @@ UPDATE `creature_template` SET `AIName` = 'SmartAI', `ScriptName` = '' WHERE `en
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
 (@ENTRY, 0, 0, 0, 0, 0, 100, 0, 10000, 15000, 0, 0, 11, 31282, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Time between 10 - 15 seconds (IC) - Self: Cast spell Infected Wound (31282) on Victim');
 
+

--- a/data/sql/updates/pending_db_world/infectedwildkinfix.sql
+++ b/data/sql/updates/pending_db_world/infectedwildkinfix.sql
@@ -3,7 +3,7 @@ SET @ENTRY := 17322;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryOrGuid` = @ENTRY;
 UPDATE `creature_template` SET `AIName` = 'SmartAI', `ScriptName` = '' WHERE `entry` = @ENTRY;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
-(@ENTRY, 0, 0, 0, 0, 0, 100, 0, 10000, 15000, 0, 0, 11, 31282, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Time between 10 - 15 seconds (IC) - Self: Cast spell Infected Wound (31282) with flags aura not present on Victim');
+(@ENTRY, 0, 0, 0, 0, 0, 100, 0, 10000, 15000, 0, 0, 11, 31282, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Time between 10 - 15 seconds (IC) - Self: Cast spell Infected Wound (31282) on Victim');
 
 
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 17322 AND `SourceId` = 0;

--- a/data/sql/updates/pending_db_world/infectedwildkinfix.sql
+++ b/data/sql/updates/pending_db_world/infectedwildkinfix.sql
@@ -1,0 +1,9 @@
+ -- Infected Wildkin smart ai
+SET @ENTRY := 17322;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryOrGuid` = @ENTRY;
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `ScriptName` = '' WHERE `entry` = @ENTRY;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+(@ENTRY, 0, 0, 0, 0, 0, 100, 0, 10000, 15000, 0, 0, 11, 31282, 32, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Time between 10 - 15 seconds (IC) - Self: Cast spell Infected Wound (31282) with flags aura not present on Victim');
+
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 17322 AND `SourceId` = 0;


### PR DESCRIPTION
## Changes Proposed:
Creature uses Infected Wound.

## Issues Addressed:
Infected Wildkin uses Infected Wound on target.
[Video](https://www.youtube.com/watch?v=nAx98HkQUqw&feature=youtu.be&ab_channel=Roddan)
Closes: https://github.com/azerothcore/azerothcore-wotlk/issues/16897

## SOURCE:
Retail & Youtube & Sniff.

## Tests Performed:
Teleport to Bloodmyst Isle and attack it.


## How to Test the Changes:
1. Teleport to Bloodmyst Isle or Spawn the NPC.

## Known Issues and TODO List:
None so far.
