### PR TITLE
fix(DB/SAI):  Cuergo's Gold improvements

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1696799173938352600.sql
+++ b/data/sql/updates/pending_db_world/rev_1696799173938352600.sql
@@ -5,6 +5,11 @@ DELETE FROM `smart_scripts` WHERE (`source_type` = 1 AND `entryorguid` = 142189)
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (142189, 1, 0, 0, 70, 0, 100, 0, 2, 0, 0, 0, 0, 0, 80, 14218900, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Inconspicuous Landmark - On Gameobject State Changed - Run Script');
 
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 14218900);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(14218900, 9, 0, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 50, 142194, 300, 0, 0, 0, 0, 1, 0, 0, 0, 0, -2, -3, 0, 0, 'Inconspicuous Landmark - Actionlist - Summon Gameobject \'Pirate\'s Treasure!\''),
+(14218900, 9, 1, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 12, 7898, 3, 5000, 0, 0, 0, 1, 0, 0, 0, 0, -2, -3, 0, 0, 'Inconspicuous Landmark - Actionlist - Summon Creature \'Pirate treasure trigger mob\'');
+
 DELETE FROM `gameobject` WHERE `id` = 142189;
 INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`, `Comment`) VALUES
 (17231, 142189, 1, 0, 0, 1, 1, -10249.2, -3981.8, 1.66783, -0.750491, 0, 0, -0.366501, 0.930418, 600, 100, 1, '', NULL, NULL),

--- a/data/sql/updates/pending_db_world/rev_1696799173938352600.sql
+++ b/data/sql/updates/pending_db_world/rev_1696799173938352600.sql
@@ -1,5 +1,5 @@
 -- Quest: Cuergo's Gold
-UPDATE `gameobject_template` SET `AIName` = 'SmartGameObjectAI' WHERE `entry` = 142189;
+UPDATE `gameobject_template` SET `AIName` = 'SmartGameObjectAI', `ScriptName` = '' WHERE `entry` = 142189;
 
 DELETE FROM `smart_scripts` WHERE (`source_type` = 1 AND `entryorguid` = 142189);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1696799173938352600.sql
+++ b/data/sql/updates/pending_db_world/rev_1696799173938352600.sql
@@ -1,0 +1,65 @@
+-- Quest: Cuergo's Gold
+UPDATE `gameobject_template` SET `AIName` = 'SmartGameObjectAI' WHERE `entry` = 142189;
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 1 AND `entryorguid` = 142189);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(142189, 1, 0, 0, 70, 0, 100, 0, 2, 0, 0, 0, 0, 0, 80, 14218900, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Inconspicuous Landmark - On Gameobject State Changed - Run Script');
+
+DELETE FROM `gameobject` WHERE `id` = 142189;
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`, `Comment`) VALUES
+(17231, 142189, 1, 0, 0, 1, 1, -10249.2, -3981.8, 1.66783, -0.750491, 0, 0, -0.366501, 0.930418, 600, 100, 1, '', NULL, NULL),
+(17232, 142189, 1, 0, 0, 1, 1, -10119.7, -4052.46, 5.33005, -0.366519, 0, 0, -0.182235, 0.983255, 600, 100, 1, '', NULL, NULL),
+(17233, 142189, 1, 0, 0, 1, 1, -10050.8, -3717.16, 5.44262, 2.65289, 0, 0, 0.970295, 0.241925, 600, 100, 1, '', NULL, NULL),
+(17234, 142189, 1, 0, 0, 1, 1, -10154.2, -3948.64, 7.74473, 2.65289, 0, 0, 0, 0, 600, 100, 1, '', NULL, NULL),
+(17235, 142189, 1, 0, 0, 1, 1, -10285.8, -3881.83, 1.07085, -2.26893, 0, 0, -0.906307, 0.422619, 600, 100, 1, '', NULL, NULL),
+(17236, 142189, 1, 0, 0, 1, 1, -10217, -3817.65, 1.35298, 2.65289, 0, 0, 0.970295, 0.241925, 600, 100, 1, '', NULL, NULL);
+
+DELETE FROM `pool_template` WHERE `entry` IN (355,112);
+INSERT INTO `pool_template` (`entry`, `max_limit`, `description`) VALUES (112, 1, 'Tanaris - Inconspicuous Landmark Pool');
+
+DELETE FROM `pool_gameobject` WHERE `pool_entry` IN (355,112);
+INSERT INTO `pool_gameobject` (`guid`, `pool_entry`, `chance`, `description`) VALUES
+(17231, 112, 0, 'Inconspicuous Landmark'),
+(17232, 112, 0, 'Inconspicuous Landmark'),
+(17233, 112, 0, 'Inconspicuous Landmark'),
+(17234, 112, 0, 'Inconspicuous Landmark'),
+(17235, 112, 0, 'Inconspicuous Landmark'),
+(17236, 112, 0, 'Inconspicuous Landmark');
+
+-- Pirate treasure trigger mob
+UPDATE `creature_template` SET `flags_extra` = `flags_extra`|128 WHERE `entry` = 7898;
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 7898) AND (`source_type` = 0);
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 789800) AND (`source_type` = 9);
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(7898, 0, 0, 1, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 7899, 1, 300000, 0, 0, 0, 202, 25, 2, 1, 0, 0, 0, 0, 0, 'Pirate treasure trigger mob - On Just Summoned - Summon Creature \'Treasure Hunting Pirate\''),
+(7898, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 7902, 1, 300000, 0, 0, 0, 202, 25, 2, 1, 0, 0, 0, 0, 0, 'Pirate treasure trigger mob - On Just Summoned - Summon Creature \'Treasure Hunting Buccaneer\''),
+(7898, 0, 2, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 7901, 1, 300000, 0, 0, 0, 202, 25, 1, 1, 0, 0, 0, 0, 0, 'Pirate treasure trigger mob - On Just Summoned - Summon Creature \'Treasure Hunting Swashbuckler\'');
+
+UPDATE `creature_template` SET `AIName`='SmartAI' WHERE `entry` IN (7899,7901,7902);
+DELETE FROM `smart_scripts` WHERE `source_type` = 0  AND `entryorguid` IN (7899,7901,7902);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+-- Treasure Hunting Pirate
+(7899, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 0, 0, 1, 3, 0, 0, 20, 142194, 0, 0, 0, 0, 0, 0, 0, 'Treasure Hunting Pirate - On Just Summoned - Move To Closest Creature \'Pirate\'s Treasure!\''),
+(7899, 0, 1, 0, 34, 0, 100, 0, 8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Treasure Hunting Pirate - On Reached Point 0 - Say Line 0'),
+(7899, 0, 2, 0, 0, 0, 100, 0, 3000, 7000, 8200, 18100, 0, 0, 11, 11976, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Treasure Hunting Pirate - In Combat - Cast \'Strike\''),
+-- Treasure Hunting Swashbuckler
+(7901, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 0, 0, 1, 3, 0, 0, 20, 142194, 0, 0, 0, 0, 0, 0, 0, 'Treasure Hunting Swashbuckler - On Just Summoned - Move To Closest Creature \'Pirate\'s Treasure!\''),
+(7901, 0, 1, 0, 34, 0, 100, 0, 8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Treasure Hunting Swashbuckler - On Reached Point 0 - Say Line 0'),
+(7901, 0, 2, 0, 0, 0, 100, 0, 10200, 23100, 21900, 28400, 0, 0, 11, 6713, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Treasure Hunting Swashbuckler - In Combat - Cast \'Disarm\''),
+-- Treasure Hunting Buccaneer
+(7902, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 0, 0, 1, 3, 0, 0, 20, 142194, 0, 0, 0, 0, 0, 0, 0, 'Treasure Hunting Buccaneer - On Just Summoned - Move To Closest Creature \'Pirate\'s Treasure!\''),
+(7902, 0, 1, 0, 34, 0, 100, 0, 8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Treasure Hunting Buccaneer - On Reached Point 0 - Say Line 0'),
+(7902, 0, 2, 0, 0, 0, 100, 0, 3000, 7000, 8200, 18100, 0, 0, 11, 11976, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Treasure Hunting Buccaneer - In Combat - Cast \'Strike\'');
+
+DELETE FROM `creature_text` WHERE `CreatureID` IN (7899,7901,7902);
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(7899,0,0,'Hey!  Get away from our treasure!',12,0,100,0,0,0,3931,0,'Treasure Hunting Pirate'),
+(7899,0,1,'That\'s our treasure, you lubber!',12,0,100,0,0,0,3931,0,'Treasure Hunting Pirate'),
+(7899,0,2,'We didn\'t hide this stuff just you could steal it!',12,0,100,0,0,0,3931,0,'Treasure Hunting Pirate'),
+(7901,0,0,'Hey!  Get away from our treasure!',12,0,100,0,0,0,3931,0,'Treasure Hunting Swashbuckler'),
+(7901,0,1,'That\'s our treasure, you lubber!',12,0,100,0,0,0,3931,0,'Treasure Hunting Swashbuckler'),
+(7901,0,2,'We didn\'t hide this stuff just you could steal it!',12,0,100,0,0,0,3931,0,'Treasure Hunting Swashbuckler'),
+(7902,0,0,'Hey!  Get away from our treasure!',12,0,100,0,0,0,3931,0,'Treasure Hunting Buccaneer'),
+(7902,0,1,'That\'s our treasure, you lubber!',12,0,100,0,0,0,3931,0,'Treasure Hunting Buccaneer'),
+(7902,0,2,'We didn\'t hide this stuff just you could steal it!',12,0,100,0,0,0,3931,0,'Treasure Hunting Buccaneer');

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -15,34 +15,8 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* ContentData
-go_cat_figurine (the "trap" version of GO, two different exist)
-go_barov_journal
-go_ethereum_prison
-go_ethereum_stasis
-go_sacred_fire_of_life
-go_shrine_of_the_birds
-go_southfury_moonstone
-go_resonite_cask
-go_tablet_of_the_seven
-go_tele_to_dalaran_crystal
-go_tele_to_violet_stand
-go_scourge_cage
-go_jotunheim_cage
-go_table_theka
-go_soulwell
-go_bashir_crystalforge
-go_soulwell
-go_dragonflayer_cage
-go_tadpole_cage
-go_amberpine_outhouse
-go_hive_pod
-go_veil_skith_cage
-EndContentData */
-
 #include "CellImpl.h"
 #include "GameObjectAI.h"
-#include "GameTime.h"
 #include "GridNotifiersImpl.h"
 #include "Player.h"
 #include "ScriptMgr.h"
@@ -1386,41 +1360,6 @@ public:
 };
 
 /*######
-## go_inconspicuous_landmark
-######*/
-
-enum InconspicuousLandmark
-{
-    SPELL_SUMMON_PIRATES_TREASURE_AND_TRIGGER_MOB    = 11462,
-    ITEM_CUERGOS_KEY                                 = 9275,
-};
-
-class go_inconspicuous_landmark : public GameObjectScript
-{
-public:
-    go_inconspicuous_landmark() : GameObjectScript("go_inconspicuous_landmark")
-    {
-        _lastUsedTime = GameTime::GetGameTime().count();
-    }
-
-    bool OnGossipHello(Player* player, GameObject* /*go*/) override
-    {
-        if (player->HasItemCount(ITEM_CUERGOS_KEY))
-            return true;
-
-        if (_lastUsedTime > GameTime::GetGameTime().count())
-            return true;
-
-        _lastUsedTime = GameTime::GetGameTime().count() + MINUTE;
-        player->CastSpell(player, SPELL_SUMMON_PIRATES_TREASURE_AND_TRIGGER_MOB, true);
-        return true;
-    }
-
-private:
-    uint32 _lastUsedTime;
-};
-
-/*######
 ## go_soulwell
 ######*/
 
@@ -1989,7 +1928,6 @@ void AddSC_go_scripts()
     new go_arcane_prison();
     new go_jotunheim_cage();
     new go_table_theka();
-    new go_inconspicuous_landmark();
     new go_soulwell();
     new go_dragonflayer_cage();
     new go_amberpine_outhouse();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Upon reset they return to their initial spawn positions, not next to the chest.

To fully close the issues, it would allegedly require sniffing every single Inconspicuous Landmark's spawns, since the NPCs are based on waypoints as seen on the Trinity issue sniff.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Progress https://github.com/azerothcore/azerothcore-wotlk/issues/8407
- Progress https://github.com/chromiecraft/chromiecraft/issues/1998

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://www.youtube.com/watch?v=h2a9XKZpktM
https://github.com/TrinityCore/TrinityCore/issues/24962 - sniff, confirming that [11462](https://wowgaming.altervista.org/aowow/?spell=11462) [(and the other summon spells)](https://wowgaming.altervista.org/aowow/?search=Summon+Treasure+Hunting) are not used

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

.additem 9254
.go xyz -10260 -3915 2 1
Find one of the 6 Inconspicuous Landmark
Interact with it, chest should spawn and briefly after the mobs, which should run to the chest and talk upon reaching it.
If they reset (run away/.gm on) they should return to their original spawning position

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Idk how many Inconspicuous Landmark should be active at once. (currently, 1)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
