### PR TITLE
feature/on-name-query-hooks

### DIFF
--- a/src/server/game/Guilds/Guild.cpp
+++ b/src/server/game/Guilds/Guild.cpp
@@ -1265,6 +1265,8 @@ void Guild::HandleQuery(WorldSession* session)
 
     response.Info.GuildName = m_name;
 
+    sScriptMgr->OnGuildNameQueryOpcode(this, session, response.Info.GuildName);
+
     session->SendPacket(response.Write());
     LOG_DEBUG("guild", "SMSG_GUILD_QUERY_RESPONSE [{}]", session->GetPlayerInfo());
 }
@@ -1773,6 +1775,8 @@ void Guild::SendInfo(WorldSession* session) const
     guildInfo.CreateDate = m_createdDate;
     guildInfo.NumMembers = int32(m_members.size());
     guildInfo.NumAccounts = m_accountsNumber;
+
+    sScriptMgr->OnGuildNameQueryOpcode(this, session, guildInfo.GuildName);
 
     session->SendPacket(guildInfo.Write());
     LOG_DEBUG("guild", "SMSG_GUILD_INFO [{}]", session->GetPlayerInfo());

--- a/src/server/game/Handlers/QueryHandler.cpp
+++ b/src/server/game/Handlers/QueryHandler.cpp
@@ -24,6 +24,7 @@
 #include "Opcodes.h"
 #include "Pet.h"
 #include "Player.h"
+#include "ScriptMgr.h"
 #include "World.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
@@ -43,8 +44,11 @@ void WorldSession::SendNameQueryOpcode(ObjectGuid guid)
 
     Player* player = ObjectAccessor::FindConnectedPlayer(guid);
 
+    std::string name = playerData->Name;
+    sScriptMgr->OnPlayerSendNameQueryOpcode(player, name);
+
     data << uint8(0);                               // name known
-    data << playerData->Name;                       // played name
+    data << name;                                   // player name
     data << uint8(0);                               // realm name - only set for cross realm interaction (such as Battlegrounds)
     data << uint8(player ? player->getRace() : playerData->Race);
     data << uint8(playerData->Sex);

--- a/src/server/game/Scripting/ScriptDefines/GuildScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/GuildScript.cpp
@@ -79,6 +79,11 @@ bool ScriptMgr::CanGuildSendBankList(Guild const* guild, WorldSession* session, 
     CALL_ENABLED_BOOLEAN_HOOKS(GuildScript, GUILDHOOK_CAN_GUILD_SEND_BANK_LIST, !script->CanGuildSendBankList(guild, session, tabId, sendAllSlots));
 }
 
+void ScriptMgr::OnGuildNameQueryOpcode(Guild const* guild, WorldSession* session, std::string& name)
+{
+    CALL_ENABLED_HOOKS(GuildScript, GUILDHOOK_ON_NAME_QUERY_OPCODE, script->OnNameQueryOpcode(guild, session, name));
+}
+
 GuildScript::GuildScript(const char* name, std::vector<uint16> enabledHooks)
     : ScriptObject(name, GUILDHOOK_END)
 {

--- a/src/server/game/Scripting/ScriptDefines/GuildScript.h
+++ b/src/server/game/Scripting/ScriptDefines/GuildScript.h
@@ -81,7 +81,7 @@ public:
 
     [[nodiscard]] virtual bool CanGuildSendBankList(Guild const* /*guild*/, WorldSession* /*session*/, uint8 /*tabId*/, bool /*sendAllSlots*/) { return true; }
 
-    virtual void OnNameQueryOpcode(Guild const* guild, WorldSession* session, std::string& name) {}
+    virtual void OnNameQueryOpcode(Guild const* /*guild*/, WorldSession* /*session*/, std::string& /*name*/) {}
 };
 
 #endif

--- a/src/server/game/Scripting/ScriptDefines/GuildScript.h
+++ b/src/server/game/Scripting/ScriptDefines/GuildScript.h
@@ -36,6 +36,7 @@ enum GuildHook
     GUILDHOOK_ON_EVENT,
     GUILDHOOK_ON_BANK_EVENT,
     GUILDHOOK_CAN_GUILD_SEND_BANK_LIST,
+    GUILDHOOK_ON_NAME_QUERY_OPCODE,
     GUILDHOOK_END
 };
 
@@ -79,6 +80,8 @@ public:
     virtual void OnBankEvent(Guild* /*guild*/, uint8 /*eventType*/, uint8 /*tabId*/, ObjectGuid::LowType /*playerGuid*/, uint32 /*itemOrMoney*/, uint16 /*itemStackCount*/, uint8 /*destTabId*/) { }
 
     [[nodiscard]] virtual bool CanGuildSendBankList(Guild const* /*guild*/, WorldSession* /*session*/, uint8 /*tabId*/, bool /*sendAllSlots*/) { return true; }
+
+    virtual void OnNameQueryOpcode(Guild const* guild, WorldSession* session, std::string& name) {}
 };
 
 #endif

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -925,6 +925,11 @@ void ScriptMgr::OnPlayerSendListInventory(Player* player, ObjectGuid vendorGuid,
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_SEND_LIST_INVENTORY, script->OnPlayerSendListInventory(player, vendorGuid, vendorEntry));
 }
 
+void ScriptMgr::OnPlayerSendNameQueryOpcode(Player* player, std::string& name)
+{
+    CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_SEND_NAME_QUERY_OPCODE, script->OnPlayerSendNameQueryOpcode(player, name));
+}
+
 PlayerScript::PlayerScript(const char* name, std::vector<uint16> enabledHooks)
     : ScriptObject(name, PLAYERHOOK_END)
 {

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.h
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.h
@@ -210,6 +210,7 @@ enum PlayerHook
     PLAYERHOOK_CAN_RESURRECT,
     PLAYERHOOK_ON_CAN_GIVE_LEVEL,
     PLAYERHOOK_ON_SEND_LIST_INVENTORY,
+    PLAYERHOOK_ON_SEND_NAME_QUERY_OPCODE,
     PLAYERHOOK_END
 };
 
@@ -803,6 +804,14 @@ public:
      * @param vendorEntry Entry of the vendor player is interacting with
      */
     virtual void OnPlayerSendListInventory(Player* /*player*/, ObjectGuid /*vendorGuid*/, uint32& /*vendorEntry*/) {}
+
+    /**
+     * @brief This hooks is called whenever a players name is sent to the client, can be used to alter it
+     *
+     * @param player Contains information about the Player
+     * @param name Name about to be sent to the client for the player
+     */
+    virtual void OnPlayerSendNameQueryOpcode(Player* /*player*/, std::string& /*name*/) {}
 };
 
 #endif

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -465,6 +465,7 @@ public: /* PlayerScript */
     bool OnPlayerCanResurrect(Player* player);
     bool OnPlayerCanGiveLevel(Player* player, uint8 newLevel);
     void OnPlayerSendListInventory(Player* player, ObjectGuid vendorGuid, uint32& vendorEntry);
+    void OnPlayerSendNameQueryOpcode(Player* player, std::string& name);
 
     // Anti cheat
     void AnticheatSetCanFlybyServer(Player* player, bool apply);
@@ -500,6 +501,7 @@ public: /* GuildScript */
     void OnGuildEvent(Guild* guild, uint8 eventType, ObjectGuid::LowType playerGuid1, ObjectGuid::LowType playerGuid2, uint8 newRank);
     void OnGuildBankEvent(Guild* guild, uint8 eventType, uint8 tabId, ObjectGuid::LowType playerGuid, uint32 itemOrMoney, uint16 itemStackCount, uint8 destTabId);
     bool CanGuildSendBankList(Guild const* guild, WorldSession* session, uint8 tabId, bool sendAllSlots);
+    void OnGuildNameQueryOpcode(Guild const* guild, WorldSession* session, std::string& name);
 
 public: /* GroupScript */
     void OnGroupAddMember(Group* group, ObjectGuid guid);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
Simply adds a new script hook
-  This is very useful for adding custom info to players name, e.g. Paragon Level or if using a Guild Level module then display the guilds level in the guild name
