### PR TITLE
fix(Core/SpellQueue): Fix undefined behavior when processing SpellQueue.

### DIFF
--- a/src/server/game/Entities/Player/PlayerUpdates.cpp
+++ b/src/server/game/Entities/Player/PlayerUpdates.cpp
@@ -2378,7 +2378,15 @@ void Player::ProcessSpellQueue()
         if (CanExecutePendingSpellCastRequest(spellInfo))
         {
             ExecuteOrCancelSpellCastRequest(&request);
-            SpellQueue.pop_front(); // Remove from the queue
+
+            // ExecuteOrCancelSpellCastRequest() can lead to clearing the SpellQueue.
+            // Example scenario:
+            //   Handling a spell → Dealing damage to yourself (e.g., spell_pri_vampiric_touch) →
+            //   Killing yourself → Player::setDeathState() → SpellQueue.clear().
+            // Calling std::deque::pop_front() on an empty deque results in undefined behavior,
+            // so an additional check is added.
+            if (!SpellQueue.empty())
+                SpellQueue.pop_front();
         }
         else // If the first spell can't execute, stop processing
             break;


### PR DESCRIPTION
ASan:
```
==393329==ERROR: AddressSanitizer: attempting double-free on 0x602004a77310 in thread T8:
    #0 0x555555edc5bd in operator delete(void*) (/opt/azeroth-server/bin/worldserver+0x9885bd) (BuildId: 94b1b8a4438fe7573a83b5df74cccb8c99e9094a)
    #1 0x555557c67a1c in __gnu_cxx::new_allocator<unsigned char>::deallocate(unsigned char*, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ext/new_allocator.h:145:2
    #2 0x555557c67a1c in std::allocator<unsigned char>::deallocate(unsigned char*, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/allocator.h:199:25
    #3 0x555557c67a1c in std::allocator_traits<std::allocator<unsigned char> >::deallocate(std::allocator<unsigned char>&, unsigned char*, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:496:13
    #4 0x555557c67a1c in std::_Vector_base<unsigned char, std::allocator<unsigned char> >::_M_deallocate(unsigned char*, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:354:4
    #5 0x555557c67a1c in std::_Vector_base<unsigned char, std::allocator<unsigned char> >::~_Vector_base() /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:335:2
    #6 0x555557c67a1c in std::vector<unsigned char, std::allocator<unsigned char> >::~vector() /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:683:7
    #7 0x555557c67a1c in ByteBuffer::~ByteBuffer() /opt/wotlk_prod/src/server/shared/Packets/ByteBuffer.h:94:35
    #8 0x555557c67a1c in PendingSpellCastRequest::~PendingSpellCastRequest() /opt/wotlk_prod/src/server/game/Entities/Player/Player.h:1068:8
    #9 0x555557c67a1c in void std::destroy_at<PendingSpellCastRequest>(PendingSpellCastRequest*) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
    #10 0x555557c67a1c in void std::allocator_traits<std::allocator<PendingSpellCastRequest> >::destroy<PendingSpellCastRequest>(std::allocator<PendingSpellCastRequest>&, PendingSpellCastRequest*) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:537:4
    #11 0x555557c67a1c in std::deque<PendingSpellCastRequest, std::allocator<PendingSpellCastRequest> >::pop_front() /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_deque.h:1538:6
    #12 0x555557c67a1c in Player::ProcessSpellQueue() /opt/wotlk_prod/src/server/game/Entities/Player/PlayerUpdates.cpp:2376:24
    #13 0x555557c635b9 in Player::Update(unsigned int) /opt/wotlk_prod/src/server/game/Entities/Player/PlayerUpdates.cpp:82:5
    #14 0x555558383a22 in Map::Update(unsigned int, unsigned int, bool) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:769:21
    #15 0x5555583d6982 in MapUpdateRequest::call() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:44:15
    #16 0x5555583d4d9e in MapUpdater::WorkerThread() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:158:22
    #17 0x7ffff70a9252  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xdc252) (BuildId: e37fe1a879783838de78cbc8c80621fa685d58a2)
    #18 0x7ffff6d31ac2 in start_thread nptl/./nptl/pthread_create.c:442:8
    #19 0x7ffff6dc384f  misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
0x602004a77310 is located 0 bytes inside of 13-byte region [0x602004a77310,0x602004a7731d)
freed by thread T8 here:
    #0 0x555555edc5bd in operator delete(void*) (/opt/azeroth-server/bin/worldserver+0x9885bd) (BuildId: 94b1b8a4438fe7573a83b5df74cccb8c99e9094a)
    #1 0x555557b73d2a in __gnu_cxx::new_allocator<unsigned char>::deallocate(unsigned char*, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ext/new_allocator.h:145:2
    #2 0x555557b73d2a in std::allocator<unsigned char>::deallocate(unsigned char*, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/allocator.h:199:25
    #3 0x555557b73d2a in std::allocator_traits<std::allocator<unsigned char> >::deallocate(std::allocator<unsigned char>&, unsigned char*, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:496:13
    #4 0x555557b73d2a in std::_Vector_base<unsigned char, std::allocator<unsigned char> >::_M_deallocate(unsigned char*, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:354:4
    #5 0x555557b73d2a in std::_Vector_base<unsigned char, std::allocator<unsigned char> >::~_Vector_base() /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:335:2
    #6 0x555557b73d2a in std::vector<unsigned char, std::allocator<unsigned char> >::~vector() /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:683:7
    #7 0x555557b73d2a in ByteBuffer::~ByteBuffer() /opt/wotlk_prod/src/server/shared/Packets/ByteBuffer.h:94:35
    #8 0x555557b73d2a in PendingSpellCastRequest::~PendingSpellCastRequest() /opt/wotlk_prod/src/server/game/Entities/Player/Player.h:1068:8
    #9 0x555557b73d2a in void std::destroy_at<PendingSpellCastRequest>(PendingSpellCastRequest*) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
    #10 0x555557b73d2a in void std::_Destroy<PendingSpellCastRequest>(PendingSpellCastRequest*) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:149:7
    #11 0x555557b73d2a in void std::_Destroy_aux<false>::__destroy<PendingSpellCastRequest*>(PendingSpellCastRequest*, PendingSpellCastRequest*) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:163:6
    #12 0x555557b73d2a in void std::_Destroy<PendingSpellCastRequest*>(PendingSpellCastRequest*, PendingSpellCastRequest*) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:195:7
    #13 0x555557b73d2a in void std::_Destroy<PendingSpellCastRequest*, PendingSpellCastRequest>(PendingSpellCastRequest*, PendingSpellCastRequest*, std::allocator<PendingSpellCastRequest>&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:848:7
    #14 0x555557b73d2a in std::deque<PendingSpellCastRequest, std::allocator<PendingSpellCastRequest> >::_M_destroy_data_aux(std::_Deque_iterator<PendingSpellCastRequest, PendingSpellCastRequest&, PendingSpellCastRequest*>, std::_Deque_iterator<PendingSpellCastRequest, PendingSpellCastRequest&, PendingSpellCastRequest*>) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/deque.tcc:875:3
    #15 0x555557b66fa1 in std::deque<PendingSpellCastRequest, std::allocator<PendingSpellCastRequest> >::_M_destroy_data(std::_Deque_iterator<PendingSpellCastRequest, PendingSpellCastRequest&, PendingSpellCastRequest*>, std::_Deque_iterator<PendingSpellCastRequest, PendingSpellCastRequest&, PendingSpellCastRequest*>, std::allocator<PendingSpellCastRequest> const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_deque.h:2049:4
    #16 0x555557b66fa1 in std::deque<PendingSpellCastRequest, std::allocator<PendingSpellCastRequest> >::_M_erase_at_end(std::_Deque_iterator<PendingSpellCastRequest, PendingSpellCastRequest&, PendingSpellCastRequest*>) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_deque.h:2066:2
    #17 0x555557b66fa1 in std::deque<PendingSpellCastRequest, std::allocator<PendingSpellCastRequest> >::clear() /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_deque.h:1794:9
    #18 0x555557a71fa7 in Player::setDeathState(DeathState, bool) /opt/wotlk_prod/src/server/game/Entities/Player/Player.cpp:1031:20
    #19 0x555557cd6cb5 in Unit::Kill(Unit*, Unit*, bool, WeaponAttackType, SpellInfo const*, Spell const*) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:17939:17
    #20 0x555557ccbddc in Unit::DealDamage(Unit*, Unit*, unsigned int, CleanDamage const*, DamageEffectType, SpellSchoolMask, SpellInfo const*, bool, bool, Spell const*) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:1052:9
    #21 0x555557ced9af in Unit::DealSpellDamage(SpellNonMeleeDamage*, bool, Spell const*) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:1471:5
    #22 0x555558928418 in Spell::DoAllEffectOnTarget(TargetInfo*) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:2885:17
    #23 0x55555894b344 in Spell::handle_immediate() /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:4165:9
    #24 0x55555894337d in Spell::_cast(bool) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:4065:9
    #25 0x555558932e9c in Spell::cast(bool) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:3809:5
    #26 0x555558932e9c in Spell::prepare(SpellCastTargets const*, AuraEffect const*) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:3676:9
    #27 0x555557cdb44e in Unit::CastSpell(SpellCastTargets const&, SpellInfo const*, CustomSpellValues const*, TriggerCastFlags, Item*, AuraEffect const*, ObjectGuid) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:1203:19
    #28 0x555557ce5698 in Unit::CastCustomSpell(unsigned int, CustomSpellValues const&, Unit*, TriggerCastFlags, Item*, AuraEffect const*, ObjectGuid) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:1273:12
    #29 0x555557cdf5d9 in Unit::CastCustomSpell(Unit*, unsigned int, int const*, int const*, int const*, bool, Item*, AuraEffect const*, ObjectGuid) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:1244:12
    #30 0x5555572c32c5 in spell_pri_vampiric_touch::HandleDispel(DispelInfo*) /opt/wotlk_prod/src/server/scripts/Spells/spell_priest.cpp:856:29
    #31 0x555558b11f1d in Aura::CallScriptAfterDispel(DispelInfo*) /opt/wotlk_prod/src/server/game/Spells/Auras/SpellAuras.cpp:2410:22
    #32 0x555557d2d3ff in Unit::RemoveAurasDueToSpellByDispel(unsigned int, unsigned int, ObjectGuid, Unit*, unsigned char) /opt/wotlk_prod/src/server/game/Entities/Unit/Unit.cpp:4994:19
    #33 0x5555589a075e in Spell::EffectDispel(SpellEffIndex) /opt/wotlk_prod/src/server/game/Spells/SpellEffects.cpp:2658:21
    #34 0x55555892a5b4 in Spell::HandleEffects(Unit*, Item*, GameObject*, unsigned int, SpellEffectHandleMode) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:5660:9
    #35 0x55555892cd52 in Spell::DoSpellHitOnUnit(Unit*, unsigned int, bool) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:3259:13
    #36 0x555558926daf in Spell::DoAllEffectOnTarget(TargetInfo*) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:2705:35
    #37 0x55555894b344 in Spell::handle_immediate() /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:4165:9
    #38 0x55555894337d in Spell::_cast(bool) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:4065:9
    #39 0x555558933037 in Spell::prepare(SpellCastTargets const*, AuraEffect const*) /opt/wotlk_prod/src/server/game/Spells/Spell.cpp:3714:13
    #40 0x5555582cda53 in WorldSession::HandleCastSpellOpcode(WorldPacket&) /opt/wotlk_prod/src/server/game/Handlers/SpellHandler.cpp:545:12
    #41 0x555557c67987 in Player::ExecuteOrCancelSpellCastRequest(PendingSpellCastRequest*, bool) /opt/wotlk_prod/src/server/game/Entities/Player/PlayerUpdates.cpp:2363:22
    #42 0x555557c67987 in Player::ProcessSpellQueue() /opt/wotlk_prod/src/server/game/Entities/Player/PlayerUpdates.cpp:2375:13
    #43 0x555557c635b9 in Player::Update(unsigned int) /opt/wotlk_prod/src/server/game/Entities/Player/PlayerUpdates.cpp:82:5
    #44 0x555558383a22 in Map::Update(unsigned int, unsigned int, bool) /opt/wotlk_prod/src/server/game/Maps/Map.cpp:769:21
    #45 0x5555583d6982 in MapUpdateRequest::call() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:44:15
    #46 0x5555583d4d9e in MapUpdater::WorkerThread() /opt/wotlk_prod/src/server/game/Maps/MapUpdater.cpp:158:22
```

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/21427

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
