### PR TITLE
fix(Core/SmartAI): add prevent almost infinite spinning of mutual target to pets

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -108,6 +108,14 @@ bool ChaseMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
         mutualChase = true;
     }
 
+    // Prevent almost infinite spinning for pets with mutualTarget
+    // _mutualChase is false for previous check
+    if (angle && !mutualChase && !_mutualChase && mutualTarget && chaseRange < meleeRange && cOwner && cOwner->IsPet())
+    {
+        angle = Optional<ChaseAngle>();
+        mutualChase = true;
+    }
+
     // periodically check if we're already in the expected range...
     i_recheckDistance.Update(time_diff);
     if (i_recheckDistance.Passed())


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

1. fix pet spinning on caster mobs

I discovered what is going wrong when comparing a smartAI caster mob (fallen ranger: 16314) and a non-caster mob (lynx: 16348).

This is because: 
1. smartAI casts with `SMARTCAST_COMBAT_MOVE` and `SPELL_CAST_OK` removes chase movement in
 

https://github.com/azerothcore/azerothcore-wotlk/blob/90de4bb230c1e0a4900a084439a70d69409696ca/src/server/game/AI/SmartScripts/SmartScript.cpp#L682


this causes the `MutualChase` to be `false` in

https://github.com/azerothcore/azerothcore-wotlk/blob/90de4bb230c1e0a4900a084439a70d69409696ca/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp#L30


2. spin prevention should correct this, but it does not work after taunt drops (see video below). `_mutualChase` is set to `false` when running this check after the caster swaps from player to pet

https://github.com/azerothcore/azerothcore-wotlk/blob/90de4bb230c1e0a4900a084439a70d69409696ca/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp#L105

changes: add a clause to set  `mutualChase` to `true` for pets when `_mutualChase` is `false`. In subsequent updates, the original prevention clause works again

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/7067

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

https://github.com/azerothcore/azerothcore-wotlk/assets/46423958/c8871740-1f68-4d8a-bb1b-1770e25bebd5

https://github.com/azerothcore/azerothcore-wotlk/assets/46423958/1686bc52-932b-47a6-9c62-0cb99b37b98c


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

```
heal
.cast self 1908
taunt
.learn 70428
soulshard
.add 6265 10
Fallen Ranger
.npc add 16314
voidwalker
.learn 697
felhunter
.learn 691
felguard
.learn 30146
ghostpaw lynx
.npc add 16348
wolf pet
.npc add 704
.npc tame
```

Warlock lvl 20 with voidwalker
Fallen Ranger
Give HoT heal to self, voidwalker, fallen ranger

1. send pet to attack
2. taunt to gain aggro, this causes the pet to reposition behind the mob
3. let pet gain aggro or taunt wears off
4. pet moves should not reposition or spin

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
