### PR TITLE
fix(Scripts/Karazhan): Nightbane Combat Abilities

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1719929004534756216.sql
+++ b/data/sql/updates/pending_db_world/rev_1719929004534756216.sql
@@ -1,0 +1,3 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` = 30282 AND `ScriptName` = 'spell_nightbane_fireball_barrage';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES(30282, 'spell_nightbane_fireball_barrage');

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
@@ -20,9 +20,9 @@
 #include "PassiveAI.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
-#include "TaskScheduler.h"
 #include "SpellScript.h"
 #include "SpellScriptLoader.h"
+#include "TaskScheduler.h"
 #include "karazhan.h"
 
 enum Spells

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
@@ -38,8 +38,8 @@ enum Spells
     SPELL_SMOKING_BLAST_T       = 37057,
     SPELL_RAIN_OF_BONES         = 37098,
     SPELL_SUMMON_SKELETON       = 30170,
-    // Both Phases
     SPELL_DISTRACTING_ASH       = 30130,
+    // Both Phases
     SPELL_FIREBALL_BARRAGE      = 30282
 };
 
@@ -191,14 +191,7 @@ struct boss_nightbane : public BossAI
 
     void ScheduleGround()
     {
-        scheduler.Schedule(5s, 10s, GROUP_GROUND, [this](TaskContext context)
-        {
-            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true, false))
-            {
-                DoCast(target, SPELL_DISTRACTING_ASH);
-            }
-            context.Repeat(12s);
-        }).Schedule(18s, 25s, GROUP_GROUND, [this](TaskContext context)
+        scheduler.Schedule(18s, 25s, GROUP_GROUND, [this](TaskContext context)
         {
             DoCastRandomTarget(SPELL_CHARRED_EARTH, 0, 100.0f, true);
             context.Repeat(20s);

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
@@ -21,23 +21,26 @@
 #include "Player.h"
 #include "ScriptedCreature.h"
 #include "TaskScheduler.h"
+#include "SpellScript.h"
+#include "SpellScriptLoader.h"
 #include "karazhan.h"
 
 enum Spells
 {
     // Ground Phase
-    SPELL_RAIN_OF_BONES         = 37098,
-    SPELL_SMOKING_BLAST         = 37057,
-    SPELL_FIREBALL_BARRAGE      = 30282,
-    SPELL_SEARING_CINDERS       = 30127,
-    // Air Phase
-    SPELL_BELLOWING_ROAR        = 39427,
     SPELL_CLEAVE                = 30131,
-    SPELL_CHARRED_EARTH         = 30129,
-    SPELL_DISTRACTING_ASH       = 30130,
-    SPELL_SMOLDERING_BREATH     = 30210,
     SPELL_TAIL_SWEEP            = 25653,
-    SPELL_SUMMON_SKELETON       = 30170
+    SPELL_SMOLDERING_BREATH     = 30210,
+    SPELL_CHARRED_EARTH         = 30129,
+    SPELL_BELLOWING_ROAR        = 36922,
+    // Air Phase
+    SPELL_SMOKING_BLAST         = 30128,
+    SPELL_SMOKING_BLAST_T       = 37057,
+    SPELL_RAIN_OF_BONES         = 37098,
+    SPELL_SUMMON_SKELETON       = 30170,
+    // Both Phases
+    SPELL_DISTRACTING_ASH       = 30130,
+    SPELL_FIREBALL_BARRAGE      = 30282
 };
 
 enum Says
@@ -188,21 +191,28 @@ struct boss_nightbane : public BossAI
 
     void ScheduleGround()
     {
-        scheduler.Schedule(30s, GROUP_GROUND, [this](TaskContext context)
+        scheduler.Schedule(5s, 10s, GROUP_GROUND, [this](TaskContext context)
         {
-            DoCastAOE(SPELL_BELLOWING_ROAR);
-            context.Repeat(30s, 40s);
-        }).Schedule(15s, GROUP_GROUND, [this](TaskContext context)
+            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true, false))
+            {
+                DoCast(target, SPELL_DISTRACTING_ASH);
+            }
+            context.Repeat(12s);
+        }).Schedule(18s, 25s, GROUP_GROUND, [this](TaskContext context)
         {
             DoCastRandomTarget(SPELL_CHARRED_EARTH, 0, 100.0f, true);
             context.Repeat(20s);
-        }).Schedule(10s, GROUP_GROUND, [this](TaskContext context)
+        }).Schedule(25s, 35s, GROUP_GROUND, [this](TaskContext context)
         {
             DoCastVictim(SPELL_SMOLDERING_BREATH);
             context.Repeat(20s);
+        }).Schedule(45s, GROUP_GROUND, [this](TaskContext context)
+        {
+            DoCastAOE(SPELL_BELLOWING_ROAR);
+            context.Repeat(32s, 40s);
         }).Schedule(12s, GROUP_GROUND, [this](TaskContext context)
         {
-            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100, true))
+            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true))
             {
                 if (!me->HasInArc(M_PI, target))
                 {
@@ -210,14 +220,17 @@ struct boss_nightbane : public BossAI
                 }
             }
             context.Repeat(15s);
-        }).Schedule(14s, GROUP_GROUND, [this](TaskContext context)
-        {
-            DoCastRandomTarget(SPELL_SEARING_CINDERS);
-            context.Repeat(10s);
-        }).Schedule(1500ms, GROUP_GROUND, [this](TaskContext context)
+        }).Schedule(5s, GROUP_GROUND, [this](TaskContext context)
         {
             DoCastVictim(SPELL_CLEAVE);
-            context.Repeat(1500ms, 45s);
+            context.Repeat(6s, 12s);
+        }).Schedule(25s, GROUP_GROUND, [this](TaskContext context)
+        {
+            if (SelectTarget(SelectTargetMethod::MinDistance, 0, -40.0f, true))
+            {
+                DoCastAOE(SPELL_FIREBALL_BARRAGE);
+            }
+            context.Repeat(3s);
         });
     }
 
@@ -225,7 +238,7 @@ struct boss_nightbane : public BossAI
     {
         _skeletonSpawnCounter = 0;
 
-        scheduler.Schedule(2s, GROUP_AIR, [this](TaskContext)
+        scheduler.Schedule(2s, GROUP_AIR, [this](TaskContext /*context*/)
         {
             DoResetThreatList();
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f))
@@ -244,26 +257,31 @@ struct boss_nightbane : public BossAI
                     }
                 });
             }
-        }).Schedule(20s, GROUP_AIR, [this](TaskContext context)
+        }).Schedule(15s, GROUP_AIR, [this](TaskContext context)
         {
             if (Unit* target = SelectTarget(SelectTargetMethod::Random))
             {
-                me->SetFacingToObject(target);
-                DoCast(target, SPELL_DISTRACTING_ASH);
+                DoCast(target, SPELL_SMOKING_BLAST_T);
             }
-            context.Repeat(2s); //timer wrong?
-        }).Schedule(25s, GROUP_AIR, [this](TaskContext context)
+            context.Repeat(6s);
+        }).Schedule(15500ms, GROUP_AIR, [this](TaskContext context)
         {
-            //5 seconds added due to double trigger?
-            //trigger for timer in original + in rain of bones
-            //timers need some investigation
             me->SetFacingToObject(me->GetVictim());
             DoCastVictim(SPELL_SMOKING_BLAST);
-            context.Repeat(1500ms); //timer wrong?
-        }).Schedule(13s, GROUP_AIR, [this](TaskContext context)
+            context.Repeat(1500ms);
+        }).Schedule(20s, GROUP_AIR, [this](TaskContext /*context*/)
         {
-            DoCastOnFarAwayPlayers(SPELL_FIREBALL_BARRAGE, false, 80.0f);
-            context.Repeat(20s);
+            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true))
+            {
+                DoCast(target, SPELL_DISTRACTING_ASH);
+            }
+        }).Schedule(14s, GROUP_AIR, [this](TaskContext context)
+        {
+            if (SelectTarget(SelectTargetMethod::MinDistance, 0, -40.0f, true))
+            {
+                DoCastAOE(SPELL_FIREBALL_BARRAGE);
+            }
+            context.Repeat(3s);
         });
     }
 
@@ -407,22 +425,6 @@ struct boss_nightbane : public BossAI
         summons.Summon(summon);
     }
 
-    void DoCastOnFarAwayPlayers(uint32 spellid, bool triggered, float tresholddistance)
-    {
-        //resembles DoCastToAllHostilePlayers a bit/lot
-        ThreatContainer::StorageType targets = me->GetThreatMgr().GetThreatList();
-        for (ThreatContainer::StorageType::const_iterator itr = targets.begin(); itr != targets.end(); ++itr)
-        {
-            if (Unit* unit = ObjectAccessor::GetUnit(*me, (*itr)->getUnitGuid()))
-            {
-                if (unit->IsPlayer() && !unit->IsWithinDist(me, tresholddistance, false))
-                {
-                    me->CastSpell(unit, spellid, triggered);
-                }
-            }
-        }
-    }
-
     void TriggerHealthTakeOff()
     {
         if (_phase != PHASE_GROUND)
@@ -465,7 +467,7 @@ struct boss_nightbane : public BossAI
 
     void ScheduleLand()
     {
-        scheduler.Schedule(30s, GROUP_LAND, [this](TaskContext) /*context*/
+        scheduler.Schedule(35s, GROUP_LAND, [this](TaskContext) /*context*/
         {
             Talk(YELL_LAND_PHASE);
             scheduler.CancelGroup(GROUP_AIR);
@@ -510,7 +512,6 @@ public:
     {
         if (InstanceScript* instance = go->GetInstanceScript())
         {
-            // if (instance->GetBossState(DATA_NIGHTBANE) == NOT_STARTED || instance->GetBossState(DATA_NIGHTBANE) == FAIL)
             if (instance->GetBossState(DATA_NIGHTBANE) == NOT_STARTED)
             {
                 if (Creature* nightbane = instance->GetCreature(DATA_NIGHTBANE))
@@ -532,9 +533,30 @@ struct npc_nightbane_helper_target : public NullCreatureAI
     npc_nightbane_helper_target(Creature* creature) : NullCreatureAI(creature) { me->SetDisableGravity(true); }
 };
 
+// 30282 - Fireball Barrage
+class spell_nightbane_fireball_barrage : public SpellScript
+{
+    PrepareSpellScript(spell_nightbane_fireball_barrage);
+
+    void FilterTargets(std::list<WorldObject*>& targets)
+    {
+        Unit* caster = GetCaster();
+        targets.remove_if([&](WorldObject* target) -> bool
+        {
+            return !target->IsPlayer() || caster->IsWithinCombatRange(target->ToUnit(), 40.0f);
+        });
+    }
+
+    void Register() override
+    {
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_nightbane_fireball_barrage::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENEMY);
+    }
+};
+
 void AddSC_boss_nightbane()
 {
     RegisterKarazhanCreatureAI(boss_nightbane);
     new go_blackened_urn();
     RegisterKarazhanCreatureAI(npc_nightbane_helper_target);
+    RegisterSpellScript(spell_nightbane_fireball_barrage);
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).


### Air phase
air phase increased by 5s to match DBM "time until land"
https://github.com/DeadlyBossMods/DBM-BurningCrusade/blob/main/DBM-Raids-BC/Karazhan/Nightbane.lua

smoke blast:
previous: cast smoke blast trigger to random targets
now: uses the 2 smoke blast spells
1. instant cast smoking blast to random
2. smoking blast cast to highest threat

### Ground

update fear spellId:
use sniffed fear spell 36922
increases cast time from 1.5s to 2.5s

adjusted fear timing based on DBM

adjust other timings based on WCL, not sure on rescheduling/repeat timers

`Target Charred Earth`  should trigger ground effect, however it is cast directly, not used

### Both phases

distracting ash:
cast during air phase ✅
cast during ground phase ❓ **needs opinion**

not present in wrath prepatch 2008: https://www.youtube.com/watch?v=J8ZokQPr8lI
not present during ground phase in a solo sniff of Karazhan on wrath classic. Presume it is not cast on tank? Only casted on tank during air phase. Or it is only cast during air phase
visible in TBC classic VOD: https://youtu.be/Wx1XsKoh0wk?si=tp-BcAaELKGX7247&t=72

"hover" animation is due to DBC animationID 183 DragonSpitHover which is present in 335 DBC

2 versions of distracting ash:
1 which reduces chance to hit, used post nerf 2.1 which has DragonSpitHover animation
1 which reduces range of abilities, does not have DragonSpitHover, used pre 2.1

from prepatch logs (see below) it seems Nightbane can cast this one time during air phase

fireball_barrage:
every 3 seconds, check if can cast Fireball Barrage
range check reduced to >= 40yd
range only checked during ground phase and air phase, not while transitioning
no longer barrages entire raid if a player is out of range, only targets players that are out of range

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/18891

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

distracting ash ground phase
https://youtu.be/Wx1XsKoh0wk?si=tp-BcAaELKGX7247&t=72

WCL Aug 31 '22 

wrath pre patch

speed kill with skipped ground phases

https://classic.warcraftlogs.com/reports/7nrz98TtXqRkdAj1#view=replay&fight=21

picture of events in case of archive: https://i.imgur.com/4sJ0xRs.jpeg


WCL Aug 8 '22
events casts https://classic.warcraftlogs.com/reports/fXj6w4JbDR12aHqP#fight=25&type=damage-done

replay https://classic.warcraftlogs.com/reports/fXj6w4JbDR12aHqP#fight=25&view=replay

Rain of bone complete, 15 seconds till last air phase cast

picture of events in case of archive: https://i.imgur.com/4ZOseHN.jpeg

WCL Aug 15 '22. Wrath pre patch Aug 30 '22
events cast https://classic.warcraftlogs.com/reports/Hk4fBK18JZygbhXm#fight=26&type=casts&hostility=1&source=76&view=events

picture of events in case of archive: https://i.imgur.com/YChj2Yq.jpeg

replay https://classic.warcraftlogs.com/reports/Hk4fBK18JZygbhXm#fight=26&hostility=1&view=replay

wrath prepatch 2008
https://www.youtube.com/watch?v=J8ZokQPr8lI

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .go ga id 194092
4. .damage 250000 to trigger an air phase
5.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
