### PR TITLE
fix(Scripts/Events): Hallow's End Headless Horsemen fly intro

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1730310110375137038.sql
+++ b/data/sql/updates/pending_db_world/rev_1730310110375137038.sql
@@ -1,0 +1,3 @@
+--
+-- Headless Horseman: NO_MOVE_FLAGS_UPDATE - Creature won't update movement flags
+UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 512 WHERE (`entry` = 23682);

--- a/src/server/scripts/Events/hallows_end.cpp
+++ b/src/server/scripts/Events/hallows_end.cpp
@@ -1091,6 +1091,8 @@ struct boss_headless_horseman : public ScriptedAI
                 me->ReplaceAllUnitFlags(UNIT_FLAG_NONE);
                 me->StopMoving();
 
+                me->SetDisableGravity(false);
+
                 me->SetInCombatWithZone();
                 inFight = true;
                 events.ScheduleEvent(EVENT_HORSEMAN_FOLLOW, 500ms);
@@ -1187,6 +1189,7 @@ struct boss_headless_horseman : public ScriptedAI
                                 trigger->CastSpell(trigger, SPELL_EARTH_EXPLOSION, true);
                             break;
                         case 3:
+                            me->SetDisableGravity(true);
                             me->GetMotionMaster()->MovePath(236820, false);
                             me->CastSpell(me, SPELL_SHAKE_CAMERA_SMALL, true);
                             player->Say(TALK_PLAYER_FELT_DEATH);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

fixes horsemen falling out of the sky during his intro by setting his movement flags manually

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

https://github.com/user-attachments/assets/340e4944-6d0f-47f2-801d-f67ecd690519


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.



https://github.com/user-attachments/assets/dca143bd-1cbd-4b3e-beb3-f17f64eec144



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

observe location 
```
 .go xyz 1807.7548 1354.82 19.33 189 3.2035
```

1. .go ga id 186267
2. observe flight

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
