### PR TITLE
fix(Tools/MapExtractor) Update MPQ patch iterator to also load patch files 4 through 9

### DIFF
--- a/src/tools/map_extractor/System.cpp
+++ b/src/tools/map_extractor/System.cpp
@@ -1150,11 +1150,9 @@ void LoadLocaleMPQFiles(int const locale)
         if (i > 1)
             sprintf(ext, "-%i", i);
 
+        sprintf(filename, "%s/Data/%s/patch-%s%s.MPQ", input_path, langs[locale], langs[locale], ext);
         if (FileExists(filename))
-        {
-            sprintf(filename, "%s/Data/%s/patch-%s%s.MPQ", input_path, langs[locale], langs[locale], ext);
             new MPQArchive(filename);
-        }
     }
 }
 

--- a/src/tools/map_extractor/System.cpp
+++ b/src/tools/map_extractor/System.cpp
@@ -1144,15 +1144,17 @@ void LoadLocaleMPQFiles(int const locale)
     sprintf(filename, "%s/Data/%s/locale-%s.MPQ", input_path, langs[locale], langs[locale]);
     new MPQArchive(filename);
 
-    for (int i = 1; i < 5; ++i)
+    for (int i = 1; i <= 9; ++i)
     {
         char ext[3] = "";
         if (i > 1)
             sprintf(ext, "-%i", i);
 
-        sprintf(filename, "%s/Data/%s/patch-%s%s.MPQ", input_path, langs[locale], langs[locale], ext);
         if (FileExists(filename))
+        {
+            sprintf(filename, "%s/Data/%s/patch-%s%s.MPQ", input_path, langs[locale], langs[locale], ext);
             new MPQArchive(filename);
+        }
     }
 }
 


### PR DESCRIPTION
The client can support up to 10 patch files (such as patch-enUS.MPQ through patch-enUS-9.MPQ).  This change is needed if MapExtractor is to recognize all 10.

## Changes Proposed:
-  [X] Extractor (MapExtractor) 

## Issues Addressed:
Fixes an issue where the mapextractor will not read/extract from any patch files beyond patch-4.  This change will allow it to extract from all (which goes up to *-9.mpq). 

## SOURCE:
I ran into issues locally when extracting map data inside "patch-enUS-5.MPQ" (it stopped at patch-4, with the needed map data being in patch-5).

## Tests Performed:
This has been tested by the change author.  Maps were successfully exported with the mapextractor.exe following this change.

## How to Test the Changes:
Create (or rename existing to) a /Data/[localization]/patch-[localization]-5.MPQ file, then run mapextractor

## Known Issues and TODO List:
No known issues.  It's an extremely simple change.