### PR TITLE
fix(Ulduar/Tram): add rocket booster, turnaround visuals, button logic

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1715708681053405822.sql
+++ b/data/sql/updates/pending_db_world/rev_1715708681053405822.sql
@@ -1,0 +1,19 @@
+--
+-- Rocket Booster
+UPDATE `gameobject` SET `position_x`=2307.000003, `position_y`=265.6011, `position_z`=424.287993  WHERE (`id` = 194904) AND (`guid` IN (35524));
+-- Delete 2nd Activate Tram gameobject
+DELETE FROM `gameobject` WHERE `id` = 194438;
+UPDATE `gameobject_template` SET `ScriptName` = '' WHERE `entry` = 194438;
+-- Call Tram objects start as non-selectable
+UPDATE `gameobject_template_addon` SET `flags` = `flags` | 16  WHERE `entry` IN (194912, 194914);
+-- Buttons
+UPDATE `gameobject_template` SET `AIName` = 'SmartGameObjectAI', `ScriptName` = '' WHERE `entry` IN (194437,194912,194914);
+DELETE FROM `smart_scripts` WHERE (`entryorguid` IN (194437,194912,194914)) AND (`source_type` = 1);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(194437, 1, 0, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 22, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Activate Tram - On Respawn - Set Event Phase 1'),
+(194437, 1, 1, 2, 64, 1, 100, 0, 0, 0, 0, 0, 0, 0, 34, 710, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Activate Tram - On Gossip Hello - Set Instance Data 710 to 1 (Phase 1)'),
+(194437, 1, 2, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 22, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Activate Tram - On Gossip Hello - Set Event Phase 2 (Phase 1)'),
+(194437, 1, 3, 4, 64, 2, 100, 0, 0, 0, 0, 0, 0, 0, 34, 710, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Activate Tram - On Gossip Hello - Set Instance Data 710 to 0 (Phase 2)'),
+(194437, 1, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 22, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Activate Tram - On Gossip Hello - Set Event Phase 1 (Phase 2)'),
+(194912, 1, 0, 0, 64, 0, 100, 0, 0, 0, 0, 0, 0, 0, 34, 710, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Call Tram - On Gossip Hello - Set Instance Data 710 to 1'),
+(194914, 1, 0, 0, 64, 0, 100, 0, 0, 0, 0, 0, 0, 0, 34, 710, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Call Tram - On Gossip Hello - Set Instance Data 710 to 0');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -100,6 +100,15 @@ public:
         Position normalChestPosition = { 1967.152588f, -204.188461f, 432.686951f, 5.50957f };
         Position hardChestPosition = { 2035.94600f, -202.084885f, 432.686859f, 3.164077f };
 
+        // Mimiron Tram
+        ObjectGuid m_mimironTramGUID;
+        ObjectGuid m_mimironActivateTramGUID;
+        ObjectGuid m_mimironTramRocketBoosterGUID;
+        ObjectGuid m_mimironTramTurnaround1GUID;
+        ObjectGuid m_mimironTramTurnaround2GUID;
+        ObjectGuid m_mimironCallTramCenterGUID;
+        ObjectGuid m_mimironCallTramMimironGUID;
+
         // Mimiron
         ObjectGuid m_MimironDoor[3];
         ObjectGuid m_MimironLeviathanMKIIguid;
@@ -127,7 +136,6 @@ public:
         // Shared
         EventMap _events;
         bool m_mimironTramUsed;
-        ObjectGuid m_mimironTramGUID;
         ObjectGuid m_keepersgateGUID;
         ObjectGuid m_keepersGossipGUID[4];
 
@@ -170,7 +178,18 @@ public:
             // mimiron tram:
             instance->LoadGrid(2307.0f, 284.632f);
             if (GameObject* MimironTram = instance->GetGameObject(m_mimironTramGUID))
+            {
                 player->UpdateVisibilityOf(MimironTram);
+                if (StaticTransport* t = MimironTram->ToStaticTransport())
+                {
+                    if (GameObject* go = instance->GetGameObject(m_mimironTramRocketBoosterGUID))
+                        if (!go->GetTransport())
+                            t->AddPassenger(go, true);
+                    if (GameObject* go = instance->GetGameObject(m_mimironActivateTramGUID))
+                        if (!go->GetTransport())
+                            t->AddPassenger(go, true);
+                }
+            }
 
             if (!m_uiAlgalonGUID && m_algalonTimer && (m_algalonTimer <= 60 || m_algalonTimer == TIMER_ALGALON_TO_SUMMON))
             {
@@ -582,10 +601,29 @@ public:
                 case GO_SNOW_MOUND:
                     gameObject->EnableCollision(false);
                     break;
+                // Mimiron Tram
                 case GO_MIMIRON_TRAM:
                     if (GetData(TYPE_MIMIRON) == DONE)
                         m_mimironTramUsed = true;
                     m_mimironTramGUID = gameObject->GetGUID();
+                    break;
+                case GO_MIMIRON_TRAM_ROCKET_BOOSTER:
+                    m_mimironTramRocketBoosterGUID = gameObject->GetGUID();
+                    break;
+                case GO_MIMIRON_ACTIVATE_TRAM:
+                    m_mimironActivateTramGUID = gameObject->GetGUID();
+                    break;
+                case GO_MIMIRON_CALL_TRAM_CENTER:
+                    m_mimironCallTramCenterGUID = gameObject->GetGUID();
+                    break;
+                case GO_MIMIRON_CALL_TRAM_MIMIRON:
+                    m_mimironCallTramMimironGUID = gameObject->GetGUID();
+                    break;
+                case GO_DOODAD_UL_TRAIN_TURNAROUND01:
+                    m_mimironTramTurnaround1GUID = gameObject->GetGUID();
+                    break;
+                case GO_DOODAD_UL_TRAIN_TURNAROUND02:
+                    m_mimironTramTurnaround2GUID = gameObject->GetGUID();
                     break;
                 // Algalon the Observer
                 case GO_CELESTIAL_PLANETARIUM_ACCESS_10:
@@ -811,9 +849,51 @@ public:
                         if (StaticTransport* t = MimironTram->ToStaticTransport())
                         {
                             if (data == 0 && t->GetGoState() == GO_STATE_ACTIVE && t->GetPathProgress() == t->GetPauseTime())
+                            {
                                 MimironTram->SetGoState(GO_STATE_READY);
+                                if (GameObject* rocketBooster = instance->GetGameObject(m_mimironTramRocketBoosterGUID))
+                                    rocketBooster->SetGoState(GO_STATE_ACTIVE);
+                                if (GameObject* activateTramButton = instance->GetGameObject(m_mimironActivateTramGUID))
+                                    activateTramButton->SetGameObjectFlag(GO_FLAG_NOT_SELECTABLE);
+                                if (GameObject* callTramCenterButton = instance->GetGameObject(m_mimironCallTramCenterGUID))
+                                    callTramCenterButton->SetGameObjectFlag(GO_FLAG_NOT_SELECTABLE);
+                                scheduler.Schedule(30s, [this](TaskContext /*context*/)
+                                {
+                                    if (GameObject* turnaround1 = instance->GetGameObject(m_mimironTramTurnaround1GUID))
+                                        turnaround1->UseDoorOrButton();
+                                    if (GameObject* rocketBooster = instance->GetGameObject(m_mimironTramRocketBoosterGUID))
+                                        rocketBooster->SetGoState(GO_STATE_READY);
+                                }).Schedule(60s, [this](TaskContext /*context*/)
+                                {
+                                    if (GameObject* activateTramButton = instance->GetGameObject(m_mimironActivateTramGUID))
+                                        activateTramButton->RemoveGameObjectFlag(GO_FLAG_NOT_SELECTABLE);
+                                    if (GameObject* callTramMimironButton = instance->GetGameObject(m_mimironCallTramMimironGUID))
+                                        callTramMimironButton->RemoveGameObjectFlag(GO_FLAG_NOT_SELECTABLE);
+                                });
+                            }
                             if (data == 1 && t->GetGoState() == GO_STATE_READY && t->GetPathProgress() == 0)
+                            {
                                 MimironTram->SetGoState(GO_STATE_ACTIVE);
+                                if (GameObject* rocketBooster = instance->GetGameObject(m_mimironTramRocketBoosterGUID))
+                                    rocketBooster->SetGoState(GO_STATE_ACTIVE);
+                                if (GameObject* activateTramButton = instance->GetGameObject(m_mimironActivateTramGUID))
+                                    activateTramButton->SetGameObjectFlag(GO_FLAG_NOT_SELECTABLE);
+                                if (GameObject* callTramMimironButton = instance->GetGameObject(m_mimironCallTramMimironGUID))
+                                    callTramMimironButton->SetGameObjectFlag(GO_FLAG_NOT_SELECTABLE);
+                                scheduler.Schedule(33s, [this](TaskContext /*context*/)
+                                {
+                                    if (GameObject* turnaround2 = instance->GetGameObject(m_mimironTramTurnaround2GUID))
+                                        turnaround2->UseDoorOrButton();
+                                    if (GameObject* rocketBooster = instance->GetGameObject(m_mimironTramRocketBoosterGUID))
+                                        rocketBooster->SetGoState(GO_STATE_READY);
+                                }).Schedule(63s, [this](TaskContext /*context*/)
+                                {
+                                    if (GameObject* activateTramButton = instance->GetGameObject(m_mimironActivateTramGUID))
+                                        activateTramButton->RemoveGameObjectFlag(GO_FLAG_NOT_SELECTABLE);
+                                    if (GameObject* callTramCenterButton = instance->GetGameObject(m_mimironCallTramCenterGUID))
+                                        callTramCenterButton->RemoveGameObjectFlag(GO_FLAG_NOT_SELECTABLE);
+                                });
+                            }
                         }
                     break;
                 case DATA_BRANN_MEMOTESAY:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
@@ -496,33 +496,6 @@ public:
     }
 };
 
-class go_call_tram : public GameObjectScript
-{
-public:
-    go_call_tram() : GameObjectScript("go_call_tram") { }
-
-    bool OnGossipHello(Player* /*player*/, GameObject* go) override
-    {
-        InstanceScript* pInstance = go->GetInstanceScript();
-
-        if (!pInstance)
-            return false;
-
-        switch(go->GetEntry())
-        {
-            case 194914:
-            case 194438:
-                pInstance->SetData(DATA_CALL_TRAM, 0);
-                break;
-            case 194912:
-            case 194437:
-                pInstance->SetData(DATA_CALL_TRAM, 1);
-                break;
-        }
-        return true;
-    }
-};
-
 struct npc_salvaged_siege_engine : public VehicleAI
 {
     npc_salvaged_siege_engine(Creature* creature) : VehicleAI(creature) { }
@@ -560,7 +533,5 @@ void AddSC_ulduar()
     new npc_ulduar_arachnopod_destroyer();
     new spell_ulduar_arachnopod_damaged();
     new AreaTrigger_at_celestial_planetarium_enterance();
-    new go_call_tram();
-
     RegisterCreatureAI(npc_salvaged_siege_engine);
 }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -215,7 +215,15 @@ enum UlduarGameObjects
     GO_KOLOGARN_DOORS                       = 194553,
     GO_KEEPERS_GATE                         = 194255,
     GO_XT002_DOORS                          = 194631,
+
+    // Tram
     GO_MIMIRON_TRAM                         = 194675,
+    GO_MIMIRON_ACTIVATE_TRAM                = 194437,
+    GO_MIMIRON_CALL_TRAM_CENTER             = 194914,
+    GO_MIMIRON_CALL_TRAM_MIMIRON            = 194912,
+    GO_MIMIRON_TRAM_ROCKET_BOOSTER          = 194904,
+    GO_DOODAD_UL_TRAIN_TURNAROUND01         = 194915, // center
+    GO_DOODAD_UL_TRAIN_TURNAROUND02         = 194913, // mimiron
 
     // Mimiron, Hodir, Vezax
     GO_MIMIRON_ELEVATOR                     = 194749,


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

drawing of tram structure, ids - guids
![tram](https://github.com/azerothcore/azerothcore-wotlk/assets/46423958/5b0ea3ed-23e7-437d-8492-d744b2efe96e)

I used timings to get the visual effects to sync up however the `StaticTransport` events for arrival should be used, but I can't get them to emit? I tried the following
```
-- 1: event_scripts to activate the "doors" circles upon arrival
DELETE FROM `event_scripts` WHERE `id` IN (21393,21394);
INSERT INTO `event_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `dataint`, `x`, `y`, `z`, `o`)
VALUES
(21393, 0, 11, 42867, 0, 0, 0.0, 0.0, 0.0, 0.0),
(21394, 0, 11, 56125, 0, 0, 0.0, 0.0, 0.0, 0.0);
-- 2: smartAI on the tram to activate the "doors" circles upon arrival
DELETE FROM `smart_scripts` WHERE (`source_type` = 1 AND `entryorguid` = 194675);
INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
(194675, 1, 0, 0, 71, 0, 100, 0, 21394, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 14, 56125, 194913, 0, 0, 0, 0, 0, 0, 'Tram - On Event 21393 Inform - Activate Gameobject'),
(194675, 1, 1, 0, 71, 0, 100, 0, 21393, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 14, 42879, 194915, 0, 0, 0, 0, 0, 0, 'Tram - On Event 21394 Inform - Activate Gameobject');
```
3: `ProcessEvent` in instancescript 


`AddPassenger` is called `onPlayerEnter`, not sure where else to do this 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16093
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16105
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16106
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16107


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The rocket booster position was present in DB as relative to the Tram object.
"Activate Tram" object 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.



https://github.com/azerothcore/azerothcore-wotlk/assets/46423958/e988f2f8-2a83-419d-bad4-c8db52f2f926


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

tp to the tram at center

1. `.go xyz 2275 288 419.3 603 0.067`
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
