### PR TITLE
fix(Scripts/BT) Fix Gurtogg will not use acidic wound in phase 2

### DIFF
--- a/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
@@ -243,4 +243,3 @@ void AddSC_boss_gurtogg_bloodboil()
     RegisterSpellScript(spell_gurtogg_bloodboil);
     RegisterSpellScript(spell_gurtogg_eject);
 }
-}

--- a/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
@@ -61,7 +61,6 @@ enum Spells
 enum Misc
 {
     EVENT_SPELL_BERSERK             = 1,
-
     GROUP_DELAY                     = 1
 };
 
@@ -80,11 +79,14 @@ struct boss_gurtogg_bloodboil : public BossAI
         BossAI::JustEngagedWith(who);
         Talk(SAY_AGGRO);
 
-        DoCastSelf(SPELL_ACIDIC_WOUND, true);
+        if (!me->HasAura(SPELL_FEL_RAGE_SELF))
+            DoCastSelf(SPELL_ACIDIC_WOUND, true);
 
         ScheduleTimedEvent(10s, [&] {
-            if (!me->HasAura(SPELL_FEL_RAGE_SELF))
+            if (!me->HasAura(SPELL_FEL_RAGE_SELF)) {
                 me->CastCustomSpell(SPELL_BLOODBOIL, SPELLVALUE_MAX_TARGETS, 5, me, false);
+                DoCastSelf(SPELL_ACIDIC_WOUND, true);
+            }
         }, 10s);
 
         ScheduleTimedEvent(38s, [&] {
@@ -139,7 +141,7 @@ struct boss_gurtogg_bloodboil : public BossAI
         return !who->IsImmunedToDamage(SPELL_SCHOOL_MASK_ALL) && !who->HasUnitState(UNIT_STATE_CONFUSED);
     }
 
-    void KilledUnit(Unit*  /*victim*/) override
+    void KilledUnit(Unit* /*victim*/) override
     {
         if (!_recentlySpoken)
         {

--- a/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
@@ -79,7 +79,7 @@ struct boss_gurtogg_bloodboil : public BossAI
         BossAI::JustEngagedWith(who);
         Talk(SAY_AGGRO);
 
-        DoCastSelf(SPELL_ACIDIC_WOUND, true);
+        DoCastVictim(SPELL_ACIDIC_WOUND, true);
 
         ScheduleTimedEvent(10s, [&] {
             if (!me->HasAura(SPELL_FEL_RAGE_SELF))
@@ -118,7 +118,7 @@ struct boss_gurtogg_bloodboil : public BossAI
                 }, 2s);
 
                 me->m_Events.AddEventAtOffset([&] {
-                    DoCastSelf(SPELL_ACIDIC_WOUND, true);
+                    DoCastVictim(SPELL_ACIDIC_WOUND, true);
                 }, 28s);
 
                 scheduler.DelayGroup(GROUP_DELAY, 30s);

--- a/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
@@ -79,7 +79,7 @@ struct boss_gurtogg_bloodboil : public BossAI
         BossAI::JustEngagedWith(who);
         Talk(SAY_AGGRO);
 
-        DoCastVictim(SPELL_ACIDIC_WOUND, true);
+        DoCastSelf(SPELL_ACIDIC_WOUND, true);
 
         ScheduleTimedEvent(10s, [&] {
             if (!me->HasAura(SPELL_FEL_RAGE_SELF))
@@ -102,7 +102,7 @@ struct boss_gurtogg_bloodboil : public BossAI
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1, 40.0f, true))
             {
                 me->RemoveAurasByType(SPELL_AURA_MOD_TAUNT);
-                me->RemoveAura(SPELL_ACIDIC_WOUND);
+                me->RemoveAuraDueToSpell(SPELL_ACIDIC_WOUND);
                 DoCastSelf(SPELL_FEL_RAGE_SELF, true);
                 DoCast(target, SPELL_FEL_RAGE_TARGET, true);
                 DoCast(target, SPELL_FEL_RAGE_2, true);
@@ -119,7 +119,7 @@ struct boss_gurtogg_bloodboil : public BossAI
                 }, 2s);
 
                 me->m_Events.AddEventAtOffset([&] {
-                    DoCastVictim(SPELL_ACIDIC_WOUND, true);
+                    DoCastSelf(SPELL_ACIDIC_WOUND, true);
                 }, 28s);
 
                 scheduler.DelayGroup(GROUP_DELAY, 30s);

--- a/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
@@ -64,16 +64,14 @@ enum Misc
     GROUP_DELAY                     = 1
 };
 
-// Main boss class
 struct boss_gurtogg_bloodboil : public BossAI
 {
-    boss_gurtogg_bloodboil(Creature* creature) : BossAI(creature, DATA_GURTOGG_BLOODBOIL), _recentlySpoken(false), _inFelRage(false) { }
+    boss_gurtogg_bloodboil(Creature* creature) : BossAI(creature, DATA_GURTOGG_BLOODBOIL), _recentlySpoken(false) { }
 
     void Reset() override
     {
         BossAI::Reset();
         _recentlySpoken = false;
-        _inFelRage = false;
     }
 
     void JustEngagedWith(Unit* who) override
@@ -81,41 +79,30 @@ struct boss_gurtogg_bloodboil : public BossAI
         BossAI::JustEngagedWith(who);
         Talk(SAY_AGGRO);
 
-        // Apply Acidic Wound only outside Fel Rage
-        if (!_inFelRage)
-            DoCastSelf(SPELL_ACIDIC_WOUND, true);
+        DoCastSelf(SPELL_ACIDIC_WOUND, true);
 
-        // Bloodboil timer - only outside Fel Rage
         ScheduleTimedEvent(10s, [&] {
-            if (!_inFelRage) {
+            if (!me->HasAura(SPELL_FEL_RAGE_SELF))
                 me->CastCustomSpell(SPELL_BLOODBOIL, SPELLVALUE_MAX_TARGETS, 5, me, false);
-                DoCastSelf(SPELL_ACIDIC_WOUND, true);
-            }
         }, 10s);
 
-        // Fel Acid Breath
         ScheduleTimedEvent(38s, [&] {
             DoCastVictim(me->HasAura(SPELL_FEL_RAGE_SELF) ? SPELL_FEL_ACID_BREATH2 : SPELL_FEL_ACID_BREATH1);
         }, 30s);
 
-        // Eject
         ScheduleTimedEvent(14s, [&] {
             DoCastVictim(me->HasAura(SPELL_FEL_RAGE_SELF) ? SPELL_EJECT2 : SPELL_EJECT1);
         }, 20s);
 
-        // Arcing Smash
         ScheduleTimedEvent(5s, [&] {
             DoCastVictim(me->HasAura(SPELL_FEL_RAGE_SELF) ? SPELL_ARCING_SMASH2 : SPELL_ARCING_SMASH1);
         }, 15s);
 
-        // Fel Rage phase transition
         ScheduleTimedEvent(1min, [&] {
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1, 40.0f, true))
             {
-                _inFelRage = true;
                 me->RemoveAurasByType(SPELL_AURA_MOD_TAUNT);
-                
-                // Apply Fel Rage effects
+                me->RemoveAura(SPELL_ACIDIC_WOUND);
                 DoCastSelf(SPELL_FEL_RAGE_SELF, true);
                 DoCast(target, SPELL_FEL_RAGE_TARGET, true);
                 DoCast(target, SPELL_FEL_RAGE_2, true);
@@ -123,32 +110,27 @@ struct boss_gurtogg_bloodboil : public BossAI
                 DoCast(target, SPELL_FEL_RAGE_SIZE, true);
                 target->CastSpell(me, SPELL_TAUNT_GURTOGG, true);
 
-                // Additional effects
                 DoCast(target, SPELL_FEL_GEYSER_SUMMON, true);
                 DoCastSelf(SPELL_FEL_GEYSER_STUN, true);
                 DoCastSelf(SPELL_INSIGNIFICANCE, true);
 
-                // Delayed charge
                 me->m_Events.AddEventAtOffset([&] {
                     DoCastVictim(SPELL_CHARGE);
                 }, 2s);
 
-                // End Fel Rage phase after 28 seconds based on fel rage duration
                 me->m_Events.AddEventAtOffset([&] {
-                    _inFelRage = false;
+                    DoCastSelf(SPELL_ACIDIC_WOUND, true);
                 }, 28s);
 
                 scheduler.DelayGroup(GROUP_DELAY, 30s);
             }
         }, 90s);
 
-        // Enrage timer
         ScheduleUniqueTimedEvent(10min, [&] {
             Talk(SAY_ENRAGE);
             DoCastSelf(SPELL_BERSERK, true);
         }, EVENT_SPELL_BERSERK);
 
-        // Bewildering Strike
         scheduler.Schedule(28s, [this](TaskContext context) {
             context.SetGroup(GROUP_DELAY);
             DoCastVictim(SPELL_BEWILDERING_STRIKE);
@@ -191,10 +173,8 @@ struct boss_gurtogg_bloodboil : public BossAI
 
 private:
     bool _recentlySpoken;
-    bool _inFelRage;
 };
 
-// Bloodboil spell implementation
 class spell_gurtogg_bloodboil : public SpellScript
 {
     PrepareSpellScript(spell_gurtogg_bloodboil);
@@ -219,7 +199,6 @@ class spell_gurtogg_bloodboil : public SpellScript
     }
 };
 
-// Eject spell implementation
 class spell_gurtogg_eject : public SpellScript
 {
     PrepareSpellScript(spell_gurtogg_eject);

--- a/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
@@ -133,7 +133,7 @@ struct boss_gurtogg_bloodboil : public BossAI
                     DoCastVictim(SPELL_CHARGE);
                 }, 2s);
 
-                // End Fel Rage phase after 28 seconds
+                // End Fel Rage phase after 28 seconds based on fel rage duration
                 me->m_Events.AddEventAtOffset([&] {
                     _inFelRage = false;
                 }, 28s);

--- a/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
@@ -102,7 +102,6 @@ struct boss_gurtogg_bloodboil : public BossAI
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1, 40.0f, true))
             {
                 me->RemoveAurasByType(SPELL_AURA_MOD_TAUNT);
-                me->RemoveAura(SPELL_ACIDIC_WOUND);
                 DoCastSelf(SPELL_FEL_RAGE_SELF, true);
                 DoCast(target, SPELL_FEL_RAGE_TARGET, true);
                 DoCast(target, SPELL_FEL_RAGE_2, true);

--- a/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
@@ -102,7 +102,7 @@ struct boss_gurtogg_bloodboil : public BossAI
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1, 40.0f, true))
             {
                 me->RemoveAurasByType(SPELL_AURA_MOD_TAUNT);
-                me->RemoveAuraDueToSpell(SPELL_ACIDIC_WOUND);
+                me->RemoveAura(SPELL_ACIDIC_WOUND);
                 DoCastSelf(SPELL_FEL_RAGE_SELF, true);
                 DoCast(target, SPELL_FEL_RAGE_TARGET, true);
                 DoCast(target, SPELL_FEL_RAGE_2, true);

--- a/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
@@ -102,7 +102,7 @@ struct boss_gurtogg_bloodboil : public BossAI
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1, 40.0f, true))
             {
                 me->RemoveAurasByType(SPELL_AURA_MOD_TAUNT);
-                me->RemoveAura(SPELL_ACIDIC_WOUND);
+                me->RemoveAurasDueToSpell(SPELL_ACIDIC_WOUND);
                 DoCastSelf(SPELL_FEL_RAGE_SELF, true);
                 DoCast(target, SPELL_FEL_RAGE_TARGET, true);
                 DoCast(target, SPELL_FEL_RAGE_2, true);

--- a/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
@@ -79,7 +79,7 @@ struct boss_gurtogg_bloodboil : public BossAI
         BossAI::JustEngagedWith(who);
         Talk(SAY_AGGRO);
 
-        DoCastSelf(SPELL_ACIDIC_WOUND, true);
+        DoCastVictim(SPELL_ACIDIC_WOUND, true);
 
         ScheduleTimedEvent(10s, [&] {
             if (!me->HasAura(SPELL_FEL_RAGE_SELF))
@@ -102,6 +102,7 @@ struct boss_gurtogg_bloodboil : public BossAI
             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1, 40.0f, true))
             {
                 me->RemoveAurasByType(SPELL_AURA_MOD_TAUNT);
+                me->RemoveAura(SPELL_ACIDIC_WOUND);
                 DoCastSelf(SPELL_FEL_RAGE_SELF, true);
                 DoCast(target, SPELL_FEL_RAGE_TARGET, true);
                 DoCast(target, SPELL_FEL_RAGE_2, true);
@@ -118,7 +119,7 @@ struct boss_gurtogg_bloodboil : public BossAI
                 }, 2s);
 
                 me->m_Events.AddEventAtOffset([&] {
-                    DoCastSelf(SPELL_ACIDIC_WOUND, true);
+                    DoCastVictim(SPELL_ACIDIC_WOUND, true);
                 }, 28s);
 
                 scheduler.DelayGroup(GROUP_DELAY, 30s);

--- a/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_bloodboil.cpp
@@ -79,7 +79,7 @@ struct boss_gurtogg_bloodboil : public BossAI
         BossAI::JustEngagedWith(who);
         Talk(SAY_AGGRO);
 
-        DoCastVictim(SPELL_ACIDIC_WOUND, true);
+        DoCastSelf(SPELL_ACIDIC_WOUND, true);
 
         ScheduleTimedEvent(10s, [&] {
             if (!me->HasAura(SPELL_FEL_RAGE_SELF))
@@ -118,7 +118,7 @@ struct boss_gurtogg_bloodboil : public BossAI
                 }, 2s);
 
                 me->m_Events.AddEventAtOffset([&] {
-                    DoCastVictim(SPELL_ACIDIC_WOUND, true);
+                    DoCastSelf(SPELL_ACIDIC_WOUND, true);
                 }, 28s);
 
                 scheduler.DelayGroup(GROUP_DELAY, 30s);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #21204

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Use bots or other players so no reset during  bewildering strikes
2. .go c id 22948
3. Wait for fel rage and observe no acid wound
4. After fel rage acid wound should be used again

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
