### PR TITLE
fix(Scripts/IcecrownCitadel): The Lich King should switch phased instantly after reaching specefic life

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -765,13 +765,6 @@ public:
             }
         }
 
-        uint32 CalculateHealthPercentageAfterHit(uint32 damage)
-        {
-            uint32 expectedHealthAfterDamage = me->GetHealth() > damage ? me->GetHealth() - damage : 0;
-            float healthPercentageAfterHit = (static_cast<float>(expectedHealthAfterDamage) / me->GetMaxHealth()) * 100.0f;
-            return static_cast<uint32>(healthPercentageAfterHit);
-        }
-
         void DamageTaken(Unit* attacker, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
             if (!attacker || (_bFrostmournePhase && attacker->GetExactDistSq(495.708f, -2523.76f, 1049.95f) > 40.0f * 40.0f)) // frostmourne room, prevent exploiting (tele hack to get back and damage him)
@@ -780,7 +773,7 @@ public:
                 return;
             }
 
-            if (_phase == PHASE_ONE && (CalculateHealthPercentageAfterHit(damage) < 70))
+            if (_phase == PHASE_ONE && me->HealthBelowPctDamaged(70, damage))
             {
                 _phase = PHASE_TRANSITION;
                 me->SetReactState(REACT_PASSIVE);
@@ -791,7 +784,7 @@ public:
                 return;
             }
 
-            if ((CalculateHealthPercentageAfterHit(damage) < 40) && me->HasAura(SPELL_REMORSELESS_WINTER_1))
+            if (me->HealthBelowPctDamaged(40, damage) && me->HasAura(SPELL_REMORSELESS_WINTER_1))
             {
                 me->RemoveAura(SPELL_REMORSELESS_WINTER_1);
                 events.CancelEventGroup(EVENT_GROUP_ABILITIES);
@@ -801,7 +794,7 @@ public:
                 return;
             }
 
-            if ((CalculateHealthPercentageAfterHit(damage) < 10) && me->HasAura(SPELL_REMORSELESS_WINTER_2))
+            if (me->HealthBelowPctDamaged(10,damage) && me->HasAura(SPELL_REMORSELESS_WINTER_2))
             {
                 me->RemoveAura(SPELL_REMORSELESS_WINTER_2);
                 me->CastSpell((Unit*)nullptr, SPELL_QUAKE, false);
@@ -810,7 +803,7 @@ public:
                 return;
             }
 
-            if (_phase == PHASE_TWO && (CalculateHealthPercentageAfterHit(damage) < 40))
+            if (_phase == PHASE_TWO && me->HealthBelowPctDamaged(40, damage))
             {
                 _phase = PHASE_TRANSITION;
                 me->SetReactState(REACT_PASSIVE);
@@ -821,7 +814,7 @@ public:
                 return;
             }
 
-            if (_phase == PHASE_THREE && (CalculateHealthPercentageAfterHit(damage) < 10))
+            if (_phase == PHASE_THREE && me->HealthBelowPctDamaged(10,damage))
             {
                 _phase = PHASE_OUTRO;
                 EntryCheckPredicate pred(NPC_STRANGULATE_VEHICLE);

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -798,8 +798,6 @@ public:
                 events.CancelEvent(EVENT_QUAKE);
                 me->CastSpell((Unit*)nullptr, SPELL_QUAKE, false);
                 _phase = PHASE_TWO;
-
-
                 return;
             }
 


### PR DESCRIPTION
The Phases of the Lich King should be instant switch after reaching :
-> under 70% of life 
-> under 40% of life
-> under 10% of life

Everthing he is doing except when players are down in the rooms should be canceld and next phase beginn.

Before it will not much effect the gameplay except u have a full raid off BiS chars, then u reach to the point where u normale
jump from p2 to p3  while p2 is running and then u are forced to play like rumorelesswinter longer as you should even the boss is under 10% already.

In cases where u come easily to these scenario like u use mod-autobalance u make stuk as the boss is already dead and and phase of outro didnt even beginn.



<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

On Retail just go with good char and Kill the LK as fast as pos, he will not force you into these scenario.
Lot of BFA solo videos shows that the LK cancels the remorelesswinter and jumps into nextphaes p2->p3 and p3->outro

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

I only checked it now by myself as iam now longer have a community server to test these changes with multiple people.

## How to Test the Changes:

1. Kill all bosses before LK
2. Do the LK fight with a lot of good people or use autobalance or stat increasing moduls
3. profit


