### PR TITLE
fix(Scripts/Shattrath): Daily Dungeon quests holograms

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1719691851180437100.sql
+++ b/data/sql/updates/pending_db_world/rev_1719691851180437100.sql
@@ -4,7 +4,7 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_shattrath_daily_quest' WHERE 
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 24369;
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 24369);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(24369, 0, 0, 1, 1, 0, 100, 1, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - Out of Combat - Do Action ID 1 (No Repeat)'),
-(24369, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - Out of Combat - Do Action ID 1 (No Repeat)'),
-(24369, 0, 2, 3, 101, 0, 100, 0, 1, 30, 60000, 60000, 60000, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On 1 or More Players in Range - Do Action ID 1'),
-(24369, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On 1 or More Players in Range - Do Action ID 1');
+(24369, 0, 0, 1, 1, 0, 100, 1, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 10, 79464, 24854, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - Out of Combat - Do Action ID 1 (No Repeat)'),
+(24369, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 10, 79462, 24410, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - Out of Combat - Do Action ID 1 (No Repeat)'),
+(24369, 0, 2, 3, 101, 0, 100, 0, 1, 30, 60000, 60000, 60000, 0, 223, 1, 0, 0, 0, 0, 0, 10, 79464, 24854, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On 1 or More Players in Range - Do Action ID 1'),
+(24369, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 10, 79462, 24410, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On 1 or More Players in Range - Do Action ID 1');

--- a/data/sql/updates/pending_db_world/rev_1719691851180437100.sql
+++ b/data/sql/updates/pending_db_world/rev_1719691851180437100.sql
@@ -6,7 +6,7 @@ DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` IN (24369
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (24369, 0, 0, 1, 1, 0, 100, 1, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - Out of Combat - Do Action ID 1 (No Repeat)'),
 (24369, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - Out of Combat - Do Action ID 1 (No Repeat)'),
-(24369, 0, 2, 3, 19, 0, 100, 0, 0, 60000, 60000, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On Quest Taken - Do Action ID 1'),
-(24369, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On Quest Taken - Do Action ID 1'),
-(24370, 0, 2, 3, 19, 0, 100, 0, 0, 60000, 60000, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Nether-Stalker Mah\'duun - On Quest Taken - Do Action ID 1'),
-(24370, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Nether-Stalker Mah\'duun - On Quest Taken - Do Action ID 1');
+(24369, 0, 2, 3, 101, 0, 100, 0, 1, 20, 60000, 60000, 60000, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On 1 or More Players in Range - Do Action ID 1'),
+(24369, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On 1 or More Players in Range - Do Action ID 1'),
+(24370, 0, 0, 1, 101, 0, 100, 0, 1, 20, 60000, 60000, 60000, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Nether-Stalker Mah\'duun - On 1 or More Players in Range - Do Action ID 1'),
+(24370, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Nether-Stalker Mah\'duun - On 1 or More Players in Range - Do Action ID 1');

--- a/data/sql/updates/pending_db_world/rev_1719691851180437100.sql
+++ b/data/sql/updates/pending_db_world/rev_1719691851180437100.sql
@@ -1,12 +1,10 @@
 -- Shattrath Daily Normal/Heroic holograms
 UPDATE `creature_template` SET `ScriptName` = 'npc_shattrath_daily_quest' WHERE `entry` IN (24410,24854);
 
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (24369,24370);
-DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` IN (24369,24370));
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 24369;
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 24369);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (24369, 0, 0, 1, 1, 0, 100, 1, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - Out of Combat - Do Action ID 1 (No Repeat)'),
 (24369, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - Out of Combat - Do Action ID 1 (No Repeat)'),
-(24369, 0, 2, 3, 101, 0, 100, 0, 1, 20, 60000, 60000, 60000, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On 1 or More Players in Range - Do Action ID 1'),
-(24369, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On 1 or More Players in Range - Do Action ID 1'),
-(24370, 0, 0, 1, 101, 0, 100, 0, 1, 20, 60000, 60000, 60000, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Nether-Stalker Mah\'duun - On 1 or More Players in Range - Do Action ID 1'),
-(24370, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Nether-Stalker Mah\'duun - On 1 or More Players in Range - Do Action ID 1');
+(24369, 0, 2, 3, 101, 0, 100, 0, 1, 30, 60000, 60000, 60000, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On 1 or More Players in Range - Do Action ID 1'),
+(24369, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On 1 or More Players in Range - Do Action ID 1');

--- a/data/sql/updates/pending_db_world/rev_1719691851180437100.sql
+++ b/data/sql/updates/pending_db_world/rev_1719691851180437100.sql
@@ -1,0 +1,3 @@
+--
+UPDATE `creature_template` SET `ScriptName` = 'npc_shattrath_daily_heroic_quest' WHERE (`entry` = 24854);
+UPDATE `creature_template` SET `ScriptName` = 'npc_shattrath_daily_normal_quest' WHERE (`entry` = 24410);

--- a/data/sql/updates/pending_db_world/rev_1719691851180437100.sql
+++ b/data/sql/updates/pending_db_world/rev_1719691851180437100.sql
@@ -1,3 +1,12 @@
---
-UPDATE `creature_template` SET `ScriptName` = 'npc_shattrath_daily_heroic_quest' WHERE (`entry` = 24854);
-UPDATE `creature_template` SET `ScriptName` = 'npc_shattrath_daily_normal_quest' WHERE (`entry` = 24410);
+-- Shattrath Daily Normal/Heroic holograms
+UPDATE `creature_template` SET `ScriptName` = 'npc_shattrath_daily_quest' WHERE `entry` IN (24410,24854);
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` IN (24369,24370);
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` IN (24369,24370));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(24369, 0, 0, 1, 1, 0, 100, 1, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - Out of Combat - Do Action ID 1 (No Repeat)'),
+(24369, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - Out of Combat - Do Action ID 1 (No Repeat)'),
+(24369, 0, 2, 3, 19, 0, 100, 0, 0, 60000, 60000, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On Quest Taken - Do Action ID 1'),
+(24369, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Wind Trader Zhareem - On Quest Taken - Do Action ID 1'),
+(24370, 0, 2, 3, 19, 0, 100, 0, 0, 60000, 60000, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24854, 15, 0, 0, 0, 0, 0, 0, 'Nether-Stalker Mah\'duun - On Quest Taken - Do Action ID 1'),
+(24370, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 223, 1, 0, 0, 0, 0, 0, 19, 24410, 15, 0, 0, 0, 0, 0, 0, 'Nether-Stalker Mah\'duun - On Quest Taken - Do Action ID 1');

--- a/src/server/scripts/Outland/zone_shattrath_city.cpp
+++ b/src/server/scripts/Outland/zone_shattrath_city.cpp
@@ -284,7 +284,7 @@ enum ShattrathQuests
     QUEST_N_SENTINELS           = 11389, // 24434
     QUEST_N_SISTERS             = 11500, // 24854
 
-    EVENT_UPDATE_QUEST_STATUS   = 1,
+    ACTION_UPDATE_QUEST_STATUS   = 1,
 
     POOL_SHATTRATH_DAILY_H      = 356,
     POOL_SHATTRATH_DAILY_N      = 357,
@@ -300,7 +300,7 @@ struct npc_shattrath_daily_quest : public NullCreatureAI
 
     void DoAction(int32 action) override
     {
-        if (action == EVENT_UPDATE_QUEST_STATUS)
+        if (action == ACTION_UPDATE_QUEST_STATUS)
         {
             if (!me->GetEntry())
                 return;

--- a/src/server/scripts/Outland/zone_shattrath_city.cpp
+++ b/src/server/scripts/Outland/zone_shattrath_city.cpp
@@ -303,9 +303,6 @@ struct npc_shattrath_daily_quest : public NullCreatureAI
         if (action == ACTION_UPDATE_QUEST_STATUS)
         {
             uint32 creature = me->GetEntry();
-            if (creature != NPC_SHATTRATH_DAILY_H || creature != NPC_SHATTRATH_DAILY_N)
-                return;
-
             QueryResult result = CharacterDatabase.Query("SELECT `quest_id` FROM `pool_quest_save` WHERE `pool_id` = '{}'", creature == NPC_SHATTRATH_DAILY_H ? POOL_SHATTRATH_DAILY_H : POOL_SHATTRATH_DAILY_N);
             if (result)
             {

--- a/src/server/scripts/Outland/zone_shattrath_city.cpp
+++ b/src/server/scripts/Outland/zone_shattrath_city.cpp
@@ -303,7 +303,7 @@ struct npc_shattrath_daily_quest : public NullCreatureAI
         if (action == ACTION_UPDATE_QUEST_STATUS)
         {
             uint32 creature = me->GetEntry();
-            if (!creature && (creature != NPC_SHATTRATH_DAILY_H || creature != NPC_SHATTRATH_DAILY_N))
+            if (creature != NPC_SHATTRATH_DAILY_H || creature != NPC_SHATTRATH_DAILY_N)
                 return;
 
             QueryResult result = CharacterDatabase.Query("SELECT `quest_id` FROM `pool_quest_save` WHERE `pool_id` = '{}'", creature == NPC_SHATTRATH_DAILY_H ? POOL_SHATTRATH_DAILY_H : POOL_SHATTRATH_DAILY_N);

--- a/src/server/scripts/Outland/zone_shattrath_city.cpp
+++ b/src/server/scripts/Outland/zone_shattrath_city.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "CreatureScript.h"
+#include "PassiveAI.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
 #include "ScriptedEscortAI.h"
@@ -253,9 +254,170 @@ public:
     };
 };
 
+enum ShattrathQuests
+{
+    // QuestID : Creature Template ID
+
+    QUEST_H_NAZZAN = 11354, // 24410
+    QUEST_H_KELIDAN = 11362, // 24413
+    QUEST_H_BLADEFIST = 11363, // 24414
+    QUEST_H_QUAG = 11368, // 24419
+    QUEST_H_BLACKSTALKER = 11369, // 24420
+    QUEST_H_WARLORD = 11370, // 24421
+    QUEST_H_IKISS = 11372, // 24422
+    QUEST_H_SHAFFAR = 11373, // 24423
+    QUEST_H_EXARCH = 11374, // 24424
+    QUEST_H_MURMUR = 11375, // 24425
+    QUEST_H_EPOCH = 11378, // 24427
+    QUEST_H_AEONUS = 11382, // 24428
+    QUEST_H_WARP = 11384, // 24431
+    QUEST_H_CALCULATOR = 11386, // 21504
+    QUEST_H_SKYRISS = 11388, // 24435
+    QUEST_H_KAEL = 11499, // 24855
+
+    QUEST_N_CENTURIONS = 11364, // 24411
+    QUEST_N_MYRMIDONS = 11371, // 24415
+    QUEST_N_INSTRUCTORS = 11376, // 24426
+    QUEST_N_LORDS = 11383, // 24429
+    QUEST_N_CHANNELERS = 11385, // 24430
+    QUEST_N_DESTROYERS = 11387, // 24432
+    QUEST_N_SENTINELS = 11389, // 24434
+    QUEST_N_SISTERS = 11500 // 24854
+};
+
+struct npc_shattrath_daily_heroic_quest : public NullCreatureAI
+{
+    npc_shattrath_daily_heroic_quest(Creature* c) : NullCreatureAI(c)
+    {
+        QueryResult result = CharacterDatabase.Query("SELECT `quest_id` FROM `pool_quest_save` WHERE `pool_id` = 356;");
+        if (result)
+        {
+            Field *fields = result->Fetch();
+            int quest_id = fields[0].Get<int>();
+            uint32 templateID;
+
+            switch (quest_id)
+            {
+                case QUEST_H_NAZZAN:
+                    templateID = 24410;
+                    break;
+                case QUEST_H_KELIDAN:
+                    templateID = 24413;
+                    break;
+                case QUEST_H_BLADEFIST:
+                    templateID = 24414;
+                    break;
+                case QUEST_H_QUAG:
+                    templateID = 24419;
+                    break;
+                case QUEST_H_BLACKSTALKER:
+                    templateID = 24420;
+                    break;
+                case QUEST_H_WARLORD:
+                    templateID = 24421;
+                    break;
+                case QUEST_H_IKISS:
+                    templateID = 24422;
+                    break;
+                case QUEST_H_SHAFFAR:
+                    templateID = 24423;
+                    break;
+                case QUEST_H_EXARCH:
+                    templateID = 24424;
+                    break;
+                case QUEST_H_MURMUR:
+                    templateID = 24425;
+                    break;
+                case QUEST_H_EPOCH:
+                    templateID = 24427;
+                    break;
+                case QUEST_H_AEONUS:
+                    templateID = 24428;
+                    break;
+                case QUEST_H_WARP:
+                    templateID = 24431;
+                    break;
+                case QUEST_H_CALCULATOR:
+                    templateID = 21504;
+                    break;
+                case QUEST_H_SKYRISS:
+                    templateID = 24435;
+                    break;
+                case QUEST_H_KAEL:
+                    templateID = 24855;
+                    break;
+                default:
+                    break;
+            }
+
+            if (CreatureTemplate const* ci = sObjectMgr->GetCreatureTemplate(templateID))
+            {
+                CreatureModel const* model = ObjectMgr::ChooseDisplayId(ci);
+                me->SetDisplayId(model->CreatureDisplayID, model->DisplayScale);
+            }
+        }
+    }
+
+    void UpdateAI(uint32 /*diff*/) override {}
+};
+
+struct npc_shattrath_daily_normal_quest : public NullCreatureAI
+{
+    npc_shattrath_daily_normal_quest(Creature* c) : NullCreatureAI(c)
+    {
+        QueryResult result = CharacterDatabase.Query("SELECT `quest_id` FROM `pool_quest_save` WHERE `pool_id` = 357");
+        if (result)
+        {
+            Field *fields = result->Fetch();
+            int quest_id = fields[0].Get<int>();
+            uint32 templateID;
+
+            switch (quest_id)
+            {
+                case QUEST_N_CENTURIONS:
+                    templateID = 24411;
+                    break;
+                case QUEST_N_MYRMIDONS:
+                    templateID = 24415;
+                    break;
+                case QUEST_N_INSTRUCTORS:
+                    templateID = 24426;
+                    break;
+                case QUEST_N_LORDS:
+                    templateID = 24429;
+                    break;
+                case QUEST_N_CHANNELERS:
+                    templateID = 24430;
+                    break;
+                case QUEST_N_DESTROYERS:
+                    templateID = 24432;
+                    break;
+                case QUEST_N_SENTINELS:
+                    templateID = 24434;
+                    break;
+                case QUEST_N_SISTERS:
+                    templateID = 24854;
+                    break;
+                default:
+                    break;
+            }
+
+            if (CreatureTemplate const* ci = sObjectMgr->GetCreatureTemplate(templateID))
+            {
+                CreatureModel const* model = ObjectMgr::ChooseDisplayId(ci);
+                me->SetDisplayId(model->CreatureDisplayID, model->DisplayScale);
+            }
+        }
+    }
+
+    void UpdateAI(uint32 /*diff*/) override {}
+};
+
 void AddSC_shattrath_city()
 {
     new npc_shattrathflaskvendors();
     new npc_zephyr();
     new npc_kservant();
+    RegisterCreatureAI(npc_shattrath_daily_heroic_quest);
+    RegisterCreatureAI(npc_shattrath_daily_normal_quest);
 }

--- a/src/server/scripts/Outland/zone_shattrath_city.cpp
+++ b/src/server/scripts/Outland/zone_shattrath_city.cpp
@@ -257,7 +257,7 @@ public:
 enum ShattrathQuests
 {
     // QuestID : Creature Template ID
-
+    // Heroic Daily Quests
     QUEST_H_NAZZAN = 11354, // 24410
     QUEST_H_KELIDAN = 11362, // 24413
     QUEST_H_BLADEFIST = 11363, // 24414
@@ -275,6 +275,7 @@ enum ShattrathQuests
     QUEST_H_SKYRISS = 11388, // 24435
     QUEST_H_KAEL = 11499, // 24855
 
+    // Normal Daily Quests
     QUEST_N_CENTURIONS = 11364, // 24411
     QUEST_N_MYRMIDONS = 11371, // 24415
     QUEST_N_INSTRUCTORS = 11376, // 24426
@@ -282,130 +283,132 @@ enum ShattrathQuests
     QUEST_N_CHANNELERS = 11385, // 24430
     QUEST_N_DESTROYERS = 11387, // 24432
     QUEST_N_SENTINELS = 11389, // 24434
-    QUEST_N_SISTERS = 11500 // 24854
+    QUEST_N_SISTERS = 11500, // 24854
+
+    EVENT_UPDATE_QUEST_STATUS = 1,
+
+    POOL_SHATTRATH_DAILY_H = 356,
+    POOL_SHATTRATH_DAILY_N = 357,
+
+    // Image NPCs
+    NPC_SHATTRATH_DAILY_H = 24854,
+    NPC_SHATTRATH_DAILY_N = 24410,
 };
 
-struct npc_shattrath_daily_heroic_quest : public NullCreatureAI
+struct npc_shattrath_daily_quest : public NullCreatureAI
 {
-    npc_shattrath_daily_heroic_quest(Creature* c) : NullCreatureAI(c)
+    npc_shattrath_daily_quest(Creature* c) : NullCreatureAI(c) {}
+
+    void DoAction(int32 action) override
     {
-        QueryResult result = CharacterDatabase.Query("SELECT `quest_id` FROM `pool_quest_save` WHERE `pool_id` = 356;");
-        if (result)
+        if (action == EVENT_UPDATE_QUEST_STATUS)
         {
-            Field *fields = result->Fetch();
-            int quest_id = fields[0].Get<int>();
-            uint32 templateID;
+            if (!me->GetEntry())
+                return;
 
-            switch (quest_id)
+            uint32 creature = me->GetEntry();
+            QueryResult result = CharacterDatabase.Query("SELECT `quest_id` FROM `pool_quest_save` WHERE `pool_id` = '{}'", creature == NPC_SHATTRATH_DAILY_H ? POOL_SHATTRATH_DAILY_H : POOL_SHATTRATH_DAILY_N);
+            if (result)
             {
-                case QUEST_H_NAZZAN:
-                    templateID = 24410;
-                    break;
-                case QUEST_H_KELIDAN:
-                    templateID = 24413;
-                    break;
-                case QUEST_H_BLADEFIST:
-                    templateID = 24414;
-                    break;
-                case QUEST_H_QUAG:
-                    templateID = 24419;
-                    break;
-                case QUEST_H_BLACKSTALKER:
-                    templateID = 24420;
-                    break;
-                case QUEST_H_WARLORD:
-                    templateID = 24421;
-                    break;
-                case QUEST_H_IKISS:
-                    templateID = 24422;
-                    break;
-                case QUEST_H_SHAFFAR:
-                    templateID = 24423;
-                    break;
-                case QUEST_H_EXARCH:
-                    templateID = 24424;
-                    break;
-                case QUEST_H_MURMUR:
-                    templateID = 24425;
-                    break;
-                case QUEST_H_EPOCH:
-                    templateID = 24427;
-                    break;
-                case QUEST_H_AEONUS:
-                    templateID = 24428;
-                    break;
-                case QUEST_H_WARP:
-                    templateID = 24431;
-                    break;
-                case QUEST_H_CALCULATOR:
-                    templateID = 21504;
-                    break;
-                case QUEST_H_SKYRISS:
-                    templateID = 24435;
-                    break;
-                case QUEST_H_KAEL:
-                    templateID = 24855;
-                    break;
-                default:
-                    break;
-            }
+                Field *fields = result->Fetch();
+                int quest_id = fields[0].Get<int>();
+                uint32 templateID;
 
-            if (CreatureTemplate const* ci = sObjectMgr->GetCreatureTemplate(templateID))
-            {
-                CreatureModel const* model = ObjectMgr::ChooseDisplayId(ci);
-                me->SetDisplayId(model->CreatureDisplayID, model->DisplayScale);
-            }
-        }
-    }
+                if (me->GetEntry() == NPC_SHATTRATH_DAILY_H)
+                {
+                    switch (quest_id)
+                    {
+                        case QUEST_H_NAZZAN:
+                            templateID = 24410;
+                            break;
+                        case QUEST_H_KELIDAN:
+                            templateID = 24413;
+                            break;
+                        case QUEST_H_BLADEFIST:
+                            templateID = 24414;
+                            break;
+                        case QUEST_H_QUAG:
+                            templateID = 24419;
+                            break;
+                        case QUEST_H_BLACKSTALKER:
+                            templateID = 24420;
+                            break;
+                        case QUEST_H_WARLORD:
+                            templateID = 24421;
+                            break;
+                        case QUEST_H_IKISS:
+                            templateID = 24422;
+                            break;
+                        case QUEST_H_SHAFFAR:
+                            templateID = 24423;
+                            break;
+                        case QUEST_H_EXARCH:
+                            templateID = 24424;
+                            break;
+                        case QUEST_H_MURMUR:
+                            templateID = 24425;
+                            break;
+                        case QUEST_H_EPOCH:
+                            templateID = 24427;
+                            break;
+                        case QUEST_H_AEONUS:
+                            templateID = 24428;
+                            break;
+                        case QUEST_H_WARP:
+                            templateID = 24431;
+                            break;
+                        case QUEST_H_CALCULATOR:
+                            templateID = 21504;
+                            break;
+                        case QUEST_H_SKYRISS:
+                            templateID = 24435;
+                            break;
+                        case QUEST_H_KAEL:
+                            templateID = 24855;
+                            break;
+                        default:
+                            break;
+                    }
+                }
 
-    void UpdateAI(uint32 /*diff*/) override {}
-};
+                if (me->GetEntry() == NPC_SHATTRATH_DAILY_N)
+                {
+                    switch (quest_id)
+                    {
+                        case QUEST_N_CENTURIONS:
+                            templateID = 24411;
+                            break;
+                        case QUEST_N_MYRMIDONS:
+                            templateID = 24415;
+                            break;
+                        case QUEST_N_INSTRUCTORS:
+                            templateID = 24426;
+                            break;
+                        case QUEST_N_LORDS:
+                            templateID = 24429;
+                            break;
+                        case QUEST_N_CHANNELERS:
+                            templateID = 24430;
+                            break;
+                        case QUEST_N_DESTROYERS:
+                            templateID = 24432;
+                            break;
+                        case QUEST_N_SENTINELS:
+                            templateID = 24434;
+                            break;
+                        case QUEST_N_SISTERS:
+                            templateID = 24854;
+                            break;
+                        default:
+                            break;
+                    }
+                }
 
-struct npc_shattrath_daily_normal_quest : public NullCreatureAI
-{
-    npc_shattrath_daily_normal_quest(Creature* c) : NullCreatureAI(c)
-    {
-        QueryResult result = CharacterDatabase.Query("SELECT `quest_id` FROM `pool_quest_save` WHERE `pool_id` = 357");
-        if (result)
-        {
-            Field *fields = result->Fetch();
-            int quest_id = fields[0].Get<int>();
-            uint32 templateID;
-
-            switch (quest_id)
-            {
-                case QUEST_N_CENTURIONS:
-                    templateID = 24411;
-                    break;
-                case QUEST_N_MYRMIDONS:
-                    templateID = 24415;
-                    break;
-                case QUEST_N_INSTRUCTORS:
-                    templateID = 24426;
-                    break;
-                case QUEST_N_LORDS:
-                    templateID = 24429;
-                    break;
-                case QUEST_N_CHANNELERS:
-                    templateID = 24430;
-                    break;
-                case QUEST_N_DESTROYERS:
-                    templateID = 24432;
-                    break;
-                case QUEST_N_SENTINELS:
-                    templateID = 24434;
-                    break;
-                case QUEST_N_SISTERS:
-                    templateID = 24854;
-                    break;
-                default:
-                    break;
-            }
-
-            if (CreatureTemplate const* ci = sObjectMgr->GetCreatureTemplate(templateID))
-            {
-                CreatureModel const* model = ObjectMgr::ChooseDisplayId(ci);
-                me->SetDisplayId(model->CreatureDisplayID, model->DisplayScale);
+                if (CreatureTemplate const* ci = sObjectMgr->GetCreatureTemplate(templateID))
+                {
+                    CreatureModel const* model = ObjectMgr::ChooseDisplayId(ci);
+                    me->SetDisplayId(model->CreatureDisplayID, model->DisplayScale);
+                }
             }
         }
     }
@@ -418,6 +421,5 @@ void AddSC_shattrath_city()
     new npc_shattrathflaskvendors();
     new npc_zephyr();
     new npc_kservant();
-    RegisterCreatureAI(npc_shattrath_daily_heroic_quest);
-    RegisterCreatureAI(npc_shattrath_daily_normal_quest);
+    RegisterCreatureAI(npc_shattrath_daily_quest);
 }

--- a/src/server/scripts/Outland/zone_shattrath_city.cpp
+++ b/src/server/scripts/Outland/zone_shattrath_city.cpp
@@ -302,10 +302,10 @@ struct npc_shattrath_daily_quest : public NullCreatureAI
     {
         if (action == ACTION_UPDATE_QUEST_STATUS)
         {
-            if (!me->GetEntry())
+            uint32 creature = me->GetEntry();
+            if (!creature && (creature != NPC_SHATTRATH_DAILY_H || creature != NPC_SHATTRATH_DAILY_N))
                 return;
 
-            uint32 creature = me->GetEntry();
             QueryResult result = CharacterDatabase.Query("SELECT `quest_id` FROM `pool_quest_save` WHERE `pool_id` = '{}'", creature == NPC_SHATTRATH_DAILY_H ? POOL_SHATTRATH_DAILY_H : POOL_SHATTRATH_DAILY_N);
             if (result)
             {
@@ -313,7 +313,7 @@ struct npc_shattrath_daily_quest : public NullCreatureAI
                 int quest_id = fields[0].Get<int>();
                 uint32 templateID;
 
-                if (me->GetEntry() == NPC_SHATTRATH_DAILY_H)
+                if (creature == NPC_SHATTRATH_DAILY_H)
                 {
                     switch (quest_id)
                     {
@@ -370,7 +370,7 @@ struct npc_shattrath_daily_quest : public NullCreatureAI
                     }
                 }
 
-                if (me->GetEntry() == NPC_SHATTRATH_DAILY_N)
+                if (creature == NPC_SHATTRATH_DAILY_N)
                 {
                     switch (quest_id)
                     {
@@ -411,8 +411,6 @@ struct npc_shattrath_daily_quest : public NullCreatureAI
             }
         }
     }
-
-    void UpdateAI(uint32 /*diff*/) override {}
 };
 
 void AddSC_shattrath_city()

--- a/src/server/scripts/Outland/zone_shattrath_city.cpp
+++ b/src/server/scripts/Outland/zone_shattrath_city.cpp
@@ -258,41 +258,40 @@ enum ShattrathQuests
 {
     // QuestID : Creature Template ID
     // Heroic Daily Quests
-    QUEST_H_NAZZAN = 11354, // 24410
-    QUEST_H_KELIDAN = 11362, // 24413
-    QUEST_H_BLADEFIST = 11363, // 24414
-    QUEST_H_QUAG = 11368, // 24419
-    QUEST_H_BLACKSTALKER = 11369, // 24420
-    QUEST_H_WARLORD = 11370, // 24421
-    QUEST_H_IKISS = 11372, // 24422
-    QUEST_H_SHAFFAR = 11373, // 24423
-    QUEST_H_EXARCH = 11374, // 24424
-    QUEST_H_MURMUR = 11375, // 24425
-    QUEST_H_EPOCH = 11378, // 24427
-    QUEST_H_AEONUS = 11382, // 24428
-    QUEST_H_WARP = 11384, // 24431
-    QUEST_H_CALCULATOR = 11386, // 21504
-    QUEST_H_SKYRISS = 11388, // 24435
-    QUEST_H_KAEL = 11499, // 24855
-
+    QUEST_H_NAZZAN              = 11354, // 24410
+    QUEST_H_KELIDAN             = 11362, // 24413
+    QUEST_H_BLADEFIST           = 11363, // 24414
+    QUEST_H_QUAG                = 11368, // 24419
+    QUEST_H_BLACKSTALKER        = 11369, // 24420
+    QUEST_H_WARLORD             = 11370, // 24421
+    QUEST_H_IKISS               = 11372, // 24422
+    QUEST_H_SHAFFAR             = 11373, // 24423
+    QUEST_H_EXARCH              = 11374, // 24424
+    QUEST_H_MURMUR              = 11375, // 24425
+    QUEST_H_EPOCH               = 11378, // 24427
+    QUEST_H_AEONUS              = 11382, // 24428
+    QUEST_H_WARP                = 11384, // 24431
+    QUEST_H_CALCULATOR          = 11386, // 21504
+    QUEST_H_SKYRISS             = 11388, // 24435
+    QUEST_H_KAEL                = 11499, // 24855
     // Normal Daily Quests
-    QUEST_N_CENTURIONS = 11364, // 24411
-    QUEST_N_MYRMIDONS = 11371, // 24415
-    QUEST_N_INSTRUCTORS = 11376, // 24426
-    QUEST_N_LORDS = 11383, // 24429
-    QUEST_N_CHANNELERS = 11385, // 24430
-    QUEST_N_DESTROYERS = 11387, // 24432
-    QUEST_N_SENTINELS = 11389, // 24434
-    QUEST_N_SISTERS = 11500, // 24854
+    QUEST_N_CENTURIONS          = 11364, // 24411
+    QUEST_N_MYRMIDONS           = 11371, // 24415
+    QUEST_N_INSTRUCTORS         = 11376, // 24426
+    QUEST_N_LORDS               = 11383, // 24429
+    QUEST_N_CHANNELERS          = 11385, // 24430
+    QUEST_N_DESTROYERS          = 11387, // 24432
+    QUEST_N_SENTINELS           = 11389, // 24434
+    QUEST_N_SISTERS             = 11500, // 24854
 
-    EVENT_UPDATE_QUEST_STATUS = 1,
+    EVENT_UPDATE_QUEST_STATUS   = 1,
 
-    POOL_SHATTRATH_DAILY_H = 356,
-    POOL_SHATTRATH_DAILY_N = 357,
+    POOL_SHATTRATH_DAILY_H      = 356,
+    POOL_SHATTRATH_DAILY_N      = 357,
 
     // Image NPCs
-    NPC_SHATTRATH_DAILY_H = 24854,
-    NPC_SHATTRATH_DAILY_N = 24410,
+    NPC_SHATTRATH_DAILY_H       = 24854,
+    NPC_SHATTRATH_DAILY_N       = 24410
 };
 
 struct npc_shattrath_daily_quest : public NullCreatureAI


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

We update once Quest gives AI updates and then once (every 60s) on when 1 or more players are within 30y.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15322
- Closes https://github.com/chromiecraft/chromiecraft/issues/5144

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

<details>

![image](https://github.com/azerothcore/azerothcore-wotlk/assets/46330494/2c823eea-4c8c-4fbc-92f3-e6b634d1afcf)

![image](https://github.com/azerothcore/azerothcore-wotlk/assets/46330494/7629eaac-38b9-4e4e-af77-d86a5f86f7d1)

</details>

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

.go c id 24854
Compare daily HC/N quest to the 2 images
Edit pool_quest_save in characters DB
```sql 
SELECT * FROM `pool_quest_save` WHERE `pool_id` IN (356,357);
```
Edit them with questIDs from the script (356H, 357N)
Should update displayID (when more than 1 player is within 30y, 60s cd)


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [x] How can I make this rerun on new pool_quest_save (daily reset)?

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
