### PR TITLE
fix(Scripts/Spell): Fix Void Zone damage calcs for Netherspite, Blaumeux

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1713998045630729445.sql
+++ b/data/sql/updates/pending_db_world/rev_1713998045630729445.sql
@@ -1,0 +1,11 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` = 28865;
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(28865,'spell_gen_consumption');
+
+DELETE FROM `creature_template_spell` WHERE `CreatureID` = 16697;
+
+UPDATE `creature_template` SET `ScriptName` = '', `AIName` = 'SmartAI' WHERE `entry` = 16697;
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 16697);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(16697, 0, 0, 0, 60, 0, 100, 0, 0, 0, 2500, 2500, 0, 0, 11, 28865, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Void Zone - On Update - Cast \'Consumption\''),
+(16697, 0, 1, 0, 37, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Void Zone - On Initialize - Set Reactstate Passive');

--- a/src/server/scripts/Northrend/Naxxramas/boss_four_horsemen.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_four_horsemen.cpp
@@ -437,26 +437,9 @@ public:
     }
 };
 
-class spell_four_horsemen_consumption : public SpellScript
-{
-    PrepareSpellScript(spell_four_horsemen_consumption);
-
-    void HandleDamageCalc(SpellEffIndex /*effIndex*/)
-    {
-        uint32 damage = GetCaster()->GetMap()->ToInstanceMap()->GetDifficulty() == REGULAR_DIFFICULTY ? 2750 : 4250;
-        SetHitDamage(damage);
-    }
-
-    void Register() override
-    {
-        OnEffectHitTarget += SpellEffectFn(spell_four_horsemen_consumption::HandleDamageCalc, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
-    }
-};
-
 void AddSC_boss_four_horsemen()
 {
     new boss_four_horsemen();
     new spell_four_horsemen_mark();
-    RegisterSpellScript(spell_four_horsemen_consumption);
 }
 

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -5134,6 +5134,44 @@ class spell_gen_choking_vines : public AuraScript
     }
 };
 
+ // 28865 - Consumption
+class spell_gen_consumption : public SpellScript
+{
+    PrepareSpellScript(spell_gen_consumption);
+
+    void CalculateDamage(SpellEffIndex /*effIndex*/)
+    {
+        Map* map = GetCaster()->GetMap();
+        if (!map)
+        {
+            return;
+        }
+        int32 value = 0;
+        if (map->GetDifficulty() == RAID_DIFFICULTY_25MAN_NORMAL) // NAXX 25 N
+        {
+            value = urand(4500, 4700);
+        }
+        else if (map->GetId() == 533) // NAXX10 N
+        {
+            value = urand(3000, 3200);
+        }
+        else if (map->GetId() == 532) // Karazhan
+        {
+            value = urand(1110, 1310);
+        }
+        if (value)
+        {
+            SetEffectValue(value);
+        }
+    }
+
+    void Register() override
+    {
+        OnEffectLaunchTarget += SpellEffectFn(spell_gen_consumption::CalculateDamage, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
+    }
+};
+
+
 void AddSC_generic_spell_scripts()
 {
     RegisterSpellScript(spell_silithyst);
@@ -5287,5 +5325,6 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_jubling_cooldown);
     RegisterSpellScript(spell_gen_yehkinya_bramble);
     RegisterSpellScript(spell_gen_choking_vines);
+    RegisterSpellScript(spell_gen_consumption);
 }
 

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -5147,7 +5147,7 @@ class spell_gen_consumption : public SpellScript
             return;
         }
         int32 value = 0;
-        if (map->GetDifficulty() == RAID_DIFFICULTY_25MAN_NORMAL) // NAXX 25 N
+        if (map->GetDifficulty() == RAID_DIFFICULTY_25MAN_NORMAL) // NAXX25 N
         {
             value = urand(4500, 4700);
         }

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -5171,7 +5171,6 @@ class spell_gen_consumption : public SpellScript
     }
 };
 
-
 void AddSC_generic_spell_scripts()
 {
     RegisterSpellScript(spell_silithyst);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/18801 

## SOURCE:

Approach is based on https://github.com/TrinityCore/TrinityCore/commit/5eac5ee2dbee289acbde48506b04ef35a0b1d5b2

See below for notes 

<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Go to  Netherspite (requires 2 characters) or  Blaumeux Naxx10/25 (requires 1 character),
2. Stand in Void Zone
3. Observe damage with and without a damage reduction spell

```
TP Blaumeux
.go c 130962
TP Netherspite
.go c 135476
learn pain suppresion or any %damage reduction spell: 
.learn 69910
```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

EffectValues are hardcoded from the spell DBC.
```
Boss - summonspell - effect2 dummy bp
Netherspite  - 37063 - 1110
Blaumeux 10M - 28863 - 2999
Blaumeux 25M - 57463 - 4499
```

TrinityCore's approach fails due to `GetUInt32Value(UNIT_CREATED_BY_SPELL)` always being 0
```
    ...
    void CalculateDamage(SpellEffIndex /*effIndex*/)
    {
        if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(GetCaster()->GetUInt32Value(UNIT_CREATED_BY_SPELL)))
        {
          int32 value = spellInfo->GetEffect(EFFECT_1).CalcValue();
          SetEffectValue(value);
        }
        ...
```

Acore: https://github.com/azerothcore/azerothcore-wotlk/blob/b90136d80d852a5fba845e7db630484efb670d78/src/server/game/Spells/SpellEffects.cpp#L2446 

Trinitycore: https://github.com/TrinityCore/TrinityCore/blob/dad976beb4f1a865e5df5d6f03da1d00d266e1fc/src/server/game/Spells/SpellEffects.cpp#L1937

In Acore some summoned creatures' spellId is set to 0? In TC in this case it is set.
 
Substituting Acore with line below works as the spell id is now set.
```
summon = m_originalCaster->SummonCreature(entry, pos, summonType, duration, 0, nullptr, personalSpawn);
summon = m_caster->GetMap()->SummonCreature(entry, pos, properties, duration, m_originalCaster, m_spellInfo->Id, 0, personalSpawn);
```

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
