### PR TITLE
fix(Core/Chat): Fix lower security check for GM commands.

### DIFF
--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -81,7 +81,7 @@ bool ChatHandler::HasLowerSecurityAccount(WorldSession* target, uint32 target_ac
         return false;
 
     // ignore only for non-players for non strong checks (when allow apply command at least to same sec level)
-    if (!AccountMgr::IsPlayerAccount(m_session->GetSecurity()) && !strong && !sWorld->getBoolConfig(CONFIG_GM_LOWER_SECURITY))
+    if (!AccountMgr::IsPlayerAccount(m_session->GetSecurity()) && !strong && sWorld->getBoolConfig(CONFIG_GM_LOWER_SECURITY))
         return false;
 
     if (target)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -49,6 +49,7 @@
 #include "PassiveAI.h"
 #include "Pet.h"
 #include "PetAI.h"
+#include "PetPackets.h"
 #include "Player.h"
 #include "ReputationMgr.h"
 #include "ScriptMgr.h"
@@ -16689,6 +16690,12 @@ void Unit::SendPetTalk(uint32 pettalk)
     data << GetGUID();
     data << uint32(pettalk);
     owner->ToPlayer()->GetSession()->SendPacket(&data);
+}
+
+void Unit::SendPetDismissSound() const
+{
+    if (CreatureDisplayInfoEntry const* displayInfo = sCreatureDisplayInfoStore.LookupEntry(GetNativeDisplayId()))
+        SendMessageToSet(WorldPackets::Pet::PetDismissSound(static_cast<int32>(displayInfo->ModelId), GetPosition()).Write(), false);
 }
 
 void Unit::SendPetAIReaction(ObjectGuid guid)

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1946,6 +1946,7 @@ public:
 
     void SendPetActionFeedback (uint8 msg);
     void SendPetTalk (uint32 pettalk);
+    void SendPetDismissSound() const;
     void SendPetAIReaction(ObjectGuid guid);
 
     void SendPeriodicAuraLog(SpellPeriodicAuraLogInfo* pInfo);

--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -297,8 +297,11 @@ void WorldSession::HandlePetActionHelper(Unit* pet, ObjectGuid guid1, uint32 spe
                             if (pet->ToPet()->getPetType() == HUNTER_PET)
                                 GetPlayer()->RemovePet(pet->ToPet(), PET_SAVE_AS_DELETED);
                             else
+                            {
+                                pet->SendPetDismissSound();
                                 //dismissing a summoned pet is like killing them (this prevents returning a soulshard...)
                                 pet->setDeathState(DeathState::Corpse);
+                            }
                         }
                         else if (pet->HasUnitTypeMask(UNIT_MASK_MINION | UNIT_MASK_SUMMON | UNIT_MASK_GUARDIAN | UNIT_MASK_CONTROLABLE_GUARDIAN))
                         {

--- a/src/server/game/Server/Packets/PetPackets.cpp
+++ b/src/server/game/Server/Packets/PetPackets.cpp
@@ -50,3 +50,10 @@ WorldPacket const* WorldPackets::Pet::PetUnlearnedSpell::Write()
     _worldPacket << uint32(SpellID);
     return &_worldPacket;
 }
+
+WorldPacket const* WorldPackets::Pet::PetDismissSound::Write()
+{
+    _worldPacket << int32(ModelId);
+    _worldPacket << float(ModelPosition.x) << float(ModelPosition.y) << float(ModelPosition.z);
+    return &_worldPacket;
+}

--- a/src/server/game/Server/Packets/PetPackets.h
+++ b/src/server/game/Server/Packets/PetPackets.h
@@ -18,6 +18,7 @@
 #ifndef PetPackets_h__
 #define PetPackets_h__
 
+#include "G3D/Vector3.h"
 #include "ObjectGuid.h"
 #include "Packet.h"
 
@@ -93,6 +94,18 @@ namespace WorldPackets
             RequestPetInfo(WorldPacket&& packet) : ClientPacket(CMSG_REQUEST_PET_INFO, std::move(packet)) { }
 
             void Read() override { }
+        };
+
+        class PetDismissSound final : public ServerPacket
+        {
+        public:
+            PetDismissSound(int32 modelId, G3D::Vector3 modelPosition)
+                : ServerPacket(SMSG_PET_DISMISS_SOUND, 4 + 12), ModelId(modelId), ModelPosition(modelPosition) { }
+
+            WorldPacket const* Write() override;
+
+            int32 ModelId = 0;
+            G3D::Vector3 ModelPosition;
         };
     }
 }


### PR DESCRIPTION
Fixed the system that prevents the use of certain GM commands on targets whose access level (GMLevel) is higher than yours.

For example, the `.summon` command. Before the fix, you could use it on characters with a higher access level than yours. After the fix, you will receive a notification that your access level is too low.

The pull request is provided 'as is' in the interest of the entire community, in the spirit of open-source. If the AzerothCore maintainers refuse to accept it due to incorrect formatting (templates etc) or some other nonsense, you can add it to your server manually.