### PR TITLE
fix(Core): string handling and use smart pointer for strand

### DIFF
--- a/src/common/Logging/Log.cpp
+++ b/src/common/Logging/Log.cpp
@@ -29,6 +29,7 @@
 #include "Timer.h"
 #include "Tokenize.h"
 #include <chrono>
+#include <memory>
 
 Log::Log() : AppenderId(0), highestLogLevel(LOG_LEVEL_FATAL)
 {
@@ -39,7 +40,6 @@ Log::Log() : AppenderId(0), highestLogLevel(LOG_LEVEL_FATAL)
 
 Log::~Log()
 {
-    delete _strand;
     Close();
 }
 
@@ -369,7 +369,7 @@ void Log::Initialize(Acore::Asio::IoContext* ioContext)
     if (ioContext)
     {
         _ioContext = ioContext;
-        _strand = new Acore::Asio::Strand(*ioContext);
+        _strand = std::make_unique<Acore::Asio::Strand>(*ioContext);
     }
 
     LoadFromConfig();
@@ -377,8 +377,7 @@ void Log::Initialize(Acore::Asio::IoContext* ioContext)
 
 void Log::SetSynchronous()
 {
-    delete _strand;
-    _strand = nullptr;
+    _strand.reset();
     _ioContext = nullptr;
 }
 

--- a/src/common/Logging/Log.h
+++ b/src/common/Logging/Log.h
@@ -24,6 +24,7 @@
 #include "StringFormat.h"
 #include <unordered_map>
 #include <vector>
+#include <memory>
 
 class Appender;
 class Logger;
@@ -120,7 +121,7 @@ private:
     std::string m_logsTimestamp;
 
     Acore::Asio::IoContext* _ioContext;
-    Acore::Asio::Strand* _strand;
+    std::unique_ptr<Acore::Asio::Strand> _strand;
 };
 
 #define sLog Log::instance()

--- a/src/tools/map_extractor/System.cpp
+++ b/src/tools/map_extractor/System.cpp
@@ -23,6 +23,7 @@
 #include <filesystem>
 #include <set>
 #include <unordered_map>
+#include <cstring>
 
 #ifdef _WIN32
 #include "direct.h"
@@ -184,7 +185,8 @@ void HandleArgs(int argc, char* arg[])
             case 'i':
                 if (c + 1 < argc)                           // all ok
                 {
-                    strcpy(input_path, arg[(c++) + 1]);
+                    std::strncpy(input_path, arg[(c++) + 1], MAX_PATH_LENGTH - 1);
+                    input_path[MAX_PATH_LENGTH - 1] = '\0';
                 }
                 else
                 {
@@ -194,7 +196,8 @@ void HandleArgs(int argc, char* arg[])
             case 'o':
                 if (c + 1 < argc)                           // all ok
                 {
-                    strcpy(output_path, arg[(c++) + 1]);
+                    std::strncpy(output_path, arg[(c++) + 1], MAX_PATH_LENGTH - 1);
+                    output_path[MAX_PATH_LENGTH - 1] = '\0';
                 }
                 else
                 {
@@ -282,7 +285,8 @@ uint32 ReadMapDBC()
     for (uint32 x = 0; x < map_count; ++x)
     {
         map_ids[x].id = dbc.getRecord(x).getUInt(0);
-        strcpy(map_ids[x].name, dbc.getRecord(x).getString(1));
+        std::strncpy(map_ids[x].name, dbc.getRecord(x).getString(1), sizeof(map_ids[x].name) - 1);
+        map_ids[x].name[sizeof(map_ids[x].name) - 1] = '\0';
     }
     printf("Done! (%u maps loaded)\n", (uint32)map_count);
     return map_count;


### PR DESCRIPTION
## Summary
- avoid buffer overflow by replacing `strcpy` with `std::strncpy` in map extractor
- manage logging strand with `std::unique_ptr`

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost)*
- `bash apps/ci/ci-run-unit-tests.sh` *(fails: unit_tests not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7e8173c08325bdedd1d78098a77d