### PR TITLE
fix(Scripts/Magtheridon): Clicking cubes should Banish Magtheridon

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1714650326089446105.sql
+++ b/data/sql/updates/pending_db_world/rev_1714650326089446105.sql
@@ -1,0 +1,3 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` = 30166;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (30166, 'spell_magtheridon_shadow_grasp_visual');

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
@@ -71,9 +71,7 @@ enum Groups
 
 enum Actions
 {
-    ACTION_INCREASE_HELLFIRE_CHANNELER_DEATH_COUNT  = 1,
-    ACTION_BANISH_SELF = 2,
-    ACTION_BANISH_SELF_REMOVE = 3
+    ACTION_INCREASE_HELLFIRE_CHANNELER_DEATH_COUNT  = 1
 };
 
 struct boss_magtheridon : public BossAI
@@ -215,15 +213,6 @@ struct boss_magtheridon : public BossAI
                 });
             }
         }
-        else if (action == ACTION_BANISH_SELF )
-        {
-            Talk(SAY_BANISH);
-            me->CastSpell(me, SPELL_SHADOW_CAGE_STUN, true);
-        }
-        else if (action == ACTION_BANISH_SELF_REMOVE )
-        {
-            me->RemoveAurasDueToSpell(SPELL_SHADOW_CAGE_STUN);
-        }
     }
 
     void JustEngagedWith(Unit* who) override
@@ -352,15 +341,15 @@ class spell_magtheridon_shadow_grasp_visual : public AuraScript
 
     void HandleDummyApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
-        if (GetUnitOwner()->GetAuraCount(SPELL_SHADOW_GRASP_VISUAL) == 5)
+        if (GetTarget()->GetAuraCount(SPELL_SHADOW_GRASP_VISUAL) == 5)
         {
-            GetUnitOwner()->GetAI()->DoAction(ACTION_BANISH_SELF);
+            GetTarget()->CastSpell(GetTarget(), SPELL_SHADOW_CAGE, true);
         }
     }
 
     void HandleDummyRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
-        GetUnitOwner()->GetAI()->DoAction(ACTION_BANISH_SELF_REMOVE);
+        GetTarget()->RemoveAurasDueToSpell(SPELL_SHADOW_CAGE_STUN);
     }
 
     void Register() override

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
@@ -71,7 +71,8 @@ enum Groups
 
 enum Actions
 {
-    ACTION_INCREASE_HELLFIRE_CHANNELER_DEATH_COUNT  = 1
+    ACTION_INCREASE_HELLFIRE_CHANNELER_DEATH_COUNT  = 1,
+    ACTION_BANISH_SELF = 2
 };
 
 struct boss_magtheridon : public BossAI
@@ -213,6 +214,11 @@ struct boss_magtheridon : public BossAI
                 });
             }
         }
+        else if (action == ACTION_BANISH_SELF )
+        {
+            Talk(SAY_BANISH);
+            me->CastSpell(me, SPELL_SHADOW_CAGE_STUN, true);
+        }
     }
 
     void JustEngagedWith(Unit* who) override
@@ -343,7 +349,7 @@ class spell_magtheridon_shadow_grasp_visual : public AuraScript
     {
         if (GetTarget()->GetAuraCount(SPELL_SHADOW_GRASP_VISUAL) == 5)
         {
-            GetTarget()->CastSpell(GetTarget(), SPELL_SHADOW_CAGE, true);
+            GetTarget()->GetAI()->DoAction(ACTION_BANISH_SELF);
         }
     }
 

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
@@ -52,6 +52,7 @@ enum Spells
     SPELL_BERSERK               = 27680,
     SPELL_SHADOW_GRASP          = 30410,
     SPELL_SHADOW_GRASP_VISUAL   = 30166,
+    SPELL_SHADOW_CAGE_STUN      = 30168,
     SPELL_MIND_EXHAUSTION       = 44032,
     SPELL_QUAKE                 = 30657,
     SPELL_QUAKE_KNOCKBACK       = 30571,
@@ -65,13 +66,14 @@ enum Spells
 
 enum Groups
 {
-    GROUP_INTERRUPT_CHECK       = 0,
-    GROUP_EARLY_RELEASE_CHECK   = 1
+    GROUP_EARLY_RELEASE_CHECK   = 0
 };
 
 enum Actions
 {
-    ACTION_INCREASE_HELLFIRE_CHANNELER_DEATH_COUNT  = 1
+    ACTION_INCREASE_HELLFIRE_CHANNELER_DEATH_COUNT  = 1,
+    ACTION_BANISH_SELF = 2,
+    ACTION_BANISH_SELF_REMOVE = 3
 };
 
 struct boss_magtheridon : public BossAI
@@ -188,21 +190,6 @@ struct boss_magtheridon : public BossAI
         {
             DoCastSelf(SPELL_BLAST_NOVA);
             scheduler.DelayAll(10s);
-
-            _interruptScheduler.Schedule(50ms, GROUP_INTERRUPT_CHECK, [this](TaskContext context)
-            {
-                if (me->GetAuraCount(SPELL_SHADOW_GRASP_VISUAL) == 5)
-                {
-                    Talk(SAY_BANISH);
-                    me->InterruptNonMeleeSpells(true);
-                    scheduler.CancelGroup(GROUP_INTERRUPT_CHECK);
-                }
-                else
-                    context.Repeat(50ms);
-            }).Schedule(12s, GROUP_INTERRUPT_CHECK, [this](TaskContext /*context*/)
-            {
-                _interruptScheduler.CancelGroup(GROUP_INTERRUPT_CHECK);
-            });
             context.Repeat(54350ms, 55400ms);
         }).Schedule(22min, [this](TaskContext /*context*/)
         {
@@ -227,6 +214,15 @@ struct boss_magtheridon : public BossAI
                     ScheduleCombatEvents();
                 });
             }
+        }
+        else if (action == ACTION_BANISH_SELF )
+        {
+            Talk(SAY_BANISH);
+            me->CastSpell(me, SPELL_SHADOW_CAGE_STUN, true);
+        }
+        else if (action == ACTION_BANISH_SELF_REMOVE )
+        {
+            me->RemoveAurasDueToSpell(SPELL_SHADOW_CAGE_STUN);
         }
     }
 
@@ -350,6 +346,30 @@ class spell_magtheridon_shadow_grasp : public AuraScript
     }
 };
 
+class spell_magtheridon_shadow_grasp_visual : public AuraScript
+{
+    PrepareAuraScript(spell_magtheridon_shadow_grasp_visual);
+
+    void HandleDummyApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        if (GetUnitOwner()->GetAuraCount(SPELL_SHADOW_GRASP_VISUAL) == 5)
+        {
+            GetUnitOwner()->GetAI()->DoAction(ACTION_BANISH_SELF);
+        }
+    }
+
+    void HandleDummyRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        GetUnitOwner()->GetAI()->DoAction(ACTION_BANISH_SELF_REMOVE);
+    }
+
+    void Register() override
+    {
+        OnEffectApply += AuraEffectApplyFn(spell_magtheridon_shadow_grasp_visual::HandleDummyApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+        OnEffectRemove += AuraEffectRemoveFn(spell_magtheridon_shadow_grasp_visual::HandleDummyRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
 class spell_magtheridon_quake : public SpellScript
 {
     PrepareSpellScript(spell_magtheridon_quake);
@@ -417,6 +437,7 @@ void AddSC_boss_magtheridon()
     RegisterMagtheridonsLairCreatureAI(npc_target_trigger);
     RegisterSpellScript(spell_magtheridon_blaze);
     RegisterSpellScript(spell_magtheridon_shadow_grasp);
+    RegisterSpellScript(spell_magtheridon_shadow_grasp_visual);
     RegisterSpellScript(spell_magtheridon_quake);
     RegisterSpellScript(spell_magtheridon_debris_target_selector);
     new go_manticron_cube();


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/18818

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

original TBC reference https://youtu.be/YA_B7t2ojkU?si=UUr2nbMo3PON3wui&t=293

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Changes to test with 1,2,3 characters
```
        }).Schedule(3s, [this](TaskContext context) // FOR TESTING
        {
            DoCastSelf(SPELL_BLAST_NOVA);
```
```
        if (GetTarget()->GetAuraCount(SPELL_SHADOW_GRASP_VISUAL) == 3) // FOR TESTING
```

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Requires 5 characters to click cubes simultaneously to trigger banish effect

pull once and clear trash

1. `.go c 91254`
2. kill orcs to start p2
3. click cubes

- [ ] Banish should apply once 5 cubes are being channeled
- [ ] Banish should remove once 5 are no longer being channeled
- [ ] Banish should stop Blast Wave from being cast/channeled

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
