### PR TITLE
refactor(Core): Source config more aggressively from env, rephrase a few of the messages

### DIFF
--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -283,7 +283,7 @@ namespace
         return result;
     }
 
-    std::string getEnvVarName(std::string const& configName)
+    std::string GetEnvVarName(std::string const& configName)
     {
         return "AC_" + IniKeyToEnvVarKey(configName);
     }

--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -119,7 +119,7 @@ namespace
             auto const& itr = fileConfigs.find(confOption);
             if (itr != fileConfigs.end())
             {
-                PrintError(file, "> Config::LoadFile: Dublicate key name '{}' in config file '{}'", confOption, file);
+                PrintError(file, "> Config::LoadFile: Duplicate key name '{}' in config file '{}'", confOption, file);
                 return true;
             }
 
@@ -356,28 +356,30 @@ template<class T>
 T ConfigMgr::GetValueDefault(std::string const& name, T const& def, bool showLogs /*= true*/) const
 {
     std::string strValue;
+
     auto const& itr = _configOptions.find(name);
-    if (itr == _configOptions.end())
+    bool notFound = itr == _configOptions.end();
+    Optional<std::string> envVar = EnvVarForIniKey(name);
+    auto envVarName = "AC_" + IniKeyToEnvVarKey(name);
+    if (envVar)
     {
-        Optional<std::string> envVar = EnvVarForIniKey(name);
-        if (!envVar)
+        // If showLogs and this key/value pair wasn't found in the currently saved config
+        if (showLogs && (notFound || itr->second != envVar->c_str()))
         {
-            if (showLogs)
-            {
-                LOG_ERROR("server.loading", "> Config: Missing property {} in config file {}, add \"{} = {}\" to this file.",
-                    name, _filename, name, Acore::ToString(def));
-            }
-
-            return def;
-        }
-
-        if (showLogs)
-        {
-            LOG_WARN("server.loading", "Missing property {} in config file {}, recovered with environment '{}' value.",
-                name, _filename, envVar->c_str());
+            LOG_INFO("server.loading", "> Config: Found config value '{}' from environment variable '{}'.", name, envVarName );
+            AddKey(name, envVar->c_str(), "ENVIRONMENT", false, false);
         }
 
         strValue = *envVar;
+    }
+    else if (notFound)
+    {
+        if (showLogs)
+        {
+            LOG_ERROR("server.loading", "> Config: Missing property {} in config file {}, add \"{} = {}\" to this file or define '{}' as an environment variable.",
+                    name, _filename, name, Acore::ToString(def), envVarName);
+        }
+        return def;
     }
     else
     {
@@ -403,24 +405,26 @@ template<>
 std::string ConfigMgr::GetValueDefault<std::string>(std::string const& name, std::string const& def, bool showLogs /*= true*/) const
 {
     auto const& itr = _configOptions.find(name);
-    if (itr == _configOptions.end())
+    bool notFound = itr == _configOptions.end();
+    Optional<std::string> envVar = EnvVarForIniKey(name);
+    auto envVarName = "AC_" + IniKeyToEnvVarKey(name);
+    if (envVar)
     {
-        Optional<std::string> envVar = EnvVarForIniKey(name);
-        if (envVar)
+        // If showLogs and this key/value pair wasn't found in the currently saved config
+        if (showLogs && (notFound || itr->second != envVar->c_str()))
         {
-            if (showLogs)
-            {
-                LOG_WARN("server.loading", "Missing property {} in config file {}, recovered with environment '{}' value.",
-                    name, _filename, envVar->c_str());
-            }
-
-            return *envVar;
+            LOG_INFO("server.loading", "> Config: Found config value '{}' from environment variable '{}'.", name, envVarName);
+            AddKey(name, *envVar, "ENVIRONMENT", false, false);
         }
 
+        return *envVar;
+    }
+    else if (notFound)
+    {
         if (showLogs)
         {
-            LOG_ERROR("server.loading", "> Config: Missing property {} in config file {}, add \"{} = {}\" to this file.",
-                name, _filename, name, def);
+            LOG_ERROR("server.loading", "> Config: Missing property {} in config file {}, add \"{} = {}\" to this file or define '{}' as an environment variable.",
+                    name, _filename, name, def, envVarName);
         }
 
         return def;

--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -290,7 +290,7 @@ namespace
 
     Optional<std::string> EnvVarForIniKey(std::string const& key)
     {
-        std::string envKey = getEnvVarName(key);
+        std::string envKey = GetEnvVarName(key);
         char* val = std::getenv(envKey.c_str());
         if (!val)
             return std::nullopt;
@@ -388,8 +388,8 @@ T ConfigMgr::GetValueDefault(std::string const& name, T const& def, bool showLog
 
     auto const& itr = _configOptions.find(name);
     bool notFound = itr == _configOptions.end();
-    auto envVarName = getEnvVarName(name);
-    Optional<std::string> envVar = getEnvFromCache(name, envVarName);
+    auto envVarName = GetEnvVarName(name);
+    Optional<std::string> envVar = GetEnvFromCache(name, envVarName);
     if (envVar)
     {
         // If showLogs and this key/value pair wasn't found in the currently saved config
@@ -435,8 +435,8 @@ std::string ConfigMgr::GetValueDefault<std::string>(std::string const& name, std
 {
     auto const& itr = _configOptions.find(name);
     bool notFound = itr == _configOptions.end();
-    auto envVarName = getEnvVarName(name);
-    Optional<std::string> envVar = getEnvFromCache(name, envVarName);
+    auto envVarName = GetEnvVarName(name);
+    Optional<std::string> envVar = GetEnvFromCache(name, envVarName);
     if (envVar)
     {
         // If showLogs and this key/value pair wasn't found in the currently saved config

--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -337,7 +337,7 @@ bool ConfigMgr::Reload()
 
 // Check the _envVarCache if the env var is there
 // if not, check the env for the value
-Optional<std::string> getEnvFromCache(std::string const& configName, std::string const& envVarName)
+Optional<std::string> GetEnvFromCache(std::string const& configName, std::string const& envVarName)
 {
     auto foundInCache = _envVarCache.find(envVarName);
     Optional<std::string> foundInEnv;

--- a/src/server/apps/authserver/Main.cpp
+++ b/src/server/apps/authserver/Main.cpp
@@ -85,8 +85,6 @@ int main(int argc, char** argv)
     if (!sConfigMgr->LoadAppConfigs())
         return 1;
 
-    std::vector<std::string> overriddenKeys = sConfigMgr->OverrideWithEnvVariablesIfAny();
-
     // Init logging
     sLog->RegisterAppender<AppenderDB>();
     sLog->Initialize(nullptr);
@@ -102,9 +100,6 @@ int main(int argc, char** argv)
             LOG_INFO("server.authserver", "> Using SSL version:             {} (library: {})", OPENSSL_VERSION_TEXT, OpenSSL_version(OPENSSL_VERSION));
             LOG_INFO("server.authserver", "> Using Boost version:           {}.{}.{}", BOOST_VERSION / 100000, BOOST_VERSION / 100 % 1000, BOOST_VERSION % 100);
         });
-
-    for (std::string const& key : overriddenKeys)
-        LOG_INFO("server.authserver", "Configuration field {} was overridden with environment variable.", key);
 
     OpenSSLCrypto::threadsSetup();
 

--- a/src/server/apps/worldserver/Main.cpp
+++ b/src/server/apps/worldserver/Main.cpp
@@ -184,8 +184,6 @@ int main(int argc, char** argv)
     if (!sConfigMgr->LoadAppConfigs())
         return 1;
 
-    std::vector<std::string> overriddenKeys = sConfigMgr->OverrideWithEnvVariablesIfAny();
-
     std::shared_ptr<Acore::Asio::IoContext> ioContext = std::make_shared<Acore::Asio::IoContext>();
 
     // Init all logs
@@ -204,9 +202,6 @@ int main(int argc, char** argv)
             LOG_INFO("server.worldserver", "> Using SSL version:             {} (library: {})", OPENSSL_VERSION_TEXT, OpenSSL_version(OPENSSL_VERSION));
             LOG_INFO("server.worldserver", "> Using Boost version:           {}.{}.{}", BOOST_VERSION / 100000, BOOST_VERSION / 100 % 1000, BOOST_VERSION % 100);
         });
-
-    for (std::string const& key : overriddenKeys)
-        LOG_INFO("server.worldserver", "Configuration field {} was overridden with environment variable.", key);
 
     OpenSSLCrypto::threadsSetup();
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### Description

- Change the `GetValueDefault` function in `Config.cpp` to always choose environment variable over which value is in a config file
    - This is typically how environment var configs work in many programs; the environment var always take precedence over the config file
    - The removes the need to execute an `OverrideWithEnvVariablesIfAny()` step
- This fixes env vars for modules since previously, modules would be loaded after the `OverrideWithEnvVariablesIfAny()` function
- I also changed some of the output messages related to loading configurations from env vars. They kind of made it seem like a config using an environment var was recovering from an error rather than just a method of loading config values
- Additionally, the noted message would log the value of the environment variable, which is (quite) bad if you're using environment variables for database configs. Since it was removed, this is fixed.
    - `"Missing property {} in config file {}, recovered with environment '{}' value."` 
- Log lines for specific situations as of this pr:
    - Config missing from both file and environment: 

    ```
    Config: Missing property Solocraft.Enable in config file /home/mike/builds/azerothcore-wotlk/env/dist/etc/worldserver.conf, add "Solocraft.Enable = 1" to this file or define 'AC_SOLOCRAFT_ENABLE' as an environment variable.
    ```

    - Config found in environment, and it's upsert the stored config value: 

    ```
    Config: Found config value 'Solocraft.BlackwingLair.Level' from environment variable 'AC_SOLOCRAFT_BLACKWING_LAIR_LEVEL'.
    ```

- Provides an easy method to get an environment variable equivalent of a parameter name. comment out the parameter name (so the default isnt in the conf), and see what the output for the "missing property" error is

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/17109

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `git clone git@github.com:azerothcore/azerothcore-wotlk`
2. `git clone git@github.com:azerothcore/mod-solocraft azerothcore-wotlk/modules/mod-solocraft`
3. Compile the server as normal.
4. Throw in a configuration for the module to the environment
    1. For a "traditional" deployment, this can be done by setting an environment variable as you normally would:
    ```console
    $ AC_SOLOCRAFT_BLACKWING_LAIR_LEVEL=60 env/dist/bin/worldserver
    ```
    2. With docker-compose, you can create an override:
    
    ```yaml
    # docker-compose.override.yml
    services:
      ac-worldserver:
        environment:
          AC_SOLOCRAFT_BLACKWING_LAIR_LEVEL: 60
    ```

    2. The server will log that the config is being pulled in from the env var

5. Log in, create a character. Observe that the config is working. in this case, run these commands after creating your character and logging in

```console
.levelup 59
.tele bwl
```

6. Notice that the instance is working properly.

7. removed (or comment out) the relevant parameter from the modules config files and remove the env var, however you have it set. The worldserver should log an error if the config is missing and describe what to do
    1. in this case, `env/dist/etc/modules/Solocraft.conf` and `env/dist/etc/modules/Solocraft.conf.dist`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

None that I know of.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
