### PR TITLE
fix(DB/quest_offer_reward): C'Thun's Legacy turnin dialogue

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1719113163679056400.sql
+++ b/data/sql/updates/pending_db_world/rev_1719113163679056400.sql
@@ -1,2 +1,3 @@
 --
-UPDATE `quest_offer_reward` SET `RewardText`='We will leave this place on our own, $G Lord:Lady; $N - once we are certain that the evil within has been wholly destroyed. Your journey of legend is almost at an end.' WHERE `ID`=8801;
+UPDATE `quest_offer_reward` SET `RewardText`='We will leave this place on our own, $G Lord:Lady; $N - once we are certain that the evil within has been wholly destroyed. Your journey of legend is almost at an end.', `VerifiedBuild`=0 WHERE `ID`=8801;
+UPDATE `quest_request_items` SET `CompletionText`='$G Lord:Lady; $N, you have freed us of its grasp.', `VerifiedBuild`=0 WHERE `ID`=8801;

--- a/data/sql/updates/pending_db_world/rev_1719113163679056400.sql
+++ b/data/sql/updates/pending_db_world/rev_1719113163679056400.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `quest_offer_reward` SET `RewardText`='We will leave this place on our own, $G Lord:Lady; $N - once we are certain that the evil within has been wholly destroyed. Your journey of legend is almost at an end.' WHERE `ID`=8801;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
Fixes quest turn-in dialogue not respecting character gender and always using Lady instead of Lady/Lord which reflects an oversight in the original dialogue that does not exist on live servers
![before-fix-aq40d](https://github.com/azerothcore/azerothcore-wotlk/assets/53310556/136db0fa-cd24-4545-b772-1fe9a030fc13)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.
- [ ] 
Tested in-game on Windows and verified to build without errors. Dialogue was viewed as both a male and a female to verify functionality and quest was completed without issue with correct dialogue as shown below in images. No other issues caused by this change.
![image](https://github.com/azerothcore/azerothcore-wotlk/assets/53310556/30b5f0e8-f12a-4389-8f43-3faa535000f4)
![image](https://github.com/azerothcore/azerothcore-wotlk/assets/53310556/03645a43-d6d2-488b-bcb3-27dbeb0f8e26)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .additem 21221
2. Clear AQ40 and proceed to Caelestrasz
3. Verify that on turning in the quest your character receives the correct dialogue

## Known Issues and TODO List:
This change fully fixes the issue and there is no more to be done to resolve this issue.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
