### PR TITLE
fix(Core/SpellGeneric) Magic Rooster can be cast while mounted

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1728482907199736600.sql
+++ b/data/sql/updates/pending_db_world/rev_1728482907199736600.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id`=65917;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(65917, 'spell_magic_rooster_egg');

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -5311,6 +5311,30 @@ class spell_gen_steal_weapon : public AuraScript
     }
 };
 
+// 65917 - Magic Rooster
+// Due to a flaw in the spell design
+// The mount can be used, they are on another mount
+class spell_magic_rooster_egg : public SpellScript
+{
+    PrepareSpellScript(spell_magic_rooster_egg);
+
+    void HandleBeforeCast()
+    {
+        Unit* caster = GetCaster();
+
+        if (caster)
+        {
+            caster->Dismount();
+            caster->RemoveAurasByType(SPELL_AURA_MOUNTED);
+        }
+    }
+
+    void Register() override
+    {
+        BeforeCast += SpellCastFn(spell_magic_rooster_egg::HandleBeforeCast);
+    }
+};
+
 void AddSC_generic_spell_scripts()
 {
     RegisterSpellScript(spell_silithyst);
@@ -5468,4 +5492,5 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_consumption);
     RegisterSpellScript(spell_gen_sober_up);
     RegisterSpellScript(spell_gen_steal_weapon);
+    RegisterSpellScript(spell_magic_rooster_egg);
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Scripts (bosses, spell scripts, creature scripts).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/AdonisWOW/bugtracker/issues/12
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15985
- Closes https://github.com/azerothcore/azerothcore-wotlk/pull/16134
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16884
## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
- https://www.wowhead.com/wotlk/item=49290/magic-rooster-egg#comments:id=929888
```
Interestingly enough, you can mount to this mount from another and not be dismounted on the cast.
Probably a glitch, but all other mounts will dismount your current mount before mounting you on your new one.
```

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Learning the mammoth with sellers (`.additem 44235` or `.additem 44234`)
2. Learning to saddle a chicken (`.additem 46778` or `.additem 49290`)
3. While on the mammoth, cast the chicken mount (although it also works on other mounts, such as flying ones, allowing you to fly with the chicken, when it shouldn't be like that or use the mammoth vendors on it)
4. Applying the fix does not prevent the player from using the chicken on other mounts, but it does prevent it from having both auras.
5. The other solution would be to prevent the chicken from being used in this case, while already mounted. But I would have to test if this error is also occurring on the broom of the Halloween event.

```cpp
ApplySpellFix({
    47977, // Magic Broom
    65917  // Magic Rooster
    }, [](SpellInfo* spellInfo)
{
    // First two effects apply auras, which shouldn't be there
    // due to NO_TARGET applying aura on current caster (core bug)
    // Just wipe effect data, to mimic blizz-behavior
    spellInfo->Effects[EFFECT_0].Effect = 0;
    spellInfo->Effects[EFFECT_1].Effect = 0;
    spellInfo->Attributes &= ~SPELL_ATTR0_ALLOW_WHILE_MOUNTED;
});
```

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
