### PR TITLE
fix(Tools/dbimport): Add Env var support to DBimport tool

### DIFF
--- a/src/tools/dbimport/Main.cpp
+++ b/src/tools/dbimport/Main.cpp
@@ -62,6 +62,8 @@ int main(int argc, char** argv)
     if (!sConfigMgr->LoadAppConfigs())
         return 1;
 
+    std::vector<std::string> overriddenKeys = sConfigMgr->OverrideWithEnvVariablesIfAny();
+
     // Init logging
     sLog->Initialize();
 
@@ -77,6 +79,9 @@ int main(int argc, char** argv)
             LOG_INFO("dbimport", "> Using Boost version:            {}.{}.{}", BOOST_VERSION / 100000, BOOST_VERSION / 100 % 1000, BOOST_VERSION % 100);
         }
     );
+
+    for (std::string const& key : overriddenKeys)
+        LOG_INFO("dbimport", "Configuration field {} was overridden with environment variable.", key);
 
     OpenSSLCrypto::threadsSetup();
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
- Fixes DBImport to allow it to pull configuration from the environment
  - https://github.com/azerothcore/azerothcore-wotlk/pull/16817 was merged but it only added env var support for the authserver and worldserver
  - This PR extends this functionality to the dbimport tool
  - primarily, this is useful for docker
  - env var configs (partially) nullify https://github.com/azerothcore/azerothcore-wotlk/pull/16806, which I opened up in order to simplify the few config changes that docker needs

If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address.

## Issues Addressed:
- No issues exist for this.
- Setting up docker with env vars is (slightly) pointless at the moment, since the dbimport is a necessary step
  - It's typically better to handle DB migrations _outside_ of application runtime

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- build and start with env vars


## How to Test the Changes:
1. configure ./docker-compose.yaml to use env vars for dbimport

```diff
diff --git a/docker-compose.yml b/docker-compose.yml
index 16c515e33..3862fcf94 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,10 @@ services:
     <<: *ac-shared-conf
     image: acore/ac-wotlk-worldserver-local:${DOCKER_IMAGE_TAG:-master} # name of the generated image after built locally
     command: ./env/dist/bin/dbimport
+    environment:
+      AC_LOGIN_DATABASE_INFO: "ac-database;3306;root;password;acore_auth"
+      AC_WORLD_DATABASE_INFO: "ac-database;3306;root;password;acore_world"
+      AC_CHARACTER_DATABASE_INFO: "ac-database;3306;root;password;acore_characters"
     volumes:
       # read-only binaries compiled by ac-dev-server
       - ${DOCKER_VOL_BIN:-ac-bin-dev}:/azerothcore/env/dist/bin:ro
```

2. build docker containers (`./acore.sh docker build`)
3. start containers (`./acore.sh docker start:app`)
  a. The worldserver and authserver will fail, but contextually that doesn't matter; this PR is only for the db import

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- This should be rolled out into the docker-compose file in general

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
