### PR TITLE
fix (Core/Wintergrasp) Various fixes

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -167,6 +167,7 @@ bool Battlefield::Update(uint32 diff)
         m_StartGrouping = true;
         InvitePlayersInZoneToQueue();
         OnStartGrouping();
+        SendUpdateWorldStatesToWorld();
     }
 
     bool objective_changed = false;
@@ -352,6 +353,8 @@ void Battlefield::StartBattle()
     DoPlaySoundToAll(BF_START);
 
     OnBattleStart();
+
+    SendUpdateWorldStatesToWorld();
 }
 
 void Battlefield::EndBattle(bool endByTimer)
@@ -376,6 +379,8 @@ void Battlefield::EndBattle(bool endByTimer)
     // Reset battlefield timer
     m_Timer = m_NoWarBattleTime;
     SendInitWorldStatesToAll();
+
+    SendUpdateWorldStatesToWorld();
 }
 
 void Battlefield::DoPlaySoundToAll(uint32 SoundID)
@@ -402,6 +407,8 @@ void Battlefield::AskToLeaveQueue(Player* player)
 {
     // Remove player from queue
     m_PlayersInQueue[player->GetTeamId()].erase(player->GetGUID());
+    // Send notification
+    player->GetSession()->SendBfLeaveMessage(m_BattleId, BF_LEAVE_REASON_CLOSE);
 }
 
 // Called in WorldSession::HandleHearthAndResurrect

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -335,6 +335,7 @@ public:
     /// Send all worldstate data to all player in zone.
     virtual void SendInitWorldStatesToAll() = 0;
     virtual void FillInitialWorldStates(WorldPacket& /*data*/) = 0;
+    virtual void SendUpdateWorldStatesToWorld() = 0;
 
     /// Return if we can use mount in battlefield
     bool CanFlyIn() { return !m_isActive; }

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -108,6 +108,9 @@ enum WintergraspWorldStates
     BATTLEFIELD_WG_WORLD_STATE_DEFENDER          = 3802,
     BATTLEFIELD_WG_WORLD_STATE_ATTACKER          = 3803,
     BATTLEFIELD_WG_WORLD_STATE_SHOW_WORLDSTATE   = 3710,
+
+    BATTLEFIELD_WG_WORLD_STATE_CONTROL           = 3804, // Shows on the map who controls WG
+    BATTLEFIELD_WG_WORLD_STATE_ICON_ACTIVE       = 4375, // Activates "ice" icon
 };
 
 enum WintergraspAreaIds
@@ -404,6 +407,10 @@ public:
     void SendInitWorldStatesTo(Player* player);
     void SendInitWorldStatesToAll() override;
     void FillInitialWorldStates(WorldPacket& data) override;
+
+    void SendUpdateWorldStateMessage(uint32 variable, uint32 value, Player* player = nullptr);
+    void SendUpdateWorldStatesTo(Player* player);
+    void SendUpdateWorldStatesToWorld() override;
 
     void HandleKill(Player* killer, Unit* victim) override;
     void OnUnitDeath(Unit* unit) override;

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -411,6 +411,7 @@ public:
     void SendUpdateWorldStateMessage(uint32 variable, uint32 value, Player* player = nullptr);
     void SendUpdateWorldStatesTo(Player* player);
     void SendUpdateWorldStatesToWorld() override;
+    void SendUpdateWorldStates(Player* player = nullptr);
 
     void HandleKill(Player* killer, Unit* victim) override;
     void OnUnitDeath(Unit* unit) override;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -8877,13 +8877,7 @@ void Player::SendBattlefieldWorldStates()
     {
         if (BattlefieldWG* wg = (BattlefieldWG*)sBattlefieldMgr->GetBattlefieldByBattleId(BATTLEFIELD_BATTLEID_WG))
         {
-            SendUpdateWorldState(BATTLEFIELD_WG_WORLD_STATE_ATTACKER, wg->GetAttackerTeam());
-            SendUpdateWorldState(BATTLEFIELD_WG_WORLD_STATE_DEFENDER, wg->GetDefenderTeam());
-            SendUpdateWorldState(BATTLEFIELD_WG_WORLD_STATE_ACTIVE, wg->IsWarTime() ? 0 : 1); // Note: cleanup these two, their names look awkward
-            SendUpdateWorldState(BATTLEFIELD_WG_WORLD_STATE_SHOW_WORLDSTATE, wg->IsWarTime() ? 1 : 0);
-
-            for (uint32 i = 0; i < 2; ++i)
-                SendUpdateWorldState(ClockWorldState[i], uint32(GameTime::GetGameTime().count() + (wg->GetTimer() / 1000)));
+            wg->SendUpdateWorldStatesTo(this);
         }
     }
 }

--- a/src/server/scripts/Northrend/zone_wintergrasp.cpp
+++ b/src/server/scripts/Northrend/zone_wintergrasp.cpp
@@ -279,7 +279,7 @@ enum eWgQueue
     NPC_ARCANIST_BRAEDIN            = 32169,
     NPC_MAGISTER_SURDIEL            = 32170,
 
-    SPELL_FROST_ARMOR               = 31256
+    SPELL_FROST_ARMOR               = 12544
 };
 
 class npc_wg_queue : public CreatureScript


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
1. Fix NPC Spell
2. Show who controls WG on the map
3. Properly activates "ice" icon in battlegrounds tab
4. Fix issue when it was not possible to leave the queue

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.
- [x] 
1. Fix NPC Spell:
.go creature id 32169 //alliance
.go creature id 32170 //horde
click on NPC. Observe "Frost Armor" holding for 30 minutes.
![30min](https://github.com/user-attachments/assets/52a6120b-0b31-4727-8428-4cb51f5eaa1a)

2. Show who controls WG on the map:
Open map and observe new Icon
![map](https://github.com/user-attachments/assets/5e607339-2190-4af0-a8c9-9cbb3db71d6b)

3. Properly activates "ice" icon in battlegrounds tab:
Open "battlegrounds" menu, 15 minutes before start "ice" icon will became active
![ice_active](https://github.com/user-attachments/assets/46503dd0-39cc-4ee3-a17a-7e47f3ca397a)

4. Fix issue when it was not possible to leave the queue:
.go creature id 32169 //alliance
.go creature id 32170 //horde
Wait for the queue to be opened (30 min before start)
Enter the queue for WG
On newly appeared icon near minimap click "leave"
Observe how icon disappeared
![leave_queue](https://github.com/user-attachments/assets/394da250-feee-4cd7-8650-c85c219a6b07)


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
