### PR TITLE
fix(Scripts/BlackTemple): Adjust order of damage calculations for Shared Rule.

### DIFF
--- a/src/server/scripts/Outland/BlackTemple/boss_illidari_council.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_illidari_council.cpp
@@ -254,13 +254,13 @@ struct boss_illidari_council_memberAI : public ScriptedAI
     {
         InstanceScript* instance = me->GetInstanceScript();
 
-        if (me->GetHealth() <= damage)
-            damage = me->GetHealth() - 1;
-
         int32 damageTaken = damage;
         Creature* target = instance->GetCreature(DATA_ILLIDARI_COUNCIL);
 
         me->CastCustomSpell(target->ToUnit(), SPELL_SHARED_RULE_DMG, &damageTaken, &damageTaken, &damageTaken, true, nullptr, nullptr, me->GetGUID());
+
+        if (me->GetHealth() <= damage)
+            damage = me->GetHealth() - 1;
     }
 
     void KilledUnit(Unit*) override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Scripts (bosses, spell scripts, creature scripts).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/pull/19809#issuecomment-2323729656

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes:
- [X] Have not been validated.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- [X] I don't think this fully matches behavior observed on official servers, but it makes the fight completable as an interim solution.
  - Upon studying of a sniff, it definitely appears a council member with effectively no health remaining should still be relaying full damage through the Shared Rule spell. This fix definitely seems more Blizzlike than current behavior.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
