### PR TITLE
fix (Scripts/ICC): Make Valithria starting health dynamic, fix broken channeling spell

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
@@ -752,7 +752,7 @@ public:
             if (!me->IsInCombat())
                 if (me->GetSpawnId())
                     if (!me->GetCurrentSpell(CURRENT_CHANNELED_SPELL))
-                        me->CastSpell(me, SPELL_CORRUPTION, false);
+                        me->CastSpell(me, SPELL_CORRUPTION, true);
 
             if (!UpdateVictim())
                 return;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
@@ -293,16 +293,12 @@ public:
             _instance(creature->GetInstanceScript()), _portalCount(RAID_MODE<uint32>(3, 8, 3, 8))
         {
             me->SetReactState(REACT_PASSIVE);
-            _spawnHealth = 1; // just in case if not set below
-            if (CreatureData const* data = sObjectMgr->GetCreatureData(me->GetSpawnId()))
-                if (data->curhealth)
-                    _spawnHealth = data->curhealth;
         }
 
         void Reset() override
         {
             _events.Reset();
-            me->SetHealth(_spawnHealth);
+            me->SetHealth(me->GetMaxHealth() * 0.5f); // starts at 50% health
             me->LoadCreaturesAddon(true);
             // immune to percent heals
             me->ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_OBS_MOD_HEALTH, true);
@@ -440,8 +436,9 @@ public:
             // does not enter combat
             if (_instance->GetBossState(DATA_VALITHRIA_DREAMWALKER) == NOT_STARTED)
             {
-                if (me->GetHealth() != _spawnHealth) // healing when boss cannot be engaged (lower spire not finished, cheating) doesn't start the fight, prevent winning this way
-                    me->SetHealth(_spawnHealth);
+                uint32 startingHealth = me->GetMaxHealth() * 0.5f;
+                if (me->GetHealth() != startingHealth) // healing when boss cannot be engaged (lower spire not finished, cheating) doesn't start the fight, prevent winning this way
+                    me->SetHealth(startingHealth);
                 return;
             }
 
@@ -484,7 +481,6 @@ public:
     private:
         EventMap _events;
         InstanceScript* _instance;
-        uint32 _spawnHealth;
         uint32 const _portalCount;
         uint32 _missedPortals;
         bool _under25PercentTalkDone;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

This PR addresses two issues:

The `boss_valithria_dreamwalker` script does not correctly account for any change in Valithria's max health, notably from any module or process outside of the value set in the database. While this specifically impacts AutoBalance's changing in the creature's max health, it would also impact any other method of altering the creature's max health.

Additionally, I noticed that the Risen Archmages are not channeling as they should be, and my combat log is filled messages indicating that they are attempting to (incorrectly) cast Corruption over and over again. Changing the spell cast in the `npc_risen_archmage` script to triggered resolves the issue.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-autobalance/issues/164

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Install AutoBalance (or any other module that changes creature max health)
2. `.go xyz 4257.681641 2515.232422 364.535187 631 3.714955`
3. Observe that Valithria's health is at 50% of the new max health value
4. Observe that the Risen Archmages are correctly channeling their spell onto Valithria
5. Observe that the combat log is not spammed with casting messages

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
