### PR TITLE
Fix (Scripts/AI) ZG/Jeklik (Bat Boss) - fix double-run scheduler

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_jeklik.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_jeklik.cpp
@@ -113,7 +113,7 @@ struct boss_jeklik : public BossAI
     // Bat Riders (14750) counter
     uint8 batRidersCount = 0;
 
-    bool _isResetting = false;
+    bool isResetting = false;
 
     boss_jeklik(Creature* creature) : BossAI(creature, DATA_JEKLIK) { }
 
@@ -139,7 +139,7 @@ struct boss_jeklik : public BossAI
         BossAI::SetCombatMovement(false);
         batRidersCount = 0;
 
-        _isResetting = true; // causes scheduler to update even out of combat
+        isResetting = true; // causes scheduler to update even out of combat
 
         // once the path for her to come down to the ground starts, it appears to be near-impossible to stop it
         // instead, simply wait the 3 seconds it takes the path to complete, then teleport her home
@@ -162,7 +162,7 @@ struct boss_jeklik : public BossAI
         {
             me->SetVisible(true);
             me->ClearUnitState(UNIT_STATE_ROOT);
-            _isResetting = false;
+            isResetting = false;
         });
     }
 
@@ -315,7 +315,7 @@ struct boss_jeklik : public BossAI
     void UpdateAI(uint32 diff) override
     {
         // ensures that the scheduler gets updated while resetting
-        if (_isResetting)
+        if (isResetting)
         {
             scheduler.Update(diff);
         }

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_jeklik.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_jeklik.cpp
@@ -314,7 +314,7 @@ struct boss_jeklik : public BossAI
 
     void UpdateAI(uint32 diff) override
     {
-        // ensures that the scheduler gets updated even out of combat
+        // ensures that the scheduler gets updated while resetting
         if (_isResetting)
         {
             scheduler.Update(diff);

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_jeklik.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_jeklik.cpp
@@ -113,6 +113,8 @@ struct boss_jeklik : public BossAI
     // Bat Riders (14750) counter
     uint8 batRidersCount = 0;
 
+    bool _isResetting = false;
+
     boss_jeklik(Creature* creature) : BossAI(creature, DATA_JEKLIK) { }
 
     void InitializeAI() override
@@ -137,6 +139,8 @@ struct boss_jeklik : public BossAI
         BossAI::SetCombatMovement(false);
         batRidersCount = 0;
 
+        _isResetting = true; // causes scheduler to update even out of combat
+
         // once the path for her to come down to the ground starts, it appears to be near-impossible to stop it
         // instead, simply wait the 3 seconds it takes the path to complete, then teleport her home
         scheduler.Schedule(3s, [this](TaskContext)
@@ -158,6 +162,7 @@ struct boss_jeklik : public BossAI
         {
             me->SetVisible(true);
             me->ClearUnitState(UNIT_STATE_ROOT);
+            _isResetting = false;
         });
     }
 
@@ -310,9 +315,14 @@ struct boss_jeklik : public BossAI
     void UpdateAI(uint32 diff) override
     {
         // ensures that the scheduler gets updated even out of combat
-        scheduler.Update(diff);
-
-        BossAI::UpdateAI(diff);
+        if (_isResetting)
+        {
+            scheduler.Update(diff);
+        }
+        else
+        {
+            BossAI::UpdateAI(diff);
+        }
     }
 
     void JustDied(Unit* killer) override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Corrects an issue with #17573 where events happened twice as fast as intended. This was due to an oversight where the scheduler was being updated twice per `UpdateAI`, once in `boss_jeklik::UpdateAI()` as an explicit call and once in `BossAI::Update()`.

I have altered the script so that the scheduler is not needed outside of combat, and that the reset is aided by `DespawnOnEvade()`, which works great. Thanks to @Nyeriah for pointing me towards a function I didn't know about.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
None yet.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Jeklik Test:
1.`.go xyz -12261.517578 -1411.231934 130.803345`
2. Clear adds around the boss
4. Engage the boss in honorable combat
5. Observe events firing in phase 1. Charge will only fire if a threat table target is at least 8 yards away.
6. Reduce boss health to <50%
7. Observe transform to humanoid form and normal events firing.
8. Observe two bat riders appearing from the cave and flying their route, throwing bombs. No more than two bat riders appear.
9. `.gm on` then `.gm off` to reset the boss and observe her disappearing before teleporting to the cave and channeling again

Bat Rider Test:
1. Engage any bat rider in a pack on the ground
2. Observe the bat rider performing actions similar to the previous SAI
3. Reduce bat rider to 30% and observe it blow itself up as expected

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
