### PR TITLE
fix(Scripts/Ulduar): update Boss Keepers, Gossip Keepers, Yogg Keepers, Yogg-Saron

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1716230497379077638.sql
+++ b/data/sql/updates/pending_db_world/rev_1716230497379077638.sql
@@ -6,8 +6,10 @@ DELETE FROM `spell_script_names` WHERE `spell_id` = 64170;
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (64170, 'spell_keeper_freya_summon_sanity_well');
 
 DELETE FROM `spell_script_names` WHERE `spell_id` IN (62650,62670,62671,62702);
+DELETE FROM `spell_script_names` WHERE `spell_id` = 64174 AND `ScriptName` = 'spell_gen_area_aura_select_players';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
-(62650, 'spell_yogg_saron_keeper_aura'),
-(62670, 'spell_yogg_saron_keeper_aura'),
-(62671, 'spell_yogg_saron_keeper_aura'),
-(62702, 'spell_yogg_saron_keeper_aura');
+(62650, 'spell_gen_area_aura_select_players_and_caster'),
+(62670, 'spell_gen_area_aura_select_players_and_caster'),
+(62671, 'spell_gen_area_aura_select_players_and_caster'),
+(62702, 'spell_gen_area_aura_select_players_and_caster'),
+(64174, 'spell_gen_area_aura_select_players');

--- a/data/sql/updates/pending_db_world/rev_1716230497379077638.sql
+++ b/data/sql/updates/pending_db_world/rev_1716230497379077638.sql
@@ -1,0 +1,13 @@
+--
+-- Remove encounter auras minus glow aura from Keepers, add glow aura to Gossip Keepers
+UPDATE `creature_template_addon` SET `auras` = '62647' WHERE `entry` IN (33410,33411,33412,33413,33213,33241,33242,33244);
+
+DELETE FROM `spell_script_names` WHERE `spell_id` = 64170;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (64170, 'spell_keeper_freya_summon_sanity_well');
+
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (62650,62670,62671,62702);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(62650, 'spell_yogg_saron_keeper_aura'),
+(62670, 'spell_yogg_saron_keeper_aura'),
+(62671, 'spell_yogg_saron_keeper_aura'),
+(62702, 'spell_yogg_saron_keeper_aura');

--- a/data/sql/updates/pending_db_world/rev_1716230497379077638.sql
+++ b/data/sql/updates/pending_db_world/rev_1716230497379077638.sql
@@ -13,3 +13,8 @@ INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (62671, 'spell_gen_area_aura_select_players_and_caster'),
 (62702, 'spell_gen_area_aura_select_players_and_caster'),
 (64174, 'spell_gen_area_aura_select_players');
+
+-- Keeper: handle spawns with script
+DELETE FROM `creature` WHERE `id1` IN (33213,33241,33242,33244);
+-- Keeper: remove not selectable, immune to pc, immune to player; civilian
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` & ~(256 | 512 | 33554432), `flags_extra` = `flags_extra` & ~2 WHERE `entry` IN (33410,33411,33412,33413);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -46,7 +46,6 @@ enum Spells
     SPELL_COSMIC_SMASH_VISUAL_STATE     = 62300,
     SPELL_SELF_STUN                     = 65256,
     SPELL_KILL_CREDIT                   = 65184,
-    SPELL_TELEPORT                      = 62940,
     SPELL_DUAL_WIELD                    = 42459,
 
     // Algalon Stalker

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -347,7 +347,6 @@ public:
                     uint32 chestId = RAID_MODE(GO_FREYA_CHEST, GO_FREYA_CHEST_HERO);
                     chestId -= 2 * _elderCount; // offset
 
-                    me->DespawnOrUnsummon(5000);
                     if (GameObject* go = me->SummonGameObject(chestId, 2345.61f, -71.20f, 425.104f, 3.0f, 0, 0, 0, 0, 0))
                     {
                         go->ReplaceAllGameObjectFlags((GameObjectFlags)0);
@@ -359,9 +358,12 @@ public:
                     {
                         me->CastSpell(me, 65074, true); // credit
                         m_pInstance->SetData(TYPE_FREYA, DONE);
-                        // DoCastSelf(SPELL_TELEPORT); // TODO: Delay by 4 seconds to match despawn time
-                        m_pInstance->SetData(EVENT_KEEPER_TELEPORTED, DONE);
                     }
+
+                    scheduler.Schedule(4s, [this](TaskContext /*context*/)
+                    {
+                        DoCastSelf(SPELL_TELEPORT);
+                    });
                 }
             }
         }
@@ -558,6 +560,7 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
+            scheduler.Update(diff);
             if (!UpdateVictim())
                 return;
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -359,6 +359,8 @@ public:
                     {
                         me->CastSpell(me, 65074, true); // credit
                         m_pInstance->SetData(TYPE_FREYA, DONE);
+                        // DoCastSelf(SPELL_TELEPORT); // TODO: Delay by 4 seconds to match despawn time
+                        m_pInstance->SetData(EVENT_KEEPER_TELEPORTED, DONE);
                     }
                 }
             }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -360,7 +360,7 @@ public:
                         m_pInstance->SetData(TYPE_FREYA, DONE);
                     }
 
-                    scheduler.Schedule(4s, [this](TaskContext /*context*/)
+                    scheduler.Schedule(14s, [this](TaskContext /*context*/)
                     {
                         DoCastSelf(SPELL_TELEPORT);
                     });

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -366,6 +366,15 @@ public:
             }
         }
 
+        void SpellHit(Unit* /*caster*/, SpellInfo const* spellInfo) override
+        {
+            if (spellInfo->Id == SPELL_TELEPORT)
+            {
+                me->DespawnOrUnsummon();
+                m_pInstance->SetData(EVENT_KEEPER_TELEPORTED, DONE);
+            }
+        }
+
         void JustSummoned(Creature* cr) override
         {
             if (cr->GetEntry() == NPC_FREYA_UNSTABLE_SUN_BEAM)

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -383,15 +383,17 @@ public:
                     }
 
                     Talk(TEXT_DEATH);
-                    // DoCastSelf(SPELL_TELEPORT); // TODO: Delay by 9 seconds to match despawn time
-                    pInstance->SetData(EVENT_KEEPER_TELEPORTED, DONE);
-                    me->DespawnOrUnsummon(10000);
+                    scheduler.Schedule(9s, [this](TaskContext /*context*/)
+                    {
+                        DoCastSelf(SPELL_TELEPORT);
+                    });
                 }
             }
         }
 
         void UpdateAI(uint32 diff) override
         {
+            scheduler.Update(diff);
             if (me->GetPositionY() <= ENTRANCE_DOOR.GetPositionY() || me->GetPositionY() >= EXIT_DOOR.GetPositionY())
             {
                 boss_hodirAI::EnterEvadeMode();

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -499,6 +499,15 @@ public:
             DoMeleeAttackIfReady();
         }
 
+        void SpellHit(Unit* /*caster*/, SpellInfo const* spellInfo) override
+        {
+            if (spellInfo->Id == SPELL_TELEPORT)
+            {
+                me->DespawnOrUnsummon();
+                pInstance->SetData(EVENT_KEEPER_TELEPORTED, DONE);
+            }
+        }
+
         Creature* GetHelper(uint8 index)
         {
             return Helpers[index] ? ObjectAccessor::GetCreature(*me, Helpers[index]) : nullptr;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -346,6 +346,7 @@ public:
                     {
                         pInstance->SetData(TYPE_HODIR, DONE);
                         me->CastSpell(me, 64899, true); // credit
+                        pInstance->DoRemoveAurasDueToSpellOnPlayers(SPELL_BITING_COLD_PLAYER_AURA);
                     }
 
                     me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
@@ -355,7 +356,6 @@ public:
                     me->CombatStop();
                     me->InterruptNonMeleeSpells(true);
                     me->RemoveAllAuras();
-                    pInstance->DoRemoveAurasDueToSpellOnPlayers(SPELL_BITING_COLD_PLAYER_AURA);
 
                     events.Reset();
                     summons.DespawnAll();
@@ -383,6 +383,8 @@ public:
                     }
 
                     Talk(TEXT_DEATH);
+                    // DoCastSelf(SPELL_TELEPORT); // TODO: Delay by 9 seconds to match despawn time
+                    pInstance->SetData(EVENT_KEEPER_TELEPORTED, DONE);
                     me->DespawnOrUnsummon(10000);
                 }
             }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -383,7 +383,7 @@ public:
                     }
 
                     Talk(TEXT_DEATH);
-                    scheduler.Schedule(9s, [this](TaskContext /*context*/)
+                    scheduler.Schedule(14s, [this](TaskContext /*context*/)
                     {
                         DoCastSelf(SPELL_TELEPORT);
                     });

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -802,9 +802,18 @@ public:
                 case EVENT_DISAPPEAR:
                     if( pInstance )
                         pInstance->SetData(TYPE_MIMIRON, DONE);
+                    DoCastSelf(SPELL_TELEPORT);
                     summons.DespawnAll();
-                    me->DespawnOrUnsummon();
                     break;
+            }
+        }
+
+        void SpellHit(Unit* /*caster*/, SpellInfo const* spellInfo) override
+        {
+            if (spellInfo->Id == SPELL_TELEPORT)
+            {
+                me->DespawnOrUnsummon();
+                pInstance->SetData(EVENT_KEEPER_TELEPORTED, DONE);
             }
         }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -197,6 +197,7 @@ enum ThorimEvents
     EVENT_THORIM_OUTRO1                     = 13,
     EVENT_THORIM_OUTRO2                     = 14,
     EVENT_THORIM_OUTRO3                     = 15,
+    EVENT_THORIM_OUTRO4                     = 16,
 
     EVENT_DR_ACOLYTE_GH                     = 20,
     EVENT_DR_ACOLYTE_HS                     = 21,
@@ -630,6 +631,11 @@ public:
                 me->CastSpell(me, SPELL_LIGHTNING_CHARGE_BUFF, true);
                 events.RescheduleEvent(EVENT_THORIM_LIGHTNING_CHARGE, 10s, 0, EVENT_PHASE_RING);
             }
+            else if (spellInfo->Id == SPELL_TELEPORT)
+            {
+                me->DespawnOrUnsummon();
+                m_pInstance->SetData(EVENT_KEEPER_TELEPORTED, DONE);
+            }
         }
 
         void SpellHitTarget(Unit* target, SpellInfo const* spellInfo) override
@@ -773,12 +779,13 @@ public:
                     {
                         Talk(SAY_END_NORMAL_3);
                     }
-
                     // Defeat credit
                     if (m_pInstance)
                         m_pInstance->SetData(TYPE_THORIM, DONE);
-
-                    me->DespawnOrUnsummon(8000);
+                    events.ScheduleEvent(EVENT_THORIM_OUTRO4, 7s, 0, 3);
+                    break;
+                case EVENT_THORIM_OUTRO4:
+                    DoCastSelf(SPELL_TELEPORT);
                     break;
             }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -782,7 +782,7 @@ public:
                     // Defeat credit
                     if (m_pInstance)
                         m_pInstance->SetData(TYPE_THORIM, DONE);
-                    events.ScheduleEvent(EVENT_THORIM_OUTRO4, 7s, 0, 3);
+                    events.ScheduleEvent(EVENT_THORIM_OUTRO4, 14s, 0, 3);
                     break;
                 case EVENT_THORIM_OUTRO4:
                     DoCastSelf(SPELL_TELEPORT);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -1732,12 +1732,19 @@ public:
 
     struct boss_yoggsaron_keeperAI : public NullCreatureAI
     {
-        boss_yoggsaron_keeperAI(Creature* pCreature) : NullCreatureAI(pCreature) { }
+        boss_yoggsaron_keeperAI(Creature* pCreature) : NullCreatureAI(pCreature), _summons(pCreature) { }
 
         void DoAction(int32 param) override
         {
             if (me->GetEntry() == NPC_THORIM_KEEPER && param == ACTION_THORIM_START_STORM)
                 me->CastSpell(me, SPELL_TITANIC_STORM_PASSIVE, false);
+            else if (param == ACTION_DESPAWN_ADDS)
+                _summons.DespawnAll();
+        }
+
+        void JustSummoned(Creature* summon) override
+        {
+            _summons.Summon(summon);
         }
 
         void JustEngagedWith(Unit* /*who*/) override
@@ -1771,6 +1778,8 @@ public:
         {
             scheduler.Update(diff);
         }
+    private:
+        SummonList _summons;
     };
 };
 
@@ -2773,10 +2782,8 @@ class spell_keeper_freya_summon_sanity_well : public SpellScript
     void OnEffect(SpellEffIndex /*effIndex*/)
     {
         if (Unit* caster = GetCaster())
-            if (InstanceScript* instance = caster->GetInstanceScript())
-                if (Creature* sara = ObjectAccessor::GetCreature(*caster, caster->GetInstanceScript()->GetGuidData(NPC_SARA)))
-                    for (int i = 0; i < 5; i++)
-                        sara->SummonCreature(NPC_SANITY_WELL, SanityWellsPos[i]);
+            for (int i = 0; i < 5; i++)
+                caster->SummonCreature(NPC_SANITY_WELL, SanityWellsPos[i]);
     }
 
     void Register() override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -380,7 +380,6 @@ public:
         SummonList summons;
 
         uint32 _initFight;
-        ObjectGuid _keepersGUID[4];
         uint8 _summonedGuardiansCount;
         uint32 _p2TalkTimer;
         bool _secondPhase;
@@ -394,10 +393,6 @@ public:
         void JustSummoned(Creature* cr) override
         {
             summons.Summon(cr);
-            if (NPC_FREYA_KEEPER <= cr->GetEntry() && cr->GetEntry() <= NPC_THORIM_KEEPER)
-            {
-                _keepersGUID[cr->GetEntry() - NPC_FREYA_KEEPER] = cr->GetGUID();
-            }
         }
 
         void SpawnClouds()
@@ -456,8 +451,6 @@ public:
             summons.DoAction(ACTION_DESPAWN_ADDS);
             events.Reset();
             summons.DespawnAll();
-            for (uint8 i = 0; i < 4; ++i)
-                _keepersGUID[i].Clear();
 
             me->SetVisible(true);
             me->SetDisplayId(me->GetNativeDisplayId());
@@ -518,21 +511,23 @@ public:
             for (uint8 i = 0; i < 4; ++i)
                 if (m_pInstance->GetData(TYPE_WATCHERS) & (1 << i))
                 {
-                    if (_keepersGUID[i]) // prevent double spawn
-                        continue;
                     switch (i)
                     {
                         case KEEPER_FREYA:
-                            me->SummonCreature(NPC_FREYA_KEEPER, KeepersPos[KEEPER_FREYA]);
+                            if (!summons.HasEntry(NPC_FREYA_KEEPER))
+                                me->SummonCreature(NPC_FREYA_KEEPER, KeepersPos[KEEPER_FREYA]);
                             break;
                         case KEEPER_HODIR:
-                            me->SummonCreature(NPC_HODIR_KEEPER, KeepersPos[KEEPER_HODIR]);
+                            if (!summons.HasEntry(NPC_HODIR_KEEPER))
+                                me->SummonCreature(NPC_HODIR_KEEPER, KeepersPos[KEEPER_HODIR]);
                             break;
                         case KEEPER_MIMIRON:
-                            me->SummonCreature(NPC_MIMIRON_KEEPER, KeepersPos[KEEPER_MIMIRON]);
+                            if (!summons.HasEntry(NPC_MIMIRON_KEEPER))
+                                me->SummonCreature(NPC_MIMIRON_KEEPER, KeepersPos[KEEPER_MIMIRON]);
                             break;
                         case KEEPER_THORIM:
-                            me->SummonCreature(NPC_THORIM_KEEPER, KeepersPos[KEEPER_THORIM]);
+                            if (!summons.HasEntry(NPC_THORIM_KEEPER))
+                                me->SummonCreature(NPC_THORIM_KEEPER, KeepersPos[KEEPER_THORIM]);
                             break;
                     }
                 }
@@ -625,7 +620,7 @@ public:
             {
                 uint8 _count = 0;
                 for (uint8 i = 0; i < 4; ++i)
-                    if (_keepersGUID[i])
+                    if (m_pInstance->GetData(TYPE_WATCHERS) & (1 << i))
                         ++_count;
                 return _count;
             }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -1725,14 +1725,14 @@ class boss_yoggsaron_keeper : public CreatureScript
 public:
     boss_yoggsaron_keeper() : CreatureScript("boss_yoggsaron_keeper") { }
 
-    CreatureAI* GetAI(Creature* pCreature) const override
+    CreatureAI* GetAI(Creature* creature) const override
     {
-        return GetUlduarAI<boss_yoggsaron_keeperAI>(pCreature);
+        return GetUlduarAI<boss_yoggsaron_keeperAI>(creature);
     }
 
     struct boss_yoggsaron_keeperAI : public NullCreatureAI
     {
-        boss_yoggsaron_keeperAI(Creature* pCreature) : NullCreatureAI(pCreature), _summons(pCreature) { }
+        boss_yoggsaron_keeperAI(Creature* creature) : NullCreatureAI(creature), _summons(creature) { }
 
         void DoAction(int32 param) override
         {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -402,9 +402,9 @@ public:
         void AttackStart(Unit*) override { }
         void MoveInLineOfSight(Unit*) override { }
 
-        void JustSummoned(Creature* cr) override
+        void JustSummoned(Creature* summon) override
         {
-            summons.Summon(cr);
+            summons.Summon(summon);
         }
 
         void SpawnClouds()

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -273,6 +273,14 @@ struct LocationsXY
     float x, y, z;
 };
 
+Position const GossipKeepersPos[4] =
+{
+    {1945.6823f, 33.342014f, 411.44083f, 5.270895f}, // Freya
+    {1945.7609f, -81.52171f,  411.4407f, 1.029744f}, // Hodir
+    {2028.7656f,  17.42014f, 411.44458f, 3.857178f}, // Mimiron
+    {2028.8219f, -65.73573f, 411.44257f, 2.460914f}  // Thorim
+};
+
 const Position KeepersPos[4] =
 {
     {1939.32f,   42.165f, 338.415f, 5.17955f}, // Freya
@@ -280,6 +288,10 @@ const Position KeepersPos[4] =
     {2036.81f,  25.6646f, 338.415f, 3.74227f}, // Mimiron
     {2036.59f, -73.8499f, 338.415f, 2.34819f}  // Thorim
 };
+
+const uint32 TABLE_KEEPER_ENTRY[4] = {NPC_FREYA_KEEPER, NPC_HODIR_KEEPER, NPC_MIMIRON_KEEPER, NPC_THORIM_KEEPER};
+const uint32 TABLE_GOSSIP_ENTRY[4] = {NPC_FREYA_GOSSIP, NPC_HODIR_GOSSIP, NPC_MIMIRON_GOSSIP, NPC_THORIM_GOSSIP};
+const uint32 TABLE_KEEPER_TYPE[4]  = {TYPE_FREYA,             TYPE_HODIR,       TYPE_MIMIRON,       TYPE_THORIM};
 
 static LocationsXY yoggPortalLoc[] =
 {
@@ -460,7 +472,7 @@ public:
 
             _initFight = 1;
 
-            SpawnKeepers();
+            UpdateKeeperSpawns();
             _summonedGuardiansCount = 0;
             _p2TalkTimer = 0;
             _secondPhase = false;
@@ -492,6 +504,7 @@ public:
             me->SetInCombatWithZone();
             AttackStart(target);
 
+            DespawnGossipKeepers();
             // Engage Keepers
             summons.DoZoneInCombat();
 
@@ -506,31 +519,27 @@ public:
             me->setActive(true);
         }
 
-        void SpawnKeepers()
+        void DespawnGossipKeepers()
         {
-            for (uint8 i = 0; i < 4; ++i)
+            for (uint8 i = KEEPER_FREYA; i <= KEEPER_THORIM; i++)
+                summons.DespawnEntry(TABLE_GOSSIP_ENTRY[i]);
+        }
+
+        void UpdateKeeperSpawns()
+        {
+            for (uint8 i = KEEPER_FREYA; i <= KEEPER_THORIM; i++)
+            {
                 if (m_pInstance->GetData(TYPE_WATCHERS) & (1 << i))
                 {
-                    switch (i)
-                    {
-                        case KEEPER_FREYA:
-                            if (!summons.HasEntry(NPC_FREYA_KEEPER))
-                                me->SummonCreature(NPC_FREYA_KEEPER, KeepersPos[KEEPER_FREYA]);
-                            break;
-                        case KEEPER_HODIR:
-                            if (!summons.HasEntry(NPC_HODIR_KEEPER))
-                                me->SummonCreature(NPC_HODIR_KEEPER, KeepersPos[KEEPER_HODIR]);
-                            break;
-                        case KEEPER_MIMIRON:
-                            if (!summons.HasEntry(NPC_MIMIRON_KEEPER))
-                                me->SummonCreature(NPC_MIMIRON_KEEPER, KeepersPos[KEEPER_MIMIRON]);
-                            break;
-                        case KEEPER_THORIM:
-                            if (!summons.HasEntry(NPC_THORIM_KEEPER))
-                                me->SummonCreature(NPC_THORIM_KEEPER, KeepersPos[KEEPER_THORIM]);
-                            break;
-                    }
+                    if (!summons.HasEntry(TABLE_KEEPER_ENTRY[i]))
+                        me->SummonCreature(TABLE_KEEPER_ENTRY[i], KeepersPos[i]);
                 }
+                else if (m_pInstance->GetData(TABLE_KEEPER_TYPE[i]) == DONE)
+                {
+                    if (!summons.HasEntry(TABLE_GOSSIP_ENTRY[i]))
+                        me->SummonCreature(TABLE_GOSSIP_ENTRY[i], GossipKeepersPos[i]);
+                }
+            }
         }
 
         void InformCloud()
@@ -634,7 +643,7 @@ public:
         {
             if (param == ACTION_SARA_UPDATE_SUMMON_KEEPERS)
             {
-                SpawnKeepers();
+                UpdateKeeperSpawns();
             }
             else if (param == ACTION_BRAIN_DAMAGED)
             {
@@ -660,6 +669,10 @@ public:
             {
                 summons.DespawnEntry(NPC_VOICE_OF_YOGG_SARON);
                 summons.DespawnEntry(NPC_BRAIN_OF_YOGG_SARON);
+                summons.DespawnEntry(NPC_MIMIRON_GOSSIP);
+                summons.DespawnEntry(NPC_HODIR_GOSSIP);
+                summons.DespawnEntry(NPC_FREYA_GOSSIP);
+                summons.DespawnEntry(NPC_THORIM_GOSSIP);
                 summons.DespawnEntry(NPC_MIMIRON_KEEPER);
                 summons.DespawnEntry(NPC_HODIR_KEEPER);
                 summons.DespawnEntry(NPC_FREYA_KEEPER);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -1719,10 +1719,7 @@ public:
 
     struct boss_yoggsaron_keeperAI : public NullCreatureAI
     {
-        boss_yoggsaron_keeperAI(Creature* pCreature) : NullCreatureAI(pCreature)
-        {
-            me->ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_MOD_SCALE, true);
-        }
+        boss_yoggsaron_keeperAI(Creature* pCreature) : NullCreatureAI(pCreature) { }
 
         void DoAction(int32 param) override
         {
@@ -2766,8 +2763,7 @@ class spell_keeper_freya_summon_sanity_well : public SpellScript
             if (InstanceScript* instance = caster->GetInstanceScript())
                 if (Creature* sara = ObjectAccessor::GetCreature(*caster, caster->GetInstanceScript()->GetGuidData(NPC_SARA)))
                     for (int i = 0; i < 5; i++)
-                        if (Creature* summon = sara->SummonCreature(NPC_SANITY_WELL, SanityWellsPos[i]))
-                            summon->ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_MOD_SCALE, true);
+                        sara->SummonCreature(NPC_SANITY_WELL, SanityWellsPos[i]);
     }
 
     void Register() override
@@ -2994,27 +2990,6 @@ public:
     }
 };
 
-// 62650 - Fortitude of Frost
-// 62670 - Resilience of Nature
-// 62671 - Speed of Invention
-// 62702 - Fury of the Storm
-class spell_yogg_saron_keeper_aura : public AuraScript
-{
-    PrepareAuraScript(spell_yogg_saron_keeper_aura);
-
-        bool CanApply(Unit* target)
-        {
-            if (target->GetTypeId() != TYPEID_PLAYER && target != GetCaster())
-                return false;
-            return true;
-        }
-
-    void Register() override
-    {
-        DoCheckAreaTarget += AuraCheckAreaTargetFn(spell_yogg_saron_keeper_aura::CanApply);
-    }
-};
-
 class achievement_yogg_saron_drive_me_crazy : public AchievementCriteriaScript
 {
 public:
@@ -3117,7 +3092,6 @@ void AddSC_boss_yoggsaron()
     new spell_yogg_saron_in_the_maws_of_the_old_god();
     new spell_yogg_saron_target_selectors();
     new spell_yogg_saron_grim_reprisal();
-    RegisterSpellScript(spell_yogg_saron_keeper_aura);
 
     // ACHIEVEMENTS
     new achievement_yogg_saron_drive_me_crazy();

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -667,6 +667,11 @@ public:
             }
             else if (param == ACTION_YOGG_SARON_DEATH)
             {
+                // Despawn everything but Yogg-Saron's corpse
+                summons.DoAction(ACTION_DESPAWN_ADDS);
+                summons.DespawnEntry(NPC_CRUSHER_TENTACLE);
+                summons.DespawnEntry(NPC_CONSTRICTOR_TENTACLE);
+                summons.DespawnEntry(NPC_CORRUPTOR_TENTACLE);
                 summons.DespawnEntry(NPC_VOICE_OF_YOGG_SARON);
                 summons.DespawnEntry(NPC_BRAIN_OF_YOGG_SARON);
                 summons.DespawnEntry(NPC_MIMIRON_GOSSIP);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -716,8 +716,11 @@ public:
                     break;
                 case TYPE_WATCHERS:
                     m_auiEncounter[type] |= 1 << data;
+                    if (Creature* sara = instance->GetCreature(m_saraGUID))
+                    {
+                        sara->AI()->DoAction(ACTION_SARA_UPDATE_SUMMON_KEEPERS);
+                    }
                     break;
-
                 case DATA_MAGE_BARRIER:
                     m_mageBarrier = data;
                     break;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -667,8 +667,6 @@ public:
                 case TYPE_THORIM:
                 case TYPE_FREYA:
                     m_auiEncounter[type] = data;
-                    if (Creature* sara = instance->GetCreature(m_saraGUID))
-                        sara->AI()->DoAction(ACTION_SARA_UPDATE_SUMMON_KEEPERS);
                     if (GetData(TYPE_MIMIRON) == DONE && GetData(TYPE_FREYA) == DONE && GetData(TYPE_HODIR) == DONE && GetData(TYPE_THORIM) == DONE)
                     {
                         if (GameObject* go = instance->GetGameObject(m_keepersgateGUID))
@@ -689,6 +687,8 @@ public:
                     break;
                 case TYPE_WATCHERS:
                     m_auiEncounter[type] |= 1 << data;
+                    [[fallthrough]];
+                case EVENT_KEEPER_TELEPORTED:
                     if (Creature* sara = instance->GetCreature(m_saraGUID))
                         sara->AI()->DoAction(ACTION_SARA_UPDATE_SUMMON_KEEPERS);
                     break;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -377,7 +377,6 @@ public:
                     break;
                 case NPC_SARA:
                     m_saraGUID = creature->GetGUID();
-                    creature->AI()->DoAction(ACTION_SARA_UPDATE_SUMMON_KEEPERS);
                     break;
                 case NPC_BRAIN_OF_YOGG_SARON:
                     m_yoggsaronBrainGUID = creature->GetGUID();

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -370,22 +370,6 @@ public:
                 case NPC_MIMIRON_ACU:
                     m_MimironACUguid = creature->GetGUID();
                     break;
-                case NPC_FREYA_GOSSIP:
-                    m_keepersGossipGUID[TYPE_FREYA - TYPE_FREYA] = creature->GetGUID();
-                    ShowKeeperGossip(TYPE_FREYA, creature);
-                    break;
-                case NPC_HODIR_GOSSIP:
-                    m_keepersGossipGUID[TYPE_HODIR - TYPE_FREYA] = creature->GetGUID();
-                    ShowKeeperGossip(TYPE_HODIR, creature);
-                    break;
-                case NPC_THORIM_GOSSIP:
-                    m_keepersGossipGUID[TYPE_THORIM - TYPE_FREYA] = creature->GetGUID();
-                    ShowKeeperGossip(TYPE_THORIM, creature);
-                    break;
-                case NPC_MIMIRON_GOSSIP:
-                    m_keepersGossipGUID[TYPE_MIMIRON - TYPE_FREYA] = creature->GetGUID();
-                    ShowKeeperGossip(TYPE_MIMIRON, creature);
-                    break;
                 case NPC_ELDER_IRONBRANCH:
                 case NPC_ELDER_STONEBARK:
                 case NPC_ELDER_BRIGHTLEAF:
@@ -393,6 +377,7 @@ public:
                     break;
                 case NPC_SARA:
                     m_saraGUID = creature->GetGUID();
+                    creature->AI()->DoAction(ACTION_SARA_UPDATE_SUMMON_KEEPERS);
                     break;
                 case NPC_BRAIN_OF_YOGG_SARON:
                     m_yoggsaronBrainGUID = creature->GetGUID();
@@ -431,19 +416,6 @@ public:
         {
             if (GetData(encounter) == DONE)
                 go->SetGoState(state);
-        }
-
-        void ShowKeeperGossip(uint8 type, Creature* cr, ObjectGuid guid = ObjectGuid::Empty)
-        {
-            if (!cr)
-            {
-                cr = instance->GetCreature(guid);
-                if (!cr)
-                    return;
-            }
-
-            bool on = (GetData(type) == DONE && !(GetData(TYPE_WATCHERS) & (1 << (type - TYPE_FREYA))));
-            cr->SetVisible(on);
         }
 
         void OnGameObjectCreate(GameObject* gameObject) override
@@ -695,7 +667,8 @@ public:
                 case TYPE_THORIM:
                 case TYPE_FREYA:
                     m_auiEncounter[type] = data;
-                    ShowKeeperGossip(type, nullptr, m_keepersGossipGUID[type - TYPE_FREYA]);
+                    if (Creature* sara = instance->GetCreature(m_saraGUID))
+                        sara->AI()->DoAction(ACTION_SARA_UPDATE_SUMMON_KEEPERS);
                     if (GetData(TYPE_MIMIRON) == DONE && GetData(TYPE_FREYA) == DONE && GetData(TYPE_HODIR) == DONE && GetData(TYPE_THORIM) == DONE)
                     {
                         if (GameObject* go = instance->GetGameObject(m_keepersgateGUID))
@@ -717,9 +690,7 @@ public:
                 case TYPE_WATCHERS:
                     m_auiEncounter[type] |= 1 << data;
                     if (Creature* sara = instance->GetCreature(m_saraGUID))
-                    {
                         sara->AI()->DoAction(ACTION_SARA_UPDATE_SUMMON_KEEPERS);
-                    }
                     break;
                 case DATA_MAGE_BARRIER:
                     m_mageBarrier = data;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
@@ -76,8 +76,8 @@ enum UldGameObjects
 
 enum UldSpells
 {
-    SPELL_KEEPER_TELEPORT       = 62940,
     SPELL_SIMPLE_TELEPORT       = 12980,
+    SPELL_KEEPER_TELEPORT       = 62940,
     SPELL_SNOW_MOUND_PARTICLES  = 64615
 };
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
@@ -21,6 +21,7 @@
 #include "GameObjectScript.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
+#include "PassiveAI.h"
 #include "ScriptedGossip.h"
 #include "SpellAuraEffects.h"
 #include "SpellScript.h"

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
@@ -56,6 +56,11 @@ enum Texts
     SAY_KEEPER_CHOSEN_ANNOUNCE  = 1,
 };
 
+enum UldActions
+{
+    ACTION_KEEPER_OUTRO         = 0,
+};
+
 enum UldNPCs
 {
     NPC_WINTER_JORMUNGAR        = 34137,
@@ -72,6 +77,7 @@ enum UldGameObjects
 enum UldSpells
 {
     SPELL_KEEPER_TELEPORT       = 62940,
+    SPELL_SIMPLE_TELEPORT       = 12980,
     SPELL_SNOW_MOUND_PARTICLES  = 64615
 };
 
@@ -79,6 +85,61 @@ class npc_ulduar_keeper : public CreatureScript
 {
 public:
     npc_ulduar_keeper() : CreatureScript("npc_ulduar_keeper_gossip") { }
+
+    struct npc_ulduar_keeperAI : public NullCreatureAI
+    {
+        npc_ulduar_keeperAI(Creature* creature) : NullCreatureAI(creature) { }
+
+        void Reset() override
+        {
+            scheduler.Schedule(500ms, [this](TaskContext /*context*/)
+            {
+                DoCastSelf(SPELL_SIMPLE_TELEPORT);
+            });
+        }
+
+        void DoAction(int32 param) override
+        {
+            if (param == ACTION_KEEPER_OUTRO)
+            {
+                switch (me->GetEntry())
+                {
+                    case NPC_FREYA_GOSSIP:
+                        _keeper = KEEPER_FREYA;
+                        break;
+                    case NPC_HODIR_GOSSIP:
+                        _keeper = KEEPER_HODIR;
+                        break;
+                    case NPC_MIMIRON_GOSSIP:
+                        _keeper = KEEPER_MIMIRON;
+                        break;
+                    case NPC_THORIM_GOSSIP:
+                        _keeper = KEEPER_THORIM;
+                        break;
+                    default:
+                        return;
+                }
+                scheduler.Schedule(1s, [this](TaskContext /*context*/)
+                {
+                    DoCastSelf(SPELL_KEEPER_TELEPORT);
+                    me->DespawnOrUnsummon(2s, 0s);
+                    me->GetInstanceScript()->SetData(TYPE_WATCHERS, _keeper);
+                });
+            }
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            scheduler.Update(diff);
+        }
+    private:
+        uint8 _keeper;
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return GetUlduarAI<npc_ulduar_keeperAI>(creature);
+    }
 
     bool OnGossipHello(Player* player, Creature* creature) override
     {
@@ -112,7 +173,6 @@ public:
     bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action) override
     {
         ClearGossipMenuFor(player);
-        uint8 _keeper = 0;
         switch (action)
         {
             case GOSSIP_ACTION_INFO_DEF+1:
@@ -121,34 +181,12 @@ public:
                 break;
             case GOSSIP_ACTION_INFO_DEF+2:
             {
-                switch (creature->GetEntry())
-                {
-                    case NPC_FREYA_GOSSIP:
-                        _keeper = KEEPER_FREYA;
-                        break;
-                    case NPC_HODIR_GOSSIP:
-                        _keeper = KEEPER_HODIR;
-                        break;
-                    case NPC_MIMIRON_GOSSIP:
-                        _keeper = KEEPER_MIMIRON;
-                        break;
-                    case NPC_THORIM_GOSSIP:
-                        _keeper = KEEPER_THORIM;
-                        break;
-                }
-
                 creature->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
                 CloseGossipMenuFor(player);
 
                 creature->AI()->Talk(SAY_KEEPER_CHOSEN_TO_PLAYER, player);
                 creature->AI()->Talk(SAY_KEEPER_CHOSEN_ANNOUNCE);
-                creature->CastSpell(creature, SPELL_KEEPER_TELEPORT);
-
-                if (creature->GetInstanceScript())
-                {
-                    creature->GetInstanceScript()->SetData(TYPE_WATCHERS, _keeper);
-                    creature->DespawnOrUnsummon(2s, 0s);
-                }
+                creature->AI()->DoAction(ACTION_KEEPER_OUTRO);
             }
         }
         return true;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
@@ -92,7 +92,7 @@ public:
 
         void Reset() override
         {
-            scheduler.Schedule(500ms, [this](TaskContext /*context*/)
+            scheduler.Schedule(250ms, [this](TaskContext /*context*/)
             {
                 DoCastSelf(SPELL_SIMPLE_TELEPORT);
             });
@@ -122,9 +122,16 @@ public:
                 scheduler.Schedule(1s, [this](TaskContext /*context*/)
                 {
                     DoCastSelf(SPELL_KEEPER_TELEPORT);
-                    me->DespawnOrUnsummon(2s, 0s);
-                    me->GetInstanceScript()->SetData(TYPE_WATCHERS, _keeper);
                 });
+            }
+        }
+
+        void SpellHit(Unit* /*caster*/, SpellInfo const* spellInfo) override
+        {
+            if (spellInfo->Id == SPELL_TELEPORT)
+            {
+                me->DespawnOrUnsummon();
+                me->GetInstanceScript()->SetData(TYPE_WATCHERS, _keeper);
             }
         }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
@@ -51,7 +51,9 @@ enum Texts
     GOSSIP_MENU_CONFIRM         = 10333,
     NPC_TEXT_CONFIRM            = 14325,
 
-    SAY_KEEPER_SELECTED         = 1,
+    // Chosen
+    SAY_KEEPER_CHOSEN_TO_PLAYER = 0,
+    SAY_KEEPER_CHOSEN_ANNOUNCE  = 1,
 };
 
 enum UldNPCs
@@ -69,6 +71,7 @@ enum UldGameObjects
 
 enum UldSpells
 {
+    SPELL_KEEPER_TELEPORT       = 62940,
     SPELL_SNOW_MOUND_PARTICLES  = 64615
 };
 
@@ -121,30 +124,30 @@ public:
                 switch (creature->GetEntry())
                 {
                     case NPC_FREYA_GOSSIP:
-                        creature->AI()->Talk(SAY_KEEPER_SELECTED);
                         _keeper = KEEPER_FREYA;
                         break;
                     case NPC_HODIR_GOSSIP:
-                        creature->AI()->Talk(SAY_KEEPER_SELECTED);
                         _keeper = KEEPER_HODIR;
                         break;
                     case NPC_MIMIRON_GOSSIP:
-                        creature->AI()->Talk(SAY_KEEPER_SELECTED);
                         _keeper = KEEPER_MIMIRON;
                         break;
                     case NPC_THORIM_GOSSIP:
-                        creature->AI()->Talk(SAY_KEEPER_SELECTED);
                         _keeper = KEEPER_THORIM;
                         break;
                 }
 
-                creature->ReplaceAllNpcFlags(UNIT_NPC_FLAG_NONE);
+                creature->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
                 CloseGossipMenuFor(player);
+
+                creature->AI()->Talk(SAY_KEEPER_CHOSEN_TO_PLAYER, player);
+                creature->AI()->Talk(SAY_KEEPER_CHOSEN_ANNOUNCE);
+                creature->CastSpell(creature, SPELL_KEEPER_TELEPORT);
 
                 if (creature->GetInstanceScript())
                 {
                     creature->GetInstanceScript()->SetData(TYPE_WATCHERS, _keeper);
-                    creature->DespawnOrUnsummon(6000);
+                    creature->DespawnOrUnsummon(2s, 0s);
                 }
             }
         }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -284,7 +284,10 @@ enum UlduarMisc
     TIMER_ALGALON_TO_SUMMON                 = 200,
     TIMER_ALGALON_SUMMONED                  = 100,
 
-    // Yogg'Saron
+    // Algalon the Observer, Freya, Hodir, Mimiron, Thorim, Gossip Keepers
+    SPELL_TELEPORT                          = 62940,
+
+    // Yogg-Saron
     ACTION_SARA_UPDATE_SUMMON_KEEPERS       = 4,
     KEEPER_FREYA                            = 0,
     KEEPER_HODIR                            = 1,

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -287,6 +287,9 @@ enum UlduarMisc
     // Algalon the Observer, Freya, Hodir, Mimiron, Thorim, Gossip Keepers
     SPELL_TELEPORT                          = 62940,
 
+    // Freya, Hodir, Mimiron, Thorim
+    EVENT_KEEPER_TELEPORTED                 = 62941,
+
     // Yogg-Saron
     ACTION_SARA_UPDATE_SUMMON_KEEPERS       = 4,
     KEEPER_FREYA                            = 0,

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -284,6 +284,8 @@ enum UlduarMisc
     TIMER_ALGALON_TO_SUMMON                 = 200,
     TIMER_ALGALON_SUMMONED                  = 100,
 
+    // Yogg'Saron
+    ACTION_SARA_UPDATE_SUMMON_KEEPERS       = 4,
     KEEPER_FREYA                            = 0,
     KEEPER_HODIR                            = 1,
     KEEPER_MIMIRON                          = 2,

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -628,6 +628,7 @@ class spell_gen_black_magic_enchant : public AuraScript
 };
 
 // 53642 - The Might of Mograine
+// 64174 - Protective Gaze
 class spell_gen_area_aura_select_players : public AuraScript
 {
     PrepareAuraScript(spell_gen_area_aura_select_players);
@@ -639,6 +640,24 @@ class spell_gen_area_aura_select_players : public AuraScript
     void Register() override
     {
         DoCheckAreaTarget += AuraCheckAreaTargetFn(spell_gen_area_aura_select_players::CheckAreaTarget);
+    }
+};
+
+// 62650 - Fortitude of Frost
+// 62670 - Resilience of Nature
+// 62671 - Speed of Invention
+// 62702 - Fury of the Storm
+class spell_gen_area_aura_select_players_and_caster : public AuraScript
+{
+    PrepareAuraScript(spell_gen_area_aura_select_players_and_caster);
+
+    bool CheckAreaTarget(Unit* target)
+    {
+        return target->GetTypeId() == TYPEID_PLAYER || target == GetCaster();
+    }
+    void Register() override
+    {
+        DoCheckAreaTarget += AuraCheckAreaTargetFn(spell_gen_area_aura_select_players_and_caster::CheckAreaTarget);
     }
 };
 
@@ -5193,6 +5212,7 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_disabled_above_63);
     RegisterSpellScript(spell_gen_black_magic_enchant);
     RegisterSpellScript(spell_gen_area_aura_select_players);
+    RegisterSpellScript(spell_gen_area_aura_select_players_and_caster);
     RegisterSpellScriptWithArgs(spell_gen_select_target_count, "spell_gen_select_target_count_15_1", TARGET_UNIT_SRC_AREA_ENEMY, 1);
     RegisterSpellScriptWithArgs(spell_gen_select_target_count, "spell_gen_select_target_count_15_2", TARGET_UNIT_SRC_AREA_ENEMY, 2);
     RegisterSpellScriptWithArgs(spell_gen_select_target_count, "spell_gen_select_target_count_15_5", TARGET_UNIT_SRC_AREA_ENEMY, 5);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Adds better interactions between Boss Keepers, Gossip Keepers, Keepers and Sara

Changes to Keeper AI, Keeper Auras/Buffs, Sanity Well summons, Boss Keeper outro,...

Core generic spellscript to handle Keeper Aura conditions

### Interactions between Gossip Keepers, Keepers
before fight: Gossip appear after "tp" trigger from Boss
on fight: Gossip Keepers despawn
on wipe: Gossip respawn
on fight end: Gossip do not respawn

before fight: talked to Keepers are spawned, they do not give buffs
on fight: Keepers give buffs only to players and themselves. should grow in size
on wipe: Keepers despawn, buffs go away
on reset: Keepers spawn, no buffs
on fight end: Keepers despawn, no buffs

### Detailed list:

- [ ] Keeper Boss despawn by casting Teleport spell
- [ ] Thorim, Hodir, Freya despawn timer lengthened based on reference video
- [ ] make Keeper aura buffs only affect players and Keeper. 
- [ ] sniffed Gossip Keeper positions from DF. These are also present in TC 335
- [ ] sniffed Gossip Keeper on appear spell"Simple Teleport" Wrath Classic
- [ ] remove encounter auras from Keepers, application handled by script
- [ ] add glow aura to Gossip Keeper
- [ ] Freya's summon Sanity Well handled by spell_effect_script
- [ ] Keeper auras should only target players and themselves
- [ ] Keepers increase their size by their own buff, removed scaling immunity
- [ ] Remove Gossip spawns, handled with script
- [ ] Update flags on Keepers, should be selectable, factions handle immune to pc/npc, remove civilian status
- [ ] Keepers should cast teleport spell, despawn and then appear as a Gossip Keeper
- [ ] Gossip Keepers, Keepers are tied to Yogg-Saron fight. Sara summons/despawns them
- [ ] Keepers use scheduler
- [ ] Gossip Keepers, upon Gossip complete, speak to player, speak to all, then 1 second they cast teleport, after cast (1s) they despawn and appear below

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/18937

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Ensidia vs yogg part 1 + 2
https://www.youtube.com/watch?v=iatGk4TOlEA
https://www.youtube.com/watch?v=ZyuuBwpOfbQ

 Retail: Keepers Hodir, Thorim, Freya, Mimiron + Mimi Gossip Uld10 https://youtu.be/8zqbQxv8Mow

Retail: Sara Yogg Saron Uld10 https://youtu.be/ZJPCXVfR5zg 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

2 WoW Clients to see teleport source location and destination

Recommended to make macros of the following commands for easy teleporting

Reset the instance
```
.tele ulduar
.instance unbind all
```

Setup the instance: activate, teleporter and disable Sara's anti-cheat
``` 
Flame Leviathan
.go c id 33113
XT
.go c id 33293
Vezax
.go c id 33271
```

Go creature
```
Gossip Thorim
.go c id 33242
 Gossip Freya
.go c id 33241
 Gossip Hodir
.go c id 33213 
Gossip Mimiron
.go c id 33244
Freya boss
.go c id 32906
Thorim boss
.go c id 32865
Mimiron boss
.go c id 33350
```

Death Touch to kill / trigger RP, except Mimiron
```
.cast 5
```

1. Setup the instance

2. Teleport around the instance
	a. Hodir, Thorim, Freya, Mimiron room: boss will teleport/despawn
	b. Ring of Observation: Gossip Keepers
	c. Sara/Yogg-Saron Room: yogg Keepers

Interactions:
1. Boss Keeper Kill:
	a. End of encounter RP/Text starts (unchanged)
	b. Boss casts teleport and despawns
	c. Gossip Keeper spawns in Ring of Observation. Gossip Keepers appear with a teleport effect
2. Gossip dialog complete:
	a. Gossip Keeper speaks 2 lines: 1 to player. 1 to everyone
	b. After 1 second, Gossip casts teleport
	c. Upon completion, Gossip dissapears and appears in Sara's room
3. Engage Sara / Yogg-Saron
	a. Gossip Keepers despawn
	b. Keepers cast abilities. They grow in size, are selectable, have their own buff
	c. Only players and their respective Keeper have buff. Pets do not have buffs. Sanity Well's do not grow in size
	d. Freya summons Sanity Well's
	e. Mimiron debuff's small tentacles in p2
	f. Thorim casts Lightning Storm upon p3 (last phase)
4. Wipe on Sara / Yogg-Saron 
	a. Gossip Keepers appear
	b. Keepers appear
	c. No buffs
	d. No Sanity Well's are active
5.  Finish / Win encounter (Requires 1 char inside portal and 1 outside to avoid evade/despawn)
	a. `.cast 22663` Nefarian's barrier, immune self to some effect
	b. Gossip Keepers do not appear
	c. Keepers despawn
	d. No buffs
	e. No Sanity Well's are active

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] (failed) use conditions to handle aura applying only to caster and players, instead of new generic spellscript
- [ ] Sara shouldn't instantly respawn
- [ ] Rework freya/hodir scheduler+eventmap to single scheduler
22663
- [ ] Yogg's fight requires 2 characters, 1 in and 1 outside portals. Fight should not reset if no players are outside

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
