### PR TITLE
fix(DB): set game_event_* tables to use smallint

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1749848424024494127.sql
+++ b/data/sql/updates/pending_db_world/rev_1749848424024494127.sql
@@ -4,4 +4,3 @@ ALTER TABLE `game_event_gameobject` MODIFY COLUMN `eventEntry` smallint NOT NULL
 ALTER TABLE `game_event_model_equip` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event.';
 ALTER TABLE `game_event_npc_vendor` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event.';
 ALTER TABLE `game_event_pool` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
-ALTER TABLE `game_event_seasonal_questrelation` MODIFY COLUMN `eventEntry` smallint DEFAULT 0 NOT NULL COMMENT 'Entry of the game event';

--- a/data/sql/updates/pending_db_world/rev_1749848424024494127.sql
+++ b/data/sql/updates/pending_db_world/rev_1749848424024494127.sql
@@ -1,7 +1,7 @@
 --
-ALTER TABLE `game_event_creature` MODIFY COLUMN `eventEntry` tinyint unsigned NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
-ALTER TABLE `game_event_gameobject` MODIFY COLUMN `eventEntry` tinyint unsigned NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
-ALTER TABLE `game_event_model_equip` MODIFY COLUMN `eventEntry` tinyint unsigned NOT NULL COMMENT 'Entry of the game event.';
-ALTER TABLE `game_event_npc_vendor` MODIFY COLUMN `eventEntry` tinyint unsigned NOT NULL COMMENT 'Entry of the game event.';
-ALTER TABLE `game_event_pool` MODIFY COLUMN `eventEntry` tinyint unsigned NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
-ALTER TABLE `game_event_seasonal_questrelation` MODIFY COLUMN `eventEntry` tinyint unsigned DEFAULT 0 NOT NULL COMMENT 'Entry of the game event';
+ALTER TABLE `game_event_creature` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
+ALTER TABLE `game_event_gameobject` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
+ALTER TABLE `game_event_model_equip` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event.';
+ALTER TABLE `game_event_npc_vendor` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event.';
+ALTER TABLE `game_event_pool` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
+ALTER TABLE `game_event_seasonal_questrelation` MODIFY COLUMN `eventEntry` smallint DEFAULT 0 NOT NULL COMMENT 'Entry of the game event';

--- a/data/sql/updates/pending_db_world/rev_1749848424024494127.sql
+++ b/data/sql/updates/pending_db_world/rev_1749848424024494127.sql
@@ -1,6 +1,6 @@
 --
 ALTER TABLE `game_event_creature` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
 ALTER TABLE `game_event_gameobject` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
-ALTER TABLE `game_event_model_equip` MODIFY COLUMN `eventEntry` unsigned tinyint NOT NULL COMMENT 'Entry of the game event.';
+ALTER TABLE `game_event_model_equip` MODIFY COLUMN `eventEntry` tinyint unsigned NOT NULL COMMENT 'Entry of the game event.';
 ALTER TABLE `game_event_npc_vendor` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event.';
 ALTER TABLE `game_event_pool` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';

--- a/data/sql/updates/pending_db_world/rev_1749848424024494127.sql
+++ b/data/sql/updates/pending_db_world/rev_1749848424024494127.sql
@@ -1,0 +1,7 @@
+--
+ALTER TABLE `game_event_creature` MODIFY COLUMN `eventEntry` tinyint unsigned NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
+ALTER TABLE `game_event_gameobject` MODIFY COLUMN `eventEntry` tinyint unsigned NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
+ALTER TABLE `game_event_model_equip` MODIFY COLUMN `eventEntry` tinyint unsigned NOT NULL COMMENT 'Entry of the game event.';
+ALTER TABLE `game_event_npc_vendor` MODIFY COLUMN `eventEntry` tinyint unsigned NOT NULL COMMENT 'Entry of the game event.';
+ALTER TABLE `game_event_pool` MODIFY COLUMN `eventEntry` tinyint unsigned NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
+ALTER TABLE `game_event_seasonal_questrelation` MODIFY COLUMN `eventEntry` tinyint unsigned DEFAULT 0 NOT NULL COMMENT 'Entry of the game event';

--- a/data/sql/updates/pending_db_world/rev_1749848424024494127.sql
+++ b/data/sql/updates/pending_db_world/rev_1749848424024494127.sql
@@ -1,6 +1,6 @@
 --
 ALTER TABLE `game_event_creature` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
 ALTER TABLE `game_event_gameobject` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';
-ALTER TABLE `game_event_model_equip` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event.';
+ALTER TABLE `game_event_model_equip` MODIFY COLUMN `eventEntry` unsigned tinyint NOT NULL COMMENT 'Entry of the game event.';
 ALTER TABLE `game_event_npc_vendor` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event.';
 ALTER TABLE `game_event_pool` MODIFY COLUMN `eventEntry` smallint NOT NULL COMMENT 'Entry of the game event. Put negative entry to remove during event.';

--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -512,7 +512,7 @@ void GameEventMgr::LoadEventCreatureData()
             Field* fields = result->Fetch();
 
             ObjectGuid::LowType guid = fields[0].Get<uint32>();
-            int16 eventId = fields[1].Get<int8>();
+            int16 eventId = fields[1].Get<int16>();
 
             CreatureData const* data = sObjectMgr->GetCreatureData(guid);
             if (!data)
@@ -562,7 +562,7 @@ void GameEventMgr::LoadEventGameObjectData()
             Field* fields = result->Fetch();
 
             ObjectGuid::LowType guid = fields[0].Get<uint32>();
-            int16 eventId = fields[1].Get<int8>();
+            int16 eventId = fields[1].Get<int16>();
 
             int32 internal_event_id = _gameEvent.size() + eventId - 1;
 
@@ -1020,7 +1020,7 @@ void GameEventMgr::LoadEventPoolData()
             Field* fields = result->Fetch();
 
             uint32 entry = fields[0].Get<uint32>();
-            int16 eventId = fields[1].Get<int8>();
+            int16 eventId = fields[1].Get<int16>();
 
             int32 internal_event_id = _gameEvent.size() + eventId - 1;
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -2184,7 +2184,7 @@ void ObjectMgr::LoadCreatures()
         data.movementType       = fields[15].Get<uint8>();
         data.spawnMask          = fields[16].Get<uint8>();
         data.phaseMask          = fields[17].Get<uint32>();
-        int16 gameEvent         = fields[18].Get<int8>();
+        int16 gameEvent         = fields[18].Get<int16>();
         uint32 PoolId           = fields[19].Get<uint32>();
         data.npcflag            = fields[20].Get<uint32>();
         data.unit_flags         = fields[21].Get<uint32>();
@@ -2576,7 +2576,7 @@ void ObjectMgr::LoadGameobjects()
             LOG_ERROR("sql.sql", "Table `gameobject` has gameobject (GUID: {} Entry: {}) that has wrong spawn mask {} including not supported difficulty modes for map (Id: {}), skip", guid, data.id, data.spawnMask, data.mapid);
 
         data.phaseMask      = fields[15].Get<uint32>();
-        int16 gameEvent     = fields[16].Get<int8>();
+        int16 gameEvent     = fields[16].Get<int16>();
         uint32 PoolId        = fields[17].Get<uint32>();
 
         if (data.rotation.x < -1.0f || data.rotation.x > 1.0f)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

game_event sets event_entry as an unsigned tiny int with a range from 0 to 255

Some game_event_* tables use tinyint, which limits the range from -128 to 127

game_event_model_equip was using tinyint
- https://github.com/azerothcore/azerothcore-wotlk/blob/a8cc3b7ba7817c545f006f51bd2ddb9c254955e5/src/server/game/Events/GameEventMgr.cpp#L618

Also fixes clang tidy warning:
> 'signed char' to 'int16' (aka 'short') conversion; consider casting to 'unsigned char' first.clang-tidycert-str34-c

https://clang.llvm.org/extra/clang-tidy/checks/bugprone/signed-char-misuse.html

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

fixes sql error `Out of range value for column 'eventEntry' ...` when inserting a valid game event



## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
