### PR TITLE
refactor(Misc): improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/aa_game_issues.yml
+++ b/.github/ISSUE_TEMPLATE/aa_game_issues.yml
@@ -1,4 +1,4 @@
-name: Bug report
+name: Game issues
 description: Create a bug report to help us improve.
 body:
   - type: markdown
@@ -14,14 +14,13 @@ body:
       description: |
         Description of the problem or issue here.
         Include entries of affected creatures / items / quests / spells etc.
-        If this is a crash, post the crashlog (upload to https://gist.github.com/) and include the link here.
         Never upload files! Use GIST for text and YouTube for videos!
     validations:
       required: true
   - type: textarea
     id: expected
     attributes:
-      label: Expected Blizzlike Behaviour
+      label: Expected Behaviour
       description: |
         Tell us what should happen instead.
     validations:

--- a/.github/ISSUE_TEMPLATE/bb_crash_issues.yml
+++ b/.github/ISSUE_TEMPLATE/bb_crash_issues.yml
@@ -1,0 +1,86 @@
+name: Crash / Server Crash issues
+description: Did your server crash? Post an issue here!
+title: "Crash: "
+labels: ["Priority-Critical", "HasBacktrace"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out a bug report. Remember to fill out all fields including the title above. 
+        An issue that is not properly filled out will be closed.
+  - type: textarea
+    id: current
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        If possible provide detailed steps to reproduce the crash.
+      placeholder: |
+        1. Provide the exact steps to trigger the crash.
+        2. Include any relevant configurations or commands.
+        3. Mention if the crash is consistent or intermittent.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        NOTE: Make sure your server was compiled in RelWithDebug or Debug mode as crashlogs from Release do not contain enough information.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and Screenshots
+      description: |
+        Do you have any logs or screenshots that can be useful?
+        Crash logs in text are preffered over screenshots.
+        If you have logs in text form please upload them to [Gist](https://gist.github.com/) or PasteBin and upload the link.
+    validations:
+      required: false
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: |
+        The Operating System you are having issues on.
+        i.e. Windows 11 x64, Debian 10 x64, macOS 12, Ubuntu 20.04
+    validations:
+      required: true
+  - type: textarea
+    id: deps
+    attributes:
+      label: Dependencies & versions
+      description: |
+        Relevant information about dependencies and their versions that can be useful to debug the issue.
+        Example:
+        - OpenSSL ver ...
+        - Boost ver ...
+        - MySQL ver ...
+        - Visual Studio ver ...
+        - GCC ver ...
+        - Clang ver ...
+        - CMake ver ... 
+    validations:
+      required: true
+  - type: input
+    id: commit
+    attributes:
+      label: Commit
+      description: |
+        Which commit hash are you using.
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional Context
+      description: |
+        Do you have any other relevant information about the issue?
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your contribution.
+        If you use AzerothCore regularly, we really NEED your help to:
+        - Test our fixes: https://www.azerothcore.org/wiki/How-to-test-a-PR
+        - Report issues or suggestions: https://github.com/azerothcore/azerothcore-wotlk/issues/new/choose
+        - Improve the documentation/wiki: https://www.azerothcore.org/wiki/home
+        With your help, the project can evolve much quicker!

--- a/.github/ISSUE_TEMPLATE/cc_bta_issues.yml
+++ b/.github/ISSUE_TEMPLATE/cc_bta_issues.yml
@@ -1,0 +1,75 @@
+name: Build/Tools/Apps issues
+description: Got an issue with build, tools or apps? Create an issue to let us know!
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out a bug report. Remember to fill out all fields including the title above. 
+        An issue that is not properly filled out will be closed.
+  - type: textarea
+    id: current
+    attributes:
+      label: Current Behaviour
+      description: |
+        What actually happens and how do we reproduce it?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and Screenshots
+      description: |
+        Do you have any logs or screenshots that can be useful?
+        If you have logs in text form please upload them to [Gist](https://gist.github.com/) or PasteBin and upload the link.
+    validations:
+      required: false
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: |
+        The Operating System you are having issues on.
+        i.e. Windows 11 x64, Debian 10 x64, macOS 12, Ubuntu 20.04
+    validations:
+      required: true
+  - type: textarea
+    id: deps
+    attributes:
+      label: Dependencies & versions
+      description: |
+        Relevant information about dependencies and their versions that can be useful to debug the issue.
+        Example:
+        - OpenSSL ver ...
+        - Boost ver ...
+        - MySQL ver ...
+        - Visual Studio ver ...
+        - GCC ver ...
+        - Clang ver ...
+        - CMake ver ... 
+    validations:
+      required: true
+  - type: input
+    id: commit
+    attributes:
+      label: Commit
+      description: |
+        Which commit hash are you using.
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional Context
+      description: |
+        Do you have any other relevant information about the issue?
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your contribution.
+        If you use AzerothCore regularly, we really NEED your help to:
+        - Test our fixes: https://www.azerothcore.org/wiki/How-to-test-a-PR
+        - Report issues or suggestions: https://github.com/azerothcore/azerothcore-wotlk/issues/new/choose
+        - Improve the documentation/wiki: https://www.azerothcore.org/wiki/home
+        With your help, the project can evolve much quicker!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Website
     url: https://www.azerothcore.org
@@ -6,9 +6,6 @@ contact_links:
   - name: Wiki
     url: https://www.azerothcore.org/wiki
     about: You can find plenty of information on our Wiki.
-  - name: How to ask for help
-    url: https://www.azerothcore.org/wiki/How-to-ask-for-help
-    about: Before submitting an issue we'd love if you take a minute to read this.
   - name: FAQ
     url: https://www.azerothcore.org/wiki/faq
     about: Frequently asked questions.

--- a/.github/ISSUE_TEMPLATE/dd_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/dd_feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest an idea for this project
 title: "Feature: "
-type: "Feature"
+labels: "Feature"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/ee_cc.yml
+++ b/.github/ISSUE_TEMPLATE/ee_cc.yml
@@ -1,0 +1,13 @@
+name: CC Triage
+description: This template is only used for ChromieCraft
+title: "Crash: "
+labels: ["ChromieCraft Generic"]
+body:
+  - type: textarea
+    id: current
+    attributes:
+      label: Triage
+      description: |
+        Paste the issue from ChromieCraft here.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/ee_cc.yml
+++ b/.github/ISSUE_TEMPLATE/ee_cc.yml
@@ -1,6 +1,5 @@
 name: CC Triage
 description: This template is only used for ChromieCraft
-title: "Crash: "
 labels: ["ChromieCraft Generic"]
 body:
   - type: textarea


### PR DESCRIPTION
Generally improve issue templates from one heavily game related to now 5 more specific ones.

- aa_game_issues.yml - For issues found ingame
- bb_crash_issues.yml - For crashes/server crashes
- cc_bta_issues.yml - For build/tools/apps issues
- dd_feature_request.yml - For feature requests
- ee_cc.yml - For triage issues from CC

Why are they prefix?
In the "create issue" tab on Github, the templates are sorted alphabetically from their file name.