### PR TITLE
fix(Scripts/TrialOfChampion): fail and send custom spell error when trying to mount without lance equipped

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1725926206241976759.sql
+++ b/data/sql/updates/pending_db_world/rev_1725926206241976759.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `conditions` SET `Comment` = 'Player must have aura Lance Equipped' WHERE (`SourceTypeOrReferenceId` = 16) AND (`SourceGroup` = 0) AND (`SourceEntry` IN (35644, 36588)) AND (`ConditionValue1` = 62853);

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_grand_champions.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_grand_champions.cpp
@@ -215,8 +215,6 @@ public:
             clicker->ToPlayer()->GetSession()->SendPacket(&data);
             return false;
         }
-
-        void JustEngagedWith(Unit*  /*who*/) override {}
     };
 };
 

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_grand_champions.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_grand_champions.cpp
@@ -152,16 +152,9 @@ public:
         return GetTrialOfTheChampionAI<npc_toc5_player_vehicleAI>(pCreature);
     }
 
-    struct npc_toc5_player_vehicleAI : public NullCreatureAI
+    struct npc_toc5_player_vehicleAI : public VehicleAI
     {
-        npc_toc5_player_vehicleAI(Creature* pCreature) : NullCreatureAI(pCreature)
-        {
-            conditions = sConditionMgr->GetConditionsForNotGroupedEntry(CONDITION_SOURCE_TYPE_CREATURE_TEMPLATE_VEHICLE, me->GetEntry());
-            m_ConditionsTimer = 1000;
-        }
-
-        ConditionList conditions;
-        uint16 m_ConditionsTimer;
+        npc_toc5_player_vehicleAI(Creature* creature) : VehicleAI(creature) { }
 
         void Reset() override
         {
@@ -223,22 +216,6 @@ public:
             return false;
         }
 
-        //void EnterEvadeMode() { CreatureAI::EnterEvadeMode(); }
-        void MoveInLineOfSight(Unit*  /*who*/) override {}
-        void UpdateAI(uint32 diff) override
-        {
-            if (m_ConditionsTimer <= diff)
-            {
-                if (!conditions.empty())
-                    if (Unit* passenger = me->GetVehicleKit()->GetPassenger(0))
-                        if (!sConditionMgr->IsObjectMeetToConditions(passenger, me, conditions))
-                            passenger->ExitVehicle();
-                m_ConditionsTimer = VEHICLE_CONDITION_CHECK_TIME;
-            }
-            else
-                m_ConditionsTimer -= diff;
-        }
-        void AttackStart(Unit*  /*who*/) override {}
         void JustEngagedWith(Unit*  /*who*/) override {}
     };
 };


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Currently, a players can mount a vehicle in TOC5 without having the Argent Lance equipped. The creature AI will remove the player after mounting if no Argent Lance is equipped. 

changes:
refactor `npc_toc5_player_vehicle`, use vehicleAI, it checks conditions in updateAI
add a comment to vehicle conditions in DB
check aura and send custom spell error when trying to mount without lance equipped like generic spell to mount argent tournament mounts

https://github.com/azerothcore/azerothcore-wotlk/blob/cbd74ae66365923ecaf5b493c8f9011912a5a46c/src/server/scripts/Spells/spell_generic.cpp#L3295

### details
vehicle ids: 35644, 36558
spell `67830` is used for these `npc_spellclick_spells` 

I have not found a way to add "aura required" `condition` to achieve the correct behavior, hence the hack

`16 - SOURCE_TYPE_CREATURE_TEMPLATE_VEHICLE`
checks for conditions after mounted, if fail then exit. Check must happen before mounting.

`18 - SOURCE_TYPE_SPELL_CLICK_EVENT`
enables/disables the mount icon, this is checked during HandleSpellClick(). Icon must be available to click, even if conditions are not met.

can maybe use a spellscript `CheckCast` on `67830` but looks like a generic spell. tc335 `npc_spellclick_spells` only uses `67830` for these 2 toc5 vehicles. maybe acore `npc_spellclick_spells`  needs an update for this

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
prevents issues like below
- https://github.com/azerothcore/azerothcore-wotlk/issues/3520
- https://github.com/azerothcore/azerothcore-wotlk/issues/18800

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

wrath classic, start shows mouseover

https://youtu.be/zUPY72veDI0?si=bvcCpwNxa_cR0D6F&t=159


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

alliance or horde character
```
.go c id 35644
.add 46106
```

1. try mount without lance
2. equip lance
3. mount

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.