### PR TITLE
fix(CI): simplify ci-pending-sql.sh and make it safer

### DIFF
--- a/apps/ci/ci-pending-sql.sh
+++ b/apps/ci/ci-pending-sql.sh
@@ -35,7 +35,8 @@ function import() {
     PENDING_PATH="$AC_PATH_ROOT/data/sql/updates/pending_db_$1"
     UPDATES_DIR="$UPDATES_PATH/db_$1"
 
-    LATEST_UPDATE="$(find "$UPDATES_DIR" -iname "$TODAY*.sql" | sort -h | tail -n 1)"
+    # Get latest SQL file applied to this database
+    LATEST_UPDATE="$(find "$UPDATES_DIR" -iname "*.sql" | sort -h | tail -n 1)"
 
     for entry in "$PENDING_PATH"/*.sql
     do
@@ -44,7 +45,7 @@ function import() {
             OUTPUT_FILE="${UPDATES_DIR}/${TODAY}_${INDEX}.sql"
 
             # ensure a note is added as a header comment
-            echo "-- DB update $(realpath --relative-to "$AC_PATH_ROOT" "$entry") -> $(realpath --relative-to "$AC_PATH_ROOT" "$OUTPUT_FILE")" > "$OUTPUT_FILE"
+            echo "-- DB update $(basename "$LATEST_UPDATE" .sql) -> $(basename "$OUTPUT_FILE" .sql)" > "$OUTPUT_FILE"
             # fill in the SQL contents under that
             cat "$entry" >> "$OUTPUT_FILE"
             # remove the unneeded file

--- a/apps/ci/ci-pending-sql.sh
+++ b/apps/ci/ci-pending-sql.sh
@@ -1,77 +1,56 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 CURRENT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "$CURRENT_PATH/../bash_shared/includes.sh"
 
-UPDATES_PATH="$AC_PATH_ROOT/data/sql/updates/"
+UPDATES_PATH="$AC_PATH_ROOT/data/sql/updates"
 
-COMMIT_HASH=
 
-function import() {
-    db=$1
-    folder="db_"$db
-    pendingPath="$AC_PATH_ROOT/data/sql/updates/pending_$folder"
-    updPath="$UPDATES_PATH/$folder"
-    archivedPath="$AC_PATH_ROOT/data/sql/archive/$folder/6.x"
-
-    latestUpd=$(ls -1 $updPath/ | tail -n 1)
-
-    if [ -z $latestUpd ]; then
-        latestUpd=$(ls -1 $archivedPath/ | tail -n 1)
-        echo "> Last update file for db $db is missing! Using archived file" $latestUpd
+# get_next_index "data/sql/updates/db_world/2024_10_14_22.sql"
+#   => 23
+# get_next_index ""
+#   => 00
+function get_next_index() {
+    if [[ -n "$1" ]]; then
+        PREV_COUNT="$(basename "$1" | cut -f4 -d_ | cut -f1 -d\.)"
+        printf '%02d' "$((PREV_COUNT + 1))"
+    else
+        echo "00"
     fi
+}
 
-    dateToday=$(date +%Y_%m_%d)
-    counter=0
+# lists all SQL files in the appropriate data/sql/updates/db_$1, and then moves them to a standard format, ordered by date and how many imports have happened that day. The name should be in this format:
+#
+# /path/to/data/sql/updates/db_NAME/YYYY_MM_DD_INDEX.sql
+#
+# Where INDEX is a number with a minimum with a minimum width (0-padded) of 2
+#
+# for example, "data/sql/updates/db_world/2024_10_01_03.sql" translates to "the third update in the world database from October 01, 2024"
 
-    dateLast=$latestUpd
-    tmp=${dateLast#*_*_*_}
-    oldCnt=${tmp%.sql}
-    oldDate=${dateLast%_$tmp}
+TODAY="$(date +%Y_%m_%d)"
+function import() {
+    PENDING_PATH="$AC_PATH_ROOT/data/sql/updates/pending_db_$1"
+    UPDATES_DIR="$UPDATES_PATH/db_$1"
 
-    if [ "$oldDate" = "$dateToday" ]; then
-        ((counter=10#$oldCnt+1)) # 10 # is needed to explictly add to a base 10 number
-    fi;
+    LATEST_UPDATE="$(find "$UPDATES_DIR" -iname "$TODAY*.sql" | sort -h | tail -n 1)"
 
-    for entry in "$pendingPath"/*.sql
+    for entry in "$PENDING_PATH"/*.sql
     do
-        if [[ -e $entry ]]; then
-            oldVer=$oldDate"_"$oldCnt
+        if [[ -f "$entry" ]]; then
+            INDEX="$(get_next_index "$LATEST_UPDATE")"
+            OUTPUT_FILE="${UPDATES_DIR}/${TODAY}_${INDEX}.sql"
 
-            cnt=$(printf -v counter "%02d" $counter ; echo $counter)
-
-            newVer=$dateToday"_"$cnt
-
-            newFile="$updPath/"$dateToday"_"$cnt".sql"
-
-            oldFile=$(basename "$entry")
-            prefix=${oldFile%_*.sql}
-            suffix=${oldFile#rev_}
-            rev=${suffix%.sql}
-
-            isRev=0
-            if [[ $prefix = "rev" && $rev =~ ^-?[0-9]+$ ]]; then
-                isRev=1
-            fi
-
-            echo "-- DB update $oldVer -> $newVer" > "$newFile";
-
-            cat $entry >> "$newFile";
-
-            currentHash="$(git log --diff-filter=A "$entry" | grep "^commit " | sed -e 's/commit //')"
-
-            if [[ "$COMMIT_HASH" != *"$currentHash"* ]]
-            then
-              COMMIT_HASH="$COMMIT_HASH $currentHash"
-            fi
-
-            rm $entry;
-
-            oldDate=$dateToday
-            oldCnt=$cnt
-
-            ((counter+=1))
+            # ensure a note is added as a header comment
+            echo "-- DB update $(realpath --relative-to "$AC_PATH_ROOT" "$entry") -> $(realpath --relative-to "$AC_PATH_ROOT" "$OUTPUT_FILE")" > "$OUTPUT_FILE"
+            # fill in the SQL contents under that
+            cat "$entry" >> "$OUTPUT_FILE"
+            # remove the unneeded file
+            rm -f "$entry"
+            # set the newest file to the file we just moved
+            LATEST_UPDATE="$OUTPUT_FILE"
         fi
     done
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).
-  [x] CI

Today, we ran into an issue where a pending SQL file had a space in the name. This was an issue because the previous script didn't wrap all process substitutions (`$(...)`) and variable references in double quotes, meaning.

This PR fixes this through making the script shorter and by adhering to safe shell scripting practices, using [shellcheck](https://github.com/koalaman/shellcheck) as a guide. Additionally, this PR adds comments to it's a bit more clear as to what is going on in the shell script

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- no specific issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Make a new pending sql file (`bash -x data/sql/updates/pending_db_world/create_sql.sh`)
2. Make another new pending SQL file, with a space in the name (`touch echo "--" >> "data/sql/updates/pending_db_world/its\ a\ space.sql"`)
3. run the process (`bash -x apps/ci/ci-pending-sql.sh`)
4. it won't break

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
