### PR TITLE
fix(Core/Spells): Revert ownership and follow logic adjustment for guardian summons.

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5935,6 +5935,9 @@ void Spell::SummonGuardian(uint32 i, uint32 entry, SummonPropertiesEntry const* 
     if (!caster)
         return;
 
+    if (caster->IsTotem())
+        caster = caster->ToTotem()->GetOwner();
+
     // in another case summon new
     uint8 summonLevel = caster->GetLevel();
 
@@ -6047,6 +6050,14 @@ void Spell::SummonGuardian(uint32 i, uint32 entry, SummonPropertiesEntry const* 
             ((Minion*)summon)->SetFollowAngle(m_caster->GetAbsoluteAngle(pos.GetPositionX(), pos.GetPositionY()));
         //else if (summon->HasUnitTypeMask(UNIT_MASK_MINION) && m_targets.HasDst())
         //    ((Minion*)summon)->SetFollowAngle(m_caster->GetAngle(summon));
+
+        // xinef: move this here, some auras are added in initstatsforlevel!
+        if (!summon->IsInCombat() && !summon->IsTrigger())
+        {
+            //  summon->AI()->EnterEvadeMode();
+            summon->GetMotionMaster()->Clear(false);
+            summon->GetMotionMaster()->MoveFollow(caster, PET_FOLLOW_DIST, summon->GetFollowAngle(), MOTION_SLOT_ACTIVE);
+        }
 
         if (properties && properties->Category == SUMMON_CATEGORY_ALLY)
             summon->SetFaction(caster->GetFaction());


### PR DESCRIPTION
Reverts azerothcore/azerothcore-wotlk#19599.

Closes #19658
Closes https://github.com/chromiecraft/chromiecraft/issues/7284

Opens #19514
Opens https://github.com/azerothcore/azerothcore-wotlk/issues/19514

Unfortunately, there are a *lot* of pet-related checks for whether the owner is a player or not. When the pet is not supposed to be owned by a player (sniffs lead me to strongly believe elementals should be owned by their totems), this causes quite a few problems, as seen in #19658. For now, best course of action in my opinion is to revert the commit until a better solution comes around.