### PR TITLE
fix(Battlefield/WG): set default maxplayer 120, minlevel 75

### DIFF
--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -3443,7 +3443,7 @@ Wintergrasp.PlayerMax = 120
 
 #
 #     Wintergrasp.PlayerMin
-#         Description: Minimum number of players required for Wintergrasp.
+#         Description: Minimum number of players required for Wintergrasp per team.
 #         Default:     0
 
 Wintergrasp.PlayerMin = 0

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -3436,10 +3436,10 @@ Wintergrasp.Enable = 1
 
 #
 #     Wintergrasp.PlayerMax
-#         Description: Maximum number of players allowed in Wintergrasp.
-#         Default:     240
+#         Description: Maximum number of players allowed in Wintergrasp per team.
+#         Default:     120
 
-Wintergrasp.PlayerMax = 240
+Wintergrasp.PlayerMax = 120
 
 #
 #     Wintergrasp.PlayerMin

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -3437,9 +3437,9 @@ Wintergrasp.Enable = 1
 #
 #     Wintergrasp.PlayerMax
 #         Description: Maximum number of players allowed in Wintergrasp.
-#         Default:     100
+#         Default:     240
 
-Wintergrasp.PlayerMax = 100
+Wintergrasp.PlayerMax = 240
 
 #
 #     Wintergrasp.PlayerMin
@@ -3451,9 +3451,9 @@ Wintergrasp.PlayerMin = 0
 #
 #     Wintergrasp.PlayerMinLvl
 #         Description: Required character level for the Wintergrasp battle.
-#         Default:     77
+#         Default:     75
 
-Wintergrasp.PlayerMinLvl = 77
+Wintergrasp.PlayerMinLvl = 75
 
 #
 #     Wintergrasp.BattleTimer

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -384,7 +384,7 @@ protected:
     uint32 m_MapId;                                         // MapId where is Battlefield
     Map* m_Map;
     uint32 m_MaxPlayer;                                     // Maximum number of players per team that participated to Battlefield
-    uint32 m_MinPlayer;                                     // Minimum number of player per team for Battlefield start
+    uint32 m_MinPlayer;                                     // Minimum number of players per team for Battlefield start
     uint32 m_MinLevel;                                      // Required level to participate at Battlefield
     uint32 m_BattleTime;                                    // Length of a battle
     uint32 m_NoWarBattleTime;                               // Time between two battles

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -383,8 +383,8 @@ protected:
     uint32 m_ZoneId;                                        // ZoneID of Wintergrasp = 4197
     uint32 m_MapId;                                         // MapId where is Battlefield
     Map* m_Map;
-    uint32 m_MaxPlayer;                                     // Maximum number of player that participated to Battlefield
-    uint32 m_MinPlayer;                                     // Minimum number of player for Battlefield start
+    uint32 m_MaxPlayer;                                     // Maximum number of players per team that participated to Battlefield
+    uint32 m_MinPlayer;                                     // Minimum number of player per team for Battlefield start
     uint32 m_MinLevel;                                      // Required level to participate at Battlefield
     uint32 m_BattleTime;                                    // Length of a battle
     uint32 m_NoWarBattleTime;                               // Time between two battles

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1167,7 +1167,7 @@ void World::LoadConfigSettings(bool reload)
 
     // Wintergrasp
     _int_configs[CONFIG_WINTERGRASP_ENABLE]              = sConfigMgr->GetOption<int32>("Wintergrasp.Enable", 1);
-    _int_configs[CONFIG_WINTERGRASP_PLR_MAX]             = sConfigMgr->GetOption<int32>("Wintergrasp.PlayerMax", 240);
+    _int_configs[CONFIG_WINTERGRASP_PLR_MAX]             = sConfigMgr->GetOption<int32>("Wintergrasp.PlayerMax", 120);
     _int_configs[CONFIG_WINTERGRASP_PLR_MIN]             = sConfigMgr->GetOption<int32>("Wintergrasp.PlayerMin", 0);
     _int_configs[CONFIG_WINTERGRASP_PLR_MIN_LVL]         = sConfigMgr->GetOption<int32>("Wintergrasp.PlayerMinLvl", 75);
     _int_configs[CONFIG_WINTERGRASP_BATTLETIME]          = sConfigMgr->GetOption<int32>("Wintergrasp.BattleTimer", 30);

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1167,9 +1167,9 @@ void World::LoadConfigSettings(bool reload)
 
     // Wintergrasp
     _int_configs[CONFIG_WINTERGRASP_ENABLE]              = sConfigMgr->GetOption<int32>("Wintergrasp.Enable", 1);
-    _int_configs[CONFIG_WINTERGRASP_PLR_MAX]             = sConfigMgr->GetOption<int32>("Wintergrasp.PlayerMax", 100);
+    _int_configs[CONFIG_WINTERGRASP_PLR_MAX]             = sConfigMgr->GetOption<int32>("Wintergrasp.PlayerMax", 240);
     _int_configs[CONFIG_WINTERGRASP_PLR_MIN]             = sConfigMgr->GetOption<int32>("Wintergrasp.PlayerMin", 0);
-    _int_configs[CONFIG_WINTERGRASP_PLR_MIN_LVL]         = sConfigMgr->GetOption<int32>("Wintergrasp.PlayerMinLvl", 77);
+    _int_configs[CONFIG_WINTERGRASP_PLR_MIN_LVL]         = sConfigMgr->GetOption<int32>("Wintergrasp.PlayerMinLvl", 75);
     _int_configs[CONFIG_WINTERGRASP_BATTLETIME]          = sConfigMgr->GetOption<int32>("Wintergrasp.BattleTimer", 30);
     _int_configs[CONFIG_WINTERGRASP_NOBATTLETIME]        = sConfigMgr->GetOption<int32>("Wintergrasp.NoBattleTimer", 150);
     _int_configs[CONFIG_WINTERGRASP_RESTART_AFTER_CRASH] = sConfigMgr->GetOption<int32>("Wintergrasp.CrashRestartTimer", 10);


### PR DESCRIPTION
WG minor edit: more Blizz-like for 3.3.5a.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Changed default values for
```
Wintergrasp.PlayerMax = 100
Wintergrasp.PlayerMinLvl = 77
```
to
```
Wintergrasp.PlayerMax = 240
Wintergrasp.PlayerMinLvl = 75
```

## Issues Addressed:
Default settings were not Blizz-like.

## SOURCE:
As of 3.2.0 and into 3.3.5a, this was the minimum queue level and maximum number of players in WG. [Patch notes.](https://wowpedia.fandom.com/wiki/Wintergrasp#Patch_changes)

> - Level 75 is required to queue
> - The queue will accept up to 120 players from each faction, resulting in a maximum battle of 240 players at a time.

The non-Blizz-like 77/100 settings were [copied from TrinityCore](https://github.com/TrinityCore/TrinityCore/blob/master/src/server/worldserver/worldserver.conf.dist). There they had not been changed ever since they were first added in [August 2012](https://github.com/TrinityCore/TrinityCore/commit/d22c82332bd01921889dff9a3aa583ae32368e41).

The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
1. Players at level 75, should now be able to queue for Wintergrasp.
2. Queue up to 240 players in Wintergrasp, server should now allow it.

## Known Issues and TODO List:
None.
