### PR TITLE
fix(Scripts/ZulAman): prevent early engaging of door guardians to skip timed event

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1736947882353306449.sql
+++ b/data/sql/updates/pending_db_world/rev_1736947882353306449.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 23597) AND (`source_type` = 0) AND (`id` IN (12, 18));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(23597, 0, 12, 0, 1, 1, 100, 515, 6200, 6200, 6200, 6200, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Amani\'shi Guardian - Out of Combat - Remove Flags Immune To Players & Immune To NPC\'s (Phase 1) (No Repeat) (Normal Dungeon)'),
+(23597, 0, 18, 0, 1, 2, 100, 515, 7600, 7600, 7600, 7600, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Amani\'shi Guardian - Out of Combat - Remove Flags Immune To Players & Immune To NPC\'s (Phase 2) (No Repeat) (Normal Dungeon)');

--- a/src/server/scripts/EasternKingdoms/ZulAman/instance_zulaman.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/instance_zulaman.cpp
@@ -127,6 +127,10 @@ public:
         {
             switch (creature->GetEntry())
             {
+                case NPC_AMANISHI_GUARDIAN:
+                    if (creature->GetPositionZ() >= 43.0f) // gate guardians
+                        creature->SetImmuneToPC(true);
+                    break;
                 // Akil'zon gauntlet
                 case NPC_AMANISHI_TEMPEST:
                     if (creature->GetPositionZ() >= 50.0f) // excludes Tempest in Hexlord Malacrass' trash

--- a/src/server/scripts/EasternKingdoms/ZulAman/instance_zulaman.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/instance_zulaman.cpp
@@ -65,7 +65,7 @@ ObjectData const creatureData[] =
     { NPC_JANALAI,          DATA_JANALAI        },
     { NPC_SPIRIT_LYNX,      DATA_SPIRIT_LYNX    },
     { NPC_HARRISON_JONES,   DATA_HARRISON_JONES },
-    { NPC_AMINISHI_LOOKOUT, DATA_LOOKOUT        },
+    { NPC_AMANISHI_LOOKOUT, DATA_LOOKOUT        },
     { 0,                    0                   }
 };
 
@@ -128,12 +128,12 @@ public:
             switch (creature->GetEntry())
             {
                 // Akil'zon gauntlet
-                case NPC_AMINISHI_TEMPEST:
+                case NPC_AMANISHI_TEMPEST:
                     if (creature->GetPositionZ() >= 50.0f) // excludes Tempest in Hexlord Malacrass' trash
                         AkilzonTrash.insert(creature->GetGUID());
                     break;
-                case NPC_AMINISHI_LOOKOUT:
-                case NPC_AMINISHI_PROTECTOR:
+                case NPC_AMANISHI_LOOKOUT:
+                case NPC_AMANISHI_PROTECTOR:
                 case NPC_EAGLE_TRASH_AGGRO_TRIGGER:
                     AkilzonTrash.insert(creature->GetGUID());
                     break;
@@ -226,8 +226,8 @@ public:
                         case NPC_EAGLE_TRASH_AGGRO_TRIGGER:
                             creature->DisappearAndDie();
                             break;
-                        case NPC_AMINISHI_LOOKOUT:
-                        case NPC_AMINISHI_TEMPEST:
+                        case NPC_AMANISHI_LOOKOUT:
+                        case NPC_AMANISHI_TEMPEST:
                             creature->AI()->DoAction(ACTION_START_AKILZON_GAUNTLET);
                             break;
                         default:
@@ -243,7 +243,7 @@ public:
                 {
                     if (!creature->IsAlive())
                         creature->Respawn();
-                    else if (creature->GetEntry() == NPC_AMINISHI_TEMPEST)
+                    else if (creature->GetEntry() == NPC_AMANISHI_TEMPEST)
                         creature->AI()->DoAction(ACTION_RESET_AKILZON_GAUNTLET);
                 }
             if (Creature* creature = GetCreature(DATA_LOOKOUT))
@@ -259,7 +259,7 @@ public:
 
             switch (creature->GetEntry())
             {
-                case NPC_AMINISHI_PROTECTOR:
+                case NPC_AMANISHI_PROTECTOR:
                 case NPC_AMANISHI_WIND_WALKER:
                     if (_akilzonGauntlet == NOT_STARTED && AkilzonTrash.contains(creature->GetGUID()))
                         creature->DespawnOrUnsummon(30s, 1s);
@@ -272,8 +272,8 @@ public:
         {
             switch (creature->GetEntry())
             {
-                case NPC_AMINISHI_TEMPEST:
-                case NPC_AMINISHI_PROTECTOR:
+                case NPC_AMANISHI_TEMPEST:
+                case NPC_AMANISHI_PROTECTOR:
                 case NPC_AMANISHI_WIND_WALKER:
                     if (AkilzonTrash.contains(creature->GetGUID()))
                         ResetAkilzonGauntlet();

--- a/src/server/scripts/EasternKingdoms/ZulAman/instance_zulaman.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/instance_zulaman.cpp
@@ -128,8 +128,9 @@ public:
             switch (creature->GetEntry())
             {
                 case NPC_AMANISHI_GUARDIAN:
-                    if (creature->GetPositionZ() >= 43.0f) // gate guardians
-                        creature->SetImmuneToPC(true);
+                case NPC_AMANISHI_SAVAGE:
+                    if (creature->GetPositionY() >= 1500.0f) // gate
+                        creature->SetImmuneToAll(true);
                     break;
                 // Akil'zon gauntlet
                 case NPC_AMANISHI_TEMPEST:

--- a/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
@@ -358,8 +358,7 @@ enum DisplayIds
 enum EntryIds
 {
     NPC_HARRISON_JONES_1                = 24375,
-    NPC_HARRISON_JONES_2                = 24365,
-    NPC_AMANISHI_GUARDIAN               = 23597,
+    NPC_HARRISON_JONES_2                = 24365
 };
 
 enum Weapons

--- a/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
@@ -416,7 +416,10 @@ struct npc_harrison_jones : public ScriptedAI
                 std::list<Creature*> creatures;
                 me->GetCreatureListWithEntryInGrid(creatures, NPC_AMANISHI_SAVAGE, 100.0f);
                 for (Creature* creature : creatures)
+                {
+                    creature->SetImmuneToAll(false);
                     creature->SetInCombatWithZone();
+                }
             });
             _instance->StorePersistentData(DATA_TIMED_RUN, 21);
             _instance->DoAction(ACTION_START_TIMED_RUN);

--- a/src/server/scripts/EasternKingdoms/ZulAman/zulaman.h
+++ b/src/server/scripts/EasternKingdoms/ZulAman/zulaman.h
@@ -62,9 +62,9 @@ enum CreatureIds
     NPC_AMANI_HATCHLING                 = 23598, // 42493
     // Akil'zon gauntlet
     NPC_AMANISHI_WIND_WALKER            = 24179,
-    NPC_AMINISHI_LOOKOUT                = 24175,
-    NPC_AMINISHI_PROTECTOR              = 24180,
-    NPC_AMINISHI_TEMPEST                = 24549,
+    NPC_AMANISHI_LOOKOUT                = 24175,
+    NPC_AMANISHI_PROTECTOR              = 24180,
+    NPC_AMANISHI_TEMPEST                = 24549,
     NPC_EAGLE_TRASH_AGGRO_TRIGGER       = 24223
 };
 

--- a/src/server/scripts/EasternKingdoms/ZulAman/zulaman.h
+++ b/src/server/scripts/EasternKingdoms/ZulAman/zulaman.h
@@ -60,6 +60,7 @@ enum CreatureIds
     NPC_AMANISHI_MEDICINE_MAN           = 23581,
     NPC_AMANISHI_AXE_THROWER            = 23542,
     NPC_AMANI_HATCHLING                 = 23598, // 42493
+    NPC_AMANISHI_GUARDIAN               = 23597,
     // Akil'zon gauntlet
     NPC_AMANISHI_WIND_WALKER            = 24179,
     NPC_AMANISHI_LOOKOUT                = 24175,


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

typo fix of ~~Aminishi~~ Amanishi

Set Guardians and Savages to have NPC/PC immunity on spawn. This prevents pulling through the door with pets or social-pulling by Eyes of the Beast of other trash like Amani Bears.

Found that AreaTrigger 4768, a large areatrigger that can only trigger after the gate is opened, exists but doesn't prevent any exploit. Purpose is unknown, maybe an anti-cheat warning system when players go through the door without the event, or used as a trigger to set Sacrifice Timer when re-entering the instance.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/21161

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .go c id 24358
2. Try to skip the event
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Guardians look to be missing their combat lines: "You be dead soon", "Killing you be easy"
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
