### PR TITLE
chore: rename LANG_YOU_NOT_HAVE_PERMISSION to LANG_PERMISSION_DENIED

### DIFF
--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1117,7 +1117,7 @@ void WorldSession::HandleWorldTeleportOpcode(WorldPacket& recv_data)
     if (AccountMgr::IsAdminAccount(GetSecurity()))
         GetPlayer()->TeleportTo(mapid, PositionX, PositionY, PositionZ, Orientation);
     else
-        SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
+        SendNotification(LANG_PERMISSION_DENIED);
 }
 
 void WorldSession::HandleWhoisOpcode(WorldPacket& recv_data)
@@ -1128,7 +1128,7 @@ void WorldSession::HandleWhoisOpcode(WorldPacket& recv_data)
 
     if (!AccountMgr::IsAdminAccount(GetSecurity()))
     {
-        SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
+        SendNotification(LANG_PERMISSION_DENIED);
         return;
     }
 

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -721,7 +721,7 @@ enum AcoreStrings
     LANG_NOT_ENOUGH_GOLD                = 801,
     LANG_NOT_FREE_TRADE_SLOTS           = 802,
     LANG_NOT_PARTNER_FREE_TRADE_SLOTS   = 803,
-    LANG_YOU_NOT_HAVE_PERMISSION        = 804,
+    LANG_PERMISSION_DENIED              = 804,  //  You do not have permission to perform this function.
     LANG_UNKNOWN_LANGUAGE               = 805,
     LANG_NOT_LEARNED_LANGUAGE           = 806,
     LANG_NEED_CHARACTER_NAME            = 807,


### PR DESCRIPTION

The proposed changes rename the 
lengthy (and a little ambiguous) ACoreStrings::LANG_YOU_NOT_HAVE_PERMISSION to ACoreStrings::LANG_PERMISSION_DENIED.

In an ideal world I think the LANG prefix should probably switched for STRID given its usage context.