### PR TITLE
fix(scripts/TempleOfAhnQiraj): Remove spell "Twin Empathy" (1177) that is not present on live

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1697524019251340056.sql
+++ b/data/sql/updates/pending_db_world/rev_1697524019251340056.sql
@@ -1,0 +1,2 @@
+-- Remove unneeded spell "Twin Empathy" (1177)
+DELETE FROM `spell_dbc` WHERE `Id`=1177;

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_twinemperors.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_twinemperors.cpp
@@ -25,7 +25,6 @@
 enum Spells
 {
     // Both
-    SPELL_TWIN_EMPATHY            = 1177,
     SPELL_TWIN_TELEPORT_1         = 800,
     SPELL_TWIN_TELEPORT_VISUAL    = 26638,
     SPELL_HEAL_BROTHER            = 7393,
@@ -114,7 +113,7 @@ struct boss_twinemperorsAI : public BossAI
             {
                 float dmgPct = damage / (float)me->GetMaxHealth();
                 int32 actualDmg = dmgPct * twin->GetMaxHealth();
-                twin->CastCustomSpell(twin, SPELL_TWIN_EMPATHY, &actualDmg, nullptr, nullptr, true);
+                twin->SetHealth(twin->GetHealth() - actualDmg);
             }
         }
     }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

This PR removes the spell "Twin Empathy" (1177) from the Twin Emperors encounter and the `spell_dbc` database.

The spell "Twin Empathy" was used [in WoW Classic](https://www.wowhead.com/classic/spell=1177/twin-empathy) to cause damage to one emperor to equally affect the other (informed conjecture). At some point between its original implementation and WotLK, [the spell was removed from the game](https://www.wowhead.com/wotlk/spell=1177). It no longer appears in the game's DBCs (confirmed with WoW Spell Editor). The only reason it exists in AC today is because of its entry in `spell_dbc` (shoutout to @AnchyDev).

I took a sniff on retail for this encounter and confirmed that no spell is being cast between the two emperors when health decreases.

```
ServerToClient: SMSG_UPDATE_OBJECT (0x27BF) Length: 238 ConnIdx: 1 Time: 10/17/2023 01:59:24.047 Number: 1051
NumObjUpdates: 5
MapID: 531 (531)
HasRemovedObjects: False
Data size: 227
[...]
[1] UpdateType: Values
[1] Object Guid: Full: 0xREDACTED Creature/0 R3020/S29775 Map: 531 Entry: 15275 Low: 3021144
[1] EntryID: 15275
[...]
[1] Health: 809095
```
Time passes in which there are no spells cast between the emperors.
```
ServerToClient: SMSG_UPDATE_OBJECT (0x27BF) Length: 429 ConnIdx: 1 Time: 10/17/2023 01:59:25.374 Number: 1145
NumObjUpdates: 2
MapID: 531 (531)
HasRemovedObjects: False
Data size: 418
[...]
[1] UpdateType: Values
[1] Object Guid: Full: 0xREDACTED Creature/0 R3020/S29775 Map: 531 Entry: 15275 Low: 3021144
[1] Health: 807315
```

This would seem to indicate that the health sync is being done entirely server-side without using any spell. This PR replicates that functionality in AC.

I find no evidence in AC's source files that any other encounter is using this spell.

((Side note: I found this issue while researching why AutoBalance was scaling the Twin Empathy spell. This PR gets closer to Blizzlike while having the happy side effect of fixing the issue with AutoBalance as well.))

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [X] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go creature 144285`
2. Engage the Emperors
3. Target one of the Emperors and do `.damage 100000`
4. Note that damage decreases by 100k on both bosses
5. Do `.damage 10000000`
6. Note that both emperors die as expected

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
