### PR TITLE
fix(scripts/commands) prevent crash on set motd

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1705791671858497500.sql
+++ b/data/sql/updates/pending_db_world/rev_1705791671858497500.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `command` SET `help`='Syntax: .server set motd Optional($realmId) $MOTD\r\n\r\nSet server Message of the day for the specified $realmId.\r\nIf $realmId is not provided it will update for the current realm.' WHERE  `name`='server set motd';

--- a/src/server/scripts/Commands/cs_server.cpp
+++ b/src/server/scripts/Commands/cs_server.cpp
@@ -514,10 +514,14 @@ public:
     }
 
     // Define the 'Message of the day' for the realm
-    static bool HandleServerSetMotdCommand(ChatHandler* handler, int32 realmId, Tail motd)
+    static bool HandleServerSetMotdCommand(ChatHandler* handler, Optional<int32> realmId, Tail motd)
     {
         std::wstring wMotd   = std::wstring();
         std::string  strMotd = std::string();
+
+        if (!realmId) {
+            realmId = static_cast<int32>(realm.Id.Realm);
+        }
 
         if (motd.empty())
         {
@@ -536,13 +540,13 @@ public:
 
         LoginDatabaseTransaction trans = LoginDatabase.BeginTransaction();
         LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_REP_MOTD);
-        stmt->SetData(0, realmId);
+        stmt->SetData(0, realmId.value());
         stmt->SetData(1, strMotd);
         trans->Append(stmt);
         LoginDatabase.CommitTransaction(trans);
 
         sMotdMgr->LoadMotd();
-        handler->PSendSysMessage(LANG_MOTD_NEW, realmId, strMotd);
+        handler->PSendSysMessage(LANG_MOTD_NEW, realmId.value(), strMotd);
         return true;
     }
 

--- a/src/server/scripts/Commands/cs_server.cpp
+++ b/src/server/scripts/Commands/cs_server.cpp
@@ -524,6 +524,14 @@ public:
             return false;
         }
 
+        try {
+            std::stoi(realmId);
+        } catch (...) {
+            LOG_ERROR("misc", "Invalid realm ID {} in command .server set motd $realmId $MOTD", realmId);
+
+            return false;
+        }
+
         if (motd.empty())
         {
             return false;

--- a/src/server/scripts/Commands/cs_server.cpp
+++ b/src/server/scripts/Commands/cs_server.cpp
@@ -519,24 +519,17 @@ public:
         std::wstring wMotd   = std::wstring();
         std::string  strMotd = std::string();
 
-        if (!realmId) {
+        if (!realmId)
             realmId = static_cast<int32>(realm.Id.Realm);
-        }
 
         if (motd.empty())
-        {
             return false;
-        }
 
         if (!Utf8toWStr(motd, wMotd))
-        {
             return false;
-        }
 
         if (!WStrToUtf8(wMotd, strMotd))
-        {
             return false;
-        }
 
         LoginDatabaseTransaction trans = LoginDatabase.BeginTransaction();
         LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_REP_MOTD);

--- a/src/server/scripts/Commands/cs_server.cpp
+++ b/src/server/scripts/Commands/cs_server.cpp
@@ -514,23 +514,10 @@ public:
     }
 
     // Define the 'Message of the day' for the realm
-    static bool HandleServerSetMotdCommand(ChatHandler* handler, std::string realmId, Tail motd)
+    static bool HandleServerSetMotdCommand(ChatHandler* handler, int32 realmId, Tail motd)
     {
         std::wstring wMotd   = std::wstring();
         std::string  strMotd = std::string();
-
-        if (realmId.empty())
-        {
-            return false;
-        }
-
-        try {
-            std::stoi(realmId);
-        } catch (...) {
-            LOG_ERROR("misc", "Invalid realm ID {} in command .server set motd $realmId $MOTD", realmId);
-
-            return false;
-        }
 
         if (motd.empty())
         {
@@ -549,13 +536,13 @@ public:
 
         LoginDatabaseTransaction trans = LoginDatabase.BeginTransaction();
         LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_REP_MOTD);
-        stmt->SetData(0, Acore::StringTo<int32>(realmId).value());
+        stmt->SetData(0, realmId);
         stmt->SetData(1, strMotd);
         trans->Append(stmt);
         LoginDatabase.CommitTransaction(trans);
 
         sMotdMgr->LoadMotd();
-        handler->PSendSysMessage(LANG_MOTD_NEW, Acore::StringTo<int32>(realmId).value(), strMotd);
+        handler->PSendSysMessage(LANG_MOTD_NEW, realmId, strMotd);
         return true;
     }
 


### PR DESCRIPTION
## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
".server set motd something something" currently crashes server because it understands first word as realm id

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

## Known Issues and TODO List:

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
