### PR TITLE
fix: worldport command now teleports players to the expected coordinates

### DIFF
--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -136,7 +136,7 @@ void OpcodeTable::Initialize()
     /*0x005*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_QUERY_OBJECT_POSITION,                              STATUS_NEVER);
     /*0x006*/ DEFINE_HANDLER(CMSG_QUERY_OBJECT_ROTATION,                                            STATUS_NEVER,      PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );
     /*0x007*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_QUERY_OBJECT_ROTATION,                              STATUS_NEVER);
-    /*0x008*/ DEFINE_HANDLER(CMSG_WORLD_TELEPORT,                                                   STATUS_LOGGEDIN,   PROCESS_THREADUNSAFE,   &WorldSession::HandleWorldTeleportOpcode                );
+    /*0x008*/ DEFINE_HANDLER(CMSG_WORLD_TELEPORT, STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleWorldTeleport);
     /*0x009*/ DEFINE_HANDLER(CMSG_TELEPORT_TO_UNIT,                                                 STATUS_LOGGEDIN,   PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );
     /*0x00A*/ DEFINE_HANDLER(CMSG_ZONE_MAP,                                                         STATUS_NEVER,      PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );
     /*0x00B*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_ZONE_MAP,                                           STATUS_NEVER);

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -915,7 +915,7 @@ public:                                                 // opcodes handlers
     void HandleReportPvPAFK(WorldPacket& recvData);
 
     void HandleWardenDataOpcode(WorldPacket& recvData);
-    void HandleWorldTeleportOpcode(WorldPacket& recvData);
+    void HandleWorldTeleport(WorldPacket& msg);
     void HandleMinimapPingOpcode(WorldPacket& recvData);
     void HandleRandomRollOpcode(WorldPackets::Misc::RandomRollClient& packet);
     void HandleFarSightOpcode(WorldPacket& recvData);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).


## Issues Addressed:

1. The worldport command handler's net message reading logic is wrong and the player is not teleported to the requested coordinates
2. Only online players can be teleported

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.


## How to Test the Changes:
1. Log into the game world
2. Execute the worldport command (Usage: worldport \<continentID\> [x y z] [facing])


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] The movecharacter command (NYI) could probably be handled by the worldport command handler later on, as they share the same logic

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
