### PR TITLE
feat(Core/Scripting): Implement `OnBeforeCreatureSelectLevel()` hook

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1486,9 +1486,9 @@ void Creature::SelectLevel(bool changelevel)
     uint8 minlevel = std::min(cInfo->maxlevel, cInfo->minlevel);
     uint8 maxlevel = std::max(cInfo->maxlevel, cInfo->minlevel);
     uint8 level = minlevel == maxlevel ? minlevel : urand(minlevel, maxlevel);
-
+    
     sScriptMgr->OnBeforeCreatureSelectLevel(cInfo, this, level);
-
+    
     if (changelevel)
         SetLevel(level);
 

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1487,7 +1487,10 @@ void Creature::SelectLevel(bool changelevel)
     uint8 maxlevel = std::max(cInfo->maxlevel, cInfo->minlevel);
     uint8 level = minlevel == maxlevel ? minlevel : urand(minlevel, maxlevel);
     if (changelevel)
+    {
+        sScriptMgr->OnBeforeCreatureSelectLevel(cInfo, this, level);
         SetLevel(level);
+    }
 
     CreatureBaseStats const* stats = sObjectMgr->GetCreatureBaseStats(level, cInfo->unit_class);
 

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1486,9 +1486,9 @@ void Creature::SelectLevel(bool changelevel)
     uint8 minlevel = std::min(cInfo->maxlevel, cInfo->minlevel);
     uint8 maxlevel = std::max(cInfo->maxlevel, cInfo->minlevel);
     uint8 level = minlevel == maxlevel ? minlevel : urand(minlevel, maxlevel);
-    
+
     sScriptMgr->OnBeforeCreatureSelectLevel(cInfo, this, level);
-    
+
     if (changelevel)
         SetLevel(level);
 

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1486,11 +1486,11 @@ void Creature::SelectLevel(bool changelevel)
     uint8 minlevel = std::min(cInfo->maxlevel, cInfo->minlevel);
     uint8 maxlevel = std::max(cInfo->maxlevel, cInfo->minlevel);
     uint8 level = minlevel == maxlevel ? minlevel : urand(minlevel, maxlevel);
+    
+    sScriptMgr->OnBeforeCreatureSelectLevel(cInfo, this, level);
+    
     if (changelevel)
-    {
-        sScriptMgr->OnBeforeCreatureSelectLevel(cInfo, this, level);
         SetLevel(level);
-    }
 
     CreatureBaseStats const* stats = sObjectMgr->GetCreatureBaseStats(level, cInfo->unit_class);
 

--- a/src/server/game/Scripting/ScriptDefines/AllCreatureScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/AllCreatureScript.cpp
@@ -48,7 +48,7 @@ void ScriptMgr::OnCreatureSaveToDB(Creature* creature)
     });
 }
 
-void OnBeforeCreatureSelectLevel(const CreatureTemplate* cinfo, Creature* creature, uint8& level)
+void ScriptMgr::OnBeforeCreatureSelectLevel(const CreatureTemplate* cinfo, Creature* creature, uint8& level)
 {
     ExecuteScript<AllCreatureScript>([&](AllCreatureScript* script)
     {

--- a/src/server/game/Scripting/ScriptDefines/AllCreatureScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/AllCreatureScript.cpp
@@ -48,6 +48,15 @@ void ScriptMgr::OnCreatureSaveToDB(Creature* creature)
     });
 }
 
+void OnBeforeCreatureSelectLevel(const CreatureTemplate* cinfo, Creature* creature, uint8& level)
+{
+    ExecuteScript<AllCreatureScript>([&](AllCreatureScript* script)
+    {
+        script->OnBeforeCreatureSelectLevel(cinfo, creature, level);
+    });
+
+}
+
 void ScriptMgr::Creature_SelectLevel(const CreatureTemplate* cinfo, Creature* creature)
 {
     ExecuteScript<AllCreatureScript>([&](AllCreatureScript* script)

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -555,6 +555,9 @@ public:
     // Called from End of Creature Update.
     virtual void OnAllCreatureUpdate(Creature* /*creature*/, uint32 /*diff*/) { }
 
+    // Called just before the level of the creature is set.
+    virtual void OnBeforeCreatureSelectLevel(const CreatureTemplate* /*cinfo*/, Creature* /*creature*/, uint8& /*level*/) { }
+
     // Called from End of Creature SelectLevel.
     virtual void Creature_SelectLevel(const CreatureTemplate* /*cinfo*/, Creature* /*creature*/) { }
 
@@ -2555,6 +2558,7 @@ public: /* MovementHandlerScript */
 public: /* AllCreatureScript */
     //listener function (OnAllCreatureUpdate) is called by OnCreatureUpdate
     //void OnAllCreatureUpdate(Creature* creature, uint32 diff);
+    void OnBeforeCreatureSelectLevel(const CreatureTemplate* cinfo, Creature* creature, uint8& level);
     void Creature_SelectLevel(const CreatureTemplate* cinfo, Creature* creature);
     void OnCreatureSaveToDB(Creature* creature);
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Adds the `OnBeforeCreatureSelectLevel()` hook into the `Creature::SelectLevel` function. This hook allows a module to examine and potentially change the level of a creature just before it has its level set and stats generated.

This hook allows me to avoid the "Level Up" animation that happens when entering an instance with AutoBalance or summoning a new creature that is scaled, since the level decision is made before the creature exists in the world.

This PR is in support of new features coming Very Soon™ to the [AutoBalance module](https://github.com/azerothcore/mod-autobalance).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [X] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a simple module that implements the hook
2. Change the "level" variable to any level value
3. Observe that all creatures have that value

Here is example logging output from an unreleased build of AutoBalance that illustrates the general flow:

```
AutoBalance_AllCreatureScript::OnBeforeCreatureSelectLevel: Bazzalan (16) | GUID Full: 0xf130002cff000008 Type: Creature Entry: 11519  Low: 8
AutoBalance_AllCreatureScript::OnBeforeCreatureSelectLevel: Bazzalan (16) is in map Ragefire Chasm (389-3, 5-player Normal)
AutoBalance_AllCreatureScript::ModifyCreatureAttributes: Config time for Bazzalan (16) updated to (1696060065241351).
AutoBalance_AllCreatureScript::ModifyCreatureAttributes: Creature Bazzalan (16) scaled to level (61) via dynamic scaling.
AutoBalance_AllCreatureScript::OnBeforeCreatureSelectLevel: Bazzalan (16) is set to level 61.
AutoBalance_AllCreatureScript::OnCreatureAddWorld: Bazzalan (61) added to map Ragefire Chasm (389-3, 5-player Normal)
```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
None.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
