### PR TITLE
fix(DB/gameobject_template): unlink trap 181604 from gameobject 181605

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1695556779252979200.sql
+++ b/data/sql/updates/pending_db_world/rev_1695556779252979200.sql
@@ -1,0 +1,4 @@
+-- unlink trap 181604 to fix midsummer ribbon pole beam
+DELETE FROM `gameobject_template` WHERE (`entry` = 181605);
+INSERT INTO `gameobject_template` (`entry`, `type`, `displayId`, `name`, `IconName`, `castBarCaption`, `unk1`, `size`, `Data0`, `Data1`, `Data2`, `Data3`, `Data4`, `Data5`, `Data6`, `Data7`, `Data8`, `Data9`, `Data10`, `Data11`, `Data12`, `Data13`, `Data14`, `Data15`, `Data16`, `Data17`, `Data18`, `Data19`, `Data20`, `Data21`, `Data22`, `Data23`, `AIName`, `ScriptName`, `VerifiedBuild`) VALUES
+(181605, 10, 6771, 'Ribbon Pole', '', '', '', 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 45406, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', '', 12340);


### PR DESCRIPTION
- fix for midsummer ribbon pole dance beam beeing connected to ribbon pole bottom instead of top (issue #12145)
- ribbon pole beam (spell 29712) by condition always targets NPC 17066 "Ribbon Pole Debug Target"
- all Ribbon Poles (181605) already have NPC 17066 placed on top for this purpose
- 181604 "TEST Ribbon Pole TRAP" triggers spell 29708, which spawns an additional NPC 17066 at the ribbon pole bottom everytime the ribbon pole is beeing clicked / activated
- (these additional NPCs also do NOT despawn on Event end)
- the closest NPC 17066 is then at the bottom pole and becomes target of ribbon pole beam spell (29712)
- therefore unlink trap 181604 to not spawn any unwanted NPCs anymore and get beam correctly targetting the ribbon pole top

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Progress #12145

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

.event start 1
.tele orgrimmar
.go xyz 1937 -4326 22
click on ribbon pole
observe beam connecting to the top

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
