### PR TITLE
fix(Core/Transport): Fix for passengers dropped in the middle of nowhere 

### DIFF
--- a/src/server/game/Entities/Transport/Transport.cpp
+++ b/src/server/game/Entities/Transport/Transport.cpp
@@ -584,7 +584,8 @@ void MotionTransport::DelayedTeleportTransport()
                     TransportBase::CalculatePassengerPosition(destX, destY, destZ, &destO, x, y, z, o);
 
                     Player* player = obj->ToPlayer();
-                    // Vehicle passengers are dropped in the midle of nowhere, so lets try to eject them, add to the transport and teleport
+                    // Vehicle passengers are dropped in the middle of nowhere, so lets try to eject them, add to the transport and teleport
+                    // this needs to be revisited to properly restore vehicles with passengers after transport teleportation
                     if (player->IsVehicle())
                         if (Vehicle* vehicleKit = player->GetVehicleKit())
                             for (SeatMap::iterator itr = vehicleKit->Seats.begin(); itr != vehicleKit->Seats.end(); ++itr)

--- a/src/server/game/Entities/Transport/Transport.cpp
+++ b/src/server/game/Entities/Transport/Transport.cpp
@@ -582,7 +582,21 @@ void MotionTransport::DelayedTeleportTransport()
                     float destX, destY, destZ, destO;
                     obj->m_movementInfo.transport.pos.GetPosition(destX, destY, destZ, destO);
                     TransportBase::CalculatePassengerPosition(destX, destY, destZ, &destO, x, y, z, o);
-                    if (!obj->ToPlayer()->TeleportTo(newMapId, destX, destY, destZ, destO, TELE_TO_NOT_LEAVE_TRANSPORT))
+
+                    Player* player = obj->ToPlayer();
+                    // Vehicle passengers are dropped in the midle of nowhere, so lets try to eject them, add to the transport and teleport
+                    if (player->IsVehicle())
+                        if (Vehicle* vehicleKit = player->GetVehicleKit())
+                            for (SeatMap::iterator itr = vehicleKit->Seats.begin(); itr != vehicleKit->Seats.end(); ++itr)
+                                if (Player* passenger = ObjectAccessor::GetPlayer(*player, itr->second.Passenger.Guid))
+                                {
+                                    passenger->ExitVehicle();
+                                    AddPassenger(passenger, true);
+                                    if (!passenger->TeleportTo(newMapId, destX, destY, destZ, destO, TELE_TO_NOT_LEAVE_TRANSPORT))
+                                        _passengers.erase(passenger);
+                                }
+
+                    if (!player->TeleportTo(newMapId, destX, destY, destZ, destO, TELE_TO_NOT_LEAVE_TRANSPORT))
                         _passengers.erase(obj);
                 }
                 break;


### PR DESCRIPTION
## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
Fix issue when vehicle passengers where dropped in the middle of nowhere on Transport teleport

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
TWO players required!

0. Create 2 characters, level up to 80. (.level 79)
1. `.go xyz -4263 -11331 5.4 530`
2. Obtain vehicle with additional seats on it ( `.additem 44083` )
3. Invite another player to party
4. Second player should sit on your vehicle
5. Enter any transport (like boat or zeppelin) 
6. Wait until it teleports to another location

As a result you party member will be teleported along with you, unlike before the fix when he was left in previous location

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] It would be probably awesome to teleport player without ejecting him from the seat
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
