### PR TITLE
fix(DB/gameobject_queststarter): Added queststarter records for GameObject 142122

### DIFF
--- a/data/sql/updates/pending_db_world/gameobject_142122_add_quest_starters.sql
+++ b/data/sql/updates/pending_db_world/gameobject_142122_add_quest_starters.sql
@@ -1,0 +1,5 @@
+DELETE FROM gameobject_queststarter WHERE id = 142122 AND quest IN (2781, 2875);
+
+INSERT INTO gameobject_queststarter (id, quest) VALUES 
+(142122, 2781), 
+(142122, 2875);

--- a/data/sql/updates/pending_db_world/gameobject_142122_add_quest_starters.sql
+++ b/data/sql/updates/pending_db_world/gameobject_142122_add_quest_starters.sql
@@ -1,5 +1,5 @@
-DELETE FROM gameobject_queststarter WHERE id = 142122 AND quest IN (2781, 2875);
+DELETE FROM `gameobject_queststarter` WHERE `id` = 142122 AND `quest` IN (2781, 2875);
 
-INSERT INTO gameobject_queststarter (id, quest) VALUES 
+INSERT INTO `gameobject_queststarter` (`id`, `quest`) VALUES 
 (142122, 2781), 
 (142122, 2875);


### PR DESCRIPTION
I added the records so that these quests can be initiated from both wanted posters.

GameObject
https://www.wowhead.com/wotlk/object=142122/wanted-poster

Quests:
https://www.wowhead.com/wotlk/quest=2781/wanted-caliph-scorpidsting https://www.wowhead.com/wotlk/quest=2875/wanted-andre-firebeard


![added_queststart](https://github.com/user-attachments/assets/f6518b79-73e3-4370-a8c7-1bb9b5741545)
