### PR TITLE
fix(DB/Quest): Morgan Stern [1260] not required for 1204

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1731668322577028300.sql
+++ b/data/sql/updates/pending_db_world/rev_1731668322577028300.sql
@@ -1,0 +1,3 @@
+--
+UPDATE `quest_template_addon` SET  `PrevQuestID` = 0 WHERE `id` = 1204;
+


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/20577 
- Closes https://github.com/chromiecraft/chromiecraft/issues/7503

## SOURCE:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

- Make an alliance character
- `.level 30`
- `.go creature id 4794`
- Talk to `Morgan Stern`, now you're able to start the Quest `Mudrock Soup and Bugs` without the previous quest.

