### PR TITLE
fix(DB/SpellProcEvent): Allow Hamstring, Rend, Sunder Armor to proc Sword Spec

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1746262733742509979.sql
+++ b/data/sql/updates/pending_db_world/rev_1746262733742509979.sql
@@ -1,3 +1,3 @@
 --
 -- Hamstring 0x0002, Rend 0x0020, Sunder Armor 0x4000
-UPDATE `spell_proc_event` SET `SpellFamilyMask0`=`SpellFamilyMask0` | (0x0002 | 0x0020 | 0x4000) WHERE entry=-12281;
+UPDATE `spell_proc_event` SET `SpellFamilyMask0`=`SpellFamilyMask0` | (0x0002 | 0x0020 | 0x4000) WHERE `entry`=-12281;

--- a/data/sql/updates/pending_db_world/rev_1746262733742509979.sql
+++ b/data/sql/updates/pending_db_world/rev_1746262733742509979.sql
@@ -1,0 +1,3 @@
+--
+-- Hamstring 0x0002, Rend 0x0020, Sunder Armor 0x4000
+UPDATE `spell_proc_event` SET `SpellFamilyMask0`=`SpellFamilyMask0` | (0x0002 | 0x0020 | 0x4000) WHERE entry=-12281;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Set family flags so that the below no longer fails

- https://github.com/azerothcore/azerothcore-wotlk/blob/338acf7c415de061554a653cd2e1eb775937b224/src/server/game/Spells/SpellMgr.cpp#L825


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/20250

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

<details><summary>Existing familymask via SpellWork
</summary>


![SPELLFAMILY_WARRIOR_sword_spec_proc](https://github.com/user-attachments/assets/993d7ce1-707f-4b14-bc4a-5e5873ef45c7)


</details>


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

70 Warrior with sword spec talent

custom change to set proc chance to 100
```
UPDATE spell_proc_event SET CustomChance=100.0 WHERE entry=-12281;
```

```
/stopattack
/cast hamstring
/stopattack
```

1. Attack dummy
2.
3.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.



## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] 
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
