### PR TITLE
feat(Core/Commands): Add debug command for applying a spell cooldown.

### DIFF
--- a/data/sql/updates/pending_db_world/debug-cooldown.sql
+++ b/data/sql/updates/pending_db_world/debug-cooldown.sql
@@ -1,0 +1,2 @@
+DELETE FROM `command` WHERE `name` = `debug cooldown`;
+INSERT INTO `command` (`name`, `security`, `help`) VALUES ('debug cooldown', 3, 'Syntax: .debug cooldown #spellID #cooldownTime #itemID\nApply a cooldown of the given duration (in milliseconds) for the given spell and item ID.');

--- a/data/sql/updates/pending_db_world/debug-cooldown.sql
+++ b/data/sql/updates/pending_db_world/debug-cooldown.sql
@@ -1,2 +1,2 @@
-DELETE FROM `command` WHERE `name` = `debug cooldown`;
+DELETE FROM `command` WHERE `name` = 'debug cooldown';
 INSERT INTO `command` (`name`, `security`, `help`) VALUES ('debug cooldown', 3, 'Syntax: .debug cooldown #spellID #cooldownTime #itemID\nApply a cooldown of the given duration (in milliseconds) for the given spell and item ID.');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Core (Commands).
-  [X] Database (Commands).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- [ ] This does have an issue when applying cooldowns to items with spells, e.g. a hearthstone. When supplying the hearthstone spell and item ID (`.debug cooldown 8690 1800000 6948`), the cooldown does not appear properly on the item. Logging out and back in corrects the issue, and the player cannot use the item while it's on its invisible cooldown, but it is a visual discrepancy.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
