### PR TITLE
fix(Core/Pet): Fix possible heap-use-after-free of charmInfo when handling pet action.

### DIFF
--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -432,8 +432,14 @@ void WorldSession::HandlePetActionHelper(Unit* pet, ObjectGuid guid1, uint32 spe
 
                     spell->prepare(&(spell->m_targets));
 
-                    charmInfo->SetForcedSpell(0);
-                    charmInfo->SetForcedTargetGUID();
+                    // spell->prepare() can delete charm info.
+                    // Let's refresh the pointer.
+                    charmInfo = pet->GetCharmInfo();
+                    if (charmInfo)
+                    {
+                        charmInfo->SetForcedSpell(0);
+                        charmInfo->SetForcedTargetGUID();
+                    }
                 }
                 else if (pet->ToPet() && (result == SPELL_FAILED_LINE_OF_SIGHT || result == SPELL_FAILED_OUT_OF_RANGE))
                 {


### PR DESCRIPTION
Fixes this `heap-use-after-free` error:
```
==338453==ERROR: AddressSanitizer: heap-use-after-free on address 0x60f0007e1f20 at pc 0x55555828544f bp 0x7fffda534070 sp 0x7fffda534068
WRITE of size 4 at 0x60f0007e1f20 thread T10
    #0 0x55555828544e in CharmInfo::SetForcedSpell(unsigned int) /opt/wotlk_prod/src/server/game/Entities/Unit/CharmInfo.h:176:53
    #1 0x55555828544e in WorldSession::HandlePetActionHelper(Unit*, ObjectGuid, unsigned int, unsigned short, ObjectGuid) /opt/wotlk_prod/src/server/game/Handlers/PetHandler.cpp:435:32
    #2 0x5555582804ec in WorldSession::HandlePetAction(WorldPacket&) /opt/wotlk_prod/src/server/game/Handlers/PetHandler.cpp:104:9
    #3 0x555558650f65 in WorldSession::Update(unsigned int, PacketFilter&) /opt/wotlk_prod/src/server/game/Server/WorldSession.cpp:360:35
    #4 0x55555837da8c in Map::Update(unsigned int, unsigned int, bool) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:753:22
    #5 0x55555839d8f6 in InstanceMap::Update(unsigned int, unsigned int, bool) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:3043:10
    #6 0x5555583d1aa2 in MapUpdateRequest::call() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:44:15
    #7 0x5555583cfebe in MapUpdater::WorkerThread() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:158:22
    #8 0x7ffff70a9252  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xdc252) (BuildId: e37fe1a879783838de78cbc8c80621fa685d58a2)
    #9 0x7ffff6d31ac2 in start_thread nptl/./nptl/pthread_create.c:442:8
    #10 0x7ffff6dc384f  misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81

0x60f0007e1f20 is located 80 bytes inside of 168-byte region [0x60f0007e1ed0,0x60f0007e1f78)
freed by thread T10 here:
    #0 0x555555edc5bd in operator delete(void*) (/opt/azeroth-server/bin/worldserver+0x9885bd) (BuildId: 8846f982bb719a408f7a40508eea6c898c665148)
    #1 0x555557da7cb5 in Unit::DeleteCharmInfo() /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:15884:5
    #2 0x555557da7cb5 in Unit::RemoveCharmedBy(Unit*) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:18751:9
    #3 0x555558ac813c in AuraEffect::HandleEffect(AuraApplication*, unsigned char, bool) /opt/wotlk_prod/src/server/game/Spells/Auras/SpellAuraEffects.cpp:784:5
    #4 0x555558aedd23 in AuraApplication::_HandleEffect(unsigned char, bool) /opt/wotlk_prod/src/server/game/Spells/Auras/SpellAuras.cpp:179:17
    #5 0x555557d25403 in Unit::_UnapplyAura(std::_Rb_tree_iterator<std::pair<unsigned int const, AuraApplication*> >&, AuraRemoveMode) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:4640:21
    #6 0x555557d2f249 in Unit::RemoveAllAuras() /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:5360:13
    #7 0x5555562d9350 in instance_karazhan::instance_karazhan_InstanceMapScript::SetData(unsigned int, unsigned int) /opt/wotlk_prod/src/server/scripts/EasternKingdoms/Karazhan/instance_karazhan.cpp:271:36
    #8 0x55555623e399 in npc_echo_of_medivh::HandlePieceJustDied(Creature*) /opt/wotlk_prod/src/server/scripts/EasternKingdoms/Karazhan/boss_chess_event.cpp:559:36
    #9 0x55555623acb5 in npc_chesspiece::JustDied(Unit*) /opt/wotlk_prod/src/server/scripts/EasternKingdoms/Karazhan/boss_chess_event.cpp:1642:56
    #10 0x555557cd4e2d in Unit::Kill(Unit*, Unit*, bool, WeaponAttackType, SpellInfo const*, Spell const*) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:18007:17
    #11 0x555557cc931c in Unit::DealDamage(Unit*, Unit*, unsigned int, CleanDamage const*, DamageEffectType, SpellSchoolMask, SpellInfo const*, bool, bool, Spell const*) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:1052:9
    #12 0x555557ceaeef in Unit::DealSpellDamage(SpellNonMeleeDamage*, bool, Spell const*) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:1471:5
    #13 0x555558923538 in Spell::DoAllEffectOnTarget(TargetInfo*) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:2885:17
    #14 0x5555589463e4 in Spell::handle_immediate() /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:4165:9
    #15 0x55555893e41d in Spell::_cast(bool) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:4065:9
    #16 0x55555892e012 in Spell::prepare(SpellCastTargets const*, AuraEffect const*) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:3714:13
    #17 0x5555582846bc in WorldSession::HandlePetActionHelper(Unit*, ObjectGuid, unsigned int, unsigned short, ObjectGuid) /opt/wotlk_prod/src/server/game/Handlers/PetHandler.cpp:433:28
    #18 0x5555582804ec in WorldSession::HandlePetAction(WorldPacket&) /opt/wotlk_prod/src/server/game/Handlers/PetHandler.cpp:104:9
    #19 0x555558650f65 in WorldSession::Update(unsigned int, PacketFilter&) /opt/wotlk_prod/src/server/game/Server/WorldSession.cpp:360:35
    #20 0x55555837da8c in Map::Update(unsigned int, unsigned int, bool) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:753:22
    #21 0x55555839d8f6 in InstanceMap::Update(unsigned int, unsigned int, bool) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:3043:10
    #22 0x5555583d1aa2 in MapUpdateRequest::call() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:44:15
    #23 0x5555583cfebe in MapUpdater::WorkerThread() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:158:22
    #24 0x7ffff70a9252  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xdc252) (BuildId: e37fe1a879783838de78cbc8c80621fa685d58a2)
```

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
