### PR TITLE
fix(DB/Conditions) Requires Spirit Calling Aura to loot Lesser Nether Drake Spirit (QuestID: 10853)

### DIFF
--- a/data/sql/updates/pending_db_world/fix-Spirit-Calling-q10853.sql
+++ b/data/sql/updates/pending_db_world/fix-Spirit-Calling-q10853.sql
@@ -1,0 +1,4 @@
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1 AND `SourceGroup` = 21004 AND `SourceEntry` = 31656);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorTextId`, `ScriptName`, `Comment`)
+VALUES
+(1, 21004, 31656, 0, 0, 1, 0, 38778, 0, 0, 0, 0, '', 'Requires Spirit Calling Aura to loot Lesser Nether Drake Spirit');


### PR DESCRIPTION
Requires Spirit Calling Aura to loot Lesser Nether Drake Spirit (QuestID: 10853)

## Changes Proposed:
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/20052
- Closes https://github.com/chromiecraft/chromiecraft/issues/5929

## SOURCE:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

[![Watch the video](https://img.youtube.com/vi/uXRTrUYeM6w/0.jpg)](https://youtu.be/uXRTrUYeM6w)
🔗 [Click here to watch on YouTube](https://youtu.be/uXRTrUYeM6w)


## How to Test the Changes:
1. .q a 10853
2. Kill Lesser Nether Drake and check loot with out totem aura.
3. Kill Lesser Nether Drake and check loot with totem aura.
tip: Quest item drop has 80%

## To-do / Known un-resolved issue

- If recharges are finished quest giver should also [refill your stock](https://www.wowhead.com/wotlk/npc=22312/spiritcaller-dohgar#comments:id=380042), currently it doesn't.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
