### PR TITLE
Fix (core/SpellEffects): Don't randomize summoned guardian position if target is in the DB

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -6061,8 +6061,7 @@ void Spell::SummonGuardian(uint32 i, uint32 entry, SummonPropertiesEntry const* 
         // target position is specified in the DB AND the effect has no or zero radius
         if ((totalNumGuardians == 1 && GetSpellInfo()->Effects[i].Effect != SPELL_EFFECT_SUMMON_PET) ||
             (GetSpellInfo()->Effects[i].TargetA.GetTarget() == TARGET_DEST_DB &&
-                (!GetSpellInfo()->Effects[i].HasRadius() || GetSpellInfo()->Effects[i].RadiusEntry->RadiusMax == 0))
-           )
+            (!GetSpellInfo()->Effects[i].HasRadius() || GetSpellInfo()->Effects[i].RadiusEntry->RadiusMax == 0)))
         {
             pos = *destTarget;
         }

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -6058,11 +6058,11 @@ void Spell::SummonGuardian(uint32 i, uint32 entry, SummonPropertiesEntry const* 
 
         // xinef: do not use precalculated position for effect summon pet in this function
         // it means it was cast by NPC and should have its position overridden
-        // unless the destination was specified in a DB entry
+        // unless the target is a position specified in the DB
         if
         (
             (totalNumGuardians == 1 && GetSpellInfo()->Effects[i].Effect != SPELL_EFFECT_SUMMON_PET) ||
-            (GetSpellInfo()->Effects[i].TargetA.GetTarget() == TARGET_DEST_DB)
+            (!GetSpellInfo()->Effects[i].HasRadius() && GetSpellInfo()->Effects[i].TargetA.GetTarget() == TARGET_DEST_DB)
         )
         {
             pos = *destTarget;

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -6057,13 +6057,12 @@ void Spell::SummonGuardian(uint32 i, uint32 entry, SummonPropertiesEntry const* 
         Position pos;
 
         // xinef: do not use precalculated position for effect summon pet in this function
-        // it means it was cast by NPC and should have its position overridden
-        // unless the target is a position specified in the DB
-        if
-        (
-            (totalNumGuardians == 1 && GetSpellInfo()->Effects[i].Effect != SPELL_EFFECT_SUMMON_PET) ||
-            (!GetSpellInfo()->Effects[i].HasRadius() && GetSpellInfo()->Effects[i].TargetA.GetTarget() == TARGET_DEST_DB)
-        )
+        // it means it was cast by NPC and should have its position overridden unless the
+        // target position is specified in the DB AND the effect has no or zero radius
+        if ((totalNumGuardians == 1 && GetSpellInfo()->Effects[i].Effect != SPELL_EFFECT_SUMMON_PET) ||
+            (GetSpellInfo()->Effects[i].TargetA.GetTarget() == TARGET_DEST_DB &&
+                (!GetSpellInfo()->Effects[i].HasRadius() || GetSpellInfo()->Effects[i].RadiusEntry->RadiusMax == 0))
+           )
         {
             pos = *destTarget;
         }

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -6058,7 +6058,12 @@ void Spell::SummonGuardian(uint32 i, uint32 entry, SummonPropertiesEntry const* 
 
         // xinef: do not use precalculated position for effect summon pet in this function
         // it means it was cast by NPC and should have its position overridden
-        if (totalNumGuardians == 1 && GetSpellInfo()->Effects[i].Effect != SPELL_EFFECT_SUMMON_PET)
+        // unless the destination was specified in a DB entry
+        if
+        (
+            (totalNumGuardians == 1 && GetSpellInfo()->Effects[i].Effect != SPELL_EFFECT_SUMMON_PET) ||
+            (GetSpellInfo()->Effects[i].TargetA.GetTarget() == TARGET_DEST_DB)
+        )
         {
             pos = *destTarget;
         }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Adds an extra condition to the position randomization function for summoned guardian. This condition ensures that if the target for the summon is from the DB (`spell_target_position`) that it will appear exactly at that position every time.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Needed for #17398
- Related to #12257
- Related to https://github.com/chromiecraft/chromiecraft/issues/3709

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Before applying the PR:
1. `.go xyz 4032.49 -3357.65 115.06 329 1.52`
2. Engage Baron Rivendare (10440)
3. Observe that the first wave of skeletons appear exactly at the spell effect on each bone pile
4. Observe that subsequent waves appear in a radius around this point, sometimes causing skeletons to be summoned outside the room (through the wall)
5. Observe that the corpses from the skeletons are in different positions each time (because they are being summoned into random positions around the target position)

![image](https://github.com/azerothcore/azerothcore-wotlk/assets/19712078/2c3813fc-867a-47d2-8931-300385af1c90)

After applying the PR:
1. `.go xyz 4032.49 -3357.65 115.06 329 1.52`
2. Engage Baron Rivendare (10440)
3. Observe that all waves of skeletons appear exactly at the spell effect on each bone pile, in the same spot each time. None of them disappear into the wall.
4. Observe that the corpses from the skeletons overlap near-perfectly because they are being summoned to the exact target position each time

![image](https://github.com/azerothcore/azerothcore-wotlk/assets/19712078/e294af0c-79c3-4c30-8ca5-87e0a0e9a758)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
