### PR TITLE
fix(Warden) Warden Anti-Cheat Timing Attack Protection MAC

### DIFF
--- a/src/server/game/Warden/WardenMac.cpp
+++ b/src/server/game/Warden/WardenMac.cpp
@@ -27,6 +27,21 @@
 #include "WorldPacket.h"
 #include "WorldSession.h"
 
+// Constant-time byte comparison function to prevent timing attacks
+static bool ConstantTimeCompare(const void* a, const void* b, size_t size)
+{
+    const unsigned char* a_ptr = static_cast<const unsigned char*>(a);
+    const unsigned char* b_ptr = static_cast<const unsigned char*>(b);
+    unsigned char result = 0;
+    for (size_t i = 0; i < size; ++i)
+    {
+        // CRYPTO_memcmp implementation
+        result |= a_ptr[i] ^ b_ptr[i];
+    }
+    // Will be 0 only if all bytes match
+    return (result == 0);
+}
+
 WardenMac::WardenMac() : Warden()
 {
 }
@@ -152,8 +167,8 @@ void WardenMac::HandleHashResult(ByteBuffer& buff)
 
     //const uint8 validHash[20] = { 0x56, 0x8C, 0x05, 0x4C, 0x78, 0x1A, 0x97, 0x2A, 0x60, 0x37, 0xA2, 0x29, 0x0C, 0x22, 0xB5, 0x25, 0x71, 0xA0, 0x6F, 0x4E };
 
-    // Verify key
-    if (memcmp(buff.contents() + 1, sha1.GetDigest().data(), 20) != 0)
+    // Verify key using constant-time comparison
+    if (!ConstantTimeCompare(buff.contents() + 1, sha1.GetDigest().data(), 20))
     {
         LOG_DEBUG("warden", "Request hash reply: failed");
         ApplyPenalty(0, "Request hash reply: failed");


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

This PR addresses a timing attack vulnerability in the Mac version of the Warden anti-cheat system by implementing constant-time comparison for hash verification. The current implementation uses memcmp() which leaks timing information based on where differences occur in the compared data, potentially allowing attackers to extract secret values byte-by-byte.
The fix replaces vulnerable memcmp() calls with a constant-time comparison function that's functionally equivalent to OpenSSL's CRYPTO_memcmp() - a well-established cryptographic standard for preventing timing side-channel attacks.

Ref https://github.com/openssl/openssl/blob/50316c18a0468bb0191904d7615955c9b47f061f/crypto/cpuid.c#L199

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

I don't have an older Mac to try testing

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Verify that players aren't inadvertently flagged or disconnected by Warden due to the comparison changes.
2. Ensure that the Warden module loading and hash verification work as expected.
3. Verify that all memory/module/driver/MPQ checks still operate correctly.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
