### PR TITLE
Revert "fix(Core/Spells): SPELL_ATTR1_IMMUNITY_PURGES_EFFECT should not remov…"

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5122,9 +5122,6 @@ void Unit::RemoveAurasByType(AuraType auraType, ObjectGuid casterGUID, Aura* exc
         if (aura != except && (!casterGUID || aura->GetCasterGUID() == casterGUID)
                 && ((negative && !aurApp->IsPositive()) || (positive && aurApp->IsPositive())))
         {
-            if (aura->GetSpellInfo()->HasAttribute(SPELL_ATTR0_NO_IMMUNITIES))
-                continue;
-
             uint32 removedAuras = m_removedAurasCount;
             RemoveAura(aurApp);
             if (m_removedAurasCount > removedAuras + 1)
@@ -5260,12 +5257,11 @@ void Unit::RemoveAurasWithMechanic(uint32 mechanic_mask, AuraRemoveMode removemo
         Aura const* aura = iter->second->GetBase();
         if (!except || aura->GetId() != except)
         {
-            if (!aura->GetSpellInfo()->HasAttribute(SPELL_ATTR0_NO_IMMUNITIES))
-                if (aura->GetSpellInfo()->GetAllEffectsMechanicMask() & mechanic_mask)
-                {
-                    RemoveAura(iter, removemode);
-                    continue;
-                }
+            if (aura->GetSpellInfo()->GetAllEffectsMechanicMask() & mechanic_mask)
+            {
+                RemoveAura(iter, removemode);
+                continue;
+            }
         }
         ++iter;
     }


### PR DESCRIPTION
Reverts azerothcore/azerothcore-wotlk#20032

Causes issues with warrior instances. Cant think of a solution to this atm.