### PR TITLE
fix(DB/SAI): 'Threat from Above' giving double credit on kill

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1720533126868678600.sql
+++ b/data/sql/updates/pending_db_world/rev_1720533126868678600.sql
@@ -1,0 +1,10 @@
+-- Quest: Threat from Above, creatures already have KillCredit for 23450
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 22143) AND (`source_type` = 0) AND (`id` IN (4));
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 22144) AND (`source_type` = 0) AND (`id` IN (4));
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 22148) AND (`source_type` = 0) AND (`id` IN (2));
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 23022);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(23022, 0, 0, 0, 0, 0, 100, 0, 0, 0, 2400, 3800, 0, 0, 11, 15232, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Gordunni Soulreaper - In Combat - Cast \'Shadow Bolt\''),
+(23022, 0, 1, 0, 0, 0, 100, 0, 4000, 6000, 18000, 25000, 0, 0, 11, 20464, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Gordunni Soulreaper - In Combat - Cast \'Summon Skeleton\''),
+(23022, 0, 2, 0, 2, 0, 100, 0, 0, 30, 30000, 35000, 0, 0, 11, 20743, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Gordunni Soulreaper - Between 0-30% Health - Cast \'Drain Life\'');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Creatures already had KillCredit for 23450
Also correct [Gordunni Soulreaper's](https://wowgaming.altervista.org/aowow/?npc=23022) "smart" script

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/18406
- Closes https://github.com/chromiecraft/chromiecraft/issues/6611

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://youtu.be/P2-OXOH-OIQ?t=83 (even source for that drainlife has castflag 1(was already there))

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

.quest add 11096
.go c id 22143
kill

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Missing [Gordunni Soulreapers](https://wowgaming.altervista.org/aowow/?npc=23022) spawns
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
