### PR TITLE
fix(Scripts/Midsummer): Randomize ribbon pole beam color

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1695820418952974700.sql
+++ b/data/sql/updates/pending_db_world/rev_1695820418952974700.sql
@@ -1,6 +1,6 @@
 -- #12145 midsummer add spell script spell_midsummer_ribbon_pole_visual
-DELETE FROM acore_world.spell_script_names WHERE spell_id IN (29531, 29705, 29726, 29727);
-INSERT INTO acore_world.spell_script_names (spell_id, ScriptName) VALUES
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (29531, 29705, 29726, 29727);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (29531, 'spell_midsummer_ribbon_pole_visual'),
 (29705, 'spell_midsummer_ribbon_pole_visual'),
 (29726, 'spell_midsummer_ribbon_pole_visual'),

--- a/data/sql/updates/pending_db_world/rev_1695820418952974700.sql
+++ b/data/sql/updates/pending_db_world/rev_1695820418952974700.sql
@@ -1,0 +1,7 @@
+-- #12145 midsummer add spell script spell_midsummer_ribbon_pole_visual
+DELETE FROM acore_world.spell_script_names WHERE spell_id IN (29531, 29705, 29726, 29727);
+INSERT INTO acore_world.spell_script_names (spell_id, ScriptName) VALUES
+(29531, 'spell_midsummer_ribbon_pole_visual'),
+(29705, 'spell_midsummer_ribbon_pole_visual'),
+(29726, 'spell_midsummer_ribbon_pole_visual'),
+(29727, 'spell_midsummer_ribbon_pole_visual');

--- a/src/server/scripts/Events/midsummer.cpp
+++ b/src/server/scripts/Events/midsummer.cpp
@@ -214,6 +214,17 @@ class spell_midsummer_ribbon_pole : public AuraScript
 {
     PrepareAuraScript(spell_midsummer_ribbon_pole)
 
+    bool Validate(SpellInfo const* /*spell*/) override
+    {
+        return ValidateSpellInfo(
+            {
+                SPELL_RIBBON_POLE_XP,
+                SPELL_TEST_RIBBON_POLE_CHANNEL_BLUE,
+                SPELL_TEST_RIBBON_POLE_CHANNEL_RED,
+                SPELL_TEST_RIBBON_POLE_CHANNEL_PINK
+            });
+    }
+
     void HandleEffectPeriodic(AuraEffect const* /*aurEff*/)
     {
         PreventDefaultAction();

--- a/src/server/scripts/Events/midsummer.cpp
+++ b/src/server/scripts/Events/midsummer.cpp
@@ -200,6 +200,10 @@ class spell_gen_crab_disguise : public AuraScript
 enum RibbonPole
 {
     SPELL_RIBBON_POLE_CHANNEL_VISUAL    = 29172,
+    SPELL_RIBBON_POLE_CHANNEL_VISUAL_2  = 29531,
+    SPELL_TEST_RIBBON_POLE_CHANNEL_BLUE = 29705,
+    SPELL_TEST_RIBBON_POLE_CHANNEL_RED  = 29726,
+    SPELL_TEST_RIBBON_POLE_CHANNEL_PINK = 29727,
     SPELL_RIBBON_POLE_XP                = 29175,
     SPELL_RIBBON_POLE_FIREWORKS         = 46971,
 
@@ -218,7 +222,9 @@ class spell_midsummer_ribbon_pole : public AuraScript
             Creature* cr = target->FindNearestCreature(NPC_RIBBON_POLE_DEBUG_TARGET, 10.0f);
             if (!cr)
             {
-                target->RemoveAura(SPELL_RIBBON_POLE_CHANNEL_VISUAL);
+                target->RemoveAura(SPELL_TEST_RIBBON_POLE_CHANNEL_BLUE);
+                target->RemoveAura(SPELL_TEST_RIBBON_POLE_CHANNEL_RED);
+                target->RemoveAura(SPELL_TEST_RIBBON_POLE_CHANNEL_PINK);
                 SetDuration(1);
                 return;
             }
@@ -243,7 +249,19 @@ class spell_midsummer_ribbon_pole : public AuraScript
     void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         Unit* ar = GetTarget();
-        ar->CastSpell(ar, SPELL_RIBBON_POLE_CHANNEL_VISUAL, true);
+        switch (urand(0, 2))
+        {
+            case 0:
+                ar->CastSpell(ar, SPELL_TEST_RIBBON_POLE_CHANNEL_BLUE, true);
+                break;
+            case 1:
+                ar->CastSpell(ar, SPELL_TEST_RIBBON_POLE_CHANNEL_RED, true);
+                break;
+            case 2:
+            default:
+                ar->CastSpell(ar, SPELL_TEST_RIBBON_POLE_CHANNEL_PINK, true);
+                break;
+        }
     }
 
     void Register() override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Progress #12145

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

.event start 1
.tele orgrimmar
.go xyz 1937 -4326 22
click on ribbon pole
observe randomized beam color (blue/red/pink)
walk away from ribbon pole until beam disappears
repeat

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
