### PR TITLE
fix. fatal error: comparison of integers of different signs

### DIFF
--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_kazrogal.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_kazrogal.cpp
@@ -160,7 +160,7 @@ public:
         {
             Unit* target = GetTarget();
 
-            if (target->GetPower(POWER_MANA) < aurEff->GetBaseAmount())
+            if (target->GetPower(POWER_MANA) < (unsigned)aurEff->GetBaseAmount())
             {
                 target->CastSpell(target, SPELL_MARK_DAMAGE, true, nullptr, aurEff);
                 // Remove aura

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_kazrogal.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_kazrogal.cpp
@@ -160,7 +160,7 @@ public:
         {
             Unit* target = GetTarget();
 
-            if (target->GetPower(POWER_MANA) < (unsigned)aurEff->GetBaseAmount())
+            if ((int32)target->GetPower(POWER_MANA) < aurEff->GetBaseAmount())
             {
                 target->CastSpell(target, SPELL_MARK_DAMAGE, true, nullptr, aurEff);
                 // Remove aura


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

```
[ 60%] Building CXX object src/server/game/CMakeFiles/game.dir/Scripting/ScriptDefines/UnitScript.cpp.o
/Users/runner/work/azerothcore-wotlk/azerothcore-wotlk/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_kazrogal.cpp:164:46: fatal error: comparison of integers of different signs: 'uint32' (aka 'unsigned int') and 'int32' (aka 'int') [-Wsign-compare]
            if (target->GetPower(POWER_MANA) < aurEff->GetBaseAmount())
[ 60%] Building CXX object src/server/game/CMakeFiles/game.dir/Scripting/ScriptDefines/VehicleScript.cpp.o
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [src/server/scripts/CMakeFiles/scripts.dir/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_kazrogal.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in github action.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
