### PR TITLE
feat(Core/Optimization): Correctly document sendBuffer size and optimize it.

### DIFF
--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -364,11 +364,11 @@ Network.OutKBuff = -1
 
 #
 #    Network.OutUBuff
-#        Description: Amount of memory (in bytes) reserved in the user space per connection for
-#                     output buffering.
-#         Default:    65536
+#        Description: Amount of memory (in bytes) reserved initially in the user space per
+#                     connection for output buffering.
+#         Default:    4096
 
-Network.OutUBuff = 65536
+Network.OutUBuff = 4096
 
 #
 #    Network.TcpNoDelay:

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -184,7 +184,7 @@ bool WorldSocket::Update()
                 if (!queued->empty())
                     buffer.Write(queued->contents(), queued->size());
             }
-            else    // single packet larger than 4096 bytes
+            else    // single packet larger than standard buffer size (Network.OutUBuff)
             {
                 MessageBuffer packetBuffer(queued->size() + header.getHeaderLength());
                 packetBuffer.Write(header.header, header.getHeaderLength());


### PR DESCRIPTION
While looking at #18628 and trying to understand, how the buffer works, I first noticed that the comment in the current code is wrong.
The buffer is not statically set to 4kB but instead initialized with 4kB and later resized to 64kB. This makes the impact on the CPU time to allocate that buffer (previously on every update even without queued packets) even more pronounced.

So the first commit is a definite fix of the documentation.

The following two commits are a proposal and up for discussion. When players are alone in the wilds, allocating a 64kB buffer every time seems wasted. On the other hand, in raids or cities, having a small buffer also doesn't seem that efficient.
Therefore, we could start with a 4kB sized buffer (as previously implied with the comment) and then increase its size (permanently) when we encounter a single very large packet that needs resizing anyway. Still limit the maximum size we regularly allocate to 64kB.

I cannot test if the reduced default buffer size leads to a measurable performance increase with many players or if it causes more buffers to be required leading to a performance decrease. This should be tested by someone with the means to it. In general, it should lead to a slight decrease in memory usage with many players.

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
