### PR TITLE
chore(Common/Debugging): change report codestyle

### DIFF
--- a/src/common/Debugging/Errors.cpp
+++ b/src/common/Debugging/Errors.cpp
@@ -62,16 +62,16 @@ namespace
     inline std::string MakeMessage(std::string_view messageType, std::string_view file, uint32 line, std::string_view function,
         std::string_view message, std::string_view fmtMessage = {}, std::string_view debugInfo = {})
     {
-        std::string msg = Acore::StringFormatFmt("\n>> {}\n\n# Location '{}:{}'\n# Function '{}'\n# Condition '{}'\n", messageType, file, line, function, message);
+        std::string msg = Acore::StringFormatFmt("\n>> {}\n\n# Location: {}:{}\n# Function: {}\n# Condition: {}\n", messageType, file, line, function, message);
 
         if (!fmtMessage.empty())
         {
-            msg.append(Acore::StringFormatFmt("# Message '{}'\n", fmtMessage));
+            msg.append(Acore::StringFormatFmt("# Message: {}\n", fmtMessage));
         }
 
         if (!debugInfo.empty())
         {
-            msg.append(Acore::StringFormatFmt("\n# Debug info: '{}'\n", debugInfo));
+            msg.append(Acore::StringFormatFmt("\n# Debug info: {}\n", debugInfo));
         }
 
         return Acore::StringFormatFmt(


### PR DESCRIPTION
## Changes Proposed:
- [x] Core (common lib).

- Example abort msg:
```
/home/winfidonarleyan/Git/azerothcore-wotlk/cmake-build-relwithdebinfo/src/server/apps/authserver

#----------------------------------------------------------------------#
 
>> ABORTED

# Location '/home/winfidonarleyan/Git/azerothcore-wotlk/src/server/apps/authserver/Main.cpp:82'
# Function 'main'
# Message 'Abort fmt msg. Data: Test data'
 
#----------------------------------------------------------------------#
```

- Example assert msg
```
#----------------------------------------------------------------------#
 
>> ASSERTION FAILED

# Location: /home/winfidonarleyan/Git/azerothcore-wotlk/src/server/apps/authserver/Main.cpp:82
# Function: main
# Condition: false
# Message: Abort fmt msg. Data: Test data
 
#----------------------------------------------------------------------#
```