### PR TITLE
fix(Scripts/TheEye): Update Kaelthas Phoenix timers

### DIFF
--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -472,11 +472,11 @@ struct boss_kaelthas : public BossAI
             {
                 DoCastRandomTarget(SPELL_FLAME_STRIKE, 0, 100.0f);
             }, 30250ms, 50650ms);
-            ScheduleTimedEvent(20000ms, [&]
+            ScheduleTimedEvent(71000ms, [&]
             {
                 Talk(SAY_SUMMON_PHOENIX);
                 DoCastSelf(SPELL_PHOENIX);
-            }, 31450ms, 66550ms);
+            }, 61450ms, 96550ms);
             ScheduleTimedEvent(5s, [&]
             {
                 scheduler.DelayAll(30s);
@@ -735,11 +735,11 @@ struct boss_kaelthas : public BossAI
         {
             DoCastRandomTarget(SPELL_FLAME_STRIKE, 0, 100.0f);
         }, 30250ms, 50650ms);
-        ScheduleTimedEvent(30000ms, [&]
+        ScheduleTimedEvent(50000ms, [&]
         {
             Talk(SAY_SUMMON_PHOENIX);
             DoCastSelf(SPELL_PHOENIX);
-        }, 31450ms, 66550ms);
+        }, 35450ms, 41550ms);
         //sequence
         ScheduleTimedEvent(20s, 23s, [&]
         {


### PR DESCRIPTION
Changes to initial timers are ok / predictable because of previous events.
repeated casts cannot be set appropriately because of the delayall in https://github.com/azerothcore/azerothcore-wotlk/blob/e4136639e3b1ce4e4fc73204872d988588d60aee/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp#L480 with 90 seconds repeat cycle and the delayall in https://github.com/azerothcore/azerothcore-wotlk/blob/e4136639e3b1ce4e4fc73204872d988588d60aee/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp#L754 with 50 sec cycle. Both will cross-over with phoenix cycle resulting in atleast 1 summon happening without the delay at some point.

Options would be to rework the script, using DBM timers as minimum or using DBM timers as a frequency to achieve most of the time (which is this proposal)


<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/6875 includes links to source

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
