### PR TITLE
feat (core/cs): Make `.go xyz` ignore non-numeric data to improve copy-paste usability

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1700285808976576988.sql
+++ b/data/sql/updates/pending_db_world/rev_1700285808976576988.sql
@@ -1,0 +1,4 @@
+-- Update `.go xyz` syntax
+DELETE FROM `command` WHERE `name`='go xyz';
+INSERT INTO `command` (`name`, `security`, `help`) VALUES
+('go xyz', 1, '\rSyntax: .go xyz #x #y [#z [#mapid [#orientation]]]\r\rTeleport player to point with (#x,#y,#z) coordinates at map #mapid with orientation #orientation.\r\rIf #z is not provided, ground/water level will be used. If #mapid is not provided, the current map will be used. If #orientation is not provided, the current orientation will be used.\r\rNon-numbers are allowed and will be ignored.');

--- a/src/server/scripts/Commands/cs_go.cpp
+++ b/src/server/scripts/Commands/cs_go.cpp
@@ -295,14 +295,14 @@ public:
      * @brief Teleports the GM to the specified world coordinates, optionally specifying map ID and orientation.
      *
      * @param handler The ChatHandler that is handling the command.
-     * @param inputCoords The coordinates to teleport to in format "x y z [mapId [orientation]]".
+     * @param args The coordinates to teleport to in format "x y z [mapId [orientation]]".
      * @return true The command was successful.
      * @return false The command was unsuccessful (show error or syntax)
      */
-    static bool HandleGoXYZCommand(ChatHandler* handler, Tail inputCoords)
+    static bool HandleGoXYZCommand(ChatHandler* handler, Tail args)
     {
         std::wstring wInputCoords;
-        if (!Utf8toWStr(inputCoords, wInputCoords))
+        if (!Utf8toWStr(args, wInputCoords))
         {
             return false;
         }

--- a/src/server/scripts/Commands/cs_go.cpp
+++ b/src/server/scripts/Commands/cs_go.cpp
@@ -343,7 +343,7 @@ public:
         float y = locationValues[1];
         float z = locationValues.size() >= 3 ? locationValues[2] : std::max(map->GetHeight(x, y, MAX_HEIGHT), map->GetWaterLevel(x, y));
         // map ID (locationValues[3]) already handled above
-        float o = locationValues.size() >= 5 ? locationValues[4] : 0.0f;
+        float o = locationValues.size() >= 5 ? locationValues[4] : player->GetOrientation();
 
         if (!MapMgr::IsValidMapCoord(mapId, x, y, z, o))
         {

--- a/src/server/scripts/Commands/cs_go.cpp
+++ b/src/server/scripts/Commands/cs_go.cpp
@@ -316,7 +316,7 @@ public:
             return false;
         }
 
-        // create a new vector of floats that only contains args that look like floats
+        // create a new vector of floats that only contains args that look like floats (or integer for mapId)
         std::vector<float> floatValues;
         for (const std::wstring& value : delimitedValues)
         {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Rewrites the command handler function for `.go xyz` to handle flexible inputs. The new implementation will use regex to extract float and integer values from the provided arguments and will discard any other characters.

Since the parsing doesn't care about any of the surrounding text, many different versions of coordinates are supported by this implementation. The only requirement is that the numbers are in the right order (`x y [z [mapId [orientation]]]`) and have at least one delimiter character (not a number) between each number.

The following all work as expected:
`.go xyz 4073.1 -3536.1 123.5 329 2.8` - previously-required format
`.go xyz 4073.2-3536.2,123.5` - any non-number works as a delimiter
`.go xyz Position: X: 4073.3 Y: -3536.3 Z: 123.5` - sniff parse format
`.go xyz Position: X: 4073.4 Y: -3536.4 Z: 123.5 329 O: 2.8` - sniff parse format with `mapId` inserted
`.go xyz (4073.5f,-3536.5f,123.5f` - C++ format, doesn't have to be complete
`.go xyz Position(4073.6f, -3536.6f, 123.5f, 329 2.8f)` - C++ position with `mapId` inserted
`.go xyz 4073.7-3536.7f123.5?329` - any non-number works as a delimiter
`.go xyz This IsAStupidTextBut4073.8ItWorks Fine-3536.8BecauseOf123.5RegExParsing329`

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

`.tel strath` -- puts you in the correct map for the commands that don't specify one

Try each of these cases one at a time. Each one should move you diagonally slightly so you can tell it worked. Some will have orientation and others won't.

`.go xyz 4073.1 -3536.1 123.5 329 0.1`
`.go xyz 4073.2-3536.2,123.5`
`.go xyz Position: X: 4073.3 Y: -3536.3 Z: 123.5`
`.go xyz Position: X: 4073.4 Y: -3536.4 Z: 123.5 329 O: 0.1`
`.go xyz (4073.5f,-3536.5f,123.5f`
`.go xyz Position(4073.6f, -3536.6f, 123.5f, 329 0.1f)`
`.go xyz 4073.7-3536.7f123.5?329`
`.go xyz This IsAStupidTextBut4073.8ItWorks Fine-3536.8BecauseOf123.5RegExParsing329`

Feel free to bring in your own test cases. As long as the numbers are in the correct order (`x, y, [z [mapId [orientation]]]`) with at least one non-number character between each number it should work fine.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
The ordering of parameters is weird when copy-pasting. I'd like to find a way to make the mapId be "whatever the last argument is" while still giving the option to omit it entirely. I considered making is so that `x y z o` all need to be in float format (`123.0` rather than `123`), so then I can just find the last number that isn't in that format, but I want feedback before I implement that.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
