### PR TITLE
Item storage rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 /data/sql/custom/*
 /src/server/scripts/Custom/*
 !/src/server/scripts/Custom/README.md
+*.idx
 
 /*.override.yml
 /*.override.yaml

--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -2364,8 +2364,8 @@ void AchievementMgr::CompletedAchievement(AchievementEntry const* achievement)
 
         CharacterDatabaseTransaction trans = CharacterDatabase.BeginTransaction();
 
-        Item* item = reward->itemId ? Item::CreateItem(reward->itemId, 1, GetPlayer()) : nullptr;
-        if (item)
+        auto item = reward->itemId ? Item::CreateItem(reward->itemId, 1, GetPlayer()) : nullptr;
+        if (item != nullptr)
         {
             // save new item before send
             item->SaveToDB(trans);                               // save for prevent lost at next mail load, if send fail then item will deleted

--- a/src/server/game/AuctionHouse/AuctionHouseMgr.h
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.h
@@ -178,20 +178,17 @@ private:
     ~AuctionHouseMgr();
 
 public:
-    typedef std::unordered_map<ObjectGuid, Item*> ItemMap;
+    typedef std::unordered_map<ObjectGuid, std::shared_ptr<Item>> ItemMap;
 
     static AuctionHouseMgr* instance();
 
     AuctionHouseObject* GetAuctionsMap(uint32 factionTemplateId);
     AuctionHouseObject* GetAuctionsMapByHouseId(uint8 auctionHouseId);
 
-    Item* GetAItem(ObjectGuid itemGuid)
+    std::shared_ptr<Item> GetAItem(ObjectGuid itemGuid)
     {
-        ItemMap::const_iterator itr = _mAitems.find(itemGuid);
-        if (itr != _mAitems.end())
-            return itr->second;
-
-        return nullptr;
+        const auto itr = _mAitems.find(itemGuid);
+        return itr != _mAitems.end() ? itr->second : nullptr;
     }
 
     //auction messages
@@ -202,7 +199,7 @@ public:
     void SendAuctionOutbiddedMail(AuctionEntry* auction, uint32 newPrice, Player* newBidder, CharacterDatabaseTransaction trans, bool sendNotification = true, bool sendMail = true);
     void SendAuctionCancelledToBidderMail(AuctionEntry* auction, CharacterDatabaseTransaction trans, bool sendMail = true);
 
-    static uint32 GetAuctionDeposit(AuctionHouseEntry const* entry, uint32 time, Item* pItem, uint32 count);
+    static uint32 GetAuctionDeposit(AuctionHouseEntry const* entry, uint32 time, std::shared_ptr<Item> pItem, uint32 count);
     static AuctionHouseEntry const* GetAuctionHouseEntry(uint32 factionTemplateId);
     static AuctionHouseEntry const* GetAuctionHouseEntryFromHouse(uint8 houseId);
 
@@ -211,7 +208,7 @@ public:
     void LoadAuctionItems();
     void LoadAuctions();
 
-    void AddAItem(Item* it);
+    void AddAItem(std::shared_ptr<Item> it);
     bool RemoveAItem(ObjectGuid itemGuid, bool deleteFromDB = false, CharacterDatabaseTransaction* trans = nullptr);
 
     void Update();

--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -776,9 +776,11 @@ void PlayerMenu::SendQuestGiverRequestItems(Quest const* quest, ObjectGuid npcGU
     if (qsitr != _player->getQuestStatusMap().end() && qsitr->second.Status == QUEST_STATUS_INCOMPLETE)
     {
         for (uint8 i = 0; i < 6; ++i)
+        {
             if (quest->RequiredItemId[i] && qsitr->second.ItemCount[i] < quest->RequiredItemCount[i])
                 if (_player->GetItemCount(quest->RequiredItemId[i], false) >= quest->RequiredItemCount[i])
                     qsitr->second.ItemCount[i] = quest->RequiredItemCount[i];
+        }
 
         if (_player->CanCompleteQuest(quest->GetQuestId()))
         {

--- a/src/server/game/Entities/Item/Container/Bag.cpp
+++ b/src/server/game/Entities/Item/Container/Bag.cpp
@@ -122,9 +122,8 @@ bool Bag::LoadFromDB(ObjectGuid::LowType guid, ObjectGuid owner_guid, const Fiel
     // cleanup bag content related item value fields (its will be filled correctly from `character_inventory`)
     for (uint8 i = 0; i < MAX_BAG_SIZE; ++i)
     {
-        auto item = m_bagslot[i];
         SetGuidValue(CONTAINER_FIELD_SLOT_1 + (i * 2), ObjectGuid::Empty);
-        item.reset();
+        m_bagslot[i].reset();
     }
 
     return true;
@@ -151,7 +150,6 @@ uint32 Bag::GetFreeSlots() const
 void Bag::RemoveItem(uint8 slot, bool /*update*/)
 {
     ASSERT(slot < MAX_BAG_SIZE);
-
 
     if (auto pItem = m_bagslot.at(slot))
         pItem->SetContainer(nullptr);

--- a/src/server/game/Entities/Item/Container/Bag.cpp
+++ b/src/server/game/Entities/Item/Container/Bag.cpp
@@ -34,7 +34,7 @@ Bag::~Bag()
 {
     for (uint32 i = 0; i < MAX_BAG_SIZE; ++i)
     {
-        auto item = m_bagslot[i];
+        auto item = m_bagslot.at(i);
         if (item == nullptr || !item->IsInWorld())
         {
             continue;
@@ -57,19 +57,23 @@ void Bag::AddToWorld()
 {
     Item::AddToWorld();
 
-    for (const auto item : m_bagslot)
+    for (uint32 i = 0; i < GetBagSize(); ++i)
     {
-        if (item != nullptr)
+        if (const auto item = m_bagslot.at(i))
+        {
             item->AddToWorld();
+        }
     }
 }
 
 void Bag::RemoveFromWorld()
 {
-    for (const auto item : m_bagslot)
+    for (uint32 i = 0; i < GetBagSize(); ++i)
     {
-        if (item != nullptr)
+        if (const auto item = m_bagslot.at(i))
+        {
             item->RemoveFromWorld();
+        }
     }
 
     Item::RemoveFromWorld();
@@ -123,7 +127,7 @@ bool Bag::LoadFromDB(ObjectGuid::LowType guid, ObjectGuid owner_guid, const Fiel
     for (uint8 i = 0; i < MAX_BAG_SIZE; ++i)
     {
         SetGuidValue(CONTAINER_FIELD_SLOT_1 + (i * 2), ObjectGuid::Empty);
-        m_bagslot[i].reset();
+        m_bagslot.at(i).reset();
     }
 
     return true;
@@ -178,8 +182,10 @@ void Bag::BuildCreateUpdateBlockForPlayer(UpdateData* data, Player* target)
     Item::BuildCreateUpdateBlockForPlayer(data, target);
 
     for (uint32 i = 0; i < GetBagSize(); ++i)
-        if (m_bagslot[i])
-            m_bagslot[i]->BuildCreateUpdateBlockForPlayer(data, target);
+    {
+        if (const auto pItem = m_bagslot.at(i))
+            pItem->BuildCreateUpdateBlockForPlayer(data, target);
+    }
 }
 
 bool Bag::IsEmpty() const
@@ -192,7 +198,7 @@ uint32 Bag::GetItemCount(uint32 item, const std::shared_ptr<Item> ignoreItem /*=
     uint32 count = 0;
     for (uint32 i = 0; i < GetBagSize(); ++i)
     {
-        const auto pItem = m_bagslot[i];
+        const auto pItem = m_bagslot.at(i);
         if (pItem && pItem != ignoreItem && pItem->GetEntry() == item)
             count += pItem->GetCount();
     }
@@ -201,7 +207,7 @@ uint32 Bag::GetItemCount(uint32 item, const std::shared_ptr<Item> ignoreItem /*=
     {
         for (uint32 i = 0; i < GetBagSize(); ++i)
         {
-            const auto pItem = m_bagslot[i];
+            const auto pItem = m_bagslot.at(i);
             if (pItem != nullptr && pItem != ignoreItem && pItem->GetTemplate()->Socket[0].Color)
                 count += pItem->GetGemCountWithID(item);
         }
@@ -213,8 +219,9 @@ uint32 Bag::GetItemCount(uint32 item, const std::shared_ptr<Item> ignoreItem /*=
 uint32 Bag::GetItemCountWithLimitCategory(uint32 limitCategory, const std::shared_ptr<Item> ignoreItem /*= nullptr*/) const
 {
     uint32 count = 0;
-    for (const auto pItem : m_bagslot)
+    for (uint32 i = 0; i < GetBagSize(); ++i)
     {
+        const auto pItem = m_bagslot.at(i);
         if (pItem == nullptr || pItem == ignoreItem)
         {
             continue;
@@ -230,9 +237,11 @@ uint32 Bag::GetItemCountWithLimitCategory(uint32 limitCategory, const std::share
 uint8 Bag::GetSlotByItemGUID(ObjectGuid guid) const
 {
     for (uint32 i = 0; i < GetBagSize(); ++i)
-        if (m_bagslot[i] != 0)
-            if (m_bagslot[i]->GetGUID() == guid)
-                return i;
+    {
+        const auto pItem = m_bagslot.at(i);
+        if (pItem != nullptr && pItem->GetGUID() == guid)
+            return i;
+    }
 
     return NULL_SLOT;
 }

--- a/src/server/game/Entities/Item/Container/Bag.cpp
+++ b/src/server/game/Entities/Item/Container/Bag.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "Bag.h"
-#include "DatabaseEnv.h"
 #include "Log.h"
 #include "ObjectMgr.h"
 #include "Player.h"
@@ -58,7 +57,7 @@ void Bag::AddToWorld()
 {
     Item::AddToWorld();
 
-    for (auto item : m_bagslot)
+    for (const auto item : m_bagslot)
     {
         if (item != nullptr)
             item->AddToWorld();
@@ -67,7 +66,7 @@ void Bag::AddToWorld()
 
 void Bag::RemoveFromWorld()
 {
-    for (auto item : m_bagslot)
+    for (const auto item : m_bagslot)
     {
         if (item != nullptr)
             item->RemoveFromWorld();
@@ -102,8 +101,8 @@ bool Bag::Create(ObjectGuid::LowType guidlow, uint32 itemid, Player const* owner
     for (uint8 i = 0; i < MAX_BAG_SIZE; ++i)
     {
         SetGuidValue(CONTAINER_FIELD_SLOT_1 + (i * 2), ObjectGuid::Empty);
-        m_bagslot[i] = nullptr;
     }
+    m_bagslot.fill(nullptr);
 
     return true;
 }
@@ -113,7 +112,7 @@ void Bag::SaveToDB(CharacterDatabaseTransaction trans)
     Item::SaveToDB(trans);
 }
 
-bool Bag::LoadFromDB(ObjectGuid::LowType guid, ObjectGuid owner_guid, Field* fields, uint32 entry)
+bool Bag::LoadFromDB(ObjectGuid::LowType guid, ObjectGuid owner_guid, const Field* fields, uint32 entry)
 {
     if (!Item::LoadFromDB(guid, owner_guid, fields, entry))
         return false;

--- a/src/server/game/Entities/Item/Container/Bag.h
+++ b/src/server/game/Entities/Item/Container/Bag.h
@@ -19,6 +19,7 @@
 #define ACORE_BAG_H
 
 // Maximum 36 Slots ((CONTAINER_END - CONTAINER_FIELD_SLOT_1)/2
+#include <memory>
 #define MAX_BAG_SIZE 36                                     // 2.0.12
 
 #include "Item.h"
@@ -35,15 +36,18 @@ public:
 
     bool Create(ObjectGuid::LowType guidlow, uint32 itemid, Player const* owner) override;
 
-    void StoreItem(uint8 slot, Item* pItem, bool update);
+    void StoreItem(uint8 slot, std::shared_ptr<Item> pItem, bool update);
     void RemoveItem(uint8 slot, bool update);
 
-    [[nodiscard]] Item* GetItemByPos(uint8 slot) const;
-    uint32 GetItemCount(uint32 item, Item* eItem = nullptr) const;
-    uint32 GetItemCountWithLimitCategory(uint32 limitCategory, Item* skipItem = nullptr) const;
+    [[nodiscard]] std::shared_ptr<Item> GetItemByPos(uint8 slot) const;
+    uint32 GetItemCount(uint32 item, const std::shared_ptr<Item> ignoreItem = nullptr) const;
+    uint32 GetItemCountWithLimitCategory(uint32 limitCategory, const std::shared_ptr<Item> ignoreItem = nullptr) const;
 
     [[nodiscard]] uint8 GetSlotByItemGUID(ObjectGuid guid) const;
+
+    // If the bag is empty returns true
     [[nodiscard]] bool IsEmpty() const;
+
     [[nodiscard]] uint32 GetFreeSlots() const;
     [[nodiscard]] uint32 GetBagSize() const { return GetUInt32Value(CONTAINER_FIELD_NUM_SLOTS); }
 
@@ -59,9 +63,14 @@ public:
 
     std::string GetDebugInfo() const override;
 
+    // Returns current bag object (this) as shared_ptr
+    std::shared_ptr<Bag> GetSharedPtr() const
+    {
+        return std::static_pointer_cast<Bag>(shared_from_this());
+    }
 protected:
     // Bag Storage space
-    Item* m_bagslot[MAX_BAG_SIZE];
+    std::array<std::shared_ptr<Item>, MAX_BAG_SIZE> m_bagslot;
 };
 
 inline Item* NewItemOrBag(ItemTemplate const* proto)

--- a/src/server/game/Entities/Item/Container/Bag.h
+++ b/src/server/game/Entities/Item/Container/Bag.h
@@ -55,7 +55,7 @@ public:
     // overwrite virtual Item::SaveToDB
     void SaveToDB(CharacterDatabaseTransaction trans) override;
     // overwrite virtual Item::LoadFromDB
-    bool LoadFromDB(ObjectGuid::LowType guid, ObjectGuid owner_guid, Field* fields, uint32 entry) override;
+    bool LoadFromDB(ObjectGuid::LowType guid, ObjectGuid owner_guid, const Field* fields, uint32 entry) override;
     // overwrite virtual Item::DeleteFromDB
     void DeleteFromDB(CharacterDatabaseTransaction trans) override;
 
@@ -64,7 +64,7 @@ public:
     std::string GetDebugInfo() const override;
 
     // Returns current bag object (this) as shared_ptr
-    std::shared_ptr<Bag> GetSharedPtr() const
+    std::shared_ptr<Bag> GetSharedPtr()
     {
         return std::static_pointer_cast<Bag>(shared_from_this());
     }
@@ -73,8 +73,8 @@ protected:
     std::array<std::shared_ptr<Item>, MAX_BAG_SIZE> m_bagslot;
 };
 
-inline Item* NewItemOrBag(ItemTemplate const* proto)
+inline std::shared_ptr<Item> NewItemOrBag(ItemTemplate const* proto)
 {
-    return (proto->InventoryType == INVTYPE_BAG) ? new Bag : new Item;
+    return (proto->InventoryType == INVTYPE_BAG) ? std::make_shared<Bag>() : std::make_shared<Item>();
 }
 #endif

--- a/src/server/game/Entities/Item/Item.h
+++ b/src/server/game/Entities/Item/Item.h
@@ -220,8 +220,8 @@ bool ItemCanGoIntoBag(ItemTemplate const* proto, ItemTemplate const* pBagProto);
 class Item : public Object, public std::enable_shared_from_this<Item>
 {
 public:
-    static Item* CreateItem(uint32 item, uint32 count, Player const* player = nullptr, bool clone = false, uint32 randomPropertyId = 0);
-    Item* CloneItem(uint32 count, Player const* player = nullptr) const;
+    static std::shared_ptr<Item> CreateItem(uint32 item, uint32 count, Player const* player = nullptr, bool clone = false, uint32 randomPropertyId = 0);
+    std::shared_ptr<Item> CloneItem(uint32 count, Player const* player = nullptr) const;
 
     Item();
 
@@ -240,7 +240,7 @@ public:
     [[nodiscard]] bool IsBoundByEnchant() const;
     [[nodiscard]] bool IsBoundByTempEnchant() const;
     virtual void SaveToDB(CharacterDatabaseTransaction trans);
-    virtual bool LoadFromDB(ObjectGuid::LowType guid, ObjectGuid owner_guid, Field* fields, uint32 entry);
+    virtual bool LoadFromDB(ObjectGuid::LowType guid, ObjectGuid owner_guid, const Field* fields, uint32 entry);
     static void DeleteFromDB(CharacterDatabaseTransaction trans, ObjectGuid::LowType itemGuid);
     virtual void DeleteFromDB(CharacterDatabaseTransaction trans);
     static void DeleteFromInventoryDB(CharacterDatabaseTransaction trans, ObjectGuid::LowType itemGuid);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -4810,7 +4810,7 @@ void Player::DurabilityPointsLossAll(int32 points, bool inventory)
             std::shared_ptr<Bag> pBag = nullptr;
             if (auto item = GetItemByPos(INVENTORY_SLOT_BAG_0, i))
             {
-                pBag = std::move(item->ToBag());
+                pBag = item->ToBag();
             }
 
             if (pBag == nullptr)

--- a/src/server/game/Entities/Player/PlayerMisc.cpp
+++ b/src/server/game/Entities/Player/PlayerMisc.cpp
@@ -503,10 +503,10 @@ void Player::SendItemRetrievalMail(std::vector<std::pair<uint32, uint32>> mailIt
 
         for (auto const& [itemEntry, itemCount] : items)
         {
-            if (Item* mailItem = Item::CreateItem(itemEntry, itemCount))
+            if (auto mailItem = Item::CreateItem(itemEntry, itemCount))
             {
                 mailItem->SaveToDB(trans);
-                draft.AddItem(mailItem);
+                draft.AddItem(std::move(mailItem));
             }
         }
 

--- a/src/server/game/Entities/Player/PlayerUpdates.cpp
+++ b/src/server/game/Entities/Player/PlayerUpdates.cpp
@@ -933,7 +933,7 @@ bool Player::UpdateSkillPro(uint16 SkillId, int32 Chance, uint32 step)
     return false;
 }
 
-void Player::UpdateWeaponSkill(Unit* victim, WeaponAttackType attType, Item* item /*= nullptr*/)
+void Player::UpdateWeaponSkill(Unit* victim, WeaponAttackType attType, std::shared_ptr<Item> item /*= nullptr*/)
 {
     if (IsInFeralForm())
         return; // always maximized SKILL_FERAL_COMBAT in fact
@@ -948,13 +948,13 @@ void Player::UpdateWeaponSkill(Unit* victim, WeaponAttackType attType, Item* ite
 
     uint32 weapon_skill_gain = sWorld->getIntConfig(CONFIG_SKILL_GAIN_WEAPON);
 
-    Item* tmpitem = GetWeaponForAttack(attType, true);
-    if (item && item != tmpitem && !item->IsBroken())
+    auto tmpitem = GetWeaponForAttack(attType, true);
+    if (item != nullptr && item != tmpitem && !item->IsBroken())
     {
         tmpitem = item;
     }
 
-    if (!tmpitem && attType == BASE_ATTACK)
+    if (tmpitem == nullptr && attType == BASE_ATTACK)
     {
         // Keep unarmed & fist weapon skills in sync
         UpdateSkill(SKILL_UNARMED, weapon_skill_gain);
@@ -979,7 +979,7 @@ void Player::UpdateWeaponSkill(Unit* victim, WeaponAttackType attType, Item* ite
     UpdateAllCritPercentages();
 }
 
-void Player::UpdateCombatSkills(Unit* victim, WeaponAttackType attType, bool defence, Item* item /*= nullptr*/)
+void Player::UpdateCombatSkills(Unit* victim, WeaponAttackType attType, bool defence, std::shared_ptr<Item> item /*= nullptr*/)
 {
     uint8  playerLevel = GetLevel();
     uint16 currentSkillValue = defence ? GetBaseDefenseSkillValue() : GetBaseWeaponSkillValue(attType);

--- a/src/server/game/Entities/Player/TradeData.cpp
+++ b/src/server/game/Entities/Player/TradeData.cpp
@@ -23,7 +23,7 @@ TradeData* TradeData::GetTraderData() const
     return m_trader->GetTradeData();
 }
 
-Item* TradeData::GetItem(TradeSlots slot) const
+std::shared_ptr<Item> TradeData::GetItem(TradeSlots slot) const
 {
     return m_items[slot] ? m_player->GetItemByGuid(m_items[slot]) : nullptr;
 }
@@ -46,17 +46,19 @@ TradeSlots TradeData::GetTradeSlotForItem(ObjectGuid itemGuid) const
     return TRADE_SLOT_INVALID;
 }
 
-Item* TradeData::GetSpellCastItem() const
+std::shared_ptr<Item> TradeData::GetSpellCastItem() const
 {
     return m_spellCastItem ? m_player->GetItemByGuid(m_spellCastItem) : nullptr;
 }
 
-void TradeData::SetItem(TradeSlots slot, Item* item)
+void TradeData::SetItem(TradeSlots slot, std::shared_ptr<Item> item)
 {
     ObjectGuid itemGuid = item ? item->GetGUID() : ObjectGuid::Empty;
 
     if (m_items[slot] == itemGuid)
+    {
         return;
+    }
 
     m_items[slot] = itemGuid;
 
@@ -73,12 +75,14 @@ void TradeData::SetItem(TradeSlots slot, Item* item)
     SetSpell(0);
 }
 
-void TradeData::SetSpell(uint32 spell_id, Item* castItem /*= nullptr*/)
+void TradeData::SetSpell(uint32 spell_id, std::shared_ptr<Item> castItem /*= nullptr*/)
 {
     ObjectGuid itemGuid = castItem ? castItem->GetGUID() : ObjectGuid::Empty;
 
     if (m_spell == spell_id && m_spellCastItem == itemGuid)
+    {
         return;
+    }
 
     m_spell = spell_id;
     m_spellCastItem = itemGuid;

--- a/src/server/game/Entities/Player/TradeData.h
+++ b/src/server/game/Entities/Player/TradeData.h
@@ -41,15 +41,15 @@ public:                                                 // constructors
     [[nodiscard]] Player* GetTrader() const { return m_trader; }
     [[nodiscard]] TradeData* GetTraderData() const;
 
-    [[nodiscard]] Item* GetItem(TradeSlots slot) const;
+    [[nodiscard]] std::shared_ptr<Item> GetItem(TradeSlots slot) const;
     [[nodiscard]] bool HasItem(ObjectGuid itemGuid) const;
     [[nodiscard]] TradeSlots GetTradeSlotForItem(ObjectGuid itemGuid) const;
-    void SetItem(TradeSlots slot, Item* item);
+    void SetItem(TradeSlots slot, std::shared_ptr<Item> item);
 
     [[nodiscard]] uint32 GetSpell() const { return m_spell; }
-    void SetSpell(uint32 spell_id, Item* castItem = nullptr);
+    void SetSpell(uint32 spell_id, std::shared_ptr<Item> castItem = nullptr);
 
-    [[nodiscard]] Item*  GetSpellCastItem() const;
+    [[nodiscard]] std::shared_ptr<Item> GetSpellCastItem() const;
     [[nodiscard]] bool HasSpellCastItem() const { return m_spellCastItem; }
 
     [[nodiscard]] uint32 GetMoney() const { return m_money; }

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -445,7 +445,7 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
                                     continue;
                                 }
 
-                                for (const auto& effInfo : spellproto->Effects)
+                                for (auto const& effInfo : spellproto->Effects)
                                 {
                                     if (effInfo.ApplyAuraName == SPELL_AURA_MOD_ATTACK_POWER)
                                     {

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1278,7 +1278,7 @@ public:
     void SetAuraStack(uint32 spellId, Unit* target, uint32 stack);
 
     // aura apply/remove helpers - you should better not use these
-    Aura* _TryStackingOrRefreshingExistingAura(SpellInfo const* newAura, uint8 effMask, Unit* caster, int32* baseAmount = nullptr, Item* castItem = nullptr, ObjectGuid casterGUID = ObjectGuid::Empty, bool periodicReset = false);
+    Aura* _TryStackingOrRefreshingExistingAura(SpellInfo const* newAura, uint8 effMask, Unit* caster, int32* baseAmount = nullptr, std::shared_ptr<Item> castItem = nullptr, ObjectGuid casterGUID = ObjectGuid::Empty, bool periodicReset = false);
     void _AddAura(UnitAura* aura, Unit* caster);
     AuraApplication* _CreateAuraApplication(Aura* aura, uint8 effMask);
     void _ApplyAuraEffect(Aura* aura, uint8 effIndex);
@@ -1537,17 +1537,17 @@ public:
     void CastDelayedSpellWithPeriodicAmount(Unit* caster, uint32 spellId, AuraType auraType, int32 addAmount, uint8 effectIndex = 0);
 
     // SpellCastResult methods
-    SpellCastResult CastSpell(SpellCastTargets const& targets, SpellInfo const* spellInfo, CustomSpellValues const* value, TriggerCastFlags triggerFlags = TRIGGERED_NONE, Item* castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
-    SpellCastResult CastSpell(Unit* victim, uint32 spellId, bool triggered, Item* castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
-    SpellCastResult CastSpell(Unit* victim, uint32 spellId, TriggerCastFlags triggerFlags = TRIGGERED_NONE, Item* castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
-    SpellCastResult CastSpell(Unit* victim, SpellInfo const* spellInfo, bool triggered, Item* castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
-    SpellCastResult CastSpell(Unit* victim, SpellInfo const* spellInfo, TriggerCastFlags triggerFlags = TRIGGERED_NONE, Item* castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
-    SpellCastResult CastSpell(float x, float y, float z, uint32 spellId, bool triggered, Item* castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
-    SpellCastResult CastSpell(GameObject* go, uint32 spellId, bool triggered, Item* castItem = nullptr, AuraEffect* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
-    SpellCastResult CastCustomSpell(Unit* victim, uint32 spellId, int32 const* bp0, int32 const* bp1, int32 const* bp2, bool triggered, Item* castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
-    SpellCastResult CastCustomSpell(uint32 spellId, SpellValueMod mod, int32 value, Unit* victim, bool triggered, Item* castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
-    SpellCastResult CastCustomSpell(uint32 spellId, SpellValueMod mod, int32 value, Unit* victim = nullptr, TriggerCastFlags triggerFlags = TRIGGERED_NONE, Item* castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
-    SpellCastResult CastCustomSpell(uint32 spellId, CustomSpellValues const& value, Unit* victim = nullptr, TriggerCastFlags triggerFlags = TRIGGERED_NONE, Item* castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
+    SpellCastResult CastSpell(SpellCastTargets const& targets, SpellInfo const* spellInfo, CustomSpellValues const* value, TriggerCastFlags triggerFlags = TRIGGERED_NONE, std::shared_ptr<Item> castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
+    SpellCastResult CastSpell(Unit* victim, uint32 spellId, bool triggered, std::shared_ptr<Item> castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
+    SpellCastResult CastSpell(Unit* victim, uint32 spellId, TriggerCastFlags triggerFlags = TRIGGERED_NONE, std::shared_ptr<Item> castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
+    SpellCastResult CastSpell(Unit* victim, SpellInfo const* spellInfo, bool triggered, std::shared_ptr<Item> castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
+    SpellCastResult CastSpell(Unit* victim, SpellInfo const* spellInfo, TriggerCastFlags triggerFlags = TRIGGERED_NONE, std::shared_ptr<Item> castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
+    SpellCastResult CastSpell(float x, float y, float z, uint32 spellId, bool triggered, std::shared_ptr<Item> castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
+    SpellCastResult CastSpell(GameObject* go, uint32 spellId, bool triggered, std::shared_ptr<Item> castItem = nullptr, AuraEffect* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
+    SpellCastResult CastCustomSpell(Unit* victim, uint32 spellId, int32 const* bp0, int32 const* bp1, int32 const* bp2, bool triggered, std::shared_ptr<Item> castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
+    SpellCastResult CastCustomSpell(uint32 spellId, SpellValueMod mod, int32 value, Unit* victim, bool triggered, std::shared_ptr<Item> castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
+    SpellCastResult CastCustomSpell(uint32 spellId, SpellValueMod mod, int32 value, Unit* victim = nullptr, TriggerCastFlags triggerFlags = TRIGGERED_NONE, std::shared_ptr<Item> castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
+    SpellCastResult CastCustomSpell(uint32 spellId, CustomSpellValues const& value, Unit* victim = nullptr, TriggerCastFlags triggerFlags = TRIGGERED_NONE, std::shared_ptr<Item> castItem = nullptr, AuraEffect const* triggeredByAura = nullptr, ObjectGuid originalCaster = ObjectGuid::Empty);
 
     /*********************************************************/
     /***     METHODS RELATED TO GAMEOBJECT & DYNOBEJCTS    ***/

--- a/src/server/game/Globals/ObjectAccessor.cpp
+++ b/src/server/game/Globals/ObjectAccessor.cpp
@@ -142,10 +142,11 @@ Object* ObjectAccessor::GetObjectByTypeMask(WorldObject const& p, ObjectGuid con
 {
     switch (guid.GetHigh())
     {
-        case HighGuid::Item:
+        /*case HighGuid::Item:
             if (typemask & TYPEMASK_ITEM && p.IsPlayer())
-                return ((Player const&)p).GetItemByGuid(guid);
+                return ((Player const&)p).GetItemByGuid(guid).get();
             break;
+        */
         case HighGuid::Player:
             if (typemask & TYPEMASK_PLAYER)
                 return GetPlayer(p, guid);

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -10273,10 +10273,10 @@ void ObjectMgr::SendServerMail(Player* player, uint32 id, uint32 reqLevel, uint3
         MailDraft draft(subject, body);
 
         draft.AddMoney(player->GetTeamId() == TEAM_ALLIANCE ? rewardMoneyA : rewardMoneyH);
-        if (Item* mailItem = Item::CreateItem(player->GetTeamId() == TEAM_ALLIANCE ? rewardItemA : rewardItemH, player->GetTeamId() == TEAM_ALLIANCE ? rewardItemCountA : rewardItemCountH))
+        if (auto mailItem = Item::CreateItem(player->GetTeamId() == TEAM_ALLIANCE ? rewardItemA : rewardItemH, player->GetTeamId() == TEAM_ALLIANCE ? rewardItemCountA : rewardItemCountH))
         {
             mailItem->SaveToDB(trans);
-            draft.AddItem(mailItem);
+            draft.AddItem(std::move(mailItem));
         }
 
         draft.SendMailTo(trans, MailReceiver(player), sender);

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1476,9 +1476,11 @@ void Group::CountTheRoll(Rolls::iterator rollI, Map* allowedMap)
                         roll->getLoot()->NotifyItemRemoved(roll->itemSlot);
                         roll->getLoot()->unlootedCount--;
                         AllowedLooterSet looters = item->GetAllowedLooters();
-                        Item* _item = player->StoreNewItem(dest, roll->itemid, true, item->randomPropertyId, looters);
-                        if (_item)
+                        auto _item = player->StoreNewItem(dest, roll->itemid, true, item->randomPropertyId, looters);
+                        if (_item != nullptr)
+                        {
                             sScriptMgr->OnGroupRollRewardItem(player, _item, _item->GetCount(), NEED, roll);
+                        }
                         player->UpdateLootAchievements(item, roll->getLoot());
                     }
                     else
@@ -1546,9 +1548,11 @@ void Group::CountTheRoll(Rolls::iterator rollI, Map* allowedMap)
                             roll->getLoot()->NotifyItemRemoved(roll->itemSlot);
                             roll->getLoot()->unlootedCount--;
                             AllowedLooterSet looters = item->GetAllowedLooters();
-                            Item* _item = player->StoreNewItem(dest, roll->itemid, true, item->randomPropertyId, looters);
-                            if (_item)
+                            auto _item = player->StoreNewItem(dest, roll->itemid, true, item->randomPropertyId, looters);
+                            if (_item != nullptr)
+                            {
                                 sScriptMgr->OnGroupRollRewardItem(player, _item, _item->GetCount(), GREED, roll);
+                            }
                             player->UpdateLootAchievements(item, roll->getLoot());
                         }
                         else

--- a/src/server/game/Handlers/BankHandler.cpp
+++ b/src/server/game/Handlers/BankHandler.cpp
@@ -71,9 +71,11 @@ void WorldSession::HandleAutoBankItemOpcode(WorldPackets::Bank::AutoBankItem& pa
         return;
     }
 
-    Item* item = _player->GetItemByPos(packet.Bag, packet.Slot);
-    if (!item)
+    auto item = _player->GetItemByPos(packet.Bag, packet.Slot);
+    if (item == nullptr)
+    {
         return;
+    }
 
     ItemPosCountVec dest;
     InventoryResult msg = _player->CanBankItem(NULL_BAG, NULL_SLOT, dest, item, false);
@@ -105,9 +107,11 @@ void WorldSession::HandleAutoStoreBankItemOpcode(WorldPackets::Bank::AutoStoreBa
         return;
     }
 
-    Item* item = _player->GetItemByPos(packet.Bag, packet.Slot);
-    if (!item)
+    auto item = _player->GetItemByPos(packet.Bag, packet.Slot);
+    if (item == nullptr)
+    {
         return;
+    }
 
     if (_player->IsBankPos(packet.Bag, packet.Slot))                    // moving from bank to inventory
     {
@@ -120,8 +124,10 @@ void WorldSession::HandleAutoStoreBankItemOpcode(WorldPackets::Bank::AutoStoreBa
         }
 
         _player->RemoveItem(packet.Bag, packet.Slot, true);
-        if (Item const* storedItem = _player->StoreItem(dest, item, true))
+        if (const auto storedItem = _player->StoreItem(dest, item, true))
+        {
             _player->ItemAddedQuestCheck(storedItem->GetEntry(), storedItem->GetCount());
+        }
     }
     else                                                    // moving from inventory to bank
     {

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -1787,8 +1787,8 @@ void WorldSession::HandleEquipmentSetSave(WorldPacket& recvData)
         }
 
         // xinef: some cheating checks
-        Item* item = _player->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
-        if (!item || item->GetGUID() != itemGuid)
+        auto item = _player->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
+        if (item == nullptr || item->GetGUID() != itemGuid)
         {
             eqSet.Items[i].Clear();
             continue;
@@ -1834,15 +1834,17 @@ void WorldSession::HandleEquipmentSetUse(WorldPacket& recvData)
         if (_player->IsInCombat() && i != EQUIPMENT_SLOT_MAINHAND && i != EQUIPMENT_SLOT_OFFHAND && i != EQUIPMENT_SLOT_RANGED)
             continue;
 
-        Item* item = nullptr;
+        std::shared_ptr<Item> item = nullptr;
         if (itemGuid)
+        {
             item = _player->GetItemByGuid(itemGuid);
+        }
 
         uint16 dstpos = i | (INVENTORY_SLOT_BAG_0 << 8);
 
         InventoryResult msg;
-        Item* uItem = _player->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
-        if (uItem)
+        std::shared_ptr<Item> uItem = _player->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
+        if (uItem != nullptr)
         {
             if (uItem->IsEquipped())
             {
@@ -1854,7 +1856,7 @@ void WorldSession::HandleEquipmentSetUse(WorldPacket& recvData)
                 }
             }
 
-            if (!item)
+            if (item == nullptr)
             {
                 ItemPosCountVec sDest;
                 msg = _player->CanStoreItem(NULL_BAG, NULL_SLOT, sDest, uItem, false);

--- a/src/server/game/Handlers/LootHandler.cpp
+++ b/src/server/game/Handlers/LootHandler.cpp
@@ -58,9 +58,8 @@ void WorldSession::HandleAutostoreLootItemOpcode(WorldPacket& recvData)
     }
     else if (lguid.IsItem())
     {
-        Item* pItem = player->GetItemByGuid(lguid);
-
-        if (!pItem)
+        auto pItem = player->GetItemByGuid(lguid);
+        if (pItem == nullptr)
         {
             player->SendLootRelease(lguid);
             return;
@@ -151,7 +150,7 @@ void WorldSession::HandleLootMoneyOpcode(WorldPacket& /*recvData*/)
             }
         case HighGuid::Item:
             {
-                if (Item* item = player->GetItemByGuid(guid))
+                if (auto item = player->GetItemByGuid(guid))
                 {
                     loot = &item->loot;
                     shareMoney = false;
@@ -351,9 +350,11 @@ void WorldSession::DoLootRelease(ObjectGuid lguid)
     }
     else if (lguid.IsItem())
     {
-        Item* pItem = player->GetItemByGuid(lguid);
-        if (!pItem)
+        auto pItem = player->GetItemByGuid(lguid);
+        if (pItem == nullptr)
+        {
             return;
+        }
 
         loot = &pItem->loot;
         ItemTemplate const* proto = pItem->GetTemplate();
@@ -503,7 +504,7 @@ void WorldSession::HandleLootMasterGiveOpcode(WorldPacket& recvData)
     AllowedLooterSet looters = item.GetAllowedLooters();
 
     // not move item from loot to target inventory
-    Item* newitem = target->StoreNewItem(dest, item.itemid, true, item.randomPropertyId, looters);
+    auto newitem = target->StoreNewItem(dest, item.itemid, true, item.randomPropertyId, looters);
     target->SendNewItem(newitem, uint32(item.count), false, false, true);
     target->UpdateLootAchievements(&item, loot);
 

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -106,7 +106,7 @@ void WorldSession::HandleGossipSelectOptionOpcode(WorldPacket& recv_data)
 
     Creature* unit = nullptr;
     GameObject* go = nullptr;
-    Item* item = nullptr;
+    std::shared_ptr<Item> item;
     if (guid.IsCreatureOrVehicle())
     {
         unit = GetPlayer()->GetNPCIfCanInteractWith(guid, UNIT_NPC_FLAG_NONE);
@@ -164,18 +164,18 @@ void WorldSession::HandleGossipSelectOptionOpcode(WorldPacket& recv_data)
     }
     if (!code.empty())
     {
-        if (unit)
+        if (unit != nullptr)
         {
             unit->AI()->sGossipSelectCode(_player, menuId, gossipListId, code.c_str());
             if (!sScriptMgr->OnGossipSelectCode(_player, unit, _player->PlayerTalkClass->GetGossipOptionSender(gossipListId), _player->PlayerTalkClass->GetGossipOptionAction(gossipListId), code.c_str()))
                 _player->OnGossipSelect(unit, gossipListId, menuId);
         }
-        else if (go)
+        else if (go != nullptr)
         {
             go->AI()->GossipSelectCode(_player, menuId, gossipListId, code.c_str());
             sScriptMgr->OnGossipSelectCode(_player, go, _player->PlayerTalkClass->GetGossipOptionSender(gossipListId), _player->PlayerTalkClass->GetGossipOptionAction(gossipListId), code.c_str());
         }
-        else if (item)
+        else if (item != nullptr)
         {
             sScriptMgr->OnGossipSelectCode(_player, item, _player->PlayerTalkClass->GetGossipOptionSender(gossipListId), _player->PlayerTalkClass->GetGossipOptionAction(gossipListId), code.c_str());
         }
@@ -186,19 +186,19 @@ void WorldSession::HandleGossipSelectOptionOpcode(WorldPacket& recv_data)
     }
     else
     {
-        if (unit)
+        if (unit != nullptr)
         {
             unit->AI()->sGossipSelect(_player, menuId, gossipListId);
             if (!sScriptMgr->OnGossipSelect(_player, unit, _player->PlayerTalkClass->GetGossipOptionSender(gossipListId), _player->PlayerTalkClass->GetGossipOptionAction(gossipListId)))
                 _player->OnGossipSelect(unit, gossipListId, menuId);
         }
-        else if (go)
+        else if (go != nullptr)
         {
             go->AI()->GossipSelect(_player, menuId, gossipListId);
             if (!sScriptMgr->OnGossipSelect(_player, go, _player->PlayerTalkClass->GetGossipOptionSender(gossipListId), _player->PlayerTalkClass->GetGossipOptionAction(gossipListId)))
                 _player->OnGossipSelect(go, gossipListId, menuId);
         }
-        else if (item)
+        else if (item != nullptr)
         {
             sScriptMgr->OnGossipSelect(_player, item, _player->PlayerTalkClass->GetGossipOptionSender(gossipListId), _player->PlayerTalkClass->GetGossipOptionAction(gossipListId));
         }

--- a/src/server/game/Handlers/NPCHandler.cpp
+++ b/src/server/game/Handlers/NPCHandler.cpp
@@ -909,10 +909,10 @@ void WorldSession::HandleRepairItemOpcode(WorldPacket& recvData)
     if (itemGUID)
     {
         LOG_DEBUG("network", "ITEM: Repair item, item {}, npc {}", itemGUID.ToString(), npcGUID.ToString());
-
-        Item* item = _player->GetItemByGuid(itemGUID);
-        if (item)
+        if (auto item = _player->GetItemByGuid(itemGUID))
+        {
             _player->DurabilityRepair(item->GetPos(), true, discountMod, guildBank);
+        }
     }
     else
     {

--- a/src/server/game/Handlers/PetitionsHandler.cpp
+++ b/src/server/game/Handlers/PetitionsHandler.cpp
@@ -179,9 +179,11 @@ void WorldSession::HandlePetitionBuyOpcode(WorldPacket& recvData)
     }
 
     _player->ModifyMoney(-(int32)cost);
-    Item* charter = _player->StoreNewItem(dest, charterid, true);
-    if (!charter)
+    auto charter = _player->StoreNewItem(dest, charterid, true);
+    if (charter == nullptr)
+    {
         return;
+    }
 
     charter->SetUInt32Value(ITEM_FIELD_ENCHANTMENT_1_1, charter->GetGUID().GetCounter());
     // ITEM_FIELD_ENCHANTMENT_1_1 is guild/arenateam id
@@ -332,9 +334,11 @@ void WorldSession::HandlePetitionRenameOpcode(WorldPacket& recvData)
     recvData >> petitionGuid;                              // guid
     recvData >> newName;                                   // new name
 
-    Item* item = _player->GetItemByGuid(petitionGuid);
-    if (!item)
+    auto item = _player->GetItemByGuid(petitionGuid);
+    if (item == nullptr)
+    {
         return;
+    }
 
     Petition const* petition = sPetitionMgr->GetPetition(petitionGuid);
     if (!petition)
@@ -649,9 +653,11 @@ void WorldSession::HandleTurnInPetitionOpcode(WorldPacket& recvData)
     recvData >> petitionGuid;
 
     // Check if player really has the required petition charter
-    Item* item = _player->GetItemByGuid(petitionGuid);
-    if (!item)
+    auto item = _player->GetItemByGuid(petitionGuid);
+    if (item == nullptr)
+    {
         return;
+    }
 
     LOG_DEBUG("network", "Petition {} turned in by {}", petitionGuid.ToString(), _player->GetGUID().ToString());
 

--- a/src/server/game/Mails/Mail.h
+++ b/src/server/game/Mails/Mail.h
@@ -117,7 +117,7 @@ private:
 
 class MailDraft
 {
-    typedef std::map<ObjectGuid, Item*> MailItemMap;
+    typedef std::map<ObjectGuid, std::shared_ptr<Item>> MailItemMap;
 
 public:                                                 // Constructors
     explicit MailDraft(uint16 mailTemplateId, bool need_items = true)
@@ -133,7 +133,7 @@ public:                                                 // Accessors
     [[nodiscard]] std::string const& GetBody() const { return m_body; }
 
 public:                                                 // modifiers
-    MailDraft& AddItem(Item* item);
+    MailDraft& AddItem(std::shared_ptr<Item> item);
     MailDraft& AddMoney(uint32 money) { m_money = money; return *this; }
     MailDraft& AddCOD(uint32 COD) { m_COD = COD; return *this; }
 

--- a/src/server/game/Petitions/PetitionMgr.cpp
+++ b/src/server/game/Petitions/PetitionMgr.cpp
@@ -119,7 +119,7 @@ void PetitionMgr::RemovePetitionByOwnerAndType(ObjectGuid ownerGuid, uint8 type)
             {
                 if (Player* owner = ObjectAccessor::FindConnectedPlayer(ownerGuid))
                 {
-                    if (Item* item = owner->GetItemByGuid(itr->first))
+                    if (auto item = owner->GetItemByGuid(itr->first))
                     {
                         owner->DestroyItem(item->GetBagSlot(), item->GetSlot(), true);
                     }

--- a/src/server/game/Scripting/MapScripts.cpp
+++ b/src/server/game/Scripting/MapScripts.cpp
@@ -287,13 +287,20 @@ void Map::ScriptsProcess()
         ScriptAction const& step = iter->second;
 
         Object* source = nullptr;
+
+        // TODO: replace this with better solution
+        // Assign item to keep pointer active
+        std::shared_ptr<Item> item;
         if (step.sourceGUID)
         {
             switch (step.sourceGUID.GetHigh())
             {
                 case HighGuid::Item: // as well as HIGHGUID_CONTAINER
                     if (Player* player = ObjectAccessor::GetPlayer(this, step.ownerGUID))
-                        source = player->GetItemByGuid(step.sourceGUID);
+                    {
+                        item = player->GetItemByGuid(step.sourceGUID);
+                        source = item.get();
+                    }
                     break;
                 case HighGuid::Unit:
                 case HighGuid::Vehicle:
@@ -746,7 +753,7 @@ void Map::ScriptsProcess()
                     InventoryResult msg = pReceiver->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, step.script->CreateItem.ItemEntry, step.script->CreateItem.Amount);
                     if (msg == EQUIP_ERR_OK)
                     {
-                        if (Item* item = pReceiver->StoreNewItem(dest, step.script->CreateItem.ItemEntry, true))
+                        if (auto item = pReceiver->StoreNewItem(dest, step.script->CreateItem.ItemEntry, true))
                             pReceiver->SendNewItem(item, step.script->CreateItem.Amount, false, true);
                     }
                     else

--- a/src/server/game/Scripting/ScriptDefines/AllItemScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/AllItemScript.cpp
@@ -21,7 +21,7 @@
 #include "ScriptMgrMacros.h"
 #include "ScriptedGossip.h"
 
-bool ScriptMgr::OnQuestAccept(Player* player, Item* item, Quest const* quest)
+bool ScriptMgr::OnQuestAccept(Player* player, std::shared_ptr<Item> item, Quest const* quest)
 {
     ASSERT(player);
     ASSERT(item);
@@ -42,7 +42,7 @@ bool ScriptMgr::OnQuestAccept(Player* player, Item* item, Quest const* quest)
     return tempScript ? tempScript->OnQuestAccept(player, item, quest) : false;
 }
 
-bool ScriptMgr::OnItemUse(Player* player, Item* item, SpellCastTargets const& targets)
+bool ScriptMgr::OnItemUse(Player* player, std::shared_ptr<Item> item, SpellCastTargets const& targets)
 {
     ASSERT(player);
     ASSERT(item);
@@ -80,7 +80,7 @@ bool ScriptMgr::OnItemExpire(Player* player, ItemTemplate const* proto)
     return tempScript ? tempScript->OnExpire(player, proto) : false;
 }
 
-bool ScriptMgr::OnItemRemove(Player* player, Item* item)
+bool ScriptMgr::OnItemRemove(Player* player, std::shared_ptr<Item> item)
 {
     ASSERT(player);
     ASSERT(item);
@@ -99,7 +99,7 @@ bool ScriptMgr::OnItemRemove(Player* player, Item* item)
     return tempScript ? tempScript->OnRemove(player, item) : false;
 }
 
-bool ScriptMgr::OnCastItemCombatSpell(Player* player, Unit* victim, SpellInfo const* spellInfo, Item* item)
+bool ScriptMgr::OnCastItemCombatSpell(Player* player, Unit* victim, SpellInfo const* spellInfo, std::shared_ptr<Item> item)
 {
     ASSERT(player);
     ASSERT(victim);
@@ -110,7 +110,7 @@ bool ScriptMgr::OnCastItemCombatSpell(Player* player, Unit* victim, SpellInfo co
     return tempScript ? tempScript->OnCastItemCombatSpell(player, victim, spellInfo, item) : true;
 }
 
-void ScriptMgr::OnGossipSelect(Player* player, Item* item, uint32 sender, uint32 action)
+void ScriptMgr::OnGossipSelect(Player* player, std::shared_ptr<Item> item, uint32 sender, uint32 action)
 {
     ASSERT(player);
     ASSERT(item);
@@ -126,7 +126,7 @@ void ScriptMgr::OnGossipSelect(Player* player, Item* item, uint32 sender, uint32
     }
 }
 
-void ScriptMgr::OnGossipSelectCode(Player* player, Item* item, uint32 sender, uint32 action, const char* code)
+void ScriptMgr::OnGossipSelectCode(Player* player, std::shared_ptr<Item> item, uint32 sender, uint32 action, const char* code)
 {
     ASSERT(player);
     ASSERT(item);

--- a/src/server/game/Scripting/ScriptDefines/AllItemScript.h
+++ b/src/server/game/Scripting/ScriptDefines/AllItemScript.h
@@ -19,6 +19,7 @@
 #define SCRIPT_OBJECT_ALL_ITEM_SCRIPT_H_
 
 #include "ScriptObject.h"
+#include <memory>
 
 class AllItemScript : public ScriptObject
 {

--- a/src/server/game/Scripting/ScriptDefines/AllItemScript.h
+++ b/src/server/game/Scripting/ScriptDefines/AllItemScript.h
@@ -27,22 +27,22 @@ protected:
 
 public:
     // Called when a player accepts a quest from the item.
-    [[nodiscard]] virtual bool CanItemQuestAccept(Player* /*player*/, Item* /*item*/, Quest const* /*quest*/) { return true; }
+    [[nodiscard]] virtual bool CanItemQuestAccept(Player* /*player*/, std::shared_ptr<Item> /*item*/, Quest const* /*quest*/) { return true; }
 
     // Called when a player uses the item.
-    [[nodiscard]] virtual bool CanItemUse(Player* /*player*/, Item* /*item*/, SpellCastTargets const& /*targets*/) { return false; }
+    [[nodiscard]] virtual bool CanItemUse(Player* /*player*/, std::shared_ptr<Item> /*item*/, SpellCastTargets const& /*targets*/) { return false; }
 
     // Called when the item is destroyed.
-    [[nodiscard]] virtual bool CanItemRemove(Player* /*player*/, Item* /*item*/) { return true; }
+    [[nodiscard]] virtual bool CanItemRemove(Player* /*player*/, std::shared_ptr<Item> /*item*/) { return true; }
 
     // Called when the item expires (is destroyed).
     [[nodiscard]] virtual bool CanItemExpire(Player* /*player*/, ItemTemplate const* /*proto*/) { return true; }
 
     // Called when a player selects an option in an item gossip window
-    virtual void OnItemGossipSelect(Player* /*player*/, Item* /*item*/, uint32 /*sender*/, uint32 /*action*/) { }
+    virtual void OnItemGossipSelect(Player* /*player*/, std::shared_ptr<Item> /*item*/, uint32 /*sender*/, uint32 /*action*/) { }
 
     // Called when a player selects an option in an item gossip window
-    virtual void OnItemGossipSelectCode(Player* /*player*/, Item* /*item*/, uint32 /*sender*/, uint32 /*action*/, const char* /*code*/) { }
+    virtual void OnItemGossipSelectCode(Player* /*player*/, std::shared_ptr<Item> /*item*/, uint32 /*sender*/, uint32 /*action*/, const char* /*code*/) { }
 };
 
 #endif

--- a/src/server/game/Scripting/ScriptDefines/AllSpellScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/AllSpellScript.cpp
@@ -79,7 +79,7 @@ void ScriptMgr::OnDummyEffect(WorldObject* caster, uint32 spellID, SpellEffIndex
     CALL_ENABLED_HOOKS(AllSpellScript, ALLSPELLHOOK_ON_DUMMY_EFFECT_CREATURE, script->OnDummyEffect(caster, spellID, effIndex, creatureTarget));
 }
 
-void ScriptMgr::OnDummyEffect(WorldObject* caster, uint32 spellID, SpellEffIndex effIndex, Item* itemTarget)
+void ScriptMgr::OnDummyEffect(WorldObject* caster, uint32 spellID, SpellEffIndex effIndex, std::shared_ptr<Item> itemTarget)
 {
     CALL_ENABLED_HOOKS(AllSpellScript, ALLSPELLHOOK_ON_DUMMY_EFFECT_ITEM, script->OnDummyEffect(caster, spellID, effIndex, itemTarget));
 }

--- a/src/server/game/Scripting/ScriptDefines/AllSpellScript.h
+++ b/src/server/game/Scripting/ScriptDefines/AllSpellScript.h
@@ -99,7 +99,7 @@ public:
      * @param effIndex Contains information about the SpellEffIndex
      * @param itemTarget Contains information about the Item
      */
-    virtual void OnDummyEffect(WorldObject* /*caster*/, uint32 /*spellID*/, SpellEffIndex /*effIndex*/, Item* /*itemTarget*/) { }
+    virtual void OnDummyEffect(WorldObject* /*caster*/, uint32 /*spellID*/, SpellEffIndex /*effIndex*/, std::shared_ptr<Item> /*itemTarget*/) { }
 };
 
 // Compatibility for old scripts

--- a/src/server/game/Scripting/ScriptDefines/AllSpellScript.h
+++ b/src/server/game/Scripting/ScriptDefines/AllSpellScript.h
@@ -19,6 +19,7 @@
 #define SCRIPT_OBJECT_ALL_SPELL_SCRIPT_H_
 
 #include "ScriptObject.h"
+#include <memory>
 #include <vector>
 
 enum AllSpellHook

--- a/src/server/game/Scripting/ScriptDefines/GuildScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/GuildScript.cpp
@@ -59,7 +59,7 @@ void ScriptMgr::OnGuildMemberDepositMoney(Guild* guild, Player* player, uint32& 
     CALL_ENABLED_HOOKS(GuildScript, GUILDHOOK_ON_MEMBER_DEPOSIT_MONEY, script->OnMemberDepositMoney(guild, player, amount));
 }
 
-void ScriptMgr::OnGuildItemMove(Guild* guild, Player* player, Item* pItem, bool isSrcBank, uint8 srcContainer, uint8 srcSlotId, bool isDestBank, uint8 destContainer, uint8 destSlotId)
+void ScriptMgr::OnGuildItemMove(Guild* guild, Player* player, std::shared_ptr<Item> pItem, bool isSrcBank, uint8 srcContainer, uint8 srcSlotId, bool isDestBank, uint8 destContainer, uint8 destSlotId)
 {
     CALL_ENABLED_HOOKS(GuildScript, GUILDHOOK_ON_ITEM_MOVE, script->OnItemMove(guild, player, pItem, isSrcBank, srcContainer, srcSlotId, isDestBank, destContainer, destSlotId));
 }

--- a/src/server/game/Scripting/ScriptDefines/GuildScript.h
+++ b/src/server/game/Scripting/ScriptDefines/GuildScript.h
@@ -20,6 +20,7 @@
 
 #include "ObjectGuid.h"
 #include "ScriptObject.h"
+#include <memory>
 #include <vector>
 
 enum GuildHook

--- a/src/server/game/Scripting/ScriptDefines/GuildScript.h
+++ b/src/server/game/Scripting/ScriptDefines/GuildScript.h
@@ -72,7 +72,7 @@ public:
     virtual void OnMemberDepositMoney(Guild* /*guild*/, Player* /*player*/, uint32& /*amount*/) { }
 
     // Called when a guild member moves an item in a guild bank.
-    virtual void OnItemMove(Guild* /*guild*/, Player* /*player*/, Item* /*pItem*/, bool /*isSrcBank*/, uint8 /*srcContainer*/, uint8 /*srcSlotId*/, bool /*isDestBank*/, uint8 /*destContainer*/, uint8 /*destSlotId*/) { }
+    virtual void OnItemMove(Guild* /*guild*/, Player* /*player*/, std::shared_ptr<Item> /*pItem*/, bool /*isSrcBank*/, uint8 /*srcContainer*/, uint8 /*srcSlotId*/, bool /*isDestBank*/, uint8 /*destContainer*/, uint8 /*destSlotId*/) { }
 
     virtual void OnEvent(Guild* /*guild*/, uint8 /*eventType*/, ObjectGuid::LowType /*playerGuid1*/, ObjectGuid::LowType /*playerGuid2*/, uint8 /*newRank*/) { }
 

--- a/src/server/game/Scripting/ScriptDefines/ItemScript.h
+++ b/src/server/game/Scripting/ScriptDefines/ItemScript.h
@@ -29,25 +29,25 @@ public:
     [[nodiscard]] bool IsDatabaseBound() const override { return true; }
 
     // Called when a player accepts a quest from the item.
-    [[nodiscard]] virtual bool OnQuestAccept(Player* /*player*/, Item* /*item*/, Quest const* /*quest*/) { return false; }
+    [[nodiscard]] virtual bool OnQuestAccept(Player* /*player*/, std::shared_ptr<Item> /*item*/, Quest const* /*quest*/) { return false; }
 
     // Called when a player uses the item.
-    [[nodiscard]] virtual bool OnUse(Player* /*player*/, Item* /*item*/, SpellCastTargets const& /*targets*/) { return false; }
+    [[nodiscard]] virtual bool OnUse(Player* /*player*/, std::shared_ptr<Item> /*item*/, SpellCastTargets const& /*targets*/) { return false; }
 
     // Called when the item is destroyed.
-    [[nodiscard]] virtual bool OnRemove(Player* /*player*/, Item* /*item*/) { return false; }
+    [[nodiscard]] virtual bool OnRemove(Player* /*player*/, std::shared_ptr<Item> /*item*/) { return false; }
 
     // Called before casting a combat spell from this item (chance on hit spells of item template, can be used to prevent cast if returning false)
-    [[nodiscard]] virtual bool OnCastItemCombatSpell(Player* /*player*/, Unit* /*victim*/, SpellInfo const* /*spellInfo*/, Item* /*item*/) { return true; }
+    [[nodiscard]] virtual bool OnCastItemCombatSpell(Player* /*player*/, Unit* /*victim*/, SpellInfo const* /*spellInfo*/, std::shared_ptr<Item> /*item*/) { return true; }
 
     // Called when the item expires (is destroyed).
     [[nodiscard]] virtual bool OnExpire(Player* /*player*/, ItemTemplate const* /*proto*/) { return false; }
 
     // Called when a player selects an option in an item gossip window
-    virtual void OnGossipSelect(Player* /*player*/, Item* /*item*/, uint32 /*sender*/, uint32 /*action*/) { }
+    virtual void OnGossipSelect(Player* /*player*/, std::shared_ptr<Item> /*item*/, uint32 /*sender*/, uint32 /*action*/) { }
 
     // Called when a player selects an option in an item gossip window
-    virtual void OnGossipSelectCode(Player* /*player*/, Item* /*item*/, uint32 /*sender*/, uint32 /*action*/, const char* /*code*/) { }
+    virtual void OnGossipSelectCode(Player* /*player*/, std::shared_ptr<Item> /*item*/, uint32 /*sender*/, uint32 /*action*/, const char* /*code*/) { }
 };
 
 #endif

--- a/src/server/game/Scripting/ScriptDefines/MiscScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/MiscScript.cpp
@@ -59,17 +59,17 @@ void ScriptMgr::OnDestructInstanceSave(InstanceSave* origin)
     CALL_ENABLED_HOOKS(MiscScript, MISCHOOK_ON_DESTRUCT_INSTANCE_SAVE, script->OnDestructInstanceSave(origin));
 }
 
-void ScriptMgr::OnItemCreate(Item* item, ItemTemplate const* itemProto, Player const* owner)
+void ScriptMgr::OnItemCreate(std::shared_ptr<Item> item, ItemTemplate const* itemProto, Player const* owner)
 {
     CALL_ENABLED_HOOKS(MiscScript, MISCHOOK_ON_ITEM_CREATE, script->OnItemCreate(item, itemProto, owner));
 }
 
-bool ScriptMgr::CanApplySoulboundFlag(Item* item, ItemTemplate const* proto)
+bool ScriptMgr::CanApplySoulboundFlag(std::shared_ptr<Item> item, ItemTemplate const* proto)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(MiscScript, MISCHOOK_CAN_APPLY_SOULBOUND_FLAG, !script->CanApplySoulboundFlag(item, proto));
 }
 
-bool ScriptMgr::CanItemApplyEquipSpell(Player* player, Item* item)
+bool ScriptMgr::CanItemApplyEquipSpell(Player* player, std::shared_ptr<Item> item)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(MiscScript, MISCHOOK_CAN_ITEM_APPLY_EQUIP_SPELL, !script->CanItemApplyEquipSpell(player, item));
 }

--- a/src/server/game/Scripting/ScriptDefines/MiscScript.h
+++ b/src/server/game/Scripting/ScriptDefines/MiscScript.h
@@ -69,11 +69,11 @@ public:
 
     virtual void OnDestructInstanceSave(InstanceSave* /*origin*/) { }
 
-    virtual void OnItemCreate(Item* /*item*/, ItemTemplate const* /*itemProto*/, Player const* /*owner*/) { }
+    virtual void OnItemCreate(std::shared_ptr<Item> /*item*/, ItemTemplate const* /*itemProto*/, Player const* /*owner*/) { }
 
-    [[nodiscard]] virtual bool CanApplySoulboundFlag(Item* /*item*/, ItemTemplate const* /*proto*/) { return true; }
+    [[nodiscard]] virtual bool CanApplySoulboundFlag(std::shared_ptr<Item> /*item*/, ItemTemplate const* /*proto*/) { return true; }
 
-    [[nodiscard]] virtual bool CanItemApplyEquipSpell(Player* /*player*/, Item* /*item*/) { return true; }
+    [[nodiscard]] virtual bool CanItemApplyEquipSpell(Player* /*player*/, std::shared_ptr<Item> /*item*/) { return true; }
 
     [[nodiscard]] virtual bool CanSendAuctionHello(WorldSession const* /*session*/, ObjectGuid /*guid*/, Creature* /*creature*/) { return true; }
 

--- a/src/server/game/Scripting/ScriptDefines/MiscScript.h
+++ b/src/server/game/Scripting/ScriptDefines/MiscScript.h
@@ -20,6 +20,7 @@
 
 #include "ObjectGuid.h"
 #include "ScriptObject.h"
+#include <memory>
 #include <vector>
 
 enum MiscHook

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -334,17 +334,17 @@ void ScriptMgr::OnPlayerBeingCharmed(Player* player, Unit* charmer, uint32 oldFa
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_BEING_CHARMED, script->OnBeingCharmed(player, charmer, oldFactionId, newFactionId));
 }
 
-void ScriptMgr::OnAfterPlayerSetVisibleItemSlot(Player* player, uint8 slot, Item* item)
+void ScriptMgr::OnAfterPlayerSetVisibleItemSlot(Player* player, uint8 slot, std::shared_ptr<Item> item)
 {
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_AFTER_SET_VISIBLE_ITEM_SLOT, script->OnAfterSetVisibleItemSlot(player, slot, item));
 }
 
-void ScriptMgr::OnAfterPlayerMoveItemFromInventory(Player* player, Item* it, uint8 bag, uint8 slot, bool update)
+void ScriptMgr::OnAfterPlayerMoveItemFromInventory(Player* player, std::shared_ptr<Item> it, uint8 bag, uint8 slot, bool update)
 {
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_AFTER_MOVE_ITEM_FROM_INVENTORY, script->OnAfterMoveItemFromInventory(player, it, bag, slot, update));
 }
 
-void ScriptMgr::OnEquip(Player* player, Item* it, uint8 bag, uint8 slot, bool update)
+void ScriptMgr::OnEquip(Player* player, std::shared_ptr<Item> it, uint8 bag, uint8 slot, bool update)
 {
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_EQUIP, script->OnEquip(player, it, bag, slot, update));
 }
@@ -364,7 +364,7 @@ void ScriptMgr::OnGetMaxPersonalArenaRatingRequirement(Player const* player, uin
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_GET_MAX_PERSONAL_ARENA_RATING_REQUIREMENT, script->OnGetMaxPersonalArenaRatingRequirement(player, minSlot, maxArenaRating));
 }
 
-void ScriptMgr::OnLootItem(Player* player, Item* item, uint32 count, ObjectGuid lootguid)
+void ScriptMgr::OnLootItem(Player* player, std::shared_ptr<Item> item, uint32 count, ObjectGuid lootguid)
 {
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_LOOT_ITEM, script->OnLootItem(player, item, count, lootguid));
 }
@@ -374,17 +374,17 @@ void ScriptMgr::OnBeforeFillQuestLootItem(Player* player, LootItem& item)
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_BEFORE_FILL_QUEST_LOOT_ITEM, script->OnBeforeFillQuestLootItem(player, item));
 }
 
-void ScriptMgr::OnStoreNewItem(Player* player, Item* item, uint32 count)
+void ScriptMgr::OnStoreNewItem(Player* player, std::shared_ptr<Item> item, uint32 count)
 {
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_STORE_NEW_ITEM, script->OnStoreNewItem(player, item, count));
 }
 
-void ScriptMgr::OnCreateItem(Player* player, Item* item, uint32 count)
+void ScriptMgr::OnCreateItem(Player* player, std::shared_ptr<Item> item, uint32 count)
 {
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_CREATE_ITEM, script->OnCreateItem(player, item, count));
 }
 
-void ScriptMgr::OnQuestRewardItem(Player* player, Item* item, uint32 count)
+void ScriptMgr::OnQuestRewardItem(Player* player, std::shared_ptr<Item> item, uint32 count)
 {
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_QUEST_REWARD_ITEM, script->OnQuestRewardItem(player, item, count));
 }
@@ -394,12 +394,12 @@ bool ScriptMgr::CanPlaceAuctionBid(Player* player, AuctionEntry* auction)
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_PLACE_AUCTION_BID, !script->CanPlaceAuctionBid(player, auction));
 }
 
-void ScriptMgr::OnGroupRollRewardItem(Player* player, Item* item, uint32 count, RollVote voteType, Roll* roll)
+void ScriptMgr::OnGroupRollRewardItem(Player* player, std::shared_ptr<Item> item, uint32 count, RollVote voteType, Roll* roll)
 {
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_GROUP_ROLL_REWARD_ITEM, script->OnGroupRollRewardItem(player, item, count, voteType, roll));
 }
 
-bool ScriptMgr::OnBeforeOpenItem(Player* player, Item* item)
+bool ScriptMgr::OnBeforeOpenItem(Player* player, std::shared_ptr<Item> item)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_ON_BEFORE_OPEN_ITEM, !script->OnBeforeOpenItem(player, item));
 }
@@ -449,7 +449,7 @@ void ScriptMgr::OnBeforeBuyItemFromVendor(Player* player, ObjectGuid vendorguid,
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_BEFORE_BUY_ITEM_FROM_VENDOR, script->OnBeforeBuyItemFromVendor(player, vendorguid, vendorslot, item, count, bag, slot));
 }
 
-void ScriptMgr::OnAfterStoreOrEquipNewItem(Player* player, uint32 vendorslot, Item* item, uint8 count, uint8 bag, uint8 slot, ItemTemplate const* pProto, Creature* pVendor, VendorItem const* crItem, bool bStore)
+void ScriptMgr::OnAfterStoreOrEquipNewItem(Player* player, uint32 vendorslot, std::shared_ptr<Item> item, uint8 count, uint8 bag, uint8 slot, ItemTemplate const* pProto, Creature* pVendor, VendorItem const* crItem, bool bStore)
 {
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_AFTER_STORE_OR_EQUIP_NEW_ITEM, script->OnAfterStoreOrEquipNewItem(player, vendorslot, item, count, bag, slot, pProto, pVendor, crItem, bStore));
 }
@@ -514,12 +514,12 @@ bool ScriptMgr::CanGroupAccept(Player* player, Group* group)
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_GROUP_ACCEPT, !script->CanGroupAccept(player, group));
 }
 
-bool ScriptMgr::CanSellItem(Player* player, Item* item, Creature* creature)
+bool ScriptMgr::CanSellItem(Player* player, std::shared_ptr<Item> item, Creature* creature)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_SELL_ITEM, !script->CanSellItem(player, item, creature));
 }
 
-bool ScriptMgr::CanSendMail(Player* player, ObjectGuid receiverGuid, ObjectGuid mailbox, std::string& subject, std::string& body, uint32 money, uint32 COD, Item* item)
+bool ScriptMgr::CanSendMail(Player* player, ObjectGuid receiverGuid, ObjectGuid mailbox, std::string& subject, std::string& body, uint32 money, uint32 COD, std::shared_ptr<Item> item)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_SEND_MAIL, !script->CanSendMail(player, receiverGuid, mailbox, subject, body, money, COD, item));
 }
@@ -639,7 +639,7 @@ void ScriptMgr::OnApplyItemModsBefore(Player* player, uint8 slot, bool apply, ui
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_APPLY_ITEM_MODS_BEFORE, script->OnApplyItemModsBefore(player, slot, apply, itemProtoStatNumber, statType, val));
 }
 
-void ScriptMgr::OnApplyEnchantmentItemModsBefore(Player* player, Item* item, EnchantmentSlot slot, bool apply, uint32 enchant_spell_id, uint32& enchant_amount)
+void ScriptMgr::OnApplyEnchantmentItemModsBefore(Player* player, std::shared_ptr<Item> item, EnchantmentSlot slot, bool apply, uint32 enchant_spell_id, uint32& enchant_amount)
 {
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_APPLY_ENCHANTMENT_ITEM_MODS_BEFORE, script->OnApplyEnchantmentItemModsBefore(player, item, slot, apply, enchant_spell_id, enchant_amount));
 }
@@ -659,12 +659,12 @@ void ScriptMgr::OnGetFeralApBonus(Player* player, int32& feral_bonus, int32 dpsM
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_GET_FERAL_AP_BONUS, script->OnGetFeralApBonus(player, feral_bonus, dpsMod, proto, ssv));
 }
 
-bool ScriptMgr::CanApplyWeaponDependentAuraDamageMod(Player* player, Item* item, WeaponAttackType attackType, AuraEffect const* aura, bool apply)
+bool ScriptMgr::CanApplyWeaponDependentAuraDamageMod(Player* player, std::shared_ptr<Item> item, WeaponAttackType attackType, AuraEffect const* aura, bool apply)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_APPLY_WEAPON_DEPENDENT_AURA_DAMAGE_MOD, !script->CanApplyWeaponDependentAuraDamageMod(player, item, attackType, aura, apply));
 }
 
-bool ScriptMgr::CanApplyEquipSpell(Player* player, SpellInfo const* spellInfo, Item* item, bool apply, bool form_change)
+bool ScriptMgr::CanApplyEquipSpell(Player* player, SpellInfo const* spellInfo, std::shared_ptr<Item> item, bool apply, bool form_change)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_APPLY_EQUIP_SPELL, !script->CanApplyEquipSpell(player, spellInfo, item, apply, form_change));
 }
@@ -674,12 +674,12 @@ bool ScriptMgr::CanApplyEquipSpellsItemSet(Player* player, ItemSetEffect* eff)
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_APPLY_EQUIP_SPELLS_ITEM_SET, !script->CanApplyEquipSpellsItemSet(player, eff));
 }
 
-bool ScriptMgr::CanCastItemCombatSpell(Player* player, Unit* target, WeaponAttackType attType, uint32 procVictim, uint32 procEx, Item* item, ItemTemplate const* proto)
+bool ScriptMgr::CanCastItemCombatSpell(Player* player, Unit* target, WeaponAttackType attType, uint32 procVictim, uint32 procEx, std::shared_ptr<Item> item, ItemTemplate const* proto)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_CAST_ITEM_COMBAT_SPELL, !script->CanCastItemCombatSpell(player, target, attType, procVictim, procEx, item, proto));
 }
 
-bool ScriptMgr::CanCastItemUseSpell(Player* player, Item* item, SpellCastTargets const& targets, uint8 cast_count, uint32 glyphIndex)
+bool ScriptMgr::CanCastItemUseSpell(Player* player, std::shared_ptr<Item> item, SpellCastTargets const& targets, uint8 cast_count, uint32 glyphIndex)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_CAST_ITEM_USE_SPELL, !script->CanCastItemUseSpell(player, item, targets, cast_count, glyphIndex));
 }
@@ -689,7 +689,7 @@ void ScriptMgr::OnApplyAmmoBonuses(Player* player, ItemTemplate const* proto, fl
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_APPLY_AMMO_BONUSES, script->OnApplyAmmoBonuses(player, proto, currentAmmoDPS));
 }
 
-bool ScriptMgr::CanEquipItem(Player* player, uint8 slot, uint16& dest, Item* pItem, bool swap, bool not_loading)
+bool ScriptMgr::CanEquipItem(Player* player, uint8 slot, uint16& dest, std::shared_ptr<Item> pItem, bool swap, bool not_loading)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_EQUIP_ITEM, !script->CanEquipItem(player, slot, dest, pItem, swap, not_loading));
 }
@@ -704,12 +704,12 @@ bool ScriptMgr::CanUseItem(Player* player, ItemTemplate const* proto, InventoryR
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_USE_ITEM, !script->CanUseItem(player, proto, result));
 }
 
-bool ScriptMgr::CanSaveEquipNewItem(Player* player, Item* item, uint16 pos, bool update)
+bool ScriptMgr::CanSaveEquipNewItem(Player* player, std::shared_ptr<Item> item, uint16 pos, bool update)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_SAVE_EQUIP_NEW_ITEM, !script->CanSaveEquipNewItem(player, item, pos, update));
 }
 
-bool ScriptMgr::CanApplyEnchantment(Player* player, Item* item, EnchantmentSlot slot, bool apply, bool apply_dur, bool ignore_condition)
+bool ScriptMgr::CanApplyEnchantment(Player* player, std::shared_ptr<Item> item, EnchantmentSlot slot, bool apply, bool apply_dur, bool ignore_condition)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_APPLY_ENCHANTMENT, !script->CanApplyEnchantment(player, item, slot, apply, apply_dur, ignore_condition));
 }
@@ -724,7 +724,7 @@ bool ScriptMgr::PassedQuestKilledMonsterCredit(Player* player, Quest const* qinf
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_PASSED_QUEST_KILLED_MONSTER_CREDIT, !script->PassedQuestKilledMonsterCredit(player, qinfo, entry, real_entry, guid));
 }
 
-bool ScriptMgr::CheckItemInSlotAtLoadInventory(Player* player, Item* item, uint8 slot, uint8& err, uint16& dest)
+bool ScriptMgr::CheckItemInSlotAtLoadInventory(Player* player, std::shared_ptr<Item> item, uint8 slot, uint8& err, uint16& dest)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CHECK_ITEM_IN_SLOT_AT_LOAD_INVENTORY, !script->CheckItemInSlotAtLoadInventory(player, item, slot, err, dest));
 }
@@ -789,7 +789,7 @@ bool ScriptMgr::CanInitTrade(Player* player, Player* target)
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_INIT_TRADE, !script->CanInitTrade(player, target));
 }
 
-bool ScriptMgr::CanSetTradeItem(Player* player, Item* tradedItem, uint8 tradeSlot)
+bool ScriptMgr::CanSetTradeItem(Player* player, std::shared_ptr<Item> tradedItem, uint8 tradeSlot)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_SET_TRADE_ITEM, !script->CanSetTradeItem(player, tradedItem, tradeSlot));
 }

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.h
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.h
@@ -392,13 +392,13 @@ public:
     virtual void OnBeingCharmed(Player* /*player*/, Unit* /*charmer*/, uint32 /*oldFactionId*/, uint32 /*newFactionId*/) { }
 
     // To change behaviour of set visible item slot
-    virtual void OnAfterSetVisibleItemSlot(Player* /*player*/, uint8 /*slot*/, Item* /*item*/) { }
+    virtual void OnAfterSetVisibleItemSlot(Player* /*player*/, uint8 /*slot*/, std::shared_ptr<Item> /*item*/) { }
 
     // After an item has been moved from inventory
-    virtual void OnAfterMoveItemFromInventory(Player* /*player*/, Item* /*it*/, uint8 /*bag*/, uint8 /*slot*/, bool /*update*/) { }
+    virtual void OnAfterMoveItemFromInventory(Player* /*player*/, std::shared_ptr<Item> /*it*/, uint8 /*bag*/, uint8 /*slot*/, bool /*update*/) { }
 
     // After an item has been equipped
-    virtual void OnEquip(Player* /*player*/, Item* /*it*/, uint8 /*bag*/, uint8 /*slot*/, bool /*update*/) { }
+    virtual void OnEquip(Player* /*player*/, std::shared_ptr<Item> /*it*/, uint8 /*bag*/, uint8 /*slot*/, bool /*update*/) { }
 
     // After player enters queue for BG
     virtual void OnPlayerJoinBG(Player* /*player*/) { }
@@ -410,28 +410,28 @@ public:
     virtual void OnGetMaxPersonalArenaRatingRequirement(Player const* /*player*/, uint32 /*minSlot*/, uint32& /*maxArenaRating*/) const {}
 
     //After looting item
-    virtual void OnLootItem(Player* /*player*/, Item* /*item*/, uint32 /*count*/, ObjectGuid /*lootguid*/) { }
+    virtual void OnLootItem(Player* /*player*/, std::shared_ptr<Item> /*item*/, uint32 /*count*/, ObjectGuid /*lootguid*/) { }
 
     //Before looting item
     virtual void OnBeforeFillQuestLootItem(Player* /*player*/, LootItem& /*item*/) { }
 
     //After looting item (includes master loot).
-    virtual void OnStoreNewItem(Player* /*player*/, Item* /*item*/, uint32 /*count*/) { }
+    virtual void OnStoreNewItem(Player* /*player*/, std::shared_ptr<Item> /*item*/, uint32 /*count*/) { }
 
     //After creating item (eg profession item creation)
-    virtual void OnCreateItem(Player* /*player*/, Item* /*item*/, uint32 /*count*/) { }
+    virtual void OnCreateItem(Player* /*player*/, std::shared_ptr<Item> /*item*/, uint32 /*count*/) { }
 
     // After receiving item as a quest reward
-    virtual void OnQuestRewardItem(Player* /*player*/, Item* /*item*/, uint32 /*count*/) { }
+    virtual void OnQuestRewardItem(Player* /*player*/, std::shared_ptr<Item> /*item*/, uint32 /*count*/) { }
 
     // When placing a bid or buying out an auction
     [[nodiscard]] virtual bool CanPlaceAuctionBid(Player* /*player*/, AuctionEntry* /*auction*/) { return true; }
 
     // After receiving item as a group roll reward
-    virtual void OnGroupRollRewardItem(Player* /*player*/, Item* /*item*/, uint32 /*count*/, RollVote /*voteType*/, Roll* /*roll*/) { }
+    virtual void OnGroupRollRewardItem(Player* /*player*/, std::shared_ptr<Item> /*item*/, uint32 /*count*/, RollVote /*voteType*/, Roll* /*roll*/) { }
 
     //Before opening an item
-    [[nodiscard]] virtual bool OnBeforeOpenItem(Player* /*player*/, Item* /*item*/) { return true; }
+    [[nodiscard]] virtual bool OnBeforeOpenItem(Player* /*player*/, std::shared_ptr<Item> /*item*/) { return true; }
 
     // After completed a quest
     [[nodiscard]] virtual bool OnBeforeQuestComplete(Player* /*player*/, uint32 /*quest_id*/) { return true; }
@@ -449,7 +449,7 @@ public:
     virtual void OnBeforeStoreOrEquipNewItem(Player* /*player*/, uint32 /*vendorslot*/, uint32& /*item*/, uint8 /*count*/, uint8 /*bag*/, uint8 /*slot*/, ItemTemplate const* /*pProto*/, Creature* /*pVendor*/, VendorItem const* /*crItem*/, bool /*bStore*/) { };
 
     //After buying something from any vendor
-    virtual void OnAfterStoreOrEquipNewItem(Player* /*player*/, uint32 /*vendorslot*/, Item* /*item*/, uint8 /*count*/, uint8 /*bag*/, uint8 /*slot*/, ItemTemplate const* /*pProto*/, Creature* /*pVendor*/, VendorItem const* /*crItem*/, bool /*bStore*/) { };
+    virtual void OnAfterStoreOrEquipNewItem(Player* /*player*/, uint32 /*vendorslot*/, std::shared_ptr<Item> /*item*/, uint8 /*count*/, uint8 /*bag*/, uint8 /*slot*/, ItemTemplate const* /*pProto*/, Creature* /*pVendor*/, VendorItem const* /*crItem*/, bool /*bStore*/) { };
 
     virtual void OnAfterUpdateMaxPower(Player* /*player*/, Powers& /*power*/, float& /*value*/) { }
 
@@ -487,9 +487,9 @@ public:
 
     [[nodiscard]] virtual bool CanGroupAccept(Player* /*player*/, Group* /*group*/) { return true; }
 
-    [[nodiscard]] virtual bool CanSellItem(Player* /*player*/, Item* /*item*/, Creature* /*creature*/) { return true; }
+    [[nodiscard]] virtual bool CanSellItem(Player* /*player*/, std::shared_ptr<Item> /*item*/, Creature* /*creature*/) { return true; }
 
-    [[nodiscard]] virtual bool CanSendMail(Player* /*player*/, ObjectGuid /*receiverGuid*/, ObjectGuid /*mailbox*/, std::string& /*subject*/, std::string& /*body*/, uint32 /*money*/, uint32 /*COD*/, Item* /*item*/) { return true; }
+    [[nodiscard]] virtual bool CanSendMail(Player* /*player*/, ObjectGuid /*receiverGuid*/, ObjectGuid /*mailbox*/, std::string& /*subject*/, std::string& /*body*/, uint32 /*money*/, uint32 /*COD*/, std::shared_ptr<Item> /*item*/) { return true; }
 
     virtual void PetitionBuy(Player* /*player*/, Creature* /*creature*/, uint32& /*charterid*/, uint32& /*cost*/, uint32& /*type*/) { }
 
@@ -546,7 +546,7 @@ public:
 
     virtual void OnApplyItemModsBefore(Player* /*player*/, uint8 /*slot*/, bool /*apply*/, uint8 /*itemProtoStatNumber*/, uint32 /*statType*/, int32& /*val*/) { }
 
-    virtual void OnApplyEnchantmentItemModsBefore(Player* /*player*/, Item* /*item*/, EnchantmentSlot /*slot*/, bool /*apply*/, uint32 /*enchant_spell_id*/, uint32& /*enchant_amount*/) { }
+    virtual void OnApplyEnchantmentItemModsBefore(Player* /*player*/, std::shared_ptr<Item> /*item*/, EnchantmentSlot /*slot*/, bool /*apply*/, uint32 /*enchant_spell_id*/, uint32& /*enchant_amount*/) { }
 
     virtual void OnApplyWeaponDamage(Player* /*player*/, uint8 /*slot*/, ItemTemplate const* /*proto*/, float& /*minDamage*/, float& /*maxDamage*/, uint8 /*damageIndex*/) { }
 
@@ -554,33 +554,33 @@ public:
 
     virtual void OnGetFeralApBonus(Player* /*player*/, int32& /*feral_bonus*/, int32 /*dpsMod*/, ItemTemplate const* /*proto*/, ScalingStatValuesEntry const* /*ssv*/) { }
 
-    [[nodiscard]] virtual bool CanApplyWeaponDependentAuraDamageMod(Player* /*player*/, Item* /*item*/, WeaponAttackType /*attackType*/, AuraEffect const* /*aura*/, bool /*apply*/) { return true; }
+    [[nodiscard]] virtual bool CanApplyWeaponDependentAuraDamageMod(Player* /*player*/, std::shared_ptr<Item> /*item*/, WeaponAttackType /*attackType*/, AuraEffect const* /*aura*/, bool /*apply*/) { return true; }
 
-    [[nodiscard]] virtual bool CanApplyEquipSpell(Player* /*player*/, SpellInfo const* /*spellInfo*/, Item* /*item*/, bool /*apply*/, bool /*form_change*/) { return true; }
+    [[nodiscard]] virtual bool CanApplyEquipSpell(Player* /*player*/, SpellInfo const* /*spellInfo*/, std::shared_ptr<Item> /*item*/, bool /*apply*/, bool /*form_change*/) { return true; }
 
     [[nodiscard]] virtual bool CanApplyEquipSpellsItemSet(Player* /*player*/, ItemSetEffect* /*eff*/) { return true; }
 
-    [[nodiscard]] virtual bool CanCastItemCombatSpell(Player* /*player*/, Unit* /*target*/, WeaponAttackType /*attType*/, uint32 /*procVictim*/, uint32 /*procEx*/, Item* /*item*/, ItemTemplate const* /*proto*/) { return true; }
+    [[nodiscard]] virtual bool CanCastItemCombatSpell(Player* /*player*/, Unit* /*target*/, WeaponAttackType /*attType*/, uint32 /*procVictim*/, uint32 /*procEx*/, std::shared_ptr<Item> /*item*/, ItemTemplate const* /*proto*/) { return true; }
 
-    [[nodiscard]] virtual bool CanCastItemUseSpell(Player* /*player*/, Item* /*item*/, SpellCastTargets const& /*targets*/, uint8 /*cast_count*/, uint32 /*glyphIndex*/) { return true; }
+    [[nodiscard]] virtual bool CanCastItemUseSpell(Player* /*player*/, std::shared_ptr<Item> /*item*/, SpellCastTargets const& /*targets*/, uint8 /*cast_count*/, uint32 /*glyphIndex*/) { return true; }
 
     virtual void OnApplyAmmoBonuses(Player* /*player*/, ItemTemplate const* /*proto*/, float& /*currentAmmoDPS*/) { }
 
-    [[nodiscard]] virtual bool CanEquipItem(Player* /*player*/, uint8 /*slot*/, uint16& /*dest*/, Item* /*pItem*/, bool /*swap*/, bool /*not_loading*/) { return true; }
+    [[nodiscard]] virtual bool CanEquipItem(Player* /*player*/, uint8 /*slot*/, uint16& /*dest*/, std::shared_ptr<Item> /*pItem*/, bool /*swap*/, bool /*not_loading*/) { return true; }
 
     [[nodiscard]] virtual bool CanUnequipItem(Player* /*player*/, uint16 /*pos*/, bool /*swap*/) { return true; }
 
     [[nodiscard]] virtual bool CanUseItem(Player* /*player*/, ItemTemplate const* /*proto*/, InventoryResult& /*result*/) { return true; }
 
-    [[nodiscard]] virtual bool CanSaveEquipNewItem(Player* /*player*/, Item* /*item*/, uint16 /*pos*/, bool /*update*/) { return true; }
+    [[nodiscard]] virtual bool CanSaveEquipNewItem(Player* /*player*/, std::shared_ptr<Item> /*item*/, uint16 /*pos*/, bool /*update*/) { return true; }
 
-    [[nodiscard]] virtual bool CanApplyEnchantment(Player* /*player*/, Item* /*item*/, EnchantmentSlot /*slot*/, bool /*apply*/, bool /*apply_dur*/, bool /*ignore_condition*/) { return true; }
+    [[nodiscard]] virtual bool CanApplyEnchantment(Player* /*player*/, std::shared_ptr<Item> /*item*/, EnchantmentSlot /*slot*/, bool /*apply*/, bool /*apply_dur*/, bool /*ignore_condition*/) { return true; }
 
     virtual void OnGetQuestRate(Player* /*player*/, float& /*result*/) { }
 
     [[nodiscard]] virtual bool PassedQuestKilledMonsterCredit(Player* /*player*/, Quest const* /*qinfo*/, uint32 /*entry*/, uint32 /*real_entry*/, ObjectGuid /*guid*/) { return true; }
 
-    [[nodiscard]] virtual bool CheckItemInSlotAtLoadInventory(Player* /*player*/, Item* /*item*/, uint8 /*slot*/, uint8& /*err*/, uint16& /*dest*/) { return true; }
+    [[nodiscard]] virtual bool CheckItemInSlotAtLoadInventory(Player* /*player*/, std::shared_ptr<Item> /*item*/, uint8 /*slot*/, uint8& /*err*/, uint16& /*dest*/) { return true; }
 
     [[nodiscard]] virtual bool NotAvoidSatisfy(Player* /*player*/, DungeonProgressionRequirements const* /*ar*/, uint32 /*target_map*/, bool /*report*/) { return true; }
 
@@ -615,7 +615,7 @@ public:
      *
      * @return True if you want to continue setting the item in the trade slot, false if you want to cancel the trade
      */
-    [[nodiscard]] virtual bool CanSetTradeItem(Player* /*player*/, Item* /*tradedItem*/, uint8 /*tradeSlot*/) { return true; }
+    [[nodiscard]] virtual bool CanSetTradeItem(Player* /*player*/, std::shared_ptr<Item> /*tradedItem*/, uint8 /*tradeSlot*/) { return true; }
 
     virtual void OnSetServerSideVisibility(Player* /*player*/, ServerSideVisibilityType& /*type*/, AccountTypes& /*sec*/) { }
 

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -199,13 +199,13 @@ public: /* InstanceMapScript */
     InstanceScript* CreateInstanceScript(InstanceMap* map);
 
 public: /* ItemScript */
-    bool OnQuestAccept(Player* player, Item* item, Quest const* quest);
-    bool OnItemUse(Player* player, Item* item, SpellCastTargets const& targets);
+    bool OnQuestAccept(Player* player, std::shared_ptr<Item> item, Quest const* quest);
+    bool OnItemUse(Player* player, std::shared_ptr<Item> item, SpellCastTargets const& targets);
     bool OnItemExpire(Player* player, ItemTemplate const* proto);
-    bool OnItemRemove(Player* player, Item* item);
-    bool OnCastItemCombatSpell(Player* player, Unit* victim, SpellInfo const* spellInfo, Item* item);
-    void OnGossipSelect(Player* player, Item* item, uint32 sender, uint32 action);
-    void OnGossipSelectCode(Player* player, Item* item, uint32 sender, uint32 action, const char* code);
+    bool OnItemRemove(Player* player, std::shared_ptr<Item> item);
+    bool OnCastItemCombatSpell(Player* player, Unit* victim, SpellInfo const* spellInfo, std::shared_ptr<Item> item);
+    void OnGossipSelect(Player* player, std::shared_ptr<Item>item, uint32 sender, uint32 action);
+    void OnGossipSelectCode(Player* player, std::shared_ptr<Item> item, uint32 sender, uint32 action, const char* code);
 
 public: /* CreatureScript */
     bool OnGossipHello(Player* player, Creature* creature);
@@ -352,26 +352,26 @@ public: /* PlayerScript */
     void OnGossipSelect(Player* player, uint32 menu_id, uint32 sender, uint32 action);
     void OnGossipSelectCode(Player* player, uint32 menu_id, uint32 sender, uint32 action, const char* code);
     void OnPlayerBeingCharmed(Player* player, Unit* charmer, uint32 oldFactionId, uint32 newFactionId);
-    void OnAfterPlayerSetVisibleItemSlot(Player* player, uint8 slot, Item* item);
-    void OnAfterPlayerMoveItemFromInventory(Player* player, Item* it, uint8 bag, uint8 slot, bool update);
-    void OnEquip(Player* player, Item* it, uint8 bag, uint8 slot, bool update);
+    void OnAfterPlayerSetVisibleItemSlot(Player* player, uint8 slot, std::shared_ptr<Item> item);
+    void OnAfterPlayerMoveItemFromInventory(Player* player, std::shared_ptr<Item> it, uint8 bag, uint8 slot, bool update);
+    void OnEquip(Player* player, std::shared_ptr<Item> it, uint8 bag, uint8 slot, bool update);
     void OnPlayerJoinBG(Player* player);
     void OnPlayerJoinArena(Player* player);
     void OnGetMaxPersonalArenaRatingRequirement(Player const* player, uint32 minSlot, uint32& maxArenaRating) const;
-    void OnLootItem(Player* player, Item* item, uint32 count, ObjectGuid lootguid);
+    void OnLootItem(Player* player, std::shared_ptr<Item> item, uint32 count, ObjectGuid lootguid);
     void OnBeforeFillQuestLootItem(Player* player, LootItem& item);
-    void OnStoreNewItem(Player* player, Item* item, uint32 count);
-    void OnCreateItem(Player* player, Item* item, uint32 count);
-    void OnQuestRewardItem(Player* player, Item* item, uint32 count);
+    void OnStoreNewItem(Player* player, std::shared_ptr<Item> item, uint32 count);
+    void OnCreateItem(Player* player, std::shared_ptr<Item> item, uint32 count);
+    void OnQuestRewardItem(Player* player, std::shared_ptr<Item> item, uint32 count);
     bool CanPlaceAuctionBid(Player* player, AuctionEntry* auction);
-    void OnGroupRollRewardItem(Player* player, Item* item, uint32 count, RollVote voteType, Roll* roll);
-    bool OnBeforeOpenItem(Player* player, Item* item);
+    void OnGroupRollRewardItem(Player* player, std::shared_ptr<Item> item, uint32 count, RollVote voteType, Roll* roll);
+    bool OnBeforeOpenItem(Player* player, std::shared_ptr<Item> item);
     bool OnBeforePlayerQuestComplete(Player* player, uint32 quest_id);
     void OnQuestComputeXP(Player* player, Quest const* quest, uint32& xpValue);
     void OnBeforePlayerDurabilityRepair(Player* player, ObjectGuid npcGUID, ObjectGuid itemGUID, float& discountMod, uint8 guildBank);
     void OnBeforeBuyItemFromVendor(Player* player, ObjectGuid vendorguid, uint32 vendorslot, uint32& item, uint8 count, uint8 bag, uint8 slot);
     void OnBeforeStoreOrEquipNewItem(Player* player, uint32 vendorslot, uint32& item, uint8 count, uint8 bag, uint8 slot, ItemTemplate const* pProto, Creature* pVendor, VendorItem const* crItem, bool bStore);
-    void OnAfterStoreOrEquipNewItem(Player* player, uint32 vendorslot, Item* item, uint8 count, uint8 bag, uint8 slot, ItemTemplate const* pProto, Creature* pVendor, VendorItem const* crItem, bool bStore);
+    void OnAfterStoreOrEquipNewItem(Player* player, uint32 vendorslot, std::shared_ptr<Item> item, uint8 count, uint8 bag, uint8 slot, ItemTemplate const* pProto, Creature* pVendor, VendorItem const* crItem, bool bStore);
     void OnAfterUpdateMaxPower(Player* player, Powers& power, float& value);
     void OnAfterUpdateMaxHealth(Player* player, float& value);
     void OnBeforeUpdateAttackPowerAndDamage(Player* player, float& level, float& val2, bool ranged);
@@ -391,8 +391,8 @@ public: /* PlayerScript */
     bool CanBattleFieldPort(Player* player, uint8 arenaType, BattlegroundTypeId BGTypeID, uint8 action);
     bool CanGroupInvite(Player* player, std::string& membername);
     bool CanGroupAccept(Player* player, Group* group);
-    bool CanSellItem(Player* player, Item* item, Creature* creature);
-    bool CanSendMail(Player* player, ObjectGuid receiverGuid, ObjectGuid mailbox, std::string& subject, std::string& body, uint32 money, uint32 COD, Item* item);
+    bool CanSellItem(Player* player, std::shared_ptr<Item> item, Creature* creature);
+    bool CanSendMail(Player* player, ObjectGuid receiverGuid, ObjectGuid mailbox, std::string& subject, std::string& body, uint32 money, uint32 COD, std::shared_ptr<Item> item);
     void PetitionBuy(Player* player, Creature* creature, uint32& charterid, uint32& cost, uint32& type);
     void PetitionShowList(Player* player, Creature* creature, uint32& CharterEntry, uint32& CharterDispayID, uint32& CharterCost);
     void OnRewardKillRewarder(Player* player, KillRewarder* rewarder, bool isDungeon, float& rate);
@@ -411,24 +411,24 @@ public: /* PlayerScript */
     void OnCustomScalingStatValueBefore(Player* player, ItemTemplate const* proto, uint8 slot, bool apply, uint32& CustomScalingStatValue);
     void OnCustomScalingStatValue(Player* player, ItemTemplate const* proto, uint32& statType, int32& val, uint8 itemProtoStatNumber, uint32 ScalingStatValue, ScalingStatValuesEntry const* ssv);
     void OnApplyItemModsBefore(Player* player, uint8 slot, bool apply, uint8 itemProtoStatNumber, uint32 statType, int32& val);
-    void OnApplyEnchantmentItemModsBefore(Player* player, Item* item, EnchantmentSlot slot, bool apply, uint32 enchant_spell_id, uint32& enchant_amount);
+    void OnApplyEnchantmentItemModsBefore(Player* player, std::shared_ptr<Item> item, EnchantmentSlot slot, bool apply, uint32 enchant_spell_id, uint32& enchant_amount);
     void OnApplyWeaponDamage(Player* player, uint8 slot, ItemTemplate const* proto, float& minDamage, float& maxDamage, uint8 damageIndex);
     bool CanArmorDamageModifier(Player* player);
     void OnGetFeralApBonus(Player* player, int32& feral_bonus, int32 dpsMod, ItemTemplate const* proto, ScalingStatValuesEntry const* ssv);
-    bool CanApplyWeaponDependentAuraDamageMod(Player* player, Item* item, WeaponAttackType attackType, AuraEffect const* aura, bool apply);
-    bool CanApplyEquipSpell(Player* player, SpellInfo const* spellInfo, Item* item, bool apply, bool form_change);
+    bool CanApplyWeaponDependentAuraDamageMod(Player* player, std::shared_ptr<Item> item, WeaponAttackType attackType, AuraEffect const* aura, bool apply);
+    bool CanApplyEquipSpell(Player* player, SpellInfo const* spellInfo, std::shared_ptr<Item> item, bool apply, bool form_change);
     bool CanApplyEquipSpellsItemSet(Player* player, ItemSetEffect* eff);
-    bool CanCastItemCombatSpell(Player* player, Unit* target, WeaponAttackType attType, uint32 procVictim, uint32 procEx, Item* item, ItemTemplate const* proto);
-    bool CanCastItemUseSpell(Player* player, Item* item, SpellCastTargets const& targets, uint8 cast_count, uint32 glyphIndex);
+    bool CanCastItemCombatSpell(Player* player, Unit* target, WeaponAttackType attType, uint32 procVictim, uint32 procEx, std::shared_ptr<Item> item, ItemTemplate const* proto);
+    bool CanCastItemUseSpell(Player* player, std::shared_ptr<Item> item, SpellCastTargets const& targets, uint8 cast_count, uint32 glyphIndex);
     void OnApplyAmmoBonuses(Player* player, ItemTemplate const* proto, float& currentAmmoDPS);
-    bool CanEquipItem(Player* player, uint8 slot, uint16& dest, Item* pItem, bool swap, bool not_loading);
+    bool CanEquipItem(Player* player, uint8 slot, uint16& dest, std::shared_ptr<Item> pItem, bool swap, bool not_loading);
     bool CanUnequipItem(Player* player, uint16 pos, bool swap);
     bool CanUseItem(Player* player, ItemTemplate const* proto, InventoryResult& result);
-    bool CanSaveEquipNewItem(Player* player, Item* item, uint16 pos, bool update);
-    bool CanApplyEnchantment(Player* player, Item* item, EnchantmentSlot slot, bool apply, bool apply_dur, bool ignore_condition);
+    bool CanSaveEquipNewItem(Player* player, std::shared_ptr<Item> item, uint16 pos, bool update);
+    bool CanApplyEnchantment(Player* player, std::shared_ptr<Item> item, EnchantmentSlot slot, bool apply, bool apply_dur, bool ignore_condition);
     void OnGetQuestRate(Player* player, float& result);
     bool PassedQuestKilledMonsterCredit(Player* player, Quest const* qinfo, uint32 entry, uint32 real_entry, ObjectGuid guid);
-    bool CheckItemInSlotAtLoadInventory(Player* player, Item* item, uint8 slot, uint8& err, uint16& dest);
+    bool CheckItemInSlotAtLoadInventory(Player* player, std::shared_ptr<Item> item, uint8 slot, uint8& err, uint16& dest);
     bool NotAvoidSatisfy(Player* player, DungeonProgressionRequirements const* ar, uint32 target_map, bool report);
     bool NotVisibleGloballyFor(Player* player, Player const* u);
     void OnGetArenaPersonalRating(Player* player, uint8 slot, uint32& result);
@@ -441,7 +441,7 @@ public: /* PlayerScript */
     bool CanJoinLfg(Player* player, uint8 roles, lfg::LfgDungeonSet& dungeons, const std::string& comment);
     bool CanEnterMap(Player* player, MapEntry const* entry, InstanceTemplate const* instance, MapDifficulty const* mapDiff, bool loginCheck);
     bool CanInitTrade(Player* player, Player* target);
-    bool CanSetTradeItem(Player* player, Item* tradedItem, uint8 tradeSlot);
+    bool CanSetTradeItem(Player* player, std::shared_ptr<Item> tradedItem, uint8 tradeSlot);
     void OnSetServerSideVisibility(Player* player, ServerSideVisibilityType& type, AccountTypes& sec);
     void OnSetServerSideVisibilityDetect(Player* player, ServerSideVisibilityType& type, AccountTypes& sec);
     void OnPlayerResurrect(Player* player, float restore_percent, bool applySickness);
@@ -489,7 +489,7 @@ public: /* GuildScript */
     void OnGuildDisband(Guild* guild);
     void OnGuildMemberWitdrawMoney(Guild* guild, Player* player, uint32& amount, bool isRepair);
     void OnGuildMemberDepositMoney(Guild* guild, Player* player, uint32& amount);
-    void OnGuildItemMove(Guild* guild, Player* player, Item* pItem, bool isSrcBank, uint8 srcContainer, uint8 srcSlotId,
+    void OnGuildItemMove(Guild* guild, Player* player, std::shared_ptr<Item> pItem, bool isSrcBank, uint8 srcContainer, uint8 srcSlotId,
                          bool isDestBank, uint8 destContainer, uint8 destSlotId);
     void OnGuildEvent(Guild* guild, uint8 eventType, ObjectGuid::LowType playerGuid1, ObjectGuid::LowType playerGuid2, uint8 newRank);
     void OnGuildBankEvent(Guild* guild, uint8 eventType, uint8 tabId, ObjectGuid::LowType playerGuid, uint32 itemOrMoney, uint16 itemStackCount, uint8 destTabId);
@@ -614,7 +614,7 @@ public: /* SpellSC */
     void OnBeforeAuraRankForLevel(SpellInfo const* spellInfo, SpellInfo const* latestSpellInfo, uint8 level);
     void OnDummyEffect(WorldObject* caster, uint32 spellID, SpellEffIndex effIndex, GameObject* gameObjTarget);
     void OnDummyEffect(WorldObject* caster, uint32 spellID, SpellEffIndex effIndex, Creature* creatureTarget);
-    void OnDummyEffect(WorldObject* caster, uint32 spellID, SpellEffIndex effIndex, Item* itemTarget);
+    void OnDummyEffect(WorldObject* caster, uint32 spellID, SpellEffIndex effIndex, std::shared_ptr<Item> itemTarget);
 
 public: /* GameEventScript */
     void OnGameEventStart(uint16 EventID);
@@ -658,9 +658,9 @@ public: /* MiscScript */
     void OnDestructGroup(Group* origin);
     void OnConstructInstanceSave(InstanceSave* origin);
     void OnDestructInstanceSave(InstanceSave* origin);
-    void OnItemCreate(Item* item, ItemTemplate const* itemProto, Player const* owner);
-    bool CanApplySoulboundFlag(Item* item, ItemTemplate const* proto);
-    bool CanItemApplyEquipSpell(Player* player, Item* item);
+    void OnItemCreate(std::shared_ptr<Item> item, ItemTemplate const* itemProto, Player const* owner);
+    bool CanApplySoulboundFlag(std::shared_ptr<Item> item, ItemTemplate const* proto);
+    bool CanItemApplyEquipSpell(Player* player, std::shared_ptr<Item> item);
     bool CanSendAuctionHello(WorldSession const* session, ObjectGuid guid, Creature* creature);
     void ValidateSpellAtCastSpell(Player* player, uint32& oldSpellId, uint32& spellId, uint8& castCount, uint8& castFlags);
     void OnPlayerSetPhase(const AuraEffect* auraEff, AuraApplication const* aurApp, uint8 mode, bool apply, uint32& newPhase);

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -31,6 +31,7 @@
 #include "GossipDef.h"
 #include "Packet.h"
 #include "SharedDefines.h"
+#include "TradeData.h"
 #include "World.h"
 #include <map>
 #include <memory>
@@ -1120,11 +1121,11 @@ protected:
 
 private:
     // private trade methods
-    void moveItems(Item* myItems[], Item* hisItems[]);
+    void moveItems(const std::array<std::shared_ptr<Item>, TRADE_SLOT_TRADED_COUNT>& myItems, const std::array<std::shared_ptr<Item>, TRADE_SLOT_TRADED_COUNT>& hisItems);
 
     bool CanUseBank(ObjectGuid bankerGUID = ObjectGuid::Empty) const;
 
-    bool recoveryItem(Item* pItem);
+    bool recoveryItem(std::shared_ptr<Item> pItem);
 
     // logging helper
     void LogUnexpectedOpcode(WorldPacket* packet, char const* status, const char* reason);

--- a/src/server/game/Spells/Auras/SpellAuraEffects.h
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.h
@@ -38,7 +38,7 @@ enum BrewfestEntries
 class AuraEffect
 {
     friend void Aura::_InitEffects(uint8 effMask, Unit* caster, int32* baseAmount);
-    friend Aura* Unit::_TryStackingOrRefreshingExistingAura(SpellInfo const* newAura, uint8 effMask, Unit* caster, int32* baseAmount, Item* castItem, ObjectGuid casterGUID, bool noPeriodicReset);
+    friend Aura* Unit::_TryStackingOrRefreshingExistingAura(SpellInfo const* newAura, uint8 effMask, Unit* caster, int32* baseAmount, std::shared_ptr<Item> castItem, ObjectGuid casterGUID, bool noPeriodicReset);
     friend Aura::~Aura();
 private:
     ~AuraEffect();

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -323,7 +323,7 @@ uint8 Aura::BuildEffectMaskForOwner(SpellInfo const* spellProto, uint8 avalibleE
     return effMask & avalibleEffectMask;
 }
 
-Aura* Aura::TryRefreshStackOrCreate(SpellInfo const* spellproto, uint8 tryEffMask, WorldObject* owner, Unit* caster, int32* baseAmount /*= nullptr*/, Item* castItem /*= nullptr*/, ObjectGuid casterGUID /*= ObjectGuid::Empty*/, bool* refresh /*= nullptr*/, bool periodicReset /*= false*/)
+Aura* Aura::TryRefreshStackOrCreate(SpellInfo const* spellproto, uint8 tryEffMask, WorldObject* owner, Unit* caster, int32* baseAmount /*= nullptr*/, std::shared_ptr<Item> castItem /*= nullptr*/, ObjectGuid casterGUID /*= ObjectGuid::Empty*/, bool* refresh /*= nullptr*/, bool periodicReset /*= false*/)
 {
     ASSERT_NODEBUGINFO(spellproto);
     ASSERT_NODEBUGINFO(owner);
@@ -349,7 +349,7 @@ Aura* Aura::TryRefreshStackOrCreate(SpellInfo const* spellproto, uint8 tryEffMas
         return Create(spellproto, effMask, owner, caster, baseAmount, castItem, casterGUID);
 }
 
-Aura* Aura::TryCreate(SpellInfo const* spellproto, uint8 tryEffMask, WorldObject* owner, Unit* caster, int32* baseAmount /*= nullptr*/, Item* castItem /*= nullptr*/, ObjectGuid casterGUID /*= ObjectGuid::Empty*/, ObjectGuid itemGUID /*= ObjectGuid::Empty*/)
+Aura* Aura::TryCreate(SpellInfo const* spellproto, uint8 tryEffMask, WorldObject* owner, Unit* caster, int32* baseAmount /*= nullptr*/, std::shared_ptr<Item> castItem /*= nullptr*/, ObjectGuid casterGUID /*= ObjectGuid::Empty*/, ObjectGuid itemGUID /*= ObjectGuid::Empty*/)
 {
     ASSERT_NODEBUGINFO(spellproto);
     ASSERT_NODEBUGINFO(owner);
@@ -361,7 +361,7 @@ Aura* Aura::TryCreate(SpellInfo const* spellproto, uint8 tryEffMask, WorldObject
     return Create(spellproto, effMask, owner, caster, baseAmount, castItem, casterGUID, itemGUID);
 }
 
-Aura* Aura::Create(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, Item* castItem, ObjectGuid casterGUID, ObjectGuid itemGUID /*= ObjectGuid::Empty*/)
+Aura* Aura::Create(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, std::shared_ptr<Item> castItem, ObjectGuid casterGUID, ObjectGuid itemGUID /*= ObjectGuid::Empty*/)
 {
     ASSERT_NODEBUGINFO(effMask);
     ASSERT_NODEBUGINFO(spellproto);
@@ -406,7 +406,7 @@ Aura* Aura::Create(SpellInfo const* spellproto, uint8 effMask, WorldObject* owne
     return aura;
 }
 
-Aura::Aura(SpellInfo const* spellproto, WorldObject* owner, Unit* caster, Item* castItem, ObjectGuid casterGUID, ObjectGuid itemGUID /*= ObjectGuid::Empty*/) :
+Aura::Aura(SpellInfo const* spellproto, WorldObject* owner, Unit* caster, std::shared_ptr<Item> castItem, ObjectGuid casterGUID, ObjectGuid itemGUID /*= ObjectGuid::Empty*/) :
     m_spellInfo(spellproto), m_casterGuid(casterGUID ? casterGUID : caster->GetGUID()),
     m_castItemGuid(itemGUID ? itemGUID : castItem ? castItem->GetGUID() : ObjectGuid::Empty), m_castItemEntry(castItem ? castItem->GetEntry() : 0), m_applyTime(GameTime::GetGameTime().count()),
     m_owner(owner), m_timeCla(0), m_updateTargetMapInterval(0),
@@ -2270,7 +2270,7 @@ bool Aura::IsProcTriggeredOnEvent(AuraApplication* aurApp, ProcEventInfo& eventI
     {
         if (!GetSpellInfo()->HasAttribute(SPELL_ATTR3_NO_PROC_EQUIP_REQUIREMENT))
         {
-            Item* item = nullptr;
+            std::shared_ptr<Item> item = nullptr;
             if (GetSpellInfo()->EquippedItemClass == ITEM_CLASS_WEAPON)
             {
                 if (target->ToPlayer()->IsInFeralForm())
@@ -2763,7 +2763,7 @@ SpellInfo const* Aura::GetTriggeredByAuraSpellInfo() const
     return m_triggeredByAuraSpellInfo;
 }
 
-UnitAura::UnitAura(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, Item* castItem, ObjectGuid casterGUID, ObjectGuid itemGUID /*= ObjectGuid::Empty*/)
+UnitAura::UnitAura(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, std::shared_ptr<Item> castItem, ObjectGuid casterGUID, ObjectGuid itemGUID /*= ObjectGuid::Empty*/)
     : Aura(spellproto, owner, caster, castItem, casterGUID, itemGUID)
 {
     m_AuraDRGroup = DIMINISHING_NONE;
@@ -2866,7 +2866,7 @@ void UnitAura::FillTargetMap(std::map<Unit*, uint8>& targets, Unit* caster)
     }
 }
 
-DynObjAura::DynObjAura(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, Item* castItem, ObjectGuid casterGUID, ObjectGuid itemGUID /*= ObjectGuid::Empty*/)
+DynObjAura::DynObjAura(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, std::shared_ptr<Item> castItem, ObjectGuid casterGUID, ObjectGuid itemGUID /*= ObjectGuid::Empty*/)
     : Aura(spellproto, owner, caster, castItem, casterGUID, itemGUID)
 {
     LoadScripts();

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -85,15 +85,15 @@ public:
 
 class Aura
 {
-    friend Aura* Unit::_TryStackingOrRefreshingExistingAura(SpellInfo const* newAura, uint8 effMask, Unit* caster, int32* baseAmount, Item* castItem, ObjectGuid casterGUID, bool noPeriodicReset);
+    friend Aura* Unit::_TryStackingOrRefreshingExistingAura(SpellInfo const* newAura, uint8 effMask, Unit* caster, int32* baseAmount, std::shared_ptr<Item> castItem, ObjectGuid casterGUID, bool noPeriodicReset);
 public:
     typedef std::map<ObjectGuid, AuraApplication*> ApplicationMap;
 
     static uint8 BuildEffectMaskForOwner(SpellInfo const* spellProto, uint8 avalibleEffectMask, WorldObject* owner);
-    static Aura* TryRefreshStackOrCreate(SpellInfo const* spellproto, uint8 tryEffMask, WorldObject* owner, Unit* caster, int32* baseAmount = nullptr, Item* castItem = nullptr, ObjectGuid casterGUID = ObjectGuid::Empty, bool* refresh = nullptr, bool periodicReset = false);
-    static Aura* TryCreate(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount = nullptr, Item* castItem = nullptr, ObjectGuid casterGUID = ObjectGuid::Empty, ObjectGuid itemGUID = ObjectGuid::Empty);
-    static Aura* Create(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, Item* castItem, ObjectGuid casterGUID, ObjectGuid itemGUID = ObjectGuid::Empty);
-    explicit Aura(SpellInfo const* spellproto, WorldObject* owner, Unit* caster, Item* castItem, ObjectGuid casterGUID, ObjectGuid itemGUID = ObjectGuid::Empty);
+    static Aura* TryRefreshStackOrCreate(SpellInfo const* spellproto, uint8 tryEffMask, WorldObject* owner, Unit* caster, int32* baseAmount = nullptr, std::shared_ptr<Item> castItem = nullptr, ObjectGuid casterGUID = ObjectGuid::Empty, bool* refresh = nullptr, bool periodicReset = false);
+    static Aura* TryCreate(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount = nullptr, std::shared_ptr<Item> castItem = nullptr, ObjectGuid casterGUID = ObjectGuid::Empty, ObjectGuid itemGUID = ObjectGuid::Empty);
+    static Aura* Create(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, std::shared_ptr<Item> castItem, ObjectGuid casterGUID, ObjectGuid itemGUID = ObjectGuid::Empty);
+    explicit Aura(SpellInfo const* spellproto, WorldObject* owner, Unit* caster, std::shared_ptr<Item> castItem, ObjectGuid casterGUID, ObjectGuid itemGUID = ObjectGuid::Empty);
     void _InitEffects(uint8 effMask, Unit* caster, int32* baseAmount);
     virtual ~Aura();
 
@@ -277,10 +277,10 @@ private:
 
 class UnitAura : public Aura
 {
-    friend Aura* Aura::Create(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, Item* castItem, ObjectGuid casterGUID, ObjectGuid itemGUID);
+    friend Aura* Aura::Create(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, std::shared_ptr<Item> castItem, ObjectGuid casterGUID, ObjectGuid itemGUID);
 
 protected:
-    explicit UnitAura(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, Item* castItem, ObjectGuid casterGUID, ObjectGuid itemGUID = ObjectGuid::Empty);
+    explicit UnitAura(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, std::shared_ptr<Item> castItem, ObjectGuid casterGUID, ObjectGuid itemGUID = ObjectGuid::Empty);
 
 public:
     void _ApplyForTarget(Unit* target, Unit* caster, AuraApplication* aurApp) override;
@@ -300,10 +300,10 @@ private:
 
 class DynObjAura : public Aura
 {
-    friend Aura* Aura::Create(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, Item* castItem, ObjectGuid casterGUID, ObjectGuid itemGUID);
+    friend Aura* Aura::Create(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, std::shared_ptr<Item> castItem, ObjectGuid casterGUID, ObjectGuid itemGUID);
 
 protected:
-    explicit DynObjAura(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, Item* castItem, ObjectGuid casterGUID, ObjectGuid itemGUID = ObjectGuid::Empty);
+    explicit DynObjAura(SpellInfo const* spellproto, uint8 effMask, WorldObject* owner, Unit* caster, int32* baseAmount, std::shared_ptr<Item> castItem, ObjectGuid casterGUID, ObjectGuid itemGUID = ObjectGuid::Empty);
 
 public:
     void Remove(AuraRemoveMode removeMode = AURA_REMOVE_BY_DEFAULT) override;

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -138,9 +138,9 @@ public:
     void RemoveObjectTarget();
 
     ObjectGuid GetItemTargetGUID() const { return m_itemTargetGUID; }
-    Item* GetItemTarget() const { return m_itemTarget; }
+    std::shared_ptr<Item> GetItemTarget() const { return m_itemTarget; }
     uint32 GetItemTargetEntry() const { return m_itemTargetEntry; }
-    void SetItemTarget(Item* item);
+    void SetItemTarget(std::shared_ptr<Item> item);
     void SetTradeItemTarget(Player* caster);
     void UpdateTradeSlotItem();
 
@@ -191,7 +191,7 @@ private:
 
     // objects (can be used at spell creating and after Update at casting)
     WorldObject* m_objectTarget;
-    Item* m_itemTarget;
+    std::shared_ptr<Item> m_itemTarget;
 
     // object GUID/etc, can be used always
     ObjectGuid m_objectTargetGUID;
@@ -517,12 +517,12 @@ public:
     void SendChannelStart(uint32 duration);
     void SendResurrectRequest(Player* target);
 
-    void HandleEffects(Unit* pUnitTarget, Item* pItemTarget, GameObject* pGOTarget, uint32 i, SpellEffectHandleMode mode);
+    void HandleEffects(Unit* pUnitTarget, std::shared_ptr<Item> pItemTarget, GameObject* pGOTarget, uint32 i, SpellEffectHandleMode mode);
     void HandleThreatSpells();
 
     SpellInfo const* const m_spellInfo;
-    Item* m_CastItem;
-    Item* m_weaponItem;
+    std::shared_ptr<Item> m_CastItem;
+    std::shared_ptr<Item> m_weaponItem;
     ObjectGuid m_castItemGUID;
     uint8 m_cast_count;
     uint32 m_glyphIndex;
@@ -653,7 +653,7 @@ public:
 
     // Current targets, to be used in SpellEffects (MUST BE USED ONLY IN SPELL EFFECTS)
     Unit* unitTarget;
-    Item* itemTarget;
+    std::shared_ptr<Item> itemTarget;
     GameObject* gameObjTarget;
     WorldLocation* destTarget;
     int32 damage;
@@ -697,7 +697,7 @@ public:
 
     struct ItemTargetInfo
     {
-        Item*  item;
+        std::shared_ptr<Item> item;
         uint8 effectMask;
     };
     std::list<ItemTargetInfo> m_UniqueItemInfo;
@@ -706,7 +706,7 @@ public:
 
     void AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid = true, bool implicit = true);
     void AddGOTarget(GameObject* target, uint32 effectMask);
-    void AddItemTarget(Item* item, uint32 effectMask);
+    void AddItemTarget(std::shared_ptr<Item> item, uint32 effectMask);
     void AddDestTarget(SpellDestination const& dest, uint32 effIndex);
 
     void DoAllEffectOnTarget(TargetInfo* target);

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1934,7 +1934,7 @@ SpellCastResult SpellInfo::CheckTarget(Unit const* caster, WorldObject const* ta
     return SPELL_CAST_OK;
 }
 
-SpellCastResult SpellInfo::CheckExplicitTarget(Unit const* caster, WorldObject const* target, Item const* itemTarget) const
+SpellCastResult SpellInfo::CheckExplicitTarget(Unit const* caster, WorldObject const* target, const std::shared_ptr<Item> itemTarget) const
 {
     uint32 neededTargets = GetExplicitTargetMask();
     if (!target)

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -479,7 +479,7 @@ public:
     SpellCastResult CheckShapeshift(uint32 form) const;
     SpellCastResult CheckLocation(uint32 map_id, uint32 zone_id, uint32 area_id, Player* player = nullptr, bool strict = true) const;
     SpellCastResult CheckTarget(Unit const* caster, WorldObject const* target, bool implicit = true) const;
-    SpellCastResult CheckExplicitTarget(Unit const* caster, WorldObject const* target, Item const* itemTarget = nullptr) const;
+    SpellCastResult CheckExplicitTarget(Unit const* caster, WorldObject const* target, const std::shared_ptr<Item> itemTarget = nullptr) const;
     bool CheckTargetCreatureType(Unit const* target) const;
 
     // xinef: aura stacking

--- a/src/server/game/Spells/SpellScript.cpp
+++ b/src/server/game/Spells/SpellScript.cpp
@@ -440,7 +440,7 @@ GameObject* SpellScript::GetExplTargetGObj()
     return m_spell->m_targets.GetGOTarget();
 }
 
-Item* SpellScript::GetExplTargetItem()
+std::shared_ptr<Item> SpellScript::GetExplTargetItem()
 {
     return m_spell->m_targets.GetItemTarget();
 }
@@ -481,7 +481,7 @@ Player* SpellScript::GetHitPlayer()
         return nullptr;
 }
 
-Item* SpellScript::GetHitItem()
+std::shared_ptr<Item> SpellScript::GetHitItem()
 {
     if (!IsInTargetHook())
     {
@@ -617,7 +617,7 @@ void SpellScript::SetEffectValue(int32 value)
     m_spell->damage = value;
 }
 
-Item* SpellScript::GetCastItem()
+std::shared_ptr<Item> SpellScript::GetCastItem()
 {
     return m_spell->m_CastItem;
 }

--- a/src/server/game/Spells/SpellScript.h
+++ b/src/server/game/Spells/SpellScript.h
@@ -414,7 +414,7 @@ public:
     GameObject* GetExplTargetGObj();
 
     // returns: Item which was selected as an explicit spell target or nullptr if there's no target
-    Item* GetExplTargetItem();
+    std::shared_ptr<Item> GetExplTargetItem();
 
     // methods useable only during spell hit on target, or during spell launch on target:
     // returns: target of current effect if it was Unit otherwise nullptr
@@ -424,7 +424,7 @@ public:
     // returns: target of current effect if it was Player otherwise nullptr
     Player* GetHitPlayer();
     // returns: target of current effect if it was Item otherwise nullptr
-    Item* GetHitItem();
+    std::shared_ptr<Item> GetHitItem();
     // returns: target of current effect if it was GameObject otherwise nullptr
     GameObject* GetHitGObj();
     // returns: destination of current effect
@@ -461,7 +461,7 @@ public:
     void SetEffectValue(int32 value);
 
     // returns: cast item if present.
-    Item* GetCastItem();
+    std::shared_ptr<Item> GetCastItem();
 
     // Creates item. Calls Spell::DoCreateItem method.
     void CreateItem(uint32 effIndex, uint32 itemId);

--- a/src/server/scripts/Commands/cs_bag.cpp
+++ b/src/server/scripts/Commands/cs_bag.cpp
@@ -82,37 +82,42 @@ public:
         // in inventory
         for (uint8 i = INVENTORY_SLOT_ITEM_START; i < INVENTORY_SLOT_ITEM_END; ++i)
         {
-            if (Item* item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
+            auto item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
+            if (item == nullptr)
             {
-                if (ItemTemplate const* itemTemplate = item->GetTemplate())
-                {
-                    if (itemTemplate->Quality <= itemQuality)
-                    {
-                        player->DestroyItem(INVENTORY_SLOT_BAG_0, i, true);
-                        ++removedItems[itemTemplate->Quality];
-                    }
-                }
+                continue;
+            }
+
+            ItemTemplate const* itemTemplate = item->GetTemplate();
+            if (itemTemplate != nullptr && itemTemplate->Quality <= itemQuality)
+            {
+                player->DestroyItem(INVENTORY_SLOT_BAG_0, i, true);
+                ++removedItems[itemTemplate->Quality];
             }
         }
 
         // in inventory bags
         for (uint8 i = INVENTORY_SLOT_BAG_START; i < INVENTORY_SLOT_BAG_END; i++)
         {
-            if (Bag* bag = player->GetBagByPos(i))
+            auto bag = player->GetBagByPos(i);
+            if (bag == nullptr)
             {
-                for (uint32 j = 0; j < bag->GetBagSize(); j++)
+                continue;
+            }
+
+            for (uint32 j = 0; j < bag->GetBagSize(); j++)
+            {
+                auto item = bag->GetItemByPos(j);
+                if (item == nullptr)
                 {
-                    if (Item* item = bag->GetItemByPos(j))
-                    {
-                        if (ItemTemplate const* itemTemplate = item->GetTemplate())
-                        {
-                            if (itemTemplate->Quality <= itemQuality)
-                            {
-                                player->DestroyItem(i, j, true);
-                                ++removedItems[itemTemplate->Quality];
-                            }
-                        }
-                    }
+                    continue;
+                }
+
+                const auto* itemTemplate = item->GetTemplate();
+                if (itemTemplate->Quality <= itemQuality)
+                {
+                    player->DestroyItem(i, j, true);
+                    ++removedItems[itemTemplate->Quality];
                 }
             }
         }

--- a/src/server/scripts/Commands/cs_character.cpp
+++ b/src/server/scripts/Commands/cs_character.cpp
@@ -936,33 +936,36 @@ public:
 
         if (BagSlot == 1)
         {
-            for (uint32 i = 23; i < 39; i++)
+            for (uint8 i = INVENTORY_SLOT_ITEM_START; i < INVENTORY_SLOT_ITEM_END; i++)
             {
-                if (Item* item = target->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
+                const auto item = target->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
+                if (item == nullptr)
                 {
-                    Counter++;
-                    std::ostringstream ItemString;
-                    ItemString << std::hex << ItemQualityColors[item->GetTemplate()->Quality];
-
-                    handler->PSendSysMessage("{} - |c{}|Hitem:{}:0:0:0:0:0:0:0:0:0|h[{}]|h|r - {}", Counter, ItemString.str(), item->GetEntry(), item->GetTemplate()->Name1, item->GetCount());
+                    continue;
                 }
+
+                ++Counter;
+                std::ostringstream ItemString;
+                ItemString << std::hex << ItemQualityColors[item->GetTemplate()->Quality];
+
+                handler->PSendSysMessage("{} - |c{}|Hitem:{}:0:0:0:0:0:0:0:0:0|h[{}]|h|r - {}", Counter, ItemString.str(), item->GetEntry(), item->GetTemplate()->Name1, item->GetCount());
             }
         }
-        else
+        else if (const auto bag = target->GetBagByPos(BagSlot))
         {
-            if (Bag* bag = target->GetBagByPos(BagSlot))
+            for (uint32 i = 0; i < bag->GetBagSize(); i++)
             {
-                for (uint32 i = 0; i < bag->GetBagSize(); i++)
+                auto item = target->GetItemByPos(BagSlot, i);
+                if (item == nullptr)
                 {
-                    if (Item* item = target->GetItemByPos(BagSlot, i))
-                    {
-                        Counter++;
-                        std::ostringstream ItemString;
-                        ItemString << std::hex << ItemQualityColors[item->GetTemplate()->Quality];
-
-                        handler->PSendSysMessage("{} - |c{}|Hitem:{}:0:0:0:0:0:0:0:0:0|h[{}]|h|r - {}", Counter, ItemString.str(), item->GetEntry(), item->GetTemplate()->Name1, item->GetCount());
-                    }
+                    continue;
                 }
+
+                ++Counter;
+                std::ostringstream ItemString;
+                ItemString << std::hex << ItemQualityColors[item->GetTemplate()->Quality];
+
+                handler->PSendSysMessage("{} - |c{}|Hitem:{}:0:0:0:0:0:0:0:0:0|h[{}]|h|r - {}", Counter, ItemString.str(), item->GetEntry(), item->GetTemplate()->Name1, item->GetCount());
             }
         }
 

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -988,15 +988,14 @@ public:
 
     static bool HandleDebugGetItemValueCommand(ChatHandler* handler, ObjectGuid::LowType guid, uint32 index)
     {
-        Item* i = handler->GetPlayer()->GetItemByGuid(ObjectGuid(HighGuid::Item, 0, guid));
+        const auto item = handler->GetPlayer()->GetItemByGuid(ObjectGuid(HighGuid::Item, 0, guid));
 
-        if (!i)
+        if (item == item || index >= item->GetValuesCount())
+        {
             return false;
+        }
 
-        if (index >= i->GetValuesCount())
-            return false;
-
-        uint32 value = i->GetUInt32Value(index);
+        const uint32 value = item->GetUInt32Value(index);
 
         handler->PSendSysMessage("Item {}: value at {} is {}", guid, index, value);
 
@@ -1005,29 +1004,27 @@ public:
 
     static bool HandleDebugSetItemValueCommand(ChatHandler* handler, ObjectGuid::LowType guid, uint32 index, uint32 value)
     {
-        Item* i = handler->GetPlayer()->GetItemByGuid(ObjectGuid(HighGuid::Item, 0, guid));
+        auto item = handler->GetPlayer()->GetItemByGuid(ObjectGuid(HighGuid::Item, 0, guid));
 
-        if (!i)
+        if (item == nullptr || item->GetValuesCount())
+        {
             return false;
+        }
 
-        if (index >= i->GetValuesCount())
-            return false;
-
-        i->SetUInt32Value(index, value);
-
+        item->SetUInt32Value(index, value);
         return true;
     }
 
     static bool HandleDebugItemExpireCommand(ChatHandler* handler, ObjectGuid::LowType guid)
     {
-        Item* i = handler->GetPlayer()->GetItemByGuid(ObjectGuid(HighGuid::Item, guid));
-
-        if (!i)
+        auto item = handler->GetPlayer()->GetItemByGuid(ObjectGuid(HighGuid::Item, guid));
+        if (item == nullptr)
+        {
             return false;
+        }
 
-        handler->GetPlayer()->DestroyItem(i->GetBagSlot(), i->GetSlot(), true);
-        sScriptMgr->OnItemExpire(handler->GetPlayer(), i->GetTemplate());
-
+        handler->GetPlayer()->DestroyItem(item->GetBagSlot(), item->GetSlot(), true);
+        sScriptMgr->OnItemExpire(handler->GetPlayer(), item->GetTemplate());
         return true;
     }
 

--- a/src/server/scripts/Commands/cs_inventory.cpp
+++ b/src/server/scripts/Commands/cs_inventory.cpp
@@ -119,15 +119,13 @@ public:
         // Check bags
         for (uint8 i = INVENTORY_SLOT_BAG_START; i < INVENTORY_SLOT_BAG_END; i++)
         {
-            if (Bag* bag = target->GetBagByPos(i))
+            if (const auto bag = target->GetBagByPos(i))
             {
-                if (ItemTemplate const* bagTemplate = bag->GetTemplate())
+                const auto* bagTemplate = bag->GetTemplate();
+                if (bagTemplate->Class == ITEM_CLASS_CONTAINER || bagTemplate->Class == ITEM_CLASS_QUIVER)
                 {
-                    if (bagTemplate->Class == ITEM_CLASS_CONTAINER || bagTemplate->Class == ITEM_CLASS_QUIVER)
-                    {
-                        haveFreeSlot = true;
-                        freeSlotsInBags[bagTemplate->SubClass] += bag->GetFreeSlots();
-                    }
+                    haveFreeSlot = true;
+                    freeSlotsInBags[bagTemplate->SubClass] += bag->GetFreeSlots();
                 }
             }
             else

--- a/src/server/scripts/Commands/cs_item.cpp
+++ b/src/server/scripts/Commands/cs_item.cpp
@@ -98,10 +98,10 @@ public:
             CharacterDatabaseTransaction trans = CharacterDatabase.BeginTransaction();
 
             // Save to prevent loss at next mail load. Item deletes on fail
-            if (Item* item = Item::CreateItem(itemEntry, itemCount, 0))
+            if (auto item = Item::CreateItem(itemEntry, itemCount, nullptr))
             {
                 item->SaveToDB(trans);
-                draft.AddItem(item);
+                draft.AddItem(std::move(item));
             }
 
             draft.SendMailTo(trans, MailReceiver(player.GetGUID().GetCounter()), sender);
@@ -328,10 +328,10 @@ public:
                             continue;
                         }
 
-                        if (Item* item = Item::CreateItem(reqItem, iece->reqitemcount[count]))
+                        if (auto item = Item::CreateItem(reqItem, iece->reqitemcount[count]))
                         {
                             item->SaveToDB(trans);
-                            draft.AddItem(item);
+                            draft.AddItem(std::move(item));
                             foundItems = true;
                         }
                     }

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -1753,7 +1753,7 @@ public:
             return false;
         }
 
-        Item* item = playerTarget->StoreNewItem(dest, itemId, true);
+        auto item = playerTarget->StoreNewItem(dest, itemId, true);
 
         Player* p = handler->GetSession() ? handler->GetSession()->GetPlayer() : nullptr;
         // remove binding (let GM give it to another player later)
@@ -1761,7 +1761,7 @@ public:
         {
             for (auto const& itemPos : dest)
             {
-                if (Item* item1 = p->GetItemByPos(itemPos.pos))
+                if (auto item1 = p->GetItemByPos(itemPos.pos))
                 {
                     item1->SetBinding(false);
                 }
@@ -1813,7 +1813,7 @@ public:
 
                 if (msg == EQUIP_ERR_OK)
                 {
-                    Item* item = playerTarget->StoreNewItem(dest, itemTemplate.ItemId, true);
+                    auto item = playerTarget->StoreNewItem(dest, itemTemplate.ItemId, true);
 
                     // remove binding (let GM give it to another player later)
                     if (player == playerTarget)

--- a/src/server/scripts/Commands/cs_quest.cpp
+++ b/src/server/scripts/Commands/cs_quest.cpp
@@ -261,7 +261,7 @@ public:
                 uint8           msg = player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, id, count - curItemCount);
                 if (msg == EQUIP_ERR_OK)
                 {
-                    Item* item = player->StoreNewItem(dest, id, true);
+                    const auto item = player->StoreNewItem(dest, id, true);
                     player->SendNewItem(item, count - curItemCount, true, false);
                 }
             }
@@ -373,10 +373,10 @@ public:
 
                 for (auto const& itr : questItems)
                 {
-                    if (Item* item = Item::CreateItem(itr.first, itr.second))
+                    if (auto item = Item::CreateItem(itr.first, itr.second))
                     {
                         item->SaveToDB(trans);
-                        draft.AddItem(item);
+                        draft.AddItem(std::move(item));
                     }
                 }
 
@@ -617,10 +617,10 @@ public:
                         continue;
                     }
 
-                    if (Item* item = Item::CreateItem(itr.first, itr.second))
+                    if (auto item = Item::CreateItem(itr.first, itr.second))
                     {
                         item->SaveToDB(trans);
-                        draft.AddItem(item);
+                        draft.AddItem(std::move(item));
                     }
                 }
 

--- a/src/server/scripts/Commands/cs_reset.cpp
+++ b/src/server/scripts/Commands/cs_reset.cpp
@@ -673,8 +673,7 @@ private:
         int16 count = 0;
         for (uint8 i = BUYBACK_SLOT_START; i < BUYBACK_SLOT_END; ++i)
         {
-            Item* pItem = playerTarget->GetItemFromBuyBackSlot(i);
-            if (pItem)
+            if (playerTarget->GetItemFromBuyBackSlot(i) != nullptr)
             {
                 playerTarget->RemoveItemFromBuyBackSlot(i, true);
                 ++count;

--- a/src/server/scripts/Commands/cs_reset.cpp
+++ b/src/server/scripts/Commands/cs_reset.cpp
@@ -522,8 +522,7 @@ private:
         int16 count = 0;
         for (uint8 i = EQUIPMENT_SLOT_START; i < EQUIPMENT_SLOT_END; ++i)
         {
-            Item* pItem = playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
-            if (pItem)
+            if (playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i) != nullptr)
             {
                 playerTarget->DestroyItem(INVENTORY_SLOT_BAG_0, i, true);
                 ++count;
@@ -544,8 +543,7 @@ private:
         // Default bagpack :
         for (uint8 i = INVENTORY_SLOT_ITEM_START; i < INVENTORY_SLOT_ITEM_END; ++i)
         {
-            Item* pItem = playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
-            if (pItem)
+            if (playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i) != nullptr)
             {
                 playerTarget->DestroyItem(INVENTORY_SLOT_BAG_0, i, true);
                 ++count;
@@ -555,17 +553,24 @@ private:
         // Bag slots
         for (uint8 i = INVENTORY_SLOT_BAG_START; i < INVENTORY_SLOT_BAG_END; ++i)
         {
-            Bag* pBag = (Bag*)playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
-            if (pBag)
+            std::shared_ptr<Bag> pBag = nullptr;
+
+            if (auto item = playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
             {
-                for (uint8 j = 0; j < pBag->GetBagSize(); ++j)
+                pBag = item->ToBag();
+            }
+
+            if (pBag == nullptr)
+            {
+                continue;
+            }
+
+            for (uint8 j = 0; j < pBag->GetBagSize(); ++j)
+            {
+                if (pBag->GetItemByPos(j) != nullptr)
                 {
-                    Item* pItem = pBag->GetItemByPos(j);
-                    if (pItem)
-                    {
-                        playerTarget->DestroyItem(i, j, true);
-                        ++count;
-                    }
+                    playerTarget->DestroyItem(i, j, true);
+                    ++count;
                 }
             }
         }
@@ -584,8 +589,7 @@ private:
         // Normal bank slot
         for (uint8 i = BANK_SLOT_ITEM_START; i < BANK_SLOT_ITEM_END; ++i)
         {
-            Item* pItem = playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
-            if (pItem)
+            if (playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i) != nullptr)
             {
                 playerTarget->DestroyItem(INVENTORY_SLOT_BAG_0, i, true);
                 ++count;
@@ -595,17 +599,23 @@ private:
         // Bank bagslots
         for (uint8 i = BANK_SLOT_BAG_START; i < BANK_SLOT_BAG_END; ++i)
         {
-            Bag* pBag = (Bag*)playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
-            if (pBag)
+            std::shared_ptr<Bag> pBag = nullptr;
+            if (auto item = playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
             {
-                for (uint8 j = 0; j < pBag->GetBagSize(); ++j)
+                pBag = item->ToBag();
+            }
+
+            if (pBag == nullptr)
+            {
+                continue;
+            }
+
+            for (uint8 j = 0; j < pBag->GetBagSize(); ++j)
+            {
+                if (pBag->GetItemByPos(j) != nullptr)
                 {
-                    Item* pItem = pBag->GetItemByPos(j);
-                    if (pItem)
-                    {
-                        playerTarget->DestroyItem(i, j, true);
-                        ++count;
-                    }
+                    playerTarget->DestroyItem(i, j, true);
+                    ++count;
                 }
             }
         }
@@ -623,8 +633,7 @@ private:
         int16 count = 0;
         for (uint8 i = KEYRING_SLOT_START; i < KEYRING_SLOT_END; ++i)
         {
-            Item* pItem = playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
-            if (pItem)
+            if (playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i) != nullptr)
             {
                 playerTarget->DestroyItem(INVENTORY_SLOT_BAG_0, i, true);
                 ++count;
@@ -644,8 +653,7 @@ private:
         int16 count = 0;
         for (uint8 i = CURRENCYTOKEN_SLOT_START; i < CURRENCYTOKEN_SLOT_END; ++i)
         {
-            Item* pItem = playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
-            if (pItem)
+            if (playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i) != nullptr)
             {
                 playerTarget->DestroyItem(INVENTORY_SLOT_BAG_0, i, true);
                 ++count;
@@ -687,8 +695,13 @@ private:
         // Standard bag slots
         for (uint8 i = INVENTORY_SLOT_BAG_START; i < INVENTORY_SLOT_BAG_END; ++i)
         {
-            Bag* pBag = (Bag*)playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
-            if (pBag)
+            std::shared_ptr<Bag> pBag = nullptr;
+            if (auto item = playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
+            {
+                pBag = item->ToBag();
+            }
+
+            if (pBag != nullptr)
             {
                 playerTarget->DestroyItem(INVENTORY_SLOT_BAG_0, i, true);
                 ++count;
@@ -709,8 +722,13 @@ private:
         // Bank bags
         for (uint8 i = BANK_SLOT_BAG_START; i < BANK_SLOT_BAG_END; ++i)
         {
-            Bag* pBag = (Bag*)playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
-            if (pBag)
+            std::shared_ptr<Bag> pBag = nullptr;
+            if (auto item = playerTarget->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
+            {
+                pBag = item->ToBag();
+            }
+
+            if (pBag != nullptr)
             {
                 // prevent no empty ?
                 playerTarget->DestroyItem(INVENTORY_SLOT_BAG_0, i, true);

--- a/src/server/scripts/Commands/cs_send.cpp
+++ b/src/server/scripts/Commands/cs_send.cpp
@@ -123,10 +123,10 @@ public:
 
         for (auto const& [itemID, itemCount] : itemList)
         {
-            if (Item* item = Item::CreateItem(itemID, itemCount, handler->GetSession() ? handler->GetSession()->GetPlayer() : 0))
+            if (auto item = Item::CreateItem(itemID, itemCount, handler->GetSession() ? handler->GetSession()->GetPlayer() : 0))
             {
                 item->SaveToDB(trans); // save for prevent lost at next mail load, if send fail then item will deleted
-                draft.AddItem(item);
+                draft.AddItem(std::move(item));
             }
         }
 

--- a/src/server/scripts/Events/brewfest.cpp
+++ b/src/server/scripts/Events/brewfest.cpp
@@ -1077,7 +1077,7 @@ class spell_brewfest_fill_keg : public SpellScript
     {
         if (GetCaster() && GetCaster()->ToPlayer())
         {
-            if (Item* itemCaster = GetCastItem())
+            if (auto itemCaster = GetCastItem())
             {
                 Player* player = GetCaster()->ToPlayer();
                 uint32 item = 0;
@@ -1146,7 +1146,7 @@ class spell_brewfest_unfill_keg : public SpellScript
     {
         if (GetCaster() && GetCaster()->ToPlayer())
         {
-            if (Item* itemCaster = GetCastItem())
+            if (auto itemCaster = GetCastItem())
             {
                 uint32 item = GetEmptyEntry(itemCaster->GetEntry());
                 Player* player = GetCaster()->ToPlayer();

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_viscidus.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_viscidus.cpp
@@ -204,7 +204,7 @@ struct boss_viscidus : public BossAI
         SpellSchoolMask spellSchoolMask = spellInfo->GetSchoolMask();
         if (spellInfo->EquippedItemClass == ITEM_CLASS_WEAPON && spellInfo->EquippedItemSubClassMask & (1 << ITEM_SUBCLASS_WEAPON_WAND))
         {
-            if (Item* pItem = caster->ToPlayer()->GetWeaponForAttack(RANGED_ATTACK))
+            if (auto pItem = caster->ToPlayer()->GetWeaponForAttack(RANGED_ATTACK))
             {
                 spellSchoolMask = SpellSchoolMask(1 << pItem->GetTemplate()->Damage[0].DamageType);
             }

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
@@ -143,7 +143,7 @@ public:
                     if (!plr->IsGameMaster() && plr->IsInCombat() /*performance*/)
                     {
                         for (uint8 i = EQUIPMENT_SLOT_START; i < EQUIPMENT_SLOT_END; ++i) // loop through equipped items
-                            if (Item* item = plr->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
+                            if (auto item = plr->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
                                 if (!IsValidDedicatedInsanityItem(item->GetTemplate()))
                                 {
                                     bDedicatedInsanity = false;

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/instance_halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/instance_halls_of_reflection.cpp
@@ -485,13 +485,21 @@ public:
                                         c->SetDisableGravity(true);
                                         c->SetVisible(true);
 
-                                        Item* i;
-                                        i = p->GetWeaponForAttack(BASE_ATTACK);
-                                        c->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 0, i ? i->GetEntry() : 0);
-                                        i = p->GetWeaponForAttack(OFF_ATTACK);
-                                        c->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 1, i ? i->GetEntry() : 0);
-                                        i = p->GetWeaponForAttack(RANGED_ATTACK);
-                                        c->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 2, i ? i->GetEntry() : 0);
+                                        if (auto i = p->GetWeaponForAttack(BASE_ATTACK))
+                                        {
+                                            c->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 0, i ? i->GetEntry() : 0);
+                                        }
+
+                                        if (auto i = p->GetWeaponForAttack(OFF_ATTACK))
+                                        {
+                                            c->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 1, i ? i->GetEntry() : 0);
+                                        }
+
+                                        if (auto i = p->GetWeaponForAttack(RANGED_ATTACK))
+                                        {
+                                            c->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 2, i ? i->GetEntry() : 0);
+                                        }
+
                                         p->CastSpell(c, SPELL_HOR_CLONE, true);
                                         p->CastSpell(c, SPELL_HOR_CLONE_NAME, true);
                                     }

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
@@ -2739,12 +2739,18 @@ public:
                     if (!target->IsClass(CLASS_DRUID))
                         if (Player* p = target->ToPlayer())
                         {
-                            if (Item* i = p->GetWeaponForAttack(BASE_ATTACK))
+                            if (auto i = p->GetWeaponForAttack(BASE_ATTACK))
+                            {
                                 me->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 0, i->GetEntry());
-                            if (Item* i = p->GetWeaponForAttack(OFF_ATTACK))
+                            }
+                            if (auto i = p->GetWeaponForAttack(OFF_ATTACK))
+                            {
                                 me->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 1, i->GetEntry());
-                            if (Item* i = p->GetWeaponForAttack(RANGED_ATTACK))
+                            }
+                            if (auto i = p->GetWeaponForAttack(RANGED_ATTACK))
+                            {
                                 me->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 2, i->GetEntry());
+                            }
 
                             target->CastSpell(c, 60352, true); // Mirror Image, clone visual appearance
                         }

--- a/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
@@ -236,7 +236,7 @@ public:
         uint8 msg = player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, itemId, 1);
         if (msg == EQUIP_ERR_OK)
         {
-            if (Item* item = player->StoreNewItem(dest, itemId, true))
+            if (auto item = player->StoreNewItem(dest, itemId, true))
             {
                 player->SendNewItem(item, 1, true, true);
             }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -309,7 +309,7 @@ public:
                     if (!plr->IsGameMaster() && plr->IsInCombat() /*performance*/)
                     {
                         for (uint8 i = EQUIPMENT_SLOT_START; i < EQUIPMENT_SLOT_END; ++i) // loop through equipped items
-                            if (Item* item = plr->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
+                            if (auto item = plr->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
                                 if (!IsValidHeraldItem(item->GetTemplate()))
                                 {
                                     _heraldOfTheTitans = false;

--- a/src/server/scripts/OutdoorPvP/OutdoorPvPNA.cpp
+++ b/src/server/scripts/OutdoorPvP/OutdoorPvPNA.cpp
@@ -456,7 +456,7 @@ bool OPvPCapturePointNA::HandleCustomSpell(Player* player, uint32 spellId, GameO
             return true;
         }
 
-        Item* item = player->StoreNewItem(dest, NA_HALAA_BOMB, true);
+        auto item = player->StoreNewItem(dest, NA_HALAA_BOMB, true);
 
         if (count > 0 && item)
         {

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2245,8 +2245,10 @@ class spell_gen_clone_weapon_aura : public AuraScript
 
                     if (Player* player = caster->ToPlayer())
                     {
-                        if (Item* mainItem = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND))
+                        if (auto mainItem = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND))
+                        {
                             target->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID, mainItem->GetEntry());
+                        }
                     }
                     else
                         target->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID, caster->GetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID));
@@ -2259,8 +2261,10 @@ class spell_gen_clone_weapon_aura : public AuraScript
 
                     if (Player* player = caster->ToPlayer())
                     {
-                        if (Item* offItem = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND))
+                        if (auto offItem = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND))
+                        {
                             target->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 1, offItem->GetEntry());
+                        }
                     }
                     else
                         target->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 1, caster->GetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 1));
@@ -2272,8 +2276,10 @@ class spell_gen_clone_weapon_aura : public AuraScript
 
                     if (Player* player = caster->ToPlayer())
                     {
-                        if (Item* rangedItem = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_RANGED))
+                        if (auto rangedItem = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_RANGED))
+                        {
                             target->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 2, rangedItem->GetEntry());
+                        }
                     }
                     else
                         target->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 2, caster->GetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 2));
@@ -4185,7 +4191,7 @@ class spell_gen_bonked : public SpellScript
 
             if (Aura const* onGuardAura = target->GetAura(SPELL_ON_GUARD))
             {
-                if (Item* item = target->GetItemByGuid(onGuardAura->GetCastItemGUID()))
+                if (auto item = target->GetItemByGuid(onGuardAura->GetCastItemGUID()))
                 {
                     target->DestroyItemCount(item->GetEntry(), 1, true);
                 }
@@ -4947,13 +4953,15 @@ class spell_gen_spirit_of_competition_participant : public SpellScript
         {
             player->CastSpell(player, SPELL_SPIRIT_OF_COMPETITION_PARTICIPANT_EFFECT, true);
 
-            Item* item = Item::CreateItem(ITEM_COMPETITORS_TABARD, 1);
-            if (!item)
+            auto item = Item::CreateItem(ITEM_COMPETITORS_TABARD, 1);
+            if (item == nullptr)
+            {
                 return;
+            }
 
             CharacterDatabaseTransaction trans = CharacterDatabase.BeginTransaction();
             MailDraft(MAIL_THE_COMPETITIORS_TABARD)
-                .AddItem(item)
+                .AddItem(std::move(item))
                 .SendMailTo(trans, player, MailSender(NPC_SPIRIT_OF_COMPETITION), MAIL_CHECK_MASK_HAS_BODY);
             CharacterDatabase.CommitTransaction(trans);
         }
@@ -4980,13 +4988,15 @@ class spell_gen_spirit_of_competition_winner : public SpellScript
         {
             player->CastSpell(player, SPELL_SPIRIT_OF_COMPETITION_WINNER_EFFECT, true);
 
-            Item* item = Item::CreateItem(ITEM_GOLD_MEDALLION, 1);
-            if (!item)
+            auto item = Item::CreateItem(ITEM_GOLD_MEDALLION, 1);
+            if (item == nullptr)
+            {
                 return;
+            }
 
             CharacterDatabaseTransaction trans = CharacterDatabase.BeginTransaction();
             MailDraft(MAIL_A_GOLD_MEDALLION)
-                .AddItem(item)
+                .AddItem(std::move(item))
                 .SendMailTo(trans, player, MailSender(NPC_SPIRIT_OF_COMPETITION), MAIL_CHECK_MASK_HAS_BODY);
             CharacterDatabase.CommitTransaction(trans);
         }
@@ -5255,7 +5265,7 @@ class spell_gen_steal_weapon : public AuraScript
         {
             if (Player* player = target->ToPlayer())
             {
-                if (Item* mainItem = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND))
+                if (auto mainItem = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND))
                 {
                     stealer->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID, mainItem->GetEntry());
                     stealer->CastSpell(stealer, SPELL_STEAL_WEAPON, true);

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -1348,8 +1348,10 @@ public:
     void HandleDummy(SpellEffIndex /*effIndex*/)
     {
         Unit* caster = GetCaster();
-        if (Item* item = GetCastItem())
+        if (auto item = GetCastItem())
+        {
             caster->CastSpell(caster, _triggeredSpellId, true, item);
+        }
     }
 
     void Register() override
@@ -2931,12 +2933,16 @@ class spell_item_nigh_invulnerability : public SpellScript
     void HandleDummy(SpellEffIndex /* effIndex */)
     {
         Unit* caster = GetCaster();
-        if (Item* castItem = GetCastItem())
+        if (auto castItem = GetCastItem())
         {
             if (roll_chance_i(86))                  // Nigh-Invulnerability   - success
+            {
                 caster->CastSpell(caster, SPELL_NIGH_INVULNERABILITY, true, castItem);
+            }
             else                                    // Complete Vulnerability - backfire in 14% casts
+            {
                 caster->CastSpell(caster, SPELL_COMPLETE_VULNERABILITY, true, castItem);
+            }
         }
     }
 
@@ -3538,7 +3544,9 @@ class spell_item_eggnog : public SpellScript
     void HandleScript(SpellEffIndex /* effIndex */)
     {
         if (roll_chance_i(40))
-            GetCaster()->CastSpell(GetHitUnit(), roll_chance_i(50) ? SPELL_EGG_NOG_REINDEER : SPELL_EGG_NOG_SNOWMAN, GetCastItem());
+        {
+            GetCaster()->CastSpell(GetHitUnit(), roll_chance_i(50) ? SPELL_EGG_NOG_REINDEER : SPELL_EGG_NOG_SNOWMAN, false, GetCastItem());
+        }
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -807,7 +807,7 @@ class spell_q1846_bending_shinbone : public SpellScript
 
     void HandleScriptEffect(SpellEffIndex /* effIndex */)
     {
-        Item* target = GetHitItem();
+        auto target = GetHitItem();
         Unit* caster = GetCaster();
         if (!target && !caster->IsPlayer())
             return;
@@ -1126,7 +1126,7 @@ class spell_q11730_ultrasonic_screwdriver : public SpellScript
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
     {
-        Item* castItem = GetCastItem();
+        auto castItem = GetCastItem();
         Unit* caster = GetCaster();
         if (Creature* target = GetHitCreature())
         {

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -226,7 +226,7 @@ class spell_rog_deadly_poison : public SpellScript
 
         if (Unit* target = GetHitUnit())
         {
-            Item* item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+            auto item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
 
             if (item == GetCastItem())
                 item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);

--- a/src/server/scripts/World/item_scripts.cpp
+++ b/src/server/scripts/World/item_scripts.cpp
@@ -36,7 +36,7 @@ class item_only_for_flight : public ItemScript
 public:
     item_only_for_flight() : ItemScript("item_only_for_flight") { }
 
-    bool OnUse(Player* player, Item* item, SpellCastTargets const& /*targets*/) override
+    bool OnUse(Player* player, std::shared_ptr<Item> item, SpellCastTargets const& /*targets*/) override
     {
         uint32 itemId = item->GetEntry();
         bool disabled = false;
@@ -77,7 +77,7 @@ class item_incendiary_explosives : public ItemScript
 public:
     item_incendiary_explosives() : ItemScript("item_incendiary_explosives") { }
 
-    bool OnUse(Player* player, Item* item, SpellCastTargets const& /*targets*/) override
+    bool OnUse(Player* player, std::shared_ptr<Item> item, SpellCastTargets const& /*targets*/) override
     {
         if (player->FindNearestCreature(26248, 15) || player->FindNearestCreature(26249, 15))
             return false;
@@ -145,7 +145,7 @@ class item_petrov_cluster_bombs : public ItemScript
 public:
     item_petrov_cluster_bombs() : ItemScript("item_petrov_cluster_bombs") { }
 
-    bool OnUse(Player* player, Item* item, const SpellCastTargets& /*targets*/) override
+    bool OnUse(Player* player, std::shared_ptr<Item> item, const SpellCastTargets& /*targets*/) override
     {
         if (player->GetZoneId() != ZONE_ID_HOWLING)
             return false;
@@ -175,7 +175,7 @@ class item_captured_frog : public ItemScript
 public:
     item_captured_frog() : ItemScript("item_captured_frog") { }
 
-    bool OnUse(Player* player, Item* item, SpellCastTargets const& /*targets*/) override
+    bool OnUse(Player* player, std::shared_ptr<Item> item, SpellCastTargets const& /*targets*/) override
     {
         if (player->GetQuestStatus(QUEST_THE_PERFECT_SPIES) == QUEST_STATUS_INCOMPLETE)
         {
@@ -197,7 +197,7 @@ class item_generic_limit_chance_above_60 : public ItemScript
 public:
     item_generic_limit_chance_above_60() : ItemScript("item_generic_limit_chance_above_60") { }
 
-    bool OnCastItemCombatSpell(Player* /*player*/, Unit* victim, SpellInfo const* /*spellInfo*/, Item* /*item*/) override
+    bool OnCastItemCombatSpell(Player* /*player*/, Unit* victim, SpellInfo const* /*spellInfo*/, std::shared_ptr<Item> /*item*/) override
     {
         // spell proc chance gets severely reduced on victims > 60 (formula unknown)
         if (victim->GetLevel() > 60)

--- a/src/server/scripts/World/npc_professions.cpp
+++ b/src/server/scripts/World/npc_professions.cpp
@@ -304,7 +304,7 @@ bool EquippedOk(Player* player, uint32 spellId)
         if (!reqSpell)
             continue;
 
-        Item* item = nullptr;
+        std::shared_ptr<Item> item;
         for (uint8 j = EQUIPMENT_SLOT_START; j < EQUIPMENT_SLOT_END; ++j)
         {
             item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, j);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:

- This PR is initial rewrite of item storage. This work replaces raw pointer usage with shared_ptr pointer usage, where shared_ptr prevents deallocation, lifetime, multithreading and potential memory leak issues.

Information about shared_ptr can be found at https://en.cppreference.com/w/cpp/memory/shared_ptr

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

To correctly test this pr, you must use runtime debugger and memory analysis tools (valgrind or memaloc sanitizer)
Any item operation can be viable to perform tests, like:
1) Item trading
2) Item destruction:
2.1) removing item from bag
2.2) Destroying item with disenchanting
2.3) Destroying item with milling
2.4) Destroying item as reagent for buffs
2.5) Destroying item as reagent for crafting (blacksmithing, alchemy and etc)
2.6) Selling item to vendor and then logging out. Buyout tab should be empty after relog
3) Test item with buyout - sell item to vendor and buyback without relogging in game
4) Test item in auction house (deposit, buyout or auction cancellation)
5) Try to send & receive item via mail:
5.1) Try to send item with and without empty sockets
5.2) Try to send item with and without permament and temporal enchants
5.3) Try to split item (stackable items, like reagents)
6) Basic player relogging
7) Basic player teleportation
8) Player kick from world
9) Try item spell casts, like trinkets, scrolls or other temporal (or permament) items like potions or permament flasks

At base analyse memory usage, in case you can create custom item destructor to analyse destructor (for console output or debugging points).
At base, due shared_ptr mechanic, shared_ptr object is destroyed when atomic counter reaches 0


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] optimize this pr and add std::move calls to avoid non necessary atomic counter increments (good for performance)
- [ ] add template based function to add container security, which would prevent several containers keeping memory address. For example, to ensure that item is not stored in bank and in player's inventory at same time
- [ ] Add custom destructor to help for analysis (only for WITH_CORE_DEBUG cmake option)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
