### PR TITLE
fix(Scripts/Spells): warlock demonic pact

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1720633619992216684.sql
+++ b/data/sql/updates/pending_db_world/rev_1720633619992216684.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (53646, 54909);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(53646, 'spell_warl_demonic_pact_aura'),
+(54909, 'spell_warl_demonic_pact_aura');

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9692,30 +9692,6 @@ bool Unit::HandleProcTriggerSpell(Unit* victim, uint32 damage, AuraEffect* trigg
                     return false;
                 break;
             }
-        // Demonic Pact
-        case 48090:
-            {
-                // Get talent aura from owner
-                if (IsPet())
-                    if (Unit* owner = GetOwner())
-                    {
-                        if (HasSpellCooldown(trigger_spell_id))
-                            return false;
-                        AddSpellCooldown(trigger_spell_id, 0, cooldown);
-
-                        if (AuraEffect* aurEff = owner->GetDummyAuraEffect(SPELLFAMILY_WARLOCK, 3220, 0))
-                        {
-                            int32 spellPower = owner->SpellBaseDamageBonusDone(SpellSchoolMask(SPELL_SCHOOL_MASK_MAGIC));
-                            if (AuraEffect const* demonicAuraEffect = GetAuraEffect(trigger_spell_id, EFFECT_0))
-                                spellPower -= demonicAuraEffect->GetAmount();
-
-                            basepoints0 = int32((aurEff->GetAmount() * spellPower + 100.0f) / 100.0f);
-                            CastCustomSpell(this, trigger_spell_id, &basepoints0, &basepoints0, nullptr, true, castItem, triggeredByAura);
-                            return true;
-                        }
-                    }
-                break;
-            }
         case 46916:  // Slam! (Bloodsurge proc)
         case 52437:  // Sudden Death
             {

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -4699,12 +4699,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AttributesEx2 |= SPELL_ATTR2_IGNORE_LINE_OF_SIGHT;
     });
 
-    // Demonic Pact
-    ApplySpellFix({ 48090 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->AttributesEx2 |= SPELL_ATTR2_IGNORE_LINE_OF_SIGHT;
-    });
-
     // Ancestral Awakening
     ApplySpellFix({ 52759 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -1328,38 +1328,38 @@ class spell_warl_demonic_pact_aura : public AuraScript
 {
     PrepareAuraScript(spell_warl_demonic_pact_aura);
 
-        bool Validate(SpellInfo const* /*spellInfo*/) override
-        {
-            return ValidateSpellInfo({ SPELL_WARLOCK_DEMONIC_PACT_PROC });
-        }
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_WARLOCK_DEMONIC_PACT_PROC });
+    }
 
-        bool CheckProc(ProcEventInfo& eventInfo)
-        {
-            return eventInfo.GetActor() && eventInfo.GetActor()->IsPet();
-        }
+    bool CheckProc(ProcEventInfo& eventInfo)
+    {
+        return eventInfo.GetActor() && eventInfo.GetActor()->IsPet();
+    }
 
-        void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
-        {
-            PreventDefaultAction();
+    void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
+    {
+        PreventDefaultAction();
 
-            if (Unit* owner = eventInfo.GetActor()->GetOwner())
+        if (Unit* owner = eventInfo.GetActor()->GetOwner())
+        {
+            int32 currentBonus = 0;
+            if (AuraEffect* aurEff = owner->GetAuraEffect(SPELL_WARLOCK_DEMONIC_PACT_PROC, EFFECT_0))
             {
-                int32 currentBonus = 0;
-                if (AuraEffect* aurEff = owner->GetAuraEffect(SPELL_WARLOCK_DEMONIC_PACT_PROC, EFFECT_0))
-                {
-                    currentBonus = aurEff->GetAmount();
-                }
+                currentBonus = aurEff->GetAmount();
+            }
 
-                if (AuraEffect* aurEff = owner->GetDummyAuraEffect(SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_DEMONIC_PACT, EFFECT_0))
-                {
-                    int32 spellDamageMinusBonus = owner->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_MAGIC) - currentBonus;
-                    if (spellDamageMinusBonus < 0)
-                        return;
-                    int32 bp = int32((aurEff->GetAmount() / 100.0f) * spellDamageMinusBonus);
-                    owner->CastCustomSpell((Unit*)nullptr, SPELL_WARLOCK_DEMONIC_PACT_PROC, &bp, &bp, 0, true, nullptr, aurEff);
-                }
+            if (AuraEffect* aurEff = owner->GetDummyAuraEffect(SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_DEMONIC_PACT, EFFECT_0))
+            {
+                int32 spellDamageMinusBonus = owner->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_MAGIC) - currentBonus;
+                if (spellDamageMinusBonus < 0)
+                    return;
+                int32 bp = int32((aurEff->GetAmount() / 100.0f) * spellDamageMinusBonus);
+                owner->CastCustomSpell((Unit*)nullptr, SPELL_WARLOCK_DEMONIC_PACT_PROC, &bp, &bp, 0, true, nullptr, aurEff);
             }
         }
+    }
 
     void Register() override
     {

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -1344,9 +1344,19 @@ class spell_warl_demonic_pact_aura : public AuraScript
 
             if (Unit* owner = eventInfo.GetActor()->GetOwner())
             {
+                int32 currentBonus = 0;
+                if (AuraEffect* aurEff = owner->GetAuraEffect(SPELL_WARLOCK_DEMONIC_PACT_PROC, EFFECT_0))
+                {
+                    currentBonus = aurEff->GetAmount();
+                }
+
                 if (AuraEffect* aurEff = owner->GetDummyAuraEffect(SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_DEMONIC_PACT, EFFECT_0))
                 {
-                    int32 bp0 = static_cast<int32>((aurEff->GetAmount() * owner->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_MAGIC) + 100.0f) / 100.0f);
+                    int32 spellDamageMinusBonus = owner->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_MAGIC) - currentBonus;
+                    if (spellDamageMinusBonus < 0)
+                        return;
+                    int32 bp0 = int32((aurEff->GetAmount() / 100.0f) * spellDamageMinusBonus);
+
                     owner->CastCustomSpell(SPELL_WARLOCK_DEMONIC_PACT_PROC, SPELLVALUE_BASE_POINT0, bp0, (Unit*)nullptr, true, nullptr, aurEff);
                 }
             }

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -1324,52 +1324,41 @@ class spell_warl_glyph_of_voidwalker : public AuraScript
 };
 
 // 54909, 53646 - Demonic Pact
-class spell_warl_demonic_pact : public SpellScriptLoader
+class spell_warl_demonic_pact_aura : public AuraScript
 {
-    public:
-        spell_warl_demonic_pact() : SpellScriptLoader("spell_warl_demonic_pact") { }
+    PrepareAuraScript(spell_warl_demonic_pact_aura);
 
-        class spell_warl_demonic_pact_AuraScript : public AuraScript
+        bool Validate(SpellInfo const* /*spellInfo*/) override
         {
-            PrepareAuraScript(spell_warl_demonic_pact_AuraScript);
+            if (!sSpellMgr->GetSpellInfo(SPELL_WARLOCK_DEMONIC_PACT_PROC))
+                return false;
+            return true;
+        }
 
-            bool Validate(SpellInfo const* /*spellInfo*/) override
+        bool CheckProc(ProcEventInfo& eventInfo)
+        {
+            return eventInfo.GetActor() && eventInfo.GetActor()->IsPet();
+        }
+
+        void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
+        {
+            PreventDefaultAction();
+
+            if (Unit* owner = eventInfo.GetActor()->GetOwner())
             {
-                if (!sSpellMgr->GetSpellInfo(SPELL_WARLOCK_DEMONIC_PACT_PROC))
-                    return false;
-                return true;
-            }
-
-            bool CheckProc(ProcEventInfo& eventInfo)
-            {
-                return eventInfo.GetActor() && eventInfo.GetActor()->IsPet();
-            }
-
-            void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
-            {
-                PreventDefaultAction();
-
-                if (Unit* owner = eventInfo.GetActor()->GetOwner())
+                if (AuraEffect* aurEff = owner->GetDummyAuraEffect(SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_DEMONIC_PACT, EFFECT_0))
                 {
-                    if (AuraEffect* aurEff = owner->GetDummyAuraEffect(SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_DEMONIC_PACT, EFFECT_0))
-                    {
-                        int32 bp0 = static_cast<int32>((aurEff->GetAmount() * owner->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_MAGIC) + 100.0f) / 100.0f);
-                        owner->CastCustomSpell(SPELL_WARLOCK_DEMONIC_PACT_PROC, SPELLVALUE_BASE_POINT0, bp0, (Unit*)nullptr, true, nullptr, aurEff);
-                    }
+                    int32 bp0 = static_cast<int32>((aurEff->GetAmount() * owner->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_MAGIC) + 100.0f) / 100.0f);
+                    owner->CastCustomSpell(SPELL_WARLOCK_DEMONIC_PACT_PROC, SPELLVALUE_BASE_POINT0, bp0, (Unit*)nullptr, true, nullptr, aurEff);
                 }
             }
-
-            void Register() override
-            {
-                DoCheckProc += AuraCheckProcFn(spell_warl_demonic_pact_AuraScript::CheckProc);
-                OnEffectProc += AuraEffectProcFn(spell_warl_demonic_pact_AuraScript::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
-            }
-        };
-
-        AuraScript* GetAuraScript() const override
-        {
-            return new spell_warl_demonic_pact_AuraScript();
         }
+
+    void Register() override
+    {
+        DoCheckProc += AuraCheckProcFn(spell_warl_demonic_pact_aura::CheckProc);
+        OnEffectProc += AuraEffectProcFn(spell_warl_demonic_pact_aura::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
+    }
 };
 
 void AddSC_warlock_spell_scripts()
@@ -1405,6 +1394,6 @@ void AddSC_warlock_spell_scripts()
     RegisterSpellScript(spell_warl_shadowburn);
     RegisterSpellScript(spell_warl_glyph_of_felguard);
     RegisterSpellScript(spell_warl_glyph_of_voidwalker);
-    new spell_warl_demonic_pact();
+    RegisterSpellScript(spell_warl_demonic_pact_aura);
 }
 

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -1330,9 +1330,7 @@ class spell_warl_demonic_pact_aura : public AuraScript
 
         bool Validate(SpellInfo const* /*spellInfo*/) override
         {
-            if (!sSpellMgr->GetSpellInfo(SPELL_WARLOCK_DEMONIC_PACT_PROC))
-                return false;
-            return true;
+            return ValidateSpellInfo({ SPELL_WARLOCK_DEMONIC_PACT_PROC });
         }
 
         bool CheckProc(ProcEventInfo& eventInfo)

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -1355,9 +1355,8 @@ class spell_warl_demonic_pact_aura : public AuraScript
                     int32 spellDamageMinusBonus = owner->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_MAGIC) - currentBonus;
                     if (spellDamageMinusBonus < 0)
                         return;
-                    int32 bp0 = int32((aurEff->GetAmount() / 100.0f) * spellDamageMinusBonus);
-
-                    owner->CastCustomSpell(SPELL_WARLOCK_DEMONIC_PACT_PROC, SPELLVALUE_BASE_POINT0, bp0, (Unit*)nullptr, true, nullptr, aurEff);
+                    int32 bp = int32((aurEff->GetAmount() / 100.0f) * spellDamageMinusBonus);
+                    owner->CastCustomSpell((Unit*)nullptr, SPELL_WARLOCK_DEMONIC_PACT_PROC, &bp, &bp, 0, true, nullptr, aurEff);
                 }
             }
         }

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -1328,58 +1328,44 @@ class spell_warl_demonic_pact_aura : public AuraScript
 {
     PrepareAuraScript(spell_warl_demonic_pact_aura);
 
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_WARLOCK_DEMONIC_PACT_PROC });
-    }
-
-    bool Load() override
-    {
-        _groupId = sSpellMgr->GetSpellGroup(SPELL_WARLOCK_DEMONIC_PACT_PROC);
-        return true;
-    }
-
-    bool CheckProc(ProcEventInfo& eventInfo)
-    {
-        return eventInfo.GetActor() && eventInfo.GetActor()->IsPet();
-    }
-
-    void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
-    {
-        PreventDefaultAction();
-
-        if (Unit* owner = eventInfo.GetActor()->GetOwner())
+        bool Validate(SpellInfo const* /*spellInfo*/) override
         {
-            int32 currentBonus = 0;
-            Unit::AuraEffectList const& auraList = owner->GetAuraEffectsByType(SPELL_AURA_MOD_DAMAGE_DONE);
-            for (auto const& aurEff : auraList)
-            {
-                uint32 auraGroup = aurEff->GetAuraGroup();
-                if (!_groupId || !auraGroup || auraGroup != _groupId)
-                    continue;
-                currentBonus += aurEff->GetAmount();
-            }
+            return ValidateSpellInfo({ SPELL_WARLOCK_DEMONIC_PACT_PROC });
+        }
 
-            int32 spellDamageMinusBonus = owner->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_MAGIC) - currentBonus;
-            if (spellDamageMinusBonus < 0)
-                return;
+        bool CheckProc(ProcEventInfo& eventInfo)
+        {
+            return eventInfo.GetActor() && eventInfo.GetActor()->IsPet();
+        }
 
-            if (AuraEffect* aurEff = owner->GetDummyAuraEffect(SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_DEMONIC_PACT, EFFECT_0))
+        void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
+        {
+            PreventDefaultAction();
+
+            if (Unit* owner = eventInfo.GetActor()->GetOwner())
             {
-                int32 bp = int32((aurEff->GetAmount() / 100.0f) * spellDamageMinusBonus);
-                owner->CastCustomSpell((Unit*)nullptr, SPELL_WARLOCK_DEMONIC_PACT_PROC, &bp, &bp, 0, true, nullptr, aurEff);
+                int32 currentBonus = 0;
+                if (AuraEffect* aurEff = owner->GetAuraEffect(SPELL_WARLOCK_DEMONIC_PACT_PROC, EFFECT_0))
+                {
+                    currentBonus = aurEff->GetAmount();
+                }
+
+                if (AuraEffect* aurEff = owner->GetDummyAuraEffect(SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_DEMONIC_PACT, EFFECT_0))
+                {
+                    int32 spellDamageMinusBonus = owner->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_MAGIC) - currentBonus;
+                    if (spellDamageMinusBonus < 0)
+                        return;
+                    int32 bp = int32((aurEff->GetAmount() / 100.0f) * spellDamageMinusBonus);
+                    owner->CastCustomSpell((Unit*)nullptr, SPELL_WARLOCK_DEMONIC_PACT_PROC, &bp, &bp, 0, true, nullptr, aurEff);
+                }
             }
         }
-    }
 
     void Register() override
     {
         DoCheckProc += AuraCheckProcFn(spell_warl_demonic_pact_aura::CheckProc);
         OnEffectProc += AuraEffectProcFn(spell_warl_demonic_pact_aura::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
     }
-
-private:
-    uint32 _groupId;
 };
 
 void AddSC_warlock_spell_scripts()


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

* moves Demonic Pact (DP) handling from Unit
* remove spell info correction as flag is already set
* apply DP effect to EFFECT_1 which allows healing power to scale with warlock's SP 
* remove DP effect from DP calculation, this fixes the "stacking with itself"

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/3783

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

2 spells: 53646, 54909

Pets proc 53646, unknown 54909

![demonic_pact_spells](https://github.com/azerothcore/azerothcore-wotlk/assets/46423958/9669d2c4-2251-480c-8828-9ab8e8dc3fe8)

~~Is 54909 the aura that's supposed to proc Demonic Pact during metamorphosis? (not implemented)~~

~~`Stances: FORM_METAMORPHOSIS`~~

~~pre-3.3 demonic pact does not proc for crits during metamorphosis, see shadow bolt crit at timestamp https://youtu.be/L8ZWBfwYr2U?si=xjY9TDDoYokC_qHX&t=400~~

~~3.3.x footage ICC with 12 second duration, so before 3.3.3, no DP refresh on metamorphosis crits~~
~~https://wowpedia.fandom.com/wiki/Demonic_Pact~~

~~Is it supposed to in 3.3.5?~~
~~https://wowpedia.fandom.com/wiki/Demonic_Pact~~
~~3.3.3 included changes to ICD and duration, maybe this was included?~~

likely 3.3.3 footage, posted ~2months after 3.3 release https://www.youtube.com/watch?v=bc8jEi8wBsE crit during meta, no DP

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1283 sp, belf warlock
```
necklace
.add 44215
staff
.add 50731
sp enchant staff
.add 45056
sp gems
.add 40113 3
ring
.add 46046
robe
.add 14106
```
wrath totem 
```
add fire totem
.add 5176 
wrath totem 4  280sp
.cast 57722
wrath totem 1 100sp
.cast 30706
kill totem
/target totem of wrath
.die
```

make pet crit
```
target dummy
.cast self 62382 triggered
```

can be tested with 1 warlock with a gear set above to have 1100+ sp, so that unequip/equip staff will change sp below/above totem of wrath rank 1 (100sp)


use macro on dummy to trigger crit faster,

in case you want to speed up procs: lower icd by
```
SET @ICD:=5000;
UPDATE `spell_proc_event` SET `Cooldown`=@ICD WHERE `entry` IN (53646, 54909);
```

### test spell group for regressions:

- https://github.com/azerothcore/azerothcore-wotlk/issues/3790

1.spawn totem of wrath
2. weak pact, without staff (<1000sp), can't override
3. strong pact, with staff (>1000sp), can

### test values
from https://github.com/azerothcore/azerothcore-wotlk/issues/3783#issuecomment-735447185:
1. equip 1283sp 

see if values match:
test values, base-Damage: 1283 | Demonic-Pact: 128 => Total: 1411

this should not increase, remains at 1411, only refreshes duration with ICD 20s

healing power should also increase by same amount (128)



## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
