### PR TITLE
chore(DB/Creature): Correct VerifiedBuild for unverified chess piece spells.

### DIFF
--- a/data/sql/updates/pending_db_world/verify-your-builds.sql
+++ b/data/sql/updates/pending_db_world/verify-your-builds.sql
@@ -1,0 +1,1 @@
+UPDATE `creature_template_spell` SET `VerifiedBuild` = 0 WHERE `CreatureID` IN (17211, 17469, 21160, 21664, 21682, 21683, 21684, 21726, 21747, 21748, 21750, 21752);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [X] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes the issue mentioned [here](https://github.com/azerothcore/azerothcore-wotlk/issues/17176#issuecomment-1704349834). No one else was gonna do it.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Source is not applicable to this change.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR:
- [X] Has not been tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
- [X] This PR does not require testing.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
