### PR TITLE
fix(DB/Quest) - "Fine Gold Thread" is now repeatable

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1747574437797050200.sql
+++ b/data/sql/updates/pending_db_world/rev_1747574437797050200.sql
@@ -1,0 +1,2 @@
+-- Sets SpecialFlags from 0 to 1, allowing Fine Gold Thread to be repeatable.
+UPDATE `quest_template_addon` SET `SpecialFlags` = 1 WHERE (`ID` = 4785);

--- a/data/sql/updates/pending_db_world/rev_1747574437797050200.sql
+++ b/data/sql/updates/pending_db_world/rev_1747574437797050200.sql
@@ -1,2 +1,2 @@
 -- Sets SpecialFlags from 0 to 1, allowing Fine Gold Thread to be repeatable.
-UPDATE `quest_template_addon` SET `SpecialFlags` = 1 WHERE (`ID` = 4785);
+UPDATE `quest_template_addon` SET `SpecialFlags` = `SpecialFlags` | 1 WHERE (`ID` = 4785);


### PR DESCRIPTION
Sets SpecialFlags from 0 to 1, allowing Fine Gold Thread to be repeatable.

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/8047

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Source: https://www.wowhead.com/wotlk/quest=4785/fine-gold-thread ( thanks @amed80 )

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

- Make a warlock
- `.level 32`
- `quest add 4783` // Components for the Enchanted Gold Bloodrobe (4/5)
- `quest complete 4783` // Components for the Enchanted Gold Bloodrobe (4/5)
- `quest reward 4783` // Components for the Enchanted Gold Bloodrobe (4/5)
- `quest add 4785` // Fine Gold Thread
- `quest complete 4785` // Fine Gold Thread
- `quest reward 4785` // Fine Gold Thread
- `go c i 2670` // Xizk Goodstitch 
- Interact `Xizk Goodstitch` has a repetable quest, delete your `Fine Gold Thread` and see you can pick it again

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
