### PR TITLE
fix(Scripts/Spells): add warrior heroic strike daze bonus damage

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1741106880644889078.sql
+++ b/data/sql/updates/pending_db_world/rev_1741106880644889078.sql
@@ -1,0 +1,7 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (29707, 30324, 47449, 47450) AND `ScriptName` = 'spell_warr_heroic_strike';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(29707, 'spell_warr_heroic_strike'),
+(30324, 'spell_warr_heroic_strike'),
+(47449, 'spell_warr_heroic_strike'),
+(47450, 'spell_warr_heroic_strike');

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -909,40 +909,40 @@ class spell_warr_heroic_strike : public SpellScript
 
     void HandleOnHit()
     {
-        if (Unit* target = GetHitUnit())
+        Unit* target = GetHitUnit();
+        if (!target)
+            return;
+        std::list<AuraEffect*> AuraEffectList = target->GetAuraEffectsByType(SPELL_AURA_MOD_DECREASE_SPEED);
+        bool bonusDamage = false;
+        for (AuraEffect* eff : AuraEffectList)
         {
-            std::list<AuraEffect*> AuraEffectList = target->GetAuraEffectsByType(SPELL_AURA_MOD_DECREASE_SPEED);
-            bool bonusDamage = false;
-            for (AuraEffect* eff : AuraEffectList)
-            {
-                const SpellInfo* spellInfo = eff->GetSpellInfo();
-                if (!spellInfo)
-                    continue;
+            const SpellInfo* spellInfo = eff->GetSpellInfo();
+            if (!spellInfo)
+                continue;
 
-                // Warrior Spells: Piercing Howl or Dazed (29703)
-                if (spellInfo->SpellFamilyName == SPELLFAMILY_WARRIOR && (spellInfo->SpellFamilyFlags[1] & (0x20 | 0x200000)))
-                {
-                    bonusDamage = true;
-                    break;
-                }
-
-                // Generic Daze: icon 15 with mechanic daze or snare
-                if ((spellInfo->SpellIconID == 15)
-                    && ((spellInfo->Mechanic == MECHANIC_DAZE || spellInfo->HasEffectMechanic(MECHANIC_DAZE))
-                       || (spellInfo->Mechanic == MECHANIC_SNARE || spellInfo->HasEffectMechanic(MECHANIC_SNARE))
-                       )
-                )
-                {
-                    bonusDamage = true;
-                    break;
-                }
-            }
-            if (bonusDamage)
+            // Warrior Spells: Piercing Howl or Dazed (29703)
+            if (spellInfo->SpellFamilyName == SPELLFAMILY_WARRIOR && (spellInfo->SpellFamilyFlags[1] & (0x20 | 0x200000)))
             {
-                int32 damage = GetHitDamage();
-                AddPct(damage, 35); // "Causes ${0.35*$m1} additional damage against Dazed targets."
-                SetHitDamage(damage);
+                bonusDamage = true;
+                break;
             }
+
+            // Generic Daze: icon 15 with mechanic daze or snare
+            if ((spellInfo->SpellIconID == 15)
+                && ((spellInfo->Mechanic == MECHANIC_DAZE || spellInfo->HasEffectMechanic(MECHANIC_DAZE))
+                    || (spellInfo->Mechanic == MECHANIC_SNARE || spellInfo->HasEffectMechanic(MECHANIC_SNARE))
+                    )
+            )
+            {
+                bonusDamage = true;
+                break;
+            }
+        }
+        if (bonusDamage)
+        {
+            int32 damage = GetHitDamage();
+            AddPct(damage, 35); // "Causes ${0.35*$m1} additional damage against Dazed targets."
+            SetHitDamage(damage);
         }
     }
 

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -903,6 +903,12 @@ class spell_warr_retaliation : public AuraScript
 // 30324 - Heroic Strike (Rank 11)
 // 47449 - Heroic Strike (Rank 12)
 // 47450 - Heroic Strike (Rank 13)
+enum DazeSpells
+{
+    ICON_GENERIC_DAZE                   = 15,
+    SPELL_GENERIC_AFTERMATH             = 18118,
+};
+
 class spell_warr_heroic_strike : public SpellScript
 {
     PrepareSpellScript(spell_warr_heroic_strike);
@@ -927,11 +933,20 @@ class spell_warr_heroic_strike : public SpellScript
                 break;
             }
 
-            // Generic Daze: icon 15 with mechanic daze or snare
-            if ((spellInfo->SpellIconID == 15)
+            if ((spellInfo->SpellIconID == ICON_GENERIC_DAZE)
                 && ((spellInfo->Mechanic == MECHANIC_DAZE || spellInfo->HasEffectMechanic(MECHANIC_DAZE))
                     || (spellInfo->Mechanic == MECHANIC_SNARE || spellInfo->HasEffectMechanic(MECHANIC_SNARE))
                     )
+            )
+            {
+                bonusDamage = true;
+                break;
+            }
+
+            // Generic Daze: icon 15 with mechanic daze or snare
+            if ((spellInfo->Id == SPELL_GENERIC_AFTERMATH)
+                || (spellInfo->SpellFamilyName == SPELLFAMILY_MAGE && (spellInfo->SpellFamilyFlags[1] & 0x40)) // Blast Wave
+                || (spellInfo->SpellFamilyName == SPELLFAMILY_PALADIN && (spellInfo->SpellFamilyFlags[2] & 0x4000)) // Avenger's Shield
             )
             {
                 bonusDamage = true;

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -933,6 +933,7 @@ class spell_warr_heroic_strike : public SpellScript
                 break;
             }
 
+            // Generic Daze: icon 15 with mechanic daze or snare
             if ((spellInfo->SpellIconID == ICON_GENERIC_DAZE)
                 && ((spellInfo->Mechanic == MECHANIC_DAZE || spellInfo->HasEffectMechanic(MECHANIC_DAZE))
                     || (spellInfo->Mechanic == MECHANIC_SNARE || spellInfo->HasEffectMechanic(MECHANIC_SNARE))
@@ -943,7 +944,6 @@ class spell_warr_heroic_strike : public SpellScript
                 break;
             }
 
-            // Generic Daze: icon 15 with mechanic daze or snare
             if ((spellInfo->Id == SPELL_GENERIC_AFTERMATH)
                 || (spellInfo->SpellFamilyName == SPELLFAMILY_MAGE && (spellInfo->SpellFamilyFlags[1] & 0x40)) // Blast Wave
                 || (spellInfo->SpellFamilyName == SPELLFAMILY_PALADIN && (spellInfo->SpellFamilyFlags[2] & 0x4000)) // Avenger's Shield


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Add bonus damage to Heroic Strike (Ranks 10,11,12,13) if the target is afflicted by a Daze

"Daze" is ambiguous. https://wowpedia.fandom.com/wiki/Daze

- [x] 31935 Avenger's Shield (Rank 1)  - MECHANIC_SNARE
- [x] 11113 Blast Wave (Rank 1) - MECHANIC_SNARE
- [x] 17174 Concussive Shot - MECHANIC_SNARE
- [x] 35101 Concussive Barrage (Hunter talent) - MECHANIC_SNARE
- [x] 18118 Aftermath  - MECHANIC_SNARE
- [x] Piercing Howl
- [x] Shield Bash
- [x] 50259 Dazed (Feral Charge Cat)
- [x] Generic Daze with icon 15

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/21644

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Target Dummy
```
.tele darnassus
```
With dummy targetted apply a Daze
```
.cast self 15571 triggered
```
cast Heroic Strike with/without Daze
observe damage


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
