### PR TITLE
fix(Core/Spells): weapon damage based magic abilities gain too much effect from spell aura % damage increase

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13194,8 +13194,7 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
             if (!spellProto || (spellProto->ValidateAttribute6SpellDamageMods(this, *i, false) &&
                 sScriptMgr->IsNeedModMeleeDamagePercent(this, *i, DoneTotalMod, spellProto)))
             {
-                int32 bonusSchoolMask = (*i)->GetMiscValue();
-                if (!(bonusSchoolMask & SPELL_SCHOOL_MASK_NORMAL) && (bonusSchoolMask & damageSchoolMask))
+                if (((*i)->GetMiscValue() & damageSchoolMask))
                 {
                     if ((*i)->GetSpellInfo()->EquippedItemClass == -1)
                         AddPct(DoneTotalMod, (*i)->GetAmount());

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13194,7 +13194,8 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
             if (!spellProto || (spellProto->ValidateAttribute6SpellDamageMods(this, *i, false) &&
                 sScriptMgr->IsNeedModMeleeDamagePercent(this, *i, DoneTotalMod, spellProto)))
             {
-                if (((*i)->GetMiscValue() & damageSchoolMask))
+                int32 bonusSchoolMask = (*i)->GetMiscValue();
+                if (!(bonusSchoolMask & SPELL_SCHOOL_MASK_NORMAL) && (bonusSchoolMask & damageSchoolMask))
                 {
                     if ((*i)->GetSpellInfo()->EquippedItemClass == -1)
                         AddPct(DoneTotalMod, (*i)->GetAmount());

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3581,30 +3581,26 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
         }
     }
 
-    // apply to non-weapon bonus weapon total pct effect, weapon total flat effect included in weapon damage
-    if (fixed_bonus || spell_bonus)
+    bool const isPhysical = (m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL);
+    if (isPhysical && (fixed_bonus || spell_bonus))
     {
         UnitMods unitMod;
         switch (m_attackType)
         {
-            default:
-            case BASE_ATTACK:
-                unitMod = UNIT_MOD_DAMAGE_MAINHAND;
-                break;
-            case OFF_ATTACK:
-                unitMod = UNIT_MOD_DAMAGE_OFFHAND;
-                break;
-            case RANGED_ATTACK:
-                unitMod = UNIT_MOD_DAMAGE_RANGED;
-                break;
+        default:
+        case BASE_ATTACK:
+            unitMod = UNIT_MOD_DAMAGE_MAINHAND;
+            break;
+        case OFF_ATTACK:
+            unitMod = UNIT_MOD_DAMAGE_OFFHAND;
+            break;
+        case RANGED_ATTACK:
+            unitMod = UNIT_MOD_DAMAGE_RANGED;
+            break;
         }
-
-        if (m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL)
-        {
-            float weapon_total_pct = m_caster->GetModifierValue(unitMod, TOTAL_PCT);
-            fixed_bonus = int32(fixed_bonus * weapon_total_pct);
-            spell_bonus = int32(spell_bonus * weapon_total_pct);
-        }
+        float weapon_total_pct = m_caster->GetModifierValue(unitMod, TOTAL_PCT);
+        fixed_bonus = int32(fixed_bonus * weapon_total_pct);
+        spell_bonus = int32(spell_bonus * weapon_total_pct);
     }
 
     int32 weaponDamage = 0;
@@ -3612,15 +3608,11 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
     if (m_caster->GetEntry() == 27893)
     {
         if (Unit* owner = m_caster->GetOwner())
-            weaponDamage = owner->CalculateDamage(m_attackType, normalized, true);
-    }
-    else if (m_spellInfo->Id == 5019) // Wands
-    {
-        weaponDamage = m_caster->CalculateDamage(m_attackType, true, false);
+            weaponDamage = owner->CalculateDamage(m_attackType, normalized, isPhysical);
     }
     else
     {
-        weaponDamage = m_caster->CalculateDamage(m_attackType, normalized, true);
+        weaponDamage = m_caster->CalculateDamage(m_attackType, normalized, isPhysical);
     }
 
     // Sequence is important

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3620,7 +3620,12 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
     }
     else
     {
-        weaponDamage = m_caster->CalculateDamage(m_attackType, normalized, true);
+        //Abilities that deal magic damage based on weapon percent damage interact with percent damage modifiers incorrectly in CalculateDamage()
+        //This is the lowest risk way to fix this bug, but if someone who understands CalculateDamage() very well wants to see why this happens that would be better
+        bool isPhysical = true;
+        if (const SpellInfo* spellInfo = GetSpellInfo())
+            isPhysical = spellInfo->GetSchoolMask() == SpellSchoolMask::SPELL_SCHOOL_MASK_NORMAL;
+        weaponDamage = m_caster->CalculateDamage(m_attackType, normalized, isPhysical);
     }
 
     // Sequence is important

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3620,12 +3620,7 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
     }
     else
     {
-        //Abilities that deal magic damage based on weapon percent damage interact with percent damage modifiers incorrectly in CalculateDamage()
-        //This is the lowest risk way to fix this bug, but if someone who understands CalculateDamage() very well wants to see why this happens that would be better
-        bool isPhysical = true;
-        if (const SpellInfo* spellInfo = GetSpellInfo())
-            isPhysical = spellInfo->GetSchoolMask() == SpellSchoolMask::SPELL_SCHOOL_MASK_NORMAL;
-        weaponDamage = m_caster->CalculateDamage(m_attackType, normalized, isPhysical);
+        weaponDamage = m_caster->CalculateDamage(m_attackType, normalized, true);
     }
 
     // Sequence is important


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/22220

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

**Methodology**
List of SpellIds to use while testing this
49143 - Frost Strike (Magic damage based on both Weapon % damage and flat damage)
45902 - Blood Strike (Physical damage based on both Weapon % damage and flat damage)
45477 - Icy Touch (Magic damage dealing spell)
53209 - Chimera Shot (Magic damage based on Weapon % damage only)

48266 - Blood presence for damage buff

To test, get an average damage of a spell without the aura (for spells that have damage ranges). Write it down as X
Apply a % damage buff to yourself. Write it down as Y
Get an average damage of a spell with the aura active (for spells that have damage ranges). Write that down as Z

Z/X should equal very close to Y (within statistical variation)

For ease of testing you can optionally turn up the damage % buff on blood presence or make a custom spell with a really high value of aura name 79

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Without this change, go to a target dummy and use a magic weapon damage ability like Frost Strike, and a physical weapon damage ability like blood strike
2. Gain a aura name 79 Percent damage modifier (such as blood presence)
3. Cast those spells again and calculate how much extra damage was **actually** added to both spells from blood presence (Your physical spell will work as expected, the magic spell will gain way too much benefit)
4. With this change, repeat the above steps

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
