### PR TITLE
fix(Scripts/Spell) Rogue glyph of backstab (port from TrinityCore)

### DIFF
--- a/data/sql/updates/pending_db_world/16_rogue_glyph_of_backstab.sql
+++ b/data/sql/updates/pending_db_world/16_rogue_glyph_of_backstab.sql
@@ -1,0 +1,3 @@
+UPDATE `spell_proc_event` SET `SpellFamilyMask0`=0x00000004 WHERE `entry`=56800;
+DELETE FROM `spell_script_names` WHERE `spell_id`=63975;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES  (63975, 'spell_rog_glyph_of_backstab_triggered');

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7567,16 +7567,8 @@ bool Unit::HandleDummyAuraProc(Unit* victim, uint32 damage, AuraEffect* triggere
                     // Glyph of Backstab
                     case 56800:
                         {
-                            if (victim)
-                                if (AuraEffect* aurEff = victim->GetAuraEffect(SPELL_AURA_PERIODIC_DAMAGE, SPELLFAMILY_ROGUE, 0x100000, 0, 0, GetGUID()))
-                                    if (Aura* aur = aurEff->GetBase())
-                                        if (!aur->IsRemoved() && aur->GetDuration() > 0)
-                                            if ((aur->GetApplyTime() + aur->GetMaxDuration() / 1000 + 5) > (GameTime::GetGameTime().count() + aur->GetDuration() / 1000) )
-                                            {
-                                                aur->SetDuration(aur->GetDuration() + 2000);
-                                                return true;
-                                            }
-                            return false;
+                            triggered_spell_id = 63975;
+                            break;
                         }
                     // Deadly Throw Interrupt
                     case 32748:

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -843,7 +843,6 @@ public:
     }
 };
 
-
 void AddSC_rogue_spell_scripts()
 {
     RegisterSpellScript(spell_rog_savage_combat);

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -41,8 +41,7 @@ enum RogueSpells
     SPELL_ROGUE_PREY_ON_THE_WEAK                = 58670,
     SPELL_ROGUE_SHIV_TRIGGERED                  = 5940,
     SPELL_ROGUE_TRICKS_OF_THE_TRADE_DMG_BOOST   = 57933,
-    SPELL_ROGUE_TRICKS_OF_THE_TRADE_PROC        = 59628,
-    SPELL_ROGUE_T10_2P_BONUS                    = 70804
+    SPELL_ROGUE_TRICKS_OF_THE_TRADE_PROC        = 59628
 };
 
 class spell_rog_savage_combat : public AuraScript

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -41,7 +41,7 @@ enum RogueSpells
     SPELL_ROGUE_PREY_ON_THE_WEAK                = 58670,
     SPELL_ROGUE_SHIV_TRIGGERED                  = 5940,
     SPELL_ROGUE_TRICKS_OF_THE_TRADE_DMG_BOOST   = 57933,
-    SPELL_ROGUE_TRICKS_OF_THE_TRADE_PROC        = 59628
+    SPELL_ROGUE_TRICKS_OF_THE_TRADE_PROC        = 59628,
 };
 
 class spell_rog_savage_combat : public AuraScript
@@ -823,7 +823,6 @@ public:
 
                 if (countMin < countMax)
                 {
-
                     bonusDuration += 2000;
                     aurEff->GetBase()->SetDuration(aurEff->GetBase()->GetDuration() + 2000);
                     aurEff->GetBase()->SetMaxDuration(countMin + 2000);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
 **Current Behaviour**
Currently [Glyph of Backstab](https://www.wowhead.com/wotlk/item=42956/glyph-of-backstab) makes the [Rupture](https://www.wowhead.com/wotlk/spell=15583/rupture) doesn't deal damage last 6 seconds before DOT debuff end.
**Expected Blizzlike Behaviour**
Glyph upgrades [Backstab](https://www.wowhead.com/wotlk/spell=34614/backstab) to prolongs DOT debuff of Rupture per 2 seconds each time Backstab used (up to 6 seconds).
**Steps to reproduce the problem**:

0) Don't use poisons on your weapons (it simplifies the test);
1) Use Glyph of Backstab;
2) Stack 5 CP on Training Dummy;
3) Spend 5 CP on Rupture ability;
4) Use Backstab 3 times;
5) Write `/stopattack` to game chat and observe the DOT ticks of Rupture (should deal damage every 2 seconds);
6) After Rupture debuff reach 6 seconds left it will not deal damage anymore, but should deal damage 3 times.


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

This fix made with @tagrim