### PR TITLE
fix(Scripts/Spells): Warrior IntimidationShout

### DIFF
--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -547,7 +547,7 @@ class spell_warr_intimidating_shout : public SpellScript
         targets.remove(GetExplTargetWorldObject());
         uint32 maxTargets = GetSpellInfo()->MaxAffectedTargets;
         if (targets.size() > maxTargets)
-        targets.resize(maxTargets);
+            targets.resize(maxTargets);
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -542,9 +542,12 @@ class spell_warr_intimidating_shout : public SpellScript
 {
     PrepareSpellScript(spell_warr_intimidating_shout);
 
-    void FilterTargets(std::list<WorldObject*>& unitList)
+    void FilterTargets(std::list<WorldObject*>& targets)
     {
-        unitList.remove(GetExplTargetWorldObject());
+        targets.remove(GetExplTargetWorldObject());
+        uint32 maxTargets = GetSpellInfo()->MaxAffectedTargets;
+        if (targets.size() > maxTargets)
+        targets.resize(maxTargets);
     }
 
     void Register() override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

The AoE effects of Intimidation Shout select targets independently.

If there are more than 5 targets, each effect may drop different units, causing some units to be feared, others to have increased speed, and more than 5 to have the fear visual. 

EFFECT_1 and EFFECT_2 filter the same initial list from searcher. So instead of reducing randomly later, resize in spellscript.

https://github.com/azerothcore/azerothcore-wotlk/blob/a23b13defea47fa806b85074d108eaf19561ee50/src/server/game/Spells/Spell.cpp#L1319

https://github.com/azerothcore/azerothcore-wotlk/blob/a23b13defea47fa806b85074d108eaf19561ee50/src/server/game/Spells/Spell.cpp#L1333



## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/20584
- Closes https://github.com/chromiecraft/chromiecraft/issues/7410
## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

.npc add temp 19833 

spawn some snakes

to root snakes use Automation Root 39258


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
