### PR TITLE
fix(Script/Sunwell): Implement raycast to prevent Singularity throwing players through walls

### DIFF
--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -423,25 +423,24 @@ class spell_entropius_void_zone_visual_aura : public AuraScript
 class spell_entropius_black_hole_effect : public SpellScript
 {
     PrepareSpellScript(spell_entropius_black_hole_effect);
-    float RaycastToObstacle(Unit* unit, float angle, float targetZ, float maxDist = 20.0f)
+    float RaycastToObstacle(Unit* unit, float angle, float z, float maxDist = 20.0f)
     {
         float baseX = unit->GetPositionX();
         float baseY = unit->GetPositionY();
-        float baseZ = unit->GetPositionZ();
         float targetX = baseX + maxDist * cos(angle);
         float targetY = baseY + maxDist * sin(angle);
         float hitX, hitY, hitZ;
         if (VMAP::VMapFactory::createOrGetVMapMgr()->GetObjectHitPos(
                 unit->GetMapId(),
-                baseX, baseY, baseZ,
-                targetX, targetY, targetZ,
+                baseX, baseY, z,
+                targetX, targetY, z,
                 hitX, hitY, hitZ,
                 0.0f))
         {
             return std::sqrt(
                 std::pow(hitX - baseX, 2) +
                 std::pow(hitY - baseY, 2) +
-                std::pow(hitZ - baseZ, 2)
+                std::pow(hitZ - z, 2)  // Changed baseZ to z
             );
         }
         return maxDist;
@@ -453,13 +452,12 @@ class spell_entropius_black_hole_effect : public SpellScript
         Unit* target = GetHitUnit();
         if (!target)
             return;
-
         Position pos;
         if (target->GetDistance(GetCaster()) < 5.0f)
         {
             float o = frand(0, 2 * M_PI);
-            float z = GetCaster()->GetPositionZ() + frand(1.0f, 2.0f);
-            float safeDistance = RaycastToObstacle(target, o, z, 10.0f);
+            float z = GetCaster()->GetPositionZ() + frand(2.0f, 5.0f);
+            float safeDistance = RaycastToObstacle(GetCaster(), o, z, 10.0f); // try caster, not target
             float actualDistance = std::min(8.0f, safeDistance * 0.8f);
 
             pos.Relocate(

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -23,6 +23,7 @@
 #include "SpellScript.h"
 #include "SpellScriptLoader.h"
 #include "sunwell_plateau.h"
+#include "VMapFactory.h"
 
 enum Spells
 {

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -24,6 +24,7 @@
 #include "SpellScriptLoader.h"
 #include "sunwell_plateau.h"
 #include "VMapFactory.h"
+#include "VMapMgr2.h"
 
 enum Spells
 {

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -422,24 +422,27 @@ class spell_entropius_black_hole_effect : public SpellScript
 {
     PrepareSpellScript(spell_entropius_black_hole_effect);
 
-    float RaycastToObstacle(Unit* unit, float angle, float maxDist = 20.0f, float stepSize = 3.0f)
+    float RaycastToObstacle(Unit* unit, float angle, float maxDist = 20.0f)
     {
         float baseX = unit->GetPositionX();
         float baseY = unit->GetPositionY();
         float baseZ = unit->GetPositionZ();
 
-        for (float dist = stepSize; dist <= maxDist; dist += stepSize)
-        {
-            float testX = baseX + dist * cos(angle);
-            float testY = baseY + dist * sin(angle);
+        float targetX = baseX + maxDist * cos(angle);
+        float targetY = baseY + maxDist * sin(angle);
+        float targetZ = baseZ;
 
-            // If LOS is broken, we found an obstacle
-            if (!unit->IsWithinLOS(testX, testY, baseZ))
-                return dist - stepSize; // Return the last safe distance
+        float hitX, hitY, hitZ;
+
+        if (VMAP::VMapFactory::createOrGetVMapMgr()->GetObjectHitPos(unit->GetMapId(), baseX, baseY, baseZ, targetX, targetY, targetZ, hitX, hitY, hitZ, 0.0f))
+        {
+            // Compute actual distance to the obstacle
+            return std::hypot(hitX - baseX, hitY - baseY);
         }
 
         return maxDist; // No obstacle found within range
     }
+
     void HandlePull(SpellEffIndex effIndex)
     {
         PreventHitDefaultEffect(effIndex);

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -458,7 +458,7 @@ class spell_entropius_black_hole_effect : public SpellScript
         if (target->GetDistance(GetCaster()) < 5.0f)
         {
             float o = frand(0, 2 * M_PI);
-            float z = GetCaster()->GetPositionZ() + frand(2.0f, 5.0f);
+            float z = GetCaster()->GetPositionZ() + frand(1.0f, 2.0f);
             float safeDistance = RaycastToObstacle(target, o, z, 10.0f);
             float actualDistance = std::min(8.0f, safeDistance * 0.8f);
 

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -439,21 +439,21 @@ class spell_entropius_black_hole_effect : public SpellScript
                 0.0f))
         {
             return std::sqrt(
-                std::pow(hitX - baseX, 2) + 
-                std::pow(hitY - baseY, 2) + 
+                std::pow(hitX - baseX, 2) +
+                std::pow(hitY - baseY, 2) +
                 std::pow(hitZ - baseZ, 2)
             );
         }
         return maxDist;
     }
-    
+
     void HandlePull(SpellEffIndex effIndex)
     {
         PreventHitDefaultEffect(effIndex);
         Unit* target = GetHitUnit();
         if (!target)
             return;
-        
+
         Position pos;
         if (target->GetDistance(GetCaster()) < 5.0f)
         {
@@ -461,7 +461,7 @@ class spell_entropius_black_hole_effect : public SpellScript
             float z = GetCaster()->GetPositionZ() + frand(2.0f, 5.0f);
             float safeDistance = RaycastToObstacle(target, o, z, 10.0f);
             float actualDistance = std::min(8.0f, safeDistance * 0.8f);
-            
+
             pos.Relocate(
                 GetCaster()->GetPositionX() + actualDistance * cos(o),
                 GetCaster()->GetPositionY() + actualDistance * sin(o),
@@ -470,12 +470,12 @@ class spell_entropius_black_hole_effect : public SpellScript
         }
         else
             pos.Relocate(GetCaster()->GetPositionX(), GetCaster()->GetPositionY(), GetCaster()->GetPositionZ() + 1.0f);
-        
+
         float speedXY = float(GetSpellInfo()->Effects[effIndex].MiscValue) * 0.1f;
         float speedZ = target->GetDistance(pos) / speedXY * 0.5f * Movement::gravity;
         target->GetMotionMaster()->MoveJump(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), speedXY, speedZ);
     }
-    
+
     void Register() override
     {
         OnEffectHitTarget += SpellEffectFn(spell_entropius_black_hole_effect::HandlePull, EFFECT_0, SPELL_EFFECT_PULL_TOWARDS_DEST);

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -423,55 +423,59 @@ class spell_entropius_void_zone_visual_aura : public AuraScript
 class spell_entropius_black_hole_effect : public SpellScript
 {
     PrepareSpellScript(spell_entropius_black_hole_effect);
-
-    float RaycastToObstacle(Unit* unit, float angle, float maxDist = 20.0f)
+    float RaycastToObstacle(Unit* unit, float angle, float targetZ, float maxDist = 20.0f)
     {
         float baseX = unit->GetPositionX();
         float baseY = unit->GetPositionY();
         float baseZ = unit->GetPositionZ();
-
         float targetX = baseX + maxDist * cos(angle);
         float targetY = baseY + maxDist * sin(angle);
-        float targetZ = baseZ;
-
         float hitX, hitY, hitZ;
-
-        if (VMAP::VMapFactory::createOrGetVMapMgr()->GetObjectHitPos(unit->GetMapId(), baseX, baseY, baseZ, targetX, targetY, targetZ, hitX, hitY, hitZ, 0.0f))
+        if (VMAP::VMapFactory::createOrGetVMapMgr()->GetObjectHitPos(
+                unit->GetMapId(), 
+                baseX, baseY, baseZ, 
+                targetX, targetY, targetZ, 
+                hitX, hitY, hitZ, 
+                0.0f))
         {
-            // Compute actual distance to the obstacle
-            return std::hypot(hitX - baseX, hitY - baseY);
+            return std::sqrt(
+                std::pow(hitX - baseX, 2) + 
+                std::pow(hitY - baseY, 2) + 
+                std::pow(hitZ - baseZ, 2)
+            );
         }
-
-        return maxDist; // No obstacle found within range
+        return maxDist;
     }
-
+    
     void HandlePull(SpellEffIndex effIndex)
     {
         PreventHitDefaultEffect(effIndex);
         Unit* target = GetHitUnit();
         if (!target)
             return;
-
+        
         Position pos;
         if (target->GetDistance(GetCaster()) < 5.0f)
         {
             float o = frand(0, 2 * M_PI);
-            float safeDistance = RaycastToObstacle(target, o, 10.0f);
+            float z = GetCaster()->GetPositionZ() + frand(2.0f, 5.0f);
+            float safeDistance = RaycastToObstacle(target, o, z, 10.0f);
             float actualDistance = std::min(8.0f, safeDistance * 0.8f);
-
-            pos.Relocate(GetCaster()->GetPositionX() + actualDistance * cos(o),
-                         GetCaster()->GetPositionY() + actualDistance * sin(o),
-                         GetCaster()->GetPositionZ() + frand(2.0f, 5.0f));
+            
+            pos.Relocate(
+                GetCaster()->GetPositionX() + actualDistance * cos(o),
+                GetCaster()->GetPositionY() + actualDistance * sin(o),
+                z
+            );
         }
         else
             pos.Relocate(GetCaster()->GetPositionX(), GetCaster()->GetPositionY(), GetCaster()->GetPositionZ() + 1.0f);
-
+        
         float speedXY = float(GetSpellInfo()->Effects[effIndex].MiscValue) * 0.1f;
         float speedZ = target->GetDistance(pos) / speedXY * 0.5f * Movement::gravity;
-
         target->GetMotionMaster()->MoveJump(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), speedXY, speedZ);
     }
-
+    
     void Register() override
     {
         OnEffectHitTarget += SpellEffectFn(spell_entropius_black_hole_effect::HandlePull, EFFECT_0, SPELL_EFFECT_PULL_TOWARDS_DEST);

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -432,10 +432,10 @@ class spell_entropius_black_hole_effect : public SpellScript
         float targetY = baseY + maxDist * sin(angle);
         float hitX, hitY, hitZ;
         if (VMAP::VMapFactory::createOrGetVMapMgr()->GetObjectHitPos(
-                unit->GetMapId(), 
-                baseX, baseY, baseZ, 
-                targetX, targetY, targetZ, 
-                hitX, hitY, hitZ, 
+                unit->GetMapId(),
+                baseX, baseY, baseZ,
+                targetX, targetY, targetZ,
+                hitX, hitY, hitZ,
                 0.0f))
         {
             return std::sqrt(

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -456,7 +456,7 @@ class spell_entropius_black_hole_effect : public SpellScript
         if (target->GetDistance(GetCaster()) < 5.0f)
         {
             float o = frand(0, 2 * M_PI);
-            float z = GetCaster()->GetPositionZ() + frand(2.0f, 5.0f);
+            float z = GetCaster()->GetPositionZ() + frand(1.0f, 2.0f);
             float safeDistance = RaycastToObstacle(GetCaster(), o, z, 10.0f);
             float actualDistance = std::min(8.0f, safeDistance * 0.8f);
 

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -440,7 +440,7 @@ class spell_entropius_black_hole_effect : public SpellScript
             return std::sqrt(
                 std::pow(hitX - baseX, 2) +
                 std::pow(hitY - baseY, 2) +
-                std::pow(hitZ - z, 2)  // Changed baseZ to z
+                std::pow(hitZ - z, 2)
             );
         }
         return maxDist;
@@ -457,7 +457,7 @@ class spell_entropius_black_hole_effect : public SpellScript
         {
             float o = frand(0, 2 * M_PI);
             float z = GetCaster()->GetPositionZ() + frand(2.0f, 5.0f);
-            float safeDistance = RaycastToObstacle(GetCaster(), o, z, 10.0f); // try caster, not target
+            float safeDistance = RaycastToObstacle(GetCaster(), o, z, 10.0f);
             float actualDistance = std::min(8.0f, safeDistance * 0.8f);
 
             pos.Relocate(


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
This PR implements raycasting functionality to prevent Singularity from throwing players through walls in the Entropius encounter. The method checks for obstacles by incrementally testing line-of-sight along a vector, returning the distance to the first collision.
~~While initially implemented for the black hole effect, this functionality could benefit many other game mechanics (knockbacks, teleports, placement checks). Exposing it as an API would allow future developers to avoid wall clipping issues without duplicating code.
The challenge is determining appropriate placement - Unit.cpp maybe since it leverages IsWithinLOS, but it's pretty bloated already~~

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/21924

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .go c id 25741
2. dmg to 2nd phase
3. Check to see if singularity throws through wall

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] It might be better to have RaycastToObstacle available. Not sure where??
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
