### PR TITLE
fix(Core/BG): Fix double method call on removing a player

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -11339,8 +11339,6 @@ void Player::LeaveBattleground(Battleground* bg)
     if (bg->isArena() && (bg->GetStatus() == STATUS_IN_PROGRESS || bg->GetStatus() == STATUS_WAIT_JOIN))
         sScriptMgr->OnBattlegroundDesertion(this, ARENA_DESERTION_TYPE_LEAVE_BG);
 
-    bg->RemovePlayerAtLeave(this);
-
     // xinef: reset corpse reclaim time
     m_deathExpireTime = GameTime::GetGameTime().count();
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes none.- Idk how or why this is not causing some other issues tbh.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Myself. I was creating a module I had in mind and noticed the hook OnBattlegroundRemovePlayerAtLeave was executed twice when a player left a bg. I put a breakpoint on the code and these are the two call stacks:
1. The wrong one. 
![image](https://github.com/user-attachments/assets/c63c94c0-591c-40d7-b00b-eae04cd88684)

2. The good one.
![image](https://github.com/user-attachments/assets/623c5d67-107f-4f1d-8aa2-5568bd86efd7)

Basically this method shouldn't be called by Player::LeaveBattleground and should be called by BattlegroundMap.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Use some module that uses BGScript::OnBattlegroundRemovePlayerAtLeave hook and log something, you should see it twice.
2. Make sure it doesn't break anything else.

