### PR TITLE
refactor(Scripts/BlackTemple) remove tanks from Fatal Attraction after setting the target amount

### DIFF
--- a/src/server/scripts/Outland/BlackTemple/boss_mother_shahraz.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_mother_shahraz.cpp
@@ -102,11 +102,7 @@ struct boss_mother_shahraz : public BossAI
 
         ScheduleTimedEvent(50s, [&] {
             Talk(SAY_SPELL);
-            // weights for 1, 2, or 3 targets
-            static double chances[] = {5.0, 15.0, 80.0};
-            uint32 selectedIndex = urandweighted(3, chances);
-            uint32 numTargets = selectedIndex + 1;
-            me->CastCustomSpell(SPELL_FATAL_ATTRACTION, SPELLVALUE_MAX_TARGETS, numTargets, me, false);
+            DoCast(SPELL_FATAL_ATTRACTION);
         }, 1min);
 
         me->m_Events.AddEventAtOffset([&] {
@@ -298,6 +294,7 @@ class spell_mother_shahraz_fatal_attraction : public SpellScript
 
     void FilterTargets(std::list<WorldObject*>& targets)
     {
+        Acore::Containers::RandomResize(targets, 3);
         targets.remove_if(Acore::UnitAuraCheck(true, SPELL_SABER_LASH_IMMUNITY));
     }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

In similar veins as with https://github.com/azerothcore/azerothcore-wotlk/pull/22014

It feels more natural that Fatal Attraction teleporting less than 3 targets is somewhat unintentional on blizzards side, rather them deciding on some values to teleport less (or even 1 target, which makes the whole spell a non-issue for the raid)

This means the chances in a regular raid environment with 3 tanks are: 
3 targets: (22/25) x (21/24) x (20/23) = ~67%
2 targets: 3x (22/25) x (21/24) x (3/23) = ~30%
1 target: 3x (22/25) x (3/24) x (2/23) = ~2.7%
0 targets: (3/25) x (2/24) x (1/23) = ~0.04%

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

assemble 4+ characters
.go c id 22947

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
