### PR TITLE
fix(Scripts/Zuldrak) Spell: Scourge Disguise and related stuff

### DIFF
--- a/data/sql/updates/pending_db_world/scourge_disguise.sql
+++ b/data/sql/updates/pending_db_world/scourge_disguise.sql
@@ -1,0 +1,28 @@
+-- Fix double cast of Scourge Disguise
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 28669);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+(28669, 0, 0, 1, 54, 0, 100, 512, 0, 0, 0, 0, 0, 0, 28, 51966, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Just Summoned - Remove \'Scourge Disguise[51966]\''),
+(28669, 0, 1, 2, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 11, 52191, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Just Summoned - Cast \'Scourge Disguise[52191]\''),
+(28669, 0, 2, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 80, 2866900, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Just Summoned - Run Script'),
+(28669, 0, 3, 0, 40, 0, 100, 512, 62, 28669, 0, 0, 0, 0, 11, 52220, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Waypoint 62 Reached - Cast \'Kill Credit\''),
+(28669, 0, 4, 5, 40, 0, 100, 512, 63, 28669, 0, 0, 0, 0, 28, 52191, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Waypoint 63 Reached - Remove \'Scourge Disguise[52191]\''),
+(28669, 0, 5, 6, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 75, 52192, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Waypoint 63 Reached - Cast \'Scourge Disguise[52192]\''),
+(28669, 0, 6, 7, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 75, 51971, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Waypoint 63 Reached - Cast \'Scourge Disguise Instability[51971]\''),
+(28669, 0, 7, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 11, 50630, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Waypoint 63 Reached - Cast \'Eject All Passengers\'');
+
+-- Add or Remove linked to Scourge Disguise  spells
+DELETE FROM `spell_linked_spell` WHERE (`spell_trigger` IN ( -52010, -52192, -51966, 51966, 52192));
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES
+(-52010, -52192, 0, 'Remove Scourge Disguise [52192]'),
+(-52010, -51966, 0, 'Remove Scourge Disguise [51966]'),
+(-52192, -51971, 0, 'Remove Scourge Disguise Instability [51971]'),
+(-51966, -51971, 0, 'Remove Scourge Disguise Instability [51971]'),
+(51966, -52192, 0, 'Remove Scourge Disguise [52192]'),
+(51966, 51971, 0, 'Add Scourge Disguise Instability [51971]'),
+(52192, -51966, 0, 'Remove Scourge Disguise [51966]'),
+(52192, 51971, 0, 'Add Scourge Disguise Instability [51971]');
+
+-- Attach script to Scourge Disguise Instability
+DELETE FROM `spell_script_names` WHERE (`spell_id` = 51971);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(51971, 'spell_scourge_disguise_instability');

--- a/src/server/scripts/Northrend/zone_zuldrak.cpp
+++ b/src/server/scripts/Northrend/zone_zuldrak.cpp
@@ -976,7 +976,7 @@ class spell_scourge_disguise_instability : public AuraScript
             if (player->HasAura(SPELL_SCOURGE_DISGUISE) || player->HasAura(SPELL_SCOURGE_DISGUISE_INSTANT_CAST))
             {
                 uint32 textId = Acore::Containers::SelectRandomContainerElement(scourgeDisguiseTextIDs);
-                player->Talk(textId, CHAT_MSG_RAID_BOSS_EMOTE, 0, player);
+                player->Unit::Whisper(textId, player, true);
 
                 player->CastSpell(player, SPELL_SCOURGE_DISGUISE_EXPIRING, true);
             }

--- a/src/server/scripts/Northrend/zone_zuldrak.cpp
+++ b/src/server/scripts/Northrend/zone_zuldrak.cpp
@@ -956,6 +956,7 @@ enum ScourgeDisguiseInstability
     SCOURGE_DISGUISE_FAILING_MESSAGE_2       = 28758, // Scourge Disguise Failing! Run for cover!
     SCOURGE_DISGUISE_FAILING_MESSAGE_3       = 28759, // Scourge Disguise Failing! Hide quickly!
 };
+const std::vector<uint32> scourgeDisguiseTextIDs = { SCOURGE_DISGUISE_FAILING_MESSAGE_1, SCOURGE_DISGUISE_FAILING_MESSAGE_2, SCOURGE_DISGUISE_FAILING_MESSAGE_3 };
 
 class spell_scourge_disguise_instability : public AuraScript
 {
@@ -974,12 +975,9 @@ class spell_scourge_disguise_instability : public AuraScript
             Player* player = caster->ToPlayer();
             if (player->HasAura(SPELL_SCOURGE_DISGUISE) || player->HasAura(SPELL_SCOURGE_DISGUISE_INSTANT_CAST))
             {
-                player->Talk(
-                    RAND(SCOURGE_DISGUISE_FAILING_MESSAGE_1, SCOURGE_DISGUISE_FAILING_MESSAGE_2, SCOURGE_DISGUISE_FAILING_MESSAGE_3),
-                    CHAT_MSG_RAID_BOSS_EMOTE,
-                    0,
-                    player
-                );
+                uint32 textId = Acore::Containers::SelectRandomContainerElement(scourgeDisguiseTextIDs);
+                player->Talk(textId, CHAT_MSG_RAID_BOSS_EMOTE, 0, player);
+
                 player->CastSpell(player, SPELL_SCOURGE_DISGUISE_EXPIRING, true);
             }
         }

--- a/src/server/scripts/Northrend/zone_zuldrak.cpp
+++ b/src/server/scripts/Northrend/zone_zuldrak.cpp
@@ -23,6 +23,7 @@
 #include "ScriptedGossip.h"
 #include "SpellAuras.h"
 #include "SpellInfo.h"
+#include "SpellScript.h"
 #include "SpellScriptLoader.h"
 #include "Vehicle.h"
 
@@ -956,7 +957,7 @@ enum ScourgeDisguiseInstability
     SCOURGE_DISGUISE_FAILING_MESSAGE_2       = 28758, // Scourge Disguise Failing! Run for cover!
     SCOURGE_DISGUISE_FAILING_MESSAGE_3       = 28759, // Scourge Disguise Failing! Hide quickly!
 };
-const std::vector<uint32> scourgeDisguiseTextIDs = { SCOURGE_DISGUISE_FAILING_MESSAGE_1, SCOURGE_DISGUISE_FAILING_MESSAGE_2, SCOURGE_DISGUISE_FAILING_MESSAGE_3 };
+std::vector<uint32> const scourgeDisguiseTextIDs = { SCOURGE_DISGUISE_FAILING_MESSAGE_1, SCOURGE_DISGUISE_FAILING_MESSAGE_2, SCOURGE_DISGUISE_FAILING_MESSAGE_3 };
 
 class spell_scourge_disguise_instability : public AuraScript
 {

--- a/src/server/scripts/Northrend/zone_zuldrak.cpp
+++ b/src/server/scripts/Northrend/zone_zuldrak.cpp
@@ -950,13 +950,20 @@ public:
     }
 };
 
+enum ScourgeDisguiseInstability
+{
+    SCOURGE_DISGUISE_FAILING_MESSAGE_1       = 28552, // Scourge Disguise Failing! Find a safe place!
+    SCOURGE_DISGUISE_FAILING_MESSAGE_2       = 28758, // Scourge Disguise Failing! Run for cover!
+    SCOURGE_DISGUISE_FAILING_MESSAGE_3       = 28759, // Scourge Disguise Failing! Hide quickly!
+};
+
 class spell_scourge_disguise_instability : public AuraScript
 {
     PrepareAuraScript(spell_scourge_disguise_instability)
 
     void HandleApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
-        SetDuration(urand(3*60*1000, 5*60*1000));
+        SetDuration(urand(3 * MINUTE * IN_MILLISECONDS, 5 * MINUTE * IN_MILLISECONDS));
     }
 
     void HandleRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
@@ -967,11 +974,13 @@ class spell_scourge_disguise_instability : public AuraScript
             Player* player = caster->ToPlayer();
             if (player->HasAura(SPELL_SCOURGE_DISGUISE) || player->HasAura(SPELL_SCOURGE_DISGUISE_INSTANT_CAST))
             {
-                WorldPacket data;
-                ChatHandler::BuildChatPacket(data, CHAT_MSG_RAID_BOSS_EMOTE, LANG_UNIVERSAL, player, player, "Scourge Disguise Failing! Find a safeplace!");
-                player->GetSession()->SendPacket(&data);
-
-                player->CastSpell(GetUnitOwner(), SPELL_SCOURGE_DISGUISE_EXPIRING, true);
+                player->Talk(
+                    RAND(SCOURGE_DISGUISE_FAILING_MESSAGE_1, SCOURGE_DISGUISE_FAILING_MESSAGE_2, SCOURGE_DISGUISE_FAILING_MESSAGE_3),
+                    CHAT_MSG_RAID_BOSS_EMOTE,
+                    0,
+                    player
+                );
+                player->CastSpell(player, SPELL_SCOURGE_DISGUISE_EXPIRING, true);
             }
         }
     }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
1. Scourge Disguise spell [51966, 52192] is "unstable" and should be removed after some time with message informing player about it: "Scourge Disguise Failing! Find a safe place!"
2. Quest "Dark horizon" [12664]: When NPC Gorebag [28666] sends player on a fly mount to see some places it casted another copy of "Scourge Disguise" on player, which caused 2 active auras being on a player at the same time. And if 1 aura was removed - second aura didnt had any effect.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

TELEPORT
.go xyz 6278.02 -1933.10 239.60

HOW TO TEST ITEM/SPELL:
// Choker
.additem 38699

Use choker, wait 3-5 minutes. Now you should see that spell is going to end, and it will be actually removed.

HOW TO TEST QUEST:
// Choker
.additem 38699
// dark horizon quest
.quest add 12664
// Gorebag
.go creature id 28666 (beware of agro, use choker first)

Talk to NPC, take a ride, see that you have only 1 active aura of "Scourge Disguise" after ride is over.


## Known Issues and TODO List:
After the ride event from quest dark horizon[12664] player end up with "Scourge Disguise"[52192] aura, which is different one that player gets when he use Choker ("Scourge Disguise"[51966]). So if player uses choker while having 52192 aura - it will be removed after 8 seconds.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
