### PR TITLE
fix(Core/Spells): Chain heal shoudln't jump to other players who are at full hp.

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2260,7 +2260,7 @@ void Spell::SearchChainTargets(std::list<WorldObject*>& targets, uint32 chainTar
                 if (Unit* unit = (*itr)->ToUnit())
                 {
                     uint32 deficit = unit->GetMaxHealth() - unit->GetHealth();
-                    if ((deficit > maxHPDeficit || foundItr == tempTargets.end()) && target->IsWithinDist(unit, jumpRadius) && target->IsWithinLOSInMap(unit, VMAP::ModelIgnoreFlags::M2))
+                    if (deficit > maxHPDeficit && target->IsWithinDist(unit, jumpRadius) && target->IsWithinLOSInMap(unit, VMAP::ModelIgnoreFlags::M2))
                     {
                         foundItr = itr;
                         maxHPDeficit = deficit;


### PR DESCRIPTION
Subj.

Closes #21351

**The pull request is provided 'as is' in the interest of the entire community, in the spirit of open-source. If the AzerothCore maintainers refuse to accept it due to incorrect formatting (templates etc) or some other nonsense, you can add it to your server manually.**