### PR TITLE
fix(Scripts/Midsummer): Correct behavior for Striking Back quests.

### DIFF
--- a/data/sql/updates/pending_db_world/striking-back-init.sql
+++ b/data/sql/updates/pending_db_world/striking-back-init.sql
@@ -41,7 +41,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (188154, 1, 0, 0, 62, 0, 100, 0, 9276, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
 (188154, 1, 1, 0, 62, 0, 100, 0, 9276, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip');
 
-DELETE FROM `creature` WHERE `id1` IN (26116, 26178, 26204, 26214, 26215, 26216);
+DELETE FROM `creature` WHERE `guid` IN (245628, 245629, 245630, 245631, 245632, 245633);
+DELETE FROM `game_event_creature` WHERE (`eventEntry` = 1 AND `guid` IN (245628, 245629, 245630, 245631, 245632, 245633));
 
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
 (26116, 0, 0, 'You will not stop the Frost Lord from entering this world, mortal. The Tidehunter\'s might will crush that of Ragnaros once and for all, leaving your land a frozen paradise!', 12, 0, 100, 1, 2000, 0, 25372, 0, 'Frostwave Lieutenant intro speech');

--- a/data/sql/updates/pending_db_world/striking-back-init.sql
+++ b/data/sql/updates/pending_db_world/striking-back-init.sql
@@ -1,0 +1,89 @@
+UPDATE `gameobject_template` SET `AIName` = 'SmartGameObjectAI' WHERE `entry` IN (188049, 188130, 188134, 188135, 188137, 188138, 188139, 188143, 188144, 188145, 188146, 188147, 188148, 188149, 188150, 188151, 188152, 188153, 188154);
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 1 AND `entryorguid` IN (188049, 188130, 188134, 188135, 188137, 188138, 188139, 188143, 188144, 188145, 188146, 188147, 188148, 188149, 188150, 188151, 188152, 188153, 188154));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(188049, 1, 0, 0, 62, 0, 100, 0, 9213, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188049, 1, 1, 0, 62, 0, 100, 0, 9213, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188130, 1, 0, 0, 62, 0, 100, 0, 9251, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188130, 1, 1, 0, 62, 0, 100, 0, 9251, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188134, 1, 0, 0, 62, 0, 100, 0, 9254, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188134, 1, 1, 0, 62, 0, 100, 0, 9254, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188135, 1, 0, 0, 62, 0, 100, 0, 9255, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188135, 1, 1, 0, 62, 0, 100, 0, 9255, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188137, 1, 0, 0, 62, 0, 100, 0, 9256, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188137, 1, 1, 0, 62, 0, 100, 0, 9256, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188138, 1, 0, 0, 62, 0, 100, 0, 9257, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188138, 1, 1, 0, 62, 0, 100, 0, 9257, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188139, 1, 0, 0, 62, 0, 100, 0, 9258, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188139, 1, 1, 0, 62, 0, 100, 0, 9258, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188143, 1, 0, 0, 62, 0, 100, 0, 9264, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188143, 1, 1, 0, 62, 0, 100, 0, 9264, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188144, 1, 0, 0, 62, 0, 100, 0, 9265, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188144, 1, 1, 0, 62, 0, 100, 0, 9265, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188145, 1, 0, 0, 62, 0, 100, 0, 9266, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188145, 1, 1, 0, 62, 0, 100, 0, 9266, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188146, 1, 0, 0, 62, 0, 100, 0, 9267, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188146, 1, 1, 0, 62, 0, 100, 0, 9267, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188147, 1, 0, 0, 62, 0, 100, 0, 9268, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188147, 1, 1, 0, 62, 0, 100, 0, 9268, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188148, 1, 0, 0, 62, 0, 100, 0, 9269, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188148, 1, 1, 0, 62, 0, 100, 0, 9269, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188149, 1, 0, 0, 62, 0, 100, 0, 9271, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188149, 1, 1, 0, 62, 0, 100, 0, 9271, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188150, 1, 0, 0, 62, 0, 100, 0, 9272, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188150, 1, 1, 0, 62, 0, 100, 0, 9272, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188151, 1, 0, 0, 62, 0, 100, 0, 9273, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188151, 1, 1, 0, 62, 0, 100, 0, 9273, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188152, 1, 0, 0, 62, 0, 100, 0, 9274, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188152, 1, 1, 0, 62, 0, 100, 0, 9274, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188153, 1, 0, 0, 62, 0, 100, 0, 9275, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188153, 1, 1, 0, 62, 0, 100, 0, 9275, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip'),
+(188154, 1, 0, 0, 62, 0, 100, 0, 9276, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
+(188154, 1, 1, 0, 62, 0, 100, 0, 9276, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip');
+
+DELETE FROM `creature` WHERE `id1` IN (26116, 26178, 26204, 26214, 26215, 26216);
+
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(26116, 0, 0, 'You will not stop the Frost Lord from entering this world, mortal. The Tidehunter\'s might will crush that of Ragnaros once and for all, leaving your land a frozen paradise!', 12, 0, 100, 1, 2000, 0, 25372, 0, 'Frostwave Lieutenant intro speech');
+
+UPDATE `creature_text` SET `comment` = 'Hailstone Lieutenant intro speech' WHERE `CreatureID` = 26178; -- Formerly 'Frostwave Lieutenant intro speech'
+UPDATE `creature_text` SET `comment` = 'Glacial Templar intro speech' WHERE `CreatureID` = 26216; -- Formerly 'Templar intro speech'
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (26116, 26178, 26204, 26214, 26215, 26216);
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` IN (26116, 26178, 26204, 26214, 26215, 26216));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(26116, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostwave Lieutenant - On Just Summoned - Say Line 0'),
+(26178, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Hailstone Lieutenant - On Just Summoned - Say Line 0'),
+(26204, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Chillwind Lieutenant - On Just Summoned - Say Line 0'),
+(26214, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frigid Lieutenant - On Just Summoned - Say Line 0'),
+(26215, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Lieutenant - On Just Summoned - Say Line 0'),
+(26216, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Templar - On Just Summoned - Say Line 0');
+
+DELETE FROM `spell_script_names` WHERE `spell_id` = 46592 AND `ScriptName` = 'spell_midsummer_summon_ahune_lieutenant';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (46592, 'spell_midsummer_summon_ahune_lieutenant');
+
+/*
+GObject GUIDs
+guid;id/entry;Data3(gossip_menu)
+49453;188148;9269 -- Silithus
+49454;188149;9271
+49455;188150;9272
+54031;188049;9213 -- Ashenvale
+54944;188137;9256
+54945;188138;9257
+81467;188130;9251 -- Desolace
+81468;188134;9254
+81469;188135;9255
+81470;188139;9258 -- Stranglethorn
+81471;188143;9264
+81472;188144;9265
+81473;188145;9266 -- Searing Gorge
+81474;188146;9267
+81475;188147;9268
+81476;188151;9273 -- Hellfire
+81477;188152;9274
+81478;188153;9275
+81479;188154;9276
+220100;187882 -- Ahune
+*/

--- a/data/sql/updates/pending_db_world/striking-back-init.sql
+++ b/data/sql/updates/pending_db_world/striking-back-init.sql
@@ -1,30 +1,5 @@
 UPDATE `gameobject_template` SET `AIName` = 'SmartGameObjectAI' WHERE `entry` IN (188049, 188130, 188134, 188135, 188137, 188138, 188139, 188143, 188144, 188145, 188146, 188147, 188148, 188149, 188150, 188151, 188152, 188153, 188154);
 
-/*
-GObject GUIDs
-guid;id/entry;Data3(gossip_menu);questID
-49453;188148;9269;11953 -- Silithus
-49454;188149;9271;11953
-49455;188150;9272;11953
-54031;188049;9213;11917 -- Ashenvale
-54944;188137;9256;11917
-54945;188138;9257;11917
-81467;188130;9251;11947 -- Desolace
-81468;188134;9254;11947
-81469;188135;9255;11947
-81470;188139;9258;11948 -- Stranglethorn
-81471;188143;9264;11948
-81472;188144;9265;11948
-81473;188145;9266;11952 -- Searing Gorge
-81474;188146;9267;11952
-81475;188147;9268;11952
-81476;188151;9273;11954 -- Hellfire
-81477;188152;9274;11954
-81478;188153;9275;11954
-81479;188154;9276;11954
-220100;187882 -- Ahune
-*/
-
 DELETE FROM `smart_scripts` WHERE (`source_type` = 1 AND `entryorguid` IN (188049, 188130, 188134, 188135, 188137, 188138, 188139, 188143, 188144, 188145, 188146, 188147, 188148, 188149, 188150, 188151, 188152, 188153, 188154));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (188049, 1, 0, 0, 62, 0, 100, 0, 9213, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),

--- a/data/sql/updates/pending_db_world/striking-back-init.sql
+++ b/data/sql/updates/pending_db_world/striking-back-init.sql
@@ -2,26 +2,26 @@ UPDATE `gameobject_template` SET `AIName` = 'SmartGameObjectAI' WHERE `entry` IN
 
 /*
 GObject GUIDs
-guid;id/entry;Data3(gossip_menu)
-49453;188148;9269 -- Silithus
-49454;188149;9271
-49455;188150;9272
-54031;188049;9213 -- Ashenvale
-54944;188137;9256
-54945;188138;9257
-81467;188130;9251 -- Desolace
-81468;188134;9254
-81469;188135;9255
-81470;188139;9258 -- Stranglethorn
-81471;188143;9264
-81472;188144;9265
-81473;188145;9266 -- Searing Gorge
-81474;188146;9267
-81475;188147;9268
-81476;188151;9273 -- Hellfire
-81477;188152;9274
-81478;188153;9275
-81479;188154;9276
+guid;id/entry;Data3(gossip_menu);questID
+49453;188148;9269;11953 -- Silithus
+49454;188149;9271;11953
+49455;188150;9272;11953
+54031;188049;9213;11917 -- Ashenvale
+54944;188137;9256;11917
+54945;188138;9257;11917
+81467;188130;9251;11947 -- Desolace
+81468;188134;9254;11947
+81469;188135;9255;11947
+81470;188139;9258;11948 -- Stranglethorn
+81471;188143;9264;11948
+81472;188144;9265;11948
+81473;188145;9266;11952 -- Searing Gorge
+81474;188146;9267;11952
+81475;188147;9268;11952
+81476;188151;9273;11954 -- Hellfire
+81477;188152;9274;11954
+81478;188153;9275;11954
+81479;188154;9276;11954
 220100;187882 -- Ahune
 */
 
@@ -81,6 +81,28 @@ INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionTex
 (9251, 0, 0, 'Lay your hand on the Ice Stone.', 25218, 1, 1, 0, 0, 0, 0, '', 0, 0),
 (9254, 0, 0, 'Lay your hand on the Ice Stone.', 25218, 1, 1, 0, 0, 0, 0, '', 0, 0),
 (9255, 0, 0, 'Lay your hand on the Ice Stone.', 25218, 1, 1, 0, 0, 0, 0, '', 0, 0);
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 15 AND `SourceGroup` IN (9213, 9251, 9254, 9255, 9256, 9257, 9258, 9264, 9265, 9266, 9267, 9268, 9269, 9271, 9272, 9273, 9274, 9275, 9276) AND `SourceEntry` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 9213, 0, 0, 0, 47, 0, 11917, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9251, 0, 0, 0, 47, 0, 11947, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9254, 0, 0, 0, 47, 0, 11947, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9255, 0, 0, 0, 47, 0, 11947, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9256, 0, 0, 0, 47, 0, 11917, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9257, 0, 0, 0, 47, 0, 11917, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9258, 0, 0, 0, 47, 0, 11948, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9264, 0, 0, 0, 47, 0, 11948, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9265, 0, 0, 0, 47, 0, 11948, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9266, 0, 0, 0, 47, 0, 11952, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9267, 0, 0, 0, 47, 0, 11952, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9268, 0, 0, 0, 47, 0, 11952, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9269, 0, 0, 0, 47, 0, 11953, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9271, 0, 0, 0, 47, 0, 11953, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9272, 0, 0, 0, 47, 0, 11953, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9273, 0, 0, 0, 47, 0, 11954, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9274, 0, 0, 0, 47, 0, 11954, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9275, 0, 0, 0, 47, 0, 11954, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress'),
+(15, 9276, 0, 0, 0, 47, 0, 11954, 8, 0, 0, 0, 0, '', 'If player has quest \'Striking Back\' in progress');
 
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (26116, 26178, 26204, 26214, 26215, 26216);
 

--- a/data/sql/updates/pending_db_world/striking-back-init.sql
+++ b/data/sql/updates/pending_db_world/striking-back-init.sql
@@ -1,5 +1,30 @@
 UPDATE `gameobject_template` SET `AIName` = 'SmartGameObjectAI' WHERE `entry` IN (188049, 188130, 188134, 188135, 188137, 188138, 188139, 188143, 188144, 188145, 188146, 188147, 188148, 188149, 188150, 188151, 188152, 188153, 188154);
 
+/*
+GObject GUIDs
+guid;id/entry;Data3(gossip_menu)
+49453;188148;9269 -- Silithus
+49454;188149;9271
+49455;188150;9272
+54031;188049;9213 -- Ashenvale
+54944;188137;9256
+54945;188138;9257
+81467;188130;9251 -- Desolace
+81468;188134;9254
+81469;188135;9255
+81470;188139;9258 -- Stranglethorn
+81471;188143;9264
+81472;188144;9265
+81473;188145;9266 -- Searing Gorge
+81474;188146;9267
+81475;188147;9268
+81476;188151;9273 -- Hellfire
+81477;188152;9274
+81478;188153;9275
+81479;188154;9276
+220100;187882 -- Ahune
+*/
+
 DELETE FROM `smart_scripts` WHERE (`source_type` = 1 AND `entryorguid` IN (188049, 188130, 188134, 188135, 188137, 188138, 188139, 188143, 188144, 188145, 188146, 188147, 188148, 188149, 188150, 188151, 188152, 188153, 188154));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (188049, 1, 0, 0, 62, 0, 100, 0, 9213, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
@@ -44,11 +69,18 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 DELETE FROM `creature` WHERE `guid` IN (245628, 245629, 245630, 245631, 245632, 245633);
 DELETE FROM `game_event_creature` WHERE (`eventEntry` = 1 AND `guid` IN (245628, 245629, 245630, 245631, 245632, 245633));
 
+DELETE FROM `creature_text` WHERE `CreatureID` = 26116;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
 (26116, 0, 0, 'You will not stop the Frost Lord from entering this world, mortal. The Tidehunter\'s might will crush that of Ragnaros once and for all, leaving your land a frozen paradise!', 12, 0, 100, 1, 2000, 0, 25372, 0, 'Frostwave Lieutenant intro speech');
 
 UPDATE `creature_text` SET `comment` = 'Hailstone Lieutenant intro speech' WHERE `CreatureID` = 26178; -- Formerly 'Frostwave Lieutenant intro speech'
 UPDATE `creature_text` SET `comment` = 'Glacial Templar intro speech' WHERE `CreatureID` = 26216; -- Formerly 'Templar intro speech'
+
+DELETE FROM `gossip_menu_option` WHERE `MenuID` IN (9251, 9254, 9255);
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`, `BoxBroadcastTextID`, `VerifiedBuild`) VALUES
+(9251, 0, 0, 'Lay your hand on the Ice Stone.', 25218, 1, 1, 0, 0, 0, 0, '', 0, 0),
+(9254, 0, 0, 'Lay your hand on the Ice Stone.', 25218, 1, 1, 0, 0, 0, 0, '', 0, 0),
+(9255, 0, 0, 'Lay your hand on the Ice Stone.', 25218, 1, 1, 0, 0, 0, 0, '', 0, 0);
 
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (26116, 26178, 26204, 26214, 26215, 26216);
 
@@ -63,28 +95,3 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 DELETE FROM `spell_script_names` WHERE `spell_id` = 46592 AND `ScriptName` = 'spell_midsummer_summon_ahune_lieutenant';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (46592, 'spell_midsummer_summon_ahune_lieutenant');
-
-/*
-GObject GUIDs
-guid;id/entry;Data3(gossip_menu)
-49453;188148;9269 -- Silithus
-49454;188149;9271
-49455;188150;9272
-54031;188049;9213 -- Ashenvale
-54944;188137;9256
-54945;188138;9257
-81467;188130;9251 -- Desolace
-81468;188134;9254
-81469;188135;9255
-81470;188139;9258 -- Stranglethorn
-81471;188143;9264
-81472;188144;9265
-81473;188145;9266 -- Searing Gorge
-81474;188146;9267
-81475;188147;9268
-81476;188151;9273 -- Hellfire
-81477;188152;9274
-81478;188153;9275
-81479;188154;9276
-220100;187882 -- Ahune
-*/

--- a/data/sql/updates/pending_db_world/striking-back-init.sql
+++ b/data/sql/updates/pending_db_world/striking-back-init.sql
@@ -108,12 +108,12 @@ UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (26116, 261
 
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` IN (26116, 26178, 26204, 26214, 26215, 26216));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(26116, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostwave Lieutenant - On Just Summoned - Say Line 0'),
-(26178, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Hailstone Lieutenant - On Just Summoned - Say Line 0'),
-(26204, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Chillwind Lieutenant - On Just Summoned - Say Line 0'),
-(26214, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frigid Lieutenant - On Just Summoned - Say Line 0'),
-(26215, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Lieutenant - On Just Summoned - Say Line 0'),
-(26216, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Templar - On Just Summoned - Say Line 0');
+(26116, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostwave Lieutenant - On Just Summoned - Say Line 0'), -- 122: Frost Nova, 8056: Frost Shock
+(26178, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Hailstone Lieutenant - On Just Summoned - Say Line 0'), -- 5164: Knockdown, 5276: Freeze
+(26204, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Chillwind Lieutenant - On Just Summoned - Say Line 0'), -- 6982: Gust of Wind, 23115: Frost Shock
+(26214, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frigid Lieutenant - On Just Summoned - Say Line 0'), -- 3131: Frost Breath
+(26215, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Lieutenant - On Just Summoned - Say Line 0'), -- 14907: Frost Nova, 15089: Frost Shock
+(26216, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Templar - On Just Summoned - Say Line 0'); -- 5164: Knockdown, 14907: Frost Nova, 15089: Frost Shock
 
 DELETE FROM `spell_script_names` WHERE `spell_id` = 46592 AND `ScriptName` = 'spell_midsummer_summon_ahune_lieutenant';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (46592, 'spell_midsummer_summon_ahune_lieutenant');

--- a/data/sql/updates/pending_db_world/striking-back-init.sql
+++ b/data/sql/updates/pending_db_world/striking-back-init.sql
@@ -41,7 +41,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (188154, 1, 0, 0, 62, 0, 100, 0, 9276, 0, 0, 0, 0, 11, 46595, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Cast \'Summon Ice Stone Lieutenant, Trigger\''),
 (188154, 1, 1, 0, 62, 0, 100, 0, 9276, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Ice Stone - On Gossip Option 0 Selected - Close Gossip');
 
-DELETE FROM `creature` WHERE `guid` IN (245628, 245629, 245630, 245631, 245632, 245633);
+DELETE FROM `creature` WHERE (`guid` IN (245628, 245629, 245630, 245631, 245632, 245633) AND `id1` IN (26116, 26178, 26204, 26214, 26215, 26216));
 DELETE FROM `game_event_creature` WHERE (`eventEntry` = 1 AND `guid` IN (245628, 245629, 245630, 245631, 245632, 245633));
 
 DELETE FROM `creature_text` WHERE `CreatureID` = 26116;

--- a/data/sql/updates/pending_db_world/striking-back-init.sql
+++ b/data/sql/updates/pending_db_world/striking-back-init.sql
@@ -108,12 +108,29 @@ UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (26116, 261
 
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` IN (26116, 26178, 26204, 26214, 26215, 26216));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(26116, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostwave Lieutenant - On Just Summoned - Say Line 0'), -- 122: Frost Nova, 8056: Frost Shock
-(26178, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Hailstone Lieutenant - On Just Summoned - Say Line 0'), -- 5164: Knockdown, 5276: Freeze
-(26204, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Chillwind Lieutenant - On Just Summoned - Say Line 0'), -- 6982: Gust of Wind, 23115: Frost Shock
-(26214, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frigid Lieutenant - On Just Summoned - Say Line 0'), -- 3131: Frost Breath
-(26215, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Lieutenant - On Just Summoned - Say Line 0'), -- 14907: Frost Nova, 15089: Frost Shock
-(26216, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Templar - On Just Summoned - Say Line 0'); -- 5164: Knockdown, 14907: Frost Nova, 15089: Frost Shock
+(26116, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostwave Lieutenant - On Just Summoned - Say Line 0'),
+(26116, 0, 1, 0, 0, 0, 100, 0, 12000, 20000, 28000, 40000, 0, 11, 122, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostwave Lieutenant - In Combat - Cast \'Frost Nova\''),
+(26116, 0, 2, 0, 0, 0, 100, 0, 4000, 12000, 8000, 24000, 0, 11, 8056, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostwave Lieutenant - In Combat - Cast \'Frost Shock\''),
+
+(26178, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Hailstone Lieutenant - On Just Summoned - Say Line 0'),
+(26178, 0, 1, 0, 0, 0, 100, 0, 4000, 12000, 12000, 24000, 0, 11, 5164, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Hailstone Lieutenant - In Combat - Cast \'Knockdown\''),
+(26178, 0, 2, 0, 0, 0, 100, 1, 12000, 30000, 0, 0, 0, 11, 5276, 128, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 'Hailstone Lieutenant - In Combat - Cast \'Freeze\' (No Repeat)'),
+
+(26204, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Chillwind Lieutenant - On Just Summoned - Say Line 0'),
+(26204, 0, 1, 0, 0, 0, 100, 1, 4000, 8000, 0, 0, 0, 11, 6982, 128, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 'Chillwind Lieutenant - In Combat - Cast \'Gust of Wind\' (No Repeat)'),
+(26204, 0, 2, 0, 0, 0, 100, 0, 4000, 12000, 12000, 24000, 0, 11, 23115, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Chillwind Lieutenant - In Combat - Cast \'Frost Shock\''),
+
+(26214, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frigid Lieutenant - On Just Summoned - Say Line 0'),
+(26214, 0, 1, 0, 0, 0, 100, 0, 4000, 12000, 12000, 24000, 0, 11, 3131, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Frigid Lieutenant - In Combat - Cast \'Frost Breath\''),
+
+(26215, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Lieutenant - On Just Summoned - Say Line 0'),
+(26215, 0, 1, 0, 0, 0, 100, 0, 12000, 20000, 28000, 40000, 0, 11, 14907, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Lieutenant - In Combat - Cast \'Frost Nova\''),
+(26215, 0, 2, 0, 0, 0, 100, 0, 4000, 12000, 8000, 24000, 0, 11, 15089, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Lieutenant - In Combat - Cast \'Frost Shock\''),
+
+(26216, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Templar - On Just Summoned - Say Line 0'),
+(26216, 0, 1, 0, 0, 0, 100, 0, 4000, 12000, 12000, 24000, 0, 11, 5164, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Hailstone Lieutenant - In Combat - Cast \'Knockdown\''),
+(26216, 0, 2, 0, 0, 0, 100, 0, 12000, 20000, 28000, 40000, 0, 11, 14907, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Templar - In Combat - Cast \'Frost Nova\''),
+(26216, 0, 3, 0, 0, 0, 100, 0, 4000, 12000, 8000, 24000, 0, 11, 15089, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Glacial Templar - In Combat - Cast \'Frost Shock\'');
 
 DELETE FROM `spell_script_names` WHERE `spell_id` = 46592 AND `ScriptName` = 'spell_midsummer_summon_ahune_lieutenant';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (46592, 'spell_midsummer_summon_ahune_lieutenant');

--- a/src/server/scripts/Events/midsummer.cpp
+++ b/src/server/scripts/Events/midsummer.cpp
@@ -1195,6 +1195,49 @@ class spell_midsummer_torch_catch : public SpellScript
     }
 };
 
+// 46592 - Summon Ahune Lieutenant
+class spell_midsummer_summon_ahune_lieutenant : public SpellScript
+{
+    PrepareSpellScript(spell_midsummer_summon_ahune_lieutenant);
+
+    void HandleDummy(SpellEffIndex /*effIndex*/)
+    {
+        Unit* caster = GetCaster();
+        uint32 zoneId = caster->GetZoneId();
+        uint32 npcEntry = 0;
+
+        switch (zoneId)
+        {
+        case 331: // Ashenvale
+            npcEntry = 26116;
+            break;
+        case 405: // Desolace
+            npcEntry = 26178;
+            break;
+        case 33: // Stranglethorn Vale
+            npcEntry = 26204;
+            break;
+        case 51: // Searing Gorge
+            npcEntry = 26214;
+            break;
+        case 1377: // Silithus
+            npcEntry = 26215;
+            break;
+        case 3483: // Hellfire Peninsula
+            npcEntry = 26216;
+            break;
+        }
+
+        if (npcEntry)
+            caster->SummonCreature(npcEntry, caster->GetPosition(), TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, MINUTE * IN_MILLISECONDS);
+    }
+
+    void Register() override
+    {
+        OnEffectHit += SpellEffectFn(spell_midsummer_summon_ahune_lieutenant::HandleDummy, EFFECT_1, SPELL_EFFECT_APPLY_AURA);
+    }
+};
+
 void AddSC_event_midsummer_scripts()
 {
     // Player
@@ -1215,5 +1258,6 @@ void AddSC_event_midsummer_scripts()
     RegisterSpellScript(spell_midsummer_fling_torch);
     RegisterSpellScript(spell_midsummer_juggling_torch);
     RegisterSpellScript(spell_midsummer_torch_catch);
+    RegisterSpellScript(spell_midsummer_summon_ahune_lieutenant);
 }
 

--- a/src/server/scripts/Events/midsummer.cpp
+++ b/src/server/scripts/Events/midsummer.cpp
@@ -1209,22 +1209,22 @@ class spell_midsummer_summon_ahune_lieutenant : public SpellScript
         switch (zoneId)
         {
         case 331: // Ashenvale
-            npcEntry = 26116;
+            npcEntry = 26116; // Frostwave Lieutenant
             break;
         case 405: // Desolace
-            npcEntry = 26178;
+            npcEntry = 26178; // Hailstone Lieutenant
             break;
         case 33: // Stranglethorn Vale
-            npcEntry = 26204;
+            npcEntry = 26204; // Chillwind Lieutenant
             break;
         case 51: // Searing Gorge
-            npcEntry = 26214;
+            npcEntry = 26214; // Frigid Lieutenant
             break;
         case 1377: // Silithus
-            npcEntry = 26215;
+            npcEntry = 26215; // Glacial Lieutenant
             break;
         case 3483: // Hellfire Peninsula
-            npcEntry = 26216;
+            npcEntry = 26216; // Glacial Templar
             break;
         }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #12151

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Live research (checked on live servers, i.e. Classic WotLK)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [X] The changes promoted by this pull request come partially or entirely from another project (cherry-pick), in this case [CMaNGOS](https://github.com/cmangos/mangos-wotlk/commit/91268f6631e142a0d36e3e4a78ba82e1f84a0206)/[xfurry](https://github.com/xfurry).

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR is being tested as changes are made.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
- [X] This pull request requires further testing.
1. `.quest add 11917/11947/11948/11952/11953/11954`
2. Go to the respective Ice Stone object.
3. Summon the lieutenant of Ahune.
4. Observe their speech and combat AI.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- [X] Combat SmartAI needs to be added for the various lieutenants, as they aren't currently casting any spells during combat.
- [X] The Desolace Ice Stone gossip menus are missing their summon menu option. That needs to be added.
- [ ] The Ice Stones are supposed to have an animation as the lieutenant is summoned and despawn, based on Wrath Classic videos. I apparently can't find a sniff of these guys being summoned, so I don't know how that's being handled. Currently, the stones remain active after the summon, don't know that I want to try to hack some solution together that I don't know is right.
- [X] Conditions need to be added for the gossip menu options.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
