### PR TITLE
fix(DB/spell_custom_attr): Allow Armor Shatter/Puncture armor to stack

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1696540155725328200.sql
+++ b/data/sql/updates/pending_db_world/rev_1696540155725328200.sql
@@ -1,0 +1,7 @@
+-- Annihilator - Armor Shatter
+DELETE FROM `spell_custom_attr` WHERE `spell_id`=16928;
+INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (16928, 4194304);
+
+-- Bashguuder & Bashguuder - Puncture Armor
+DELETE FROM `spell_custom_attr` WHERE `spell_id`=17315;
+INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (17315, 4194304);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/9646

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Make 2 warriors
.additem 12798
.additem 13286
Attacking with the same weapon (on 2+ characters) stacks the debuff.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Stack rules for 5%/weakness are cooked. [The Puncture Armor ability found on the Rivenspike, Bashguuder, Digmaster 5000, and Vibroblade will no longer stack with Faerie Fire.](https://wowwiki-archive.fandom.com/wiki/Patch_1.8.0)
(Digmaster 5000, and Vibroblade use different spell (that does not stack), but still shouldn't be stacking with 5%)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
