### PR TITLE
(db/Creautre) - Corrected Behaviour for the quest The Missing Survey Team

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1743112818280220600.sql
+++ b/data/sql/updates/pending_db_world/rev_1743112818280220600.sql
@@ -1,0 +1,5 @@
+-- Removes `Quest Giver` from template and adds `Hide Nameplate` (this requires clear cache if seen before)
+UPDATE `creature_template` SET `npcflag` = `npcflag` &~ 2, `type_flags` = `type_flags` | 1048576 WHERE (`entry` = 17600);
+ 
+-- Adds the `Quest Giver` to the only NPC (by GUID) that allow you to deliver the quest.
+UPDATE `creature` SET `npcflag` = `npcflag` | 2, ` WHERE (`id1` = 17600 AND `guid` = 84427);


### PR DESCRIPTION
- Quest Giver (npc_flag) removed from the creature_template (17600) and added the no_nameplate flag to the (type_flag).
- Added quest giver (npc_flag) to the guid (creature) 84427

![image](https://github.com/user-attachments/assets/447a87a7-d819-4533-b9bf-410ac505f793)


## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/21792

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

- Clear your cache
- Make a dreanei
- Make sure you've nameplates visible for NPCs
- `.level 19`
- `.quest add 9620` // The Missing Survey Team
- `.go c i 17600` // Draenei Cartographer
- Only the dreanei that's facing the pillar will allow you to deliver the quest (and the nameplates are also not visible).


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- I'm unaware how to remove the "bodies" names. as type_flags doesnt exist for creature so isnt something i could remove from the template and only have name for the creature as i did for the quest.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
