### PR TITLE
fix(Core/Quest): AllowableRaces to uint32 for custom Racemasks

### DIFF
--- a/data/sql/updates/pending_db_world/uint32_quest_template.sql
+++ b/data/sql/updates/pending_db_world/uint32_quest_template.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `quest_template` MODIFY COLUMN `AllowableRaces` int;

--- a/data/sql/updates/pending_db_world/uint32_quest_template.sql
+++ b/data/sql/updates/pending_db_world/uint32_quest_template.sql
@@ -1,1 +1,2 @@
-ALTER TABLE `quest_template` MODIFY COLUMN `AllowableRaces` int unsigned NOT NULL DEFAULT 0;
+--
+ALTER TABLE `quest_template` MODIFY COLUMN `AllowableRaces` INT UNSIGNED NOT NULL DEFAULT 0;

--- a/data/sql/updates/pending_db_world/uint32_quest_template.sql
+++ b/data/sql/updates/pending_db_world/uint32_quest_template.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `quest_template` MODIFY COLUMN `AllowableRaces` int;
+ALTER TABLE `quest_template` MODIFY COLUMN `AllowableRaces` int unsigned NOT NULL DEFAULT 0;

--- a/src/server/game/Quests/QuestDef.cpp
+++ b/src/server/game/Quests/QuestDef.cpp
@@ -38,7 +38,7 @@ Quest::Quest(Field* questRecord)
     Type = questRecord[5].Get<uint16>();
     SuggestedPlayers = questRecord[6].Get<uint8>();
     TimeAllowed = questRecord[7].Get<uint32>();
-    AllowableRaces = questRecord[8].Get<uint16>();
+    AllowableRaces = questRecord[8].Get<uint32>();
     RequiredFactionId1 = questRecord[9].Get<uint16>();
     RequiredFactionId2 = questRecord[10].Get<uint16>();
     RequiredFactionValue1 = questRecord[11].Get<int32>();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

closes https://github.com/azerothcore/azerothcore-wotlk/issues/16912
## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Set the AllowableRaces column in quest_template to a higher value than uint16
2. Check if you have any erros on starting the server according to this PR
3. Confirm that its working

- U need custom races to test this PR

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
