### PR TITLE
Fix(core): Support MariaDB 10.x when using mysql client libraries

### DIFF
--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -383,7 +383,7 @@ void DatabaseWorkerPool<T>::KeepAlive()
 *
 * Adapted from stackoverflow response
 * https://stackoverflow.com/a/2941508
-* 
+*
 * @param mysqlVersion The output from GetServerInfo()/mysql_get_server_info()
 * @return Returns true if the Server version is incompatible
 */
@@ -391,7 +391,7 @@ bool DatabaseIncompatibleVersion(std::string const mysqlVersion)
 {
     // anon func to turn a version string into an array of uint8
     // "1.2.3" => [1, 2, 3]
-    auto parse = [](const std::string& input)
+    auto parse = [](std::string const& input)
     {
         std::vector<uint8> result;
         std::istringstream parser(input);

--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -371,17 +371,22 @@ void DatabaseWorkerPool<T>::KeepAlive()
         Enqueue(new PingOperation);
 }
 
-// Returns true if the version string given is incompatible
-//
-// Intended to be used with mysql_get_server_info()'s output as the source
-//
-// DatabaseIncompatibleVersion("8.0.35") => false
-// DatabaseIncompatibleVersion("5.6.6") => true
-// DatabaseIncompatibleVersion("5.5.5-10.5.5-MariaDB") => false
-// DatabaseIncompatibleVersion("5.5.5-10.4.0-MariaDB") => true
-//
-// Adapted from stackoverflow response
-// https://stackoverflow.com/a/2941508
+/**
+* @brief Returns true if the version string given is incompatible
+*
+* Intended to be used with mysql_get_server_info()'s output as the source
+*
+* DatabaseIncompatibleVersion("8.0.35") => false
+* DatabaseIncompatibleVersion("5.6.6") => true
+* DatabaseIncompatibleVersion("5.5.5-10.5.5-MariaDB") => false
+* DatabaseIncompatibleVersion("5.5.5-10.4.0-MariaDB") => true
+*
+* Adapted from stackoverflow response
+* https://stackoverflow.com/a/2941508
+* 
+* @param mysqlVersion The output from GetServerInfo()/mysql_get_server_info()
+* @return Returns true if the Server version is incompatible
+*/
 bool DatabaseIncompatibleVersion(std::string const mysqlVersion)
 {
     // anon func to turn a version string into an array of uint8

--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -41,7 +41,6 @@
 #include <sstream>
 #endif
 
-
 class PingOperation : public SQLOperation
 {
     //! Operation for idle delaythreads

--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -450,10 +450,10 @@ uint32 DatabaseWorkerPool<T>::OpenConnections(InternalIndex type, uint8 numConne
             _connections[type].clear();
             return error;
         }
-        else if (DatabaseIncompatibleVersion(connection->SelectServerVersion()))
+        else if (DatabaseIncompatibleVersion(connection->GetServerInfo()))
         {
             LOG_ERROR("sql.driver", "AzerothCore does not support MySQL versions below 5.7 or MariaDB versions below 10.5.\n\nFound server version: {}. Server compiled with: {}.",
-                connection->SelectServerVersion(), MYSQL_VERSION_ID);
+                connection->GetServerInfo(), MYSQL_VERSION_ID);
             return 1;
         }
         else

--- a/src/server/database/Database/DatabaseWorkerPool.h
+++ b/src/server/database/Database/DatabaseWorkerPool.h
@@ -24,14 +24,32 @@
 #include <array>
 #include <vector>
 
-// MARIADB_VERSION_ID is defined if using libmariadbclient instead of libmysqlclient
+/** @file DatabaseWorkerPool.h */
+
+/**
+* @def MIN_MYSQL_CLIENT_VERSION
+* The minimum MariaDB Client Version
+* MARIADB_VERSION_ID is defined if using libmariadbclient instead of libmysqlclient
+*/
 #if MARIADB_VERSION_ID >= 100600
 #define MIN_MYSQL_CLIENT_VERSION 30203u
 #else
+/**
+* @def MIN_MYSQL_CLIENT_VERSION
+* The minimum MySQL Client Version
+*/
 #define MIN_MYSQL_CLIENT_VERSION 50700u
 #endif
 
+/**
+* @def MIN_MYSQL_SERVER_VERSION
+* The minimum MySQL Server Version
+*/
 #define MIN_MYSQL_SERVER_VERSION "5.7.0"
+/**
+* @def MIN_MARIADB_SERVER_VERSION
+* The minimum MariaDB Server Version
+*/
 #define MIN_MARIADB_SERVER_VERSION "10.5.0"
 
 template <typename T>

--- a/src/server/database/Database/DatabaseWorkerPool.h
+++ b/src/server/database/Database/DatabaseWorkerPool.h
@@ -24,6 +24,16 @@
 #include <array>
 #include <vector>
 
+// MARIADB_VERSION_ID is defined if using libmariadbclient instead of libmysqlclient
+#if MARIADB_VERSION_ID >= 100600
+#define MIN_MYSQL_CLIENT_VERSION 30203u
+#else
+#define MIN_MYSQL_CLIENT_VERSION 50700u
+#endif
+
+#define MIN_MYSQL_SERVER_VERSION "5.7.0"
+#define MIN_MARIADB_SERVER_VERSION "10.5.0"
+
 template <typename T>
 class ProducerConsumerQueue;
 

--- a/src/server/database/Database/MySQLConnection.cpp
+++ b/src/server/database/Database/MySQLConnection.cpp
@@ -27,8 +27,8 @@
 #include "Timer.h"
 #include "Tokenize.h"
 #include "Transaction.h"
-#include "Util.h"
 #include <errmsg.h>
+#include <mysql.h>
 #include <mysqld_error.h>
 
 MySQLConnectionInfo::MySQLConnectionInfo(std::string_view infoString)
@@ -484,6 +484,11 @@ void MySQLConnection::Unlock()
 uint32 MySQLConnection::GetServerVersion() const
 {
     return mysql_get_server_version(m_Mysql);
+}
+
+std::string MySQLConnection::SelectServerVersion() const
+{
+    return mysql_get_server_info(m_Mysql);
 }
 
 MySQLPreparedStatement* MySQLConnection::GetPreparedStatement(uint32 index)

--- a/src/server/database/Database/MySQLConnection.cpp
+++ b/src/server/database/Database/MySQLConnection.cpp
@@ -486,7 +486,7 @@ uint32 MySQLConnection::GetServerVersion() const
     return mysql_get_server_version(m_Mysql);
 }
 
-std::string MySQLConnection::SelectServerVersion() const
+std::string MySQLConnection::GetServerInfo() const
 {
     return mysql_get_server_info(m_Mysql);
 }

--- a/src/server/database/Database/MySQLConnection.h
+++ b/src/server/database/Database/MySQLConnection.h
@@ -94,6 +94,9 @@ protected:
     void Unlock();
 
     [[nodiscard]] uint32 GetServerVersion() const;
+    // This uses a query to get the server version.
+    // Useful in checking between MySQL and MariaDB
+    [[nodiscard]] std::string SelectServerVersion() const;
     MySQLPreparedStatement* GetPreparedStatement(uint32 index);
     void PrepareStatement(uint32 index, std::string_view sql, ConnectionFlags flags);
 

--- a/src/server/database/Database/MySQLConnection.h
+++ b/src/server/database/Database/MySQLConnection.h
@@ -94,9 +94,7 @@ protected:
     void Unlock();
 
     [[nodiscard]] uint32 GetServerVersion() const;
-    // This uses a query to get the server version.
-    // Useful in checking between MySQL and MariaDB
-    [[nodiscard]] std::string SelectServerVersion() const;
+    [[nodiscard]] std::string GetServerInfo() const;
     MySQLPreparedStatement* GetPreparedStatement(uint32 index);
     void PrepareStatement(uint32 index, std::string_view sql, ConnectionFlags flags);
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Change the way the MySQL/MariaDB's version is checked to account for the `5.5.5` prefix that mariadb `10.x` uses

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Related to issue https://github.com/azerothcore/azerothcore-wotlk/issues/18113 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

error appears when setting the database container to `mariadb:10.6`

```
Opening DatabasePool 'acore_auth'. Asynchronous connections: 1, synchronous connections: 1.
Database "acore_auth" does not exist
Do you want to create it? [yes (default) / no]:
AzerothCore does not support MySQL versions below 5.7 or MariaDB versions below 10.5.

Found server version: 50505. Server compiled with: 80035.
DatabasePool Login NOT opened. There were errors opening the MySQL connections. Check your log file for specific errors
...
MySQL server ver: 5.5.5-10.6.16-MariaDB-1:10.6.16+maria~ubu2004 
```

Notice on the last line that it sees the Mariadb Version with the `5.5.5-` prefix. Newer versions of mariadb don't actually do this - this was changed in MariaDB 11.0

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

This PR has been tested with MariaDB versions:

- 10.5
- 10.6
- 10.11
- 11.2


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. checkout master
2. create `docker-compose.override.yaml` file with contents:

```yaml
services:
  ac-database:
    image: mariadb:10.6
```

3. run `docker compose up --build`. The db import will fail due to the version check not working properly
4. checkout this branch
5. run `docker compose up --build`. The db import will fail for a different reason

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- MariaDB is actually broken for a different reason - the collation of the `db_world.item_dbc` table isn't compatible. Issue incoming for that

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
