### PR TITLE
Correct default metric interval

### DIFF
--- a/src/common/Metric/Metric.cpp
+++ b/src/common/Metric/Metric.cpp
@@ -71,7 +71,7 @@ void Metric::LoadFromConfigs()
 {
     bool previousValue = _enabled;
     _enabled = sConfigMgr->GetOption<bool>("Metric.Enable", false);
-    _updateInterval = sConfigMgr->GetOption<int32>("Metric.Interval", 10);
+    _updateInterval = sConfigMgr->GetOption<int32>("Metric.Interval", 1);
 
     if (_updateInterval < 1)
     {

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -781,8 +781,8 @@ Metric.Enable = 0
 #
 #    Metric.Interval
 #        Description: Interval between every batch of data sent in seconds.
-#		      Longer interval means larger batch of data. If the batch
-#		      is too big, it might get rejected.
+#                     Longer interval means larger batch of data. If the batch
+#                     is too big, it might get rejected.
 #        Default:     1 second
 #
 

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -780,11 +780,13 @@ Metric.Enable = 0
 
 #
 #    Metric.Interval
-#        Description: Interval between every batch of data sent in seconds
-#        Default:     10 seconds
+#        Description: Interval between every batch of data sent in seconds.
+#		      Longer interval means larger batch of data. If the batch
+#		      is too big, it might get rejected.
+#        Default:     1 second
 #
 
-Metric.Interval = 10
+Metric.Interval = 1
 
 #
 #    Metric.ConnectionInfo


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
- Change the default metric interval to 1 second instead of 10 seconds.
- Added some further explanation to the description.
## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Not being able to gather any data in Grafana due to batch of data being too large to be sent.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
I no longer get an error in worldserver.exe console, and I get data in Grafana as expected.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1) Follow this guide on how to set up monitoring: https://www.azerothcore.org/wiki/monitoring-azerothcore-with-grafana
2) See that you get data as expected.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
