### PR TITLE
fix(DB/disables): disable spell 28784 'Summon Midsummer Bonfire Bunnies'

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1719133251740575200.sql
+++ b/data/sql/updates/pending_db_world/rev_1719133251740575200.sql
@@ -1,0 +1,4 @@
+-- disable spell 28784 'Summon Midsummer Bonfire Bunnies'
+DELETE FROM `disables` WHERE `sourceType` = 0 AND `entry` = 28784;
+INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, `comment`) VALUES
+(0, 28784, 8, '', '', 'Spell Summon Midsummer Bonfire Bunnies unused');


### PR DESCRIPTION
- all midsummer bonfire gameobjects have a linked trap "181290 Midsummer Bonfire Spawn Trap"
- the trap is linked to the spell "28784 Summon Midsummer Bonfire Bunnies" which then spawns npc "16592 Midsummer Bonfire", npc "16606 Midsummer Bonfire Despawner" and gameobject "181371 Midsummer Bonfire Spell Focus" i have no idea how this trap is beeing triggered, but it's doing only harm right now
- therefore disable the spell completely as it is not required for the current implementation
- this can be revisited later if the implementation should be updated to actually make use of this spell

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

hopefully fixes issues like this (observed on CC):
![WoWScrnShot_062324_105012](https://github.com/azerothcore/azerothcore-wotlk/assets/7723845/389017f7-eb67-4a78-b3bb-1ac3f6e05a12)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
