### PR TITLE
Talentpoints hook

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13584,6 +13584,7 @@ uint32 Player::CalculateTalentsPoints() const
     }
 
     talentPointsForLevel += m_extraBonusTalentCount;
+    sScriptMgr->OnPLayerCalculateTalentsPoints(this, talentPointsForLevel);
     return uint32(talentPointsForLevel * sWorld->getRate(RATE_TALENT));
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13584,7 +13584,7 @@ uint32 Player::CalculateTalentsPoints() const
     }
 
     talentPointsForLevel += m_extraBonusTalentCount;
-    sScriptMgr->OnPLayerCalculateTalentsPoints(this, talentPointsForLevel);
+    sScriptMgr->OnCalculateTalentsPoints(this, talentPointsForLevel);
     return uint32(talentPointsForLevel * sWorld->getRate(RATE_TALENT));
 }
 

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -54,9 +54,9 @@ void ScriptMgr::OnPlayerJustDied(Player* player)
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_PLAYER_JUST_DIED, script->OnPlayerJustDied(player));
 }
 
-void ScriptMgr::OnPLayerCalculateTalentsPoints(Player* player, uint32 talentPointsForLevel)
+void ScriptMgr::OnPLayerCalculateTalentsPoints(Player const* player, uint32 talentPointsForLevel)
 {
-    CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_CALCULATE_TALENTS_POINTS, script->OnPlayerJustDied(player));
+    CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_CALCULATE_TALENTS_POINTS, script->OnPLayerCalculateTalentsPoints(player, talentPointsForLevel));
 }
 
 void ScriptMgr::OnPlayerReleasedGhost(Player* player)

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -54,7 +54,7 @@ void ScriptMgr::OnPlayerJustDied(Player* player)
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_PLAYER_JUST_DIED, script->OnPlayerJustDied(player));
 }
 
-void ScriptMgr::OnCalculateTalentsPoints(Player const* player, uint32 talentPointsForLevel)
+void ScriptMgr::OnCalculateTalentsPoints(Player const* player, uint32& talentPointsForLevel)
 {
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_CALCULATE_TALENTS_POINTS, script->OnCalculateTalentsPoints(player, talentPointsForLevel));
 }

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -54,9 +54,9 @@ void ScriptMgr::OnPlayerJustDied(Player* player)
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_PLAYER_JUST_DIED, script->OnPlayerJustDied(player));
 }
 
-void ScriptMgr::OnPLayerCalculateTalentsPoints(Player const* player, uint32 talentPointsForLevel)
+void ScriptMgr::OnCalculateTalentsPoints(Player const* player, uint32 talentPointsForLevel)
 {
-    CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_CALCULATE_TALENTS_POINTS, script->OnPLayerCalculateTalentsPoints(player, talentPointsForLevel));
+    CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_CALCULATE_TALENTS_POINTS, script->OnCalculateTalentsPoints(player, talentPointsForLevel));
 }
 
 void ScriptMgr::OnPlayerReleasedGhost(Player* player)

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -54,6 +54,11 @@ void ScriptMgr::OnPlayerJustDied(Player* player)
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_PLAYER_JUST_DIED, script->OnPlayerJustDied(player));
 }
 
+void ScriptMgr::OnPLayerCalculateTalentsPoints(Player* player, uint32 talentPointsForLevel)
+{
+    CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_CALCULATE_TALENTS_POINTS, script->OnPlayerJustDied(player));
+}
+
 void ScriptMgr::OnPlayerReleasedGhost(Player* player)
 {
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_PLAYER_RELEASED_GHOST, script->OnPlayerReleasedGhost(player));

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.h
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.h
@@ -215,7 +215,7 @@ public:
     virtual void OnPlayerJustDied(Player* /*player*/) { }
 
     // Called player talent points are calculated
-    virtual void OnCalculateTalentsPoints(Player const* /*player*/, uint32 /*talentPointsForLevel*/) { }
+    virtual void OnCalculateTalentsPoints(Player const* /*player*/, uint32& /*talentPointsForLevel*/) { }
 
     // Called when clicking the release button
     virtual void OnPlayerReleasedGhost(Player* /*player*/) { }

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.h
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.h
@@ -215,7 +215,7 @@ public:
     virtual void OnPlayerJustDied(Player* /*player*/) { }
 
     // Called player talent points are calculated
-    virtual void OnPLayerCalculateTalentsPoints(Player* /*player*/, uint32 /*talentPointsForLevel*/) { }
+    virtual void OnPLayerCalculateTalentsPoints(Player const* /*player*/, uint32 /*talentPointsForLevel*/) { }
 
     // Called when clicking the release button
     virtual void OnPlayerReleasedGhost(Player* /*player*/) { }

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.h
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.h
@@ -215,7 +215,7 @@ public:
     virtual void OnPlayerJustDied(Player* /*player*/) { }
 
     // Called player talent points are calculated
-    virtual void OnPLayerCalculateTalentsPoints(Player const* /*player*/, uint32 /*talentPointsForLevel*/) { }
+    virtual void OnCalculateTalentsPoints(Player const* /*player*/, uint32 /*talentPointsForLevel*/) { }
 
     // Called when clicking the release button
     virtual void OnPlayerReleasedGhost(Player* /*player*/) { }

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.h
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.h
@@ -28,6 +28,7 @@
 enum PlayerHook
 {
     PLAYERHOOK_ON_PLAYER_JUST_DIED,
+    PLAYERHOOK_ON_CALCULATE_TALENTS_POINTS,
     PLAYERHOOK_ON_PLAYER_RELEASED_GHOST,
     PLAYERHOOK_ON_SEND_INITIAL_PACKETS_BEFORE_ADD_TO_MAP,
     PLAYERHOOK_ON_BATTLEGROUND_DESERTION,
@@ -212,6 +213,9 @@ protected:
 public:
     // Called when a player dies
     virtual void OnPlayerJustDied(Player* /*player*/) { }
+
+    // Called player talent points are calculated
+    virtual void OnPLayerCalculateTalentsPoints(Player* /*player*/, uint32 /*talentPointsForLevel*/) { }
 
     // Called when clicking the release button
     virtual void OnPlayerReleasedGhost(Player* /*player*/) { }

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -297,8 +297,8 @@ public: /* PlayerScript */
     void OnBeforePlayerUpdate(Player* player, uint32 p_time);
     void OnPlayerUpdate(Player* player, uint32 p_time);
     void OnSendInitialPacketsBeforeAddToMap(Player* player, WorldPacket& data);
-    void OnPlayerJustDied(Player* player, uint32 talentPointsForLevel);
-    void OnPLayerCalculateTalentsPoints(Player* player);
+    void OnPlayerJustDied(Player* player);
+    void OnPLayerCalculateTalentsPoints(Player* player, uint32 talentPointsForLevel);
     void OnPlayerReleasedGhost(Player* player);
     void OnPVPKill(Player* killer, Player* killed);
     void OnPlayerPVPFlagChange(Player* player, bool state);

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -298,7 +298,7 @@ public: /* PlayerScript */
     void OnPlayerUpdate(Player* player, uint32 p_time);
     void OnSendInitialPacketsBeforeAddToMap(Player* player, WorldPacket& data);
     void OnPlayerJustDied(Player* player);
-    void OnPLayerCalculateTalentsPoints(Player* player, uint32 talentPointsForLevel);
+    void OnPLayerCalculateTalentsPoints(Player const* player, uint32 talentPointsForLevel);
     void OnPlayerReleasedGhost(Player* player);
     void OnPVPKill(Player* killer, Player* killed);
     void OnPlayerPVPFlagChange(Player* player, bool state);

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -298,7 +298,7 @@ public: /* PlayerScript */
     void OnPlayerUpdate(Player* player, uint32 p_time);
     void OnSendInitialPacketsBeforeAddToMap(Player* player, WorldPacket& data);
     void OnPlayerJustDied(Player* player);
-    void OnPLayerCalculateTalentsPoints(Player const* player, uint32 talentPointsForLevel);
+    void OnCalculateTalentsPoints(Player const* player, uint32 talentPointsForLevel);
     void OnPlayerReleasedGhost(Player* player);
     void OnPVPKill(Player* killer, Player* killed);
     void OnPlayerPVPFlagChange(Player* player, bool state);

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -298,7 +298,7 @@ public: /* PlayerScript */
     void OnPlayerUpdate(Player* player, uint32 p_time);
     void OnSendInitialPacketsBeforeAddToMap(Player* player, WorldPacket& data);
     void OnPlayerJustDied(Player* player);
-    void OnCalculateTalentsPoints(Player const* player, uint32 talentPointsForLevel);
+    void OnCalculateTalentsPoints(Player const* player, uint32& talentPointsForLevel);
     void OnPlayerReleasedGhost(Player* player);
     void OnPVPKill(Player* killer, Player* killed);
     void OnPlayerPVPFlagChange(Player* player, bool state);

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -297,7 +297,8 @@ public: /* PlayerScript */
     void OnBeforePlayerUpdate(Player* player, uint32 p_time);
     void OnPlayerUpdate(Player* player, uint32 p_time);
     void OnSendInitialPacketsBeforeAddToMap(Player* player, WorldPacket& data);
-    void OnPlayerJustDied(Player* player);
+    void OnPlayerJustDied(Player* player, uint32 talentPointsForLevel);
+    void OnPLayerCalculateTalentsPoints(Player* player);
     void OnPlayerReleasedGhost(Player* player);
     void OnPVPKill(Player* killer, Player* killed);
     void OnPlayerPVPFlagChange(Player* player, bool state);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Added hook in Player.CalculateTalentsPoints() function to be able to overwrite the "talentPointsForLevel" variable. resulting in being able to make custom talent points distributions throughout leveling. 

This PR proposes changes to:
-  [x ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
For an easy to add module i grabbed the mod-random-enchants module since it already uses some hooks. so i just added the one i created to the random_enchants.h file in the public function declerations:
```
void OnCalculateTalentsPoints(Player const* player, uint32& talentPointsForLevel) override; 
```
then at the bottom of the random_enchants.cpp file implemented the hook as such:
```
void RandomEnchantsPlayer::OnCalculateTalentsPoints(Player const* player, uint32& talentPointsForLevel)
{
    talentPointsForLevel = player->GetLevel();
}
```
it compiled and runs fine, i created a character and set it to lvl 20. and as expected the available talent points are set to 20. 

I also tested to make sure nothing broke without the module active. but with my hooks in place. And when i logged on the talent points were set to 11 which is the correct default if the talentPointsForLevel var isn't altered.



Added info:
source random enchants module i used to implement newly created hook: https://github.com/azerothcore/mod-random-enchants

i am part of the discord server: amyfang.
please feel free to contect me if there are any questions!

added context:
i plan on making DK a playable class starting from lvl 1, this is still a long ways to go, but this hook is needed to alter the talent points calculation since there is a specific bit for deadknights in the calculation that would not make talentpoints function below lvl 55. ALSO quite a while ago i was running a server with my buddies and we altered the talent points to give extra points every few levels to make the leveling experience snappy and more fun/powerfull. I know there is also a config flag to set rate, but with this hook there are so many more fun things that can be implemented.

thanks for your time, love the project!

