### PR TITLE
fix(Core/Script/Deathknight) Lock Deathknights from the dungeonfinder until they complete their starting zone

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1748972350605073197.sql
+++ b/data/sql/updates/pending_db_world/rev_1748972350605073197.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `ScriptName` = 'npc_king_varian_wrynn' WHERE (`entry` = 29611);

--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -422,6 +422,8 @@ namespace lfg
                 lockData = LFG_LOCKSTATUS_TOO_HIGH_LEVEL;
             else if (dungeon->seasonal && !IsSeasonActive(dungeon->id))
                 lockData = LFG_LOCKSTATUS_NOT_IN_SEASON;
+            else if (player->IsClass(CLASS_DEATH_KNIGHT) && !(player->IsQuestRewarded(13188) || player->IsQuestRewarded(13189)))
+                lockData = LFG_LOCKSTATUS_QUEST_NOT_COMPLETED;
             else if (ar)
             {
                 // Check required items

--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -422,7 +422,7 @@ namespace lfg
                 lockData = LFG_LOCKSTATUS_TOO_HIGH_LEVEL;
             else if (dungeon->seasonal && !IsSeasonActive(dungeon->id))
                 lockData = LFG_LOCKSTATUS_NOT_IN_SEASON;
-            else if (player->IsClass(CLASS_DEATH_KNIGHT) && !(player->IsQuestRewarded(13188) || player->IsQuestRewarded(13189)))
+            else if (player->IsClass(CLASS_DEATH_KNIGHT) && !player->IsGameMaster() &&!(player->IsQuestRewarded(13188) || player->IsQuestRewarded(13189)))
                 lockData = LFG_LOCKSTATUS_QUEST_NOT_COMPLETED;
             else if (ar)
             {

--- a/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
@@ -472,7 +472,6 @@ public:
     }
 };
 
-
 enum KingVarianWrynn : uint32
 {
     // Deathknight Starting Zone End

--- a/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
@@ -472,6 +472,30 @@ public:
     }
 };
 
+
+enum KingVarianWrynn : uint32
+{
+    // Deathknight Starting Zone End
+    QUEST_WHERE_KINGS_WALK       = 13188,
+};
+
+class npc_king_varian_wrynn : public CreatureScript
+{
+public:
+    npc_king_varian_wrynn() : CreatureScript("npc_king_varian_wrynn") { }
+
+    bool OnQuestReward(Player* player, Creature* /*creature*/, Quest const* quest, uint32 /*item*/) override
+    {
+
+        if (quest->GetQuestId() == QUEST_WHERE_KINGS_WALK)
+        {
+            sLFGMgr->InitializeLockedDungeons(player);
+        }
+
+        return true;
+    }
+};
+
 void AddSC_stormwind_city()
 {
     new npc_tyrion();

--- a/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
@@ -501,4 +501,5 @@ void AddSC_stormwind_city()
     new npc_tyrion_spybot();
     new npc_lord_gregor_lescovar();
     new npc_marzon_silent_blade();
+    new npc_king_varian_wrynn();
 }

--- a/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
@@ -487,9 +487,7 @@ public:
     {
 
         if (quest->GetQuestId() == QUEST_WHERE_KINGS_WALK)
-        {
             sLFGMgr->InitializeLockedDungeons(player);
-        }
 
         return true;
     }

--- a/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
+++ b/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
@@ -214,9 +214,7 @@ public:
         {
             case (QUEST_FOR_THE_HORDE):
                 if (creature && creature->AI())
-                {
                     creature->AI()->DoAction(ACTION_START_TALKING);
-                }
                 break;
             case (QUEST_WARCHIEFS_BLESSING):
                 sLFGMgr->InitializeLockedDungeons(player);

--- a/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
+++ b/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
@@ -33,6 +33,7 @@ EndContentData */
 #include "ScriptedCreature.h"
 #include "ScriptedGossip.h"
 #include "TaskScheduler.h"
+#include "LFGMgr.h"
 
 /*######
 ## npc_shenthul
@@ -152,9 +153,12 @@ enum ThrallWarchief : uint32
     GO_UNADORNED_SPIKE             = 175787,
 
     // What the Wind Carries (ID: 6566)
-    QUEST_WHAT_THE_WIND_CARRIES     = 6566,
-    GOSSIP_MENU_THRALL              = 3664,
-    GOSSIP_RESPONSE_THRALL_FIRST    = 5733,
+    QUEST_WHAT_THE_WIND_CARRIES    = 6566,
+    GOSSIP_MENU_THRALL             = 3664,
+    GOSSIP_RESPONSE_THRALL_FIRST   = 5733,
+
+    // Deathknight Starting Zone End
+    QUEST_WARCHIEFS_BLESSING       = 13189,
 };
 
 const Position heraldOfThrallPos = { -462.404f, -2637.68f, 96.0656f, 5.8606f };
@@ -204,7 +208,7 @@ public:
         return true;
     }
 
-    bool OnQuestReward(Player* /*player*/, Creature* creature, Quest const* quest, uint32 /*item*/) override
+    bool OnQuestReward(Player* player, Creature* creature, Quest const* quest, uint32 /*item*/) override
     {
         if (quest->GetQuestId() == QUEST_FOR_THE_HORDE)
         {
@@ -212,6 +216,11 @@ public:
             {
                 creature->AI()->DoAction(ACTION_START_TALKING);
             }
+        }
+
+        if (quest->GetQuestId() == QUEST_WARCHIEFS_BLESSING)
+        {
+            sLFGMgr->InitializeLockedDungeons(player);
         }
 
         return true;

--- a/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
+++ b/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
@@ -210,17 +210,19 @@ public:
 
     bool OnQuestReward(Player* player, Creature* creature, Quest const* quest, uint32 /*item*/) override
     {
-        if (quest->GetQuestId() == QUEST_FOR_THE_HORDE)
+        switch (quest->GetQuestId())
         {
-            if (creature && creature->AI())
-            {
-                creature->AI()->DoAction(ACTION_START_TALKING);
-            }
-        }
-
-        if (quest->GetQuestId() == QUEST_WARCHIEFS_BLESSING)
-        {
-            sLFGMgr->InitializeLockedDungeons(player);
+            case (QUEST_FOR_THE_HORDE):
+                if (creature && creature->AI())
+                {
+                    creature->AI()->DoAction(ACTION_START_TALKING);
+                }
+                break;
+            case (QUEST_WARCHIEFS_BLESSING):
+                sLFGMgr->InitializeLockedDungeons(player);
+                break;
+            default:
+                break;
         }
 
         return true;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/22267

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.

![image](https://github.com/user-attachments/assets/a1addbf7-3d02-4fdb-be63-130454bf3b3c)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Create a Deathknight
See the dungeon finder locked
.gm on (so that you can leave the area)
Alliance:
.quest add 13188
.go c id 29611
Hand in the quest

Horde:
.quest add 13189
.go c id 4949
Hand in the quest

Queue dungeonfinder

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
