### PR TITLE
fix(Scripts/BlackTemple): Ensure Illidari council health is balanced across wipes.

### DIFF
--- a/src/server/scripts/Outland/BlackTemple/boss_illidari_council.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_illidari_council.cpp
@@ -146,9 +146,10 @@ struct boss_illidari_council : public BossAI
 
     void DoAction(int32 param) override
     {
-        if (!me->isActiveObject() && param == ACTION_START_ENCOUNTER)
+        if (param == ACTION_START_ENCOUNTER)
         {
-            me->setActive(true);
+            if (!me->isActiveObject())
+                me->setActive(true);
 
             bool spoken = false;
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Scripts (bosses, spell scripts, creature scripts).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue. Depending on how the fight is reset, the council creature can break and no longer balance health between the council members.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes:
- [X] Have not been validated.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
- [X] This pull request requires further testing.
1. Engage the Illidari council.
2. Wipe.
3. Reset the fight.
4. Observe the council.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
