### PR TITLE
fix(Warden) Warden Anti-Cheat Timing Attack Protection WINDOWS

### DIFF
--- a/src/server/game/Warden/WardenWin.cpp
+++ b/src/server/game/Warden/WardenWin.cpp
@@ -38,13 +38,11 @@ static bool ConstantTimeCompare(const void* a, const void* b, size_t size)
     const unsigned char* a_ptr = static_cast<const unsigned char*>(a);
     const unsigned char* b_ptr = static_cast<const unsigned char*>(b);
     unsigned char result = 0;
-    
     for (size_t i = 0; i < size; ++i)
     {
         // CRYPTO_memcmp implementation
         result |= a_ptr[i] ^ b_ptr[i];
     }
-    
     // Will be 0 only if all bytes match
     return (result == 0);
 }

--- a/src/server/game/Warden/WardenWin.cpp
+++ b/src/server/game/Warden/WardenWin.cpp
@@ -19,7 +19,6 @@
 #include "ByteBuffer.h"
 #include "Common.h"
 #include "CryptoRandom.h"
-#include <openssl/crypto.h>
 #include "GameTime.h"
 #include "HMAC.h"
 #include "Log.h"
@@ -32,6 +31,7 @@
 #include "World.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
+#include <openssl/crypto.h>
 
 // GUILD is the shortest string that has no client validation (RAID only sends if in a raid group)
 static constexpr char _luaEvalPrefix[] = "local S,T,R=SendAddonMessage,function()";

--- a/src/server/game/Warden/WardenWin.cpp
+++ b/src/server/game/Warden/WardenWin.cpp
@@ -19,6 +19,7 @@
 #include "ByteBuffer.h"
 #include "Common.h"
 #include "CryptoRandom.h"
+#include <openssl/crypto.h>
 #include "GameTime.h"
 #include "HMAC.h"
 #include "Log.h"
@@ -31,21 +32,6 @@
 #include "World.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
-
-// Constant-time byte comparison function to prevent timing attacks
-static bool ConstantTimeCompare(const void* a, const void* b, size_t size)
-{
-    const unsigned char* a_ptr = static_cast<const unsigned char*>(a);
-    const unsigned char* b_ptr = static_cast<const unsigned char*>(b);
-    unsigned char result = 0;
-    for (size_t i = 0; i < size; ++i)
-    {
-        // CRYPTO_memcmp implementation
-        result |= a_ptr[i] ^ b_ptr[i];
-    }
-    // Will be 0 only if all bytes match
-    return (result == 0);
-}
 
 // GUILD is the shortest string that has no client validation (RAID only sends if in a raid group)
 static constexpr char _luaEvalPrefix[] = "local S,T,R=SendAddonMessage,function()";
@@ -246,7 +232,7 @@ void WardenWin::HandleHashResult(ByteBuffer& buff)
     buff.rpos(buff.wpos());
 
     // Verify key using constant-time comparison
-    if (!ConstantTimeCompare(buff.contents() + 1, Module.ClientKeySeedHash, Acore::Crypto::Constants::SHA1_DIGEST_LENGTH_BYTES))
+    if (CRYPTO_memcmp(buff.contents() + 1, Module.ClientKeySeedHash, Acore::Crypto::Constants::SHA1_DIGEST_LENGTH_BYTES) != 0)
     {
         LOG_DEBUG("warden", "Request hash reply: failed");
         ApplyPenalty(0, "Request hash reply: failed");
@@ -665,7 +651,7 @@ void WardenWin::HandleData(ByteBuffer& buff)
             WardenCheckResult const* rs = sWardenCheckMgr->GetWardenResultById(checkId);
 
             std::vector<uint8> result = rs->Result.ToByteVector(0, false);
-            if (!ConstantTimeCompare(buff.contents() + buff.rpos(), result.data(), rd->Length))
+            if (CRYPTO_memcmp(buff.contents() + buff.rpos(), result.data(), rd->Length) != 0)
             {
                 LOG_DEBUG("warden", "RESULT MEM_CHECK fail CheckId {} account Id {}", checkId, _session->GetAccountId());
                 checkFailed = checkId;
@@ -683,7 +669,7 @@ void WardenWin::HandleData(ByteBuffer& buff)
         case MODULE_CHECK:
         {
             uint8 const byte = 0xE9;
-            if (!ConstantTimeCompare(buff.contents() + buff.rpos(), &byte, sizeof(uint8)))
+            if (CRYPTO_memcmp(buff.contents() + buff.rpos(), &byte, sizeof(uint8)) != 0)
             {
                 if (type == PAGE_CHECK_A || type == PAGE_CHECK_B)
                 {
@@ -746,7 +732,7 @@ void WardenWin::HandleData(ByteBuffer& buff)
             }
 
             WardenCheckResult const* rs = sWardenCheckMgr->GetWardenResultById(checkId);
-            if (!ConstantTimeCompare(buff.contents() + buff.rpos(), rs->Result.ToByteArray<20>(false).data(), Acore::Crypto::Constants::SHA1_DIGEST_LENGTH_BYTES))
+            if (CRYPTO_memcmp(buff.contents() + buff.rpos(), rs->Result.ToByteArray<20>(false).data(), Acore::Crypto::Constants::SHA1_DIGEST_LENGTH_BYTES) != 0)
             {
                 LOG_DEBUG("warden", "RESULT MPQ_CHECK fail, CheckId {} account Id {}", checkId, _session->GetAccountId());
                 checkFailed = checkId;

--- a/src/server/game/Warden/WardenWin.cpp
+++ b/src/server/game/Warden/WardenWin.cpp
@@ -32,6 +32,23 @@
 #include "WorldPacket.h"
 #include "WorldSession.h"
 
+// Constant-time byte comparison function to prevent timing attacks
+static bool ConstantTimeCompare(const void* a, const void* b, size_t size)
+{
+    const unsigned char* a_ptr = static_cast<const unsigned char*>(a);
+    const unsigned char* b_ptr = static_cast<const unsigned char*>(b);
+    unsigned char result = 0;
+    
+    for (size_t i = 0; i < size; ++i)
+    {
+        // CRYPTO_memcmp implementation
+        result |= a_ptr[i] ^ b_ptr[i];
+    }
+    
+    // Will be 0 only if all bytes match
+    return (result == 0);
+}
+
 // GUILD is the shortest string that has no client validation (RAID only sends if in a raid group)
 static constexpr char _luaEvalPrefix[] = "local S,T,R=SendAddonMessage,function()";
 static constexpr char _luaEvalMidfix[] = " end R=S and T()if R then S('_TW',";
@@ -230,8 +247,8 @@ void WardenWin::HandleHashResult(ByteBuffer& buff)
 {
     buff.rpos(buff.wpos());
 
-    // Verify key
-    if (memcmp(buff.contents() + 1, Module.ClientKeySeedHash, Acore::Crypto::Constants::SHA1_DIGEST_LENGTH_BYTES) != 0)
+    // Verify key using constant-time comparison
+    if (!ConstantTimeCompare(buff.contents() + 1, Module.ClientKeySeedHash, Acore::Crypto::Constants::SHA1_DIGEST_LENGTH_BYTES))
     {
         LOG_DEBUG("warden", "Request hash reply: failed");
         ApplyPenalty(0, "Request hash reply: failed");
@@ -650,7 +667,7 @@ void WardenWin::HandleData(ByteBuffer& buff)
             WardenCheckResult const* rs = sWardenCheckMgr->GetWardenResultById(checkId);
 
             std::vector<uint8> result = rs->Result.ToByteVector(0, false);
-            if (memcmp(buff.contents() + buff.rpos(), result.data(), rd->Length) != 0)
+            if (!ConstantTimeCompare(buff.contents() + buff.rpos(), result.data(), rd->Length))
             {
                 LOG_DEBUG("warden", "RESULT MEM_CHECK fail CheckId {} account Id {}", checkId, _session->GetAccountId());
                 checkFailed = checkId;
@@ -668,7 +685,7 @@ void WardenWin::HandleData(ByteBuffer& buff)
         case MODULE_CHECK:
         {
             uint8 const byte = 0xE9;
-            if (memcmp(buff.contents() + buff.rpos(), &byte, sizeof(uint8)) != 0)
+            if (!ConstantTimeCompare(buff.contents() + buff.rpos(), &byte, sizeof(uint8)))
             {
                 if (type == PAGE_CHECK_A || type == PAGE_CHECK_B)
                 {
@@ -731,7 +748,7 @@ void WardenWin::HandleData(ByteBuffer& buff)
             }
 
             WardenCheckResult const* rs = sWardenCheckMgr->GetWardenResultById(checkId);
-            if (memcmp(buff.contents() + buff.rpos(), rs->Result.ToByteArray<20>(false).data(), Acore::Crypto::Constants::SHA1_DIGEST_LENGTH_BYTES) != 0) // SHA1
+            if (!ConstantTimeCompare(buff.contents() + buff.rpos(), rs->Result.ToByteArray<20>(false).data(), Acore::Crypto::Constants::SHA1_DIGEST_LENGTH_BYTES))
             {
                 LOG_DEBUG("warden", "RESULT MPQ_CHECK fail, CheckId {} account Id {}", checkId, _session->GetAccountId());
                 checkFailed = checkId;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

This PR addresses a timing attack vulnerability in the Windows version of the Warden anti-cheat system by implementing constant-time comparison for hash verification. The current implementation uses memcmp() which leaks timing information based on where differences occur in the compared data, potentially allowing attackers to extract secret values byte-by-byte.
The fix replaces vulnerable memcmp() calls with a constant-time comparison function ~~that's functionally equivalent to OpenSSL's~~ CRYPTO_memcmp() - a well-established cryptographic standard for preventing timing side-channel attacks.

Ref https://github.com/openssl/openssl/blob/50316c18a0468bb0191904d7615955c9b47f061f/crypto/cpuid.c#L199

The vulnerability exists because memcmp() returns as soon as it finds a difference between arrays:

```c++
// Vulnerable code
if (memcmp(buff.contents() + 1, Module.ClientKeySeedHash, Acore::Crypto::Constants::SHA1_DIGEST_LENGTH_BYTES) != 0)
```

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/2177

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Verify that players aren't inadvertently flagged or disconnected by Warden due to the comparison changes.
2. Ensure that the Warden module loading and hash verification work as expected.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
