### PR TITLE
fix(Scripts/TheEye): Kael'thas p5 transition, flight, MotionMaster:MoveTakeoff

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1726786940038269786.sql
+++ b/data/sql/updates/pending_db_world/rev_1726786940038269786.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` = 36092;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(36092, 'spell_kaelthas_kael_explodes');

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -520,7 +520,7 @@ void MotionMaster::MoveLand(uint32 id, float x, float y, float z, float speed /*
 /**
  * @brief Use to move the unit from the ground to the air. Doesn't work with UNIT_FLAG_DISABLE_MOVE
  */
-void MotionMaster::MoveTakeoff(uint32 id, Position const& pos, float speed /* = 0.0f*/)
+void MotionMaster::MoveTakeoff(uint32 id, Position const& pos, float speed /* = 0.0f*/, bool skipAnimation)
 {
     if (_owner->HasUnitFlag(UNIT_FLAG_DISABLE_MOVE))
         return;
@@ -538,7 +538,10 @@ void MotionMaster::MoveTakeoff(uint32 id, Position const& pos, float speed /* = 
         init.SetVelocity(speed);
     }
 
-    init.SetAnimation(Movement::ToFly);
+    if (!skipAnimation)
+    {
+        init.SetAnimation(Movement::ToFly);
+    }
     init.Launch();
     Mutate(new EffectMovementGenerator(id), MOTION_SLOT_ACTIVE);
 }
@@ -546,10 +549,10 @@ void MotionMaster::MoveTakeoff(uint32 id, Position const& pos, float speed /* = 
 /**
  * @brief Use to move the unit from the air to the ground. Doesn't work with UNIT_FLAG_DISABLE_MOVE
  */
-void MotionMaster::MoveTakeoff(uint32 id, float x, float y, float z, float speed /* = 0.0f*/)
+void MotionMaster::MoveTakeoff(uint32 id, float x, float y, float z, float speed /* = 0.0f*/, bool skipAnimation)
 {
     Position pos = {x, y, z, 0.0f};
-    MoveTakeoff(id, pos, speed);
+    MoveTakeoff(id, pos, speed, skipAnimation);
 }
 
 void MotionMaster::MoveKnockbackFrom(float srcX, float srcY, float speedXY, float speedZ)

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -217,8 +217,8 @@ public:
     // These two movement types should only be used with creatures having landing/takeoff animations
     void MoveLand(uint32 id, Position const& pos, float speed = 0.0f);
     void MoveLand(uint32 id, float x, float y, float z, float speed = 0.0f); // pussywizard: added for easy calling by passing 3 floats x, y, z
-    void MoveTakeoff(uint32 id, Position const& pos, float speed = 0.0f);
-    void MoveTakeoff(uint32 id, float x, float y, float z, float speed = 0.0f); // pussywizard: added for easy calling by passing 3 floats x, y, z
+    void MoveTakeoff(uint32 id, Position const& pos, float speed = 0.0f, bool skipAnimation = false);
+    void MoveTakeoff(uint32 id, float x, float y, float z, float speed = 0.0f, bool skipAnimation = false); // pussywizard: added for easy calling by passing 3 floats x, y, z
 
     void MoveCharge(float x, float y, float z, float speed = SPEED_CHARGE, uint32 id = EVENT_CHARGE, const Movement::PointsArray* path = nullptr, bool generatePath = false, float orientation = 0.0f, ObjectGuid targetGUID = ObjectGuid::Empty);
     void MoveCharge(PathGenerator const& path, float speed = SPEED_CHARGE, ObjectGuid targetGUID = ObjectGuid::Empty);

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -92,7 +92,7 @@ enum KTSpells
     SPELL_KAEL_EXPLODES4                = 36354,
     SPELL_KAEL_EXPLODES5                = 36092,
     SPELL_GROW                          = 36184,
-    SPELL_KEAL_STUNNED                  = 36185,
+    SPELL_KAEL_STUNNED                  = 36185,
     SPELL_KAEL_FULL_POWER               = 36187,
     SPELL_FLOATING_DROWNED              = 36550,
     SPELL_DARK_BANISH_STATE             = 52241, // wrong visual apparently
@@ -522,8 +522,6 @@ struct boss_kaelthas : public BossAI
             me->RemoveAurasDueToSpell(SPELL_NETHERBEAM_AURA2);
             me->RemoveAurasDueToSpell(SPELL_NETHERBEAM_AURA3);
             DoCastSelf(SPELL_KAEL_EXPLODES5, true);
-            DoCastSelf(SPELL_FLOATING_DROWNED);
-            //me->CastSpell(me, SPELL_KEAL_STUNNED, true);
         }, EVENT_SCENE_8);
         ScheduleUniqueTimedEvent(22000ms, [&]
         {
@@ -567,8 +565,8 @@ struct boss_kaelthas : public BossAI
         ScheduleUniqueTimedEvent(32000ms, [&]
         {
             me->RemoveAurasDueToSpell(SPELL_FLOATING_DROWNED);
-            me->RemoveAurasDueToSpell(SPELL_KEAL_STUNNED);
             DoCastSelf(SPELL_KAEL_FULL_POWER);
+            // me->RemoveAurasDueToSpell(SPELL_KAEL_STUNNED);
             DoCastSelf(SPELL_KAEL_PHASE_TWO, true);
             DoCastSelf(SPELL_PURE_NETHER_BEAM4, true);
             DoCastSelf(SPELL_PURE_NETHER_BEAM5, true);
@@ -1324,6 +1322,27 @@ class spell_kaelthas_remove_enchanted_weapons : public SpellScript
     }
 };
 
+// 36092 - Kael Explodes
+class spell_kaelthas_kael_explodes : public SpellScript
+{
+    PrepareSpellScript(spell_kaelthas_kael_explodes);
+
+    void HandleScriptEffect(SpellEffIndex /*effIndex*/)
+    {
+        Unit* caster = GetCaster();
+        // caster->CastSpell((Unit*)nullptr, SPELL_KAEL_STUNNED, TRIGGERED_NONE);
+        caster->CastSpell((Unit*)nullptr, SPELL_FLOATING_DROWNED, TRIGGERED_NONE);
+        caster->PlayDirectSound(3320);
+        caster->PlayDirectSound(10845);
+        caster->PlayDirectSound(6539);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_kaelthas_kael_explodes::HandleScriptEffect, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+    }
+};
+
 void AddSC_boss_kaelthas()
 {
     RegisterTheEyeAI(boss_kaelthas);
@@ -1343,4 +1362,5 @@ void AddSC_boss_kaelthas()
     RegisterSpellScript(spell_kaelthas_summon_nether_vapor);
     RegisterSpellScript(spell_kael_pyroblast);
     RegisterSpellScript(spell_kaelthas_remove_enchanted_weapons);
+    RegisterSpellScript(spell_kaelthas_kael_explodes);
 }

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -301,23 +301,7 @@ struct boss_kaelthas : public BossAI
             _phase = PHASE_SINGLE_ADVISOR;
             me->SetInCombatWithZone();
             me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_DISABLE_MOVE);
-            Talk(SAY_INTRO);
-            DoCastAOE(SPELL_REMOVE_ENCHANTED_WEAPONS, true);
-            ScheduleUniqueTimedEvent(23s, [&]
-            {
-                Talk(SAY_INTRO_THALADRED);
-            }, EVENT_PREFIGHT_PHASE1_01);
-            ScheduleUniqueTimedEvent(30s, [&]
-            {
-                if (Creature* thaladred = summons.GetCreatureWithEntry(NPC_THALADRED))
-                {
-                    thaladred->SetReactState(REACT_AGGRESSIVE);
-                    thaladred->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
-                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
-                        thaladred->AI()->AttackStart(target);
-                    thaladred->SetInCombatWithZone();
-                }
-            }, EVENT_PREFIGHT_PHASE1_02);
+            PhaseKaelExecute();
         }
     }
 

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -466,6 +466,7 @@ struct boss_kaelthas : public BossAI
     void ExecuteMiddleEvent()
     {
         me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
+        me->RemoveAllAttackers();
         scheduler.ClearValidator();
         me->SetTarget();
         me->SetFacingTo(M_PI);
@@ -677,7 +678,6 @@ struct boss_kaelthas : public BossAI
                 _transitionSceneReached = true;
                 scheduler.CancelAll();
                 me->AttackStop();
-                me->RemoveAllAttackers();
                 me->CastStop();
                 me->SetReactState(REACT_PASSIVE);
                 me->GetMotionMaster()->MovePoint(POINT_MIDDLE, me->GetHomePosition(), true, true);

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -673,12 +673,11 @@ struct boss_kaelthas : public BossAI
             {
                 _transitionSceneReached = true;
                 scheduler.CancelAll();
+                me->AttackStop();
                 me->CastStop();
                 me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
                 me->SetReactState(REACT_PASSIVE);
                 me->GetMotionMaster()->MovePoint(POINT_MIDDLE, me->GetHomePosition(), true, true);
-                me->ClearUnitState(UNIT_STATE_MELEE_ATTACKING);
-                me->SendMeleeAttackStop();
 
                 ThreatContainer::StorageType threatList = me->GetThreatMgr().GetThreatList();
                 for (ThreatContainer::StorageType::const_iterator i = threatList.begin(); i != threatList.end(); ++i)

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -674,19 +674,11 @@ struct boss_kaelthas : public BossAI
                 _transitionSceneReached = true;
                 scheduler.CancelAll();
                 me->AttackStop();
+                me->RemoveAllAttackers();
                 me->CastStop();
                 me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
                 me->SetReactState(REACT_PASSIVE);
                 me->GetMotionMaster()->MovePoint(POINT_MIDDLE, me->GetHomePosition(), true, true);
-
-                ThreatContainer::StorageType threatList = me->GetThreatMgr().GetThreatList();
-                for (ThreatContainer::StorageType::const_iterator i = threatList.begin(); i != threatList.end(); ++i)
-                {
-                    if (Unit* target = ObjectAccessor::GetUnit(*me, (*i)->getUnitGuid()))
-                    {
-                       target->AttackStop();
-                    }
-                }
             }
         });
         ScheduleTimedEvent(1000ms, [&]

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -301,7 +301,24 @@ struct boss_kaelthas : public BossAI
         {
             _phase = PHASE_SINGLE_ADVISOR;
             me->SetInCombatWithZone();
-            PhaseKaelExecute();
+            me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_DISABLE_MOVE);
+            Talk(SAY_INTRO);
+            DoCastAOE(SPELL_REMOVE_ENCHANTED_WEAPONS, true);
+            ScheduleUniqueTimedEvent(23s, [&]
+            {
+                Talk(SAY_INTRO_THALADRED);
+            }, EVENT_PREFIGHT_PHASE1_01);
+            ScheduleUniqueTimedEvent(30s, [&]
+            {
+                if (Creature* thaladred = summons.GetCreatureWithEntry(NPC_THALADRED))
+                {
+                    thaladred->SetReactState(REACT_AGGRESSIVE);
+                    thaladred->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
+                        thaladred->AI()->AttackStart(target);
+                    thaladred->SetInCombatWithZone();
+                }
+            }, EVENT_PREFIGHT_PHASE1_02);
         }
     }
 

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -190,7 +190,9 @@ enum KTTransitionScene
     EVENT_SCENE_13                      = 62,
     EVENT_SCENE_14                      = 63,
     EVENT_SCENE_15                      = 64,
-    EVENT_SCENE_16                      = 65
+    EVENT_SCENE_16                      = 65,
+    EVENT_SCENE_17                      = 66,
+    EVENT_SCENE_18                      = 67
 };
 
 enum KTActions
@@ -566,16 +568,24 @@ struct boss_kaelthas : public BossAI
             if (Creature* trigger = me->SummonCreature(WORLD_TRIGGER, me->GetPositionX()-5, me->GetPositionY()+5, me->GetPositionZ()+15.0f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 60000))
                 trigger->CastSpell(me, SPELL_PURE_NETHER_BEAM3, true);
         }, EVENT_SCENE_14);
+        ScheduleUniqueTimedEvent(30500ms, [&]
+        {
+            me->SetFacingTo(M_PI);
+            me->RemoveAurasDueToSpell(SPELL_FLOATING_DROWNED);
+            me->CastStop();
+        }, EVENT_SCENE_15);
+        ScheduleUniqueTimedEvent(30700ms, [&]
+        {
+            me->CastStop();
+            DoCastSelf(SPELL_KAEL_FULL_POWER);
+        }, EVENT_SCENE_16);
         ScheduleUniqueTimedEvent(32000ms, [&]
         {
-            me->RemoveAurasDueToSpell(SPELL_FLOATING_DROWNED);
-            // me->RemoveAurasDueToSpell(SPELL_KAEL_STUNNED);
-            DoCastSelf(SPELL_KAEL_FULL_POWER, true);
             DoCastSelf(SPELL_KAEL_PHASE_TWO, true);
             DoCastSelf(SPELL_PURE_NETHER_BEAM4, true);
             DoCastSelf(SPELL_PURE_NETHER_BEAM5, true);
             DoCastSelf(SPELL_PURE_NETHER_BEAM6, true);
-        }, EVENT_SCENE_15);
+        }, EVENT_SCENE_17);
         ScheduleUniqueTimedEvent(36000ms, [&]
         {
             summons.DespawnEntry(WORLD_TRIGGER);
@@ -583,10 +593,9 @@ struct boss_kaelthas : public BossAI
             me->GetMotionMaster()->Clear();
             me->RemoveAurasDueToSpell(SPELL_DARK_BANISH_STATE); // WRONG VISUAL
             me->SetDisableGravity(true);
-            me->SetOrientation(M_PI);
             me->SendMovementFlagUpdate();
             me->GetMotionMaster()->MoveLand(POINT_START_LAST_PHASE, me->GetHomePosition(), 2.99f);
-        }, EVENT_SCENE_16);
+        }, EVENT_SCENE_18);
     }
 
     void IntroduceNewAdvisor(KTYells talkIntroduction, KTActions kaelAction)
@@ -1334,8 +1343,8 @@ class spell_kaelthas_kael_explodes : public SpellScript
     void HandleScriptEffect(SpellEffIndex /*effIndex*/)
     {
         Unit* caster = GetCaster();
-        // caster->CastSpell((Unit*)nullptr, SPELL_KAEL_STUNNED, true);
         caster->CastSpell((Unit*)nullptr, SPELL_FLOATING_DROWNED, true);
+        // caster->CastSpell((Unit*)nullptr, SPELL_KAEL_STUNNED, true);
         caster->PlayDirectSound(3320);
         caster->PlayDirectSound(10845);
         caster->PlayDirectSound(6539);

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -486,7 +486,7 @@ struct boss_kaelthas : public BossAI
                     trigger->CastSpell(me, SPELL_NETHERBEAM1 + i, false);
             me->SetDisableGravity(true);
             me->SendMovementFlagUpdate();
-            me->GetMotionMaster()->MoveTakeoff(POINT_AIR, me->GetPositionX(), me->GetPositionY(), 75.0f, 2.99);
+            me->GetMotionMaster()->MoveTakeoff(POINT_AIR, me->GetPositionX(), me->GetPositionY(), 75.0f, 2.99, true); // AnimType Movement::ToFly does not exist for Kael
             DoCastSelf(SPELL_GROW, true);
         }, EVENT_SCENE_3);
         ScheduleUniqueTimedEvent(7000ms, [&]


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

1. refactor, handle script_effect of final Kael'thas explode ( 36092 - Kael Explodes) with script that [adds sounds (cp from cmangos)](https://github.com/cmangos/mangos-wotlk/blame/fe732710aed998e5a6a53f8edc3573d8d4a3f706/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/the_eye/boss_kaelthas.cpp#L1456C11-L1456C11), stunned unused
2. Kael no longer becomes unselectable after reaching 50% hp threshold. At 50% he stops attacking and once he reaches home, he becomes unselectable and removes attackers
3. Add `skipAnimation` arg to MoveTakeoff. This prevented setting a drowned state after the spline movement finishes. Possibly need for below and maybe to handle Illidan's flight
- https://github.com/azerothcore/azerothcore-wotlk/issues/19056 
4. properly land. This fixes the linked issue. set gravity needs to be re-set after finishing the spline and before starting the landing [(see my explanation here)](https://github.com/azerothcore/azerothcore-wotlk/issues/18551#issuecomment-2363987415)  land spline uses type EFFECT_MOTION_TYPE for `MoveInform`
5. extra scene event to display the cast animation (BATTLE_ROAR) of `SPELL_KAEL_FULL_POWER`

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/18488

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

a. original wrath
kael untargetable. instead of at 50%, untargetable applied once Kael reaches home position

https://youtu.be/oTI0orxwfO4&t=476

wrath 8:22 full animation

https://youtu.be/oTI0orxwfO4&t=502


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


https://github.com/user-attachments/assets/4a02f7ab-ad14-4e09-829a-b106bea84f79



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

```
tp kael
.go c id 19622
.cheat god
.damage 300000
Nefarian's Barrier - CC immune
.cast 22663
```

1. go to kael
2. kill all advisors together to trigger kael
3. hit kael to 50%
4. observe rp

commit 9e82ac997cd9 enables kael at the start, hit him to 50% to start transition

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] missing more purple beams and sounds compared to source footage
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
