### PR TITLE
ResurrectPlayer add 'OnBeforePlayerResurrect' hook

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -4385,6 +4385,19 @@ void Player::BuildPlayerRepop()
 
 void Player::ResurrectPlayer(float restore_percent, bool applySickness)
 {
+    LOG_DEBUG("entities.player", "Player::ResurrectPlayer: enter Resurrecting player {} ({})", GetName(), GetGUID().ToString());
+
+    //call the beforePlayerResurrect script first
+    //if false is returned, no resurrection will occur
+    if (!sScriptMgr->OnBeforePlayerResurrect(this, restore_percent, applySickness))
+    {
+        LOG_DEBUG("entities.player", "Player::ResurrectPlayer: OnBeforePlayerResurrect returned false for player {} ({})", GetName(), GetGUID().ToString());
+        return;
+    }
+
+    LOG_DEBUG("entities.player", "Player::ResurrectPlayer: begin Resurrecting player {} ({})", GetName(), GetGUID().ToString());
+        
+
     WorldPacket data(SMSG_DEATH_RELEASE_LOC, 4 * 4);        // remove spirit healer position
     data << uint32(-1);
     data << float(0);

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -1487,6 +1487,26 @@ void ScriptMgr::OnSetServerSideVisibilityDetect(Player* player, ServerSideVisibi
 //    });
 //}
 
+bool ScriptMgr::OnBeforePlayerResurrect(Player* player, float restore_percent, bool applySickness)
+{
+    auto ret = IsValidBoolScript<PlayerScript>([&](PlayerScript* script)
+    {
+        LOG_DEBUG("scripts.hook", "ScriptMgr - OnBeforePlayerResurrect begin");
+        bool scriptRet = script->OnBeforePlayerResurrect(player, restore_percent, applySickness);
+        //print script name and scriptRet to logs
+        LOG_DEBUG("scripts.hook", "ScriptMgr - OnBeforePlayerResurrect - Script: {} , scriptRet: {} ", script->GetName(), scriptRet ? "true" : "false");
+        return !scriptRet;
+        
+    });
+
+    if (ret && *ret)
+    {
+        return false;
+    }
+
+    return true;
+}
+
 void ScriptMgr::OnPlayerResurrect(Player* player, float restore_percent, bool applySickness)
 {
     ExecuteScript<PlayerScript>([&](PlayerScript* script)

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -1379,6 +1379,9 @@ public:
 
     virtual void OnSetServerSideVisibilityDetect(Player* /*player*/, ServerSideVisibilityType& /*type*/, AccountTypes& /*sec*/) { }
 
+    // Called when a player is about to be resurrected, if false is returned the player will not be resurrected
+    [[nodiscard]] virtual bool OnBeforePlayerResurrect(Player* /*player*/, float /*restore_percent*/, bool /*applySickness*/) { return true; }
+    
     virtual void OnPlayerResurrect(Player* /*player*/, float /*restore_percent*/, bool /*applySickness*/) { }
 
     // Called before selecting the graveyard when releasing spirit
@@ -2442,6 +2445,7 @@ public: /* PlayerScript */
     bool CanInitTrade(Player* player, Player* target);
     void OnSetServerSideVisibility(Player* player, ServerSideVisibilityType& type, AccountTypes& sec);
     void OnSetServerSideVisibilityDetect(Player* player, ServerSideVisibilityType& type, AccountTypes& sec);
+    bool OnBeforePlayerResurrect(Player* player, float restore_percent, bool applySickness);
     void OnPlayerResurrect(Player* player, float restore_percent, bool applySickness);
     void OnBeforeChooseGraveyard(Player* player, TeamId teamId, bool nearCorpse, uint32& graveyardOverride);
     bool CanPlayerUseChat(Player* player, uint32 type, uint32 language, std::string& msg);

--- a/src/server/game/Scripting/ScriptMgrMacros.h
+++ b/src/server/game/Scripting/ScriptMgrMacros.h
@@ -25,14 +25,23 @@ inline Optional<bool> IsValidBoolScript(std::function<bool(ScriptName*)> execute
 {
     if (ScriptRegistry<ScriptName>::ScriptPointerList.empty())
         return {};
-
+    
+    bool ret = false;
     for (auto const& [scriptID, script] : ScriptRegistry<ScriptName>::ScriptPointerList)
     {
-        if (executeHook(script))
-            return true;
-    }
+        LOG_DEBUG("scripts.execute", "IsValidBoolScript - Valid script found for {}", typeid(ScriptName).name());
+        LOG_DEBUG("scripts.execute", "IsValidBoolScript - Script ID: {}", scriptID);
+        LOG_DEBUG("scripts.execute", "IsValidBoolScript - Script Name: {}", script->GetName());
+        //get script method name
 
-    return false;
+        if (executeHook(script))
+        {
+            LOG_DEBUG("scripts.execute", "IsValidBoolScript - Script executed return true");
+            ret = true;
+        }else
+            LOG_DEBUG("scripts.execute", "IsValidBoolScript - Script executed return false");
+    }
+    return ret;
 }
 
 template<typename ScriptName, class T>


### PR DESCRIPTION
## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Adds the PlayerScript OnBeforePlayerResurrect() hook at the begining of  Player::ResurrectPlayer() function, triggered before player resurrection proceed.  Resurrection will not be applied when It returns false. Thus, module can control whether a player can be resurrected or not  by implement the hook handler.

The original intention was to easily imlement a hardcore mode similar to the official Steel Soul through the Eluna module. Therefore, after this PR merge, I will submit  "PLAYER_EVENT_BEFORE_RESURRECT" PR to the Eluna module (which has already been tested but, you know, due to code dependencies).

Notice： This implementation is not perfect (although it does not affect the actual prevention of resurrection). I found that there are different pre-processing steps when players are resurrected under different circumstances, but they are scattered in different processing logic. For example, when performing a "Corpse Run" resurrection, the tombstone disappears first (surprisingly, not after resurrection). Some situations have already been identified, and they may potentially cause issues. I will list them in the known issues section below.

I haven't traced every instance of code calling for player character resurrection, but I believe that placing this hook in various processing logics may not be the best choice. As part of the proposed solution, it includes these two aspects:
1. Making Player::ResurrectPlayer() return a Boolean value.
2. Moving some of the pre-processing steps after the resurrection logic and determining whether to perform additional processing based on its return value.

addtional: fix 'IsValidBoolScript' to call all registered scripts , for example , both module A and  module  B implement playerScript, may handler the same hook ,  only one module will be triggered before.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #17370
- Closes #17388 


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
I tested it using Lua scripts (through the Eluna module), but it should also be relatively straightforward to test by writing a script class for implementing playerScript.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- When resurrecting via the "Corpse Run" method and preventing the resurrection, both the corpse and the tombstone disappear. This prevents the possibility of resurrecting via this method when conditions allow it later.
- When a Death Knight dies in their starting area and is resurrected by the "Valkyr", if the resurrection is prevented, the character will not be in the ghost state (appearing as if resurrected but not actually). However, the character becomes stuck and unable to move. Using the "unstuck" button in the Help interface returns the character to the graveyard in ghost form.
