### PR TITLE
fix(Scripts/ObsidianSanctum): add Flame Tsunami knockback

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1718486949488763477.sql
+++ b/data/sql/updates/pending_db_world/rev_1718486949488763477.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (57491, 60241);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(57491, 'spell_obsidian_sanctum_flame_tsunami'),
+(60241, 'spell_obsidian_sanctum_flame_tsunami_leap');

--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
@@ -103,6 +103,7 @@ enum Spells
     // Misc
     SPELL_FADE_ARMOR                            = 60708,
     SPELL_FLAME_TSUNAMI_DAMAGE_AURA             = 57492,
+    SPELL_FLAME_TSUNAMI_LEAP                    = 60241,
     SPELL_SARTHARION_PYROBUFFET_TRIGGER         = 57557,
 };
 
@@ -1572,6 +1573,51 @@ private:
     bool _spawned;
 };
 
+// 57491 - Flame Tsunami
+class spell_obsidian_sanctum_flame_tsunami : public SpellScript
+{
+    PrepareSpellScript(spell_obsidian_sanctum_flame_tsunami);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_FLAME_TSUNAMI_LEAP });
+    }
+
+    void HandleHit(SpellEffIndex /*effIndex*/)
+    {
+        if (Unit* target = GetHitUnit())
+        {
+            if (!target->HasAura(SPELL_FLAME_TSUNAMI_LEAP))
+            {
+                target->CastSpell(target, SPELL_FLAME_TSUNAMI_LEAP, true);
+                bool isFacingSouth = std::fabs(GetCaster()->GetOrientation() - M_PI) < M_PI / 4;
+                target->KnockbackFrom(isFacingSouth ? 3283.44f : 3208.44f , target->GetPositionY(), 12.5f, 9.0f);
+            }
+        }
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_obsidian_sanctum_flame_tsunami::HandleHit, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
+    }
+};
+
+// 60241 - Flame Tsunami
+class spell_obsidian_sanctum_flame_tsunami_leap : public SpellScript
+{
+    PrepareSpellScript(spell_obsidian_sanctum_flame_tsunami_leap);
+
+    void HandleLeapBack(SpellEffIndex effIndex)
+    {
+        PreventHitEffect(effIndex);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_obsidian_sanctum_flame_tsunami_leap::HandleLeapBack, EFFECT_0, SPELL_EFFECT_LEAP_BACK);
+    }
+};
+
 void AddSC_boss_sartharion()
 {
     new boss_sartharion();
@@ -1580,4 +1626,6 @@ void AddSC_boss_sartharion()
     new boss_sartharion_vesperon();
     new npc_twilight_summon();
     RegisterSpellScript(spell_sartharion_lava_strike);
+    RegisterSpellScript(spell_obsidian_sanctum_flame_tsunami);
+    RegisterSpellScript(spell_obsidian_sanctum_flame_tsunami_leap);
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

1. refactors lava_strike spellscript
2. add Flame Tsunami knockback

knockback spell (id: 60241) uses SPELL_EFFECT_LEAP_BACK (id: 138), however in [acore this is limited to only do forward/backwards movement of the caster](https://github.com/azerothcore/azerothcore-wotlk/blob/5dae761a947956775ceea5a87dc39bf420b947e6/src/server/game/Spells/SpellEffects.cpp#L5026). There are only 21 spells that use it effect

pic1: caster can move only forwards or backwards

pic2: Tsunami knockback, player should be knocked back following orientation of caster

There are only 21 spells that use this effect and only I know of 2 that do not follow pic1. They are: Sartharion Tsunami Knockback and Icehowl leap (id: 66733) to the hidden center "stalker npc" implemented in TC.

![leap](https://github.com/azerothcore/azerothcore-wotlk/assets/46423958/3e5faf16-99f7-49cb-8781-eababf7432b5)

LEAP_BACK TC 335 https://github.com/TrinityCore/TrinityCore/blob/858477148727b79be51d8c785a12af78c465dbb8/src/server/game/Spells/SpellEffects.cpp#L4340

LEAP_BACK CMangos wotlk https://github.com/cmangos/mangos-wotlk/blob/bd63be95ae8e084c748eb5129366a7533edc02c4/src/game/Spells/SpellEffects.cpp#L11558

It's a bit of a hack but it follows CMangos that handles leap back as a knockback. Tsunami knockback still applies aura as EFFECT_1 to only do 1 knockback

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/2891

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

video1 og wrath: https://github.com/azerothcore/azerothcore-wotlk/issues/2891#issuecomment-614206857

video2 classic wrath: https://youtu.be/knkjN7fzRlY?si=EwbTBnwJVS5i0TvM&t=113

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. go to Obsidian Sanctum
3. clear trash including 3 drakes
4. root sartharion with GM spell
5. surf waves

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Sartharion's boundary feels too strict. Stepping in lava resets the boss
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
