### PR TITLE
fix(DB/Creature): Royal Blue Flutterer uses Rake

### DIFF
--- a/data/sql/updates/pending_db_world/RoyalBlueFluttererFix.sql
+++ b/data/sql/updates/pending_db_world/RoyalBlueFluttererFix.sql
@@ -1,0 +1,9 @@
+ -- Royal Blue Flutterer smart ai
+SET @ENTRY := 17350;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryOrGuid` = @ENTRY;
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `ScriptName` = '' WHERE `entry` = @ENTRY;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+(@ENTRY, 0, 0, 0, 0, 0, 100, 0, 9500, 12000, 12000, 13000, 11, 36332, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Every 12 - 13 seconds (9.5 - 12s initially) (IC) - Self: Cast spell Rake (36332) on Victim');
+
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 17350 AND `SourceId` = 0;


### PR DESCRIPTION
## Changes Proposed:
Creature uses Rake.

## Issues Addressed:
Royal Blue Flutterer uses Rake on target.
[Video](https://www.youtube.com/watch?v=pf19I10Jf-o&ab_channel=Roddan)
Closes: https://github.com/azerothcore/azerothcore-wotlk/issues/16896

## SOURCE:
Retail & Youtube & Sniff.

## Tests Performed:
Teleport to Bloodmyst Isle and attack it.


## How to Test the Changes:
1. Teleport to Bloodmyst Isle or Spawn the NPC.

## Known Issues and TODO List:
None so far.
