### PR TITLE
fix(DB/Procs):  Skullflame Shield & Demon Forged Breastplate

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1698228038574727200.sql
+++ b/data/sql/updates/pending_db_world/rev_1698228038574727200.sql
@@ -1,0 +1,8 @@
+-- Skullflame Shield / Demon Forged Breastplate proc on critical/normal/partial block
+DELETE FROM `spell_proc_event` WHERE `entry`=16611; -- Demon Forged Breastplate
+DELETE FROM `spell_proc_event` WHERE `entry`=18815; -- Drain Life
+DELETE FROM `spell_proc_event` WHERE `entry`=18816; -- Flamestrike
+INSERT INTO `spell_proc_event` (`entry`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `procFlags`, `procEx`, `procPhase`, `ppmRate`, `CustomChance`, `Cooldown`) VALUES
+(16611, 0, 0, 0, 0, 0, 0, 67, 0, 0, 0, 0),
+(18815, 0, 0, 0, 0, 0, 0, 67, 0, 0, 0, 0),
+(18816, 0, 0, 0, 0, 0, 0, 67, 0, 0, 0, 0);

--- a/data/sql/updates/pending_db_world/rev_1698228038574727200.sql
+++ b/data/sql/updates/pending_db_world/rev_1698228038574727200.sql
@@ -1,7 +1,6 @@
 -- Skullflame Shield / Demon Forged Breastplate proc on critical/normal/partial block
-DELETE FROM `spell_proc_event` WHERE `entry`=16611; -- Demon Forged Breastplate
-DELETE FROM `spell_proc_event` WHERE `entry`=18815; -- Drain Life
-DELETE FROM `spell_proc_event` WHERE `entry`=18816; -- Flamestrike
+-- Demon Forged Breastplate, Drain Life, Flamestrike
+DELETE FROM `spell_proc_event` WHERE `entry` IN (16611,18815,18816);
 INSERT INTO `spell_proc_event` (`entry`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `procFlags`, `procEx`, `procPhase`, `ppmRate`, `CustomChance`, `Cooldown`) VALUES
 (16611, 0, 0, 0, 0, 0, 0, 67, 0, 0, 0, 0),
 (18815, 0, 0, 0, 0, 0, 0, 67, 0, 0, 0, 0),


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Should proc on critical/normal/partial block

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/6164

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

"struck" = damage taken
"hit by" = can be without taking damage (regarding https://github.com/azerothcore/azerothcore-wotlk/pull/17574)

>Just to expand a little, skullflame can actually push out decent numbers - it's the block value / rating that is the key decider.
If you full block it won't proc, so u need to switch around your gear (block value) to utilize it on strat where it's easy to get enough block value to full block. Once you get t4+ gear your lowering your gear value too much for it to be viable in strat. It was used early on to support part of the larger pulls in strat but FRD is significantly better.

https://www.reddit.com/r/classicwow/comments/rrmpre/skullflame_shield_is_it_actually_being_used/

>Being "struck in combat" requires you take damage. Because of this a totally blocked hit functions different than a partially blocked hit. If partially block the attack so that you take some damage, but block a portion, then you are considered struck in combat. If you block enough so that you block the entire hit, and your combat log just says "Block" with no damage, then that is not considered struck in combat. This also applies for Reckoning and Redoubt, for Paladins. Reckoning and Redoubt will only proc from a block that deals damage. I've actually tested to confirm this.

https://www.wowhead.com/wotlk/item=1168/skullflame-shield#comments:id=131641:reply=22495
## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

.additem 12628 / 1168
.aura 10021 (100% block)

Both items should proc when you take (phyiscal ability/melee) normal hit, critical hit and you take damage from a partial block. Nothing else should proc them.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
