### PR TITLE
fix(DB/SAI): Hellfire Warder should not overlap rain of fire

### DIFF
--- a/data/sql/updates/pending_db_world/hellfirewarder.sql
+++ b/data/sql/updates/pending_db_world/hellfirewarder.sql
@@ -1,4 +1,0 @@
---
-DELETE FROM `smart_scripts` WHERE (`entryorguid` = 18829) AND (`source_type` = 0) AND (`id` IN (2));
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(18829, 0, 2, 0, 0, 0, 100, 0, 8200, 8800, 12150, 19450, 0, 11, 34435, 32, 0, 1, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 'Hellfire Warder - In Combat - Cast \'Rain of Fire\'');

--- a/data/sql/updates/pending_db_world/hellfirewarder.sql
+++ b/data/sql/updates/pending_db_world/hellfirewarder.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 18829) AND (`source_type` = 0) AND (`id` IN (2));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(18829, 0, 2, 0, 0, 0, 100, 0, 8200, 8800, 12150, 19450, 0, 11, 34435, 32, 0, 1, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 'Hellfire Warder - In Combat - Cast \'Rain of Fire\'');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  only cast if target has no aura from spell flag

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/6012

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->



## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->



<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
