### PR TITLE
fix(DB/Creature): Remove extra Shaffar adds

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1748707579733807961.sql
+++ b/data/sql/updates/pending_db_world/rev_1748707579733807961.sql
@@ -1,0 +1,10 @@
+-- Link pre-spawned Ethereal Beacons to Nexus-Prince Shaffar so they respawn on reset
+SET @SHAFFAR_GUID := 91162;
+SET @AI_FLAGS := 1 | 2 | 8 | 16;
+
+DELETE FROM `creature_formations` WHERE `leaderGUID` = @SHAFFAR_GUID;
+INSERT INTO `creature_formations` (`leaderGUID`, `memberGUID`, `dist`, `angle`, `groupAI`, `point_1`, `point_2`) VALUES
+(@SHAFFAR_GUID, @SHAFFAR_GUID, 0, 0, @AI_FLAGS, 0, 0),
+(@SHAFFAR_GUID, 91131, 0, 0, @AI_FLAGS, 0, 0),
+(@SHAFFAR_GUID, 91132, 0, 0, @AI_FLAGS, 0, 0),
+(@SHAFFAR_GUID, 91133, 0, 0, @AI_FLAGS, 0, 0);

--- a/src/server/scripts/Outland/Auchindoun/ManaTombs/boss_nexusprince_shaffar.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ManaTombs/boss_nexusprince_shaffar.cpp
@@ -66,13 +66,7 @@ struct boss_nexusprince_shaffar : public BossAI
     void Reset() override
     {
         _Reset();
-        float dist = 8.0f;
-        float posX, posY, posZ, angle;
-        me->GetHomePosition(posX, posY, posZ, angle);
         summons.DespawnAll();
-        me->SummonCreature(NPC_BEACON, posX - dist, posY - dist, posZ, angle, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 7200000);
-        me->SummonCreature(NPC_BEACON, posX - dist, posY + dist, posZ, angle, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 7200000);
-        me->SummonCreature(NPC_BEACON, posX + dist, posY, posZ, angle, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 7200000);
     }
 
     void MoveInLineOfSight(Unit* who) override


### PR DESCRIPTION
Nexus-Prince Shaffar in Mana Tombs spawns his three Ethereal Beacons via a script. Together with the pre-spawned ones, the fight incorrectly starts with six Beacons instead.
Remove the pre-spawned ones to fix this.

TrinityCore fixed this issue a while ago:
https://github.com/TrinityCore/TrinityCore/issues/24325

Relates to AzerothCore issue #18895, but doesn't fix it completely (the damage numbers still seem way off).


## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

## Issues Addressed:
- Alleviates https://github.com/azerothcore/azerothcore-wotlk/issues/18895, but does not fix it completely.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [X] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found** (Not a cherry-pick, but an adaptation of [this TrinityCore change](https://github.com/TrinityCore/TrinityCore/commit/05aeb142a8af481163e9905e4a194765c10510fb))

## Tests Performed:
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
1. Enter Mana Tombs,
2. proceed to Nexus-Prince Shaffar,
3. observe that only three Ethereal Beacons are present.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
