### PR TITLE
fix(Core/Logging): revert commit e3432102f7e66968f53c6e9afb11d7844e95…

### DIFF
--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -172,10 +172,10 @@ void World::LoadConfigSettings(bool reload)
             LOG_ERROR("server.loading", "World settings reload fail: can't read settings.");
             return;
         }
-    }
 
-    sLog->LoadFromConfig();
-    sMetric->LoadFromConfigs();
+        sLog->LoadFromConfig();
+        sMetric->LoadFromConfigs();
+    }
 
     // Set realm id and enable db logging
     sLog->SetRealmId(realm.Id.Realm);


### PR DESCRIPTION
this reverts commit e3432102f7e66968f53c6e9afb11d7844e9517be
* closes https://github.com/azerothcore/azerothcore-wotlk/issues/21592

Reason

1.  We initialize logs here
https://github.com/azerothcore/azerothcore-wotlk/blob/826b55dffba73f12e1c04f49a239b4e6cedc9f9e/src/server/apps/worldserver/Main.cpp#L191

2. Later we initialize world which loads config settings which then would initialize metric and logs again causing them to overwrite/remove the logs to this point. Which means on startup the logs would've been initialized twice. This should not happen and should only be happening on reload case.
https://github.com/azerothcore/azerothcore-wotlk/blob/826b55dffba73f12e1c04f49a239b4e6cedc9f9e/src/server/apps/worldserver/Main.cpp#L307
https://github.com/azerothcore/azerothcore-wotlk/blob/826b55dffba73f12e1c04f49a239b4e6cedc9f9e/src/server/game/World/World.cpp#L1284