### PR TITLE
fix(Core/Pet): Fix possible crash when using dangling pointer as pets spell target and fix possible memory leak.

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -47,7 +47,7 @@ Pet::Pet(Player* owner, PetType type) : Guardian(nullptr, owner ? owner->GetGUID
     m_auraRaidUpdateMask(0),
     m_loading(false),
     m_petRegenTimer(PET_FOCUS_REGEN_INTERVAL),
-    m_tempspellTarget(nullptr),
+    m_tempspellTarget(),
     m_tempoldTarget(),
     m_tempspellIsPositive(false),
     m_tempspell(0)
@@ -716,9 +716,11 @@ void Pet::Update(uint32 diff)
 
                 if (m_tempspell)
                 {
-                    Unit* tempspellTarget = m_tempspellTarget;
-                    Unit* tempoldTarget = nullptr;
+                    Unit* tempspellTarget = nullptr;
+                    if (!m_tempspellTarget.IsEmpty())
+                        tempspellTarget = ObjectAccessor::GetUnit(*this, m_tempspellTarget);
 
+                    Unit* tempoldTarget = nullptr;
                     if (!m_tempoldTarget.IsEmpty())
                         tempoldTarget = ObjectAccessor::GetUnit(*this, m_tempoldTarget);
 
@@ -758,7 +760,7 @@ void Pet::Update(uint32 diff)
 
                                 CastSpell(tempspellTarget, tempspell, false);
                                 m_tempspell = 0;
-                                m_tempspellTarget = nullptr;
+                                m_tempspellTarget = ObjectGuid::Empty;
 
                                 if (tempspellIsPositive)
                                 {
@@ -798,7 +800,7 @@ void Pet::Update(uint32 diff)
                     else
                     {
                         m_tempspell = 0;
-                        m_tempspellTarget = nullptr;
+                        m_tempspellTarget = ObjectGuid::Empty;
                         m_tempoldTarget = ObjectGuid::Empty;
                         m_tempspellIsPositive = false;
 
@@ -2433,7 +2435,7 @@ void Pet::CastWhenWillAvailable(uint32 spellid, Unit* spellTarget, ObjectGuid ol
     if (!spellTarget)
         return;
 
-    m_tempspellTarget = spellTarget;
+    m_tempspellTarget = spellTarget->GetGUID();
     m_tempspell = spellid;
     m_tempspellIsPositive = spellIsPositive;
 
@@ -2445,7 +2447,7 @@ void Pet::ClearCastWhenWillAvailable()
 {
     m_tempspellIsPositive = false;
     m_tempspell = 0;
-    m_tempspellTarget = nullptr;
+    m_tempspellTarget = ObjectGuid::Empty;
     m_tempoldTarget = ObjectGuid::Empty;
 }
 

--- a/src/server/game/Entities/Pet/Pet.h
+++ b/src/server/game/Entities/Pet/Pet.h
@@ -158,7 +158,7 @@ protected:
 
     std::unique_ptr<DeclinedName> m_declinedname;
 
-    Unit*      m_tempspellTarget;
+    ObjectGuid m_tempspellTarget;
     ObjectGuid m_tempoldTarget;
     bool       m_tempspellIsPositive;
     uint32     m_tempspell;

--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -441,7 +441,10 @@ void WorldSession::HandlePetActionHelper(Unit* pet, ObjectGuid guid1, uint32 spe
                     bool haspositiveeffect = false;
 
                     if (!unit_target)
+                    {
+                        delete spell;
                         return;
+                    }
 
                     // search positive effects for spell
                     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)


### PR DESCRIPTION
Fixes `heap-use-after-free` error:
```
==230820==ERROR: AddressSanitizer: heap-use-after-free on address 0x626052dd0668 at pc 0x555557a3c630 bp 0x7fffc925b650 sp 0x7fffc925b648
READ of size 1 at 0x626052dd0668 thread T15
    #0 0x555557a3c62f in Unit::IsAlive() const /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.h:1707:50
    #1 0x555557a3c62f in Pet::Update(unsigned int) /opt/wotlk_prod/src/server/game/Entities/Pet/Pet.cpp:734:61
    #2 0x5555580d9057 in void Acore::ObjectUpdater::Visit<Creature>(GridRefMgr<Creature>&) /opt/wotlk_prod/src/server/game/Grids/Notifiers/GridNotifiers.cpp:366:18
    #3 0x5555583c207d in void VisitorHelper<Acore::ObjectUpdater, Creature>(Acore::ObjectUpdater&, ContainerMapList<Creature>&) /opt/wotlk_prod/src/common/Dynamic/TypeContainerVisitor.h:43:7
    #4 0x5555583c207d in void VisitorHelper<Acore::ObjectUpdater, Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > >(Acore::ObjectUpdater&, ContainerMapList<TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > >&) /opt/wotlk_prod/src/common/Dynamic/TypeContainerVisitor.h:49:5
    #5 0x5555583c207d in void VisitorHelper<Acore::ObjectUpdater, Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > >(Acore::ObjectUpdater&, ContainerMapList<TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > >&) /opt/wotlk_prod/src/common/Dynamic/TypeContainerVisitor.h:50:5
    #6 0x5555583c207d in void VisitorHelper<Acore::ObjectUpdater, GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > >(Acore::ObjectUpdater&, ContainerMapList<TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > >&) /opt/wotlk_prod/src/common/Dynamic/TypeContainerVisitor.h:50:5
    #7 0x5555583c207d in void VisitorHelper<Acore::ObjectUpdater, TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > >(Acore::ObjectUpdater&, TypeMapContainer<TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > >&) /opt/wotlk_prod/src/common/Dynamic/TypeContainerVisitor.h:56:5
    #8 0x5555583c207d in TypeContainerVisitor<Acore::ObjectUpdater, TypeMapContainer<TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > > >::Visit(TypeMapContainer<TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > >&) /opt/wotlk_prod/src/common/Dynamic/TypeContainerVisitor.h:90:9
    #9 0x5555583c207d in void Grid<Player, TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > >, TypeList<GameObject, TypeList<Creature, TypeList<DynamicObject, TypeList<Corpse, TypeNull> > > > >::Visit<Acore::ObjectUpdater>(TypeContainerVisitor<Acore::ObjectUpdater, TypeMapContainer<TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > > >&) /opt/wotlk_prod/src/server/game/Grids/Grid.h:96:17
    #10 0x5555583c207d in void NGrid<8u, Player, TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > >, TypeList<GameObject, TypeList<Creature, TypeList<DynamicObject, TypeList<Corpse, TypeNull> > > > >::VisitGrid<Acore::ObjectUpdater, TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > >(unsigned int, unsigned int, TypeContainerVisitor<Acore::ObjectUpdater, TypeMapContainer<TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > > >&) /opt/wotlk_prod/src/server/game/Grids/NGrid.h:102:27
    #11 0x55555837d422 in void Map::Visit<Acore::ObjectUpdater, TypeMapContainer<TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > > >(Cell const&, TypeContainerVisitor<Acore::ObjectUpdater, TypeMapContainer<TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > > >&) /opt/wotlk_prod/src/server/game/Maps/Map.h:881:25
    #12 0x55555837d422 in Map::VisitNearbyCellsOf(WorldObject*, TypeContainerVisitor<Acore::ObjectUpdater, TypeMapContainer<TypeList<GameObject, TypeList<Creature, TypeList<DynamicObject, TypeList<Corpse, TypeNull> > > > > >&, TypeContainerVisitor<Acore::ObjectUpdater, TypeMapContainer<TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > > >&, TypeContainerVisitor<Acore::ObjectUpdater, TypeMapContainer<TypeList<GameObject, TypeList<Creature, TypeList<DynamicObject, TypeList<Corpse, TypeNull> > > > > >&, TypeContainerVisitor<Acore::ObjectUpdater, TypeMapContainer<TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > > >&) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:727:13
    #13 0x55555837ca98 in Map::VisitNearbyCellsOfPlayer(Player*, TypeContainerVisitor<Acore::ObjectUpdater, TypeMapContainer<TypeList<GameObject, TypeList<Creature, TypeList<DynamicObject, TypeList<Corpse, TypeNull> > > > > >&, TypeContainerVisitor<Acore::ObjectUpdater, TypeMapContainer<TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > > >&, TypeContainerVisitor<Acore::ObjectUpdater, TypeMapContainer<TypeList<GameObject, TypeList<Creature, TypeList<DynamicObject, TypeList<Corpse, TypeNull> > > > > >&, TypeContainerVisitor<Acore::ObjectUpdater, TypeMapContainer<TypeList<GameObject, TypeList<Player, TypeList<Creature, TypeList<Corpse, TypeList<DynamicObject, TypeNull> > > > > > >&) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:674:5
    #14 0x55555837deed in Map::Update(unsigned int, unsigned int, bool) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:820:9
    #15 0x5555583d18d2 in MapUpdateRequest::call() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:44:15
    #16 0x5555583cfcee in MapUpdater::WorkerThread() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:158:22
    #17 0x7ffff70a9252  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xdc252) (BuildId: e37fe1a879783838de78cbc8c80621fa685d58a2)
    #18 0x7ffff6d31ac2 in start_thread nptl/./nptl/pthread_create.c:442:8
    #19 0x7ffff6dc384f  misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81

0x626052dd0668 is located 1384 bytes inside of 11368-byte region [0x626052dd0100,0x626052dd2d68)
freed by thread T0 here:
    #0 0x555555edc5bd in operator delete(void*) (/opt/azeroth-server/bin/worldserver+0x9885bd) (BuildId: 8dc98c5ce141be4a8504ad653d93742fa56a0224)
    #1 0x555558388be6 in void Map::DeleteFromWorld<Creature>(Creature*) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:423:5
    #2 0x555558388be6 in void Map::RemoveFromMap<Creature>(Creature*, bool) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:958:9
    #3 0x555558388be6 in Map::RemoveAllObjectsInRemoveList() /opt/wotlk_prod/src/server/game/Maps/Map.cpp:2737:17
    #4 0x5555583cb201 in MapMgr::Update(unsigned int) /opt/wotlk_prod/src/server/game/Maps/MapMgr.cpp:281:31
    #5 0x555558c72968 in World::Update(unsigned int) /opt/wotlk_prod/src/server/game/World/World.cpp:2402:18
    #6 0x555555ef2614 in WorldUpdateLoop() /opt/wotlk_prod/src/server/apps/worldserver/Main.cpp:586:17
    #7 0x555555ee367a in main /opt/wotlk_prod/src/server/apps/worldserver/Main.cpp:398:5
    #8 0x7ffff6cc6d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
```

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
