### PR TITLE
fix(DB/StranglethornVale): Spirit of Zandalar limit to 63 and below, apply to Booty Bay

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1717779996280157826.sql
+++ b/data/sql/updates/pending_db_world/rev_1717779996280157826.sql
@@ -1,0 +1,20 @@
+--
+DELETE FROM `creature_text` WHERE `CreatureID` = 15076 AND `ID` = 0;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(15076, 0, 0, 'The Blood God, the Soulflayer, has been defeated!  We are imperiled no longer!', 14, 0, 100, 5, 0, 0, 10612, 1, 'Zandalarian Emissary');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 15076;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 15076;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(15076, 0, 0, 1, 38, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Zandalarian Emissary - On Data Set 0 0 - Say Line 0'),
+(15076, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 67, 0, 50000, 50000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Zandalarian Emissary - On Data Set 0 0 - Create Timed Event'),
+(15076, 0, 2, 0, 59, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 24425, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Zandalarian Emissary - On Timed Event 0 Triggered - Cast \'Spirit of Zandalar\'');
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 13) AND (`SourceGroup` = 4) AND (`SourceEntry` = 24425);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 4, 24425, 0, 0, 27, 0, 63, 4, 0, 0, 0, 0, '', 'Spirit of Zandalar - Player must be level 63 or lower');
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 14875) AND (`source_type` = 0) AND (`id` IN (1, 4));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(14875, 0, 1, 4, 20, 0, 100, 512, 8183, 0, 0, 0, 0, 0, 53, 0, 14875, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Molthor - On Quest \'The Heart of Hakkar\' Finished - Start Waypoint'),
+(14875, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 45, 0, 0, 0, 0, 0, 0, 10, 436, 15076, 0, 0, 0, 0, 0, 0, 'Molthor - On Quest \'The Heart of Hakkar\' Finished - Set Data 0 0');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Limits Spirit of Zandalar to players level 63 and below

Adds Text and AI to Zandalarian Emissary in Booty Bay to cast Spirit of Zandalar after 50 seconds upon Heart of Hakkar turn in on Yojamba Island

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://wowpedia.fandom.com/wiki/Patch_2.1.0  
![image](https://github.com/azerothcore/azerothcore-wotlk/assets/46423958/6837c1d1-abee-4b83-895e-b7457d1cb5a2)

Booty Bay emissary yell 0:18 https://youtu.be/agOCLnzevDs?si=ouFqKBZ73nr9XzCi&t=15 


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Yojamba
```
.add 19802
.go c id 14875
```

Booty Bay
```
.go c 436
```

recommended to test with 2 characters or more

1 character to turn in on Yojamba
1 character in Booty Bay
1 or more characters that do not fit level range 64 or higher

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Unkown purpose 14994 Zandalarian Event Generator 
- [ ] Buff is not area wide, limited to 100yd range from Emissary/Molthor

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
