### PR TITLE
fix (DB\Creatures): Added an event for Warlock NPCs to craft gems when a quest is completed

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1700315570944394100.sql
+++ b/data/sql/updates/pending_db_world/rev_1700315570944394100.sql
@@ -10,9 +10,9 @@ DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 626600)
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (626600, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender  - Remove Gossip and Quest Giver npc flags from self.'),
 (626600, 9, 1, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 0, 11, 16633, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - Cast self - Create Item Visual'),
-(626600, 9, 2, 0, 0, 0, 100, 0, 6500, 6500, 0, 0, 0, 0, 15, 4975, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - On Script - Quest Credit \'The Completed Orb of Noh\'Orahil\''),
+(626600, 9, 2, 0, 0, 0, 100, 0, 7000, 7000, 0, 0, 0, 0, 15, 4975, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - On Script - Quest Credit \'The Completed Orb of Noh\'Orahil\''),
 (626600, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 15, 4964, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - On Script - Quest Credit \'The Completed Orb of Dar\'Orahil\''),
-(626600, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip and Quest Giver npc flags to self.');
+(626600, 9, 4, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 0, 82, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - Add Gossip and Quest Giver npc flags to self.');
 
 
 

--- a/data/sql/updates/pending_db_world/rev_1700315570944394100.sql
+++ b/data/sql/updates/pending_db_world/rev_1700315570944394100.sql
@@ -1,0 +1,15 @@
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 6266;
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 6266);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(6266, 0, 0, 0, 19, 0, 100, 512, 4975, 0, 0, 0, 0, 0, 80, 626600, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - On Quest \'The Completed Orb of Noh\'Orahil\' Taken - Run Script'),
+(6266, 0, 1, 0, 19, 0, 100, 512, 4964, 0, 0, 0, 0, 0, 80, 626600, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - On Quest \'The Completed Orb of Dar\'Orahil\' Taken - Run Script');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 626600);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(626600, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender  - Remove Gossip and Quest Giver npc flags from self.'),
+(626600, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 16633, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - Cast self - Create Item Visual'),
+(626600, 9, 2, 0, 0, 0, 100, 0, 10000, 10000, 0, 0, 0, 0, 15, 4975, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - On Script - Quest Credit \'The Completed Orb of Noh\'Orahil\''),
+(626600, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 15, 4964, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - On Script - Quest Credit \'The Completed Orb of Dar\'Orahil\''),
+(626600, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip and Quest Giver npc flags to self.');
+
+

--- a/data/sql/updates/pending_db_world/rev_1700315570944394100.sql
+++ b/data/sql/updates/pending_db_world/rev_1700315570944394100.sql
@@ -9,9 +9,10 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 626600);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (626600, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender  - Remove Gossip and Quest Giver npc flags from self.'),
-(626600, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 16633, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - Cast self - Create Item Visual'),
-(626600, 9, 2, 0, 0, 0, 100, 0, 10000, 10000, 0, 0, 0, 0, 15, 4975, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - On Script - Quest Credit \'The Completed Orb of Noh\'Orahil\''),
+(626600, 9, 1, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 0, 11, 16633, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - Cast self - Create Item Visual'),
+(626600, 9, 2, 0, 0, 0, 100, 0, 6500, 6500, 0, 0, 0, 0, 15, 4975, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - On Script - Quest Credit \'The Completed Orb of Noh\'Orahil\''),
 (626600, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 15, 4964, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Menara Voidrender - On Script - Quest Credit \'The Completed Orb of Dar\'Orahil\''),
 (626600, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip and Quest Giver npc flags to self.');
+
 
 

--- a/data/sql/updates/pending_db_world/rev_1700315570944394100.sql
+++ b/data/sql/updates/pending_db_world/rev_1700315570944394100.sql
@@ -1,3 +1,5 @@
+UPDATE `quest_template_addon` SET `SpecialFlags` = 2 WHERE (`ID` = 4964);
+
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 6266;
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 6266);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Added behavior after completing a mission for Warlock quest NPCs
https://clipchamp.com/watch/bMvNGFhxr6f Videos from Blizzard servers
## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.
1. Create Warlock
2. .level40+
3. .go xyz -782.5499 -3711.31 41.36 1
4. .quest add 4976 
5. Complete the quest
6. Wait for the emote to finish
7. Accept the assignment of "Tecompel de Obbendal 'Olahir" or "Tecompel de Obbenno 'Olahir".
8. She is supposed to use spells to craft jewelry.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
