### PR TITLE
feat(Core/Optimization): Reduce CPU consumption by allocating sendBuffer only when it is needed.

### DIFF
--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -161,42 +161,45 @@ void WorldSocket::CheckIpCallback(PreparedQueryResult result)
 bool WorldSocket::Update()
 {
     EncryptableAndCompressiblePacket* queued;
-    MessageBuffer buffer(_sendBufferSize);
-    while (_bufferQueue.Dequeue(queued))
+    if (_bufferQueue.Dequeue(queued)) 
     {
-        queued->CompressIfNeeded();
-
-        ServerPktHeader header(queued->size() + 2, queued->GetOpcode());
-        if (queued->NeedsEncryption())
-            _authCrypt.EncryptSend(header.header, header.getHeaderLength());
-
-        if (buffer.GetRemainingSpace() < queued->size() + header.getHeaderLength())
+        // Allocate buffer only when it's needed but not on every Update() call.
+        MessageBuffer buffer(_sendBufferSize);
+        do 
         {
+            queued->CompressIfNeeded();
+            ServerPktHeader header(queued->size() + 2, queued->GetOpcode());
+            if (queued->NeedsEncryption())
+                _authCrypt.EncryptSend(header.header, header.getHeaderLength());
+
+            if (buffer.GetRemainingSpace() < queued->size() + header.getHeaderLength())
+            {
+                QueuePacket(std::move(buffer));
+                buffer.Resize(_sendBufferSize);
+            }
+
+            if (buffer.GetRemainingSpace() >= queued->size() + header.getHeaderLength())
+            {
+                buffer.Write(header.header, header.getHeaderLength());
+                if (!queued->empty())
+                    buffer.Write(queued->contents(), queued->size());
+            }
+            else    // single packet larger than 4096 bytes
+            {
+                MessageBuffer packetBuffer(queued->size() + header.getHeaderLength());
+                packetBuffer.Write(header.header, header.getHeaderLength());
+                if (!queued->empty())
+                    packetBuffer.Write(queued->contents(), queued->size());
+
+                QueuePacket(std::move(packetBuffer));
+            }
+
+            delete queued;
+        } while (_bufferQueue.Dequeue(queued));
+
+        if (buffer.GetActiveSize() > 0)
             QueuePacket(std::move(buffer));
-            buffer.Resize(_sendBufferSize);
-        }
-
-        if (buffer.GetRemainingSpace() >= queued->size() + header.getHeaderLength())
-        {
-            buffer.Write(header.header, header.getHeaderLength());
-            if (!queued->empty())
-                buffer.Write(queued->contents(), queued->size());
-        }
-        else    // single packet larger than 4096 bytes
-        {
-            MessageBuffer packetBuffer(queued->size() + header.getHeaderLength());
-            packetBuffer.Write(header.header, header.getHeaderLength());
-            if (!queued->empty())
-                packetBuffer.Write(queued->contents(), queued->size());
-
-            QueuePacket(std::move(packetBuffer));
-        }
-
-        delete queued;
     }
-
-    if (buffer.GetActiveSize() > 0)
-        QueuePacket(std::move(buffer));
 
     if (!BaseSocket::Update())
         return false;

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -161,11 +161,11 @@ void WorldSocket::CheckIpCallback(PreparedQueryResult result)
 bool WorldSocket::Update()
 {
     EncryptableAndCompressiblePacket* queued;
-    if (_bufferQueue.Dequeue(queued)) 
+    if (_bufferQueue.Dequeue(queued))
     {
         // Allocate buffer only when it's needed but not on every Update() call.
         MessageBuffer buffer(_sendBufferSize);
-        do 
+        do
         {
             queued->CompressIfNeeded();
             ServerPktHeader header(queued->size() + 2, queued->GetOpcode());


### PR DESCRIPTION
We have a network thread that makes approximately 1k invocations per second of this function for every socket:
https://github.com/azerothcore/azerothcore-wotlk/blob/73340b94e3dbcc67da8e52ea5ddea06298c2c6d4/src/server/game/Server/WorldSocket.cpp#L161-L166
 
Most of the time, `_bufferQueue` remains empty, and we should do nothing inside this function. 
However, for each call, we allocate a 4KB buffer even when it is unnecessary. 
As a result, a significant portion of CPU time is dedicated to the allocation and deallocation of this buffer.

Below, you can observe the reduction in CPU consumption (with one player online) after implementing this change.
Before:
<img width="436" alt="Screenshot 2024-03-29 at 16 23 54" src="https://github.com/azerothcore/azerothcore-wotlk/assets/444158/d8777a40-5b74-4045-abc4-2a56b07967e9">
After:
<img width="436" alt="Screenshot 2024-03-29 at 16 30 58" src="https://github.com/azerothcore/azerothcore-wotlk/assets/444158/eac5d5fd-db2d-4e54-bd21-a32e4a1e8bfd">


<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
