### PR TITLE
fix(DB/Loch Modan): adjusting x, y and z axes for nodes

### DIFF
--- a/data/sql/updates/pending_db_world/2023_10_29_00.sql
+++ b/data/sql/updates/pending_db_world/2023_10_29_00.sql
@@ -1,0 +1,5 @@
+UPDATE `gameobject` SET `position_x` = -5737.2, `position_y` = -3880.4, `position_z` = 330 WHERE `guid` = 75928 and `id` = 1732;
+
+UPDATE `gameobject` SET `position_x` = -5737.2, `position_y` = -3880.4, `position_z` = 330 WHERE `guid` = 75927 and `id` = 1731;
+
+UPDATE `gameobject` SET `position_x` = -5737.2, `position_y` = -3880.4, `position_z` = 330 WHERE `guid` = 75929 and `id` = 1733;


### PR DESCRIPTION
**Current Behaviour**
Mining node is stuck midway up a vertical surface making it impossible to mine.
Co ordinates: 68.41, 67.97

## How to Test the Changes:
Go to Ironband's Excavation Site, coordinates: 68.41, 67.97
![immagine](https://github.com/azerothcore/azerothcore-wotlk/assets/148633595/66182acb-34e4-4789-9d1f-f0cd9be91b90)



**Before datafix:**
![immagine](https://github.com/azerothcore/azerothcore-wotlk/assets/148633595/426a99f3-27e9-44b6-a580-1b108ccf4c7b)




**After datafix:**
![immagine](https://github.com/azerothcore/azerothcore-wotlk/assets/148633595/1e4c8ca2-bb40-48be-93ac-44ffebcf276e)

