### PR TITLE
fix(DB/Text): creature_text cleanup

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1691367589804532144.sql
+++ b/data/sql/updates/pending_db_world/rev_1691367589804532144.sql
@@ -1,2 +1,1 @@
-DELETE FROM `creature_text` WHERE `TEXT`='Behold the might of the Alliance! The dread lady, Onyxia, hangs from the arches! Let the rallying cry of the dragon slayer lift your spirits!' AND `CreatureID` = 14394;
-DELETE FROM `creature_text` WHERE `TEXT`='Citizens and allies of Stormwind, on this day, history has been made. $n has laid waste to that which had attempted to usurp the rule of the kingdom. Gather round and join me in honoring our heroes.' AND `CreatureID` = 14394;
+DELETE FROM `creature_text` WHERE (`BroadcastTextId`, `CreatureID`) IN ((9496, 14394), (9495, 14394));

--- a/data/sql/updates/pending_db_world/rev_1691367589804532144.sql
+++ b/data/sql/updates/pending_db_world/rev_1691367589804532144.sql
@@ -1,0 +1,2 @@
+DELETE FROM `creature_text` WHERE `TEXT`='Behold the might of the Alliance! The dread lady, Onyxia, hangs from the arches! Let the rallying cry of the dragon slayer lift your spirits!' AND `CreatureID` = 14394;
+DELETE FROM `creature_text` WHERE `TEXT`='Citizens and allies of Stormwind, on this day, history has been made. $n has laid waste to that which had attempted to usurp the rule of the kingdom. Gather round and join me in honoring our heroes.' AND `CreatureID` = 14394;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Deletes 2 unnecessary rows of text that aren't used anywhere in the game, and was removed in patch 3.2.2 
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://wowpedia.fandom.com/wiki/Celebrating_Good_Times

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
