### PR TITLE
fix(DB/Event): Adjustments to BlizzCon L70ETC concert event.

### DIFF
--- a/data/sql/updates/pending_db_world/l70etc-dmf.sql
+++ b/data/sql/updates/pending_db_world/l70etc-dmf.sql
@@ -1,1 +1,1 @@
-UPDATE `game_event` SET `start_time`='2008-07-31 12:00:00', `end_time`='2008-08-05 12:00:00', `description` = 'L70ETC BlizzCon Concert' WHERE `eventEntry` = 32;
+UPDATE `game_event` SET `start_time`='2008-07-31 12:00:00', `end_time`='2008-08-05 12:00:00', `occurence` = 60, `description` = 'L70ETC BlizzCon Concert' WHERE `eventEntry` = 32;

--- a/data/sql/updates/pending_db_world/l70etc-dmf.sql
+++ b/data/sql/updates/pending_db_world/l70etc-dmf.sql
@@ -1,0 +1,1 @@
+UPDATE `game_event` SET `start_time`='2008-07-31 12:00:00', `end_time`='2008-08-05 12:00:00', `description` = 'L70ETC BlizzCon Concert' WHERE `eventEntry` = 32;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16530

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR:
- [X] Has not been tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
- [X] This pull request can be tested by following the reproduction steps provided in the linked issue.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- [ ] Strictly speaking, I doubt this change is entirely correct. Like I said in the linked issue, I believe the stage elements and bruisers should all be permanently spawned for the duration of the event (i.e. 07/31 - 08/05) and the band members are just invisible until the next hour comes, but this is a problem that can be solved later. I would also say these mobs should have their SAI be pretty agnostic of where it is they're spawned, seeing as Blizz used the same creature IDs for the BlizzCon, Shattrath tavern, and Blackrock Depths concerts, for all I know all we need to do for those is just spawn them, but again, problem for later.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
