### PR TITLE
Fix(DB): Quest-ID: 8353-8355-8356-8357-8311-Conditions

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1692366711663255300.sql
+++ b/data/sql/updates/pending_db_world/rev_1692366711663255300.sql
@@ -1,4 +1,4 @@
---Table Condition: Fix Quests: 8353 - 8355 - 8356 - 8357 - 8311
+-- Table Condition: Fix Quests: 8353 - 8355 - 8356 - 8357 - 8311 --
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8353) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
 
@@ -10,20 +10,20 @@ DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGrou
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8311) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(19, 0, 8311, 0, 0, 12, 0, 12, 0, 0, 0, 0, 0, '', NULL);
+(19, 0, 8311, 0, 0, 12, 0, 12, 0, 0, 0, 0, 0, 'Set the Quest available during the Hallows End event', NULL);
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8356) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(19, 0, 8356, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', NULL);
+(19, 0, 8356, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, 'Prevents quest from being available after completing quest Hallows End Treats for Jespers', NULL);
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8355) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(19, 0, 8355, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', NULL);
+(19, 0, 8355, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, 'Prevents quest from being available after completing quest Hallows End Treats for Jespers', NULL);
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8353) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(19, 0, 8353, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', NULL);
+(19, 0, 8353, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, 'Prevents quest from being available after completing quest Hallows End Treats for Jespers', NULL);
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8357) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(19, 0, 8357, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', NULL);
+(19, 0, 8357, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, 'Prevents quest from being available after completing quest Hallows End Treats for Jespers', NULL);

--- a/data/sql/updates/pending_db_world/rev_1692366711663255300.sql
+++ b/data/sql/updates/pending_db_world/rev_1692366711663255300.sql
@@ -1,4 +1,4 @@
--- Table Condition: Fix Quests: 8353 - 8355 - 8356 - 8357 - 8311 --
+-- Table Condition - Fix Quests - 8353 - 8355 - 8356 - 8357 - 8311 --
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8353) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
 

--- a/data/sql/updates/pending_db_world/rev_1692366711663255300.sql
+++ b/data/sql/updates/pending_db_world/rev_1692366711663255300.sql
@@ -9,8 +9,7 @@ DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGrou
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8357) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8311) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(19, 0, 8311, 0, 0, 12, 0, 12, 0, 0, 0, 0, 0, 'Set the Quest available during the Hallows End event', NULL);
+
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8356) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1692366711663255300.sql
+++ b/data/sql/updates/pending_db_world/rev_1692366711663255300.sql
@@ -1,0 +1,29 @@
+--Table Condition: Fix Quests: 8353 - 8355 - 8356 - 8357 - 8311
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8353) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8355) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8356) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8357) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8311) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(19, 0, 8311, 0, 0, 12, 0, 12, 0, 0, 0, 0, 0, '', NULL);
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8356) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(19, 0, 8356, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', NULL);
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8355) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(19, 0, 8355, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', NULL);
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8353) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(19, 0, 8353, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', NULL);
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8357) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(19, 0, 8357, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', NULL);

--- a/data/sql/updates/pending_db_world/rev_1692366711663255300.sql
+++ b/data/sql/updates/pending_db_world/rev_1692366711663255300.sql
@@ -13,16 +13,16 @@ DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGrou
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8356) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(19, 0, 8356, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, 'Prevents quest from being available after completing quest Hallows End Treats for Jespers', NULL);
+(19, 0, 8356, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', 'Prevents quest from being available after completing quest Hallows End Treats for Jespers');
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8355) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(19, 0, 8355, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, 'Prevents quest from being available after completing quest Hallows End Treats for Jespers', NULL);
+(19, 0, 8355, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', 'Prevents quest from being available after completing quest Hallows End Treats for Jespers');
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8353) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(19, 0, 8353, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, 'Prevents quest from being available after completing quest Hallows End Treats for Jespers', NULL);
+(19, 0, 8353, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', 'Prevents quest from being available after completing quest Hallows End Treats for Jespers');
 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8357) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(19, 0, 8357, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, 'Prevents quest from being available after completing quest Hallows End Treats for Jespers', NULL);
+(19, 0, 8357, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', 'Prevents quest from being available after completing quest Hallows End Treats for Jespers');

--- a/data/sql/updates/pending_db_world/rev_1692366711663255300.sql
+++ b/data/sql/updates/pending_db_world/rev_1692366711663255300.sql
@@ -1,28 +1,10 @@
 -- Table Condition - Fix Quests - 8353 - 8355 - 8356 - 8357 - 8311 --
 
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8353) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` IN (8353, 8355, 8356, 8357, 8311)) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
 
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8355) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
-
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8356) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
-
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8357) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
-
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8311) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
-
-
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8356) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` IN (8353, 8355, 8356, 8357)) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(19, 0, 8356, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', 'Prevents quest from being available after completing quest Hallows End Treats for Jespers');
-
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8355) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(19, 0, 8355, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', 'Prevents quest from being available after completing quest Hallows End Treats for Jespers');
-
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8353) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(19, 0, 8353, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', 'Prevents quest from being available after completing quest Hallows End Treats for Jespers');
-
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 8357) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 47) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8311) AND (`ConditionValue2` = 64) AND (`ConditionValue3` = 0);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(19, 0, 8356, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', 'Prevents quest from being available after completing quest Hallows End Treats for Jespers'),
+(19, 0, 8355, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', 'Prevents quest from being available after completing quest Hallows End Treats for Jespers'),
+(19, 0, 8353, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', 'Prevents quest from being available after completing quest Hallows End Treats for Jespers'),
 (19, 0, 8357, 0, 0, 47, 0, 8311, 64, 0, 1, 0, 0, '', 'Prevents quest from being available after completing quest Hallows End Treats for Jespers');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

I set the condition that the Sub-Quests:
- [Flexing for Nougat](https://www.wowhead.com/quest=8356/flexing-for-nougat#comments:id=2774071)
- [Incoming Gumdrop](https://www.wowhead.com/quest=8355/incoming-gumdrop)
- [Chicken Clucking for a Mint](https://www.wowhead.com/quest=8353/chicken-clucking-for-a-mint)
- [Dancing for Marzipan](https://www.wowhead.com/quest=8357/dancing-for-marzipan)

They must disappear as soon as Quest **(Main)** - [Hallow's End Treats for Jesper!](https://www.wowhead.com/quest=8311/hallows-end-treats-for-jesper) is completed.


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/4327
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/17030

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.
- [x] Video Test : 
[![Anteprima](https://user-images.githubusercontent.com/1884642/261620185-4cda2168-77ad-4799-a7cb-996fffbb735e.png)](https://www.youtube.com/embed/HGFepl5wRyc)

<img src="https://github.com/chromiecraft/chromiecraft/assets/1884642/ec362c64-7d6c-4139-9c81-34d5903cad10" width="300">


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
