### PR TITLE
fix(Scripts/TempestKeep): revamp Kael'Thas

### DIFF
--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -23,7 +23,7 @@
 #include "WorldPacket.h"
 #include "the_eye.h"
 
-enum Yells
+enum KTYells
 {
     // Kael'thas Speech
     SAY_INTRO                           = 0,
@@ -54,7 +54,7 @@ enum Yells
     EMOTE_THALADRED_FIXATE              = 2
 };
 
-enum Spells
+enum KTSpells
 {
     // _phase 2 spells
     SPELL_SUMMON_WEAPONS                = 36976,
@@ -138,7 +138,7 @@ enum Spells
     SPELL_SILENCE                       = 30225
 };
 
-enum Phases
+enum KTPhases
 {
     PHASE_NONE                          = 0,
     PHASE_SINGLE_ADVISOR                = 1,
@@ -148,7 +148,7 @@ enum Phases
     PHASE_FINAL                         = 5
 };
 
-enum Misc
+enum KTMisc
 {
     POINT_MIDDLE                        = 1,
     POINT_AIR                           = 2,
@@ -163,7 +163,7 @@ enum Misc
     NPC_STAFF_OF_DISINTEGRATION         = 21274,
 };
 
-enum PreFightEvents
+enum KTPreFightEvents
 {
     EVENT_PREFIGHT_PHASE1_01              = 1,
     EVENT_PREFIGHT_PHASE1_02              = 2,
@@ -173,7 +173,7 @@ enum PreFightEvents
     EVENT_PREFIGHT_PHASE6_03              = 6,
 };
 
-enum TransitionScene
+enum KTTransitionScene
 {
     EVENT_SCENE_1                       = 50, // NYI
     EVENT_SCENE_2                       = 51,
@@ -193,7 +193,7 @@ enum TransitionScene
     EVENT_SCENE_16                      = 65
 };
 
-enum KaelActions
+enum KTActions
 {
     ACTION_START_SANGUINAR              = 0,
     ACTION_START_CAPERNIAN              = 1,
@@ -202,7 +202,7 @@ enum KaelActions
     ACTION_PROGRESS_PHASE_CHECK         = 4
 };
 
-enum SpellGroups
+enum KTSpellGroups
 {
     GROUP_PROGRESS_PHASE                = 0,
     GROUP_PYROBLAST                     = 1,

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -296,17 +296,7 @@ struct boss_kaelthas : public BossAI
             me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
             me->SetReactState(REACT_PASSIVE);
             me->GetMotionMaster()->MovePoint(POINT_MIDDLE, me->GetHomePosition(), true, true);
-            me->ClearUnitState(UNIT_STATE_MELEE_ATTACKING);
-            me->SendMeleeAttackStop();
-
-            ThreatContainer::StorageType threatList = me->GetThreatMgr().GetThreatList();
-            for (ThreatContainer::StorageType::const_iterator i = threatList.begin(); i != threatList.end(); ++i)
-            {
-                if (Unit* target = ObjectAccessor::GetUnit(*me, (*i)->getUnitGuid()))
-                {
-                    target->AttackStop();
-                }
-            }
+            me->RemoveAllAttackers();
         }
     };
 

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -79,7 +79,7 @@ enum Spells
     SPELL_FLAME_STRIKE                  = 36735,
     SPELL_FLAME_STRIKE_DAMAGE           = 36731,
 
-    // Event
+    // transition scene spells
     SPELL_NETHERBEAM_AURA1              = 36364,
     SPELL_NETHERBEAM_AURA2              = 36370,
     SPELL_NETHERBEAM_AURA3              = 36371,
@@ -138,57 +138,43 @@ enum Spells
     SPELL_SILENCE                       = 30225
 };
 
-enum Misc
+enum Phases
 {
-    POINT_MIDDLE                        = 1,
-    POINT_AIR                           = 2,
-    POINT_START_LAST_PHASE              = 3,
-    DATA_RESURRECT_CAST                 = 1,
-    NPC_WORLD_TRIGGER                   = 19871,
-    NPC_NETHER_VAPOR                    = 21002,
-    NPC_NETHERSTRAND_LONGBOW            = 21268,
-    NPC_STAFF_OF_DISINTEGRATION         = 21274,
-
     PHASE_NONE                          = 0,
     PHASE_SINGLE_ADVISOR                = 1,
     PHASE_WEAPONS                       = 2,
     PHASE_TRANSITION                    = 3,
     PHASE_ALL_ADVISORS                  = 4,
-    PHASE_FINAL                         = 5,
+    PHASE_FINAL                         = 5
+};
 
-    EVENT_PREFIGHT_PHASE11              = 1,
-    EVENT_PREFIGHT_PHASE12              = 2,
-    EVENT_PREFIGHT_PHASE21              = 3,
-    EVENT_PREFIGHT_PHASE22              = 4,
-    EVENT_PREFIGHT_PHASE31              = 5,
-    EVENT_PREFIGHT_PHASE32              = 6,
-    EVENT_PREFIGHT_PHASE41              = 7,
-    EVENT_PREFIGHT_PHASE42              = 8,
-    EVENT_PREFIGHT_PHASE51              = 9,
-    EVENT_PREFIGHT_PHASE52              = 10,
-    EVENT_PREFIGHT_PHASE61              = 11,
-    EVENT_PREFIGHT_PHASE62              = 12,
-    EVENT_PREFIGHT_PHASE63              = 13,
-    EVENT_PREFIGHT_PHASE71              = 14,
-    EVENT_GATHER_ADVISORS               = 15,
+enum Misc
+{
+    POINT_MIDDLE                        = 1,
+    POINT_AIR                           = 2,
+    POINT_START_LAST_PHASE              = 3,
 
-    EVENT_SPELL_SEQ_1                   = 30,
-    EVENT_SPELL_SEQ_2                   = 31,
-    EVENT_SPELL_SEQ_3                   = 32,
-    EVENT_SPELL_FIREBALL                = 33,
-    EVENT_SPELL_PYROBLAST               = 34,
-    EVENT_SPELL_FLAMESTRIKE             = 35,
-    EVENT_SPELL_ARCANE_DISRUPTION       = 36,
-    EVENT_SPELL_MIND_CONTROL            = 37,
-    EVENT_SPELL_SUMMON_PHOENIX          = 38,
-    EVENT_CHECK_HEALTH                  = 39,
-    EVENT_SPELL_GRAVITY_LAPSE           = 40,
-    EVENT_GRAVITY_LAPSE_END             = 41,
-    EVENT_SPELL_SHOCK_BARRIER           = 42,
-    EVENT_SPELL_NETHER_BEAM             = 43,
-    EVENT_SPELL_NETHER_VAPOR            = 44,
+    DATA_RESURRECT_CAST                 = 1,
 
-    EVENT_SCENE_1                       = 50,
+    NPC_WORLD_TRIGGER                   = 19871,
+    NPC_NETHER_VAPOR                    = 21002,
+    NPC_NETHERSTRAND_LONGBOW            = 21268,
+    NPC_STAFF_OF_DISINTEGRATION         = 21274,
+};
+
+enum PreFightEvents
+{
+    EVENT_PREFIGHT_PHASE1_01              = 1,
+    EVENT_PREFIGHT_PHASE1_02              = 2,
+    EVENT_PREFIGHT_PHASE5_01              = 3,
+    EVENT_PREFIGHT_PHASE5_02              = 4,
+    EVENT_PREFIGHT_PHASE6_02              = 5,
+    EVENT_PREFIGHT_PHASE6_03              = 6,
+};
+
+enum TransitionScene
+{
+    EVENT_SCENE_1                       = 50, // NYI
     EVENT_SCENE_2                       = 51,
     EVENT_SCENE_3                       = 52,
     EVENT_SCENE_4                       = 53,
@@ -296,15 +282,6 @@ struct boss_kaelthas : public BossAI
         SetRoomState(GO_STATE_READY);
         me->SetDisableGravity(false);
         me->SetWalk(false);
-        ScheduleHealthCheckEvent(50, [&]{
-            scheduler.CancelAll();
-            me->CastStop();
-            me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
-            me->SetReactState(REACT_PASSIVE);
-            me->GetMotionMaster()->MovePoint(POINT_MIDDLE, me->GetHomePosition(), true, true);
-            me->ClearUnitState(UNIT_STATE_MELEE_ATTACKING);
-            me->SendMeleeAttackStop();
-        });
     }
 
     void AttackStart(Unit* who) override
@@ -313,17 +290,23 @@ struct boss_kaelthas : public BossAI
             BossAI::AttackStart(who);
     }
 
+    void JustReachedHome() override
+    {
+        Reset();
+    }
+
     void MoveInLineOfSight(Unit* who) override
     {
         if (_phase == PHASE_NONE && who->GetTypeId() == TYPEID_PLAYER && me->IsValidAttackTarget(who))
         {
             _phase = PHASE_SINGLE_ADVISOR;
             me->SetInCombatWithZone();
+            me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_DISABLE_MOVE);
             Talk(SAY_INTRO);
             ScheduleUniqueTimedEvent(23s, [&]
             {
                 Talk(SAY_INTRO_THALADRED);
-            }, EVENT_PREFIGHT_PHASE11);
+            }, EVENT_PREFIGHT_PHASE1_01);
             ScheduleUniqueTimedEvent(30s, [&]
             {
                 if (Creature* thaladred = summons.GetCreatureWithEntry(NPC_THALADRED))
@@ -334,13 +317,8 @@ struct boss_kaelthas : public BossAI
                         thaladred->AI()->AttackStart(target);
                     thaladred->SetInCombatWithZone();
                 }
-            }, EVENT_PREFIGHT_PHASE12);
+            }, EVENT_PREFIGHT_PHASE1_02);
         }
-    }
-
-    void JustEngagedWith(Unit* who) override
-    {
-        BossAI::JustEngagedWith(who);
     }
 
     void KilledUnit(Unit* victim) override
@@ -376,7 +354,7 @@ struct boss_kaelthas : public BossAI
                     Talk(SAY_PHASE2_WEAPON);
                     DoCastSelf(SPELL_SUMMON_WEAPONS);
                     _phase = PHASE_WEAPONS;
-                }, EVENT_PREFIGHT_PHASE51);
+                }, EVENT_PREFIGHT_PHASE5_01);
                 ScheduleUniqueTimedEvent(9s, [&]{
                     summons.DoForAllSummons([&](WorldObject* summon)
                     {
@@ -397,7 +375,7 @@ struct boss_kaelthas : public BossAI
                     {
                         PhaseAllAdvisorsExecute();
                     });
-                }, EVENT_PREFIGHT_PHASE52);
+                }, EVENT_PREFIGHT_PHASE5_02);
                 break;
             case ACTION_PROGRESS_PHASE_CHECK:
                 if (_phase == PHASE_ALL_ADVISORS)
@@ -671,7 +649,7 @@ struct boss_kaelthas : public BossAI
         Talk(SAY_PHASE3_ADVANCE);
         ScheduleUniqueTimedEvent(6s, [&]{
             DoCastSelf(SPELL_RESURRECTION);
-        }, EVENT_PREFIGHT_PHASE62);
+        }, EVENT_PREFIGHT_PHASE6_02);
         ScheduleUniqueTimedEvent(12s, [&]{
             _phase = PHASE_ALL_ADVISORS;
             summons.DoForAllSummons([&](WorldObject* summon)
@@ -694,7 +672,7 @@ struct boss_kaelthas : public BossAI
             {
                 PhaseKaelExecute();
             });
-        }, EVENT_PREFIGHT_PHASE63);
+        }, EVENT_PREFIGHT_PHASE6_03);
     }
 
     void PhaseKaelExecute()
@@ -703,7 +681,7 @@ struct boss_kaelthas : public BossAI
         Talk(SAY_PHASE4_INTRO2);
         _phase = PHASE_FINAL;
         DoResetThreatList();
-        me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_DISABLE_MOVE);
+        me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_DISABLE_MOVE);
         if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
         {
             AttackStart(target);
@@ -721,7 +699,6 @@ struct boss_kaelthas : public BossAI
             Talk(SAY_SUMMON_PHOENIX);
             DoCastSelf(SPELL_PHOENIX);
         }, 35450ms, 41550ms);
-        //sequence
         ScheduleTimedEvent(20s, 23s, [&]
         {
             if (roll_chance_i(50))
@@ -756,12 +733,32 @@ struct boss_kaelthas : public BossAI
             return;
 
         DoMeleeAttackIfReady();
+
+        ScheduleHealthCheckEvent(50, [&]{
+            scheduler.CancelAll();
+            me->CastStop();
+            me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
+            me->SetReactState(REACT_PASSIVE);
+            me->GetMotionMaster()->MovePoint(POINT_MIDDLE, me->GetHomePosition(), true, true);
+            me->ClearUnitState(UNIT_STATE_MELEE_ATTACKING);
+            me->SendMeleeAttackStop();
+
+            ThreatContainer::StorageType threatList = me->GetThreatMgr().GetThreatList();
+            for (ThreatContainer::StorageType::const_iterator i = threatList.begin(); i != threatList.end(); ++i)
+            {
+                if (Unit* target = ObjectAccessor::GetUnit(*me, (*i)->getUnitGuid()))
+                {
+                   target->AttackStop();
+                }
+            }
+        });
     }
 
     bool CheckEvadeIfOutOfCombatArea() const override
     {
         return me->GetHomePosition().GetExactDist2d(me) > 165.0f || !SelectTargetFromPlayerList(165.0f);
     }
+
 private:
     uint32 _phase;
 };

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -296,7 +296,17 @@ struct boss_kaelthas : public BossAI
             me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
             me->SetReactState(REACT_PASSIVE);
             me->GetMotionMaster()->MovePoint(POINT_MIDDLE, me->GetHomePosition(), true, true);
-            me->RemoveAllAttackers();
+            me->ClearUnitState(UNIT_STATE_MELEE_ATTACKING);
+            me->SendMeleeAttackStop();
+
+            ThreatContainer::StorageType threatList = me->GetThreatMgr().GetThreatList();
+            for (ThreatContainer::StorageType::const_iterator i = threatList.begin(); i != threatList.end(); ++i)
+            {
+                if (Unit* target = ObjectAccessor::GetUnit(*me, (*i)->getUnitGuid()))
+                {
+                    target->AttackStop();
+                }
+            }
         }
     };
 

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -287,6 +287,29 @@ struct boss_kaelthas : public BossAI
         me->SetWalk(false);
     }
 
+    void DamageTaken(Unit*, uint32&, DamageEffectType, SpellSchoolMask) override
+    {
+        if (me->HealthBelowPct(50) && !_transitionSceneReached)
+        {
+            _transitionSceneReached = true;
+            me->CastStop();
+            me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
+            me->SetReactState(REACT_PASSIVE);
+            me->GetMotionMaster()->MovePoint(POINT_MIDDLE, me->GetHomePosition(), true, true);
+            me->ClearUnitState(UNIT_STATE_MELEE_ATTACKING);
+            me->SendMeleeAttackStop();
+
+            ThreatContainer::StorageType threatList = me->GetThreatMgr().GetThreatList();
+            for (ThreatContainer::StorageType::const_iterator i = threatList.begin(); i != threatList.end(); ++i)
+            {
+                if (Unit* target = ObjectAccessor::GetUnit(*me, (*i)->getUnitGuid()))
+                {
+                    target->AttackStop();
+                }
+            }
+        }
+    };
+
     void AttackStart(Unit* who) override
     {
         if (_phase == PHASE_FINAL /* check is scheduled&& events.GetNextEventTime(EVENT_GRAVITY_LAPSE_END) == 0*/)
@@ -501,7 +524,7 @@ struct boss_kaelthas : public BossAI
                     trigger->CastSpell(me, SPELL_NETHERBEAM1 + i, false);
             me->SetDisableGravity(true);
             me->SendMovementFlagUpdate();
-            me->GetMotionMaster()->MoveTakeoff(POINT_AIR, me->GetPositionX(), me->GetPositionY(), 75.0f, 2.99);
+            me->GetMotionMaster()->MoveTakeoff(POINT_AIR, me->GetPositionX(), me->GetPositionY(), 75.0f, 2.99f);
             DoCastSelf(SPELL_GROW, true);
         }, EVENT_SCENE_3);
         ScheduleUniqueTimedEvent(7000ms, [&]
@@ -734,29 +757,6 @@ struct boss_kaelthas : public BossAI
             return;
 
         DoMeleeAttackIfReady();
-
-        ScheduleHealthCheckEvent(50, [&]{
-            if(!_transitionSceneReached)
-            {
-                _transitionSceneReached = true;
-                scheduler.CancelAll();
-                me->CastStop();
-                me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
-                me->SetReactState(REACT_PASSIVE);
-                me->GetMotionMaster()->MovePoint(POINT_MIDDLE, me->GetHomePosition(), true, true);
-                me->ClearUnitState(UNIT_STATE_MELEE_ATTACKING);
-                me->SendMeleeAttackStop();
-
-                ThreatContainer::StorageType threatList = me->GetThreatMgr().GetThreatList();
-                for (ThreatContainer::StorageType::const_iterator i = threatList.begin(); i != threatList.end(); ++i)
-                {
-                    if (Unit* target = ObjectAccessor::GetUnit(*me, (*i)->getUnitGuid()))
-                    {
-                       target->AttackStop();
-                    }
-                }
-            }
-        });
     }
 
     bool CheckEvadeIfOutOfCombatArea() const override

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -152,7 +152,7 @@ enum Misc
 {
     POINT_MIDDLE                        = 1,
     POINT_AIR                           = 2,
-    POINT_LAND                          = 3,                     
+    POINT_LAND                          = 3,           
     POINT_START_LAST_PHASE              = 4,
 
     DATA_RESURRECT_CAST                 = 1,

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -152,7 +152,7 @@ enum Misc
 {
     POINT_MIDDLE                        = 1,
     POINT_AIR                           = 2,
-    POINT_LAND                          = 3,           
+    POINT_LAND                          = 3,
     POINT_START_LAST_PHASE              = 4,
 
     DATA_RESURRECT_CAST                 = 1,
@@ -499,7 +499,6 @@ struct boss_kaelthas : public BossAI
             for (uint8 i = 0; i < 2; ++i)
                 if (Creature* trigger = me->SummonCreature(WORLD_TRIGGER, triggersPos[i], TEMPSUMMON_TIMED_DESPAWN, 60000))
                     trigger->CastSpell(me, SPELL_NETHERBEAM1 + i, false);
-            me->DisableSpline();
             me->SetDisableGravity(true);
             me->SendMovementFlagUpdate();
             me->GetMotionMaster()->MoveTakeoff(POINT_AIR, me->GetPositionX(), me->GetPositionY(), 75.0f, 2.99);
@@ -600,13 +599,9 @@ struct boss_kaelthas : public BossAI
             me->CastStop();
             me->GetMotionMaster()->Clear();
             me->RemoveAurasDueToSpell(SPELL_DARK_BANISH_STATE); // WRONG VISUAL
-            me->GetMotionMaster()->MoveTakeoff(POINT_LAND, me->GetPositionX(), me->GetPositionY(), 48.0f, 2.99);
-        }, EVENT_SCENE_16);
-        ScheduleUniqueTimedEvent(50000ms, [&]
-        {
+            me->GetMotionMaster()->MoveLand(POINT_LAND, me->GetPositionX(), me->GetPositionY(), 48.0f, 2.99f); // Moveland doesn't handle POINT_START_LAST_PHASE so we need to use MovePoint
             me->GetMotionMaster()->MovePoint(POINT_START_LAST_PHASE, me->GetHomePosition(), false, true);
-            me->ClearUnitState(UNIT_FLAG_STUNNED);
-        }, 66);
+        }, EVENT_SCENE_16);
     }
 
     void IntroduceNewAdvisor(Yells talkIntroduction, KaelActions kaelAction)

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -604,7 +604,7 @@ struct boss_kaelthas : public BossAI
         }, EVENT_SCENE_16);
     }
 
-    void IntroduceNewAdvisor(Yells talkIntroduction, KaelActions kaelAction)
+    void IntroduceNewAdvisor(KTYells talkIntroduction, KTActions kaelAction)
     {
         std::chrono::milliseconds attackStartTimer = 0ms;
         EyeNPCs advisorNPCId = NPC_THALADRED;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

* Force AttackStop for all members of the threatlist before the transition event during the last
* Fix some unit flag logics
* Fix the reset logic
* Cleanup a little the script and remove unused enums


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/19548 and https://github.com/azerothcore/azerothcore-wotlk/issues/18486 . Partial fix for https://github.com/azerothcore/azerothcore-wotlk/issues/18488

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.

* another test would be welcome. I found it difficult to reproduce the initial outcome. Even if the logic would dictate that it's fixed know.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [X] This pull request can be tested by following the reproduction steps provided in the linked issue
- [X] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

- Enter Tempest Keep.
- Make your way to Kael'thas.
- Get to his final phase transition.
- Observe you can attack him despite not being able to attack him.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] During the transition scene, when Kael'Thas descending he have a walk animation

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
