### PR TITLE
fix(DB/Kalimdor): limit Warchief's Blessing to level 63 and below and Horde only

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1717787014792496771.sql
+++ b/data/sql/updates/pending_db_world/rev_1717787014792496771.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 13) AND (`SourceGroup` = 4) AND (`SourceEntry` = 16609);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 4, 16609, 0, 0, 27, 0, 63, 4, 0, 0, 0, 0, '', 'Warchief\'s Blessing - Player must be level 63 or lower'),
+(13, 4, 16609, 0, 0, 6, 0, 67, 0, 0, 0, 0, 0, '', 'Warchief\'s Blessing - Player must be Horde');

--- a/data/sql/updates/pending_db_world/rev_1717787014792496771.sql
+++ b/data/sql/updates/pending_db_world/rev_1717787014792496771.sql
@@ -1,5 +1,4 @@
 --
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 13) AND (`SourceGroup` = 4) AND (`SourceEntry` = 16609);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(13, 4, 16609, 0, 0, 27, 0, 63, 4, 0, 0, 0, 0, '', 'Warchief\'s Blessing - Player must be level 63 or lower'),
 (13, 4, 16609, 0, 0, 6, 0, 67, 0, 0, 0, 0, 0, '', 'Warchief\'s Blessing - Player must be Horde');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://wowpedia.fandom.com/wiki/Patch_2.1.0  
![image](https://github.com/azerothcore/azerothcore-wotlk/assets/46423958/6837c1d1-abee-4b83-895e-b7457d1cb5a2)  list omits WCB

wowhead https://www.wowhead.com/tbc/guide/raid-consumables-flasks-elixirs-potions-wow-burning-crusade-classic
![image](https://github.com/azerothcore/azerothcore-wotlk/assets/46423958/0ac6fc7b-7491-4126-a6e9-9dbb9bc9c3e5)

can no longer apply to Alliance
https://wowpedia.fandom.com/wiki/Warchief%27s_Blessing

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Go to Thrall
```
.quest remove  4974
.quest add 4974
.quest  complete  4974
```

Crossroads
```
.tele crossroads
```

- must be 63 or lower
- Horde only

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
