### PR TITLE
refactor(Deps/OpenSSL): Deprecate OpenSSL 1.x

### DIFF
--- a/src/common/Cryptography/ARC4.cpp
+++ b/src/common/Cryptography/ARC4.cpp
@@ -20,11 +20,7 @@
 
 Acore::Crypto::ARC4::ARC4() : _ctx(EVP_CIPHER_CTX_new())
 {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
     _cipher = EVP_CIPHER_fetch(nullptr, "RC4", nullptr);
-#else
-    EVP_CIPHER const* _cipher = EVP_rc4();
-#endif
 
     EVP_CIPHER_CTX_init(_ctx);
     int result = EVP_EncryptInit_ex(_ctx, _cipher, nullptr, nullptr, nullptr);
@@ -34,10 +30,7 @@ Acore::Crypto::ARC4::ARC4() : _ctx(EVP_CIPHER_CTX_new())
 Acore::Crypto::ARC4::~ARC4()
 {
     EVP_CIPHER_CTX_free(_ctx);
-
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
     EVP_CIPHER_free(_cipher);
-#endif
 }
 
 void Acore::Crypto::ARC4::Init(uint8 const* seed, size_t len)

--- a/src/common/Cryptography/ARC4.h
+++ b/src/common/Cryptography/ARC4.h
@@ -40,9 +40,7 @@ namespace Acore::Crypto
         template <typename Container>
         void UpdateData(Container& c) { UpdateData(std::data(c), std::size(c)); }
     private:
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
         EVP_CIPHER* _cipher;
-#endif
         EVP_CIPHER_CTX* _ctx;
     };
 }

--- a/src/common/Cryptography/BigNumber.cpp
+++ b/src/common/Cryptography/BigNumber.cpp
@@ -57,20 +57,7 @@ void BigNumber::SetQword(uint64 val)
 void BigNumber::SetBinary(uint8 const* bytes, int32 len, bool littleEndian)
 {
     if (littleEndian)
-    {
-#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x10100000L
-        uint8* array = new uint8[len];
-
-        for (int i = 0; i < len; i++)
-            array[i] = bytes[len - 1 - i];
-
-        BN_bin2bn(array, len, _bn);
-
-        delete[] array;
-#else
         BN_lebin2bn(bytes, len, _bn);
-#endif
-    }
     else
         BN_bin2bn(bytes, len, _bn);
 }
@@ -197,27 +184,8 @@ bool BigNumber::IsNegative() const
 
 void BigNumber::GetBytes(uint8* buf, size_t bufsize, bool littleEndian) const
 {
-#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x10100000L
-    int nBytes = GetNumBytes();
-    ASSERT(nBytes >= 0, "Bignum has negative number of bytes ({}).", nBytes);
-    std::size_t numBytes = static_cast<std::size_t>(nBytes);
-
-    // too large to store
-    ASSERT(numBytes <= bufsize, "Buffer of size {} is too small to hold bignum with {} bytes.\n", bufsize, numBytes);
-
-    // If we need more bytes than length of BigNumber set the rest to 0
-    if (numBytes < bufsize)
-        memset((void*)buf, 0, bufsize);
-
-    BN_bn2bin(_bn, buf + (bufsize - numBytes));
-
-    // openssl's BN stores data internally in big endian format, reverse if little endian desired
-    if (littleEndian)
-        std::reverse(buf, buf + bufsize);
-#else
     int res = littleEndian ? BN_bn2lebinpad(_bn, buf, bufsize) : BN_bn2binpad(_bn, buf, bufsize);
     ASSERT(res > 0, "Buffer of size {} is too small to hold bignum with {} bytes.\n", bufsize, BN_num_bytes(_bn));
-#endif
 }
 
 std::vector<uint8> BigNumber::ToByteVector(int32 minSize, bool littleEndian) const

--- a/src/common/Cryptography/CryptoHash.h
+++ b/src/common/Cryptography/CryptoHash.h
@@ -34,13 +34,8 @@ namespace Acore::Impl
     {
         typedef EVP_MD const* (*HashCreator)();
 
-#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x10100000L
-        static EVP_MD_CTX* MakeCTX() noexcept { return EVP_MD_CTX_create(); }
-        static void DestroyCTX(EVP_MD_CTX* ctx) { EVP_MD_CTX_destroy(ctx); }
-#else
         static EVP_MD_CTX* MakeCTX() noexcept { return EVP_MD_CTX_new(); }
         static void DestroyCTX(EVP_MD_CTX* ctx) { EVP_MD_CTX_free(ctx); }
-#endif
     };
 
     template <GenericHashImpl::HashCreator HashCreator, size_t DigestLength>

--- a/src/common/Cryptography/OpenSSLCrypto.cpp
+++ b/src/common/Cryptography/OpenSSLCrypto.cpp
@@ -18,34 +18,12 @@
 #include "OpenSSLCrypto.h"
 #include "Errors.h"
 #include <openssl/crypto.h> // NOTE: this import is NEEDED (even though some IDEs report it as unused)
-
-#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x1010000fL
-#include <vector>
-#include <thread>
-#include <mutex>
-
-std::vector<std::mutex*> cryptoLocks;
-
-static void lockingCallback(int mode, int type, char const* /*file*/, int /*line*/)
-{
-    if (mode & CRYPTO_LOCK)
-        cryptoLocks[type]->lock();
-    else
-        cryptoLocks[type]->unlock();
-}
-
-static void threadIdCallback(CRYPTO_THREADID * id)
-{
-    (void)id;
-    CRYPTO_THREADID_set_numeric(id, std::hash<std::thread::id>()(std::this_thread::get_id()));
-}
-#elif OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/provider.h>
+
 OSSL_PROVIDER* LegacyProvider;
 OSSL_PROVIDER* DefaultProvider;
-#endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L && AC_PLATFORM == AC_PLATFORM_WINDOWS
+#if AC_PLATFORM == AC_PLATFORM_WINDOWS
 #include <boost/dll/runtime_symbol_info.hpp>
 #include <filesystem>
 
@@ -63,43 +41,16 @@ void SetupLibrariesForWindows()
 
 void OpenSSLCrypto::threadsSetup()
 {
-#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x1010000fL
-    cryptoLocks.resize(CRYPTO_num_locks());
-
-    for (int i = 0 ; i < CRYPTO_num_locks(); ++i)
-    {
-        cryptoLocks[i] = new std::mutex();
-    }
-
-    (void)&threadIdCallback;
-    CRYPTO_THREADID_set_callback(threadIdCallback);
-
-    (void)&lockingCallback;
-    CRYPTO_set_locking_callback(lockingCallback);
-#elif OPENSSL_VERSION_NUMBER >= 0x30000000L
 #if AC_PLATFORM == AC_PLATFORM_WINDOWS
     SetupLibrariesForWindows();
 #endif
     LegacyProvider = OSSL_PROVIDER_load(nullptr, "legacy");
     DefaultProvider = OSSL_PROVIDER_load(nullptr, "default");
-#endif
 }
 
 void OpenSSLCrypto::threadsCleanup()
 {
-#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x1010000fL
-    CRYPTO_set_locking_callback(nullptr);
-    CRYPTO_THREADID_set_callback(nullptr);
-
-    for (int i = 0 ; i < CRYPTO_num_locks(); ++i)
-    {
-        delete cryptoLocks[i];
-    }
-
-    cryptoLocks.resize(0);
-#elif OPENSSL_VERSION_NUMBER >= 0x30000000L
     OSSL_PROVIDER_unload(LegacyProvider);
     OSSL_PROVIDER_unload(DefaultProvider);
     OSSL_PROVIDER_set_default_search_path(nullptr, nullptr);
-#endif
 }

--- a/src/server/apps/worldserver/Main.cpp
+++ b/src/server/apps/worldserver/Main.cpp
@@ -391,9 +391,6 @@ int main(int argc, char** argv)
     if (MySQL::GetLibraryVersion() < 80000)
         LOG_WARN("server", "WARNING: You are using MySQL version 5.7 which is soon EOL!\nThis version will be deprecated. Consider upgrading to MySQL 8.0 or 8.1!");
 #endif
-#if OPENSSL_VERSION_NUMBER < 0x30000000L
-    LOG_WARN("server", "WARNING: You are using OpenSSL version 1.1 which is soon EOL!\nThis version will be deprecated. Consider upgrading to OpenSSL 3.0 or 3.1!");
-#endif
 
     // Launch CliRunnable thread
     std::shared_ptr<std::thread> cliThread;


### PR DESCRIPTION
* EOL

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:

* EOL

## Tests done

Doesnt break OpenSSL 3 build

========== Build: 1 succeeded, 0 failed, 18 up-to-date, 1 skipped ==========
Using SSL version:             OpenSSL 3.3.1 4 Jun 2024 (library: OpenSSL 3.3.1 4 Jun 2024)