### PR TITLE
fix(DB/Spell): Link triggered Shattrath flask effects to flask aura and proper area.

### DIFF
--- a/data/sql/updates/pending_db_world/shattrath-flasks.sql
+++ b/data/sql/updates/pending_db_world/shattrath-flasks.sql
@@ -1,0 +1,8 @@
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` IN (-41608, -41609, -41610, -41611, -46837, -46839);
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES
+(-41609, -41607, 0, 'Shattrath Flask of Fortification'),
+(-41610, -41605, 0, 'Shattrath Flask of Mighty Restoration'),
+(-41611, -41604, 0, 'Shattrath Flask of Supreme Power'),
+(-41608, -41606, 0, 'Shattrath Flask of Relentless Assault'),
+(-46837, -46838, 0, 'Shattrath Flask of Pure Death'),
+(-46839, -46840, 0, 'Shattrath Flask of Blinding Light');

--- a/data/sql/updates/pending_db_world/shattrath-flasks.sql
+++ b/data/sql/updates/pending_db_world/shattrath-flasks.sql
@@ -7,3 +7,11 @@ INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comm
 (-46837, -46838, 0, 'Shattrath Flask of Pure Death'),
 (-46839, -46840, 0, 'Shattrath Flask of Blinding Light'),
 (-45373, -45374, 0, 'Bloodberry Elixir');
+
+UPDATE `spell_area` SET `spell` = 41607 WHERE `spell` = 41609;
+UPDATE `spell_area` SET `spell` = 41605 WHERE `spell` = 41610;
+UPDATE `spell_area` SET `spell` = 41604 WHERE `spell` = 41611;
+UPDATE `spell_area` SET `spell` = 41606 WHERE `spell` = 41608;
+UPDATE `spell_area` SET `spell` = 46838 WHERE `spell` = 46837;
+UPDATE `spell_area` SET `spell` = 46840 WHERE `spell` = 46839;
+UPDATE `spell_area` SET `spell` = 45374 WHERE `spell` = 45373;

--- a/data/sql/updates/pending_db_world/shattrath-flasks.sql
+++ b/data/sql/updates/pending_db_world/shattrath-flasks.sql
@@ -1,8 +1,9 @@
-DELETE FROM `spell_linked_spell` WHERE `spell_trigger` IN (-41608, -41609, -41610, -41611, -46837, -46839);
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` IN (-41608, -41609, -41610, -41611, -46837, -46839, -45373);
 INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES
 (-41609, -41607, 0, 'Shattrath Flask of Fortification'),
 (-41610, -41605, 0, 'Shattrath Flask of Mighty Restoration'),
 (-41611, -41604, 0, 'Shattrath Flask of Supreme Power'),
 (-41608, -41606, 0, 'Shattrath Flask of Relentless Assault'),
 (-46837, -46838, 0, 'Shattrath Flask of Pure Death'),
-(-46839, -46840, 0, 'Shattrath Flask of Blinding Light');
+(-46839, -46840, 0, 'Shattrath Flask of Blinding Light'),
+(-45373, -45374, 0, 'Bloodberry Elixir');

--- a/data/sql/updates/pending_db_world/shattrath-flasks.sql
+++ b/data/sql/updates/pending_db_world/shattrath-flasks.sql
@@ -8,10 +8,10 @@ INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comm
 (-46839, -46840, 0, 'Shattrath Flask of Blinding Light'),
 (-45373, -45374, 0, 'Bloodberry Elixir');
 
-UPDATE `spell_area` SET `spell` = 41607 WHERE `spell` = 41609;
-UPDATE `spell_area` SET `spell` = 41605 WHERE `spell` = 41610;
-UPDATE `spell_area` SET `spell` = 41604 WHERE `spell` = 41611;
-UPDATE `spell_area` SET `spell` = 41606 WHERE `spell` = 41608;
-UPDATE `spell_area` SET `spell` = 46838 WHERE `spell` = 46837;
-UPDATE `spell_area` SET `spell` = 46840 WHERE `spell` = 46839;
-UPDATE `spell_area` SET `spell` = 45374 WHERE `spell` = 45373;
+UPDATE `spell_area` SET `spell` = 41607, `aura_spell` = 41609, `autocast` = 1 WHERE `spell` = 41609;
+UPDATE `spell_area` SET `spell` = 41605, `aura_spell` = 41610, `autocast` = 1 WHERE `spell` = 41610;
+UPDATE `spell_area` SET `spell` = 41604, `aura_spell` = 41611, `autocast` = 1 WHERE `spell` = 41611;
+UPDATE `spell_area` SET `spell` = 41606, `aura_spell` = 41608, `autocast` = 1 WHERE `spell` = 41608;
+UPDATE `spell_area` SET `spell` = 46838, `aura_spell` = 46837, `autocast` = 1 WHERE `spell` = 46837;
+UPDATE `spell_area` SET `spell` = 46840, `aura_spell` = 46839, `autocast` = 1 WHERE `spell` = 46839;
+UPDATE `spell_area` SET `spell` = 45374, `aura_spell` = 45373, `autocast` = 1 WHERE `spell` = 45373;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/19786
- Likely closes https://github.com/azerothcore/azerothcore-wotlk/issues/16360
- Closes https://github.com/chromiecraft/chromiecraft/issues/7381
- Closes https://github.com/chromiecraft/chromiecraft/issues/6482

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [X] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
- [X] This pull request can be tested by following the reproduction steps provided in the linked issue.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- [X] ~~This fix further breaks https://github.com/azerothcore/azerothcore-wotlk/issues/19786 as the effects will no longer be kept outside nor inside the instances.~~ This has mostly been resolved, but unfortunately when first consuming the flask in the open world, the flask's effects are maintained until your area is updated.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
