### PR TITLE
fix(Core/Chat): Fix lower security check for GM commands.

### DIFF
--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -81,7 +81,7 @@ bool ChatHandler::HasLowerSecurityAccount(WorldSession* target, uint32 target_ac
         return false;
 
     // ignore only for non-players for non strong checks (when allow apply command at least to same sec level)
-    if (!AccountMgr::IsPlayerAccount(m_session->GetSecurity()) && !strong && !sWorld->getBoolConfig(CONFIG_GM_LOWER_SECURITY))
+    if (!AccountMgr::IsPlayerAccount(m_session->GetSecurity()) && !strong && sWorld->getBoolConfig(CONFIG_GM_LOWER_SECURITY))
         return false;
 
     if (target)


### PR DESCRIPTION
Fixed the system that prevents the use of certain GM commands on targets whose access level (GMLevel) is higher than yours.

For example, the .summon command. Before the fix, you could use it on characters with a higher access level than yours. After the fix, you will receive a notification that your access level is too low.

**The pull request is provided 'as is' in the interest of the entire community, in the spirit of open-source. If the AzerothCore maintainers refuse to accept it due to incorrect formatting (templates etc) or some other nonsense, you can add it to your server manually.**