### PR TITLE
Fix(DB): Loot Adamantite Ore

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1701536212461529900.sql
+++ b/data/sql/updates/pending_db_world/rev_1701536212461529900.sql
@@ -1,4 +1,4 @@
---Fix loot Prospecting Adamantite Ore
+-- Fix loot Prospecting Adamantite Ore --
 
 DELETE FROM `reference_loot_template` WHERE (`Entry` = 13003);
 INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1701536212461529900.sql
+++ b/data/sql/updates/pending_db_world/rev_1701536212461529900.sql
@@ -1,0 +1,12 @@
+--Fix loot Prospecting Adamantite Ore
+
+DELETE FROM `reference_loot_template` WHERE (`Entry` = 13003);
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(13003, 21929, 0, 0, 0, 1, 1, 1, 1, 'Flame Spessarite'),
+(13003, 23077, 0, 0, 0, 1, 1, 1, 1, 'Blood Garnet'),
+(13003, 23079, 0, 0, 0, 1, 1, 1, 1, 'Deep Peridot'),
+(13003, 23107, 0, 0, 0, 1, 1, 1, 1, 'Shadow Draenite'),
+(13003, 23112, 0, 0, 0, 1, 1, 1, 1, 'Golden Draenite'),
+(13003, 23117, 0, 0, 0, 1, 1, 1, 1, 'Azure Moonstone');
+
+UPDATE `prospecting_loot_template` SET `Reference` = 13003 WHERE (`entry` = 23425) AND (`Item` IN (1));


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->

**I noticed that a small calculation error was made.
the Error was not due to loot %, but to a missing reference.
In essence, (I don't know if due to inaccuracy or laziness), a double reference was made in reference to the fact that a gem must always be guaranteed. (See screenshot below).**
<details>
  <summary> Wrong Reference </summary>

![wrong loot](https://github.com/azerothcore/azerothcore-wotlk/assets/1884642/84512de7-d1f0-4fc3-8ab3-fb0a4e35d7d0)
</details>

**Consequently, this double reference led to a double loot with MaxCount "2", one given at 100% chance and the other given at 15% chance, giving rise to an "alteration" of the loot %. (See screenshots below).**
<details>
  <summary>Test 1 of 1000 Adamantite (Wrong Loot)</summary>

 ![Prosp](https://github.com/azerothcore/azerothcore-wotlk/assets/1884642/52ed3b9e-12ef-4d8f-8dda-9710b359cab7)
</details>

<details>
  <summary>Test 2 of 1000 Adamantite (Wrong Loot)</summary>

![Prosp2](https://github.com/azerothcore/azerothcore-wotlk/assets/1884642/e73410e2-2e99-43b4-b2c0-ffb78b77e8be)
</details>

<details>
  <summary>Test 3 of 1000 Adamantite (Wrong Loot)</summary>

![Prosp3](https://github.com/azerothcore/azerothcore-wotlk/assets/1884642/d16522b7-fc87-4fe1-8a2f-fce06736f0a6)
</details>


**So I created an appropriate reference for guaranteed gems. (See screenshot below).**
<details>
  <summary>Fixed Reference </summary>

![fixed loot](https://github.com/azerothcore/azerothcore-wotlk/assets/1884642/b319b0dc-36c1-4536-a653-02551d0c88c4)
</details>

**In fact, with this change, the loot now comes close to the expectations of the sources cited below**

<details>
  <summary>Test 1 of 1000 Adamantite (Fixed Loot)</summary>

![Prosp-Fixed](https://github.com/azerothcore/azerothcore-wotlk/assets/1884642/00238abc-a1e0-4128-ae00-373688db16b4)
</details>

<details>
  <summary>Test 2 of 1000 Adamantite (Fixed Loot)</summary>

![Prosp-Fixed2](https://github.com/azerothcore/azerothcore-wotlk/assets/1884642/fd3210db-ed25-4837-b6ff-15fdb47d2306)
</details>

<details>
  <summary>Test 3 of 1000 Adamantite (Fixed Loot)</summary>

![Prosp-Fixed3](https://github.com/azerothcore/azerothcore-wotlk/assets/1884642/1eb7cc5c-9dfc-465c-b964-65d1de67f548)
</details>

**These are the percentages and the tests I did.**
<details>
  <summary>Test Percentages </summary>

![calcs](https://github.com/azerothcore/azerothcore-wotlk/assets/1884642/16836ec6-1bcb-47ab-8ba5-94a4459ece81)
</details>



This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/4749
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/17922

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
-- https://github.com/azerothcore/azerothcore-wotlk/issues/14441
-- https://www.youtube.com/watch?v=T0dDBoU0zF0&t=95s
-- https://www.youtube.com/watch?v=F2IM025ZL6s&t=707s
-- https://github.com/chromiecraft/chromiecraft/issues/4749#issuecomment-1371379201

- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

<img src="https://github.com/chromiecraft/chromiecraft/assets/1884642/ec362c64-7d6c-4139-9c81-34d5903cad10" width="300">

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [X] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

```
.learn all recipes jewelcrafting
.additem 23425 1000
```

macro:
```
/cast Prospecting
/use Adamantite Ore
```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
