### PR TITLE
fix(CORE) Add mutex protection to _pendingTimeSyncRequests map access

### DIFF
--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -1639,10 +1639,8 @@ void WorldSession::SendTimeSync()
     data << uint32(_timeSyncNextCounter);
     SendPacket(&data);
 
-    {
-        std::lock_guard<std::mutex> guard(_timeSyncLock);
-        _pendingTimeSyncRequests[_timeSyncNextCounter] = getMSTime();
-    }
+    std::lock_guard<std::mutex> guard(_timeSyncLock);
+    _pendingTimeSyncRequests[_timeSyncNextCounter] = getMSTime();
 
     // Schedule next sync in 10 sec (except for the 2 first packets, which are spaced by only 5s)
     _timeSyncTimer = _timeSyncNextCounter == 0 ? 5000 : 10000;

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -1639,7 +1639,7 @@ void WorldSession::SendTimeSync()
     SendPacket(&data);
 
     {
-        std::lock_guard<std::mutex> guard(_timeSyncLock); 
+        std::lock_guard<std::mutex> guard(_timeSyncLock);
         _pendingTimeSyncRequests[_timeSyncNextCounter] = getMSTime();
     }
 

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -1638,7 +1638,10 @@ void WorldSession::SendTimeSync()
     data << uint32(_timeSyncNextCounter);
     SendPacket(&data);
 
-    _pendingTimeSyncRequests[_timeSyncNextCounter] = getMSTime();
+    {
+        std::lock_guard<std::mutex> guard(_timeSyncLock); 
+        _pendingTimeSyncRequests[_timeSyncNextCounter] = getMSTime();
+    }
 
     // Schedule next sync in 10 sec (except for the 2 first packets, which are spaced by only 5s)
     _timeSyncTimer = _timeSyncNextCounter == 0 ? 5000 : 10000;

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -1629,6 +1629,7 @@ WorldSession::DosProtection::DosProtection(WorldSession* s) :
 void WorldSession::ResetTimeSync()
 {
     _timeSyncNextCounter = 0;
+    std::lock_guard<std::mutex> guard(_timeSyncLock);
     _pendingTimeSyncRequests.clear();
 }
 

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -35,6 +35,7 @@
 #include <map>
 #include <memory>
 #include <utility>
+#include <mutex>
 
 class Creature;
 class GameObject;
@@ -1200,6 +1201,7 @@ private:
     std::map<uint32, uint32> _pendingTimeSyncRequests; // key: counter. value: server time when packet with that counter was sent.
     uint32 _timeSyncNextCounter;
     uint32 _timeSyncTimer;
+    mutable std::mutex _timeSyncLock;
 
     WorldSession(WorldSession const& right) = delete;
     WorldSession& operator=(WorldSession const& right) = delete;

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -34,8 +34,8 @@
 #include "World.h"
 #include <map>
 #include <memory>
-#include <utility>
 #include <mutex>
+#include <utility>
 
 class Creature;
 class GameObject;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
WorldSession::SendTimeSync() function was experiencing a segmentation fault when accessing the _pendingTimeSyncRequests map from multiple threads. Added mutex synchronization to prevent concurrent map access that was causing seg fault

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #21284

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
