### PR TITLE
chore(Scripts/Archimonde): removed unused variable

### DIFF
--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
@@ -19,7 +19,6 @@
 #include "Player.h"
 #include "ScriptedCreature.h"
 #include "SpellAuraEffects.h"
-#include "SpellAuras.h"
 #include "SpellScript.h"
 #include "SpellScriptLoader.h"
 #include "hyjal.h"
@@ -504,7 +503,7 @@ class spell_doomfire : public AuraScript
         int32 bp = GetSpellInfo()->Effects[EFFECT_1].CalcValue();
         float tickCoef = (static_cast<float>(aurEff->GetTickNumber() - 1) / aurEff->GetTotalTicks()); // Tick moved back to ensure proper damage on each tick
         int32 damage = bp - (bp*tickCoef);
-        SpellCastResult result = target->CastCustomSpell(target, SPELL_DOOMFIRE_DOT, &damage, &damage, &damage, true, nullptr, nullptr, target->GetGUID());
+        target->CastCustomSpell(target, SPELL_DOOMFIRE_DOT, &damage, &damage, &damage, true, nullptr, nullptr, target->GetGUID());
     }
 
     void Register() override


### PR DESCRIPTION
The `result` variable seems not used (this is also triggering a new warning when compiling with clang 15 no-pch)