### PR TITLE
fix(Core/Pets): Hunter pet scaling

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -2480,34 +2480,34 @@ Player* Pet::GetOwner() const
 
 float Pet::GetNativeObjectScale() const
 {
-    CreatureFamilyEntry const* creatureFamily = sCreatureFamilyStore.LookupEntry(GetCreatureTemplate()->family);
+    uint8 ctFamily = GetCreatureTemplate()->family;
+
+    // hackfix: Edge case where DBC scale values for DEVILSAUR pets make them too small.
+    // Therefore we take data from spirit beast instead.
+    if (ctFamily && ctFamily == CREATURE_FAMILY_DEVILSAUR)
+        ctFamily = CREATURE_FAMILY_SPIRIT_BEAST;
+
+    CreatureFamilyEntry const* creatureFamily = sCreatureFamilyStore.LookupEntry(ctFamily);
     if (creatureFamily && creatureFamily->minScale > 0.0f && getPetType() == HUNTER_PET)
     {
-        float scale;
-        if (GetLevel() >= creatureFamily->maxScaleLevel)
-            scale = creatureFamily->maxScale;
-        else if (GetLevel() <= creatureFamily->minScaleLevel)
-            scale = creatureFamily->minScale;
-        else
-            scale = creatureFamily->minScale + float(GetLevel() - creatureFamily->minScaleLevel) / creatureFamily->maxScaleLevel * (creatureFamily->maxScale - creatureFamily->minScale);
+        float minScaleLevel = creatureFamily->minScaleLevel;
+        uint8 level = getLevel();
 
-        if (CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(GetNativeDisplayId()))
-        {
-            if (displayInfo->scale > 1.f && GetCreatureTemplate()->IsExotic())
-            {
-                // Exotic pets have a scale of 1
-                scale = 1.0f;
-            }
-            else
-            {
-                scale *= displayInfo->scale;
-            }
-        }
+        float minLevelScaleMod = level >= minScaleLevel ? (level / minScaleLevel) : 0.0f;
+        float maxScaleMod = creatureFamily->maxScaleLevel - minScaleLevel;
+
+        if (minLevelScaleMod > maxScaleMod)
+            minLevelScaleMod = maxScaleMod;
+
+        float scaleMod = creatureFamily->maxScaleLevel != minScaleLevel ? scaleMod = minLevelScaleMod / maxScaleMod : 0.f;
+
+        float scale = (creatureFamily->maxScale - creatureFamily->minScale) * scaleMod + creatureFamily->minScale;
 
         return scale;
     }
-    // Fallback value if the conditions are not met
-    return 1.0f;
+
+    // take value for non-hunter pets from DB
+    return Guardian::GetNativeObjectScale();
 }
 
 std::string Pet::GenerateActionBarData() const

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -2488,7 +2488,7 @@ float Pet::GetNativeObjectScale() const
         ctFamily = CREATURE_FAMILY_SPIRIT_BEAST;
 
     CreatureFamilyEntry const* creatureFamily = sCreatureFamilyStore.LookupEntry(ctFamily);
-    if (creatureFamily && creatureFamily->minScale > 0.0f && getPetType() == HUNTER_PET)
+    if (creatureFamily && creatureFamily->minScale > 0.0f && getPetType() & HUNTER_PET)
     {
         float minScaleLevel = creatureFamily->minScaleLevel;
         uint8 level = getLevel();
@@ -2499,7 +2499,7 @@ float Pet::GetNativeObjectScale() const
         if (minLevelScaleMod > maxScaleMod)
             minLevelScaleMod = maxScaleMod;
 
-        float scaleMod = creatureFamily->maxScaleLevel != minScaleLevel ? scaleMod = minLevelScaleMod / maxScaleMod : 0.f;
+        float scaleMod = creatureFamily->maxScaleLevel != minScaleLevel ? minLevelScaleMod / maxScaleMod : 0.f;
 
         float scale = (creatureFamily->maxScale - creatureFamily->minScale) * scaleMod + creatureFamily->minScale;
 


### PR DESCRIPTION


<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
* Fix pet scaling to properly take DBC data
* Restore old removed base scale for guardians
* Edge case for Devilsaur where the DBC data is whack, therefore we use Spirit Beast data instead. Yes I know, hackfix, but I cant for the life of me find any other scaling in dbc that would fix this issue
* updated scale calculation based on client function (https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/f09564b9d01ff372506f76f2345b99e3485738d5)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/6017

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Check scaling for pets
2. Check scaling for devilsaur

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
