### PR TITLE
chore: change bg type variable uint8 -> uint16 for 3rd modules compatibility

### DIFF
--- a/src/server/game/Scripting/ScriptDefines/AllBattlegroundScript.h
+++ b/src/server/game/Scripting/ScriptDefines/AllBattlegroundScript.h
@@ -44,7 +44,7 @@ enum AllBattlegroundHook
 };
 
 enum BattlegroundBracketId : uint8;
-enum BattlegroundTypeId : uint8;
+enum BattlegroundTypeId : uint16;
 enum TeamId : uint8;
 
 class AllBattlegroundScript : public ScriptObject

--- a/src/server/shared/SharedDefines.h
+++ b/src/server/shared/SharedDefines.h
@@ -3475,7 +3475,7 @@ inline TeamId GetTeamId(PvPTeamId teamId)
 }
 
 // indexes of BattlemasterList.dbc
-enum BattlegroundTypeId : uint8
+enum BattlegroundTypeId : uint16
 {
     BATTLEGROUND_TYPE_NONE     = 0, // None
     BATTLEGROUND_AV            = 1, // Alterac Valley


### PR DESCRIPTION
This will allow values bigger than 255 to be a `BattlegroundTypeId`.
For retro-ported arenas like Tol'Viron or Tiger's Peak, where the MoP IDs are very big, it is necessary to consider this type as uint16.

I set it as WIP because I would like to make some further tests to see if other changes are needed.

related modules:
- https://github.com/Helias/mod-arena-tolviron
- https://github.com/Helias/mod-arena-tigerspeak

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to: a variable type from `uint8` to `uin16`

## Tests Performed:
tested with modules and 

## How to Test the Changes:
A successful build should be enough

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
