### PR TITLE
fix(docker): ensure conf files always exist

### DIFF
--- a/apps/compiler/includes/functions.sh
+++ b/apps/compiler/includes/functions.sh
@@ -143,6 +143,15 @@ function comp_compile() {
       find "$AC_BINPATH_FULL"  -mindepth 1 -maxdepth 1 -type f -exec sudo chown root:root -- {} +
       find "$AC_BINPATH_FULL"  -mindepth 1 -maxdepth 1 -type f -exec sudo chmod u+s  -- {} +
 
+      if [[ -n "$DOCKER" ]]; then
+          [[ -f "$confDir/worldserver.conf.dist" ]] && \
+              cp -nv "$confDir/worldserver.conf.dist" "$confDir/worldserver.conf"
+          [[ -f "$confDir/authserver.conf.dist" ]] && \
+              cp -nv "$confDir/authserver.conf.dist" "$confDir/authserver.conf"
+          [[ -f "$confDir/dbimport.conf.dist" ]] && \
+              cp -nv "$confDir/dbimport.conf.dist" "$confDir/dbimport.conf"
+      fi
+
       echo "Done"
       ;;
   esac


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [x] `acore.sh` script

This pr restores the functionality during the `./acore.sh docker build` that ensures the appropriate `.conf` files exist. 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- https://github.com/azerothcore/azerothcore-wotlk/issues/17063
- ad-hoc support in Discord
- I'm pretty sure this fixes CI failure in https://github.com/azerothcore/acore-docker/pull/27

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request seems to work fine but I'd appreciate it if someone could confirm 

1. Remove current conf files (or rename them, whatever works), `rm env/dist/etc/*.conf`
3. Run a build, `./acore.sh docker build`
4. Start the containers, everything should come up fine, `./acore.sh docker start:app`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- it might make sense to remove the volume mount to `etc`, and push people to just use env vars for config; it's easier to debug config issues if there's less places to look, and env vars in the `docker-compose.yml` is simpler and more concise than editing the config from the dist. 


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
