### PR TITLE
fix(DB/Karazhan): remove smart_script linking so Mana Warps properly die even when stunned

### DIFF
--- a/data/sql/updates/pending_db_world/mana-warp-fix.sql
+++ b/data/sql/updates/pending_db_world/mana-warp-fix.sql
@@ -1,0 +1,8 @@
+--
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 16530 AND `source_type` = 0; 
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(16530, 0, 0, 0, 25, 0, 100, 512, 0, 0, 0, 0, 0, 0, 42, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mana Warp - On Reset - Set HP Invincibility'),
+(16530, 0, 1, 0, 2, 0, 100, 513, 0, 10, 0, 0, 0, 0, 11, 37079, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mana Warp - Between Health 0-10% - Cast Warp Breach'),
+(16530, 0, 2, 0, 2, 0, 100, 513, 0, 10, 0, 0, 0, 0, 11, 29919, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mana Warp - Between Health 0-10% - Cast Warp Breach'),
+(16530, 0, 3, 0, 2, 0, 100, 513, 0, 10, 0, 0, 0, 0, 22, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mana Warp - Between Health 0-10% - Set Event Phase'),
+(16530, 0, 4, 0, 0, 1, 100, 512, 2500, 2500, 0, 0, 0, 0, 37, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mana Warp - In Combat - Die');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

https://github.com/azerothcore/azerothcore-wotlk/pull/18026 did the following:

![image](https://github.com/azerothcore/azerothcore-wotlk/assets/83884799/697650b6-63e6-47aa-8a1d-6a5784728b0d)

if the mana warps fail in casting their main growing ability (which happens only once) they fail to grow and also fail to execute the rest of the linked events (no explosion, no event setting and because of the latter no death as they are set to be invincible (stay at 1 hp). This PR simply removes the linking to fix this (all events should now fire individually)

credits to [kissingers](https://github.com/kissingers) for figuring this out

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/6554

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

N.A.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] find the rest of the issues the combat movement PR caused (but overall they seem minor)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
