### PR TITLE
fix(Core/Spells): Calculate die sides for AuraEffect baseAmount

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -381,8 +381,8 @@ pAuraEffectHandler AuraEffectHandler[TOTAL_AURAS] =
 
 AuraEffect::AuraEffect(Aura* base, uint8 effIndex, int32* baseAmount, Unit* caster):
     m_base(base), m_spellInfo(base->GetSpellInfo()),
-    m_baseAmount(baseAmount ? * baseAmount : m_spellInfo->Effects[effIndex].BasePoints), m_critChance(0),
-    m_oldAmount(0), m_isAuraEnabled(true), m_channelData(nullptr), m_spellmod(nullptr), m_periodicTimer(0), m_tickNumber(0), m_effIndex(effIndex),
+    m_baseAmount(m_spellInfo->Effects[effIndex].CalcValue()),
+    m_critChance(0), m_oldAmount(0), m_isAuraEnabled(true), m_channelData(nullptr), m_spellmod(nullptr), m_periodicTimer(0), m_tickNumber(0), m_effIndex(effIndex),
     m_canBeRecalculated(true), m_isPeriodic(false)
 {
     CalculatePeriodic(caster, true, false);

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -381,7 +381,7 @@ pAuraEffectHandler AuraEffectHandler[TOTAL_AURAS] =
 
 AuraEffect::AuraEffect(Aura* base, uint8 effIndex, int32* baseAmount, Unit* caster):
     m_base(base), m_spellInfo(base->GetSpellInfo()),
-    m_baseAmount(m_spellInfo->Effects[effIndex].CalcValue()),
+    m_baseAmount(baseAmount ? * baseAmount : m_spellInfo->Effects[effIndex].BasePoints), m_fullAmount(m_spellInfo->Effects[effIndex].CalcValue()),
     m_critChance(0), m_oldAmount(0), m_isAuraEnabled(true), m_channelData(nullptr), m_spellmod(nullptr), m_periodicTimer(0), m_tickNumber(0), m_effIndex(effIndex),
     m_canBeRecalculated(true), m_isPeriodic(false)
 {

--- a/src/server/game/Spells/Auras/SpellAuraEffects.h
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.h
@@ -55,6 +55,7 @@ public:
     uint32 GetId() const;
     uint32 GetEffIndex() const { return m_effIndex; }
     int32 GetBaseAmount() const { return m_baseAmount; }
+    int32 GetFullAmount() const { return m_fullAmount; }
     int32 GetAmplitude() const { return m_amplitude; }
 
     int32 GetMiscValueB() const;
@@ -121,6 +122,7 @@ private:
 
     SpellInfo const* const m_spellInfo;
     int32 const m_baseAmount;
+    int32 const m_fullAmount;
 
     bool m_applyResilience;
     uint8 m_casterLevel;

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -1221,7 +1221,7 @@ class spell_dk_death_coil : public SpellScript
             else
             {
                 if (AuraEffect const* auraEffect = caster->GetAuraEffect(SPELL_DK_ITEM_SIGIL_VENGEFUL_HEART, EFFECT_1))
-                    damage += auraEffect->GetBaseAmount();
+                    damage += auraEffect->GetFullAmount();
                 caster->CastCustomSpell(target, SPELL_DK_DEATH_COIL_DAMAGE, &damage, nullptr, nullptr, true);
             }
         }

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -748,7 +748,7 @@ class spell_hun_sniper_training : public AuraScript
     {
         if (Player* playerTarget = GetUnitOwner()->ToPlayer())
         {
-            int32 baseAmount = aurEff->GetBaseAmount();
+            int32 baseAmount = aurEff->GetFullAmount();
             int32 amount = playerTarget->isMoving() || aurEff->GetAmount() <= 0 ?
                             playerTarget->CalculateSpellDamage(playerTarget, GetSpellInfo(), aurEff->GetEffIndex(), &baseAmount) :
                             aurEff->GetAmount() - 1;

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -849,7 +849,7 @@ class spell_pri_vampiric_touch : public AuraScript
             if (Unit* target = GetUnitOwner())
                 if (AuraEffect const* aurEff = GetEffect(EFFECT_1))
                 {
-                    int32 damage = aurEff->GetBaseAmount();
+                    int32 damage = aurEff->GetFullAmount();
                     damage = aurEff->GetSpellInfo()->Effects[EFFECT_1].CalcValue(caster, &damage, nullptr) * 8;
                     // backfire damage
                     caster->CastCustomSpell(target, SPELL_PRIEST_VAMPIRIC_TOUCH_DISPEL, &damage, nullptr, nullptr, true, nullptr, aurEff);

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -588,7 +588,7 @@ class spell_sha_earthbind_totem : public AuraScript
             return;
         if (Player* owner = GetCaster()->GetCharmerOrOwnerPlayerOrPlayerItself())
             if (AuraEffect* aur = owner->GetDummyAuraEffect(SPELLFAMILY_SHAMAN, 2289, 0))
-                if (roll_chance_i(aur->GetBaseAmount()))
+                if (roll_chance_i(aur->GetFullAmount()))
                     GetTarget()->CastSpell((Unit*)nullptr, SPELL_SHAMAN_TOTEM_EARTHEN_POWER, true);
     }
 

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -250,7 +250,7 @@ class spell_warl_demonic_knowledge : public AuraScript
     void CalculateAmount(AuraEffect const* aurEff, int32& amount, bool& /*canBeRecalculated*/)
     {
         if (Unit* caster = GetCaster())
-            amount = CalculatePct(caster->GetStat(STAT_STAMINA) + caster->GetStat(STAT_INTELLECT), aurEff->GetBaseAmount());
+            amount = CalculatePct(caster->GetStat(STAT_STAMINA) + caster->GetStat(STAT_INTELLECT), aurEff->GetFullAmount());
     }
 
     void CalcPeriodic(AuraEffect const* /*aurEff*/, bool& isPeriodic, int32& amplitude)
@@ -992,7 +992,7 @@ class spell_warl_unstable_affliction : public AuraScript
         if (Unit* caster = GetCaster())
             if (AuraEffect const* aurEff = GetEffect(EFFECT_0))
             {
-                int32 damage = aurEff->GetBaseAmount();
+                int32 damage = aurEff->GetFullAmount();
                 damage = aurEff->GetSpellInfo()->Effects[EFFECT_0].CalcValue(caster, &damage, nullptr) * 9;
                 // backfire damage and silence
                 caster->CastCustomSpell(dispelInfo->GetDispeller(), SPELL_WARLOCK_UNSTABLE_AFFLICTION_DISPEL, &damage, nullptr, nullptr, true, nullptr, aurEff);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

**I feel like there is a better way to do this, can just use spellinfo for the mentioned spell, but this still stands. Help pls**
 
Currently ```GetBaseAmount()``` returns only the base points (without die sides)
The % should be +1 (Demonic Knowledge, per rank - 4, 8, 12)
![image](https://github.com/azerothcore/azerothcore-wotlk/assets/46330494/8a054da2-e2d7-4b82-ba42-64ddff1290b6)
https://github.com/azerothcore/azerothcore-wotlk/blob/8fbf143c0308cefcffee29d3f3585a2261c0b84d/src/server/scripts/Spells/spell_warlock.cpp#L253

I feel like other calculations with the baseAmount might be wrong.
## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/4287

https://github.com/azerothcore/azerothcore-wotlk/blob/8fbf143c0308cefcffee29d3f3585a2261c0b84d/src/server/scripts/Spells/spell_shaman.cpp#L591
https://github.com/azerothcore/azerothcore-wotlk/blob/8fbf143c0308cefcffee29d3f3585a2261c0b84d/src/server/scripts/Spells/spell_priest.cpp#L852
https://github.com/azerothcore/azerothcore-wotlk/blob/8fbf143c0308cefcffee29d3f3585a2261c0b84d/src/server/scripts/Spells/spell_dk.cpp#L1224

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] I don't see a reason why you would ever want only base points (without die sides), but that's just me, also this function (GetBaseAmount()) is only used for few things.
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
