### PR TITLE
fix a Mac build issue introduced by commit #17643

### DIFF
--- a/src/common/Utilities/StringFormat.cpp
+++ b/src/common/Utilities/StringFormat.cpp
@@ -17,7 +17,6 @@
 
 #include "StringFormat.h"
 #include "Define.h"
-#include <locale>
 
 template<class Str>
 AC_COMMON_API Str Acore::String::Trim(const Str& s, const std::locale& loc /*= std::locale()*/)

--- a/src/common/Utilities/StringFormat.h
+++ b/src/common/Utilities/StringFormat.h
@@ -21,6 +21,7 @@
 #include "Define.h"
 #include <fmt/format.h>
 #include <fmt/printf.h>
+#include <locale>
 
 namespace Acore
 {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
The Mac build fails with the following 2 error messages:
`src/common/Utilities/StringFormat.h:75:53: error: no type named 'locale' in namespace 'std'`
`src/common/Utilities/StringFormat.h:75:72: error: no member named 'locale' in namespace 'std'`

## Tests Performed:
- Built on macOS Sonoma 14.1.1 (23B81)
