### PR TITLE
Feature(Core/Wintergrasp): Implement Tug Of War system

### DIFF
--- a/data/sql/updates/pending_db_world/wg_banners_fix.sql
+++ b/data/sql/updates/pending_db_world/wg_banners_fix.sql
@@ -8,17 +8,20 @@ UPDATE `gameobject` SET `orientation`=4.71, `rotation2`=0, `rotation3`=0 WHERE (
 UPDATE `gameobject` SET `orientation`=4.71, `rotation2`=0, `rotation3`=0 WHERE (`guid`=75179);
 
 -- Add missing Fortress banners
+DELETE FROM `gameobject` WHERE (`guid` IN ( 74696, 74706, 74683));
 INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`, `Comment`) VALUES
 (74696, 192487, 571, 0, 0, 1, 128, 5158.81, 2883.13, 431.618, 3.14159, 0, 0, 0, 0, 0, 0, 0, '', 0, NULL),
 (74706, 192487, 571, 0, 0, 1, 128, 5160.34, 2798.61, 430.769, 3.14159, 0, 0, 0, 0, 0, 0, 0, '', 0, NULL),
 (74683, 192488, 571, 0, 0, 1, 64, 5280.89, 3064.95, 431.976, 1.55334, 0, 0, 0, 0, 0, 0, 0, '', 0, NULL);
 
 -- Add missing Workshop banners
+DELETE FROM `gameobject` WHERE (`guid` IN ( 75195, 75196));
 INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`, `Comment`) VALUES
 (75195, 192430, 571, 0, 0, 1, 64, 4438.38, 3361.01, 371.814, 0.0348707, 0, 0, -0.017452, 0.999848, 0, 0, 0, '', 0, NULL),
 (75196, 192430, 571, 0, 0, 1, 64, 4416.8, 2414.04, 377.487, 0.00895035, 0, 0, 0.004363, 0.99999, 0, 0, 0, '', 0, NULL);
 
 -- Add missing Tower banners
+DELETE FROM `gameobject` WHERE (`guid` IN ( 76031, 76032, 76033, 76034, 76035, 76036, 76037, 76038, 76039, 76040, 76041, 76042));
 INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`, `Comment`) VALUES
 (76031, 192501, 571, 0, 0, 1, 64, 4398.82, 2804.7, 429.792, -1.58825, 0, 0, 0, 1, 180, 0, 1, '', 0, NULL),
 (76032, 192501, 571, 0, 0, 1, 64, 4416, 2822.67, 429.851, -0.017452, 0, 0, 0, 1, 180, 0, 1, '', 0, NULL),

--- a/data/sql/updates/pending_db_world/wg_banners_fix.sql
+++ b/data/sql/updates/pending_db_world/wg_banners_fix.sql
@@ -1,6 +1,34 @@
+-- Fix invalid banner name
 UPDATE `gameobject_template` SET `name`='Alliance Banner' WHERE (`entry`=192269);
 
+-- Rotate existing banners
 UPDATE `gameobject` SET `orientation`=4.71, `rotation2`=0, `rotation3`=0 WHERE (`guid`=75186);
 UPDATE `gameobject` SET `orientation`=4.71, `rotation2`=0, `rotation3`=0 WHERE (`guid`=75190);
 UPDATE `gameobject` SET `orientation`=4.71, `rotation2`=0, `rotation3`=0 WHERE (`guid`=75191);
 UPDATE `gameobject` SET `orientation`=4.71, `rotation2`=0, `rotation3`=0 WHERE (`guid`=75179);
+
+-- Add missing Fortress banners
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`, `Comment`) VALUES
+(74696, 192487, 571, 0, 0, 1, 128, 5158.81, 2883.13, 431.618, 3.14159, 0, 0, 0, 0, 0, 0, 0, '', 0, NULL),
+(74706, 192487, 571, 0, 0, 1, 128, 5160.34, 2798.61, 430.769, 3.14159, 0, 0, 0, 0, 0, 0, 0, '', 0, NULL),
+(74683, 192488, 571, 0, 0, 1, 64, 5280.89, 3064.95, 431.976, 1.55334, 0, 0, 0, 0, 0, 0, 0, '', 0, NULL);
+
+-- Add missing Workshop banners
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`, `Comment`) VALUES
+(75195, 192430, 571, 0, 0, 1, 64, 4438.38, 3361.01, 371.814, 0.0348707, 0, 0, -0.017452, 0.999848, 0, 0, 0, '', 0, NULL),
+(75196, 192430, 571, 0, 0, 1, 64, 4416.8, 2414.04, 377.487, 0.00895035, 0, 0, 0.004363, 0.99999, 0, 0, 0, '', 0, NULL);
+
+-- Add missing Tower banners
+INSERT INTO `gameobject` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `ScriptName`, `VerifiedBuild`, `Comment`) VALUES
+(76031, 192501, 571, 0, 0, 1, 64, 4398.82, 2804.7, 429.792, -1.58825, 0, 0, 0, 1, 180, 0, 1, '', 0, NULL),
+(76032, 192501, 571, 0, 0, 1, 64, 4416, 2822.67, 429.851, -0.017452, 0, 0, 0, 1, 180, 0, 1, '', 0, NULL),
+(76033, 192501, 571, 0, 0, 1, 64, 4559.11, 3606.22, 419.999, -1.48353, 0, 0, 0, 1, 180, 0, 1, '', 0, NULL),
+(76034, 192501, 571, 0, 0, 1, 64, 4539.42, 3622.49, 420.034, -3.07177, 0, 0, 0, 1, 180, 0, 1, '', 0, NULL),
+(76035, 192501, 571, 0, 0, 1, 64, 4555.26, 3641.65, 419.974, 1.67551, 0, 0, 0, 1, 180, 0, 1, '', 0, NULL),
+(76036, 192501, 571, 0, 0, 1, 64, 4574.87, 3625.91, 420.079, 0.087266, 0, 0, 0, 1, 180, 0, 1, '', 0, NULL),
+(76037, 192501, 571, 0, 0, 1, 64, 4466.79, 1960.42, 459.144, 1.15192, 0, 0, 0, 1, 180, 0, 1, '', 0, NULL),
+(76038, 192501, 571, 0, 0, 1, 64, 4475.35, 1937.03, 459.07, -0.436332, 0, 0, 0, 1, 180, 0, 1, '', 0, NULL),
+(76039, 192501, 571, 0, 0, 1, 64, 4451.76, 1928.1, 459.076, -2.00713, 0, 0, 0, 1, 180, 0, 1, '', 0, NULL),
+(76040, 192501, 571, 0, 0, 1, 64, 4442.99, 1951.9, 459.093, 2.74016, 0, 0, 0, 1, 180, 0, 1, '', 0, NULL),
+(76041, 192501, 571, 0, 0, 1, 64, 4380.36, 2822.38, 429.882, -3.10665, 0, 0, 0, 0, 120, 0, 1, '', 0, NULL),
+(76042, 192501, 571, 0, 0, 1, 64, 4397.66, 2840.3, 429.922, 1.58825, 0, 0, 0, 0, 120, 0, 1, '', 0, NULL);

--- a/data/sql/updates/pending_db_world/wg_banners_fix.sql
+++ b/data/sql/updates/pending_db_world/wg_banners_fix.sql
@@ -1,0 +1,6 @@
+UPDATE `gameobject_template` SET `name`='Alliance Banner' WHERE (`entry`=192269);
+
+UPDATE `gameobject` SET `orientation`=4.71, `rotation2`=0, `rotation3`=0 WHERE (`guid`=75186);
+UPDATE `gameobject` SET `orientation`=4.71, `rotation2`=0, `rotation3`=0 WHERE (`guid`=75190);
+UPDATE `gameobject` SET `orientation`=4.71, `rotation2`=0, `rotation3`=0 WHERE (`guid`=75191);
+UPDATE `gameobject` SET `orientation`=4.71, `rotation2`=0, `rotation3`=0 WHERE (`guid`=75179);

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -46,6 +46,7 @@ bool BattlefieldWG::SetupBattlefield()
     m_ZoneId = BATTLEFIELD_WG_ZONEID;
     m_MapId = BATTLEFIELD_WG_MAPID;
     m_Map = sMapMgr->FindMap(m_MapId, 0);
+    m_TugOfWar = new TugOfWarWG(this);
 
     // init stalker AFTER setting map id... we spawn it at map=random memory value?...
     InitStalker(BATTLEFIELD_WG_NPC_STALKER, WintergraspStalkerPos[0], WintergraspStalkerPos[1], WintergraspStalkerPos[2], WintergraspStalkerPos[3]);
@@ -115,10 +116,9 @@ bool BattlefieldWG::SetupBattlefield()
     for (uint8 i = 0; i < WG_MAX_WORKSHOP; i++)
     {
         WGWorkshop* workshop = new WGWorkshop(this, i);
-        if (i == BATTLEFIELD_WG_WORKSHOP_SE || i == BATTLEFIELD_WG_WORKSHOP_SW)
-            workshop->GiveControlTo(GetAttackerTeam(), true);
-        else
-            workshop->GiveControlTo(GetDefenderTeam(), true);
+        TeamId controlTeam = DetermineWorkshopControl(i);
+        workshop->GiveControlTo(controlTeam, true);
+        workshop->Save();
 
         // Note: Capture point is added once the gameobject is created.
         WorkshopsList.insert(workshop);
@@ -219,6 +219,9 @@ bool BattlefieldWG::Update(uint32 diff)
 
 void BattlefieldWG::OnBattleStart()
 {
+    // Update Tug of War state, calculate bonuses
+    m_TugOfWar->OnBattleStart();
+
     // Spawn titan relic
     GameObject* go = SpawnGameObject(GO_WINTERGRASP_TITAN_S_RELIC, 5440.0f, 2840.8f, 430.43f, 0);
     if (go)
@@ -265,8 +268,7 @@ void BattlefieldWG::OnBattleStart()
 
     // Set Sliders capture points data to his owners when battle start
     for (BfCapturePointVector::const_iterator itr = m_capturePoints.begin(); itr != m_capturePoints.end(); ++itr)
-        (*itr)->SetCapturePointData((*itr)->GetCapturePointGo(),
-            (*itr)->GetCapturePointGo()->GetEntry() == GO_WINTERGRASP_FACTORY_BANNER_SE || (*itr)->GetCapturePointGo()->GetEntry() == GO_WINTERGRASP_FACTORY_BANNER_SW ? GetAttackerTeam() : GetDefenderTeam());
+        (*itr)->SetCapturePointData((*itr)->GetCapturePointGo(), (*itr)->GetTeamId());
 
     for (uint8 team = 0; team < 2; ++team)
         for (GuidUnorderedSet::const_iterator itr = m_players[team].begin(); itr != m_players[team].end(); ++itr)
@@ -343,6 +345,9 @@ void BattlefieldWG::CapturePointTaken(uint32 areaId)
 
 void BattlefieldWG::OnBattleEnd(bool endByTimer)
 {
+    // Update Tug of War state, so the buildings could be correctly assigned
+    m_TugOfWar->OnBattleEnd(endByTimer);
+
     // Remove relic
     if (GameObject* go = GetRelic())
         go->RemoveFromWorld();
@@ -403,7 +408,8 @@ void BattlefieldWG::OnBattleEnd(bool endByTimer)
 
     for (Workshop::const_iterator itr = WorkshopsList.begin(); itr != WorkshopsList.end(); ++itr)
     {
-        (*itr)->GiveControlTo((*itr)->workshopId == BATTLEFIELD_WG_WORKSHOP_SE || (*itr)->workshopId == BATTLEFIELD_WG_WORKSHOP_SW ? GetAttackerTeam() : GetDefenderTeam(), true);
+        TeamId controlTeam = DetermineWorkshopControl((*itr)->workshopId);
+        (*itr)->GiveControlTo(controlTeam, true);
         (*itr)->Save();
     }
 
@@ -500,6 +506,36 @@ void BattlefieldWG::OnBattleEnd(bool endByTimer)
     }
 }
 
+TeamId BattlefieldWG::DetermineWorkshopControl(uint8 workshopId)
+{
+    TeamId attackerTeam = GetAttackerTeam();
+    TeamId defenderTeam = GetDefenderTeam();
+    int16 scale = m_TugOfWar->GetScale();
+
+    switch (workshopId)
+    {
+        case BATTLEFIELD_WG_WORKSHOP_SE:
+        case BATTLEFIELD_WG_WORKSHOP_SW:
+            return attackerTeam;
+
+        case BATTLEFIELD_WG_WORKSHOP_NE:
+            if ((attackerTeam == TEAM_ALLIANCE && scale >= 400) ||
+                (attackerTeam == TEAM_HORDE && scale <= -400))
+                return attackerTeam;
+            break;
+
+        case BATTLEFIELD_WG_WORKSHOP_NW:
+            if ((attackerTeam == TEAM_ALLIANCE && scale >= 500) ||
+                (attackerTeam == TEAM_HORDE && scale <= -500))
+                return attackerTeam;
+            break;
+
+        default:
+            break;
+    }
+
+    return defenderTeam;
+}
 // *******************************************************
 // ******************* Reward System *********************
 // *******************************************************
@@ -699,8 +735,7 @@ void BattlefieldWG::OnGameObjectCreate(GameObject* go)
             if (workshop->workshopId == workshopId)
             {
                 WintergraspCapturePoint* capturePoint = new WintergraspCapturePoint(this, workshop->teamControl);
-                //Sending neutral team at start to set normal capture points by workshop->teamControl, TEAM_NEUTRAL is ignored at first call
-                capturePoint->SetCapturePointData(go, TEAM_NEUTRAL);
+                capturePoint->SetCapturePointData(go, workshop->teamControl);
                 capturePoint->LinkToWorkshop(workshop);
                 AddCapturePoint(capturePoint);
                 break;
@@ -803,11 +838,21 @@ void BattlefieldWG::PromotePlayer(Player* killer)
     // Updating rank of player
     if (Aura* recruitAura = killer->GetAura(SPELL_RECRUIT))
     {
+        TeamId attackerTeam = GetAttackerTeam();
+        bool fastCorporal = m_TugOfWar->CanFastPromoteToCorporal();
+        bool fastLieutenant = m_TugOfWar->CanFastPromoteToLieutenant();
+
         if (recruitAura->GetStackAmount() >= 5)
         {
             killer->RemoveAura(SPELL_RECRUIT);
             killer->CastSpell(killer, SPELL_CORPORAL, true);
             SendWarning(BATTLEFIELD_WG_TEXT_FIRSTRANK, killer);
+        }
+        else if (killer->GetTeamId() == attackerTeam && (fastCorporal || fastLieutenant))
+        {
+            killer->RemoveAura(SPELL_RECRUIT);
+            killer->CastSpell(killer, fastCorporal ? SPELL_CORPORAL : SPELL_LIEUTENANT, true);
+            SendWarning(fastCorporal ? BATTLEFIELD_WG_TEXT_FIRSTRANK: BATTLEFIELD_WG_TEXT_SECONDRANK, killer);
         }
         else
         {
@@ -1214,4 +1259,82 @@ BfGraveyardWG::BfGraveyardWG(BattlefieldWG* battlefield) : BfGraveyard(battlefie
 {
     m_Bf = battlefield;
     m_GossipTextId = 0;
+}
+
+// *******************************************************
+// ******************** Tug of War ***********************
+// *******************************************************
+TugOfWarWG::~TugOfWarWG()
+{
+}
+
+TugOfWarWG::TugOfWarWG(BattlefieldWG* battlefield)
+{
+    m_Bf = battlefield;
+    TeamId team = m_Bf->GetDefenderTeam();
+
+    if (!sWorld->getWorldState(TUG_OF_WAR_SCALE))
+    {
+        sWorld->setWorldState(TUG_OF_WAR_SCALE, uint64(0));
+    }
+    if (!sWorld->getWorldState(TUG_OF_WAR_DEFENSE_STREAK))
+    {
+        sWorld->setWorldState(TUG_OF_WAR_DEFENSE_STREAK, uint64(0));
+    }
+
+    m_Scale = sWorld->getWorldState(TUG_OF_WAR_SCALE);
+    m_DefenseStreak = sWorld->getWorldState(TUG_OF_WAR_DEFENSE_STREAK);
+    m_FastCorporal = false;
+    m_FastLieutenant = false;
+
+    LOG_WARN("server.loading", "TugOfWarWG: {}, {}. Def: {}", m_Scale, m_DefenseStreak, team);
+}
+
+void TugOfWarWG::OnBattleStart()
+{
+    TeamId attackerTeam = m_Bf->GetAttackerTeam();
+    int16 scale = (attackerTeam == TEAM_ALLIANCE) ? m_Scale : -m_Scale;
+
+    if (scale >= 700)
+    {
+        m_FastLieutenant = true;
+    }
+    else if (scale >= 600)
+    {
+        m_FastCorporal = true;
+    }
+}
+
+void TugOfWarWG::OnBattleEnd(bool endByTimer)
+{
+    TeamId team = m_Bf->GetDefenderTeam();
+
+    if (endByTimer)
+    {
+        m_DefenseStreak++;
+        sWorld->setWorldState(TUG_OF_WAR_DEFENSE_STREAK, uint64(m_DefenseStreak));
+
+        if (m_DefenseStreak >= 2)
+        {
+            if ((team == TEAM_ALLIANCE && m_Scale >= -600) || (team == TEAM_HORDE && m_Scale <= 600))
+            {
+                m_Scale += (team == TEAM_ALLIANCE ? -100 : 100);
+                sWorld->setWorldState(TUG_OF_WAR_SCALE, uint64(m_Scale));
+            }
+        }
+    }
+    else
+    {
+        m_DefenseStreak = 0;
+        sWorld->setWorldState(TUG_OF_WAR_DEFENSE_STREAK, uint64(m_DefenseStreak));
+
+        if ((team == TEAM_ALLIANCE && m_Scale >= 400) || (team == TEAM_HORDE && m_Scale <= -400))
+        {
+            m_Scale += (team == TEAM_ALLIANCE ? -100 : 100);
+            sWorld->setWorldState(TUG_OF_WAR_SCALE, uint64(m_Scale));
+        }
+    }
+
+    m_FastCorporal = false;
+    m_FastLieutenant = false;
 }

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -1271,7 +1271,6 @@ TugOfWarWG::~TugOfWarWG()
 TugOfWarWG::TugOfWarWG(BattlefieldWG* WG)
 {
     m_WG = WG;
-    TeamId team = m_WG->GetDefenderTeam();
 
     if (!sWorld->getWorldState(TUG_OF_WAR_SCALE))
     {

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -381,6 +381,7 @@ public:
      */
     void OnCreatureRemove(Creature* creature) override;
 
+    int8 GetRelatedWorkshopId(uint32 GoEntry);
     /**
      * \brief Called when a gameobject is created
      */

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -282,7 +282,7 @@ class TugOfWarWG
 {
 public:
     ~TugOfWarWG();
-    TugOfWarWG(BattlefieldWG* battlefield);
+    TugOfWarWG(BattlefieldWG* WG);
 
     int16 GetScale() { return m_Scale; }
     void OnBattleStart();
@@ -290,7 +290,7 @@ public:
     bool CanFastPromoteToCorporal() { return m_FastCorporal; }
     bool CanFastPromoteToLieutenant() { return m_FastLieutenant; }
 protected:
-    Battlefield* m_Bf;
+    BattlefieldWG* m_WG;
     int16 m_Scale;
     uint32 m_DefenseStreak;
     bool m_FastCorporal;
@@ -487,7 +487,7 @@ public:
     }
 protected:
     bool m_isRelicInteractible;
-    TugOfWarWG* m_TugOfWar;
+    std::unique_ptr<TugOfWarWG> m_TugOfWar;
 
     Workshop WorkshopsList;
 

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -25,6 +25,7 @@
 class Group;
 class BattlefieldWG;
 class WintergraspCapturePoint;
+class TugOfWarWG;
 
 struct BfWGGameObjectBuilding;
 struct WGWorkshop;
@@ -82,8 +83,8 @@ enum WintergraspSpells
     SPELL_HORDE_CONTROLS_FACTORY_PHASE_SHIFT    = 56618,// ADDS PHASE 16
     SPELL_ALLIANCE_CONTROLS_FACTORY_PHASE_SHIFT = 56617,// ADDS PHASE 32
 
-    SPELL_HORDE_CONTROL_PHASE_SHIFT             = 55773,// ADDS PHASE 64
-    SPELL_ALLIANCE_CONTROL_PHASE_SHIFT          = 55774,// ADDS PHASE 128
+    SPELL_HORDE_CONTROL_PHASE_SHIFT             = 55773,// ADDS PHASE 65 (64 + 1)
+    SPELL_ALLIANCE_CONTROL_PHASE_SHIFT          = 55774,// ADDS PHASE 129 (128 + 1)
 };
 
 enum WintergraspData
@@ -268,6 +269,35 @@ protected:
 };
 
 /* ######################### *
+ * WinterGrasp Tug-of-War    *
+ * ######################### */
+
+enum TugOfWarWorldstates
+{
+    TUG_OF_WAR_SCALE = 99000,
+    TUG_OF_WAR_DEFENSE_STREAK = 99001,
+};
+
+class TugOfWarWG
+{
+public:
+    ~TugOfWarWG();
+    TugOfWarWG(BattlefieldWG* battlefield);
+
+    int16 GetScale() { return m_Scale; }
+    void OnBattleStart();
+    void OnBattleEnd(bool endByTimer);
+    bool CanFastPromoteToCorporal() { return m_FastCorporal; }
+    bool CanFastPromoteToLieutenant() { return m_FastLieutenant; }
+protected:
+    Battlefield* m_Bf;
+    int16 m_Scale;
+    uint32 m_DefenseStreak;
+    bool m_FastCorporal;
+    bool m_FastLieutenant;
+};
+
+/* ######################### *
  * WinterGrasp Battlefield   *
  * ######################### */
 
@@ -423,6 +453,8 @@ public:
 
     uint32 GetData(uint32 data) const override;
 
+    TeamId DetermineWorkshopControl(uint8 workshopId);
+
     bool IsKeepNpc(uint32 entry)
     {
         switch (entry)
@@ -455,6 +487,7 @@ public:
     }
 protected:
     bool m_isRelicInteractible;
+    TugOfWarWG* m_TugOfWar;
 
     Workshop WorkshopsList;
 
@@ -800,21 +833,19 @@ struct WintergraspTowerData
 };
 
 uint8 const WG_MAX_ATTACKTOWERS = 3;
-// 192414 : 0 in sql, 1 in header
-// 192278 : 0 in sql, 3 in header
 const WintergraspTowerData AttackTowers[WG_MAX_ATTACKTOWERS] =
 {
     // West tower
     {
         190356,
-        6,
+        0,
         {
-            { 4559.109863f, 3606.219971f, 419.998993f, -1.483530f, 192488, 192501 },    // Flag on tower
-            { 4539.419922f, 3622.489990f, 420.033997f, -3.071770f, 192488, 192501 },    // Flag on tower
-            { 4555.259766f, 3641.649902f, 419.973999f, 1.675510f, 192488, 192501 },     // Flag on tower
-            { 4574.870117f, 3625.909912f, 420.079010f, 0.080117f, 192488, 192501 },     // Flag on tower
-            { 4433.899902f, 3534.139893f, 360.274994f, -1.850050f, 192269, 192278 },    // Flag near workshop
-            { 4572.930176f, 3475.520020f, 363.009003f, 1.42240f, 192269, 192278 }       // Flag near bridge
+            { 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0 },
         },
         6,
         {
@@ -841,13 +872,13 @@ const WintergraspTowerData AttackTowers[WG_MAX_ATTACKTOWERS] =
     // South Tower
     {
         190357,
-        5,
+        0,
         {
-            { 4416.000000f, 2822.669922f, 429.851013f, -0.017452f, 192488, 192501 },    // Flag on tower
-            { 4398.819824f, 2804.699951f, 429.791992f, -1.588250f, 192488, 192501 },    // Flag on tower
-            { 4387.620117f, 2719.570068f, 389.934998f, -1.544620f, 192366, 192414 },    // Flag near tower
-            { 4464.120117f, 2855.449951f, 406.110992f, 0.829032f, 192366, 192429 },     // Flag near tower
-            { 4526.459961f, 2810.179932f, 391.200012f, -2.993220f, 192269, 192278 },    // Flag near bridge
+            { 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0 },
             { 0, 0, 0, 0, 0, 0 },
         },
         6,
@@ -875,12 +906,12 @@ const WintergraspTowerData AttackTowers[WG_MAX_ATTACKTOWERS] =
     // East Tower
     {
         190358,
-        4,
+        0,
         {
-            { 4466.790039f, 1960.420044f, 459.144012f, 1.151920f, 192488, 192501 },     // Flag on tower
-            { 4475.350098f, 1937.030029f, 459.070007f, -0.43633f, 192488, 192501 },     // Flag on tower
-            { 4451.759766f, 1928.099976f, 459.075989f, -2.00713f, 192488, 192501 },     // Flag on tower
-            { 4442.990234f, 1951.900024f, 459.092987f, 2.740160f, 192488, 192501 },     // Flag on tower
+            { 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0 },
             { 0, 0, 0, 0, 0, 0 },
             { 0, 0, 0, 0, 0, 0 },
         },


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

This PR adds Tug Of War system which should balance win chances for the side having a lose streak.
Also it has a minor changes to DB to fix Banners rotation and appearance.

## Issues Addressed:
1. Implement Tug Of War system
2. Fix Banners location

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
Official forum from 2010 describes Tug Of War system.
https://web.archive.org/web/20100221232731/http://forums.worldofwarcraft.com/thread.html?topicId=23329393344

- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Tug of war:
 - Lose 5 times in a row. 
 - Next battel attacker would have "Sunken Ring" under their control
 - Lose again
 - Next battel attacker would have "Sunken Ring" and "Broken Temple" under their control
 - Lose again
 - Next battel attacker would have "Sunken Ring" and "Broken Temple" under their control. Gains access to Catapults after earning 1 kill in battle
 - Lose again
 - Next battel attacker would have "Sunken Ring" and "Broken Temple" under their control. Gains access to Catapults, Siege Engines, and Demolishers after earning 1 kill in battle

## Known Issues and TODO List:
- [ ] I'm a TS/C# developer, so please someone check "memory-related stuff"
- [ ] I have no idea where I can store WG related data. I need to keep track of 2 records (tug of was score, and lose streak). Currently they are stored in Worldstate table with records IDs 99000 and 99001. Probably should be fixed.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
