### PR TITLE
fix(Scripts/Zuldrak) Npc: Blightguard; Spell: Scourge Disguise and related things

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1739981613287600500.sql
+++ b/data/sql/updates/pending_db_world/rev_1739981613287600500.sql
@@ -1,0 +1,66 @@
+-- Fix double cast of Scourge Disguise
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 28669);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+(28669, 0, 0, 1, 54, 0, 100, 512, 0, 0, 0, 0, 0, 0, 28, 51966, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Just Summoned - Remove \'Scourge Disguise[51966]\''),
+(28669, 0, 1, 2, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 11, 52191, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Just Summoned - Cast \'Scourge Disguise[52191]\''),
+(28669, 0, 2, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 80, 2866900, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Just Summoned - Run Script'),
+(28669, 0, 3, 0, 40, 0, 100, 512, 62, 28669, 0, 0, 0, 0, 11, 52220, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Waypoint 62 Reached - Cast \'Kill Credit\''),
+(28669, 0, 4, 5, 40, 0, 100, 512, 63, 28669, 0, 0, 0, 0, 28, 52191, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Waypoint 63 Reached - Remove \'Scourge Disguise[52191]\''),
+(28669, 0, 5, 6, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 75, 52192, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Waypoint 63 Reached - Cast \'Scourge Disguise[52192]\''),
+(28669, 0, 6, 7, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 75, 51971, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Waypoint 63 Reached - Cast \'Scourge Disguise Instability[51971]\''),
+(28669, 0, 7, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 11, 50630, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Flying Fiend - On Waypoint 63 Reached - Cast \'Eject All Passengers\'');
+
+-- Add or Remove linked to Scourge Disguise spells
+DELETE FROM `spell_linked_spell` WHERE (`spell_trigger` IN ( -52010, -52192, -51966, 51966, 52192));
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES
+(-52010, -52192, 0, 'Remove Scourge Disguise [52192]'),
+(-52010, -51966, 0, 'Remove Scourge Disguise [51966]'),
+(-51966, -51971, 0, 'Remove Scourge Disguise Instability [51971]'),
+(-52192, -51971, 0, 'Remove Scourge Disguise Instability [51971]'),
+(51966, -52192, 0, 'Remove Scourge Disguise [52192]'),
+(52192, -51966, 0, 'Remove Scourge Disguise [51966]'),
+(51966, 51971, 0, 'Add Scourge Disguise Instability [51971]'),
+(52192, 51971, 0, 'Add Scourge Disguise Instability [51971]');
+
+-- Attach script to Scourge Disguise Instability
+DELETE FROM `spell_script_names` WHERE `spell_id` = 51971;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(51971, 'spell_scourge_disguise_instability');
+
+-- Update Blightguard AI
+UPDATE `creature_template` SET `AIName`='SmartAI' WHERE `entry`=28603;
+
+-- Update Blightguard scripts: cast invisibility, remove aura from target, cast Shadowstrike
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 28603);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(28603, 0, 0, 0, 25, 0, 100, 0, 0, 0, 0, 0, 0, 0, 75, 52060, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Blightguard - On Reset - Cast \'Invisibility\''),
+(28603, 0, 1, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 28, 52060, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Blightguard - On Aggro - Remove Aura \'Invisibility\''),
+(28603, 0, 2, 0, 0, 0, 100, 0, 6000, 6000, 10000, 10000, 0, 0, 11, 33914, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Blightguard - In Combat - Cast \'Shadowstrike\''),
+(28603, 0, 3, 0, 24, 0, 100, 0, 51966, 0, 100, 100, 0, 0, 28, 51966, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Blightguard - On Target Has \'Scourge Disguise\' Aura - Remove \'Scourge Disguise\'[51966]'),
+(28603, 0, 4, 0, 24, 0, 100, 0, 52192, 0, 100, 100, 0, 0, 28, 52192, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Blightguard - On Target Has \'Scourge Disguise\' Aura - Remove \'Scourge Disguise\'[52192]');
+
+-- Update Blightguard spawn location (thanks to guys from Triniti Core)
+DELETE FROM `creature` WHERE `id1` = 28603;
+INSERT INTO `creature` (`guid`, `id1`, `id2`, `id3`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
+(245704, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6022.67, -2049.14, 238.189, 1.46482, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245705, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6042.88, -2119.83, 239.522, 5.55282, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245706, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6101.08, -2157.18, 239.578, 5.52926, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245707, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6176.72, -2208.48, 241.65, 0.110007, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245708, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6227.74, -2193.69, 236.211, 0.66371, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245709, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6270.34, -2053.92, 238.548, 1.23705, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245710, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6069.51, -1913.87, 236.212, 2.78429, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245711, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6017.94, -1903.71, 239.384, 3.56183, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245712, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 5981.49, -1963.15, 237.669, 4.15088, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245713, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6017.39, -2106.46, 243.382, 5.40752, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245714, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 5275.12, -1678.04, 236.349, 1.1703, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245715, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 5224.69, -1751.98, 235.717, 3.17306, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245716, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 5154.48, -1745.88, 238.291, 3.26731, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245717, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 5082.87, -1725.64, 235.624, 3.55791, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245718, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 5034.49, -1655.17, 240.16, 1.8693, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245719, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 5069.11, -1540.09, 240.561, 6.1183, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245720, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 5099.29, -1559.64, 238.941, 0.624444, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245721, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6183.62, -2102.73, 235.653, 3.42675, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245722, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6113.59, -2105.41, 234.909, 0.441447, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245723, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6091.98, -2019.44, 235.639, 1.6706, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245724, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6199.66, -1957.45, 234.049, 1.20721, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL),
+(245725, 28603, 0, 0, 571, 0, 0, 1, 1, 0, 6242.41, -2003.27, 234.282, 4.15089, 600, 10, 0, 0, 0, 1, 0, 0, 0, '', 0, 0, NULL);

--- a/src/server/scripts/Northrend/zone_zuldrak.cpp
+++ b/src/server/scripts/Northrend/zone_zuldrak.cpp
@@ -23,6 +23,8 @@
 #include "ScriptedGossip.h"
 #include "SpellAuras.h"
 #include "SpellInfo.h"
+#include "SpellScript.h"
+#include "SpellScriptLoader.h"
 #include "Vehicle.h"
 
 // Ours
@@ -240,6 +242,7 @@ enum overlordDrakuru
     SPELL_THROW_BRIGHT_CRYSTAL          = 54087,
     SPELL_TELEPORT_EFFECT               = 52096,
     SPELL_SCOURGE_DISGUISE              = 51966,
+    SPELL_SCOURGE_DISGUISE_INSTANT_CAST = 52192,
     SPELL_BLIGHT_FOG                    = 54104,
     SPELL_THROW_PORTAL_CRYSTAL          = 54209,
     SPELL_ARTHAS_PORTAL                 = 51807,
@@ -866,6 +869,46 @@ public:
     }
 };
 
+enum ScourgeDisguiseInstability
+{
+    SCOURGE_DISGUISE_FAILING_MESSAGE_1       = 28552, // Scourge Disguise Failing! Find a safe place!
+    SCOURGE_DISGUISE_FAILING_MESSAGE_2       = 28758, // Scourge Disguise Failing! Run for cover!
+    SCOURGE_DISGUISE_FAILING_MESSAGE_3       = 28759, // Scourge Disguise Failing! Hide quickly!
+};
+std::vector<uint32> const scourgeDisguiseTextIDs = { SCOURGE_DISGUISE_FAILING_MESSAGE_1, SCOURGE_DISGUISE_FAILING_MESSAGE_2, SCOURGE_DISGUISE_FAILING_MESSAGE_3 };
+
+class spell_scourge_disguise_instability : public AuraScript
+{
+    PrepareAuraScript(spell_scourge_disguise_instability)
+
+    void HandleApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        SetDuration(urand(3 * MINUTE * IN_MILLISECONDS, 5 * MINUTE * IN_MILLISECONDS));
+    }
+
+    void HandleRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* caster = GetCaster();
+        if (caster && caster->IsPlayer())
+        {
+            Player* player = caster->ToPlayer();
+            if (player->HasAura(SPELL_SCOURGE_DISGUISE) || player->HasAura(SPELL_SCOURGE_DISGUISE_INSTANT_CAST))
+            {
+                uint32 textId = Acore::Containers::SelectRandomContainerElement(scourgeDisguiseTextIDs);
+                player->Unit::Whisper(textId, player, true);
+
+                player->CastSpell(player, SPELL_SCOURGE_DISGUISE_EXPIRING, true);
+            }
+        }
+    }
+
+    void Register() override
+    {
+        OnEffectApply += AuraEffectApplyFn(spell_scourge_disguise_instability::HandleApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+        OnEffectRemove += AuraEffectRemoveFn(spell_scourge_disguise_instability::HandleRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
 void AddSC_zuldrak()
 {
     // Ours
@@ -880,4 +923,6 @@ void AddSC_zuldrak()
     new npc_crusade_recruit();
     new go_scourge_enclosure();
     new npc_storm_cloud();
+
+    RegisterSpellScript(spell_scourge_disguise_instability);
 }


### PR DESCRIPTION
Thanks to [TrinityCore](https://www.trinitycore.org/) for the provided spawn locations!

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
1. [Blightguard](https://www.wowhead.com/wotlk/npc=28603/blightguard#abilities) spawn location are missing from DB. (currently only a couple of mobs are spawned).
Also this mobs should: have invisibility and remove [Scourge Disguise](https://www.wowhead.com/wotlk/spell=51966) aura from player on attack
2. Scourge Disguise spell [51966, 52192] is "unstable" and should be removed after some time with message informing player about it: "Scourge Disguise Failing! Find a safe place!"
3. Quest "Dark horizon" [12664]: When NPC Gorebag [28666] sends player on a fly mount to see some places it casted another copy of "Scourge Disguise" on player, which caused 2 active auras being on a player at the same time. And if 1 aura was removed - second aura didnt had any effect.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
1. [Blightguard](https://www.wowhead.com/wotlk/npc=28603/blightguard#abilities)
.additem 38699 // Choker
.go xyz 6278.02 -1933.10 239.60 571
Use Choker

NPC around you should became friendly, except Blightguards.
Approach Blightguards, they should attack you and remove your Disguise aura.

2. Scourge Disguise spell
.additem 38699 // Choker
.go xyz 6278.02 -1933.10 239.60 571
Use Choker

Wait 3-5 minutes. Now you should see that spell is going to end, and it will be actually removed.

3. Quest "Dark horizon"
.additem 38699 // Choker
.go xyz 6278.02 -1933.10 239.60 571
Use Choker
.quest add 12664 // dark horizon quest
.go creature id 28666 // Gorebag

Talk to NPC, take a ride, see that you have only 1 active aura of "Scourge Disguise" after ride is over.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
