### PR TITLE
fix(Core/worldserver.conf) Clarification for AllowTwoSide.Interaction.Auction

### DIFF
--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -4207,7 +4207,8 @@ AllowTwoSide.Interaction.Arena = 0
 
 #
 #    AllowTwoSide.Interaction.Auction
-#        Description: Allow auctions between factions.
+#        Description: Allow auctions between factions. This flags all auction houses as Neutral,
+#                     and would also take a Neutral auction house cut from auctions.
 #        Default:     0 - (Disabled)
 #                     1 - (Enabled)
 


### PR DESCRIPTION
Just a small edit to help users understand how this setting works, and there will be a different AH cut if it is used. 

Changes
```
#        AllowTwoSide.Interaction.Auction
#        Description: Allow auctions between factions.
```
to
```
#        AllowTwoSide.Interaction.Auction
#        Description: Allow auctions between factions. This flags all auction houses as Neutral,
#                            and would also take a Neutral auction house cut from auctions.
```