### PR TITLE
fix(Core/PlayerTaxi): prevent pop_front crash

### DIFF
--- a/src/server/game/Entities/Player/PlayerTaxi.h
+++ b/src/server/game/Entities/Player/PlayerTaxi.h
@@ -65,9 +65,10 @@ public:
     [[nodiscard]] uint32 GetCurrentTaxiPath() const;
     uint32 NextTaxiDestination()
     {
-        if (!m_TaxiDestinations.empty())
-            m_TaxiDestinations.pop_front();
+        if (m_TaxiDestinations.empty())
+            return 0;
 
+        m_TaxiDestinations.pop_front();
         return GetTaxiDestination();
     }
 


### PR DESCRIPTION
Just playing with AI. Trying to get fixes for potential crashes automatically generated.