### PR TITLE
fix(core/character-creation): get main part of cyrillic name

### DIFF
--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -383,7 +383,7 @@ void wstrToLower(std::wstring& str) { std::transform(std::begin(str), std::end(s
 void strToUpper(std::string& str) { std::transform(std::begin(str), std::end(str), std::begin(str), charToUpper); }
 void strToLower(std::string& str) { std::transform(std::begin(str), std::end(str), std::begin(str), charToLower); }
 
-std::wstring GetMainPartOfName(std::wstring const& wname, uint32 declension)
+std::wstring GetMainPartOfName(std::wstring const& wname, uint32_t declension)
 {
     // supported only Cyrillic cases
     if (wname.empty() || !isCyrillicCharacter(wname[0]) || declension > 5)
@@ -392,22 +392,22 @@ std::wstring GetMainPartOfName(std::wstring const& wname, uint32 declension)
     }
 
     // Important: end length must be <= MAX_INTERNAL_PLAYER_NAME-MAX_PLAYER_NAME (3 currently)
-    static std::wstring const a_End    = { wchar_t(0x0430), wchar_t(0x0000) };
-    static std::wstring const o_End    = { wchar_t(0x043E), wchar_t(0x0000) };
-    static std::wstring const ya_End   = { wchar_t(0x044F), wchar_t(0x0000) };
-    static std::wstring const ie_End   = { wchar_t(0x0435), wchar_t(0x0000) };
-    static std::wstring const i_End    = { wchar_t(0x0438), wchar_t(0x0000) };
-    static std::wstring const yeru_End = { wchar_t(0x044B), wchar_t(0x0000) };
-    static std::wstring const u_End    = { wchar_t(0x0443), wchar_t(0x0000) };
-    static std::wstring const yu_End   = { wchar_t(0x044E), wchar_t(0x0000) };
-    static std::wstring const oj_End   = { wchar_t(0x043E), wchar_t(0x0439), wchar_t(0x0000) };
-    static std::wstring const ie_j_End = { wchar_t(0x0435), wchar_t(0x0439), wchar_t(0x0000) };
-    static std::wstring const io_j_End = { wchar_t(0x0451), wchar_t(0x0439), wchar_t(0x0000) };
-    static std::wstring const o_m_End  = { wchar_t(0x043E), wchar_t(0x043C), wchar_t(0x0000) };
-    static std::wstring const io_m_End = { wchar_t(0x0451), wchar_t(0x043C), wchar_t(0x0000) };
-    static std::wstring const ie_m_End = { wchar_t(0x0435), wchar_t(0x043C), wchar_t(0x0000) };
-    static std::wstring const soft_End = { wchar_t(0x044C), wchar_t(0x0000) };
-    static std::wstring const j_End    = { wchar_t(0x0439), wchar_t(0x0000) };
+    static std::wstring const a_End    = L"\u0430";
+    static std::wstring const o_End    = L"\u043E";
+    static std::wstring const ya_End   = L"\u044F";
+    static std::wstring const ie_End   = L"\u0435";
+    static std::wstring const i_End    = L"\u0438";
+    static std::wstring const yeru_End = L"\u044B";
+    static std::wstring const u_End    = L"\u0443";
+    static std::wstring const yu_End   = L"\u044E";
+    static std::wstring const oj_End   = L"\u043E\u0439";
+    static std::wstring const ie_j_End = L"\u0435\u0439";
+    static std::wstring const io_j_End = L"\u0451\u0439";
+    static std::wstring const o_m_End  = L"\u043E\u043C";
+    static std::wstring const io_m_End = L"\u0451\u043C";
+    static std::wstring const ie_m_End = L"\u0435\u043C";
+    static std::wstring const soft_End = L"\u044C";
+    static std::wstring const j_End    = L"\u0439";
 
     static std::array<std::array<std::wstring const*, 7>, 6> const dropEnds = {{
             { &a_End,  &o_End,    &ya_End,   &ie_End,  &soft_End, &j_End,    nullptr },
@@ -421,16 +421,21 @@ std::wstring GetMainPartOfName(std::wstring const& wname, uint32 declension)
 
     std::size_t const thisLen = wname.length();
     std::array<std::wstring const*, 7> const& endings = dropEnds[declension];
-    for (auto itr = endings.begin(), end = endings.end(); (itr != end) && *itr; ++itr)
+    for (const std::wstring* endingPtr : endings)
     {
-        std::wstring const& ending = **itr;
+        if (endingPtr == nullptr)
+        {
+            break;
+        }
+
+        std::wstring const& ending = *endingPtr;
         std::size_t const endLen = ending.length();
         if (endLen > thisLen)
         {
             continue;
         }
 
-        if (wname.substr(thisLen - endLen, thisLen) == ending)
+        if (wname.compare(thisLen - endLen, endLen, ending) == 0)
         {
             return wname.substr(0, thisLen - endLen);
         }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

Currently, in the Cyrillic version of the server and client, there is an issue with the declension of a name when creating a new character. You can watch the video to see what the problem is:

https://github.com/azerothcore/azerothcore-wotlk/assets/33424304/7117aee2-830c-4fff-9338-1588e8417aad

This PR solves the problem.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
I didn't find a similar issue.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
I applied them on my server and everything worked fine. The DB table `character_declinedname` was populated with correct declined names.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided below

1. Configure the server locale to be Russian.
2. Run ruRU client.
3. Create a character with a declinable name.
4. Apply declension after the character is being created.
5. There is no error dialog and you are joining the world with created character.

## Known Issues and TODO List:

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
