### PR TITLE
fix(Core): Further adjust packet structure for attack stop opcode.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3054,9 +3054,8 @@ void Unit::SendMeleeAttackStop(Unit* victim)
 
     if (victim)
     {
-        uint8 nowDead = victim->isDead();
         data << victim->GetPackGUID();
-        data << nowDead;
+        data << (uint32)victim->isDead();
     }
     SendMessageToSet(&data, true);
     LOG_DEBUG("entities.unit", "WORLD: Sent SMSG_ATTACKSTOP");

--- a/src/server/game/Handlers/CombatHandler.cpp
+++ b/src/server/game/Handlers/CombatHandler.cpp
@@ -89,9 +89,8 @@ void WorldSession::SendAttackStop(Unit const* enemy)
 
     if (enemy)
     {
-        uint8 nowDead = enemy->isDead();
         data << enemy->GetPackGUID();               // must be packed guid
-        data << nowDead;
+        data << (uint32)enemy->isDead();
     }
     SendPacket(&data);
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
I've been informed in the Discord server that `uint8` is a `char` masquerading as an unsigned integer and that `uint32` is an actual unsigned integer and that I should have used that instead, as the client handler expects an unsigned integer and not a `char`.

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes no open issues.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR:
- [X] Has not been tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
- [X] This pull request can be tested by following the reproduction steps provided in the linked issue
  - https://github.com/azerothcore/azerothcore-wotlk/issues/19429

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
