### PR TITLE
fix(Core/Object): do not add Object to Transport when summoned by a Vehicle

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2252,7 +2252,7 @@ TempSummon* Map::SummonCreature(uint32 entry, Position const& pos, SummonPropert
 
     summon->SetVisibleBySummonerOnly(visibleBySummonerOnly);
 
-    if (!AddToMap(summon->ToCreature(), summon->GetOwnerGUID().IsPlayer() || (summoner && summoner->GetTransport())))
+    if (!AddToMap(summon->ToCreature(), summon->GetOwnerGUID().IsPlayer() || (summoner && summoner->GetTransport() && !(summoner->IsUnit() && summoner->ToUnit()->IsVehicle()))))
     {
         delete summon;
         return nullptr;

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2252,7 +2252,10 @@ TempSummon* Map::SummonCreature(uint32 entry, Position const& pos, SummonPropert
 
     summon->SetVisibleBySummonerOnly(visibleBySummonerOnly);
 
-    if (!AddToMap(summon->ToCreature(), summon->GetOwnerGUID().IsPlayer() || (summoner && summoner->GetTransport() && !(summoner->IsUnit() && summoner->ToUnit()->IsVehicle()))))
+    bool summonerHasTransport = summoner && summoner->GetTransport();
+    bool summonerIsVehicle = summoner && summoner->IsUnit() && summoner->ToUnit()->IsVehicle();
+    bool checkTransport = summon->GetOwnerGUID().IsPlayer() || (summonerHasTransport && !summonerIsVehicle);
+    if (!AddToMap(summon->ToCreature(), checkTransport))
     {
         delete summon;
         return nullptr;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

There's a bug with [Traveler's Tundra Mammoth](https://wowgaming.altervista.org/aowow/?spell=61447) that occurs when mounting on a transport, the vendors are not interactable.

This bug does not occur if mounting before and then moving onto a transport.

Mounting and boarding a transport does not add the vehicle's passengers to the transport. So when summoning on the transport, there shouldn't be a need to add them to the transport.


### details

after mounting on a transport this check fails on when interacting:

https://github.com/azerothcore/azerothcore-wotlk/blob/632d7f5f9ec1b44c3288168952a68533a6791686/src/server/game/Handlers/ItemHandler.cpp#L1040

the passenger coordinates are (0, 0, 0) when comparing

https://github.com/azerothcore/azerothcore-wotlk/blob/cdc00b42bd86f07e1beb0a1327238a9163650ae3/src/server/game/Entities/Object/Object.cpp#L1221

coordinates of these passengers are not updated by the transport 
https://github.com/azerothcore/azerothcore-wotlk/blob/632d7f5f9ec1b44c3288168952a68533a6791686/src/server/game/Entities/Transport/Transport.cpp#L616

When mounting on the transport, the vehicle summons which are then added to the transport

https://github.com/azerothcore/azerothcore-wotlk/blob/cdc00b42bd86f07e1beb0a1327238a9163650ae3/src/server/game/Entities/Vehicle/Vehicle.cpp#L289

prevent the above call from adding to transport by checking the summoner type

https://github.com/azerothcore/azerothcore-wotlk/blob/cdc00b42bd86f07e1beb0a1327238a9163650ae3/src/server/game/Maps/Map.cpp#L589


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16875

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

```
with a horde character
gunship
.go xyz -437.42 1954 211.7804 631 4.72
.instance setbossstate 0 3
.instance setbossstate 1 3
.learn 61447
```

1. mount mammoth
2. interact with vendor
3. change positions

choose position, on/off transport

2nd character that is on/off transport

other transports: boats, zeppelin and gunships in icecrown

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
