### PR TITLE
feat(tools/vmap4_extractor) Add detection of collision-only material IDs

### DIFF
--- a/src/tools/vmap4_extractor/wmo.cpp
+++ b/src/tools/vmap4_extractor/wmo.cpp
@@ -395,8 +395,10 @@ int WMOGroup::ConvertToVMAPGroupWmo(FILE* output, bool preciseVectorData)
         for (int i = 0; i < nTriangles; ++i)
         {
             // Skip no collision triangles
+            // TODO: Update to use MOBR in the future to catch any possibly missed edge cases
             bool isRenderFace = (MOPY[2 * i] & WMO_MATERIAL_RENDER) && !(MOPY[2 * i] & WMO_MATERIAL_DETAIL);
-            bool isCollision = MOPY[2 * i] & WMO_MATERIAL_COLLISION || isRenderFace;
+            bool isCollisionOnlyFace = static_cast<unsigned char>(MOPY[(2 * i) + 1]) == 0xFF; // 255 is a collision-only material id
+            bool isCollision = MOPY[2 * i] & WMO_MATERIAL_COLLISION || isRenderFace || isCollisionOnlyFace;
             if (!isCollision)
                 continue;
             // Use this triangle


### PR DESCRIPTION
## Changes Proposed:
Add detection of vertices attached to triangles that map to collision-only material IDs (0xff).

This PR proposes changes to:
-  [x] Tools (vmap4_extractor)

## Issues Addressed:
Since the extractor doesn't use MOBR to determine collision-eligible faces, it can miss faces inside WMO groups that contain collision only without render batches.  
- _Note 1: This is not the case for any blizzard provided WMOs (through WOTLK) so this has **no impact** to blizz content, only custom content.  Verification below_

## SOURCE:
This 0xff material ID association has been identified ([wowdev.wiki MOPY detail](https://wowdev.wiki/WMO#MOPY_chunk)).

## Tests Performed:
This PR has been tested as follows:
- [X] Extracts have been produced and compared before-and-after the change to prove that there is absolutely no impact to existing blizzard-provided WOTLK content.  See attachment here for evidence: [WinMergeCompare-20241202.csv](https://github.com/user-attachments/files/17985320/WinMergeCompare-20241202.csv)
- [X] Tested in-game by the author on custom maps using collision-only wmo groups generated by this project: [EQ to WOW Converter](https://github.com/NathanHandley/EQWOWConverter)
- [X] Generated mmaps and regression tested in Elwin to ensure NPCs path properly around objects.  _The mmaps were binary equivalent, but tested anyway._

## How to Test the Changes:
- To verify no regression impact: You can run the extractor and compare the outputs.  If you use WinMerge, the report should look like above.
- To verify this functions on custom content, supply any custom WMOs that have collision-only groups to the vmap4_extractor.  One such project that produces this can be found here: [EQ to WOW Converter](https://github.com/NathanHandley/EQWOWConverter)

## Known Issues and TODO List:
No known issues.