### PR TITLE
fix(Scripts/Paladin): ensure Judgements of the Just procs Seal of Vengeance/Corruption

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -80,6 +80,12 @@ enum PaladinSpells
     SPELL_PALADIN_SANCTIFIED_RETRIBUTION_AURA    = 63531,
     SPELL_PALADIN_AURA_MASTERY_IMMUNE            = 64364,
 
+    SPELL_JUDGEMENTS_OF_THE_JUST                 = 68055,
+    SPELL_JUDGEMENT_OF_VENGEANCE_EFFECT          = 31804,
+    SPELL_HOLY_VENGEANCE                         = 31803,
+    SPELL_JUDGEMENT_OF_CORRUPTION_EFFECT         = 53733,
+    SPELL_BLOOD_CORRUPTION                       = 53742,
+
     SPELL_GENERIC_ARENA_DAMPENING                = 74410,
     SPELL_GENERIC_BATTLEGROUND_DAMPENING         = 74411
 };
@@ -872,10 +878,10 @@ public:
         GetCaster()->CastSpell(GetHitUnit(), _spellId, true);
         GetCaster()->CastSpell(GetHitUnit(), spellId2, true);
 
-           // Judgement of the Just
+        // Judgement of the Just
         if (GetCaster()->GetAuraEffect(SPELL_AURA_ADD_FLAT_MODIFIER, SPELLFAMILY_PALADIN, 3015, 0))
         {
-            if (GetCaster()->CastSpell(GetHitUnit(), 68055, true) && (spellId2 == 31804 || spellId2 == 53733))
+            if (GetCaster()->CastSpell(GetHitUnit(), SPELL_JUDGEMENTS_OF_THE_JUST, true) && (spellId2 == SPELL_JUDGEMENT_OF_VENGEANCE_EFFECT || spellId2 == SPELL_JUDGEMENT_OF_CORRUPTION_EFFECT))
             {
                 //hidden effect only cast when spellcast of judgements of the just is succesful
                 GetCaster()->CastSpell(GetHitUnit(), SealApplication(spellId2), true); //add hidden seal apply effect for vengeance and corruption
@@ -887,10 +893,10 @@ public:
     {
         switch (correspondingSpellId)
         {
-            case 31804: //judgement of vengeance
-                return 31803;
-            case 53733: //judgement of corruption
-                return 53742;
+            case SPELL_JUDGEMENT_OF_VENGEANCE_EFFECT:
+                return SPELL_HOLY_VENGEANCE;
+            case SPELL_JUDGEMENT_OF_CORRUPTION_EFFECT:
+                return SPELL_BLOOD_CORRUPTION;
             default:
                 return 0;
         }

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -872,9 +872,28 @@ public:
         GetCaster()->CastSpell(GetHitUnit(), _spellId, true);
         GetCaster()->CastSpell(GetHitUnit(), spellId2, true);
 
-        // Judgement of the Just
+           // Judgement of the Just
         if (GetCaster()->GetAuraEffect(SPELL_AURA_ADD_FLAT_MODIFIER, SPELLFAMILY_PALADIN, 3015, 0))
-            GetCaster()->CastSpell(GetHitUnit(), 68055, true);
+        {
+            if(GetCaster()->CastSpell(GetHitUnit(), 68055, true) && (spellId2 == 31804 || spellId2 == 53733))
+            {
+                //hidden effect only cast when spellcast of judgements of the just is succesful
+                GetCaster()->CastSpell(GetHitUnit(), SealApplication(spellId2), true); //add hidden seal apply effect for vengeance and corruption
+            }
+        }
+    }
+
+    uint32 SealApplication(uint32 correspondingSpellId)
+    {
+        switch(correspondingSpellId)
+        {
+            case 31804: //judgement of vengeance
+                return 31803;
+            case 53733: //judgement of corruption
+                return 53742;
+            default:
+                return 0;
+        }
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -875,7 +875,7 @@ public:
            // Judgement of the Just
         if (GetCaster()->GetAuraEffect(SPELL_AURA_ADD_FLAT_MODIFIER, SPELLFAMILY_PALADIN, 3015, 0))
         {
-            if(GetCaster()->CastSpell(GetHitUnit(), 68055, true) && (spellId2 == 31804 || spellId2 == 53733))
+            if (GetCaster()->CastSpell(GetHitUnit(), 68055, true) && (spellId2 == 31804 || spellId2 == 53733))
             {
                 //hidden effect only cast when spellcast of judgements of the just is succesful
                 GetCaster()->CastSpell(GetHitUnit(), SealApplication(spellId2), true); //add hidden seal apply effect for vengeance and corruption
@@ -885,7 +885,7 @@ public:
 
     uint32 SealApplication(uint32 correspondingSpellId)
     {
-        switch(correspondingSpellId)
+        switch (correspondingSpellId)
         {
             case 31804: //judgement of vengeance
                 return 31803;


### PR DESCRIPTION
## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

I can see how this PR can spark some debate, and perhaps it should. I do invite people to read the sources, as well as the original bug report. As a lot of planning went into this from the reporter's side.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16537
- Closes https://github.com/chromiecraft/chromiecraft/issues/5673

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://wowpedia.fandom.com/wiki/Patch_3.2.0
Judgments are attacks, patch 3.2:
"Judgments: All paladin judgements are now properly considered as melee attacks that cannot be dodged, blocked or parried."

Again patch 3.2, about SoC/SoCor:
"These seals have been redesigned. Only auto-attacks and Ability paladin hammeroftherighteous [Hammer of the Righteous] can place the debuff on the paladin's current target(s). However, while the seal is active, each melee swing or ability (excluding judgements) that lands on the target will deal a percentage of weapon damage as Holy damage to the target. This damage maxes out at 33% weapon damage with 5 applications of the debuff and scales upward evenly based on how many applications of the debuff are active. This Holy damage deals double-damage critical strikes. In addition, the damage-over-time debuff is now considered a melee attack for the purposes of determining its chance to hit, miss, be dodged or parried."

additional note by me: Reading the above, you can see that an effort was made to remove seal of vengeance or corruption procs on regular judgements. However, as you can also read, it does proc on any other ability. This means, that together with the judgements of the just proc, the seal should most likely proc again, even though it wouldn't proc on judgement alone. For further sources regarding judgements specifically proccing on judgements of the just, check the linked issues.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. don't learn judgements of the just
2. stand near a target dummy but not in melee range
3. apply seal of vengeance
4. cast judgement
5. see that no seal of vengeance stack has been applied
6. learn judgements of the just (prot talent) (any rank)
7. cast judgement again
8. see that a vengeance stack is applied

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

none afaik

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
