### PR TITLE
refactor(DB): Consolidate worldstate tables.

### DIFF
--- a/data/sql/updates/db_characters/worldstate-table-sync.sql
+++ b/data/sql/updates/db_characters/worldstate-table-sync.sql
@@ -1,0 +1,3 @@
+INSERT INTO `worldstates` (`entry`, `value`) SELECT `ID`, `Data` FROM `world_state`;
+
+DROP TABLE IF EXISTS `world_state`;

--- a/src/server/game/World/WorldState.cpp
+++ b/src/server/game/World/WorldState.cpp
@@ -112,8 +112,8 @@ void WorldState::Save(WorldStateSaveIds saveId)
 
 void WorldState::SaveHelper(std::string& stringToSave, WorldStateSaveIds saveId)
 {
-    CharacterDatabase.Execute("DELETE FROM world_state WHERE Id='{}'", saveId);
-    CharacterDatabase.Execute("INSERT INTO world_state(Id,Data) VALUES('{}','{}')", saveId, stringToSave.data());
+    CharacterDatabase.Execute("DELETE FROM worldstates WHERE entry='{}'", saveId);
+    CharacterDatabase.Execute("INSERT INTO worldstates(entry,value) VALUES('{}','{}')", saveId, stringToSave.data());
 }
 
 bool WorldState::IsConditionFulfilled(WorldStateCondition conditionId, WorldStateConditionState state) const


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).
-  [X] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/21874

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR:
- [X] Has not been tested.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- [ ] Should probably add comments denoting what these worldstate values are when looking at them from the DB.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
