### PR TITLE
fix(CORE/Creature): replace hardcoded gossips in zone_orgrimmar

### DIFF
--- a/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
+++ b/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
@@ -172,17 +172,17 @@ public:
     {
         ClearGossipMenuFor(player);
 
-        uint32 discussionOrder = action - GOSSIP_ACTION_INFO_DEF;
+        uint32 DiscussionOrder = action - GOSSIP_ACTION_INFO_DEF;
 
-        if (discussionOrder>= 1 && discussionOrder <= 6)
+        if (DiscussionOrder>= 1 && DiscussionOrder <= 6)
         {
-            uint32 nextAction = GOSSIP_ACTION_INFO_DEF + discussionOrder + 1;
-            uint32 gossipResponse = GOSSIP_RESPONSE_THRALL_FIRST + discussionOrder - 1;
+            uint32 NextAction = GOSSIP_ACTION_INFO_DEF + DiscussionOrder + 1;
+            uint32 GossipResponse = GOSSIP_RESPONSE_THRALL_FIRST + DiscussionOrder - 1;
 
-            AddGossipItemFor(player, GOSSIP_MENU_THRALL + discussionOrder, GOSSIP_OPTION_DEFAULT, GOSSIP_SENDER_MAIN, nextAction);
-            SendGossipMenuFor(player, gossipResponse, creature->GetGUID());
+            AddGossipItemFor(player, GOSSIP_MENU_THRALL + DiscussionOrder, GOSSIP_OPTION_DEFAULT, GOSSIP_SENDER_MAIN, NextAction);
+            SendGossipMenuFor(player, GossipResponse, creature->GetGUID());
         }
-        else if (discussionOrder == 7)
+        else if (DiscussionOrder == 7)
         {
             CloseGossipMenuFor(player);
             player->AreaExploredOrEventHappens(QUEST_WHAT_THE_WIND_CARRIES);

--- a/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
+++ b/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
@@ -37,7 +37,7 @@ EndContentData */
 ## npc_shenthul
 ######*/
 
-enum Shenthul
+enum Shenthul : uint32
 {
     QUEST_SHATTERED_SALUTE  = 2460
 };
@@ -134,7 +134,7 @@ public:
 ## npc_thrall_warchief
 ######*/
 
-enum ThrallWarchief
+enum ThrallWarchief : uint32
 {
     SPELL_CHAIN_LIGHTNING          = 16033,
     SPELL_SHOCK                    = 16034,
@@ -160,7 +160,6 @@ enum ThrallWarchief
 
 const Position heraldOfThrallPos = { -462.404f, -2637.68f, 96.0656f, 5.8606f };
 
-
 /// @todo verify abilities/timers
 class npc_thrall_warchief : public CreatureScript
 {
@@ -173,33 +172,47 @@ public:
         switch (action)
         {
             case GOSSIP_ACTION_INFO_DEF+1:
+            {
                 AddGossipItemFor(player, GOSSIP_WTWC + 1, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
                 SendGossipMenuFor(player, 5733, creature->GetGUID());
                 break;
+            }
             case GOSSIP_ACTION_INFO_DEF+2:
+            {
                 AddGossipItemFor(player, GOSSIP_WTWC + 2, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 3);
                 SendGossipMenuFor(player, 5734, creature->GetGUID());
                 break;
+            }
             case GOSSIP_ACTION_INFO_DEF+3:
+            {
                 AddGossipItemFor(player, GOSSIP_WTWC + 3, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 4);
                 SendGossipMenuFor(player, 5735, creature->GetGUID());
                 break;
+            }
             case GOSSIP_ACTION_INFO_DEF+4:
+            {
                 AddGossipItemFor(player, GOSSIP_WTWC + 4, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 5);
                 SendGossipMenuFor(player, 5736, creature->GetGUID());
                 break;
+            }
             case GOSSIP_ACTION_INFO_DEF+5:
+            {
                 AddGossipItemFor(player, GOSSIP_WTWC + 5, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 6);
                 SendGossipMenuFor(player, 5737, creature->GetGUID());
                 break;
+            }
             case GOSSIP_ACTION_INFO_DEF+6:
+            {
                 AddGossipItemFor(player, GOSSIP_WTWC + 6, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 7);
                 SendGossipMenuFor(player, 5738, creature->GetGUID());
                 break;
+            }
             case GOSSIP_ACTION_INFO_DEF+7:
+            {
                 CloseGossipMenuFor(player);
                 player->AreaExploredOrEventHappens(QUEST_WHAT_THE_WIND_CARRIES);
                 break;
+            }
         }
         return true;
     }
@@ -207,10 +220,14 @@ public:
     bool OnGossipHello(Player* player, Creature* creature) override
     {
         if (creature->IsQuestGiver())
+        {
             player->PrepareQuestMenu(creature->GetGUID());
+        }
 
         if (player->GetQuestStatus(QUEST_WHAT_THE_WIND_CARRIES) == QUEST_STATUS_INCOMPLETE)
+        {
             AddGossipItemFor(player, GOSSIP_WTWC, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
+        }
 
         SendGossipMenuFor(player, player->GetGossipTextId(creature), creature->GetGUID());
         return true;

--- a/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
+++ b/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
@@ -155,7 +155,9 @@ enum ThrallWarchief : uint32
 
     // What the Wind Carries (ID: 6566)
     QUEST_WHAT_THE_WIND_CARRIES     = 6566,
-    GOSSIP_WTWC                     = 3664
+    GOSSIP_MENU_THRALL              = 3664,
+    GOSSIP_RESPONSE_THRALL_FIRST    = 5733,
+    GOSSIP_OPTION_DEFAULT           = 0
 };
 
 const Position heraldOfThrallPos = { -462.404f, -2637.68f, 96.0656f, 5.8606f };
@@ -169,51 +171,23 @@ public:
     bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action) override
     {
         ClearGossipMenuFor(player);
-        switch (action)
+
+        uint32 discussionOrder = action - GOSSIP_ACTION_INFO_DEF;
+
+        if (discussionOrder>= 1 && discussionOrder <= 6)
         {
-            case GOSSIP_ACTION_INFO_DEF+1:
-            {
-                AddGossipItemFor(player, GOSSIP_WTWC + 1, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
-                SendGossipMenuFor(player, 5733, creature->GetGUID());
-                break;
-            }
-            case GOSSIP_ACTION_INFO_DEF+2:
-            {
-                AddGossipItemFor(player, GOSSIP_WTWC + 2, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 3);
-                SendGossipMenuFor(player, 5734, creature->GetGUID());
-                break;
-            }
-            case GOSSIP_ACTION_INFO_DEF+3:
-            {
-                AddGossipItemFor(player, GOSSIP_WTWC + 3, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 4);
-                SendGossipMenuFor(player, 5735, creature->GetGUID());
-                break;
-            }
-            case GOSSIP_ACTION_INFO_DEF+4:
-            {
-                AddGossipItemFor(player, GOSSIP_WTWC + 4, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 5);
-                SendGossipMenuFor(player, 5736, creature->GetGUID());
-                break;
-            }
-            case GOSSIP_ACTION_INFO_DEF+5:
-            {
-                AddGossipItemFor(player, GOSSIP_WTWC + 5, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 6);
-                SendGossipMenuFor(player, 5737, creature->GetGUID());
-                break;
-            }
-            case GOSSIP_ACTION_INFO_DEF+6:
-            {
-                AddGossipItemFor(player, GOSSIP_WTWC + 6, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 7);
-                SendGossipMenuFor(player, 5738, creature->GetGUID());
-                break;
-            }
-            case GOSSIP_ACTION_INFO_DEF+7:
-            {
-                CloseGossipMenuFor(player);
-                player->AreaExploredOrEventHappens(QUEST_WHAT_THE_WIND_CARRIES);
-                break;
-            }
+            uint32 nextAction = GOSSIP_ACTION_INFO_DEF + discussionOrder + 1;
+            uint32 gossipResponse = GOSSIP_RESPONSE_THRALL_FIRST + discussionOrder - 1;
+
+            AddGossipItemFor(player, GOSSIP_MENU_THRALL + discussionOrder, GOSSIP_OPTION_DEFAULT, GOSSIP_SENDER_MAIN, nextAction);
+            SendGossipMenuFor(player, gossipResponse, creature->GetGUID());
         }
+        else if (discussionOrder == 7)
+        {
+            CloseGossipMenuFor(player);
+            player->AreaExploredOrEventHappens(QUEST_WHAT_THE_WIND_CARRIES);
+        }
+
         return true;
     }
 
@@ -226,7 +200,7 @@ public:
 
         if (player->GetQuestStatus(QUEST_WHAT_THE_WIND_CARRIES) == QUEST_STATUS_INCOMPLETE)
         {
-            AddGossipItemFor(player, GOSSIP_WTWC, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
+            AddGossipItemFor(player, GOSSIP_MENU_THRALL, GOSSIP_OPTION_DEFAULT, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
         }
 
         SendGossipMenuFor(player, player->GetGossipTextId(creature), creature->GetGUID());

--- a/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
+++ b/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
@@ -136,8 +136,6 @@ public:
 
 enum ThrallWarchief
 {
-    QUEST_6566                     = 6566,
-
     SPELL_CHAIN_LIGHTNING          = 16033,
     SPELL_SHOCK                    = 16034,
 
@@ -153,18 +151,15 @@ enum ThrallWarchief
     AREA_ORGRIMMAR                 = 1637,
     AREA_RAZOR_HILL                = 362,
     AREA_CAMP_TAURAJO              = 378,
-    AREA_CROSSROADS                = 380
+    AREA_CROSSROADS                = 380,
+
+    // What the Wind Carries (ID: 6566)
+    QUEST_WHAT_THE_WIND_CARRIES     = 6566,
+    GOSSIP_WTWC                     = 3664
 };
 
 const Position heraldOfThrallPos = { -462.404f, -2637.68f, 96.0656f, 5.8606f };
 
-#define GOSSIP_HTW "Please share your wisdom with me, Warchief."
-#define GOSSIP_STW1 "What discoveries?"
-#define GOSSIP_STW2 "Usurper?"
-#define GOSSIP_STW3 "With all due respect, Warchief - why not allow them to be destroyed? Does this not strengthen our position?"
-#define GOSSIP_STW4 "I... I did not think of it that way, Warchief."
-#define GOSSIP_STW5 "I live only to serve, Warchief! My life is empty and meaningless without your guidance."
-#define GOSSIP_STW6 "Of course, Warchief!"
 
 /// @todo verify abilities/timers
 class npc_thrall_warchief : public CreatureScript
@@ -178,32 +173,32 @@ public:
         switch (action)
         {
             case GOSSIP_ACTION_INFO_DEF+1:
-                AddGossipItemFor(player, GOSSIP_ICON_CHAT, GOSSIP_STW1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
+                AddGossipItemFor(player, GOSSIP_WTWC + 1, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
                 SendGossipMenuFor(player, 5733, creature->GetGUID());
                 break;
             case GOSSIP_ACTION_INFO_DEF+2:
-                AddGossipItemFor(player, GOSSIP_ICON_CHAT, GOSSIP_STW2, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 3);
+                AddGossipItemFor(player, GOSSIP_WTWC + 2, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 3);
                 SendGossipMenuFor(player, 5734, creature->GetGUID());
                 break;
             case GOSSIP_ACTION_INFO_DEF+3:
-                AddGossipItemFor(player, GOSSIP_ICON_CHAT, GOSSIP_STW3, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 4);
+                AddGossipItemFor(player, GOSSIP_WTWC + 3, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 4);
                 SendGossipMenuFor(player, 5735, creature->GetGUID());
                 break;
             case GOSSIP_ACTION_INFO_DEF+4:
-                AddGossipItemFor(player, GOSSIP_ICON_CHAT, GOSSIP_STW4, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 5);
+                AddGossipItemFor(player, GOSSIP_WTWC + 4, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 5);
                 SendGossipMenuFor(player, 5736, creature->GetGUID());
                 break;
             case GOSSIP_ACTION_INFO_DEF+5:
-                AddGossipItemFor(player, GOSSIP_ICON_CHAT, GOSSIP_STW5, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 6);
+                AddGossipItemFor(player, GOSSIP_WTWC + 5, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 6);
                 SendGossipMenuFor(player, 5737, creature->GetGUID());
                 break;
             case GOSSIP_ACTION_INFO_DEF+6:
-                AddGossipItemFor(player, GOSSIP_ICON_CHAT, GOSSIP_STW6, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 7);
+                AddGossipItemFor(player, GOSSIP_WTWC + 6, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 7);
                 SendGossipMenuFor(player, 5738, creature->GetGUID());
                 break;
             case GOSSIP_ACTION_INFO_DEF+7:
                 CloseGossipMenuFor(player);
-                player->AreaExploredOrEventHappens(QUEST_6566);
+                player->AreaExploredOrEventHappens(QUEST_WHAT_THE_WIND_CARRIES);
                 break;
         }
         return true;
@@ -214,8 +209,8 @@ public:
         if (creature->IsQuestGiver())
             player->PrepareQuestMenu(creature->GetGUID());
 
-        if (player->GetQuestStatus(QUEST_6566) == QUEST_STATUS_INCOMPLETE)
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, GOSSIP_HTW, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
+        if (player->GetQuestStatus(QUEST_WHAT_THE_WIND_CARRIES) == QUEST_STATUS_INCOMPLETE)
+            AddGossipItemFor(player, GOSSIP_WTWC, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
 
         SendGossipMenuFor(player, player->GetGossipTextId(creature), creature->GetGUID());
         return true;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Replace hardcoded gossips for db references.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4179

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Gone through gossip with 6566 quest as male and female character.
- Checked if gossips are not available without 6566 quest.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. `.go xyz 1920 -4125 43`
2. `.quest add 6566`
3. go through gossips
Gossips looks like: (adashiel comment)
https://www.wowhead.com/wotlk/quest=6566/what-the-wind-carries

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
