### PR TITLE
(DB/Creatures): fixup Dual Wield for creatures, remove some CREATURE_FLAG_EXTRA_USE_OFFHAND_ATTACK

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1727429234467651703.sql
+++ b/data/sql/updates/pending_db_world/rev_1727429234467651703.sql
@@ -1,0 +1,10 @@
+--
+UPDATE `creature_template` SET `flags_extra` = `flags_extra` & ~2048 WHERE `entry` IN (
+3672,  -- Boahn
+20783, -- Porfus the Gem Gorger
+21639, -- Illidari Slayer
+21717, -- Dragonmaw Wrangler
+12100, -- Lava Reaver
+22076, -- Torloth the Magnificent
+22004  -- Leoroxx
+);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).


fixup of

- https://github.com/azerothcore/azerothcore-wotlk/pull/20015

removes CREATURE_FLAG_EXTRA_USE_OFFHAND_ATTACK from the following creatures with - reason:
Boahn - uses 2h
Porfus the Gem Gorger - basilisk
Illidari Slayer - uses 2h
Dragonmaw Wrangler - shield OH
Lava Reaver - elemental
Torloth the Magnificent - uses 2h
Leoroxx - uses 2h


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Progresses https://github.com/azerothcore/azerothcore-wotlk/issues/20051 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Karsius The Ancient Watcher - uses 2her as a 1her
https://www.youtube.com/watch?v=ZbDKfjHlerg

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

test query to spawn all creatures somewhere south of un'goro

https://gist.github.com/sogladev/4671f693072a74048b372c68454c9c5a

see if these are special cases where the flag should not be set

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
