### PR TITLE
fix(Scripts/Spells): warlock seed of corruption

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1719253714347835736.sql
+++ b/data/sql/updates/pending_db_world/rev_1719253714347835736.sql
@@ -4,8 +4,8 @@ INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES(32865, 'spell
 DELETE FROM `spell_script_names` WHERE `spell_id` IN (-27243, 32863, 38252, 44141, 70388);
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (-27243, 'spell_warl_seed_of_corruption_aura'),
-(32863,  'spell_warl_seed_of_corruption_aura'),
-(38252,  'spell_warl_seed_of_corruption_aura'),
-(44141,  'spell_warl_seed_of_corruption_aura'),
-(70388,  'spell_warl_seed_of_corruption_aura');
-UPDATE `spell_script_names` SET `ScriptName`='spell_warl_seed_of_corruption_aura' WHERE `spell_id` IN (36123, 39367) AND `ScriptName` = 'spell_zereketh_seed_of_corruption';
+(32863,  'spell_warl_seed_of_corruption_generic_aura'),
+(38252,  'spell_warl_seed_of_corruption_generic_aura'),
+(44141,  'spell_warl_seed_of_corruption_generic_aura'),
+(70388,  'spell_warl_seed_of_corruption_generic_aura');
+UPDATE `spell_script_names` SET `ScriptName`='spell_warl_seed_of_corruption_generic_aura' WHERE `spell_id` IN (36123, 39367) AND `ScriptName` = 'spell_zereketh_seed_of_corruption';

--- a/data/sql/updates/pending_db_world/rev_1719253714347835736.sql
+++ b/data/sql/updates/pending_db_world/rev_1719253714347835736.sql
@@ -1,9 +1,11 @@
 --
-DELETE FROM `spell_script_names` WHERE `spell_id` = 32865;
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES(32865, 'spell_warl_seed_of_corruption');
-DELETE FROM `spell_script_names` WHERE `spell_id` IN (-27243, 32863, 38252, 44141, 70388);
+UPDATE `spell_script_names` SET `ScriptName`='spell_warl_seed_of_corruption_damage' WHERE `spell_id` = -27285 AND `ScriptName` = 'spell_warl_seed_of_corruption';
+DELETE FROM `spell_script_names` WHERE `spell_id` = 32865 AND `ScriptName` = 'spell_warl_seed_of_corruption_damage';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES(32865, 'spell_warl_seed_of_corruption_damage');
+DELETE FROM `spell_script_names` WHERE `spell_id` = -27243 AND `ScriptName` = 'spell_warl_seed_of_corruption_aura';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (-27243, 'spell_warl_seed_of_corruption_aura');
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (32863, 38252, 44141, 70388) AND `ScriptName` = 'spell_warl_seed_of_corruption_generic_aura';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
-(-27243, 'spell_warl_seed_of_corruption_aura'),
 (32863,  'spell_warl_seed_of_corruption_generic_aura'),
 (38252,  'spell_warl_seed_of_corruption_generic_aura'),
 (44141,  'spell_warl_seed_of_corruption_generic_aura'),

--- a/data/sql/updates/pending_db_world/rev_1719253714347835736.sql
+++ b/data/sql/updates/pending_db_world/rev_1719253714347835736.sql
@@ -1,0 +1,11 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` = -27243;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES(-27243, 'spell_warl_seed_of_corruption_aura');
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (32863, 38252, 44141, 70388);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(32863, 'spell_warl_seed_of_corruption_generic_aura'),
+(38252, 'spell_warl_seed_of_corruption_generic_aura'),
+(44141, 'spell_warl_seed_of_corruption_generic_aura'),
+(70388, 'spell_warl_seed_of_corruption_generic_aura');
+-- spell_zereketh_seed_of_corruption to generic
+UPDATE `spell_script_names` SET `ScriptName`='spell_warl_seed_of_corruption_generic_aura' WHERE `spell_id` IN (36123, 39367);

--- a/data/sql/updates/pending_db_world/rev_1719253714347835736.sql
+++ b/data/sql/updates/pending_db_world/rev_1719253714347835736.sql
@@ -1,13 +1,11 @@
 --
 DELETE FROM `spell_script_names` WHERE `spell_id` = 32865;
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES(32865, 'spell_warl_seed_of_corruption');
-DELETE FROM `spell_script_names` WHERE `spell_id` = -27243;
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES(-27243, 'spell_warl_seed_of_corruption_aura');
-DELETE FROM `spell_script_names` WHERE `spell_id` IN (32863, 38252, 44141, 70388);
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (-27243, 32863, 38252, 44141, 70388);
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
-(32863, 'spell_warl_seed_of_corruption_generic_aura'),
-(38252, 'spell_warl_seed_of_corruption_generic_aura'),
-(44141, 'spell_warl_seed_of_corruption_generic_aura'),
-(70388, 'spell_warl_seed_of_corruption_generic_aura');
--- spell_zereketh_seed_of_corruption to generic
-UPDATE `spell_script_names` SET `ScriptName`='spell_warl_seed_of_corruption_generic_aura' WHERE `spell_id` IN (36123, 39367);
+(-27243, 'spell_warl_seed_of_corruption_aura'),
+(32863,  'spell_warl_seed_of_corruption_aura'),
+(38252,  'spell_warl_seed_of_corruption_aura'),
+(44141,  'spell_warl_seed_of_corruption_aura'),
+(70388,  'spell_warl_seed_of_corruption_aura');
+UPDATE `spell_script_names` SET `ScriptName`='spell_warl_seed_of_corruption_aura' WHERE `spell_id` IN (36123, 39367) AND `ScriptName` = 'spell_zereketh_seed_of_corruption';

--- a/data/sql/updates/pending_db_world/rev_1719253714347835736.sql
+++ b/data/sql/updates/pending_db_world/rev_1719253714347835736.sql
@@ -1,4 +1,6 @@
 --
+DELETE FROM `spell_script_names` WHERE `spell_id` = 32865;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES(32865, 'spell_warl_seed_of_corruption');
 DELETE FROM `spell_script_names` WHERE `spell_id` = -27243;
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES(-27243, 'spell_warl_seed_of_corruption_aura');
 DELETE FROM `spell_script_names` WHERE `spell_id` IN (32863, 38252, 44141, 70388);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7128,60 +7128,6 @@ bool Unit::HandleDummyAuraProc(Unit* victim, uint32 damage, AuraEffect* triggere
             }
         case SPELLFAMILY_WARLOCK:
             {
-                // Seed of Corruption
-                if (dummySpell->SpellFamilyFlags[1] & 0x00000010)
-                {
-                    if (procSpell && procSpell->SpellFamilyFlags[1] & 0x8000)
-                        return false;
-                    // if damage is more than need or target die from damage deal finish spell
-                    if (triggeredByAura->GetAmount() <= int32(damage) || GetHealth() <= damage)
-                    {
-                        // remember guid before aura delete
-                        ObjectGuid casterGuid = triggeredByAura->GetCasterGUID();
-
-                        // Remove aura (before cast for prevent infinite loop handlers)
-                        RemoveAurasDueToSpell(triggeredByAura->GetId());
-
-                        uint32 spell = sSpellMgr->GetSpellWithRank(27285, dummySpell->GetRank());
-
-                        // Cast finish spell (triggeredByAura already not exist!)
-                        if (Unit* caster = ObjectAccessor::GetUnit(*this, casterGuid))
-                        {
-                            this->CastSpell(this, 37826, true); // VISUAL!
-                            caster->CastSpell(this, spell, true, castItem);
-                        }
-
-                        return true;                            // no hidden cooldown
-                    }
-
-                    // Damage counting
-                    triggeredByAura->SetAmount(triggeredByAura->GetAmount() - damage);
-                    return true;
-                }
-                // Seed of Corruption (Mobs cast) - no die req
-                if (dummySpell->SpellFamilyFlags.IsEqual(0, 0, 0) && dummySpell->SpellIconID == 1932)
-                {
-                    // if damage is more than need deal finish spell
-                    if (triggeredByAura->GetAmount() <= int32(damage))
-                    {
-                        // remember guid before aura delete
-                        ObjectGuid casterGuid = triggeredByAura->GetCasterGUID();
-
-                        // Remove aura (before cast for prevent infinite loop handlers)
-                        RemoveAurasDueToSpell(triggeredByAura->GetId());
-
-                        // Cast finish spell (triggeredByAura already not exist!)
-                        if (Unit* caster = ObjectAccessor::GetUnit(*this, casterGuid))
-                        {
-                            this->CastSpell(this, 37826, true); // VISUAL!
-                            caster->CastSpell(this, 32865, true, castItem);
-                        }
-                        return true;                            // no hidden cooldown
-                    }
-                    // Damage counting
-                    triggeredByAura->SetAmount(triggeredByAura->GetAmount() - damage);
-                    return true;
-                }
                 switch (dummySpell->Id)
                 {
                     // Nightfall

--- a/src/server/scripts/Outland/TempestKeep/arcatraz/boss_zereketh_the_unbound.cpp
+++ b/src/server/scripts/Outland/TempestKeep/arcatraz/boss_zereketh_the_unbound.cpp
@@ -79,37 +79,8 @@ struct boss_zereketh_the_unbound : public BossAI
     }
 };
 
-// 36123, 39367 -- Seed of Corruption
-class spell_zereketh_seed_of_corruption: public AuraScript
-{
-    PrepareAuraScript(spell_zereketh_seed_of_corruption);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_CORRUPTION_PROC });
-    }
-
-    void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& /*eventInfo*/)
-    {
-        PreventDefaultAction();
-        uint32 val = GetSpellInfo()->GetEffect(EFFECT_1).BasePoints;
-        GetTarget()->RemoveAurasDueToSpell(GetSpellInfo()->Id);
-
-        if (GetCaster())
-        {
-            GetCaster()->CastCustomSpell(SPELL_CORRUPTION_PROC, SPELLVALUE_BASE_POINT0, val, GetTarget(), true);
-        }
-    }
-
-    void Register() override
-    {
-        OnEffectProc += AuraEffectProcFn(spell_zereketh_seed_of_corruption::HandleProc, EFFECT_1, SPELL_AURA_DUMMY);
-    }
-};
-
 void AddSC_boss_zereketh_the_unbound()
 {
     RegisterArcatrazCreatureAI(boss_zereketh_the_unbound);
-    RegisterSpellScript(spell_zereketh_seed_of_corruption);
 }
 

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -762,7 +762,7 @@ public:
             return;
 
         AuraRemoveMode removeMode = GetTargetApplication()->GetRemoveMode();
-        if (IsExpired() || (removeMode != AURA_REMOVE_BY_DEFAULT && (_isGeneric || removeMode != AURA_REMOVE_BY_DEATH)))
+        if (removeMode != AURA_REMOVE_BY_DEFAULT && (_isGeneric || removeMode != AURA_REMOVE_BY_DEATH))
             return;
 
         if (_isGeneric)

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -706,22 +706,9 @@ class spell_warl_seed_of_corruption : public SpellScript
 };
 
 // -27243 - Seed of Corruption
-// Monster spells, triggered only on detonation threshold reached (not on death)
-// 32863 - Seed of Corruption
-// 36123 - Seed of Corruption
-// 38252 - Seed of Corruption
-// 39367 - Seed of Corruption
-// 44141 - Seed of Corruption
-// 70388 - Seed of Corruption
 class spell_warl_seed_of_corruption_aura: public AuraScript
 {
     PrepareAuraScript(spell_warl_seed_of_corruption_aura);
-
-    bool Load() override
-    {
-        _isPlayerSpell = GetSpellInfo()->IsRankOf(sSpellMgr->GetSpellInfo(SPELL_WARLOCK_SEED_OF_CORRUPTION_R1));
-        return true;
-    }
 
     bool Validate(SpellInfo const* /*spellInfo*/) override
     {
@@ -729,7 +716,6 @@ class spell_warl_seed_of_corruption_aura: public AuraScript
             SPELL_WARLOCK_SEED_OF_CORRUPTION_DAMAGE_R1,
             SPELL_WARLOCK_SEED_OF_CORRUPTION_DAMAGE_R2,
             SPELL_WARLOCK_SEED_OF_CORRUPTION_DAMAGE_R3,
-            SPELL_WARLOCK_SEED_OF_CORRUPTION_DAMAGE_GENERIC,
             SPELL_WARLOCK_SEED_OF_CORRUPTION_VISUAL
         });
     }
@@ -749,14 +735,7 @@ class spell_warl_seed_of_corruption_aura: public AuraScript
             return;
 
         GetTarget()->CastSpell(GetTarget(), SPELL_WARLOCK_SEED_OF_CORRUPTION_VISUAL, true, nullptr, aurEff);
-        if (_isPlayerSpell)
-        {
-            GetCaster()->CastSpell(GetTarget(), sSpellMgr->GetSpellWithRank(SPELL_WARLOCK_SEED_OF_CORRUPTION_DAMAGE_R1, GetSpellInfo()->GetRank()), true, nullptr, aurEff);
-        }
-        else
-        {
-            GetCaster()->CastCustomSpell(SPELL_WARLOCK_SEED_OF_CORRUPTION_DAMAGE_GENERIC, SPELLVALUE_BASE_POINT0, GetSpellInfo()->GetEffect(EFFECT_1).CalcValue(), GetTarget(), true, nullptr, aurEff);
-        }
+        GetCaster()->CastSpell(GetTarget(), sSpellMgr->GetSpellWithRank(SPELL_WARLOCK_SEED_OF_CORRUPTION_DAMAGE_R1, GetSpellInfo()->GetRank()), true, nullptr, aurEff);
     }
 
     void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
@@ -787,16 +766,60 @@ class spell_warl_seed_of_corruption_aura: public AuraScript
 
     void Register() override
     {
-        if (_isPlayerSpell)
-        {
-            DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_warl_seed_of_corruption_aura::CalculateAmount, EFFECT_1, SPELL_AURA_DUMMY);
-            AfterEffectRemove += AuraEffectRemoveFn(spell_warl_seed_of_corruption_aura::OnRemove, EFFECT_0, SPELL_AURA_PERIODIC_DAMAGE, AURA_EFFECT_HANDLE_REAL);
-        }
+        DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_warl_seed_of_corruption_aura::CalculateAmount, EFFECT_1, SPELL_AURA_DUMMY);
+        AfterEffectRemove += AuraEffectRemoveFn(spell_warl_seed_of_corruption_aura::OnRemove, EFFECT_0, SPELL_AURA_PERIODIC_DAMAGE, AURA_EFFECT_HANDLE_REAL);
         OnEffectProc += AuraEffectProcFn(spell_warl_seed_of_corruption_aura::HandleProc, EFFECT_1, SPELL_AURA_DUMMY);
     }
+};
 
-private:
-    bool _isPlayerSpell;
+// Monster spells, triggered only on detonation threshold reached (not on death)
+// 32863 - Seed of Corruption
+// 36123 - Seed of Corruption
+// 38252 - Seed of Corruption
+// 39367 - Seed of Corruption
+// 44141 - Seed of Corruption
+// 70388 - Seed of Corruption
+class spell_warl_seed_of_corruption_generic_aura: public AuraScript
+{
+    PrepareAuraScript(spell_warl_seed_of_corruption_generic_aura);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_WARLOCK_SEED_OF_CORRUPTION_DAMAGE_GENERIC, SPELL_WARLOCK_SEED_OF_CORRUPTION_VISUAL });
+    }
+
+    void Detonate(AuraEffect const* aurEff)
+    {
+        if (!GetCaster() || !GetTarget())
+            return;
+
+        GetTarget()->CastSpell(GetTarget(), SPELL_WARLOCK_SEED_OF_CORRUPTION_VISUAL, true, nullptr, aurEff);
+        GetCaster()->CastCustomSpell(SPELL_WARLOCK_SEED_OF_CORRUPTION_DAMAGE_GENERIC, SPELLVALUE_BASE_POINT0, GetSpellInfo()->GetEffect(EFFECT_1).CalcValue(), GetTarget(), true, nullptr, aurEff);
+    }
+
+    void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
+    {
+        PreventDefaultAction();
+        DamageInfo* damageInfo = eventInfo.GetDamageInfo();
+        if (!damageInfo || !damageInfo->GetDamage())
+            return;
+
+        int32 remainingDamage = aurEff->GetAmount() - damageInfo->GetDamage();
+        if (remainingDamage > 0)
+        {
+            GetAura()->GetEffect(EFFECT_1)->SetAmount(remainingDamage);
+        }
+        else // damage threshold has been reached
+        {
+            Remove(AURA_REMOVE_BY_DEFAULT);
+            Detonate(aurEff);
+        }
+    }
+
+    void Register() override
+    {
+        OnEffectProc += AuraEffectProcFn(spell_warl_seed_of_corruption_generic_aura::HandleProc, EFFECT_1, SPELL_AURA_DUMMY);
+    }
 };
 
 // 29858 - Soulshatter
@@ -1447,6 +1470,7 @@ void AddSC_warlock_spell_scripts()
     RegisterSpellScript(spell_warl_ritual_of_doom_effect);
     RegisterSpellScript(spell_warl_seed_of_corruption);
     RegisterSpellScript(spell_warl_seed_of_corruption_aura);
+    RegisterSpellScript(spell_warl_seed_of_corruption_generic_aura);
     RegisterSpellScript(spell_warl_shadow_ward);
     RegisterSpellScript(spell_warl_siphon_life);
     RegisterSpellScript(spell_warl_soulshatter);

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -676,9 +676,10 @@ class spell_warl_ritual_of_doom_effect : public SpellScript
 };
 
 // -27285 - Seed of Corruption
-class spell_warl_seed_of_corruption : public SpellScript
+// 32865 - Seed of Corruption
+class spell_warl_seed_of_corruption_damage : public SpellScript
 {
-    PrepareSpellScript(spell_warl_seed_of_corruption);
+    PrepareSpellScript(spell_warl_seed_of_corruption_damage);
 
     void FilterTargets(std::list<WorldObject*>& targets)
     {
@@ -701,7 +702,7 @@ class spell_warl_seed_of_corruption : public SpellScript
 
     void Register() override
     {
-        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_warl_seed_of_corruption::FilterTargets, EFFECT_0, TARGET_UNIT_DEST_AREA_ENEMY);
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_warl_seed_of_corruption_damage::FilterTargets, EFFECT_0, TARGET_UNIT_DEST_AREA_ENEMY);
     }
 };
 
@@ -1468,7 +1469,7 @@ void AddSC_warlock_spell_scripts()
     RegisterSpellScript(spell_warl_health_funnel);
     RegisterSpellScript(spell_warl_life_tap);
     RegisterSpellScript(spell_warl_ritual_of_doom_effect);
-    RegisterSpellScript(spell_warl_seed_of_corruption);
+    RegisterSpellScript(spell_warl_seed_of_corruption_damage);
     RegisterSpellScript(spell_warl_seed_of_corruption_aura);
     RegisterSpellScript(spell_warl_seed_of_corruption_generic_aura);
     RegisterSpellScript(spell_warl_shadow_ward);

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -736,7 +736,7 @@ public:
             return;
 
         // effect 1 scales with 14% of caster's SP (DBC data)
-        amount = GetCaster()->SpellDamageBonusDone(GetUnitOwner(), GetSpellInfo(), amount, SPELL_DIRECT_DAMAGE, aurEff->GetEffIndex(), aurEff->GetPctMods());
+        amount = GetCaster()->SpellDamageBonusDone(GetUnitOwner(), GetSpellInfo(), amount, DOT, aurEff->GetEffIndex(), aurEff->GetPctMods());
     }
 
     void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -705,7 +705,7 @@ class spell_warl_seed_of_corruption : public SpellScript
 };
 
 // -27243 - Seed of Corruption
-// Monster spells, triggered only on amount drop (not on death)
+// Monster spells, triggered only on detonation threshold reached (not on death)
 // 32863 - Seed of Corruption
 // 36123 - Seed of Corruption
 // 38252 - Seed of Corruption


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

there are 2 kinds of seed of corruption spells:
1. player seed of corruption (r1,r2,r3)
2. generic seed of corruption cast by NPCs

differences:
1. player seed procs on creature death
1. player seed detonation threshold scales with spellpower

changes:
1. move seed proc handling from `unit.cpp` to warlock spellscript in `spell_warlock.cpp`
2. npc seed aoe: add LoS target selection
3. player seed: add damage threshold scaling with spellpower
4. player seed: proc damage on death
5. npc seed: deals damage using customspell with bp read from DBC, replaces need for custom spellscript

data detonation threshold with rank 3 seed of corruption:
before:
0sp 1518
1370sp 1518
after:
0sp 1518
1370sp 1860

do NPC spells detonate AoE hit their original target?
if not, should be filtered with `targets.remove(GetExplTargetUnit());`
for player seed AoE `GetExplTargetUnit()` is null, but is not null for NPC.


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16059
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16060
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16065

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

seed scripts for warlock + generic in TC335 https://github.com/TrinityCore/TrinityCore/commit/2ff855054f52bf2dcf81aa7a7da7bab7f8a99686#diff-ea612aafadff90005e88b243eb000369be9e5cb6f8dc85a008d31e42b156e0ec

detonation threshold scaling added in https://github.com/TrinityCore/TrinityCore/commit/df5afca27859058f725c3dc9964d967aa89ff756

player detonation hits the original target: TBC footage 0:30 https://youtu.be/j_SHaZYaoh8?si=Z4yeQ4MdqbFlw54_&t=34


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

```
npc with low hp
.npc add 2895  
npc with high hp
.npc add 3886

target npc
shield wall
.cast self 41191
dispel
.cast self 4987
```

test damage detonate
test death detonate
test evade no detonate
test expire no detonate
test dispel no detonate


damage threshold tested with debugger or possible ingame by:
increase spell power
```
staff
.add 50731
sp enchant bracer
.add 38997 
sp enchant staff
.add 45056
sp gems
.add 40113 3
```

with 1052sp: r3 seed, wait 3 ticks, cast r1 seed, tick #4 will explode and damage triggers r1 explode

only procs once if target dies by final seed
r3 seed, wait 3 ticks, reduce target hp to <400 so it dies on next tick


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
