### PR TITLE
fix(DB/Spell): Add spell effect data for Shattered Sun transform auras.

### DIFF
--- a/data/sql/updates/pending_db_world/shattered-sun-transform-serversides.sql
+++ b/data/sql/updates/pending_db_world/shattered-sun-transform-serversides.sql
@@ -1,0 +1,52 @@
+UPDATE `spell_dbc` SET `Effect_1` = 6, `EffectAura_1` = 56 WHERE `ID` IN (44918, 44919, 44920, 44921, 44922, 44923, 44924, 44925, 44926, 44927, 44928, 44929, 44930, 44931, 44932, 44962, 45155, 45156, 45157, 45158, 45159, 45160, 45161, 45162, 45163, 45164, 45165, 45166, 45167, 45168, 45169, 45170);
+
+-- All below ordered as follows:
+-- Blood Elf ♀
+-- Blood Elf ♂
+-- Draenei ♀
+-- Draenei ♂
+
+-- Phase/Tier 1
+--    Marksman
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24942 WHERE `ID` = 44921;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24963 WHERE `ID` = 44962;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24950 WHERE `ID` = 44929;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24946 WHERE `ID` = 44925;
+--    Warrior
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25116 WHERE `ID` = 45155;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25120 WHERE `ID` = 45159;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25124 WHERE `ID` = 45163;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25128 WHERE `ID` = 45167;
+-- Phase/Tier 2
+--    Marksman
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24943 WHERE `ID` = 44922;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24939 WHERE `ID` = 44918;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24951 WHERE `ID` = 44930;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24947 WHERE `ID` = 44926;
+--    Warrior
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25117 WHERE `ID` = 45156;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25121 WHERE `ID` = 45160;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25125 WHERE `ID` = 45164;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25129 WHERE `ID` = 45168;
+-- Phase/Tier 3
+--    Marksman
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24944 WHERE `ID` = 44923;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24940 WHERE `ID` = 44919;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24952 WHERE `ID` = 44931;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24948 WHERE `ID` = 44927;
+--    Warrior
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25118 WHERE `ID` = 45157;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25122 WHERE `ID` = 45161;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25126 WHERE `ID` = 45165;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25130 WHERE `ID` = 45169;
+-- Phase/Tier 4 (Final)
+--    Marksman
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24945 WHERE `ID` = 44924;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24941 WHERE `ID` = 44920;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24953 WHERE `ID` = 44932;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 24949 WHERE `ID` = 44928;
+--    Warrior
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25119 WHERE `ID` = 45158;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25123 WHERE `ID` = 45162;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25127 WHERE `ID` = 45166;
+UPDATE `spell_dbc` SET `EffectMiscValue_1` = 25131 WHERE `ID` = 45170;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Progresses https://github.com/azerothcore/azerothcore-wotlk/issues/10795

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes:
- [X] Have not been validated.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- [ ] The Shattered Sun creatures need these auras actually applied to them. According to research by (iirc) CMaNGOS, only the final fourth phase auras were used, even when the earlier phases were live on official servers. Even still, it seems the data exists for the earlier phases, so IMO the auras should have that data ready.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
