### PR TITLE
fix(Core): Correct Quest XP Display when modified by SPELL_AURA_MOD_XP_QUEST_PCT

### DIFF
--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -25,6 +25,7 @@
 #include "ScriptMgr.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
+#include "SpellAuraEffects.h"
 
 GossipMenu::GossipMenu()
 {
@@ -462,6 +463,11 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* quest, ObjectGuid npcGU
         if (player && !sScriptMgr->ShouldBeRewardedWithMoneyInsteadOfExp(player))
         {
             questXp = uint32(quest->XPValue(playerLevel) * player->GetQuestRate());
+
+            // handle SPELL_AURA_MOD_XP_QUEST_PCT auras
+            Unit::AuraEffectList const& ModXPPctAuras = player->GetAuraEffectsByType(SPELL_AURA_MOD_XP_QUEST_PCT);
+            for (Unit::AuraEffectList::const_iterator i = ModXPPctAuras.begin(); i != ModXPPctAuras.end(); ++i)
+                AddPct(questXp, (*i)->GetAmount());
         }
         else
         {
@@ -715,6 +721,11 @@ void PlayerMenu::SendQuestGiverOfferReward(Quest const* quest, ObjectGuid npcGUI
     if (player && !sScriptMgr->ShouldBeRewardedWithMoneyInsteadOfExp(player))
     {
         questXp = uint32(quest->XPValue(playerLevel) * player->GetQuestRate());
+
+        // handle SPELL_AURA_MOD_XP_QUEST_PCT auras
+        Unit::AuraEffectList const& ModXPPctAuras = player->GetAuraEffectsByType(SPELL_AURA_MOD_XP_QUEST_PCT);
+        for (Unit::AuraEffectList::const_iterator i = ModXPPctAuras.begin(); i != ModXPPctAuras.end(); ++i)
+            AddPct(questXp, (*i)->GetAmount());
     }
     else
     {

--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -25,7 +25,6 @@
 #include "ScriptMgr.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
-#include "SpellAuraEffects.h"
 
 GossipMenu::GossipMenu()
 {
@@ -462,12 +461,7 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* quest, ObjectGuid npcGU
         uint32 questXp;
         if (player && !sScriptMgr->ShouldBeRewardedWithMoneyInsteadOfExp(player))
         {
-            questXp = uint32(quest->XPValue(playerLevel) * player->GetQuestRate());
-
-            // handle SPELL_AURA_MOD_XP_QUEST_PCT auras
-            Unit::AuraEffectList const& ModXPPctAuras = player->GetAuraEffectsByType(SPELL_AURA_MOD_XP_QUEST_PCT);
-            for (Unit::AuraEffectList::const_iterator i = ModXPPctAuras.begin(); i != ModXPPctAuras.end(); ++i)
-                AddPct(questXp, (*i)->GetAmount());
+            questXp = player->CalculateQuestRewardXP(quest);
         }
         else
         {
@@ -720,12 +714,7 @@ void PlayerMenu::SendQuestGiverOfferReward(Quest const* quest, ObjectGuid npcGUI
     uint32 questXp;
     if (player && !sScriptMgr->ShouldBeRewardedWithMoneyInsteadOfExp(player))
     {
-        questXp = uint32(quest->XPValue(playerLevel) * player->GetQuestRate());
-
-        // handle SPELL_AURA_MOD_XP_QUEST_PCT auras
-        Unit::AuraEffectList const& ModXPPctAuras = player->GetAuraEffectsByType(SPELL_AURA_MOD_XP_QUEST_PCT);
-        for (Unit::AuraEffectList::const_iterator i = ModXPPctAuras.begin(); i != ModXPPctAuras.end(); ++i)
-            AddPct(questXp, (*i)->GetAmount());
+        questXp = player->CalculateQuestRewardXP(quest);
     }
     else
     {

--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -451,7 +451,6 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* quest, ObjectGuid npcGU
 
         uint32 moneyRew = 0;
         Player* player = _session->GetPlayer();
-        uint8 playerLevel = player ? player->GetLevel() : 0;
         if (player && (player->getLevel() >= sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL) || sScriptMgr->ShouldBeRewardedWithMoneyInsteadOfExp(player)))
         {
             moneyRew = quest->GetRewMoneyMaxLevel();
@@ -704,7 +703,6 @@ void PlayerMenu::SendQuestGiverOfferReward(Quest const* quest, ObjectGuid npcGUI
 
     uint32 moneyRew = 0;
     Player* player = _session->GetPlayer();
-    uint8 playerLevel = player ? player->GetLevel() : 0;
     if (player && (player->GetLevel() >= sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL) || sScriptMgr->ShouldBeRewardedWithMoneyInsteadOfExp(player)))
     {
         moneyRew = quest->GetRewMoneyMaxLevel();

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1451,6 +1451,7 @@ public:
     bool SatisfyQuestSeasonal(Quest const* qInfo, bool msg) const;
     bool GiveQuestSourceItem(Quest const* quest);
     bool TakeQuestSourceItem(uint32 questId, bool msg);
+    uint32 CalculateQuestRewardXP(Quest const* quest);
     [[nodiscard]] bool GetQuestRewardStatus(uint32 quest_id) const;
     [[nodiscard]] QuestStatus GetQuestStatus(uint32 quest_id) const;
     void SetQuestStatus(uint32 questId, QuestStatus status, bool update = true);

--- a/src/server/game/Entities/Player/PlayerQuest.cpp
+++ b/src/server/game/Entities/Player/PlayerQuest.cpp
@@ -1396,14 +1396,14 @@ bool Player::TakeQuestSourceItem(uint32 questId, bool msg)
 uint32 Player::CalculateQuestRewardXP(Quest const* quest)
 {
     // apply world quest rate
-    uint32 XP = uint32(quest->XPValue(GetLevel()) * GetQuestRate(quest->IsDFQuest()));
+    uint32 xp = uint32(quest->XPValue(GetLevel()) * GetQuestRate(quest->IsDFQuest()));
 
     // handle SPELL_AURA_MOD_XP_QUEST_PCT auras
     Unit::AuraEffectList const& ModXPPctAuras = GetAuraEffectsByType(SPELL_AURA_MOD_XP_QUEST_PCT);
     for (Unit::AuraEffectList::const_iterator i = ModXPPctAuras.begin(); i != ModXPPctAuras.end(); ++i)
-        AddPct(XP, (*i)->GetAmount());
+        AddPct(xp, (*i)->GetAmount());
 
-    return XP;
+    return xp;
 }
 
 bool Player::GetQuestRewardStatus(uint32 quest_id) const

--- a/src/server/game/Entities/Player/PlayerQuest.cpp
+++ b/src/server/game/Entities/Player/PlayerQuest.cpp
@@ -742,12 +742,7 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
     bool rewarded = IsQuestRewarded(quest_id) && !quest->IsDFQuest();
 
     // Not give XP in case already completed once repeatable quest
-    uint32 XP = rewarded ? 0 : uint32(quest->XPValue(GetLevel()) * GetQuestRate(quest->IsDFQuest()));
-
-    // handle SPELL_AURA_MOD_XP_QUEST_PCT auras
-    Unit::AuraEffectList const& ModXPPctAuras = GetAuraEffectsByType(SPELL_AURA_MOD_XP_QUEST_PCT);
-    for (Unit::AuraEffectList::const_iterator i = ModXPPctAuras.begin(); i != ModXPPctAuras.end(); ++i)
-        AddPct(XP, (*i)->GetAmount());
+    uint32 XP = rewarded ? 0 : CalculateQuestRewardXP(quest);
 
     sScriptMgr->OnQuestComputeXP(this, quest, XP);
     int32 moneyRew = 0;
@@ -1396,6 +1391,19 @@ bool Player::TakeQuestSourceItem(uint32 questId, bool msg)
     }
 
     return true;
+}
+
+uint32 Player::CalculateQuestRewardXP(Quest const* quest)
+{
+    // apply world quest rate
+    uint32 XP = uint32(quest->XPValue(GetLevel()) * GetQuestRate(quest->IsDFQuest()));
+
+    // handle SPELL_AURA_MOD_XP_QUEST_PCT auras
+    Unit::AuraEffectList const& ModXPPctAuras = GetAuraEffectsByType(SPELL_AURA_MOD_XP_QUEST_PCT);
+    for (Unit::AuraEffectList::const_iterator i = ModXPPctAuras.begin(); i != ModXPPctAuras.end(); ++i)
+        AddPct(XP, (*i)->GetAmount());
+
+    return XP;
 }
 
 bool Player::GetQuestRewardStatus(uint32 quest_id) const


### PR DESCRIPTION
The quest XP displayed on the gossip window was not modified for auras that increase quest XP gain (e.g. spell ID 57353). This commit corrects the quest XP display when accepting/returning quests, using the same code as when rewarding the quest XP.

## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Go to a quest giver and note down the XP reward displayed in the gossip menu.
2. Equip at least one heirloom item with the "Experience gained from killing monsters and completing quests increased by 10%." effect (https://www.wowhead.com/wotlk/spell=57353)
3. Close and reopen the quest giver dialog and note the displayed XP reward again. It should be correctly adjusted for the amount of bonus XP from the heirloom items. 
4. Complete and turn in the quest. The amount of XP rewarded should equal the one noted in step 3.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
