### PR TITLE
fix(Scripts/Darkshore): ensure Kerlonian Evershade is always in bear form

### DIFF
--- a/data/sql/updates/pending_db_world/remove-aura-from-kerlonian.sql
+++ b/data/sql/updates/pending_db_world/remove-aura-from-kerlonian.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_addon` SET `auras` = '' WHERE `guid` = 39059;

--- a/src/server/scripts/Kalimdor/zone_darkshore.cpp
+++ b/src/server/scripts/Kalimdor/zone_darkshore.cpp
@@ -175,6 +175,7 @@ enum Kerlonian
 
     SPELL_SLEEP_VISUAL          = 25148,
     SPELL_AWAKEN                = 17536,
+    SPELL_BEAR_FORM             = 18309,
     QUEST_SLEEPER_AWAKENED      = 5321,
     NPC_LILADRIS                = 11219                    //attackers entries unknown
 };
@@ -194,6 +195,8 @@ public:
         void Reset() override
         {
             FallAsleepTimer = urand(10000, 45000);
+
+            DoCastSelf(SPELL_BEAR_FORM);
         }
 
         void MoveInLineOfSight(Unit* who) override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

removes permanent aura because this is a spell and not an aura. it has to be cast on reset. as it is already using a script for the quest following, I put it in the reset there

If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13593
- Closes https://github.com/chromiecraft/chromiecraft/issues/4329

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

[this](https://www.youtube.com/watch?v=V_sXobA90f0&ab_channel=Bue) shows that the druid should remain a bear for the entire remainder of the quest

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go creature 39059`
2. look at the cute bear
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

none that I know of

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
