### PR TITLE
fix(Core/Pets): Correct Pet size for pets 3

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -2499,16 +2499,11 @@ float Pet::GetNativeObjectScale() const
 {
     uint8 ctFamily = GetCreatureTemplate()->family;
 
-    // hackfix: Edge case where DBC scale values for DEVILSAUR pets make them too small.
-    // Therefore we take data from spirit beast instead.
-    if (ctFamily && ctFamily == CREATURE_FAMILY_DEVILSAUR)
-        ctFamily = CREATURE_FAMILY_SPIRIT_BEAST;
-
     CreatureFamilyEntry const* creatureFamily = sCreatureFamilyStore.LookupEntry(ctFamily);
     if (creatureFamily && creatureFamily->minScale > 0.0f && getPetType() & HUNTER_PET)
     {
         float minScaleLevel = creatureFamily->minScaleLevel;
-        uint8 level = getLevel();
+        uint8 level = GetLevel();
 
         float minLevelScaleMod = level >= minScaleLevel ? (level / minScaleLevel) : 0.0f;
         float maxScaleMod = creatureFamily->maxScaleLevel - minScaleLevel;
@@ -2518,9 +2513,30 @@ float Pet::GetNativeObjectScale() const
 
         float scaleMod = creatureFamily->maxScaleLevel != minScaleLevel ? minLevelScaleMod / maxScaleMod : 0.f;
 
-        float scale = (creatureFamily->maxScale - creatureFamily->minScale) * scaleMod + creatureFamily->minScale;
+        float maxScale = creatureFamily->maxScale;
 
-        scale = std::min(scale, creatureFamily->maxScale);
+        // override maxScale
+        switch (ctFamily)
+        {
+            case CREATURE_FAMILY_CHIMAERA:
+            case CREATURE_FAMILY_CORE_HOUND:
+            case CREATURE_FAMILY_CRAB:
+            case CREATURE_FAMILY_DEVILSAUR:
+            case CREATURE_FAMILY_NETHER_RAY:
+            case CREATURE_FAMILY_RHINO:
+            case CREATURE_FAMILY_SPIDER:
+            case CREATURE_FAMILY_WARP_STALKER:
+            case CREATURE_FAMILY_WASP:
+            case CREATURE_FAMILY_WIND_SERPENT:
+                maxScale = 1.0f;
+                break;
+            default:
+                break;
+        }
+
+        float scale = (maxScale - creatureFamily->minScale) * scaleMod + creatureFamily->minScale;
+
+        scale = std::min(scale, maxScale);
 
         return scale;
     }

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -2499,6 +2499,11 @@ float Pet::GetNativeObjectScale() const
 {
     uint8 ctFamily = GetCreatureTemplate()->family;
 
+    // hackfix: Edge case where DBC scale values for DEVILSAUR pets make them too small.
+    // Therefore we take data from spirit beast instead.
+    if (ctFamily && ctFamily == CREATURE_FAMILY_DEVILSAUR)
+        ctFamily = CREATURE_FAMILY_SPIRIT_BEAST;
+
     CreatureFamilyEntry const* creatureFamily = sCreatureFamilyStore.LookupEntry(ctFamily);
     if (creatureFamily && creatureFamily->minScale > 0.0f && getPetType() & HUNTER_PET)
     {
@@ -2517,11 +2522,6 @@ float Pet::GetNativeObjectScale() const
 
         scale = std::min(scale, creatureFamily->maxScale);
 
-        if (CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(GetNativeDisplayId()))
-        {
-            if (scale < 1.f && displayInfo->scale > 1.f)
-                scale *= displayInfo->scale;
-        }
         return scale;
     }
 

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -2525,6 +2525,7 @@ float Pet::GetNativeObjectScale() const
             case CREATURE_FAMILY_NETHER_RAY:
             case CREATURE_FAMILY_RHINO:
             case CREATURE_FAMILY_SPIDER:
+            case CREATURE_FAMILY_TURTLE:
             case CREATURE_FAMILY_WARP_STALKER:
             case CREATURE_FAMILY_WASP:
             case CREATURE_FAMILY_WIND_SERPENT:


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

scaling strategy based on CreatureDisplayInfoEntry->Scale was wrong, oops

- https://github.com/azerothcore/azerothcore-wotlk/pull/18867

I went through tameable mobs from wow-petopia and assessed correctness

https://www.wow-petopia.com/classic_lk/gallery.php?id=available

I found that overriding maxScale to 1.0f in some cases did the job to achieve correctness:
```
pet, assessment, maxScaling
Chimaera, too small, ~0.6
Core Hound, too small, ~0.3
Crab, too big, ~1.3 
Wasp, too small, ~0.5
Nether ray, too small, ~0.5
Wind Serpent, too small, ~0.7
Spider, too small, ~0.6
Warp Stalker, too small, ~0.6
Rhino, too small, ~0.56
```
Birds of Prey use ~0.8f. 1.0f too big, unchanged
Spirit Beasts are 1.1f, too small if 1.0f, unchanged

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

current state in core:
2:45 level 60 https://youtu.be/8uFbGKkOk64?si=rFe-E9yFJmsndKqa&t=165

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

https://youtu.be/2KVvb7Rfo4M


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

call pet
```
.cast 883
```

tame pet
```
/script PetAbandon(); 
.npc tame
```

tp
```
.go xyz -323.967 434.108 129.699 1 4.83951
```

SQL to spawn mobs
https://gist.github.com/sogladev/c5609339796e5b93988105eb7f40989d


1. use sql above to spawn mobs
2. use tame macro
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
