### PR TITLE
fix(Core/Spell): Reset insignia spell target when it is deleted.

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5586,6 +5586,10 @@ void Spell::EffectSkinPlayerCorpse(SpellEffIndex /*effIndex*/)
         return;
 
     unitTarget->ToPlayer()->RemovedInsignia(m_caster->ToPlayer());
+
+    // We have a corpse object as the target.
+    // This target was deleted in RemovedInsignia() -> ConvertCorpseToBones().
+    m_targets.RemoveObjectTarget();
 }
 
 void Spell::EffectStealBeneficialBuff(SpellEffIndex effIndex)


### PR DESCRIPTION
Fix this `heap-use-after-free` error:
```
==338453==ERROR: AddressSanitizer: heap-use-after-free on address 0x619010687dc4 at pc 0x55555893f291 bp 0x7fffda534560 sp 0x7fffda534558
READ of size 4 at 0x619010687dc4 thread T10
    #0 0x55555893f290 in Object::GetTypeId() const /opt/wotlk_prod/src/server/game/Entities/Object/Object.h:124:53
    #1 0x55555893f290 in Object::IsCreature() const /opt/wotlk_prod/src/server/game/Entities/Object/Object.h:201:59
    #2 0x55555893f290 in Object::ToUnit() /opt/wotlk_prod/src/server/game/Entities/Object/Object.h:206:26
    #3 0x55555893f290 in SpellCastTargets::GetUnitTarget() const /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:235:32
    #4 0x55555893f290 in Spell::_cast(bool) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:4112:34
    #5 0x555558949f98 in Spell::update(unsigned int) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:4454:21
    #6 0x55555895eff9 in SpellEvent::Execute(unsigned long, unsigned int) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:8155:18
    #7 0x555559125dad in EventProcessor::Update(unsigned int) /opt/wotlk_prod/src/common/Utilities/EventProcessor.cpp:55:24
    #8 0x555557cbddbd in Unit::Update(unsigned int) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:389:14
    #9 0x555557c61fc0 in Player::Update(unsigned int) /opt/wotlk_prod/src/server/game/Entities/Player/PlayerUpdates.cpp:82:11
    #10 0x55555837eb42 in Map::Update(unsigned int, unsigned int, bool) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:769:21
    #11 0x5555583d1aa2 in MapUpdateRequest::call() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:44:15
    #12 0x5555583cfebe in MapUpdater::WorkerThread() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:158:22
    #13 0x7ffff70a9252  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xdc252) (BuildId: e37fe1a879783838de78cbc8c80621fa685d58a2)
    #14 0x7ffff6d31ac2 in start_thread nptl/./nptl/pthread_create.c:442:8
    #15 0x7ffff6dc384f  misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81

0x619010687dc4 is located 68 bytes inside of 1056-byte region [0x619010687d80,0x6190106881a0)
freed by thread T10 here:
    #0 0x555555edc5bd in operator delete(void*) (/opt/azeroth-server/bin/worldserver+0x9885bd) (BuildId: 8846f982bb719a408f7a40508eea6c898c665148)
    #1 0x55555837ae24 in Map::ConvertCorpseToBones(ObjectGuid, bool) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:3695:5
    #2 0x555557ae0b6a in Player::RemovedInsignia(Player*) /opt/wotlk_prod/src/server/game/Entities/Player/Player.cpp:7767:31
    #3 0x5555589c60d6 in Spell::EffectSkinPlayerCorpse(SpellEffIndex) /opt/wotlk_prod/src/server/game/Spells/SpellEffects.cpp:5588:29
    #4 0x5555589256d4 in Spell::HandleEffects(Unit*, Item*, GameObject*, unsigned int, SpellEffectHandleMode) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:5660:9
    #5 0x555558927d95 in Spell::DoSpellHitOnUnit(Unit*, unsigned int, bool) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:3259:13
    #6 0x555558921ecf in Spell::DoAllEffectOnTarget(TargetInfo*) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:2705:35
    #7 0x5555589463e4 in Spell::handle_immediate() /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:4165:9
    #8 0x55555893e41d in Spell::_cast(bool) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:4065:9
    #9 0x555558949f98 in Spell::update(unsigned int) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:4454:21
    #10 0x55555895eff9 in SpellEvent::Execute(unsigned long, unsigned int) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:8155:18
    #11 0x555559125dad in EventProcessor::Update(unsigned int) /opt/wotlk_prod/src/common/Utilities/EventProcessor.cpp:55:24
    #12 0x555557cbddbd in Unit::Update(unsigned int) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:389:14
    #13 0x555557c61fc0 in Player::Update(unsigned int) /opt/wotlk_prod/src/server/game/Entities/Player/PlayerUpdates.cpp:82:11
    #14 0x55555837eb42 in Map::Update(unsigned int, unsigned int, bool) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:769:21
    #15 0x5555583d1aa2 in MapUpdateRequest::call() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:44:15
    #16 0x5555583cfebe in MapUpdater::WorkerThread() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:158:22
    #17 0x7ffff70a9252  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xdc252) (BuildId: e37fe1a879783838de78cbc8c80621fa685d58a2)
```

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
