### PR TITLE
fix(Scripts/SSC): Update Hydross Mark Timers

### DIFF
--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
@@ -148,19 +148,19 @@ struct boss_hydross_the_unstable : public BossAI
             scheduler.Schedule(15s, GROUP_ABILITIES, [this](TaskContext)
             {
                 DoCastSelf(SPELL_MARK_OF_CORRUPTION1);
-            }).Schedule(15s, GROUP_ABILITIES, [this](TaskContext)
-            {
-                DoCastSelf(SPELL_MARK_OF_CORRUPTION2);
             }).Schedule(30s, GROUP_ABILITIES, [this](TaskContext)
             {
-                DoCastSelf(SPELL_MARK_OF_CORRUPTION3);
+                DoCastSelf(SPELL_MARK_OF_CORRUPTION2);
             }).Schedule(45s, GROUP_ABILITIES, [this](TaskContext)
             {
-                DoCastSelf(SPELL_MARK_OF_CORRUPTION4);
+                DoCastSelf(SPELL_MARK_OF_CORRUPTION3);
             }).Schedule(60s, GROUP_ABILITIES, [this](TaskContext)
             {
+                DoCastSelf(SPELL_MARK_OF_CORRUPTION4);
+            }).Schedule(75s, GROUP_ABILITIES, [this](TaskContext)
+            {
                 DoCastSelf(SPELL_MARK_OF_CORRUPTION5);
-            }).Schedule(75s, GROUP_ABILITIES, [this](TaskContext context)
+            }).Schedule(90s, GROUP_ABILITIES, [this](TaskContext context)
             {
                 DoCastSelf(SPELL_MARK_OF_CORRUPTION6);
                 context.Repeat(15s);
@@ -180,19 +180,19 @@ struct boss_hydross_the_unstable : public BossAI
             scheduler.Schedule(15s, GROUP_ABILITIES, [this](TaskContext)
             {
                 DoCastSelf(SPELL_MARK_OF_HYDROSS1);
-            }).Schedule(15s, GROUP_ABILITIES, [this](TaskContext)
-            {
-                DoCastSelf(SPELL_MARK_OF_HYDROSS2);
             }).Schedule(30s, GROUP_ABILITIES, [this](TaskContext)
             {
-                DoCastSelf(SPELL_MARK_OF_HYDROSS3);
+                DoCastSelf(SPELL_MARK_OF_HYDROSS2);
             }).Schedule(45s, GROUP_ABILITIES, [this](TaskContext)
             {
-                DoCastSelf(SPELL_MARK_OF_HYDROSS4);
+                DoCastSelf(SPELL_MARK_OF_HYDROSS3);
             }).Schedule(60s, GROUP_ABILITIES, [this](TaskContext)
             {
+                DoCastSelf(SPELL_MARK_OF_HYDROSS4);
+            }).Schedule(75s, GROUP_ABILITIES, [this](TaskContext)
+            {
                 DoCastSelf(SPELL_MARK_OF_HYDROSS5);
-            }).Schedule(75s, GROUP_ABILITIES, [this](TaskContext context)
+            }).Schedule(90s, GROUP_ABILITIES, [this](TaskContext context)
             {
                 DoCastSelf(SPELL_MARK_OF_HYDROSS6);
                 context.Repeat(15s);
@@ -359,4 +359,3 @@ void AddSC_boss_hydross_the_unstable()
     RegisterSpellScript(spell_hydross_cleansing_field_command);
     RegisterSpellScript(spell_hydross_mark_of_hydross);
 }
-

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
@@ -160,7 +160,7 @@ struct boss_hydross_the_unstable : public BossAI
             }).Schedule(60s, GROUP_ABILITIES, [this](TaskContext)
             {
                 DoCastSelf(SPELL_MARK_OF_CORRUPTION5);
-            }).Schedule(75s, GROUP_ABILITIES, [this](TaskContext)
+            }).Schedule(75s, GROUP_ABILITIES, [this](TaskContext context)
             {
                 DoCastSelf(SPELL_MARK_OF_CORRUPTION6);
                 context.Repeat(15s);
@@ -192,7 +192,7 @@ struct boss_hydross_the_unstable : public BossAI
             }).Schedule(60s, GROUP_ABILITIES, [this](TaskContext)
             {
                 DoCastSelf(SPELL_MARK_OF_HYDROSS5);
-            }).Schedule(75s, GROUP_ABILITIES, [this](TaskContext)
+            }).Schedule(75s, GROUP_ABILITIES, [this](TaskContext context)
             {
                 DoCastSelf(SPELL_MARK_OF_HYDROSS6);
                 context.Repeat(15s);

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
@@ -359,3 +359,4 @@ void AddSC_boss_hydross_the_unstable()
     RegisterSpellScript(spell_hydross_cleansing_field_command);
     RegisterSpellScript(spell_hydross_mark_of_hydross);
 }
+

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
@@ -145,7 +145,7 @@ struct boss_hydross_the_unstable : public BossAI
             me->ApplySpellImmune(0, IMMUNITY_SCHOOL, SPELL_SCHOOL_MASK_NATURE, true);
             DoCastSelf(SPELL_CORRUPTION, true);
 
-            scheduler.Schedule(0s, GROUP_ABILITIES, [this](TaskContext)
+            scheduler.Schedule(15s, GROUP_ABILITIES, [this](TaskContext)
             {
                 DoCastSelf(SPELL_MARK_OF_CORRUPTION1);
             }).Schedule(15s, GROUP_ABILITIES, [this](TaskContext)
@@ -163,6 +163,7 @@ struct boss_hydross_the_unstable : public BossAI
             }).Schedule(75s, GROUP_ABILITIES, [this](TaskContext)
             {
                 DoCastSelf(SPELL_MARK_OF_CORRUPTION6);
+                context.Repeat(15s);
             }).Schedule(12150ms, GROUP_ABILITIES, [this](TaskContext context)
             {
                 DoCastRandomTarget(SPELL_VILE_SLUDGE, 0, 0.0f, true, true);
@@ -176,7 +177,7 @@ struct boss_hydross_the_unstable : public BossAI
             me->ApplySpellImmune(0, IMMUNITY_SCHOOL, SPELL_SCHOOL_MASK_NATURE, false);
             me->RemoveAurasDueToSpell(SPELL_CORRUPTION);
 
-            scheduler.Schedule(0s, GROUP_ABILITIES, [this](TaskContext)
+            scheduler.Schedule(15s, GROUP_ABILITIES, [this](TaskContext)
             {
                 DoCastSelf(SPELL_MARK_OF_HYDROSS1);
             }).Schedule(15s, GROUP_ABILITIES, [this](TaskContext)
@@ -194,6 +195,7 @@ struct boss_hydross_the_unstable : public BossAI
             }).Schedule(75s, GROUP_ABILITIES, [this](TaskContext)
             {
                 DoCastSelf(SPELL_MARK_OF_HYDROSS6);
+                context.Repeat(15s);
             }).Schedule(12150ms, GROUP_ABILITIES, [this](TaskContext context)
             {
                 DoCastRandomTarget(SPELL_WATER_TOMB, 0, 0.0f, true, true);
@@ -357,4 +359,3 @@ void AddSC_boss_hydross_the_unstable()
     RegisterSpellScript(spell_hydross_cleansing_field_command);
     RegisterSpellScript(spell_hydross_mark_of_hydross);
 }
-


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:

- Closes https://github.com/chromiecraft/chromiecraft/issues/6451

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
https://www.icy-veins.com/tbc-classic/hydross-the-unstable-guide-strategy-abilities-loot
https://youtu.be/FEYAX7l5H6A?t=646
*Sound warning* https://youtu.be/J1Vph9r5ZnY&t=47
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks 

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [X] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Go to SSC's Hydross the Unstable
2. Move him across the flags
3. Check that there are 15s before he applies either Mark of Hydross or Mark of Corruption

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.