### PR TITLE
fix(Core/Creature): Set RespawnTime before AI Reset

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2094,6 +2094,7 @@ void Creature::Respawn(bool force)
             loot.clear();
             SelectLevel();
 
+            m_respawnedTime = GameTime::GetGameTime().count();
             setDeathState(DeathState::JustRespawned);
 
             // MDic - Acidmanifesto: Do not override transform auras
@@ -2125,7 +2126,6 @@ void Creature::Respawn(bool force)
             //Re-initialize reactstate that could be altered by movementgenerators
             InitializeReactState();
 
-            m_respawnedTime = GameTime::GetGameTime().count();
         }
         m_respawnedTime = GameTime::GetGameTime().count();
         // xinef: relocate notifier, fixes npc appearing in corpse position after forced respawn (instead of spawn)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`Creature::Respawn()` calls `AI->Reset()` before resetting `m_respawnedTime`. 
- https://github.com/azerothcore/azerothcore-wotlk/blob/b96acc57fb1f83e4fa44020ab62d21dee7ee53aa/src/server/game/Entities/Creature/Creature.cpp#L2117

In the case of Archimonde respawning: `AI->Reset(), SetVisible(), CreatureUnitRelocationWorker(), CanCreatureAttack()`  

The pet is valid to attack in this check and Archimonde attacks the pet 
- https://github.com/azerothcore/azerothcore-wotlk/blob/b96acc57fb1f83e4fa44020ab62d21dee7ee53aa/src/server/game/Entities/Creature/Creature.cpp#L2646

TC335 for reference: https://github.com/TrinityCore/TrinityCore/blob/b7471244adb08f112214634b27d7daf2da19aa0f/src/server/game/Entities/Creature/Creature.cpp#L2075
respawn time set before AI->Reset()

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/20235

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

warlock with invincible felhunter
```
/target hijal
/g .revive
/g .add 6265
/g .cheat cast on
/g .cast 691
/target felhunter
.cast self 22663
```

tp archimonde
```
.go c id 17968
```
trigger archimonde spawn by killing Azgalor
```
.instance setbossstate 0 3
.instance setbossstate 1 3
.instance setbossstate 2 3
.instance setbossstate 3 3
```

second character with GM mode to `.respawn`

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.cheat god` with a aggressive  felhunter  on archimonde's spawnpoint
2. trigger respawn
3. archimonde should use abilities

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
