### PR TITLE
fix(Scripts/BlackTemple): Remove Naj'entus Spines from players on engage.

### DIFF
--- a/data/sql/updates/pending_db_world/najentus-spine-removal.sql
+++ b/data/sql/updates/pending_db_world/najentus-spine-removal.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` = 40354;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (40354, 'spell_najentus_remove_spines');

--- a/src/server/scripts/Outland/BlackTemple/boss_warlord_najentus.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_warlord_najentus.cpp
@@ -19,6 +19,7 @@
 #include "ScriptedCreature.h"
 #include "SpellScriptLoader.h"
 #include "black_temple.h"
+#include "Player.h"
 #include "SpellScript.h"
 
 enum Yells

--- a/src/server/scripts/Outland/BlackTemple/boss_warlord_najentus.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_warlord_najentus.cpp
@@ -48,6 +48,11 @@ enum Events
     EVENT_ENRAGE                    = 2
 };
 
+enum Misc
+{
+    ITEM_NAJENTUS_SPINE             = 32408
+};
+
 struct boss_najentus : public BossAI
 {
     boss_najentus(Creature* creature) : BossAI(creature, DATA_HIGH_WARLORD_NAJENTUS), _canTalk(true) { }
@@ -64,6 +69,10 @@ struct boss_najentus : public BossAI
 
         BossAI::JustEngagedWith(who);
         Talk(SAY_AGGRO);
+        me->GetMap()->DoForAllPlayers([&](Player* player)
+        {
+            player->DestroyItemCount(ITEM_NAJENTUS_SPINE, 5, true);
+        });
 
         me->m_Events.AddEventAtOffset([this] {
             Talk(SAY_ENRAGE);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Scripts (bosses, spell scripts, creature scripts).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/20168
- Closes https://github.com/chromiecraft/chromiecraft/issues/7407

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
- [X] This pull request can be tested by following the reproduction steps provided in the linked issue.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
