### PR TITLE
fix(Scripts/Spells): re-add startDelay for some traps

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -5116,6 +5116,17 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Attributes |= SPELL_ATTR0_ALLOW_ITEM_SPELL_IN_PVP;
     });
 
+    ApplySpellFix({
+        43444, // Explosive Trap (Hex Lord Malacrass)
+        43447, // Freezing Trap (Hex Lord Malacrass)
+        43449, // Snake Trap (Hex Lord Malacrass)
+        45236, // Blaze
+        50745  // Blaze
+        }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_SUMMON_OBJECT_SLOT1;
+    });
+
     for (uint32 i = 0; i < GetSpellInfoStoreSize(); ++i)
     {
         SpellInfo* spellInfo = mSpellInfoMap[i];


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

There exist a few spells that summon Traps with a startDelay as [Wild, without an owner.](https://github.com/azerothcore/azerothcore-wotlk/blob/8591e9f825d9c9eb0b38fcf7e82aed387a24525e/src/server/game/Spells/SpellEffects.cpp#L3778) The core[ requires an owner set](https://github.com/azerothcore/azerothcore-wotlk/blob/8591e9f825d9c9eb0b38fcf7e82aed387a24525e/src/server/game/Entities/GameObject/GameObject.cpp#L502), so let's hack these spells to use `Spell::EffectSummonObject` [where their owner is set](https://github.com/azerothcore/azerothcore-wotlk/blob/3f527c54e35d48aa962c3ef3054687c754be1050/src/server/game/Spells/SpellEffects.cpp#L4637).

Spells are used by TBC bosses Hex Lord Malacrass and Eredar Twins

|    |   entry |   type (Trap) | name           |   Data7 (startDelay) |   spellId |
|----|---------|--------|----------------|---------|-----------|
|  0 |  186668 |      6 | Explosive Trap |       5 |     43444 |
|  1 |  186669 |      6 | Freezing Trap  |       5 |     43447 |
|  2 |  186670 |      6 | Snake Trap     |       5 |     43449 |
|  3 |  187366 |      6 | Blaze          |       1 |     45236 |
|  4 |  190402 |      6 | Blaze          |       1 |     50745 |

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/22016

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Hex Lord Malacrass as a Hunter
```
.go c id 24239
```
Eredar Twins
```
.go c id 25165
```

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
