### PR TITLE
fix(Scripts/ZulAman): Zul'Jin reduce procs of Energy Storm Aura

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1736879270259477703.sql
+++ b/data/sql/updates/pending_db_world/rev_1736879270259477703.sql
@@ -1,5 +1,3 @@
 --
 DELETE FROM `spell_script_names` WHERE `spell_id`=43983 AND `ScriptName`='spell_gen_allow_proc_from_spells_with_cost';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES(43983, 'spell_gen_allow_proc_from_spells_with_cost');
--- PROC_FLAG_DONE_SPELL_NONE_DMG_CLASS_POS | PROC_FLAG_DONE_SPELL_NONE_DMG_CLASS_NEG
-UPDATE `spell_proc_event` SET `procFlags`=`procFlags`|(1024|4096) WHERE `entry` = 43983;

--- a/data/sql/updates/pending_db_world/rev_1736879270259477703.sql
+++ b/data/sql/updates/pending_db_world/rev_1736879270259477703.sql
@@ -1,0 +1,3 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id`=43983 AND `ScriptName`='spell_energy_storm_aura';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES(43983, 'spell_energy_storm_aura');

--- a/data/sql/updates/pending_db_world/rev_1736879270259477703.sql
+++ b/data/sql/updates/pending_db_world/rev_1736879270259477703.sql
@@ -1,3 +1,5 @@
 --
-DELETE FROM `spell_script_names` WHERE `spell_id`=43983 AND `ScriptName`='spell_energy_storm_aura';
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES(43983, 'spell_energy_storm_aura');
+DELETE FROM `spell_script_names` WHERE `spell_id`=43983 AND `ScriptName`='spell_gen_allow_proc_from_spells_with_cost';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES(43983, 'spell_gen_allow_proc_from_spells_with_cost');
+-- PROC_FLAG_DONE_SPELL_NONE_DMG_CLASS_POS | PROC_FLAG_DONE_SPELL_NONE_DMG_CLASS_NEG
+UPDATE `spell_proc_event` SET `procFlags`=`procFlags`|(1024|4096) WHERE `entry` = 43983;

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_zuljin.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_zuljin.cpp
@@ -459,40 +459,10 @@ class spell_zuljin_zap : public SpellScript
     }
 };
 
-// 43983 Energy Storm
-class spell_energy_storm_aura : public AuraScript
-{
-    PrepareAuraScript(spell_energy_storm_aura);
-
-    bool AfterCheckProc(ProcEventInfo& eventInfo, bool isTriggeredAtSpellProcEvent)
-    {
-        if (!isTriggeredAtSpellProcEvent)
-            return false;
-
-        SpellInfo const* spellInfo = eventInfo.GetSpellInfo();
-        if (!spellInfo)
-            return true;
-
-        if (spellInfo->SchoolMask == SPELL_SCHOOL_MASK_NORMAL)
-            return false;
-
-        if (eventInfo.GetProcSpell() && eventInfo.GetProcSpell()->IsTriggered())
-            return false;
-
-        return true;
-    }
-
-    void Register() override
-    {
-        DoAfterCheckProc += AuraAfterCheckProcFn(spell_energy_storm_aura::AfterCheckProc);
-    }
-};
-
 void AddSC_boss_zuljin()
 {
     RegisterZulAmanCreatureAI(boss_zuljin);
     RegisterZulAmanCreatureAI(npc_zuljin_vortex);
     RegisterSpellScript(spell_claw_rage_aura);
     RegisterSpellScript(spell_zuljin_zap);
-    RegisterSpellScript(spell_energy_storm_aura);
 }

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_zuljin.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_zuljin.cpp
@@ -459,10 +459,40 @@ class spell_zuljin_zap : public SpellScript
     }
 };
 
+// 43983 Energy Storm
+class spell_energy_storm_aura : public AuraScript
+{
+    PrepareAuraScript(spell_energy_storm_aura);
+
+    bool AfterCheckProc(ProcEventInfo& eventInfo, bool isTriggeredAtSpellProcEvent)
+    {
+        if (!isTriggeredAtSpellProcEvent)
+            return false;
+
+        SpellInfo const* spellInfo = eventInfo.GetSpellInfo();
+        if (!spellInfo)
+            return true;
+
+        if (spellInfo->SchoolMask == SPELL_SCHOOL_MASK_NORMAL)
+            return false;
+
+        if (eventInfo.GetProcSpell() && eventInfo.GetProcSpell()->IsTriggered())
+            return false;
+
+        return true;
+    }
+
+    void Register() override
+    {
+        DoAfterCheckProc += AuraAfterCheckProcFn(spell_energy_storm_aura::AfterCheckProc);
+    }
+};
+
 void AddSC_boss_zuljin()
 {
     RegisterZulAmanCreatureAI(boss_zuljin);
     RegisterZulAmanCreatureAI(npc_zuljin_vortex);
     RegisterSpellScript(spell_claw_rage_aura);
     RegisterSpellScript(spell_zuljin_zap);
+    RegisterSpellScript(spell_energy_storm_aura);
 }

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -340,7 +340,8 @@ private:
 /* 55640 - Lightweave Embroidery
    67698 - Item - Coliseum 25 Normal Healer Trinket
    67752 - Item - Coliseum 25 Heroic Healer Trinket
-   69762 - Unchained Magic */
+   69762 - Unchained Magic
+   43983 - Energy Storm */
 class spell_gen_allow_proc_from_spells_with_cost : public AuraScript
 {
     PrepareAuraScript(spell_gen_allow_proc_from_spells_with_cost);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Apply the same handling as [Sindragosa's Unchained Magic](https://wowgaming.altervista.org/aowow/?spell=69762) to [Zul'Jins Energy Storm](https://wowgaming.altervista.org/aowow/?spell=43983) 

example of things that:

proc
- mana cost casts from healers/casters
- hunters mark
- paladin apply seals
- shaman shocks/summon totem
- mind blast with inner focus buff

no procs
- priest summon shadowfiend
- hunter arcane shot/explosive shot/multishot/steady shot
- warrior abilities
- paladin judgement/cs/ds
- shaman thunderstorm/storm strike

These were problematic and should no longer proc:
- cast inner focus (.cast 14751)
- use healthstone (.add 5509)
- trinkets like DST (.add 28830)
- on equip procs fiery plate gauntlets (.add 12631)
- vindication proc (paladin ret talent)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/21144

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested `.cast self 43983` on a target dummy and a breakpoint

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Go to Zul'jin
2. Trigger Eagle Phase
3. See if spells proc the zap damage effect

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
