### PR TITLE
fix(Scripts/Kalimdor): Cavern of Time custodian escort quest group completion

### DIFF
--- a/src/server/scripts/Kalimdor/zone_tanaris.cpp
+++ b/src/server/scripts/Kalimdor/zone_tanaris.cpp
@@ -242,16 +242,28 @@ public:
                         break;
                     case 24:
                         Talk(WHISPER_CUSTODIAN_14, player);
-                        DoCast(player, 34883);
-                        // below here is temporary workaround, to be removed when spell works properly
-                        player->AreaExploredOrEventHappens(10277);
+                        if (Group* group = player->GetGroup())
+                        {
+                            for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+                            {
+                                Player* player = itr->GetSource();
+
+                                // for any leave or dead (with not released body) group member at appropriate distance
+                                if (player && player->IsAtGroupRewardDistance(me) && !player->GetCorpse())
+                                    DoCast(player, 34883); // QID 10277
+
+                            }
+                        }
+                        else
+                        {
+                            DoCast(player, 34883); // QID 10277
+                        }
                         break;
                 }
             }
         }
 
         void MoveInLineOfSight(Unit* who) override
-
         {
             if (HasEscortState(STATE_ESCORT_ESCORTING))
                 return;

--- a/src/server/scripts/Kalimdor/zone_tanaris.cpp
+++ b/src/server/scripts/Kalimdor/zone_tanaris.cpp
@@ -242,22 +242,7 @@ public:
                         break;
                     case 24:
                         Talk(WHISPER_CUSTODIAN_14, player);
-                        if (Group* group = player->GetGroup())
-                        {
-                            for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
-                            {
-                                Player* player = itr->GetSource();
-
-                                // for any leave or dead (with not released body) group member at appropriate distance
-                                if (player && player->IsAtGroupRewardDistance(me) && !player->GetCorpse())
-                                    DoCast(player, 34883); // QID 10277
-
-                            }
-                        }
-                        else
-                        {
-                            DoCast(player, 34883); // QID 10277
-                        }
+                        player->GroupEventHappens(10277, me); // skip casts 34883 (QID 10277)
                         break;
                 }
             }

--- a/src/server/scripts/Kalimdor/zone_tanaris.cpp
+++ b/src/server/scripts/Kalimdor/zone_tanaris.cpp
@@ -242,7 +242,22 @@ public:
                         break;
                     case 24:
                         Talk(WHISPER_CUSTODIAN_14, player);
-                        player->GroupEventHappens(10277, me); // skip casts 34883 (QID 10277)
+                        if (Group* group = player->GetGroup())
+                        {
+                            for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+                            {
+                                Player* player = itr->GetSource();
+
+                                // for any leave or dead (with not released body) group member at appropriate distance
+                                if (player && player->IsAtGroupRewardDistance(me) && !player->GetCorpse())
+                                    DoCast(player, 34883); // QID 10277
+
+                            }
+                        }
+                        else
+                        {
+                            DoCast(player, 34883); // QID 10277
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Cast the reward quest spell on each group members if within group reward range

I opted to use the reward quest spell on each group member over `GroupEventHappens` because a reward spell exists. 

`void Spell::EffectQuestComplete(SpellEffIndex effIndex)`
`void Player::GroupEventHappens(uint32 questId, WorldObject const* pEventObject)`


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Progresses https://github.com/azerothcore/azerothcore-wotlk/issues/19591
- Closes https://github.com/chromiecraft/chromiecraft/issues/6225


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

diff to "complete" escort after 10 seconds instead of 9 minutes
```
diff --git a/src/server/scripts/Kalimdor/zone_tanaris.cpp b/src/server/scripts/Kalimdor/zone_tanaris.cpp
index fcdbaa6aa2..f08fc66ddf 100644
--- a/src/server/scripts/Kalimdor/zone_tanaris.cpp
+++ b/src/server/scripts/Kalimdor/zone_tanaris.cpp
@@ -191,3 +191,3 @@ public:
                 {
-                    case 0:
+                    case 69:
                         Talk(WHISPER_CUSTODIAN_1, player);
@@ -242,3 +242,3 @@ public:
                         break;
-                    case 24:
+                    case 0:
                         Talk(WHISPER_CUSTODIAN_14, player);
```

some macros
```
pre quest
.quest add 10279

reset q
.quest remove  10277

complete single target
/tar cust
.cast back 34883

/target char
/g .die
/target char
/g .revive
```
2 characters
group
complete prequests

1. char1: accept escort
2. char2: accept escort
3. wait 10 seconds (or 9 minutes if unmodified)
4. char 1 and char 2 have quest completed

reset if needed to test conditions, like dead or out of range

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] could move the npc to DB like in TC, but the same issue appears where quest credit is only granted to the summoner of the custodian https://github.com/TrinityCore/TrinityCore/commit/07d1b5e64b7de969ce2e287d540f3faa501381de
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
