### PR TITLE
fix(DB/SAI): Add target type correction for spell 43458 (Secrets of Wyrmskull)

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1729891925644004000.sql
+++ b/data/sql/updates/pending_db_world/rev_1729891925644004000.sql
@@ -1,0 +1,4 @@
+-- Fix quest 11343 so that quest credit spell is cast on caster, not player
+UPDATE `smart_scripts`
+SET `target_type` = 1
+WHERE `entryorguid` = 2431400 AND `action_type` = 11 AND `action_param1` = 43458;

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -40,6 +40,18 @@ void SpellMgr::LoadSpellInfoCorrections()
 {
     uint32 oldMSTime = getMSTime();
 
+    // Secrets of Wyrmskull
+    ApplySpellFix({ 43458 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(3); // 20y
+    });
+
+    // Secrets of Nifflevar
+    ApplySpellFix({ 43468 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(14); // 60y
+    });
+
     ApplySpellFix({
         467,    // Thorns (Rank 1)
         782,    // Thorns (Rank 2)

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -40,18 +40,6 @@ void SpellMgr::LoadSpellInfoCorrections()
 {
     uint32 oldMSTime = getMSTime();
 
-    // Secrets of Wyrmskull
-    ApplySpellFix({ 43458 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(3); // 20y
-    });
-
-    // Secrets of Nifflevar
-    ApplySpellFix({ 43468 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(14); // 60y
-    });
-
     ApplySpellFix({
         467,    // Thorns (Rank 1)
         782,    // Thorns (Rank 2)


### PR DESCRIPTION
The target type for the quest credit spell 43458 in the SAI quest for 11343 (The Echo of Ymiron) is wrong and should be set to SMART_TARGET_SELF. The NPC actually casts it on himself and if the player is in the appropriate radius when the spell is cast, it will give them credit. The other quest referenced here 11344 (The Anguish of Nifflevar) is actually working as intended, even though there was a bug logged against it. Because the radius for the quest completion spell (43468 - Secrets of Nifflevar) is only 30 yards, it was likely that the person who logged the bug was not standing close enough to the NPC to receive credit and assumed it was bugged. I have manually tested that quest and confirmed you do get credit if you are standing within 30 yards of the NPC. 

So to sum things up, this PR can close out issue #18874, and issue #19776 can be closed since this fix applies to the first quest mentioned there and the other quest is not actually bugged.

Closes AzerothCore issue #19776
Closes AzerothCore issue #18874

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #19776
- Closes #18874

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
