### PR TITLE
fix(DB/Creature) Fixes for Ruul Snowhoof SmartAI

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1742239694673418697.sql
+++ b/data/sql/updates/pending_db_world/rev_1742239694673418697.sql
@@ -1,0 +1,9 @@
+-- closes #5173 bullet point 2
+-- makes Ruul walk during escort as shown in videos
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 12818;
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 12818) AND (`source_type` = 0) AND (`id` IN (8, 9));
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(12818, 0, 8, 0, 1, 1, 100, 513, 5000, 5000, 0, 0, 0, 0, 3, 12819, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ruul Snowhoof - Out of Combat - Morph To Creature Ruul Snowhoof Bear Form (Phase 1) (No Repeat)'),
+(12818, 0, 9, 0, 11, 0, 100, 512, 0, 0, 0, 0, 0, 0, 3, 12819, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ruul Snowhoof - On Respawn - Morph To Creature Ruul Snowhoof Bear Form');


### PR DESCRIPTION
- Fixes point 2 from bug #5173 (Ruul now spawns in bear form in his cage). 
This bug can now be closed.
- Ruul now walks (instead of running) when out of combat during escort as seen in videos.

Thanks for Keira3 as it makes things much easier and faster.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #5173 (Parts 1 and 3 of the bug have previously been fixed and tested working) 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

[Video evidence provided in the bug report.](https://classic.wowhead.com/quest=6482/freedom-to-ruul#videos)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested the changes by doing the escort quest in full.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .go c id 12818 (As Horde)
2. Ruul should be in his cage in bear form
3. Do quest. Ruul should remain a bear until end of quest, and no long run while out of combat.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
The following issues are still observed with this quest and not fixed by this PR.

- [ ] Ruul walks through the ground at points near the cave exit
- [ ] Enemy spawns don't seem correct compared to the video evidence

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
