### PR TITLE
fix(Core/SQLField): Fix heap-buffer-overflow issue when interacting with mysql field value.

### DIFF
--- a/src/server/database/Database/Field.cpp
+++ b/src/server/database/Database/Field.cpp
@@ -212,7 +212,7 @@ T Field::GetData() const
     if (data.raw)
         result = *reinterpret_cast<T const*>(data.value);
     else
-        result = Acore::StringTo<T>(data.value);
+        result = Acore::StringTo<T>(std::string_view(data.value, data.length));
 
     // Correct double fields... this undefined behavior :/
     if constexpr (std::is_same_v<T, double>)
@@ -220,7 +220,7 @@ T Field::GetData() const
         if (data.raw && !IsType(DatabaseFieldTypes::Decimal))
             result = *reinterpret_cast<double const*>(data.value);
         else
-            result = Acore::StringTo<float>(data.value);
+            result = Acore::StringTo<float>(std::string_view(data.value, data.length));
     }
 
     // Check -1 for *_dbc db tables
@@ -230,7 +230,7 @@ T Field::GetData() const
 
         if (!tableName.empty() && tableName.size() > 4)
         {
-            auto signedResult = Acore::StringTo<int32>(data.value);
+            auto signedResult = Acore::StringTo<int32>(std::string_view(data.value, data.length));
 
             if (signedResult && !result && tableName.substr(tableName.length() - 4) == "_dbc")
             {


### PR DESCRIPTION
This PR addresses the next error from address sanitizer:
```
==2062960==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61c00001a748 at pc 0x5641942efa26 bp 0x7fff533ee730 sp 0x7fff533edef8
READ of size 5 at 0x61c00001a748 thread T0
    #0 0x5641942efa25 in __interceptor_strlen (/root/azerothcore/ac-server-2025-02-03/bin/worldserver+0x8d6a25) (BuildId: 0906f0a07ca8f8de5fd6f3a26384802c973d05ac)
    #1 0x5641973969c7 in std::char_traits<char>::length(char const*) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/char_traits.h:399:9
    #2 0x5641973969c7 in std::basic_string_view<char, std::char_traits<char> >::basic_string_view(char const*) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/string_view:132:16
    #3 0x5641973969c7 in unsigned int Field::GetData<unsigned int>() const /root/azerothcore2025-02-03/src/server/database/Database/Field.cpp:233:56
    #4 0x5641967f7d24 in std::enable_if<std::is_arithmetic_v<unsigned int>, unsigned int>::type Field::Get<unsigned int>() const /root/azerothcore2025-02-03/src/server/database/Database/Field.h:114:16
    #5 0x5641967f7d24 in Map::LoadRespawnTimes() /root/azerothcore2025-02-03/src/server/game/Maps/Map.cpp:3447:44
    #6 0x56419681a787 in MapMgr::CreateBaseMap(unsigned int) /root/azerothcore2025-02-03/src/server/game/Maps/MapMgr.cpp:88:22
    #7 0x564196901ed1 in PoolGroup<GameObject>::Spawn1Object(PoolObject*) /root/azerothcore2025-02-03/src/server/game/Pools/PoolMgr.cpp:408:29
    #8 0x56419692cc71 in PoolGroup<GameObject>::SpawnObject(ActivePoolData&, unsigned int, unsigned int) /root/azerothcore2025-02-03/src/server/game/Pools/PoolMgr.cpp:363:17
    #9 0x5641969033a5 in void PoolMgr::SpawnPool<GameObject>(unsigned int, unsigned int) /root/azerothcore2025-02-03/src/server/game/Pools/PoolMgr.cpp:1058:20
    #10 0x5641969033a5 in PoolMgr::SpawnPool(unsigned int) /root/azerothcore2025-02-03/src/server/game/Pools/PoolMgr.cpp:1083:5
    #11 0x56419691bb79 in PoolMgr::LoadFromDB() /root/azerothcore2025-02-03/src/server/game/Pools/PoolMgr.cpp:956:21
    #12 0x56419708564d in World::SetInitialWorldSettings() /root/azerothcore2025-02-03/src/server/game/World/World.cpp:1815:15
    #13 0x56419439d30e in main /root/azerothcore2025-02-03/src/server/apps/worldserver/Main.cpp:306:13
    #14 0x7f4038f3dd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #15 0x7f4038f3de3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #16 0x5641942d98e4 in _start (/root/azerothcore/ac-server-2025-02-03/bin/worldserver+0x8c08e4) (BuildId: 0906f0a07ca8f8de5fd6f3a26384802c973d05ac)

0x61c00001a748 is located 0 bytes to the right of 1736-byte region [0x61c00001a080,0x61c00001a748)
allocated by thread T0 here:
    #0 0x56419439760d in operator new[](unsigned long) (/root/azerothcore/ac-server-2025-02-03/bin/worldserver+0x97e60d) (BuildId: 0906f0a07ca8f8de5fd6f3a26384802c973d05ac)
    #1 0x5641973da428 in PreparedResultSet::PreparedResultSet(MySQLStmt*, MySQLResult*, unsigned long, unsigned int) /root/azerothcore2025-02-03/src/server/database/Database/QueryResult.cpp:309:24
    #2 0x5641973b426b in MySQLConnection::Query(PreparedStatementBase*) /root/azerothcore2025-02-03/src/server/database/Database/MySQLConnection.cpp:552:16
    #3 0x56419738140e in DatabaseWorkerPool<CharacterDatabaseConnection>::Query(PreparedStatement<CharacterDatabaseConnection>*) /root/azerothcore2025-02-03/src/server/database/Database/DatabaseWorkerPool.cpp:201:42
    #4 0x5641967f7c7b in Map::LoadRespawnTimes() /root/azerothcore2025-02-03/src/server/game/Maps/Map.cpp:3441:56
    #5 0x56419681a787 in MapMgr::CreateBaseMap(unsigned int) /root/azerothcore2025-02-03/src/server/game/Maps/MapMgr.cpp:88:22
    #6 0x564196901ed1 in PoolGroup<GameObject>::Spawn1Object(PoolObject*) /root/azerothcore2025-02-03/src/server/game/Pools/PoolMgr.cpp:408:29
    #7 0x56419692cc71 in PoolGroup<GameObject>::SpawnObject(ActivePoolData&, unsigned int, unsigned int) /root/azerothcore2025-02-03/src/server/game/Pools/PoolMgr.cpp:363:17
    #8 0x5641969033a5 in void PoolMgr::SpawnPool<GameObject>(unsigned int, unsigned int) /root/azerothcore2025-02-03/src/server/game/Pools/PoolMgr.cpp:1058:20
    #9 0x5641969033a5 in PoolMgr::SpawnPool(unsigned int) /root/azerothcore2025-02-03/src/server/game/Pools/PoolMgr.cpp:1083:5
    #10 0x56419691bb79 in PoolMgr::LoadFromDB() /root/azerothcore2025-02-03/src/server/game/Pools/PoolMgr.cpp:956:21
    #11 0x56419708564d in World::SetInitialWorldSettings() /root/azerothcore2025-02-03/src/server/game/World/World.cpp:1815:15
    #12 0x56419439d30e in main /root/azerothcore2025-02-03/src/server/apps/worldserver/Main.cpp:306:13
    #13 0x7f4038f3dd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
```

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
