### PR TITLE
fix(DB/areatrigger_teleport) - Multiple updated areatriggers.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1748021905087919900.sql
+++ b/data/sql/updates/pending_db_world/rev_1748021905087919900.sql
@@ -17,7 +17,20 @@ UPDATE `areatrigger_teleport` SET `Name` = "Blackrock Spire Entrance", `target_p
 UPDATE `areatrigger_teleport` SET `Name` = "Maraudon, The Wicked Grotto [Purple Wing] (Exit)" WHERE `ID` = 3126;
 UPDATE `areatrigger_teleport` SET `Name` = "Maraudon, Foulspore Cavern [Orange Wing] (Exit)" WHERE `ID` = 3131;
 
-UPDATE `areatrigger_teleport` SET `Name` = "Maraudon (Inside) - Purple Wing: The Wicked Grotto" WHERE `ID` = 3134;
-UPDATE `areatrigger_teleport` SET `Name` = "Maraudon (Inside) - Orange Wing: Foulspore Cavern" WHERE `ID` = 3133;
+UPDATE `areatrigger_teleport` SET `Name` = "Maraudon, The Wicked Grotto [Purple Wing] (Entrance)" WHERE `ID` = 3134;
+UPDATE `areatrigger_teleport` SET `Name` = "Maraudon, Foulspore Cavern [Orange Wing] (Entrance)" WHERE `ID` = 3133;
 
 -- Dire Maul
+UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, West Wing [South] (Exit)" WHERE `ID` = 3190;
+UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, West Wing [North](Exit)" WHERE `ID` = 3191;
+UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, North Wing (Exit)" WHERE `ID` = 3193;
+UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, East Wing [West] (Exit)" WHERE `ID` = 3194;
+UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, East Wing [South] (Exit)" WHERE `ID` = 3195;
+UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, East Wing [East] (Exit)" WHERE `ID` = 3196;
+UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, Alzzin the Wildshaper's broken wall [1-Way] (Exit)" WHERE `ID` = 3197;
+UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, East Wing [West] (Entrance)" WHERE `ID` = 3183;
+UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, East Wing [South] (Entrance)" WHERE `ID` = 3184;
+UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, East Wing [East] (Entrance)" WHERE `ID` = 3185;
+UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, West Wing [South] (Entrance)" WHERE `ID` = 3186;
+UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, West Wing [North] (Entrance)" WHERE `ID` = 3187;
+UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, North Wing (Entrance)" WHERE `ID` = 3189;

--- a/data/sql/updates/pending_db_world/rev_1748021905087919900.sql
+++ b/data/sql/updates/pending_db_world/rev_1748021905087919900.sql
@@ -33,3 +33,14 @@ UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, East Wing [East] (Entranc
 UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, West Wing [South] (Entrance)" WHERE `ID` = 3186;
 UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, West Wing [North] (Entrance)" WHERE `ID` = 3187;
 UPDATE `areatrigger_teleport` SET `Name` = "Dire Maul, North Wing (Entrance)" WHERE `ID` = 3189;
+
+-- Naxxramas
+UPDATE `areatrigger_teleport` SET `Name` = "Naxxramas, East (Entrance)" WHERE `ID` = 5191;
+UPDATE `areatrigger_teleport` SET `Name` = "Naxxramas, North (Entrance)" WHERE `ID` = 5192;
+UPDATE `areatrigger_teleport` SET `Name` = "Naxxramas, West (Entrance)" WHERE `ID` = 5193;
+UPDATE `areatrigger_teleport` SET `Name` = "Naxxramas, South (Entrance)" WHERE `ID` = 5194;
+
+UPDATE `areatrigger_teleport` SET `Name` = "Naxxramas, North-East (Exit)" WHERE `ID` = 5196;
+UPDATE `areatrigger_teleport` SET `Name` = "Naxxramas, North-West (Exit)" WHERE `ID` = 5197;
+UPDATE `areatrigger_teleport` SET `Name` = "Naxxramas, South-East (Exit)" WHERE `ID` = 5198;
+UPDATE `areatrigger_teleport` SET `Name` = "Naxxramas, South-West (Exit)" WHERE `ID` = 5199;

--- a/data/sql/updates/pending_db_world/rev_1748021905087919900.sql
+++ b/data/sql/updates/pending_db_world/rev_1748021905087919900.sql
@@ -13,7 +13,7 @@ UPDATE `areatrigger_teleport` SET `Name` = "Blackrock Spire, Exit (from inside o
 -- Blackrock Spire - Searing Gorge Instance
 UPDATE `areatrigger_teleport` SET `Name` = "Blackrock Spire Entrance", `target_position_x` = -7524.65, `target_position_y` = -1229.13, `target_position_z` = 285.731, `target_orientation` = 2.0943952 WHERE `ID` = 1470;
 
--- Maraudon 
+-- Maraudon
 UPDATE `areatrigger_teleport` SET `Name` = "Maraudon, The Wicked Grotto [Purple Wing] (Exit)" WHERE `ID` = 3126;
 UPDATE `areatrigger_teleport` SET `Name` = "Maraudon, Foulspore Cavern [Orange Wing] (Exit)" WHERE `ID` = 3131;
 UPDATE `areatrigger_teleport` SET `Name` = "Maraudon, The Wicked Grotto [Purple Wing] (Entrance)" WHERE `ID` = 3134;

--- a/data/sql/updates/pending_db_world/rev_1748021905087919900.sql
+++ b/data/sql/updates/pending_db_world/rev_1748021905087919900.sql
@@ -1,0 +1,23 @@
+-- Blackrock Mountain - Searing Gorge Instance?
+UPDATE `areatrigger_teleport` SET `Name` = "Blackrock Depths Entrance", `target_position_x` = 456.929, `target_position_y` = 34.0923, `target_position_z` = -68.0896, `target_orientation` = 4.712389 WHERE `ID` = 1466;
+
+-- The Molten Bridge | The Molten Core Window Entrance | The Molten Core Window(Lava) Entrance
+UPDATE `areatrigger_teleport` SET `target_position_x` = 1091.89, `target_position_y` = -466.985, `target_position_z` = -105.084, `target_orientation` = 3.1415927 WHERE `ID` IN (2886, 3528, 3529);
+
+-- Molten Core Entrance, Inside
+UPDATE `areatrigger_teleport` SET `Name` = "The Molten Core, Exit (from inside of the Instance)", `target_position_x` = -7508.32, `target_position_y` = -1039.74, `target_position_z` = 180.912, `target_orientation` = 3.8397243 WHERE `ID` = 2890;
+
+-- Blackrock Spire, Unknown
+UPDATE `areatrigger_teleport` SET `Name` = "Blackrock Spire, Exit (from inside of Blackwing Lair Instance)" WHERE `ID` = 3728;
+
+-- Blackrock Spire - Searing Gorge Instance
+UPDATE `areatrigger_teleport` SET `Name` = "Blackrock Spire Entrance", `target_position_x` = -7524.65, `target_position_y` = -1229.13, `target_position_z` = 285.731, `target_orientation` = 2.0943952 WHERE `ID` = 1470;
+
+-- Maraudon 
+UPDATE `areatrigger_teleport` SET `Name` = "Maraudon, The Wicked Grotto [Purple Wing] (Exit)" WHERE `ID` = 3126;
+UPDATE `areatrigger_teleport` SET `Name` = "Maraudon, Foulspore Cavern [Orange Wing] (Exit)" WHERE `ID` = 3131;
+
+UPDATE `areatrigger_teleport` SET `Name` = "Maraudon (Inside) - Purple Wing: The Wicked Grotto" WHERE `ID` = 3134;
+UPDATE `areatrigger_teleport` SET `Name` = "Maraudon (Inside) - Orange Wing: Foulspore Cavern" WHERE `ID` = 3133;
+
+-- Dire Maul

--- a/data/sql/updates/pending_db_world/rev_1748021905087919900.sql
+++ b/data/sql/updates/pending_db_world/rev_1748021905087919900.sql
@@ -16,7 +16,6 @@ UPDATE `areatrigger_teleport` SET `Name` = "Blackrock Spire Entrance", `target_p
 -- Maraudon 
 UPDATE `areatrigger_teleport` SET `Name` = "Maraudon, The Wicked Grotto [Purple Wing] (Exit)" WHERE `ID` = 3126;
 UPDATE `areatrigger_teleport` SET `Name` = "Maraudon, Foulspore Cavern [Orange Wing] (Exit)" WHERE `ID` = 3131;
-
 UPDATE `areatrigger_teleport` SET `Name` = "Maraudon, The Wicked Grotto [Purple Wing] (Entrance)" WHERE `ID` = 3134;
 UPDATE `areatrigger_teleport` SET `Name` = "Maraudon, Foulspore Cavern [Orange Wing] (Entrance)" WHERE `ID` = 3133;
 


### PR DESCRIPTION
Blackrock Moutain `areatrigger_teleport` had their instances (in and out) updated to match the sniffed values.

Sniff data (related to each cords) can bee seen [here](https://gist.github.com/TheSCREWEDSoftware/5da1e8dcdc3dcbf69727528d6b410bb9) was sniffed on retail (`11.1.5.60822`) and the cords updates for cata+ instances can be ignored. Ignore the `Facing` value of the queries as TrinityCore handles orientation differently. look for this as an example:

```
Map: 409 (Molten Core)
Position: X: 1091.89 Y: -466.985 Z: -105.084 O: 3.1415927
```

Many area triggers had the names changed to properly describe what they are related, the biggest change would be `maraudon` and `dire maul`. Using most recent examples (for wotlk areatriggers in the db) 

The place you get teleported (from an instance to outside) it's an `exit` if you got teleported into an instance its an `entrance`.

Maraudon has their wing by name and colour and dire maul has their name based on wing and map orientation.

For dire maul East wing has 3 possible spawns (west, south or east) is what it means

also added for naxxramas 4 entrances exists 

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Teleport to each following instances `Molten Core`, `Blackrock Depths` and`Blackrock Spire` and go in and out of instance portal. Note that existing moltencore will always take you out to `Lothos Riftwaker`.



## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
