### PR TITLE
fix(Core/GameObject): Remove unneeded ClearGossipMenuFor call

### DIFF
--- a/src/server/game/Scripting/ScriptDefines/GameObjectScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/GameObjectScript.cpp
@@ -128,7 +128,6 @@ uint32 ScriptMgr::GetDialogStatus(Player* player, GameObject* go)
     ASSERT(go);
 
     auto tempScript = ScriptRegistry<GameObjectScript>::GetScriptById(go->GetScriptId());
-    ClearGossipMenuFor(player);
     return tempScript ? tempScript->GetDialogStatus(player, go) : DIALOG_STATUS_SCRIPTED_NO_STATUS;
 }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

This PR essentially repeats this - #17596
But for GameObjects

Removed another unnecessary ClearGossipMenuFor call which randomly broke gossip menus.

For example, if you are talking with some NPC, and at that moment you receive/lose some item or gold, your client will send CMSG_QUESTGIVER_STATUS_MULTIPLE_QUERY. If at the same time there are some GameObjects near you that can be questgiver, then a chain of method calls will lead to ClearGossipMenuFor and your gossip menu with NPC will suddenly breaks. You won't even understand why this could happen.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.
