### PR TITLE
fix(Scripts/ScarletEnclave): Devour Humanoid castable without target …

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1748106287021534300.sql
+++ b/data/sql/updates/pending_db_world/rev_1748106287021534300.sql
@@ -9,3 +9,6 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (29103, 0, 1, 0, 24, 1, 100, 0, 52196, 1, 1000, 2000, 0, 0, 11, 53348, 0, 0, 1, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Tirisfal Crusader - On Target Buffed With \'Frostbrood Vanquisher\' - Cast \'Arrow Assault\' (Phase 1)'),
 (29103, 0, 2, 0, 9, 1, 100, 0, 2000, 4000, 4000, 6000, 40, 150, 11, 53345, 64, 0, 1, 0, 0, 9, 0, 40, 150, 0, 0, 0, 0, 0, 'Tirisfal Crusader - Within 40-150 Range - Cast \'Arrow Assault\' (Phase 1)'),
 (29103, 0, 3, 0, 8, 0, 100, 0, 53110, 0, 0, 0, 0, 0, 22, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Tirisfal Crusader - On Spellhit \'Devour Humanoid\' - Set Event Phase 2');
+
+DELETE FROM `spell_script_names` WHERE `spell_id`=53111 AND `ScriptName`='spell_q12779_an_end_to_all_things_devour_aura';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (53111, 'spell_q12779_an_end_to_all_things_devour_aura');

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -3679,13 +3679,6 @@ void AuraEffect::HandleAuraControlVehicle(AuraApplication const* aurApp, uint8 m
     }
     else
     {
-        if (GetId() == 53111) // Devour Humanoid
-        {
-            Unit::Kill(target, caster);
-            if (caster->IsCreature())
-                caster->ToCreature()->RemoveCorpse();
-        }
-
         caster->_ExitVehicle();
         // some SPELL_AURA_CONTROL_VEHICLE auras have a dummy effect on the player - remove them
         caster->RemoveAurasDueToSpell(GetId());

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter3.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter3.cpp
@@ -17,6 +17,7 @@
 
 #include "CreatureScript.h"
 #include "ScriptedCreature.h"
+#include "SpellAuras.h"
 #include "SpellInfo.h"
 #include "SpellScript.h"
 #include "SpellScriptLoader.h"
@@ -58,7 +59,33 @@ class spell_q12779_an_end_to_all_things : public SpellScript
     }
 };
 
+// 53111 - Devour Humanoid (casted by the devoured creature)
+class spell_q12779_an_end_to_all_things_devour_aura : public AuraScript
+{
+    PrepareAuraScript(spell_q12779_an_end_to_all_things_devour_aura);
+
+    void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* caster = GetCaster();
+        Unit* target = GetTarget();
+        if (!caster || !target)
+            return;
+
+        if (GetTargetApplication()->GetRemoveMode() == AURA_REMOVE_BY_EXPIRE)
+        {
+            caster->SetDisableGravity(true);
+            Unit::Kill(target, caster);
+        }
+    }
+
+    void Register() override
+    {
+        AfterEffectRemove += AuraEffectRemoveFn(spell_q12779_an_end_to_all_things_devour_aura::OnRemove, EFFECT_0, SPELL_AURA_CONTROL_VEHICLE, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
 void AddSC_the_scarlet_enclave_c3()
 {
     RegisterSpellScript(spell_q12779_an_end_to_all_things);
+    RegisterSpellScript(spell_q12779_an_end_to_all_things_devour_aura);
 }


### PR DESCRIPTION
…and targets evading while being consumed

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/22188

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

.q add 12779
.go q starter 12779
.npc add temp 29102/29103
use item, consume
try consuming outside of the 15y spell range, shouldn't work

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
