### PR TITLE
fix(Scripts/HyjalSummit): Couple Archimonde adjustments.

### DIFF
--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
@@ -265,7 +265,7 @@ struct boss_archimonde : public BossAI
         _JustEngagedWith();
         me->InterruptNonMeleeSpells(false);
         Talk(SAY_AGGRO);
-        ScheduleTimedEvent(25s, 35s, [&]
+        ScheduleTimedEvent(40s, [&]
         {
             scheduler.DelayGroup(GROUP_FEAR, 5s);
             Talk(SAY_AIR_BURST);

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
@@ -143,8 +143,8 @@ struct npc_doomfire_spirit : public ScriptedAI
 {
     npc_doomfire_spirit(Creature* creature) : ScriptedAI(creature){ }
 
-    float const _turnConstant = 0.785402f;
-    float _fAngle = urand(0, M_PI * 2);
+    float const turnConstant = 0.785402f;
+    float fAngle = urand(0, M_PI * 2);
 
     void Reset() override
     {

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
@@ -265,7 +265,7 @@ struct boss_archimonde : public BossAI
         _JustEngagedWith();
         me->InterruptNonMeleeSpells(false);
         Talk(SAY_AGGRO);
-        ScheduleTimedEvent(40s, [&]
+        ScheduleTimedEvent(25s, 35s, [&]
         {
             scheduler.DelayGroup(GROUP_FEAR, 5s);
             Talk(SAY_AIR_BURST);
@@ -320,7 +320,7 @@ struct boss_archimonde : public BossAI
             DoCastVictim(SPELL_RED_SKY_EFFECT);
             DoCastVictim(SPELL_HAND_OF_DEATH);
         }, 3s);
-        scheduler.Schedule(25s, 35s, GROUP_FEAR, [this](TaskContext context)
+        scheduler.Schedule(40s, GROUP_FEAR, [this](TaskContext context)
         {
             DoCastAOE(SPELL_FEAR);
             context.Repeat(42s);

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
@@ -143,14 +143,13 @@ struct npc_doomfire_spirit : public ScriptedAI
 {
     npc_doomfire_spirit(Creature* creature) : ScriptedAI(creature){ }
 
-    uint32 m_uiChangeTargetTimer;
-    float m_fAngle;
+    uint32 m_uiChangeTargetTimer = 1500;
+    float m_fAngle = urand(0, M_PI * 2);
 
     void Reset() override
     {
         m_uiChangeTargetTimer = 1500;
         m_fAngle = urand(0, M_PI * 2);
-        
     }
 
     Position GetFirstRandomAngleCollisionPosition(float dist, float angle)
@@ -158,7 +157,7 @@ struct npc_doomfire_spirit : public ScriptedAI
         Position pos;
         for (uint32 i = 0; i < 10; ++i)
         {
-            me->WorldObject::GetFirstCollisionPosition(dist, angle);
+            pos = me->WorldObject::GetFirstCollisionPosition(dist, angle);
             if (me->GetDistance(pos) > dist * 0.8f) // if at least 80% distance, good enough
                 break;
             angle += (M_PI / 5); // else try slightly different angle
@@ -173,19 +172,13 @@ struct npc_doomfire_spirit : public ScriptedAI
             float nextOrientation = Position::NormalizeOrientation(me->GetOrientation() + irand(-1, 1) * 0.785402f);
             Position pos = GetFirstRandomAngleCollisionPosition(8.f, nextOrientation); // both orientation and distance verified with sniffs
             me->NearTeleportTo(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), nextOrientation);
-
+            
             m_uiChangeTargetTimer = 1000;
         }
         else
             m_uiChangeTargetTimer -= diff;
 
         scheduler.Update(diff);
-
-        if (!UpdateVictim())
-            return;
-
-        if (me->HasUnitState(UNIT_STATE_CASTING))
-            return;
     }
 };
 
@@ -394,11 +387,6 @@ struct boss_archimonde : public BossAI
         {
             summoned->CastSpell(summoned, SPELL_DOOMFIRE_SPAWN);
             summoned->CastSpell(summoned, SPELL_DOOMFIRE, true, 0, 0, me->GetGUID());
-        }
-        else if (summoned->GetEntry() == CREATURE_DOOMFIRE_SPIRIT)
-        {
-            Position randomPosition = summoned->GetRandomNearPosition(40.0f);
-            summoned->GetMotionMaster()->MovePoint(0, randomPosition);
         }
         else
         {

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
@@ -143,13 +143,14 @@ struct npc_doomfire_spirit : public ScriptedAI
 {
     npc_doomfire_spirit(Creature* creature) : ScriptedAI(creature){ }
 
+    float const m_turnConstant = 0.785402f;
     float m_fAngle = urand(0, M_PI * 2);
 
     void Reset() override
     {
         scheduler.CancelAll();
         ScheduleTimedEvent(0s, [&] {
-            float nextOrientation = Position::NormalizeOrientation(me->GetOrientation() + irand(-1, 1) * 0.785402f);
+            float nextOrientation = Position::NormalizeOrientation(me->GetOrientation() + irand(-1, 1) * m_turnConstant);
             Position pos = GetFirstRandomAngleCollisionPosition(8.f, nextOrientation); // both orientation and distance verified with sniffs
             me->NearTeleportTo(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), nextOrientation);
             }, 1600ms);

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
@@ -143,19 +143,19 @@ struct npc_doomfire_spirit : public ScriptedAI
 {
     npc_doomfire_spirit(Creature* creature) : ScriptedAI(creature){ }
 
-    float const m_turnConstant = 0.785402f;
-    float m_fAngle = urand(0, M_PI * 2);
+    float const _turnConstant = 0.785402f;
+    float _fAngle = urand(0, M_PI * 2);
 
     void Reset() override
     {
         scheduler.CancelAll();
         ScheduleTimedEvent(0s, [&] {
-            float nextOrientation = Position::NormalizeOrientation(me->GetOrientation() + irand(-1, 1) * m_turnConstant);
+            float nextOrientation = Position::NormalizeOrientation(me->GetOrientation() + irand(-1, 1) * _turnConstant);
             Position pos = GetFirstRandomAngleCollisionPosition(8.f, nextOrientation); // both orientation and distance verified with sniffs
             me->NearTeleportTo(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), nextOrientation);
             }, 1600ms);
 
-        m_fAngle = urand(0, M_PI * 2);
+        _fAngle = urand(0, M_PI * 2);
     }
 
     Position GetFirstRandomAngleCollisionPosition(float dist, float angle)

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
@@ -148,11 +148,11 @@ struct npc_doomfire_spirit : public ScriptedAI
     void Reset() override
     {
         scheduler.CancelAll();
-        ScheduleTimedEvent(1500ms, [&] {
+        ScheduleTimedEvent(0s, [&] {
             float nextOrientation = Position::NormalizeOrientation(me->GetOrientation() + irand(-1, 1) * 0.785402f);
             Position pos = GetFirstRandomAngleCollisionPosition(8.f, nextOrientation); // both orientation and distance verified with sniffs
             me->NearTeleportTo(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), nextOrientation);
-            }, 1s);
+            }, 1600ms);
 
         m_fAngle = urand(0, M_PI * 2);
     }

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
@@ -143,12 +143,17 @@ struct npc_doomfire_spirit : public ScriptedAI
 {
     npc_doomfire_spirit(Creature* creature) : ScriptedAI(creature){ }
 
-    uint32 m_uiChangeTargetTimer = 1500;
     float m_fAngle = urand(0, M_PI * 2);
 
     void Reset() override
     {
-        m_uiChangeTargetTimer = 1500;
+        scheduler.CancelAll();
+        ScheduleTimedEvent(1500ms, [&] {
+            float nextOrientation = Position::NormalizeOrientation(me->GetOrientation() + irand(-1, 1) * 0.785402f);
+            Position pos = GetFirstRandomAngleCollisionPosition(8.f, nextOrientation); // both orientation and distance verified with sniffs
+            me->NearTeleportTo(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), nextOrientation);
+            }, 1s);
+
         m_fAngle = urand(0, M_PI * 2);
     }
 
@@ -167,17 +172,6 @@ struct npc_doomfire_spirit : public ScriptedAI
 
     void UpdateAI(uint32 diff) override
     {
-        if (m_uiChangeTargetTimer < diff)
-        {
-            float nextOrientation = Position::NormalizeOrientation(me->GetOrientation() + irand(-1, 1) * 0.785402f);
-            Position pos = GetFirstRandomAngleCollisionPosition(8.f, nextOrientation); // both orientation and distance verified with sniffs
-            me->NearTeleportTo(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), nextOrientation);
-
-            m_uiChangeTargetTimer = 1000;
-        }
-        else
-            m_uiChangeTargetTimer -= diff;
-
         scheduler.Update(diff);
     }
 };

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
@@ -172,7 +172,7 @@ struct npc_doomfire_spirit : public ScriptedAI
             float nextOrientation = Position::NormalizeOrientation(me->GetOrientation() + irand(-1, 1) * 0.785402f);
             Position pos = GetFirstRandomAngleCollisionPosition(8.f, nextOrientation); // both orientation and distance verified with sniffs
             me->NearTeleportTo(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), nextOrientation);
-            
+
             m_uiChangeTargetTimer = 1000;
         }
         else

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
@@ -150,12 +150,12 @@ struct npc_doomfire_spirit : public ScriptedAI
     {
         scheduler.CancelAll();
         ScheduleTimedEvent(0s, [&] {
-            float nextOrientation = Position::NormalizeOrientation(me->GetOrientation() + irand(-1, 1) * _turnConstant);
+            float nextOrientation = Position::NormalizeOrientation(me->GetOrientation() + irand(-1, 1) * turnConstant);
             Position pos = GetFirstRandomAngleCollisionPosition(8.f, nextOrientation); // both orientation and distance verified with sniffs
             me->NearTeleportTo(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), nextOrientation);
             }, 1600ms);
 
-        _fAngle = urand(0, M_PI * 2);
+        fAngle = urand(0, M_PI * 2);
     }
 
     Position GetFirstRandomAngleCollisionPosition(float dist, float angle)


### PR DESCRIPTION
Doomfire movement behavior was ported from CMaNGOS.
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Scripts (bosses, spell scripts, creature scripts).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/7167

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [X] The changes promoted by this pull request come partially from another project (cherry-pick).

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Partially tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
- [X] This pull request requires further testing.
1. Pull Archimonde.
2. Observe Doomfire behavior.
3. Observe Fear timing.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- [ ] Doomfire Spirit can teleport back and forth near collision objects (e.g. fallen trees) and get stuck. This allows the Doomfire itself to stack in a small space.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
