### PR TITLE
Fix(db/creature) black temple   illidari assassin riposte ability missing

### DIFF
--- a/data/sql/updates/pending_db_world/2024_09_11_00.sql
+++ b/data/sql/updates/pending_db_world/2024_09_11_00.sql
@@ -1,0 +1,3 @@
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 23403) AND (`source_type` = 0) AND (`id` IN (2));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(23403, 0, 2, 0, 0, 0, 100, 0, 0, 10000, 15000, 25000, 0, 0, 11, 41392, 0, 0, 0, 0, 0, 5, 5, 1, 0, 0, 0, 0, 0, 0, 'Illidari Assassin - In Combat - Cast Riposte');

--- a/data/sql/updates/pending_db_world/2024_09_13_00.sql
+++ b/data/sql/updates/pending_db_world/2024_09_13_00.sql
@@ -1,5 +1,3 @@
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 23403;
-
 UPDATE `creature_template` SET `flags_extra` = 134217728 WHERE (`entry` = 23403);
 
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 23403) AND (`source_type` = 0) AND (`id` IN (2));

--- a/data/sql/updates/pending_db_world/2024_09_13_00.sql
+++ b/data/sql/updates/pending_db_world/2024_09_13_00.sql
@@ -1,4 +1,4 @@
-UPDATE `creature_template` SET `flags_extra` = 134217728 WHERE (`entry` = 23403);
+UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 134217728 WHERE `entry` = 23403;
 
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 23403) AND (`source_type` = 0) AND (`id` IN (2));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES

--- a/data/sql/updates/pending_db_world/2024_09_13_00.sql
+++ b/data/sql/updates/pending_db_world/2024_09_13_00.sql
@@ -1,3 +1,7 @@
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 23403;
+
+UPDATE `creature_template` SET `flags_extra` = 134217728 WHERE (`entry` = 23403);
+
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 23403) AND (`source_type` = 0) AND (`id` IN (2));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(23403, 0, 2, 0, 0, 0, 100, 0, 0, 10000, 15000, 25000, 0, 0, 11, 41392, 0, 0, 0, 0, 0, 5, 5, 1, 0, 0, 0, 0, 0, 0, 'Illidari Assassin - In Combat - Cast Riposte');
+(23403, 0, 2, 0, 0, 0, 100, 0, 0, 15000, 30000, 40000, 0, 0, 11, 41392, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Illidari Assassin - In Combat - Cast Riposte');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/19876
- Closes https://github.com/chromiecraft/chromiecraft/issues/7334

Actually, the bug is a bit different from how it was described in this ticket. The first spawned Assassin only casts Paralyzing Poison and Vanish abilities (and doesn't cast Riposte). The other 3 spawns don't cast anything, they only perform melee attacks.

So in the bugfix, I didn't modify the existing spells, but I added new row for Riposte. As for the timers, I checked the logs here: [link](https://classic.warcraftlogs.com/zone/reports?zone=1011). It seems that the first Riposte is cast within 15 seconds. And then I modified flags_extra by setting DONT_OVERRIDE_SAI_ENTRY (so that all 4 NPCs use the SAI).


![Cattura](https://github.com/user-attachments/assets/3ef4a6cb-3c74-41c0-8078-09fb06f2d184)
![Cattura2](https://github.com/user-attachments/assets/f87f6275-9742-4731-b2fe-9fdeae9fe6cc)
![Cattura3](https://github.com/user-attachments/assets/e1832256-aef3-4114-9b41-90f09d9fa1cc)
![Cattura4](https://github.com/user-attachments/assets/e4e22e80-65d7-43af-942a-d98fec95b4cc)


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.
<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.