### PR TITLE
fix(Core/Scripts): Venomhide Hatchling improvements

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1696761835374043300.sql
+++ b/data/sql/updates/pending_db_world/rev_1696761835374043300.sql
@@ -1,0 +1,8 @@
+-- Venomhide Hatchling feed items
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (65200,65258,65265);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(65200, 'spell_item_venomhide_feed'),
+(65258, 'spell_item_venomhide_feed'),
+(65265, 'spell_item_venomhide_feed');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceGroup` = 1 AND `SourceEntry` IN (65200,65258,65265);

--- a/data/sql/updates/pending_db_world/rev_1696761835374043300.sql
+++ b/data/sql/updates/pending_db_world/rev_1696761835374043300.sql
@@ -9,3 +9,10 @@ INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (68360, 'spell_item_venomhide_feed');
 
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceGroup` = 1 AND `SourceEntry` IN (65200,65258,65265);
+
+-- Mor'vek
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 11701;
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 11701);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(11701, 0, 0, 0, 20, 0, 100, 0, 13906, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 19, 34320, 10, 0, 0, 0, 0, 0, 0, 'Mor\'vek - On Quest \'They Grow Up So Fast\' Finished - Despawn Closest Venomhide Hatchling');

--- a/data/sql/updates/pending_db_world/rev_1696761835374043300.sql
+++ b/data/sql/updates/pending_db_world/rev_1696761835374043300.sql
@@ -8,11 +8,22 @@ INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (68358, 'spell_item_venomhide_feed'),
 (68360, 'spell_item_venomhide_feed');
 
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceGroup` = 1 AND `SourceEntry` IN (65200,65258,65265);
-
 -- Mor'vek
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 11701;
 
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 11701);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (11701, 0, 0, 0, 20, 0, 100, 0, 13906, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 19, 34320, 10, 0, 0, 0, 0, 0, 0, 'Mor\'vek - On Quest \'They Grow Up So Fast\' Finished - Despawn Closest Venomhide Hatchling');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceGroup` = 1 AND `SourceEntry` IN (65200,65258,65265);
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 19 AND `SourceGroup` = 0 AND `ConditionTypeOrReference` = 9 AND `ConditionValue1` = 13906;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(19, 0, 13903, 0, 0, 9, 0, 13906, 0, 0, 0, 0, 0, '', 'Show quest \'Gorishi Grub\' only if on quest \'They Grow Up So Fast\''),
+(19, 0, 13917, 0, 0, 9, 0, 13906, 0, 0, 0, 0, 0, '', 'Show quest \'Gorishi Grub\' only if on quest \'They Grow Up So Fast\''),
+(19, 0, 13889, 0, 0, 9, 0, 13906, 0, 0, 0, 0, 0, '', 'Show quest \'Hungry, Hungry Hatchling\' only if on quest \'They Grow Up So Fast\''),
+(19, 0, 13915, 0, 0, 9, 0, 13906, 0, 0, 0, 0, 0, '', 'Show quest \'Hungry, Hungry Hatchling\' only if on quest \'They Grow Up So Fast\''),
+(19, 0, 13904, 0, 0, 9, 0, 13906, 0, 0, 0, 0, 0, '', 'Show quest \'Poached, Scrambled, Or Raw?\' only if on quest \'They Grow Up So Fast\''),
+(19, 0, 13916, 0, 0, 9, 0, 13906, 0, 0, 0, 0, 0, '', 'Show quest \'Poached, Scrambled, Or Raw?\' only if on quest \'They Grow Up So Fast\''),
+(19, 0, 13905, 0, 0, 9, 0, 13906, 0, 0, 0, 0, 0, '', 'Show quest \'Searing Roc Feathers\' only if on quest \'They Grow Up So Fast\''),
+(19, 0, 13914, 0, 0, 9, 0, 13906, 0, 0, 0, 0, 0, '', 'Show quest \'Searing Roc Feathers\' only if on quest \'They Grow Up So Fast\'');

--- a/data/sql/updates/pending_db_world/rev_1696761835374043300.sql
+++ b/data/sql/updates/pending_db_world/rev_1696761835374043300.sql
@@ -1,8 +1,11 @@
 -- Venomhide Hatchling feed items
-DELETE FROM `spell_script_names` WHERE `spell_id` IN (65200,65258,65265);
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (65200,65258,65265,68359,68358,68360);
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (65200, 'spell_item_venomhide_feed'),
 (65258, 'spell_item_venomhide_feed'),
-(65265, 'spell_item_venomhide_feed');
+(65265, 'spell_item_venomhide_feed'),
+(68359, 'spell_item_venomhide_feed'),
+(68358, 'spell_item_venomhide_feed'),
+(68360, 'spell_item_venomhide_feed');
 
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceGroup` = 1 AND `SourceEntry` IN (65200,65258,65265);

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4578,20 +4578,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->ChannelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE;
     });
 
-    // Feed Venomhide Hatchling - Silithid Egg
-    ApplySpellFix({ 65265 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
-        spellInfo->SpellVisual[0] = 13838;
-    });
-
-    // Feed Venomhide Hatchling - Fresh Dinosaur Meat
-    ApplySpellFix({ 65200 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
-        spellInfo->SpellVisual[0] = 13832;
-    });
-
     for (uint32 i = 0; i < GetSpellInfoStoreSize(); ++i)
     {
         SpellInfo* spellInfo = mSpellInfoMap[i];

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4578,6 +4578,20 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->ChannelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE;
     });
 
+    // Feed Venomhide Hatchling - Silithid Egg
+    ApplySpellFix({ 65265  }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
+        spellInfo->SpellVisual[0] = 13838;
+    });
+
+    // Feed Venomhide Hatchling - Fresh Dinosaur Meat
+    ApplySpellFix({ 65200 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
+        spellInfo->SpellVisual[0] = 13832;
+    });
+
     for (uint32 i = 0; i < GetSpellInfoStoreSize(); ++i)
     {
         SpellInfo* spellInfo = mSpellInfoMap[i];

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4579,7 +4579,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Feed Venomhide Hatchling - Silithid Egg
-    ApplySpellFix({ 65265  }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65265 }, [](SpellInfo* spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
         spellInfo->SpellVisual[0] = 13838;

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -3906,7 +3906,7 @@ class spell_item_venomhide_feed : public SpellScript
 
         return SPELL_FAILED_BAD_TARGETS;
     }
-    
+
     void UpdateTarget(WorldObject*& target)
     {
         if (!target)

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -3883,6 +3883,65 @@ class spell_item_worn_troll_dice : public SpellScript
     }
 };
 
+enum VenomhideHatchling
+{
+    NPC_VENOMHIDE_HATCHLING = 34320
+};
+
+class spell_item_venomhide_feed : public SpellScript
+{
+    PrepareSpellScript(spell_item_venomhide_feed)
+
+    SpellCastResult CheckCast()
+    {
+        if (Player* player = GetCaster()->ToPlayer())
+        {
+            std::list<Creature*> hatchling;
+            player->GetAllMinionsByEntry(hatchling, NPC_VENOMHIDE_HATCHLING);
+            if (!hatchling.empty())
+            {
+                return SPELL_CAST_OK;
+            }
+        }
+
+        return SPELL_FAILED_BAD_TARGETS;
+    }
+    
+    void UpdateTarget(WorldObject*& target)
+    {
+        if (!target)
+        {
+            return;
+        }
+
+        if (Player* player = GetCaster()->ToPlayer())
+        {
+            std::list<Creature*> hatchling;
+            player->GetAllMinionsByEntry(hatchling, NPC_VENOMHIDE_HATCHLING);
+            if (hatchling.empty())
+            {
+                return;
+            }
+
+            for (Creature* creature  : hatchling)
+            {
+                if (creature)
+                {
+                    target = creature;
+                    return;
+                }
+            }
+        }
+    }
+
+
+    void Register() override
+    {
+        OnCheckCast += SpellCheckCastFn(spell_item_venomhide_feed::CheckCast);
+        OnObjectTargetSelect  += SpellObjectTargetSelectFn(spell_item_venomhide_feed::UpdateTarget, EFFECT_0, TARGET_UNIT_NEARBY_ENTRY);
+    }
+};
+
 void AddSC_item_spell_scripts()
 {
     RegisterSpellScript(spell_item_massive_seaforium_charge);
@@ -4003,4 +4062,5 @@ void AddSC_item_spell_scripts()
     RegisterSpellScript(spell_item_green_whelp_armor);
     RegisterSpellScript(spell_item_elixir_of_shadows);
     RegisterSpellScript(spell_item_worn_troll_dice);
+    RegisterSpellScript(spell_item_venomhide_feed);
 }

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -3934,7 +3934,6 @@ class spell_item_venomhide_feed : public SpellScript
         }
     }
 
-
     void Register() override
     {
         OnCheckCast += SpellCheckCastFn(spell_item_venomhide_feed::CheckCast);

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -3923,7 +3923,7 @@ class spell_item_venomhide_feed : public SpellScript
                 return;
             }
 
-            for (Creature* creature  : hatchling)
+            for (Creature* creature : hatchling)
             {
                 if (creature)
                 {

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -2506,9 +2506,9 @@ enum VenomhideHatchlingMisc
     ITEM_VENOMHIDE_BABY_TOOTH = 47196,
 
     MODEL_BABY_RAPTOR              = 29251,
-    MODEL_BABY_RAPTOR_REPTILE_EYES = 29809,
-    MODEL_ADOLESCENT_RAPTOR        = 29103,
-    MODEL_FULL_RAPTOR              = 5291,
+    MODEL_BABY_RAPTOR_REPTILE_EYES = 29274,
+    MODEL_ADOLESCENT_RAPTOR        = 29275,
+    MODEL_FULL_RAPTOR              = 29276,
 };
 
 enum VenomhideHatchlingTexts


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

PR also corrects the ability to use other people's hatchling to do your quest/projectile to them.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8409
- Closes https://github.com/chromiecraft/chromiecraft/issues/2473
- Closes https://github.com/chromiecraft/chromiecraft/issues/2488
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8107
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/9296
- Closes https://github.com/chromiecraft/chromiecraft/issues/2376
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/9548
- Closes https://github.com/chromiecraft/chromiecraft/issues/2497
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/8779
- Closes https://github.com/chromiecraft/chromiecraft/issues/2610

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

```sql
-- modelid source
SELECT Name,modelid1 FROM `creature_template` WHERE `name` LIKE '%venomhide hatch%';
```
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

![growgif](https://github.com/azerothcore/azerothcore-wotlk/assets/46330494/08505d46-9d9b-404f-9eb7-398ec94e9698)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

-- Model Size
.q add 13906
.additem 47196 X (amount)

-- Using items
.additem 46380 / 46382 / 46367
Try to use items while summoned and when not, should only work while he is present.
And should have proper projectile,

-- Despawn on quest complete
.go c 88163
.q a 13906
.q c 13906
Summon the hatchling and turn in the quest, npc should despawn.

-- See if quest mark is shown when not on quest
.q add 13906
Jump on 2nd character without the quest, there shouldn't be an exclamation mark.


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] You can accept  [They Grow Up So Fast] (13906), summon the hatchling and abandon it and it will still stay, one solution would be quest check on a timer in the creature script, but that would be very, very wasteful.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
