### PR TITLE
fix(Scripts/Commands): guild commands revert back to using guild names in quotes

### DIFF
--- a/src/server/scripts/Commands/cs_guild.cpp
+++ b/src/server/scripts/Commands/cs_guild.cpp
@@ -67,6 +67,13 @@ public:
             return false;
         }
 
+        guildName = guild_commandscript::_RemoveQuotes(guildName);
+        
+        if (guildName.empty())
+        {
+            return false;
+        }
+
         Player* playerTarget = target->GetConnectedPlayer();
 
         if (playerTarget->GetGuildId())
@@ -106,6 +113,8 @@ public:
 
     static bool HandleGuildDeleteCommand(ChatHandler*, std::string_view guildName)
     {
+        guildName = guild_commandscript::_RemoveQuotes(guildName);
+        
         if (guildName.empty())
         {
             return false;
@@ -129,6 +138,13 @@ public:
         }
 
         if (!target)
+        {
+            return false;
+        }
+
+        guildName = guild_commandscript::_RemoveQuotes(guildName);
+        
+        if (guildName.empty())
         {
             return false;
         }
@@ -188,12 +204,10 @@ public:
 
     static bool HandleGuildRenameCommand(ChatHandler* handler, std::string_view oldGuildStr, std::string_view newGuildStr)
     {
-        if (!oldGuildStr.empty())
-        {
-            return false;
-        }
+        oldGuildStr = guild_commandscript::_RemoveQuotes(oldGuildStr);
+        newGuildStr = guild_commandscript::_RemoveQuotes(newGuildStr);
 
-        if (newGuildStr.empty())
+        if (oldGuildStr.empty() || newGuildStr.empty())
         {
             return false;
         }
@@ -260,6 +274,20 @@ public:
         handler->PSendSysMessage(LANG_GUILD_INFO_MOTD, guild->GetMOTD().c_str()); // Message of the Day
         handler->PSendSysMessage(LANG_GUILD_INFO_EXTRA_INFO, guild->GetInfo().c_str()); // Extra Information
         return true;
+    }
+private:
+    static std::string_view _RemoveQuotes(std::string_view inputString)
+    {
+        if (inputString.starts_with('"') && inputString.ends_with('"'))
+        {
+            inputString.remove_prefix(1);
+            inputString.remove_suffix(1);
+            return inputString;
+        }
+        else
+        {
+            return "";
+        }
     }
 };
 

--- a/src/server/scripts/Commands/cs_guild.cpp
+++ b/src/server/scripts/Commands/cs_guild.cpp
@@ -68,7 +68,7 @@ public:
         }
 
         guildName = guild_commandscript::_RemoveQuotes(guildName);
-        
+
         if (guildName.empty())
         {
             return false;
@@ -114,7 +114,7 @@ public:
     static bool HandleGuildDeleteCommand(ChatHandler*, std::string_view guildName)
     {
         guildName = guild_commandscript::_RemoveQuotes(guildName);
-        
+
         if (guildName.empty())
         {
             return false;
@@ -143,7 +143,7 @@ public:
         }
 
         guildName = guild_commandscript::_RemoveQuotes(guildName);
-        
+
         if (guildName.empty())
         {
             return false;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Ensures compatibility with the original syntax of the commands.

The new changes added in the PR made it so that quotes on guild creation, deletion, rename, etc. got broken. Looks like functionality was added to just paste in the guild names without the quotes, but it seems to also break on spaces. So I added some functionality to extract quotes from the strings again, and now the command works the same as it used to on the front-end for AC users.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/17789
- Fixes some things added in https://github.com/azerothcore/azerothcore-wotlk/pull/17515

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

N.A.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Would like some more edge case testing to see if nothing can be broken.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. use commands like `.guild create <characterName> <guildNameInQuotes>` and `.guild rename <oldNameInQuotes> <newNameInQuotes>` and observe they work again
2. use commands like `.guild create <characterName> <guildNameWithoutQuotes>` and `.guild rename <oldNameWithoutQuotes> <newNameWithoutQuotes>` and observe they throw the error that you need quotes

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
