### PR TITLE
fix(Core/Pets): Correct Pet size for bigger pets 2

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -2518,7 +2518,7 @@ float Pet::GetNativeObjectScale() const
 
         if (CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(GetNativeDisplayId()))
         {
-            if (displayInfo->scale > 1.f)
+            if (scale < 1.f && displayInfo->scale > 1.f)
                 scale *= displayInfo->scale;
         }
         return scale;

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -2498,11 +2498,6 @@ float Pet::GetNativeObjectScale() const
 {
     uint8 ctFamily = GetCreatureTemplate()->family;
 
-    // hackfix: Edge case where DBC scale values for DEVILSAUR pets make them too small.
-    // Therefore we take data from spirit beast instead.
-    if (ctFamily && ctFamily == CREATURE_FAMILY_DEVILSAUR)
-        ctFamily = CREATURE_FAMILY_SPIRIT_BEAST;
-
     CreatureFamilyEntry const* creatureFamily = sCreatureFamilyStore.LookupEntry(ctFamily);
     if (creatureFamily && creatureFamily->minScale > 0.0f && getPetType() & HUNTER_PET)
     {
@@ -2519,6 +2514,13 @@ float Pet::GetNativeObjectScale() const
 
         float scale = (creatureFamily->maxScale - creatureFamily->minScale) * scaleMod + creatureFamily->minScale;
 
+        scale = std::min(scale, creatureFamily->maxScale);
+
+        if (CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(GetNativeDisplayId()))
+        {
+            if (displayInfo->scale > 1.f)
+                scale *= displayInfo->scale;
+        }
         return scale;
     }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Pets should scale based on level and scaling range as by their DBC value. I found that this also needs to be scaled with their DisplayID, this part was missing.

This factor was added in PR

- https://github.com/azerothcore/azerothcore-wotlk/pull/14511  but later removed?

Adding it back seemed correct besides that the scaling was not capped to MaxScaling. So pets past the MaxScaleLevel were still scaled larger than they should

-  https://github.com/azerothcore/azerothcore-wotlk/pull/14511#issuecomment-1648169456

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/18412

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

DBC
https://old.wow.tools/dbc/?dbc=creaturefamily&build=3.3.5.12340#page=1

PR https://github.com/azerothcore/azerothcore-wotlk/pull/14511 

formula check, scaling is correct until maxLvl
|            | minScaling | maxScaling | minLvl | maxLvl |
| ---------- | ---------- | ---------- | ------ | ------ |
| Core Hound | 0.3        | 0.7        | 1      | 60     |
| Devilsaur  | 0.3        | 0.5        | 1      | 60     |
|            |            |            |        |        |
|            |            |            |        |        |
| Level      | Core Hound | Devilsaur  |        |        |
| 1          | 0.3068     | 0.3034     |        |        |
| 2          | 0.3136     | 0.3068     |        |        |
| 5          | 0.3339     | 0.3169     |        |        |
| 10         | 0.3678     | 0.3339     |        |        |
| 15         | 0.4017     | 0.3508     |        |        |
| 20         | 0.4356     | 0.3678     |        |        |
| 25         | 0.4695     | 0.3847     |        |        |
| 30         | 0.5034     | 0.4017     |        |        |
| 35         | 0.5373     | 0.4186     |        |        |
| 40         | 0.5712     | 0.4356     |        |        |
| 45         | 0.6051     | 0.4525     |        |        |
| 50         | 0.6390     | 0.4695     |        |        |
| 55         | 0.6729     | 0.4864     |        |        |
| 60         | 0.7068     | 0.5034     |        |        |
| 65         | 0.7407     | 0.5203     | <-- wrong       |        | 
| 70         | 0.7746     | 0.5373     |        |        |
| 75         | 0.8085     | 0.5542     |        |        |
| 80         | 0.8424     | 0.5712     |        |        |
| 85         | 0.8763     | 0.5881     |        |        |

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Spawn NPCs and tame

`.npc tame`
```
Ancient Core hound
.npc add 11673
Devilsaur
.npc add 6498
Kurken
.npc add 17447
```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
