### PR TITLE
fix(Docker): Check write access for config dir

### DIFF
--- a/apps/docker/entrypoint.sh
+++ b/apps/docker/entrypoint.sh
@@ -1,14 +1,46 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+CONF_DIR="${CONF_DIR:-/azerothcore/env/dist/etc}"
+LOGS_DIR="${LOGS_DIR:-/azerothcore/env/dist/logs}"
+
+if ! touch "$CONF_DIR/.write-test" || ! touch "$LOGS_DIR/.write-test"; then
+    cat <<EOF
+===== WARNING =====
+The current user doesn't have write permissions for
+the configuration dir ($CONF_DIR) or logs dir ($LOGS_DIR).
+It's likely that services will fail due to this.
+
+This is usually caused by cloning the repository as root,
+so the files are owned by root (uid 0).
+
+To resolve this, you can set the ownership of the
+configuration directory with the command on the host machine.
+Note that if the files are owned as root, the ownership must
+be changed as root (hence sudo).
+
+$ sudo chown -R $(id -u):$(id -g) /path/to$CONF_DIR /path/to$LOGS_DIR
+
+Alternatively, you can set the DOCKER_USER environment
+variable (on the host machine) to "root", though this
+isn't recommended.
+
+$ DOCKER_USER=root docker-compose up -d
+====================
+EOF
+fi
+
+[[ -f "$CONF_DIR/.write-test" ]] && rm -f "$CONF_DIR/.write-test"
+[[ -f "$LOGS_DIR/.write-test" ]] && rm -f "$LOGS_DIR/.write-test"
+
 # Copy all default config files to env/dist/etc if they don't already exist
 # -r == recursive
 # -n == no clobber (don't overwrite)
 # -v == be verbose
-cp -rnv /azerothcore/env/ref/etc/* /azerothcore/env/dist/etc
+cp -rnv /azerothcore/env/ref/etc/* "$CONF_DIR"
 
-CONF="/azerothcore/env/dist/etc/$ACORE_COMPONENT.conf"
-CONF_DIST="/azerothcore/env/dist/etc/$ACORE_COMPONENT.conf.dist"
+CONF="$CONF_DIR/$ACORE_COMPONENT.conf"
+CONF_DIST="$CONF_DIR/$ACORE_COMPONENT.conf.dist"
 
 # Copy the "dist" file to the "conf" if the conf doesn't already exist
 if [[ -f "$CONF_DIST" ]]; then


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

This makes it so the startup script (known as the entrypoint) for the docker containers will ensure that it owns the config and filelog directories on startup. 

This is important since there's the `dist` config files that get created during build, and these need to be transferred to the runtime config directory at runtime if they don't exist already.

Technically speaking, we could remove the bind mount (actually comment it out in the `docker-compose.yaml` file) so that the reader can see there's an option to do so. The reasoning for this is to nudge the user in the direction of using environment variables for config rather than files. On the other hand, this breaks compatibility for other users and we don't really need to do that for something so small.

## Issues Addressed:

- https://github.com/azerothcore/azerothcore-wotlk/issues/17656
    - It's common for users to clone the repo as root, which makes the config directories owned to root.
    - This is problematic because the servers for azerothcore run as non-root by default
    - As noted, the startup process creates files in the config dir, and a non-root user can't do that in a directory where they don't have write access
    - All in all this results in a somewhat confusing output on exit. It's a somewhat common thing to support.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

1. run command `sudo chown -R 0:0 env/dist` so its all owned to root
2. run `docker compose up --build ac-db-import` to build and run the db import. it should fail, with a big warning message at the top describing the error and possible resolution
3. run `sudo chown -R 1000:1000 env/dist` so it's owned to the default acore user
4. run `docker compose up --build ac-db-import`, it should build and start like normal

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
