### PR TITLE
chore(DB): Mark all updates as archived

### DIFF
--- a/data/sql/updates/pending_db_auth/rev_1705761644338772600.sql
+++ b/data/sql/updates/pending_db_auth/rev_1705761644338772600.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `updates` SET `state`='ARCHIVED' WHERE `state`='RELEASED';

--- a/data/sql/updates/pending_db_characters/rev_1705761639390139500.sql
+++ b/data/sql/updates/pending_db_characters/rev_1705761639390139500.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `updates` SET `state`='ARCHIVED' WHERE `state`='RELEASED';

--- a/data/sql/updates/pending_db_world/rev_1705761622328025800.sql
+++ b/data/sql/updates/pending_db_world/rev_1705761622328025800.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `updates` SET `state`='ARCHIVED' WHERE `state`='RELEASED';


### PR DESCRIPTION
This is kind of a trial in error for https://github.com/azerothcore/azerothcore-wotlk/pull/18197

We noticed that moving the files into archive directly when they are marked as RELEASED will cause them to run all over again. So we mark all released updates as archived before we move them into the archive folder.

The reason why is that the server runs
- base files
- archive files
- update files

in that order. so if we mark all files as archived in the updates dir after they have been moved they will first run all over again which doesn't always work.

So order of operations will be
1. Make a PR that updates deletes the current archived entries, and moves the files to the old dir, as well as after marking the current released files as archived
2. in the squash PR, move all the files from updates to archive folder