### PR TITLE
feat(Cmake): add support old policy 0153

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ message(STATUS "CMake version: ${CMAKE_VERSION}")
 
 # CMake policies (can not be handled elsewhere)
 cmake_policy(SET CMP0005 NEW)
+cmake_policy(SET CMP0153 OLD)
 
 # Set projectname (must be done AFTER setting configurationtypes)
 project(AzerothCore VERSION 3.0.0 LANGUAGES CXX C)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Fix cmake warning
```
CMake Warning (dev) at src/cmake/macros/FindMySQL.cmake:113 (exec_program):
  Policy CMP0153 is not set: The exec_program command should not be called.
  Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  Use execute_process() instead.
Call Stack (most recent call first):
  CMakeLists.txt:103 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at src/cmake/macros/FindMySQL.cmake:122 (exec_program):
  Policy CMP0153 is not set: The exec_program command should not be called.
  Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  Use execute_process() instead.
Call Stack (most recent call first):
  CMakeLists.txt:103 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
