### PR TITLE
feat(Core/Network): Add Proxy Protocol v2 support.

### DIFF
--- a/src/server/apps/authserver/Server/AuthSocketMgr.h
+++ b/src/server/apps/authserver/Server/AuthSocketMgr.h
@@ -20,6 +20,7 @@
 
 #include "AuthSession.h"
 #include "SocketMgr.h"
+#include "Config.h"
 
 class AuthSocketMgr : public SocketMgr<AuthSession>
 {

--- a/src/server/apps/authserver/Server/AuthSocketMgr.h
+++ b/src/server/apps/authserver/Server/AuthSocketMgr.h
@@ -44,7 +44,13 @@ public:
 protected:
     NetworkThread<AuthSession>* CreateThreads() const override
     {
-        return new NetworkThread<AuthSession>[1];
+        NetworkThread<AuthSession>* threads = new NetworkThread<AuthSession>[1];
+        
+        bool proxyProtocolEnabled = sConfigMgr->GetOption<bool>("EnableProxyProtocol", false, true);
+        if (proxyProtocolEnabled)
+            threads[0].EnableProxyProtocol();
+
+        return threads;
     }
 
     static void OnSocketAccept(tcp::socket&& sock, uint32 threadIndex)

--- a/src/server/apps/authserver/Server/AuthSocketMgr.h
+++ b/src/server/apps/authserver/Server/AuthSocketMgr.h
@@ -46,7 +46,7 @@ protected:
     NetworkThread<AuthSession>* CreateThreads() const override
     {
         NetworkThread<AuthSession>* threads = new NetworkThread<AuthSession>[1];
-        
+
         bool proxyProtocolEnabled = sConfigMgr->GetOption<bool>("EnableProxyProtocol", false, true);
         if (proxyProtocolEnabled)
             threads[0].EnableProxyProtocol();

--- a/src/server/apps/authserver/authserver.conf.dist
+++ b/src/server/apps/authserver/authserver.conf.dist
@@ -65,6 +65,16 @@ RealmServerPort = 3724
 BindIP = "0.0.0.0"
 
 #
+#    EnableProxyProtocol
+#        Description: Enables Proxy Protocol v2. When your server is behind a proxy, 
+#					  load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
+#					  this server and the proxy/load balancer to track the real IP address of players.
+#        Example:     1 - (Enabled)
+#        Default:     0 - (Disabled)
+
+EnableProxyProtocol = 0
+
+#
 #    PidFile
 #        Description: Auth server PID file.
 #        Example:     "./authserver.pid"  - (Enabled)

--- a/src/server/apps/authserver/authserver.conf.dist
+++ b/src/server/apps/authserver/authserver.conf.dist
@@ -67,8 +67,8 @@ BindIP = "0.0.0.0"
 #
 #    EnableProxyProtocol
 #        Description: Enables Proxy Protocol v2. When your server is behind a proxy, 
-#					  load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
-#					  this server and the proxy/load balancer to track the real IP address of players.
+#                     load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
+#                     this server and the proxy/load balancer to track the real IP address of players.
 #        Example:     1 - (Enabled)
 #        Default:     0 - (Disabled)
 

--- a/src/server/apps/authserver/authserver.conf.dist
+++ b/src/server/apps/authserver/authserver.conf.dist
@@ -66,8 +66,8 @@ BindIP = "0.0.0.0"
 
 #
 #    EnableProxyProtocol
-#        Description: Enables Proxy Protocol v2. When your server is behind a proxy, 
-#                     load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
+#        Description: Enables Proxy Protocol v2. When your server is behind a proxy,
+#                     load balancer, or similar component, you need to enable Proxy Protocol v2 on both
 #                     this server and the proxy/load balancer to track the real IP address of players.
 #        Example:     1 - (Enabled)
 #        Default:     0 - (Disabled)

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -379,6 +379,16 @@ Network.OutUBuff = 4096
 Network.TcpNodelay = 1
 
 #
+#    Network.EnableProxyProtocol
+#        Description: Enables Proxy Protocol v2. When your server is behind a proxy, 
+#					  load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
+#					  this server and the proxy/load balancer to track the real IP address of players.
+#        Example:     1 - (Enabled)
+#        Default:     0 - (Disabled)
+
+Network.EnableProxyProtocol = 0
+
+#
 ###################################################################################################
 
 ###################################################################################################

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -381,8 +381,8 @@ Network.TcpNodelay = 1
 #
 #    Network.EnableProxyProtocol
 #        Description: Enables Proxy Protocol v2. When your server is behind a proxy, 
-#					  load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
-#					  this server and the proxy/load balancer to track the real IP address of players.
+#                     load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
+#                     this server and the proxy/load balancer to track the real IP address of players.
 #        Example:     1 - (Enabled)
 #        Default:     0 - (Disabled)
 

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -380,8 +380,8 @@ Network.TcpNodelay = 1
 
 #
 #    Network.EnableProxyProtocol
-#        Description: Enables Proxy Protocol v2. When your server is behind a proxy, 
-#                     load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
+#        Description: Enables Proxy Protocol v2. When your server is behind a proxy,
+#                     load balancer, or similar component, you need to enable Proxy Protocol v2 on both
 #                     this server and the proxy/load balancer to track the real IP address of players.
 #        Example:     1 - (Enabled)
 #        Default:     0 - (Disabled)

--- a/src/server/game/Server/WorldSocketMgr.cpp
+++ b/src/server/game/Server/WorldSocketMgr.cpp
@@ -114,5 +114,13 @@ void WorldSocketMgr::OnSocketOpen(tcp::socket&& sock, uint32 threadIndex)
 
 NetworkThread<WorldSocket>* WorldSocketMgr::CreateThreads() const
 {
-    return new WorldSocketThread[GetNetworkThreadCount()];
+
+    NetworkThread<WorldSocket>* threads = new WorldSocketThread[GetNetworkThreadCount()];
+
+    bool proxyProtocolEnabled = sConfigMgr->GetOption<bool>("Network.EnableProxyProtocol", false, true);
+    if (proxyProtocolEnabled)
+        for (int i = 0; i < GetNetworkThreadCount(); i++)
+            threads[i].EnableProxyProtocol();
+
+    return threads;
 }

--- a/src/server/shared/Network/NetworkThread.h
+++ b/src/server/shared/Network/NetworkThread.h
@@ -20,6 +20,7 @@
 
 #include "DeadlineTimer.h"
 #include "Define.h"
+#include "Socket.h"
 #include "Errors.h"
 #include "IoContext.h"
 #include "Log.h"

--- a/src/server/shared/Network/NetworkThread.h
+++ b/src/server/shared/Network/NetworkThread.h
@@ -39,7 +39,7 @@ class NetworkThread
 {
 public:
     NetworkThread() :
-        _ioContext(1), _acceptSocket(_ioContext), _updateTimer(_ioContext) { }
+        _ioContext(1), _acceptSocket(_ioContext), _updateTimer(_ioContext), _proxyHeaderReadingEnabled(false) { }
 
     virtual ~NetworkThread()
     {
@@ -94,6 +94,8 @@ public:
 
     tcp::socket* GetSocketForAccept() { return &_acceptSocket; }
 
+    void EnableProxyProtocol() { _proxyHeaderReadingEnabled = true; }
+
 protected:
     virtual void SocketAdded(std::shared_ptr<SocketType> /*sock*/) { }
     virtual void SocketRemoved(std::shared_ptr<SocketType> /*sock*/) { }
@@ -105,20 +107,73 @@ protected:
         if (_newSockets.empty())
             return;
 
-        for (std::shared_ptr<SocketType> sock : _newSockets)
+        if (!_proxyHeaderReadingEnabled)
         {
+            for (std::shared_ptr<SocketType> sock : _newSockets)
+            {
+                if (!sock->IsOpen())
+                {
+                    SocketRemoved(sock);
+                    --_connections;
+                    continue;
+                }
+
+                _sockets.emplace_back(sock);
+
+                sock->Start();
+            }
+
+            _newSockets.clear();
+        }
+        else
+        {
+            HandleNewSocketsProxyReadingOnConnect();
+        }
+    }
+
+    void HandleNewSocketsProxyReadingOnConnect()
+    {
+        size_t index = 0;
+        std::vector<int> newSocketsToRemoveIndexes;
+        for (auto sock_iter = _newSockets.begin(); sock_iter != _newSockets.end(); ++sock_iter, ++index)
+        {
+            std::shared_ptr<SocketType> sock = *sock_iter;
+
             if (!sock->IsOpen())
             {
+                newSocketsToRemoveIndexes.emplace_back(index);
                 SocketRemoved(sock);
                 --_connections;
+                continue;
             }
-            else
-            {
-                _sockets.emplace_back(sock);
+
+            const auto proxyHeaderReadingState = sock->GetProxyHeaderReadingState();
+            if (proxyHeaderReadingState == PROXY_HEADER_READING_STATE_STARTED)
+                continue;
+
+            switch (proxyHeaderReadingState) {
+                case PROXY_HEADER_READING_STATE_NOT_STARTED:
+                    sock->AsyncReadProxyHeader();
+                    break;
+
+                case PROXY_HEADER_READING_STATE_FINISHED:
+                    newSocketsToRemoveIndexes.emplace_back(index);
+                    _sockets.emplace_back(sock);
+
+                    sock->Start();
+
+                    break;
+
+                default:
+                    newSocketsToRemoveIndexes.emplace_back(index);
+                    SocketRemoved(sock);
+                    --_connections;
+                    break;
             }
         }
 
-        _newSockets.clear();
+        for (int removeIndex : newSocketsToRemoveIndexes)
+            _newSockets.erase(_newSockets.begin() + removeIndex);
     }
 
     void Run()
@@ -177,6 +232,8 @@ private:
     Acore::Asio::IoContext _ioContext;
     tcp::socket _acceptSocket;
     Acore::Asio::DeadlineTimer _updateTimer;
+
+    bool _proxyHeaderReadingEnabled;
 };
 
 #endif // NetworkThread_h__

--- a/src/server/shared/Network/Socket.h
+++ b/src/server/shared/Network/Socket.h
@@ -22,6 +22,7 @@
 #include "MessageBuffer.h"
 #include <atomic>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio.hpp>
 #include <functional>
 #include <memory>
 #include <queue>
@@ -34,12 +35,25 @@ using boost::asio::ip::tcp;
 #define AC_SOCKET_USE_IOCP
 #endif
 
+enum ProxyHeaderReadingState {
+    PROXY_HEADER_READING_STATE_NOT_STARTED,
+    PROXY_HEADER_READING_STATE_STARTED,
+    PROXY_HEADER_READING_STATE_FINISHED,
+    PROXY_HEADER_READING_STATE_FAILED,
+};
+
+enum ProxyHeaderAddressFamilyAndProtocol {
+    PROXY_HEADER_ADDRESS_FAMILY_AND_PROTOCOL_TCP_V4 = 0x11,
+    PROXY_HEADER_ADDRESS_FAMILY_AND_PROTOCOL_TCP_V6 = 0x21,
+};
+
 template<class T>
 class Socket : public std::enable_shared_from_this<T>
 {
 public:
     explicit Socket(tcp::socket&& socket) : _socket(std::move(socket)), _remoteAddress(_socket.remote_endpoint().address()),
-        _remotePort(_socket.remote_endpoint().port()), _readBuffer(), _closed(false), _closing(false), _isWritingAsync(false)
+        _remotePort(_socket.remote_endpoint().port()), _readBuffer(), _closed(false), _closing(false), _isWritingAsync(false),
+        _proxyHeaderReadingState(PROXY_HEADER_READING_STATE_NOT_STARTED)
     {
         _readBuffer.Resize(READ_BLOCK_SIZE);
     }
@@ -92,9 +106,23 @@ public:
 
         _readBuffer.Normalize();
         _readBuffer.EnsureFreeSpace();
-
         _socket.async_read_some(boost::asio::buffer(_readBuffer.GetWritePointer(), _readBuffer.GetRemainingSpace()),
             std::bind(&Socket<T>::ReadHandlerInternal, this->shared_from_this(), std::placeholders::_1, std::placeholders::_2));
+    }
+
+    void AsyncReadProxyHeader()
+    {
+        if (!IsOpen())
+        {
+            return;
+        }
+
+        _proxyHeaderReadingState = PROXY_HEADER_READING_STATE_STARTED;
+
+        _readBuffer.Normalize();
+        _readBuffer.EnsureFreeSpace();
+        _socket.async_read_some(boost::asio::buffer(_readBuffer.GetWritePointer(), _readBuffer.GetRemainingSpace()),
+            std::bind(&Socket<T>::ProxyReadHeaderHandler, this->shared_from_this(), std::placeholders::_1, std::placeholders::_2));
     }
 
     void AsyncReadWithCallback(void (T::*callback)(boost::system::error_code, std::size_t))
@@ -119,6 +147,8 @@ public:
         AsyncProcessQueue();
 #endif
     }
+
+    [[nodiscard]] ProxyHeaderReadingState GetProxyHeaderReadingState() const { return _proxyHeaderReadingState; }
 
     [[nodiscard]] bool IsOpen() const { return !_closed && !_closing; }
 
@@ -185,6 +215,118 @@ private:
 
         _readBuffer.WriteCompleted(transferredBytes);
         ReadHandler();
+    }
+
+    // ProxyReadHeaderHandler reads Proxy Protocol v2 header (v1 is not supported).
+    // See https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt (2.2. Binary header format (version 2)) for more details.
+    void ProxyReadHeaderHandler(boost::system::error_code error, size_t transferredBytes)
+    {
+        if (error)
+        {
+            CloseSocket();
+            return;
+        }
+
+        _readBuffer.WriteCompleted(transferredBytes);
+
+        MessageBuffer& packet = GetReadBuffer();
+
+        const int minimumProxyProtocolV2Size = 28;
+        if (packet.GetActiveSize() < minimumProxyProtocolV2Size)
+        {
+            AsyncReadProxyHeader();
+            return;
+        }
+
+        uint8* readPointer = packet.GetReadPointer();
+
+        const uint8 signatureSize = 12;
+        const uint8 expectedSignature[signatureSize] = {0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A};
+        if (memcmp(packet.GetReadPointer(), expectedSignature, signatureSize) != 0)
+        {
+            _proxyHeaderReadingState = PROXY_HEADER_READING_STATE_FAILED;
+            LOG_ERROR("network", "Socket::ProxyReadHeaderHandler: received bad PROXY Protocol v2 signature for {}", GetRemoteIpAddress().to_string());
+            return;
+        }
+
+        const uint8 version = (readPointer[signatureSize] & 0xF0) >> 4;
+        const uint8 command = (readPointer[signatureSize] & 0xF);
+
+        if (version != 2)
+        {
+            _proxyHeaderReadingState = PROXY_HEADER_READING_STATE_FAILED;
+            LOG_ERROR("network", "Socket::ProxyReadHeaderHandler: received bad PROXY Protocol v2 signature for {}", GetRemoteIpAddress().to_string());
+            return;
+        }
+
+        const uint8 addressFamily = readPointer[13];
+        const uint16 len = (readPointer[14] << 8) | readPointer[15];
+        if (len+16 > packet.GetActiveSize())
+        {
+            AsyncReadProxyHeader();
+            return;
+        }
+
+        // Connection created by a proxy itself (health checks?), ignore and do nothing.
+        if (command == 0)
+        {
+            packet.ReadCompleted(len+16);
+            _proxyHeaderReadingState = PROXY_HEADER_READING_STATE_FINISHED;
+            return;
+        }
+
+        auto remainingLen = packet.GetActiveSize() - 16;
+        readPointer += 16; // Skip strait to address.
+
+        switch (addressFamily) {
+            case PROXY_HEADER_ADDRESS_FAMILY_AND_PROTOCOL_TCP_V4:
+            {
+                if (remainingLen < 12)
+                {
+                    AsyncReadProxyHeader();
+                    return;
+                }
+
+                boost::asio::ip::address_v4::bytes_type b;
+                auto addressSize = sizeof(b);
+
+                std::copy(readPointer, readPointer+addressSize, b.begin());
+                _remoteAddress = boost::asio::ip::address_v4(b);
+
+                readPointer += 2 * addressSize; // Skip server address.
+                _remotePort = (readPointer[0] << 8) | readPointer[1];
+
+                break;
+            }
+
+            case PROXY_HEADER_ADDRESS_FAMILY_AND_PROTOCOL_TCP_V6:
+            {
+                if (remainingLen < 36)
+                {
+                    AsyncReadProxyHeader();
+                    return;
+                }
+
+                boost::asio::ip::address_v6::bytes_type b;
+                auto addressSize = sizeof(b);
+
+                std::copy(readPointer, readPointer+addressSize, b.begin());
+                _remoteAddress = boost::asio::ip::address_v6(b);
+
+                readPointer += 2 * addressSize; // Skip server address.
+                _remotePort = (readPointer[0] << 8) | readPointer[1];
+
+                break;
+            }
+
+            default:
+                _proxyHeaderReadingState = PROXY_HEADER_READING_STATE_FAILED;
+                LOG_ERROR("network", "Socket::ProxyReadHeaderHandler: unsupported address family type {}", GetRemoteIpAddress().to_string());
+                return;
+        }
+
+        packet.ReadCompleted(len+16);
+        _proxyHeaderReadingState = PROXY_HEADER_READING_STATE_FINISHED;
     }
 
 #ifdef AC_SOCKET_USE_IOCP
@@ -283,6 +425,8 @@ private:
     std::atomic<bool> _closing;
 
     bool _isWritingAsync;
+
+    ProxyHeaderReadingState _proxyHeaderReadingState;
 };
 
 #endif // __SOCKET_H__

--- a/src/server/shared/Network/SocketMgr.h
+++ b/src/server/shared/Network/SocketMgr.h
@@ -94,8 +94,6 @@ public:
         try
         {
             std::shared_ptr<SocketType> newSocket = std::make_shared<SocketType>(std::move(sock));
-            newSocket->Start();
-
             _threads[threadIndex].AddSocket(newSocket);
         }
         catch (boost::system::system_error const& err)


### PR DESCRIPTION
In some cases, you may want to place the authserver or worldserver behind a proxy or load balancer. However, if you do this, you would lose the client's address (IP). To address this issue, most proxies and load balancers support Proxy Protocol (v1 & v2). To utilize it, we also need Proxy Protocol support on both the authserver and worldserver.

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/18100

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

I used HAProxy to test this change.
1. I changed authserver and worldserver configs by changing ports (3777 & 8026) and by enabling Proxy Protocol.
2. Run HAProxy with the next config:
```
global
    log /dev/log    local0
    log /dev/log    local1 notice
    stats timeout 30s

defaults
    log global
    mode tcp
    option tcplog
    timeout connect 5000ms
    timeout client 50000ms
    timeout server 50000ms

frontend tcp_front
    bind 0.0.0.0:3724
    default_backend tcp_back

frontend tcp_world
    bind 0.0.0.0:8085
    default_backend tcp_world_back

backend tcp_back
    server backend_server 127.0.0.1:3777 send-proxy-v2

backend tcp_world_back
    server backend_server 127.0.0.1:8026 send-proxy-v2
```
3. Login to the game using regular ports.
4. You can use `.lookup ip` command to verify players IP.


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
