### PR TITLE
fix(Scripts/SSC): make sure Insidious Whispers demons don't instantly despawn

### DIFF
--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_leotheras_the_blind.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_leotheras_the_blind.cpp
@@ -100,12 +100,11 @@ struct boss_leotheras_the_blind : public BossAI
             if (me->GetDisplayId() != me->GetNativeDisplayId())
             {
                 //is currently in metamorphosis
-                DoResetThreatList();
                 me->LoadEquipment();
                 me->RemoveAurasDueToSpell(SPELL_METAMORPHOSIS);
-
                 scheduler.RescheduleGroup(GROUP_COMBAT, 10s);
             }
+            DoResetThreatList();
             scheduler.CancelGroup(GROUP_DEMON);
             scheduler.DelayAll(10s);
 
@@ -148,8 +147,8 @@ struct boss_leotheras_the_blind : public BossAI
 
     void SummonedCreatureDies(Creature* summon, Unit*) override
     {
-        summons.Despawn(summon);
         me->SetInCombatWithZone();
+        summons.Despawn(summon);
         if (summon->GetEntry() == NPC_GREYHEART_SPELLBINDER)
         {
             if (!summons.HasEntry(NPC_GREYHEART_SPELLBINDER))
@@ -172,6 +171,7 @@ struct boss_leotheras_the_blind : public BossAI
 
     void ElfTime()
     {
+        DoResetThreatList();
         me->InterruptNonMeleeSpells(false);
         scheduler.Schedule(25050ms, 32550ms, GROUP_COMBAT, [this](TaskContext context)
         {
@@ -187,6 +187,7 @@ struct boss_leotheras_the_blind : public BossAI
 
     void DemonTime()
     {
+        DoResetThreatList();
         me->InterruptNonMeleeSpells(false);
         me->LoadEquipment(0, true);
         me->GetMotionMaster()->MoveChase(me->GetVictim(), 25.0f);

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_leotheras_the_blind.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_leotheras_the_blind.cpp
@@ -148,8 +148,8 @@ struct boss_leotheras_the_blind : public BossAI
 
     void SummonedCreatureDies(Creature* summon, Unit*) override
     {
-        me->SetInCombatWithZone();
         summons.Despawn(summon);
+        me->SetInCombatWithZone();
         if (summon->GetEntry() == NPC_GREYHEART_SPELLBINDER)
         {
             if (!summons.HasEntry(NPC_GREYHEART_SPELLBINDER))
@@ -172,6 +172,7 @@ struct boss_leotheras_the_blind : public BossAI
 
     void ElfTime()
     {
+        me->InterruptNonMeleeSpells(false);
         scheduler.Schedule(25050ms, 32550ms, GROUP_COMBAT, [this](TaskContext context)
         {
             DoCastSelf(SPELL_WHIRLWIND);
@@ -186,6 +187,7 @@ struct boss_leotheras_the_blind : public BossAI
 
     void DemonTime()
     {
+        me->InterruptNonMeleeSpells(false);
         me->LoadEquipment(0, true);
         me->GetMotionMaster()->MoveChase(me->GetVictim(), 25.0f);
         DoCastSelf(SPELL_METAMORPHOSIS, true);
@@ -240,15 +242,17 @@ struct npc_inner_demon : public ScriptedAI
         _instance = creature->GetInstanceScript();
     }
 
-    void EnterEvadeMode(EvadeReason /*why*/) override
-    {
-        me->DespawnOrUnsummon(1);
-    }
-
     void IsSummonedBy(WorldObject* summoner) override
     {
         if (!summoner)
             return;
+
+        //summoner is always the affected player
+        _affectedPlayerGUID = summoner->GetGUID();
+        if (Unit* affectedPlayer = summoner->ToUnit())
+        {
+            me->Attack(affectedPlayer, true);
+        }
 
         _scheduler.CancelAll();
         _scheduler.Schedule(4s, [this](TaskContext context)
@@ -260,30 +264,23 @@ struct npc_inner_demon : public ScriptedAI
 
     void JustDied(Unit* /*killer*/) override
     {
-        if (Creature* leotheras = _instance->GetCreature(DATA_LEOTHERAS_THE_BLIND))
+        if (Unit* affectedPlayer = ObjectAccessor::GetUnit(*me, _affectedPlayerGUID))
         {
-            leotheras->RemoveAurasDueToSpell(SPELL_INSIDIOUS_WHISPER);
+            affectedPlayer->RemoveAurasDueToSpell(SPELL_INSIDIOUS_WHISPER);
         }
     }
 
     void DamageTaken(Unit* who, uint32& damage, DamageEffectType, SpellSchoolMask) override
     {
-        if (Creature* leotheras = _instance->GetCreature(DATA_LEOTHERAS_THE_BLIND))
+        if (!who || who->GetGUID() != _affectedPlayerGUID)
         {
-            if (!who || who->GetGUID() != leotheras->GetGUID())
-            {
-                damage = 0;
-            }
+            damage = 0;
         }
     }
 
     bool CanAIAttack(Unit const* who) const override
     {
-        if (Creature* leotheras = _instance->GetCreature(DATA_LEOTHERAS_THE_BLIND))
-        {
-            return who->GetGUID() == leotheras->GetGUID();
-        }
-        return false;
+        return who->GetGUID() == _affectedPlayerGUID;
     }
 
     void UpdateAI(uint32 diff) override
@@ -300,6 +297,7 @@ struct npc_inner_demon : public ScriptedAI
 private:
     TaskScheduler _scheduler;
     InstanceScript* _instance;
+    ObjectGuid _affectedPlayerGUID;
 };
 
 class spell_leotheras_whirlwind : public SpellScriptLoader
@@ -373,7 +371,9 @@ public:
         void FilterTargets(std::list<WorldObject*>& unitList)
         {
             if (Unit* victim = GetCaster()->GetVictim())
+            {
                 unitList.remove_if(Acore::ObjectGUIDCheck(victim->GetGUID(), true));
+            }
         }
 
         void Register() override
@@ -399,9 +399,15 @@ public:
         void HandleEffectRemove(AuraEffect const*  /*aurEff*/, AuraEffectHandleModes /*mode*/)
         {
             if (GetTargetApplication()->GetRemoveMode() != AURA_REMOVE_BY_DEFAULT)
+            {
                 if (InstanceScript* instance = GetUnitOwner()->GetInstanceScript())
-                    if (Creature* leotheras = ObjectAccessor::GetCreature(*GetUnitOwner(), instance->GetGuidData(NPC_LEOTHERAS_THE_BLIND)))
+                {
+                    if (Creature* leotheras = instance->GetCreature(DATA_LEOTHERAS_THE_BLIND))
+                    {
                         leotheras->CastSpell(GetUnitOwner(), SPELL_CONSUMING_MADNESS, true);
+                    }
+                }
+            }
         }
 
         void Register() override
@@ -430,7 +436,9 @@ public:
         {
             PreventDefaultAction();
             if (Unit* victim = GetUnitOwner()->GetVictim())
+            {
                 GetUnitOwner()->CastSpell(victim, GetSpellInfo()->Effects[aurEff->GetEffIndex()].TriggerSpell, true);
+            }
         }
 
         void Register() override
@@ -458,7 +466,9 @@ public:
         {
             PreventHitDefaultEffect(effIndex);
             if (Unit* target = GetHitUnit())
+            {
                 Unit::Kill(GetCaster(), target);
+            }
         }
 
         void Register() override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Revert from my refactor because I thought summoner was the boss for some dumb reason. The actual summoner is the affected player. Renamed variables to make that more clear. Also removed despawn condition (this happened when a different player casts a spell on the demon, which made it despawn immediately). I guess this could have been a failsafe to make sure that other players can't kill the demons with spells, but I don't think this is the right behaviour. Would be nice if someone checked if I'm wrong on this though.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/17510
- Closes https://github.com/chromiecraft/chromiecraft/issues/6232

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [x] ~~DamageTaken damage set to 0 does not prevent spells from other players hitting~~ it should work
- [x] reset threat list on phase transition. see [proof](https://www.youtube.com/watch?si=f5qYxy1tSHeUvLjF&t=62&v=c5SdJIS7X80&feature=youtu.be)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
