### PR TITLE
feat(Core/Hook): New hook OnBeforePlayerLogout

### DIFF
--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -361,7 +361,7 @@ void ScriptMgr::OnPlayerLoadFromDB(Player* player)
     });
 }
 
-void ScriptMgr::OnPlayerBeforeLogout(Player* player)
+void ScriptMgr::OnBeforePlayerLogout(Player* player)
 {
     ExecuteScript<PlayerScript>([&](PlayerScript* script)
         {

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -361,11 +361,11 @@ void ScriptMgr::OnPlayerLoadFromDB(Player* player)
     });
 }
 
-void ScriptMgr::OnPlayerPreLogout(Player* player)
+void ScriptMgr::OnPlayerBeforeLogout(Player* player)
 {
     ExecuteScript<PlayerScript>([&](PlayerScript* script)
         {
-            script->OnPreLogout(player);
+            script->OnBeforeLogout(player);
         });
 }
 

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -361,6 +361,14 @@ void ScriptMgr::OnPlayerLoadFromDB(Player* player)
     });
 }
 
+void ScriptMgr::OnPlayerPreLogout(Player* player)
+{
+    ExecuteScript<PlayerScript>([&](PlayerScript* script)
+        {
+            script->OnPreLogout(player);
+        });
+}
+
 void ScriptMgr::OnPlayerLogout(Player* player)
 {
     ExecuteScript<PlayerScript>([&](PlayerScript* script)

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.h
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.h
@@ -132,6 +132,9 @@ public:
     // Called when a player logs in.
     virtual void OnLogin(Player* /*player*/) { }
 
+    // Called before the player is logged out
+    virtual void OnPreLogout(Player* /*player*/) { }
+
     // Called when a player logs out.
     virtual void OnLogout(Player* /*player*/) { }
 

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.h
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.h
@@ -133,7 +133,7 @@ public:
     virtual void OnLogin(Player* /*player*/) { }
 
     // Called before the player is logged out
-    virtual void OnPreLogout(Player* /*player*/) { }
+    virtual void OnBeforeLogout(Player* /*player*/) { }
 
     // Called when a player logs out.
     virtual void OnLogout(Player* /*player*/) { }

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -329,7 +329,7 @@ public: /* PlayerScript */
     void OnPlayerSpellCast(Player* player, Spell* spell, bool skipCheck);
     void OnPlayerLogin(Player* player);
     void OnPlayerLoadFromDB(Player* player);
-    void OnPlayerPreLogout(Player* player);
+    void OnPlayerBeforeLogout(Player* player);
     void OnPlayerLogout(Player* player);
     void OnPlayerCreate(Player* player);
     void OnPlayerSave(Player* player);

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -329,7 +329,7 @@ public: /* PlayerScript */
     void OnPlayerSpellCast(Player* player, Spell* spell, bool skipCheck);
     void OnPlayerLogin(Player* player);
     void OnPlayerLoadFromDB(Player* player);
-    void OnPlayerBeforeLogout(Player* player);
+    void OnBeforePlayerLogout(Player* player);
     void OnPlayerLogout(Player* player);
     void OnPlayerCreate(Player* player);
     void OnPlayerSave(Player* player);

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -329,6 +329,7 @@ public: /* PlayerScript */
     void OnPlayerSpellCast(Player* player, Spell* spell, bool skipCheck);
     void OnPlayerLogin(Player* player);
     void OnPlayerLoadFromDB(Player* player);
+    void OnPlayerPreLogout(Player* player);
     void OnPlayerLogout(Player* player);
     void OnPlayerCreate(Player* player);
     void OnPlayerSave(Player* player);

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -580,7 +580,7 @@ void WorldSession::LogoutPlayer(bool save)
     if (_player)
     {
         //! Call script hook before other logout events
-        sScriptMgr->OnPlayerBeforeLogout(_player);
+        sScriptMgr->OnBeforePlayerLogout(_player);
 
         if (ObjectGuid lguid = _player->GetLootGUID())
             DoLootRelease(lguid);

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -580,7 +580,7 @@ void WorldSession::LogoutPlayer(bool save)
     if (_player)
     {
         //! Call script hook before other logout events
-        sScriptMgr->OnPlayerPreLogout(_player);
+        sScriptMgr->OnPlayerBeforeLogout(_player);
 
         if (ObjectGuid lguid = _player->GetLootGUID())
             DoLootRelease(lguid);

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -579,6 +579,9 @@ void WorldSession::LogoutPlayer(bool save)
 
     if (_player)
     {
+        //! Call script hook before other logout events
+        sScriptMgr->OnPlayerPreLogout(_player);
+
         if (ObjectGuid lguid = _player->GetLootGUID())
             DoLootRelease(lguid);
 


### PR DESCRIPTION
## Changes Proposed:
Adding a new hook "OnBeforePlayerLogout" which fires _before_ the logout logic is executed for a player inside WorldSession::LogoutPlayer.  This is to support a mod I made which allows a character to change their class, which you can find [here](https://github.com/NathanHandley/mod-multi-class).

There is logic to perform before the logout save event, which made utilizing the existing OnPlayerLogout non-viable (visual item changes on class switch were not being pushed and registered on the client).  Since the save hook does not have the "logout" bool available, I was left with a choice to add this new hook or update/overload that hook.  It seems that a OnBeforeLogout could be useful for more hypothetical use cases, so I elected with this approach.  Also, this allows it to work in the situation that save on logout isn't enabled for some reason.

## Issues Addressed:
none

## SOURCE:
n/a

## Tests Performed:
- Tested on both an Ubuntu 22.04 and Windows 10 Pro server

## How to Test the Changes:
The mod [here](https://github.com/NathanHandley/mod-multi-class) uses this hook.  Install that mod, and switch your class while wearing gear.

## Known Issues and TODO List:
none
