### PR TITLE
feat(DB/Creature): Add CreateObject column in the creature table

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1693858384423226200.sql
+++ b/data/sql/updates/pending_db_world/rev_1693858384423226200.sql
@@ -4,3 +4,47 @@ ALTER TABLE `creature`
 
 -- Haggle
 UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` = 53788 AND `id1` = 14041;
+
+-- The Underbog
+SET @CGUID := 138300;
+UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` BETWEEN @CGUID+0 AND @CGUID+218;
+
+-- The Steamvault
+SET @CGUID := 142000;
+UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` BETWEEN @CGUID AND @CGUID+174;
+
+-- The Shattered Halls
+SET @CGUID := 151000;
+UPDATE `creature` SET `CreateObject` = 2 WHERE `guid` BETWEEN @CGUID+0 AND @CGUID+4;
+UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` BETWEEN @CGUID+5 AND @CGUID+18;
+UPDATE `creature` SET `CreateObject` = 3 WHERE `guid` BETWEEN @CGUID+19 AND @CGUID+34;
+UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` BETWEEN @CGUID+35 AND @CGUID+84;
+UPDATE `creature` SET `CreateObject` = 2 WHERE `guid` BETWEEN @CGUID+85 AND @CGUID+88;
+UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` BETWEEN @CGUID+89 AND @CGUID+282;
+
+-- Sethekk Halls
+SET @CGUID := 138600;
+UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` BETWEEN @CGUID+0 AND @CGUID+187;
+
+-- The Shadow Labyrinth
+SET @CGUID := 146000;
+UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` BETWEEN @CGUID+0 AND @CGUID+224;
+UPDATE `creature` SET `CreateObject` = 2 WHERE `guid` BETWEEN @CGUID+225 AND @CGUID+229;
+UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` BETWEEN @CGUID+230 AND @CGUID+235;
+
+-- The Mechanar
+SET @CGUID := 138800;
+UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` BETWEEN @CGUID+0 AND @CGUID+93;
+UPDATE `creature` SET `CreateObject` = 3 WHERE `guid` IN (138893, 138892, 138891, 138890, 138879, 138878, 138877, 138876, 138869, 138864, 138863, 138831, 138820, 138819, 138818, 138817);
+
+-- The Botanica
+SET @CGUID := 147000;
+UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` BETWEEN @CGUID+0 AND @CGUID+187;
+
+-- The Arcatraz
+SET @CGUID := 138900;
+UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` BETWEEN @CGUID+0 AND @CGUID+97;
+
+-- The Deathforge
+SET @CGUID := 83028;
+UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` BETWEEN @CGUID+0 AND @CGUID+84;

--- a/data/sql/updates/pending_db_world/rev_1693858384423226200.sql
+++ b/data/sql/updates/pending_db_world/rev_1693858384423226200.sql
@@ -1,0 +1,3 @@
+--
+ALTER TABLE `creature`
+	ADD COLUMN `CreateObject` TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `VerifiedBuild`;

--- a/data/sql/updates/pending_db_world/rev_1693858384423226200.sql
+++ b/data/sql/updates/pending_db_world/rev_1693858384423226200.sql
@@ -1,3 +1,6 @@
 --
 ALTER TABLE `creature`
 	ADD COLUMN `CreateObject` TINYINT UNSIGNED NOT NULL DEFAULT '0' AFTER `VerifiedBuild`;
+
+-- Haggle
+UPDATE `creature` SET `CreateObject` = 1 WHERE `guid` = 53788 AND `id1` = 14041;

--- a/data/sql/updates/pending_db_world/rev_1693858384423226200.sql
+++ b/data/sql/updates/pending_db_world/rev_1693858384423226200.sql
@@ -1,3 +1,3 @@
 --
 ALTER TABLE `creature`
-	ADD COLUMN `CreateObject` TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `VerifiedBuild`;
+	ADD COLUMN `CreateObject` TINYINT UNSIGNED NOT NULL DEFAULT '0' AFTER `VerifiedBuild`;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Co-Authored-By: neifion-00000000 <91289495+neifion-00000000@users.noreply.github.com>

Object spawns in sniffs appear as either CreateObject1 or CreateObject2.
CreateObject1 appears based on visibility. For example, a pathing creature in the middle of its patrol will spawn as CreateObject1.
On the other hand, a creature that died and **respawns** appears as CreateObject2, revealing its **real** spawn point. Similarly, summons and event spawns as well as "pre-spawns" appear as CO2

This column is similar to VerifiedBuild. The reason we need it for the creature table is because they are more nuanced and VerifiedBuild is less powerful then.
A creature with no VerifiedBuild will be either unknown source or custom
A creature with VerifiedBuild and CreateObject1 will be good but imperfect
A creature with VerifiedBuild and CreateObject2 will be perfect and from a confirmed spawn point

Idea from Bench: Make a distinction between normal spawns and pre-spawns in the creature table by using CreateObject = 3
Essentially they're also CO2 but it'd be good to distinguish between them

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
