### PR TITLE
fix(Scripts/TheEye): Kaelthas reduce time until all advisors phase

### DIFF
--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -597,6 +597,10 @@ struct boss_kaelthas : public BossAI
             Talk(SAY_PHASE2_WEAPON);
             DoCastSelf(SPELL_SUMMON_WEAPONS);
             _phase = PHASE_WEAPONS;
+            scheduler.Schedule(95s, GROUP_PROGRESS_PHASE, [this](TaskContext)
+            {
+                PhaseAllAdvisorsExecute();
+            });
         }, EVENT_PREFIGHT_PHASE5_01);
         ScheduleUniqueTimedEvent(9s, [&]{
             summons.DoForAllSummons([&](WorldObject* summon)
@@ -613,10 +617,6 @@ struct boss_kaelthas : public BossAI
                         }
                     }
                 }
-            });
-            scheduler.Schedule(3min, GROUP_PROGRESS_PHASE, [this](TaskContext)
-            {
-                PhaseAllAdvisorsExecute();
             });
         }, EVENT_PREFIGHT_PHASE5_02);
     }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

change timer p2 (weapons) to p3 (resurect): from 3min to 105s (1:45)
## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/20877

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TBC DBM https://github.com/DeadlyBossMods/DBM-BurningCrusade/blob/36d51585a8d5764150d355a29c29673cbaf1eaca/DBM-Raids-BC/TheEye/KaelThas.lua#L242

pre-nerf, post-nerf comparison
https://www.youtube.com/watch?v=CLCHgDFIQUg
```
prenerf
3:58 p2 text
5:33 (+95s) p3 text
5:43 (+105s) advisors

postnerf
2:28 p2 text
4:03 (+95s) p3 text
4:13 (+105s) advisors
```

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go c id 19622`
2. kill advisors 1 by 1 or cheat with .damage 300k (do not use .die), if cheat flags will be set incorrectly
3. use DBM or stopwatch to check time between weapon spawn and advisors' resurrection

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
