### PR TITLE
fix(DB/SSC): make sure Enchanted Elementals always walk and not run towards Lady Vashj

### DIFF
--- a/data/sql/updates/pending_db_world/enchanted-elemental-walk.sql
+++ b/data/sql/updates/pending_db_world/enchanted-elemental-walk.sql
@@ -1,0 +1,10 @@
+--
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 21958 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(21958, 0, 0, 0, 54, 0, 100, 512, 0, 0, 0, 0, 0, 0, 53, 0, 2195800, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enchanted Elemental - Just Summoned - Start Waypoint'),
+(21958, 0, 1, 0, 75, 0, 100, 0, 0, 21212, 2, 1000, 0, 0, 11, 38044, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enchanted Elemental - On Distance to Vashj - Cast Spell Surge'),
+(21958, 0, 2, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 38, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enchanted Elemental - On Aggro - Set In Combat With Zone');
+
+DELETE FROM `waypoints` WHERE `entry` = 2195800;
+INSERT INTO `waypoints` (`entry`, `pointid`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `point_comment`) VALUES 
+(2195800, 1, 29.415501, -924.127991, 42.901901, NULL, 0, 'Enchanted Elemental - Vashj Home Position');

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_lady_vashj.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_lady_vashj.cpp
@@ -66,26 +66,6 @@ enum Misc
     POINT_HOME                      = 1,
 };
 
-class startFollow : public BasicEvent
-{
-public:
-    startFollow(Unit* owner) : _owner(owner)  { }
-
-    bool Execute(uint64 /*execTime*/, uint32 /*diff*/) override
-    {
-        if (InstanceScript* instance = _owner->GetInstanceScript())
-        {
-            if (Creature* vashj = ObjectAccessor::GetCreature(*_owner, instance->GetGuidData(NPC_LADY_VASHJ)))
-            {
-                _owner->GetMotionMaster()->MoveFollow(vashj, 3.0f, vashj->GetAngle(_owner), MOTION_SLOT_CONTROLLED);
-            }
-        }
-        return true;
-    }
-private:
-    Unit* _owner;
-};
-
 struct boss_lady_vashj : public BossAI
 {
     boss_lady_vashj(Creature* creature) : BossAI(creature, DATA_LADY_VASHJ)
@@ -147,16 +127,11 @@ struct boss_lady_vashj : public BossAI
         {
             summon->CastSpell(summon, SPELL_MAGIC_BARRIER);
         }
-        else if (summon->GetEntry() == NPC_ENCHANTED_ELEMENTAL)
-        {
-            summon->SetWalk(true);
-            summon->m_Events.AddEvent(new startFollow(summon), summon->m_Events.CalculateTime(0));
-        }
         else if (summon->GetEntry() == NPC_TOXIC_SPOREBAT)
         {
             summon->GetMotionMaster()->MoveRandom(30.0f);
         }
-        else if (summon->GetEntry() != NPC_TAINTED_ELEMENTAL)
+        else if (summon->GetEntry() != NPC_TAINTED_ELEMENTAL && summon->GetEntry() != NPC_ENCHANTED_ELEMENTAL)
         {
             summon->GetMotionMaster()->MovePoint(POINT_HOME, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), true, true);
         }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Wanted to originally use on waypoint reached, but that failed for some reason. They cast the spell way too early. Doing a 2 waypoint path seemed to work, but it would mess up the pathing the elementals did. And as they start in a cone, it doesn't make sense to have 2 points away from the center

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/17791
- Closes https://github.com/chromiecraft/chromiecraft/issues/6250

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. engage vashj
2. get her to p2
3. see now that the elementals walk slowly

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
