### PR TITLE
fix(CORE/RAID): added correct spell to boss Anub'Arak to clear his debuffs on submerge

### DIFF
--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
@@ -194,7 +194,7 @@ class boss_anub_arak : public CreatureScript
                         if (me->HealthBelowPct(eventId*25))
                         {
                             Talk(SAY_SUBMERGE);
-                            me->CastSpell(me, SPELL_CLEAR_ALL_DEBUFFS, false);
+                            DoCastSelf(SPELL_CLEAR_ALL_DEBUFFS, true);
                             me->CastSpell(me, SPELL_IMPALE_PERIODIC, true);
                             me->CastSpell(me, SPELL_SUBMERGE, false);
                             me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE|UNIT_FLAG_NOT_SELECTABLE);

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
@@ -31,6 +31,7 @@ enum Spells
     SPELL_EMERGE                        = 53500,
     SPELL_SUBMERGE                      = 53421,
     SPELL_SELF_ROOT                     = 42716,
+    SPELL_CLEAR_ALL_DEBUFFS             = 34098,
 
     SPELL_SUMMON_DARTER                 = 53599,
     SPELL_SUMMON_ASSASSIN               = 53610,
@@ -193,6 +194,7 @@ class boss_anub_arak : public CreatureScript
                         if (me->HealthBelowPct(eventId*25))
                         {
                             Talk(SAY_SUBMERGE);
+                            me->CastSpell(me, SPELL_CLEAR_ALL_DEBUFFS, false);
                             me->CastSpell(me, SPELL_IMPALE_PERIODIC, true);
                             me->CastSpell(me, SPELL_SUBMERGE, false);
                             me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE|UNIT_FLAG_NOT_SELECTABLE);

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
@@ -88,6 +88,7 @@ enum AnubSpells
     SPELL_SUBMERGE                              = 65981,
     SPELL_EMERGE                                = 65982,
     SPELL_BERSERK                               = 26662,
+    SPELL_CLEAR_ALL_DEBUFFS                     = 34098,
 
     SPELL_FREEZING_SLASH                        = 66012,
     SPELL_PENETRATING_COLD                      = 66013,
@@ -313,7 +314,7 @@ public:
                     {
                         me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
                         bool berserk = me->HasAura(SPELL_BERSERK);
-                        me->RemoveAllAuras();
+                        me->CastSpell(me, SPELL_CLEAR_ALL_DEBUFFS, false);
                         if (berserk)
                             me->CastSpell(me, SPELL_BERSERK, true);
                         Talk(EMOTE_SUBMERGE);
@@ -681,7 +682,7 @@ public:
                     {
                         me->GetMotionMaster()->MoveIdle();
                         me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
-                        me->RemoveAllAuras();
+                        me->CastSpell(me, SPELL_CLEAR_ALL_DEBUFFS, false);
                         me->CastSpell(me, SPELL_EXPOSE_WEAKNESS, true);
                         me->CastSpell(me, SPELL_SPIDER_FRENZY, true);
                         me->CastSpell(me, SPELL_SUBMERGE, false);

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
@@ -314,7 +314,7 @@ public:
                     {
                         me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
                         bool berserk = me->HasAura(SPELL_BERSERK);
-                        me->CastSpell(me, SPELL_CLEAR_ALL_DEBUFFS, false);
+                        DoCastSelf(SPELL_CLEAR_ALL_DEBUFFS, true);
                         if (berserk)
                             me->CastSpell(me, SPELL_BERSERK, true);
                         Talk(EMOTE_SUBMERGE);

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
@@ -682,7 +682,7 @@ public:
                     {
                         me->GetMotionMaster()->MoveIdle();
                         me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
-                        me->CastSpell(me, SPELL_CLEAR_ALL_DEBUFFS, false);
+                        me->DoCastSelf(SPELL_CLEAR_ALL_DEBUFFS, true);
                         me->CastSpell(me, SPELL_EXPOSE_WEAKNESS, true);
                         me->CastSpell(me, SPELL_SPIDER_FRENZY, true);
                         me->CastSpell(me, SPELL_SUBMERGE, false);

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
@@ -682,7 +682,7 @@ public:
                     {
                         me->GetMotionMaster()->MoveIdle();
                         me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
-                        me->DoCastSelf(SPELL_CLEAR_ALL_DEBUFFS, true);
+                        DoCastSelf(SPELL_CLEAR_ALL_DEBUFFS, true);
                         me->CastSpell(me, SPELL_EXPOSE_WEAKNESS, true);
                         me->CastSpell(me, SPELL_SPIDER_FRENZY, true);
                         me->CastSpell(me, SPELL_SUBMERGE, false);


### PR DESCRIPTION
Anub'Arak (id: 34564) was using the RemoveAllAuras method when submerging.

Added correct spell and replace method with spellcast of spell ClearAllDebuffs (id: 34098)

Closes AzerothCore issue #19136



**Testing instructions :**

1. go into Trial of the Crusaders instance
2. get to Anub'Arak boss
3. let him submerge
4. observe for a debuff clear spellcast
