### PR TITLE
fix(Crash): Fix crash on ExitVehicle from Wintergarde Gryphon.

### DIFF
--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -702,7 +702,6 @@ public:
                     }
                 }
 
-            me->RemoveVehicleKit(); // not Crash (;
             events.ScheduleEvent(EVENT_TAKE_OFF, 2s);
             me->CastSpell(passenger, VEHICLE_SPELL_PARACHUTE, true);
         }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

So, the crash occurs within this function:
https://github.com/azerothcore/azerothcore-wotlk/blob/57e0b496bdc13441870f36963020271b6ae3f4fa/src/server/game/Entities/Unit/Unit.cpp#L20014-L20039

The reason for this issue is that the `m_vehicle` object gets deleted after the line mentioned below:
https://github.com/azerothcore/azerothcore-wotlk/blob/57e0b496bdc13441870f36963020271b6ae3f4fa/src/server/game/Entities/Unit/Unit.cpp#L20019

This deletion occurs in the subsequent chain of calls:

[m_vehicle->RemovePassenger(this);](https://github.com/azerothcore/azerothcore-wotlk/blob/57e0b496bdc13441870f36963020271b6ae3f4fa/src/server/game/Entities/Unit/Unit.cpp#L20019) => ... =>  [me->RemoveVehicleKit();](https://github.com/azerothcore/azerothcore-wotlk/blob/57e0b496bdc13441870f36963020271b6ae3f4fa/src/server/scripts/Northrend/zone_dragonblight.cpp#L705) => [delete m_vehicleKit;](https://github.com/azerothcore/azerothcore-wotlk/blob/57e0b496bdc13441870f36963020271b6ae3f4fa/src/server/game/Entities/Unit/Unit.cpp#L18981C5-L18981C25).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/17029
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15474

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
