### PR TITLE
fix(Core/Spell): implement taunt DR CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS 

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1718974840446011698.sql
+++ b/data/sql/updates/pending_db_world/rev_1718974840446011698.sql
@@ -1,166 +1,29 @@
 --
 UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 524288 WHERE `entry` IN
-(10184, -- Onyxia
-15928, -- Thaddius
-15931, -- Grobbulus
-15932, -- Gluth
-15936, -- Heigan the Unclean
-15952, -- Maexxna
-15953, -- Grand Widow Faerlina
-15954, -- Noth the Plaguebringer
-15956, -- Anub'Rekhan
-15989, -- Sapphiron
-15990, -- Kel'Thuzad
-16011, -- Loatheb
-16028, -- Patchwerk
-16060, -- Gothik the Harvester
-28859, -- Malygos
-28860, -- Sartharion
-30449, -- Vesperon
-30451, -- Shadron
-30452, -- Tenebron
-31125, -- Archavon the Stone Watcher
-32845, -- Hodir
-32857, -- Stormcaller Brundir
-32865, -- Thorim
-32867, -- Steelbreaker
-32871, -- Algalon the Observer
-32906, -- Freya
-32927, -- Runemaster Molgeim
-32930, -- Kologarn
-33113, -- Flame Leviathan
-33118, -- Ignis the Furnace Master
-33186, -- Razorscale
-33271, -- General Vezax
-33288, -- Yogg-Saron
-33293, -- XT-002 Deconstructor
-33432, -- Leviathan Mk II
-33515, -- Auriaya
-33651, -- VX-001
-33670, -- Aerial Command Unit
-33993, -- Emalon the Storm Watcher
-34441, -- Vivienne Blackwhisper
-34444, -- Thrakgar
-34445, -- Liandra Suncaller
-34447, -- Caiphus the Stern
-34448, -- Ruj'kah
-34449, -- Ginselle Blightslinger
-34450, -- Harkzog
-34451, -- Birana Stormhoof
-34453, -- Narrhok Steelbreaker
-34454, -- Maz'dinah
-34455, -- Broln Stouthorn
-34456, -- Malithas Brightblade
-34458, -- Gorgrim Shadowcleave
-34459, -- Erin Misthoof
-34460, -- Kavina Grovesong
-34461, -- Tyrius Duskblade
-34463, -- Shaabad
-34465, -- Velanaa
-34466, -- Anthar Forgemender
-34467, -- Alyssia Moonstalker
-34468, -- Noozle Whizzlestick
-34469, -- Melador Valestrider
-34470, -- Saamul
-34471, -- Baelnor Lightbearer
-34472, -- Irieth Shadowstep
-34474, -- Serissa Grimdabbler
-34475, -- Shocuul
-34496, -- Eydis Darkbane
-34497, -- Fjola Lightbane
-34564, -- Anub'arak
-34780, -- Lord Jaraxxus
-34796, -- Gormok the Impaler
-34797, -- Icehowl
-34799, -- Dreadscale
-35013, -- Koralon the Flame Watcher
-35144, -- Acidmaw
-36597, -- The Lich King
-36612, -- Lord Marrowgar
-36626, -- Festergut
-36627, -- Rotface
-36678, -- Professor Putricide
-36855, -- Lady Deathwhisper
-36899, -- Big Ooze
-36939, -- High Overlord Saurfang
-36948, -- Muradin Bronzebeard
-37562, -- Gas Cloud
-37813, -- Deathbringer Saurfang
-37955, -- Blood-Queen Lana'thel
-37970, -- Prince Valanar
-37972, -- Prince Keleseth
-37973, -- Prince Taldaram
-38216, -- Mutated Professor Putricide
-38433, -- Toravon the Ice Watcher
-38883, -- Idle Before Scaling
-39231, -- The Lich King (Temp)
-39625, -- General Umbriss
-39788, -- Anraphet
-39863, -- Halion
-40142, -- Halion
-40177, -- Forgemaster Throngus
-40484, -- Erudax
-40960, -- Bug 193702
-41270, -- Onyxia
-41376, -- Nefarian
-41378, -- Maloriak
-41442, -- Atramedes
-43404, -- Maloriak
-44600, -- Halfus Wyrmbreaker
-49938, -- Maloriak - Test
-51437, -- Forgemaster Throngus
-51452, -- Nefarian
-52151, -- Bloodlord Mandokir
-52409, -- Ragnaros
-52558, -- Lord Rhyolith
-52571, -- Majordomo Staghelm
-53494, -- Baleroc
-53772, -- Lord Rhyolith
-53879, -- Deathwing
-54192, -- Lord Rhyolith
-54199, -- Lord Rhyolith
-55265, -- Morchok
-55308, -- Warlord Zon'ozz
-55689, -- Hagara the Stormbinder
-56471, -- Mutated Corruption
-57773, -- Kohcrom
-60009, -- Feng the Accursed
-60016, -- Feng the Accursed
-60018, -- Feng the Accursed
-60019, -- Feng the Accursed
-60020, -- Feng the Accursed
-60709, -- Qiang the Merciless
-62511, -- Amber-Shaper Un'sok
-62711, -- Amber Monstrosity
-63666, -- Amber-Shaper Un'sok
-68078, -- Iron Qon
-68177, -- Feed Tester
-68208, -- Ji-Kun Dummy
-68397, -- Lei Shen
-69095, -- Test Subject
-69473, -- Ra-den
-69650, -- Phoenix Incubater Test
-69653, -- Phoenix Incubate and Feed Test
-69712, -- Ji-Kun
-70437, -- Lei Shen
-70640, -- Ji-Kun Area Trigger Dummy [DNT]
-71466, -- Iron Juggernaut
-71529, -- Thok the Bloodthirsty
-71658, -- Kor'kron Jailer
-71865, -- Garrosh Hellscream
-72224, -- Bug 365757 Jumper
-72249, -- Galakras
-72349, -- Garrosh Hellscream
-72616, -- Iron Juggernaut
-72748, -- Transform Dummy
-72749, -- Transform Dummy
-72750, -- Transform Dummy
-72957, -- Galakras
-73081, -- Garrosh Hellscream
-73103, -- Garrosh Hellscream
-73195, -- Kor'kron Jailer
-73462, -- Garrosh Hellscream
-73620, -- Garrosh Hellscream
-73663, -- Transform Dummy
--- Difficulties
-29249,29268,29278,29324,29373,29417,29448,29615,29701,29718,29955,29991,30061,31311,31520,31534,31535,31722,31734,32846,33070,33147,33190,33360,33449,33692,33693,33694,33724,33885,33909,33955,33994,34003,34106,34108,34109,34175,34442,34443,34566,35216,35268,35269,35347,35348,35349,35350,35351,35352,35360,35438,35439,35440,35447,35448,35449,35511,35512,35513,35514,35515,35516,35615,35616,35662,35663,35664,35665,35666,35667,35668,35669,35670,35671,35672,35673,35680,35681,35682,35683,35684,35685,35686,35687,35688,35689,35690,35691,35692,35693,35694,35695,35696,35697,35699,35700,35701,35702,35703,35704,35705,35706,35707,35708,35709,35710,35711,35712,35713,35714,35715,35716,35718,35719,35720,35721,35722,35723,35724,35725,35726,35728,35729,35730,35731,35732,35733,35734,35735,35736,35737,35738,35739,35740,35741,35742,35743,35744,35745,35746,35747,35748,35749,36538,37504,37505,37506,37957,37958,37959,38106,38123,38156,38157,38296,38297,38390,38399,38400,38401,38402,38431,38434,38435,38436,38462,38549,38550,38582,38583,38585,38586,38602,38637,38638,38639,38640,38760,38761,38769,38770,38771,38772,38784,38785,39166,39167,39168,39232,39233,39234,39864,39944,39945,40143,40144,40145,48337,48702,48822,49583,49584,49585,49974,49980,49986,51104,51105,51106,53587,53588,53589,57462,57955,57956,57976,58137,58138,58862,58863,58864);
+(10184, 15928, 15931, 15932, 15936, 15952, 15953, 15954, 15956, 15989, 15990,
+16011, 16028, 16060, 28859, 28860, 29249, 29268, 29278, 29324, 29373, 29417,
+29448, 29615, 29701, 29718, 29955, 29991, 30061, 30449, 30451, 30452, 31125,
+31311, 31520, 31534, 31535, 31722, 31734, 32845, 32846, 32857, 32865, 32867,
+32871, 32906, 32927, 32930, 33070, 33113, 33118, 33147, 33186, 33190, 33271,
+33288, 33293, 33360, 33432, 33449, 33515, 33651, 33670, 33692, 33693, 33694,
+33724, 33885, 33909, 33955, 33993, 33994, 34003, 34106, 34108, 34109, 34175,
+34441, 34442, 34443, 34444, 34445, 34447, 34448, 34449, 34450, 34451, 34453,
+34454, 34455, 34456, 34458, 34459, 34460, 34461, 34463, 34465, 34466, 34467,
+34468, 34469, 34470, 34471, 34472, 34474, 34475, 34496, 34497, 34564, 34566,
+34780, 34796, 34797, 34799, 35013, 35144, 35216, 35268, 35269, 35347, 35348,
+35349, 35350, 35351, 35352, 35360, 35438, 35439, 35440, 35447, 35448, 35449,
+35511, 35512, 35513, 35514, 35515, 35516, 35615, 35616, 35662, 35663, 35664,
+35665, 35666, 35667, 35668, 35669, 35670, 35671, 35672, 35673, 35680, 35681,
+35682, 35683, 35684, 35685, 35686, 35687, 35688, 35689, 35690, 35691, 35692,
+35693, 35694, 35695, 35696, 35697, 35699, 35700, 35701, 35702, 35703, 35704,
+35705, 35706, 35707, 35708, 35709, 35710, 35711, 35712, 35713, 35714, 35715,
+35716, 35718, 35719, 35720, 35721, 35722, 35723, 35724, 35725, 35726, 35728,
+35729, 35730, 35731, 35732, 35733, 35734, 35735, 35736, 35737, 35738, 35739,
+35740, 35741, 35742, 35743, 35744, 35745, 35746, 35747, 35748, 35749, 36538,
+36597, 36612, 36626, 36627, 36678, 36855, 36899, 36939, 36948, 37504, 37505,
+37506, 37562, 37813, 37955, 37957, 37958, 37959, 37970, 37972, 37973, 38106,
+38123, 38156, 38157, 38216, 38296, 38297, 38390, 38399, 38400, 38401, 38402,
+38431, 38433, 38434, 38435, 38436, 38462, 38549, 38550, 38582, 38583, 38585,
+38586, 38602, 38637, 38638, 38639, 38640, 38760, 38761, 38769, 38770, 38771,
+38772, 38784, 38785, 38883, 39166, 39167, 39168, 39231, 39232, 39233, 39234,
+39863, 39864, 39944, 39945, 40142, 40143, 40144, 40145);

--- a/data/sql/updates/pending_db_world/rev_1718974840446011698.sql
+++ b/data/sql/updates/pending_db_world/rev_1718974840446011698.sql
@@ -293,4 +293,5 @@ UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 524288 WHERE `ent
 40142, -- Halion
 40143, -- Halion (1)
 40144, -- Halion (2)
-40145); -- Halion (3)
+40145 -- Halion (3)
+);

--- a/data/sql/updates/pending_db_world/rev_1718974840446011698.sql
+++ b/data/sql/updates/pending_db_world/rev_1718974840446011698.sql
@@ -1,0 +1,166 @@
+--
+UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 524288 WHERE `entry` IN
+(10184, -- Onyxia
+15928, -- Thaddius
+15931, -- Grobbulus
+15932, -- Gluth
+15936, -- Heigan the Unclean
+15952, -- Maexxna
+15953, -- Grand Widow Faerlina
+15954, -- Noth the Plaguebringer
+15956, -- Anub'Rekhan
+15989, -- Sapphiron
+15990, -- Kel'Thuzad
+16011, -- Loatheb
+16028, -- Patchwerk
+16060, -- Gothik the Harvester
+28859, -- Malygos
+28860, -- Sartharion
+30449, -- Vesperon
+30451, -- Shadron
+30452, -- Tenebron
+31125, -- Archavon the Stone Watcher
+32845, -- Hodir
+32857, -- Stormcaller Brundir
+32865, -- Thorim
+32867, -- Steelbreaker
+32871, -- Algalon the Observer
+32906, -- Freya
+32927, -- Runemaster Molgeim
+32930, -- Kologarn
+33113, -- Flame Leviathan
+33118, -- Ignis the Furnace Master
+33186, -- Razorscale
+33271, -- General Vezax
+33288, -- Yogg-Saron
+33293, -- XT-002 Deconstructor
+33432, -- Leviathan Mk II
+33515, -- Auriaya
+33651, -- VX-001
+33670, -- Aerial Command Unit
+33993, -- Emalon the Storm Watcher
+34441, -- Vivienne Blackwhisper
+34444, -- Thrakgar
+34445, -- Liandra Suncaller
+34447, -- Caiphus the Stern
+34448, -- Ruj'kah
+34449, -- Ginselle Blightslinger
+34450, -- Harkzog
+34451, -- Birana Stormhoof
+34453, -- Narrhok Steelbreaker
+34454, -- Maz'dinah
+34455, -- Broln Stouthorn
+34456, -- Malithas Brightblade
+34458, -- Gorgrim Shadowcleave
+34459, -- Erin Misthoof
+34460, -- Kavina Grovesong
+34461, -- Tyrius Duskblade
+34463, -- Shaabad
+34465, -- Velanaa
+34466, -- Anthar Forgemender
+34467, -- Alyssia Moonstalker
+34468, -- Noozle Whizzlestick
+34469, -- Melador Valestrider
+34470, -- Saamul
+34471, -- Baelnor Lightbearer
+34472, -- Irieth Shadowstep
+34474, -- Serissa Grimdabbler
+34475, -- Shocuul
+34496, -- Eydis Darkbane
+34497, -- Fjola Lightbane
+34564, -- Anub'arak
+34780, -- Lord Jaraxxus
+34796, -- Gormok the Impaler
+34797, -- Icehowl
+34799, -- Dreadscale
+35013, -- Koralon the Flame Watcher
+35144, -- Acidmaw
+36597, -- The Lich King
+36612, -- Lord Marrowgar
+36626, -- Festergut
+36627, -- Rotface
+36678, -- Professor Putricide
+36855, -- Lady Deathwhisper
+36899, -- Big Ooze
+36939, -- High Overlord Saurfang
+36948, -- Muradin Bronzebeard
+37562, -- Gas Cloud
+37813, -- Deathbringer Saurfang
+37955, -- Blood-Queen Lana'thel
+37970, -- Prince Valanar
+37972, -- Prince Keleseth
+37973, -- Prince Taldaram
+38216, -- Mutated Professor Putricide
+38433, -- Toravon the Ice Watcher
+38883, -- Idle Before Scaling
+39231, -- The Lich King (Temp)
+39625, -- General Umbriss
+39788, -- Anraphet
+39863, -- Halion
+40142, -- Halion
+40177, -- Forgemaster Throngus
+40484, -- Erudax
+40960, -- Bug 193702
+41270, -- Onyxia
+41376, -- Nefarian
+41378, -- Maloriak
+41442, -- Atramedes
+43404, -- Maloriak
+44600, -- Halfus Wyrmbreaker
+49938, -- Maloriak - Test
+51437, -- Forgemaster Throngus
+51452, -- Nefarian
+52151, -- Bloodlord Mandokir
+52409, -- Ragnaros
+52558, -- Lord Rhyolith
+52571, -- Majordomo Staghelm
+53494, -- Baleroc
+53772, -- Lord Rhyolith
+53879, -- Deathwing
+54192, -- Lord Rhyolith
+54199, -- Lord Rhyolith
+55265, -- Morchok
+55308, -- Warlord Zon'ozz
+55689, -- Hagara the Stormbinder
+56471, -- Mutated Corruption
+57773, -- Kohcrom
+60009, -- Feng the Accursed
+60016, -- Feng the Accursed
+60018, -- Feng the Accursed
+60019, -- Feng the Accursed
+60020, -- Feng the Accursed
+60709, -- Qiang the Merciless
+62511, -- Amber-Shaper Un'sok
+62711, -- Amber Monstrosity
+63666, -- Amber-Shaper Un'sok
+68078, -- Iron Qon
+68177, -- Feed Tester
+68208, -- Ji-Kun Dummy
+68397, -- Lei Shen
+69095, -- Test Subject
+69473, -- Ra-den
+69650, -- Phoenix Incubater Test
+69653, -- Phoenix Incubate and Feed Test
+69712, -- Ji-Kun
+70437, -- Lei Shen
+70640, -- Ji-Kun Area Trigger Dummy [DNT]
+71466, -- Iron Juggernaut
+71529, -- Thok the Bloodthirsty
+71658, -- Kor'kron Jailer
+71865, -- Garrosh Hellscream
+72224, -- Bug 365757 Jumper
+72249, -- Galakras
+72349, -- Garrosh Hellscream
+72616, -- Iron Juggernaut
+72748, -- Transform Dummy
+72749, -- Transform Dummy
+72750, -- Transform Dummy
+72957, -- Galakras
+73081, -- Garrosh Hellscream
+73103, -- Garrosh Hellscream
+73195, -- Kor'kron Jailer
+73462, -- Garrosh Hellscream
+73620, -- Garrosh Hellscream
+73663, -- Transform Dummy
+-- Difficulties
+29249,29268,29278,29324,29373,29417,29448,29615,29701,29718,29955,29991,30061,31311,31520,31534,31535,31722,31734,32846,33070,33147,33190,33360,33449,33692,33693,33694,33724,33885,33909,33955,33994,34003,34106,34108,34109,34175,34442,34443,34566,35216,35268,35269,35347,35348,35349,35350,35351,35352,35360,35438,35439,35440,35447,35448,35449,35511,35512,35513,35514,35515,35516,35615,35616,35662,35663,35664,35665,35666,35667,35668,35669,35670,35671,35672,35673,35680,35681,35682,35683,35684,35685,35686,35687,35688,35689,35690,35691,35692,35693,35694,35695,35696,35697,35699,35700,35701,35702,35703,35704,35705,35706,35707,35708,35709,35710,35711,35712,35713,35714,35715,35716,35718,35719,35720,35721,35722,35723,35724,35725,35726,35728,35729,35730,35731,35732,35733,35734,35735,35736,35737,35738,35739,35740,35741,35742,35743,35744,35745,35746,35747,35748,35749,36538,37504,37505,37506,37957,37958,37959,38106,38123,38156,38157,38296,38297,38390,38399,38400,38401,38402,38431,38434,38435,38436,38462,38549,38550,38582,38583,38585,38586,38602,38637,38638,38639,38640,38760,38761,38769,38770,38771,38772,38784,38785,39166,39167,39168,39232,39233,39234,39864,39944,39945,40143,40144,40145,48337,48702,48822,49583,49584,49585,49974,49980,49986,51104,51105,51106,53587,53588,53589,57462,57955,57956,57976,58137,58138,58862,58863,58864);

--- a/data/sql/updates/pending_db_world/rev_1718974840446011698.sql
+++ b/data/sql/updates/pending_db_world/rev_1718974840446011698.sql
@@ -1,29 +1,296 @@
 --
 UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 524288 WHERE `entry` IN
-(10184, 15928, 15931, 15932, 15936, 15952, 15953, 15954, 15956, 15989, 15990,
-16011, 16028, 16060, 28859, 28860, 29249, 29268, 29278, 29324, 29373, 29417,
-29448, 29615, 29701, 29718, 29955, 29991, 30061, 30449, 30451, 30452, 31125,
-31311, 31520, 31534, 31535, 31722, 31734, 32845, 32846, 32857, 32865, 32867,
-32871, 32906, 32927, 32930, 33070, 33113, 33118, 33147, 33186, 33190, 33271,
-33288, 33293, 33360, 33432, 33449, 33515, 33651, 33670, 33692, 33693, 33694,
-33724, 33885, 33909, 33955, 33993, 33994, 34003, 34106, 34108, 34109, 34175,
-34441, 34442, 34443, 34444, 34445, 34447, 34448, 34449, 34450, 34451, 34453,
-34454, 34455, 34456, 34458, 34459, 34460, 34461, 34463, 34465, 34466, 34467,
-34468, 34469, 34470, 34471, 34472, 34474, 34475, 34496, 34497, 34564, 34566,
-34780, 34796, 34797, 34799, 35013, 35144, 35216, 35268, 35269, 35347, 35348,
-35349, 35350, 35351, 35352, 35360, 35438, 35439, 35440, 35447, 35448, 35449,
-35511, 35512, 35513, 35514, 35515, 35516, 35615, 35616, 35662, 35663, 35664,
-35665, 35666, 35667, 35668, 35669, 35670, 35671, 35672, 35673, 35680, 35681,
-35682, 35683, 35684, 35685, 35686, 35687, 35688, 35689, 35690, 35691, 35692,
-35693, 35694, 35695, 35696, 35697, 35699, 35700, 35701, 35702, 35703, 35704,
-35705, 35706, 35707, 35708, 35709, 35710, 35711, 35712, 35713, 35714, 35715,
-35716, 35718, 35719, 35720, 35721, 35722, 35723, 35724, 35725, 35726, 35728,
-35729, 35730, 35731, 35732, 35733, 35734, 35735, 35736, 35737, 35738, 35739,
-35740, 35741, 35742, 35743, 35744, 35745, 35746, 35747, 35748, 35749, 36538,
-36597, 36612, 36626, 36627, 36678, 36855, 36899, 36939, 36948, 37504, 37505,
-37506, 37562, 37813, 37955, 37957, 37958, 37959, 37970, 37972, 37973, 38106,
-38123, 38156, 38157, 38216, 38296, 38297, 38390, 38399, 38400, 38401, 38402,
-38431, 38433, 38434, 38435, 38436, 38462, 38549, 38550, 38582, 38583, 38585,
-38586, 38602, 38637, 38638, 38639, 38640, 38760, 38761, 38769, 38770, 38771,
-38772, 38784, 38785, 38883, 39166, 39167, 39168, 39231, 39232, 39233, 39234,
-39863, 39864, 39944, 39945, 40142, 40143, 40144, 40145);
+(10184, -- Onyxia
+15928, -- Thaddius
+15931, -- Grobbulus
+15932, -- Gluth
+15936, -- Heigan the Unclean
+15952, -- Maexxna
+15953, -- Grand Widow Faerlina
+15954, -- Noth the Plaguebringer
+15956, -- Anub'Rekhan
+15989, -- Sapphiron
+15990, -- Kel'Thuzad
+16011, -- Loatheb
+16028, -- Patchwerk
+16060, -- Gothik the Harvester
+28859, -- Malygos
+28860, -- Sartharion
+29249, -- Anub'Rekhan (1)
+29268, -- Grand Widow Faerlina (1)
+29278, -- Maexxna (1)
+29324, -- Patchwerk (1)
+29373, -- Grobbulus (1)
+29417, -- Gluth (1)
+29448, -- Thaddius (1)
+29615, -- Noth the Plaguebringer (1)
+29701, -- Heigan the Unclean (1)
+29718, -- Loatheb (1)
+29955, -- Gothik the Harvester (1)
+29991, -- Sapphiron (1)
+30061, -- Kel'Thuzad (1)
+30449, -- Vesperon
+30451, -- Shadron
+30452, -- Tenebron
+31125, -- Archavon the Stone Watcher
+31311, -- Sartharion (1)
+31520, -- Shadron (1)
+31534, -- Tenebron (1)
+31535, -- Vesperon (1)
+31722, -- Archavon the Stone Watcher (1)
+31734, -- Malygos
+32845, -- Hodir
+32846, -- Hodir (1)
+32857, -- Stormcaller Brundir
+32865, -- Thorim
+32867, -- Steelbreaker
+32871, -- Algalon the Observer
+32906, -- Freya
+32927, -- Runemaster Molgeim
+32930, -- Kologarn
+33070, -- Algalon the Observer (1)
+33113, -- Flame Leviathan
+33118, -- Ignis the Furnace Master
+33147, -- Thorim (1)
+33186, -- Razorscale
+33190, -- Ignis the Furnace Master (1)
+33271, -- General Vezax
+33288, -- Yogg-Saron
+33293, -- XT-002 Deconstructor
+33360, -- Freya (1)
+33432, -- Leviathan Mk II
+33449, -- General Vezax (1)
+33515, -- Auriaya
+33651, -- VX-001
+33670, -- Aerial Command Unit
+33692, -- Runemaster Molgeim (1)
+33693, -- Steelbreaker (1)
+33694, -- Stormcaller Brundir (1)
+33724, -- Razorscale (1)
+33885, -- XT-002 Deconstructor (1)
+33909, -- Kologarn (1)
+33955, -- Yogg-Saron (1)
+33993, -- Emalon the Storm Watcher
+33994, -- Emalon the Storm Watcher (1)
+34003, -- Flame Leviathan (1)
+34106, -- Leviathan Mk II (1)
+34108, -- VX-001 (1)
+34109, -- Aerial Command Unit (1)
+34175, -- Auriaya (1)
+34441, -- Vivienne Blackwhisper
+34442, -- Vivienne Blackwhisper (1)
+34443, -- Vivienne Blackwhisper (2)
+34444, -- Thrakgar
+34445, -- Liandra Suncaller
+34447, -- Caiphus the Stern
+34448, -- Ruj'kah
+34449, -- Ginselle Blightslinger
+34450, -- Harkzog
+34451, -- Birana Stormhoof
+34453, -- Narrhok Steelbreaker
+34454, -- Maz'dinah
+34455, -- Broln Stouthorn
+34456, -- Malithas Brightblade
+34458, -- Gorgrim Shadowcleave
+34459, -- Erin Misthoof
+34460, -- Kavina Grovesong
+34461, -- Tyrius Duskblade
+34463, -- Shaabad
+34465, -- Velanaa
+34466, -- Anthar Forgemender
+34467, -- Alyssia Moonstalker
+34468, -- Noozle Whizzlestick
+34469, -- Melador Valestrider
+34470, -- Saamul
+34471, -- Baelnor Lightbearer
+34472, -- Irieth Shadowstep
+34474, -- Serissa Grimdabbler
+34475, -- Shocuul
+34496, -- Eydis Darkbane
+34497, -- Fjola Lightbane
+34564, -- Anub'arak
+34566, -- Anub'arak (1)
+34780, -- Lord Jaraxxus
+34796, -- Gormok the Impaler
+34797, -- Icehowl
+34799, -- Dreadscale
+35013, -- Koralon the Flame Watcher
+35144, -- Acidmaw
+35216, -- Lord Jaraxxus (1)
+35268, -- Lord Jaraxxus (2)
+35269, -- Lord Jaraxxus (3)
+35347, -- Eydis Darkbane (1)
+35348, -- Eydis Darkbane (2)
+35349, -- Eydis Darkbane (3)
+35350, -- Fjola Lightbane (1)
+35351, -- Fjola Lightbane (2)
+35352, -- Fjola Lightbane (3)
+35360, -- Koralon the Flame Watcher (1)
+35438, -- Gormok the Impaler (1)
+35439, -- Gormok the Impaler (2)
+35440, -- Gormok the Impaler (3)
+35447, -- Icehowl (1)
+35448, -- Icehowl (2)
+35449, -- Icehowl (3)
+35511, -- Acidmaw (1)
+35512, -- Acidmaw (2)
+35513, -- Acidmaw (3)
+35514, -- Dreadscale (1)
+35515, -- Dreadscale (2)
+35516, -- Dreadscale (3)
+35615, -- Anub'arak (2)
+35616, -- Anub'arak (3)
+35662, -- Alyssia Moonstalker (1)
+35663, -- Alyssia Moonstalker (2)
+35664, -- Alyssia Moonstalker (3)
+35665, -- Anthar Forgemender (1)
+35666, -- Anthar Forgemender (2)
+35667, -- Anthar Forgemender (3)
+35668, -- Baelnor Lightbearer (1)
+35669, -- Baelnor Lightbearer (2)
+35670, -- Baelnor Lightbearer (3)
+35671, -- Birana Stormhoof (1)
+35672, -- Birana Stormhoof (2)
+35673, -- Birana Stormhoof (3)
+35680, -- Broln Stouthorn (1)
+35681, -- Broln Stouthorn (2)
+35682, -- Broln Stouthorn (3)
+35683, -- Caiphus the Stern (1)
+35684, -- Caiphus the Stern (2)
+35685, -- Caiphus the Stern (3)
+35686, -- Erin Misthoof (1)
+35687, -- Erin Misthoof (2)
+35688, -- Erin Misthoof (3)
+35689, -- Ginselle Blightslinger (1)
+35690, -- Ginselle Blightslinger (2)
+35691, -- Ginselle Blightslinger (3)
+35692, -- Gorgrim Shadowcleave (1)
+35693, -- Gorgrim Shadowcleave (2)
+35694, -- Gorgrim Shadowcleave (3)
+35695, -- Harkzog (1)
+35696, -- Harkzog (2)
+35697, -- Harkzog (3)
+35699, -- Irieth Shadowstep (1)
+35700, -- Irieth Shadowstep (2)
+35701, -- Irieth Shadowstep (3)
+35702, -- Kavina Grovesong (1)
+35703, -- Kavina Grovesong (2)
+35704, -- Kavina Grovesong (3)
+35705, -- Liandra Suncaller (1)
+35706, -- Liandra Suncaller (2)
+35707, -- Liandra Suncaller (3)
+35708, -- Malithas Brightblade (1)
+35709, -- Malithas Brightblade (2)
+35710, -- Malithas Brightblade (3)
+35711, -- Maz'dinah (1)
+35712, -- Maz'dinah (2)
+35713, -- Maz'dinah (3)
+35714, -- Melador Valestrider (1)
+35715, -- Melador Valestrider (2)
+35716, -- Melador Valestrider (3)
+35718, -- Narrhok Steelbreaker (1)
+35719, -- Narrhok Steelbreaker (2)
+35720, -- Narrhok Steelbreaker (3)
+35721, -- Noozle Whizzlestick (1)
+35722, -- Noozle Whizzlestick (2)
+35723, -- Noozle Whizzlestick (3)
+35724, -- Ruj'kah (1)
+35725, -- Ruj'kah (2)
+35726, -- Ruj'kah (3)
+35728, -- Saamul (1)
+35729, -- Saamul (2)
+35730, -- Saamul (3)
+35731, -- Serissa Grimdabbler (1)
+35732, -- Serissa Grimdabbler (2)
+35733, -- Serissa Grimdabbler (3)
+35734, -- Shaabad (1)
+35735, -- Shaabad (2)
+35736, -- Shaabad (3)
+35737, -- Shocuul (1)
+35738, -- Shocuul (2)
+35739, -- Shocuul (3)
+35740, -- Thrakgar (1)
+35741, -- Thrakgar (2)
+35742, -- Thrakgar (3)
+35743, -- Tyrius Duskblade (1)
+35744, -- Tyrius Duskblade (2)
+35745, -- Tyrius Duskblade (3)
+35746, -- Velanaa (1)
+35747, -- Velanaa (2)
+35748, -- Velanaa (3)
+35749, -- Vivienne Blackwhisper (3)
+36538, -- Onyxia (1)
+36597, -- The Lich King
+36612, -- Lord Marrowgar
+36626, -- Festergut
+36627, -- Rotface
+36678, -- Professor Putricide
+36855, -- Lady Deathwhisper
+36899, -- Big Ooze
+36939, -- High Overlord Saurfang
+36948, -- Muradin Bronzebeard
+37504, -- Festergut (1)
+37505, -- Festergut (2)
+37506, -- Festergut (3)
+37562, -- Gas Cloud
+37813, -- Deathbringer Saurfang
+37955, -- Blood-Queen Lana'thel
+37957, -- Lord Marrowgar (1)
+37958, -- Lord Marrowgar (2)
+37959, -- Lord Marrowgar (3)
+37970, -- Prince Valanar
+37972, -- Prince Keleseth
+37973, -- Prince Taldaram
+38106, -- Lady Deathwhisper (1)
+38123, -- Big Ooze (1)
+38156, -- High Overlord Saurfang (1)
+38157, -- Muradin Bronzebeard (1)
+38216, -- Mutated Professor Putricide
+38296, -- Lady Deathwhisper (2)
+38297, -- Lady Deathwhisper (3)
+38390, -- Rotface (1)
+38399, -- Prince Keleseth (1)
+38400, -- Prince Taldaram (1)
+38401, -- Prince Valanar (1)
+38402, -- Deathbringer Saurfang (1)
+38431, -- Professor Putricide (1)
+38433, -- Toravon the Ice Watcher
+38434, -- Blood-Queen Lana'thel (1)
+38435, -- Blood-Queen Lana'thel (2)
+38436, -- Blood-Queen Lana'thel (3)
+38462, -- Toravon the Ice Watcher (1)
+38549, -- Rotface (2)
+38550, -- Rotface (3)
+38582, -- Deathbringer Saurfang (2)
+38583, -- Deathbringer Saurfang (3)
+38585, -- Professor Putricide (2)
+38586, -- Professor Putricide (3)
+38602, -- Gas Cloud (1)
+38637, -- High Overlord Saurfang (2)
+38638, -- High Overlord Saurfang (3)
+38639, -- Muradin Bronzebeard (2)
+38640, -- Muradin Bronzebeard (3)
+38760, -- Gas Cloud (2)
+38761, -- Gas Cloud (3)
+38769, -- Prince Keleseth (2)
+38770, -- Prince Keleseth (3)
+38771, -- Prince Taldaram (2)
+38772, -- Prince Taldaram (3)
+38784, -- Prince Valanar (2)
+38785, -- Prince Valanar (3)
+38883, -- ScottG Test
+39166, -- The Lich King (1)
+39167, -- The Lich King (2)
+39168, -- The Lich King (3)
+39231, -- The Lich King (Temp)
+39232, -- The Lich King (Temp) (1)
+39233, -- The Lich King (Temp) (2)
+39234, -- The Lich King (Temp) (3)
+39863, -- Halion
+39864, -- Halion (1)
+39944, -- Halion (2)
+39945, -- Halion (3)
+40142, -- Halion
+40143, -- Halion (1)
+40144, -- Halion (2)
+40145); -- Halion (3)

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3181,6 +3181,8 @@ SpellMissInfo Spell::DoSpellHitOnUnit(Unit* unit, uint32 effectMask, bool scaleA
                 if (diminishMod == 0.0f)
                 {
                     m_spellAura->Remove();
+                    if (m_diminishGroup == DIMINISHING_TAUNT)
+                        return SPELL_MISS_IMMUNE;
                     bool found = false;
                     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
                         if (effectMask & (1 << i) && m_spellInfo->Effects[i].Effect != SPELL_EFFECT_APPLY_AURA)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS flag (extra_flags) is not set on any creature

When set, DR handling is incorrect. Most taunts have an EFFECT_APPLY_AURA  with SPELL_AURA_MOD_TAUNT as an effect AND a SPELL_EFFECT_ATTACK_ME. Currently, the former is handled by DR but SPELL_EFFECT_ATTACK_ME is still handled. Resulting in no taunt DR when the flag is set.

Some special cases have a 3rd effect:
- death grip: grip mechanic
- mocking blow: damage

sidenote: hand of reckoning only has 2 effects, damage is handled as a special case in taunteffect

changes:
- add CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS to some creature_templates
- skip handling of other effects if taunt DR's

I believe TC picked these creatures like so:
```
-- Bosses should have DR taunt immunity
-- Check creatures with CREATURE_FLAG_EXTRA_INSTANCE_BIND and Rank 3 (boss) seems ok or is better all Rank3 creatures??
-- Skip bosses with CREATURE_FLAG_EXTRA_NO_TAUNT
UPDATE `creature_template` SET `flags_extra`=`flags_extra`|0x00080000 WHERE `rank`=3 AND `flags_extra`=`flags_extra`|0x00000001 AND `flags_extra`!=`flags_extra`|0x00000100; 
```

full list of 294 creature_template with names/lvl when selecting from acore_world.creature_template 

https://gist.github.com/sogladev/2bc968578e2ee8976e73573e7105d3a8

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TC 335 https://github.com/TrinityCore/TrinityCore/commit/fe38b78c877fd30cc677913229d23bd6f5c15f0b

Quoted from TC 335 issue

> https://wowwiki.fandom.com/wiki/Diminishing_returns
> https://www.mmo-champion.com/threads/640994-Taunt-Diminishing-Returns
> 

Patch 3.3.0 (08-Dec-2009): Taunt Diminishing Returns: We've revised the system for diminishing returns on Taunt so
that creatures do not become immune to Taunt until after 5 Taunts have landed. The duration of the Taunt effect will be  reduced by 35% instead of 50% for each taunt landed. In addition, most creatures in the world will not be affected by 
 Taunt diminishing returns at all. Creatures will only have Taunt diminishing returns if they have been specifically flagged for that behavior based on the design of a given encounter.



## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

requires 2 characters

1. spawn an npc with flag set like patchwerk
2. with character 1: taunt a few times with .cheat cooldown to DR taunt. observe aura DR's
3. with character 2: press taunt. npc should not be taunted

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
