### PR TITLE
BREAKINGCHANGE(Metrics): Support InfluxDB v2

### DIFF
--- a/src/common/Metric/Metric.cpp
+++ b/src/common/Metric/Metric.cpp
@@ -126,7 +126,6 @@ void Metric::LoadFromConfigs()
             if (_org.empty() || _bucket.empty() || _token.empty())
             {
                 LOG_ERROR("metric", "InfluxDB v2 parameters missing: org, bucket, or token.");
-                _enabled = false;
                 return;
             }
         }

--- a/src/common/Metric/Metric.cpp
+++ b/src/common/Metric/Metric.cpp
@@ -99,25 +99,49 @@ void Metric::LoadFromConfigs()
     // Cancel any scheduled operation if the config changed from Enabled to Disabled.
     if (_enabled && !previousValue)
     {
-        std::string connectionInfo = sConfigMgr->GetOption<std::string>("Metric.ConnectionInfo", "");
+        std::string connectionInfo = sConfigMgr->GetOption<std::string>("Metric.InfluxDB.Connection", "");
         if (connectionInfo.empty())
         {
-            LOG_ERROR("metric", "'Metric.ConnectionInfo' not specified in configuration file.");
+            LOG_ERROR("metric", "'Metric.InfluxDB.Connection' not specified in configuration file.");
             return;
         }
 
         std::vector<std::string_view> tokens = Acore::Tokenize(connectionInfo, ';', true);
-        if (tokens.size() != 3)
+        if (tokens.size() != 2)
         {
-            LOG_ERROR("metric", "'Metric.ConnectionInfo' specified with wrong format in configuration file.");
+            LOG_ERROR("metric", "'Metric.InfluxDB.Connection' specified with wrong format in configuration file.");
             return;
         }
 
         _hostname.assign(tokens[0]);
         _port.assign(tokens[1]);
-        _databaseName.assign(tokens[2]);
-        Connect();
 
+        _useV2 = sConfigMgr->GetOption<bool>("Metric.InfluxDB.v2", false);
+        if (_useV2)
+        {
+            _org = sConfigMgr->GetOption<std::string>("Metric.InfluxDB.Org", "");
+            _bucket = sConfigMgr->GetOption<std::string>("Metric.InfluxDB.Bucket", "");
+            _token = sConfigMgr->GetOption<std::string>("Metric.InfluxDB.Token", "");
+
+            if (_org.empty() || _bucket.empty() || _token.empty())
+            {
+                LOG_ERROR("metric", "InfluxDB v2 parameters missing: org, bucket, or token.");
+                _enabled = false;
+                return;
+            }
+        }
+        else
+        {
+            if (tokens.size() != 3)
+            {
+                LOG_ERROR("metric", "'Metric.InfluxDB.Connection' specified with wrong format in configuration file.");
+                return;
+            }
+
+            _databaseName.assign(tokens[2]);
+        }
+
+        Connect();
         ScheduleSend();
         ScheduleOverallStatusLog();
     }
@@ -206,8 +230,18 @@ void Metric::SendBatch()
     if (!GetDataStream().good() && !Connect())
         return;
 
-    GetDataStream() << "POST " << "/write?db=" << _databaseName << " HTTP/1.1\r\n";
-    GetDataStream() << "Host: " << _hostname << ":" << _port << "\r\n";
+    if (_useV2)
+    {
+        GetDataStream() << "POST " << "/api/v2/write?bucket=" << _bucket
+                        << "&org=" << _org << "&precision=ns HTTP/1.1\r\n";
+        GetDataStream() << "Host: " << _hostname << ":" << _port << "\r\n";
+        GetDataStream() << "Authorization: Token " << _token << "\r\n";
+    }
+    else
+    {
+        GetDataStream() << "POST " << "/write?db=" << _databaseName << " HTTP/1.1\r\n";
+        GetDataStream() << "Host: " << _hostname << ":" << _port << "\r\n";
+    }
     GetDataStream() << "Accept: */*\r\n";
     GetDataStream() << "Content-Type: application/octet-stream\r\n";
     GetDataStream() << "Content-Transfer-Encoding: binary\r\n";

--- a/src/common/Metric/Metric.cpp
+++ b/src/common/Metric/Metric.cpp
@@ -102,14 +102,14 @@ void Metric::LoadFromConfigs()
         std::string connectionInfo = sConfigMgr->GetOption<std::string>("Metric.InfluxDB.Connection", "");
         if (connectionInfo.empty())
         {
-            LOG_ERROR("metric", "'Metric.InfluxDB.Connection' not specified in configuration file.");
+            LOG_ERROR("metric", "Metric.InfluxDB.Connection not specified in configuration file.");
             return;
         }
 
         std::vector<std::string_view> tokens = Acore::Tokenize(connectionInfo, ';', true);
         if (tokens.size() != 2)
         {
-            LOG_ERROR("metric", "'Metric.InfluxDB.Connection' specified with wrong format in configuration file.");
+            LOG_ERROR("metric", "Metric.InfluxDB.Connection specified with wrong format in configuration file.");
             return;
         }
 
@@ -134,7 +134,7 @@ void Metric::LoadFromConfigs()
         {
             if (tokens.size() != 3)
             {
-                LOG_ERROR("metric", "'Metric.InfluxDB.Connection' specified with wrong format in configuration file.");
+                LOG_ERROR("metric", "Metric.InfluxDB.Connection specified with wrong format in configuration file.");
                 return;
             }
 

--- a/src/common/Metric/Metric.h
+++ b/src/common/Metric/Metric.h
@@ -71,6 +71,10 @@ private:
     std::string _hostname;
     std::string _port;
     std::string _databaseName;
+    bool _useV2 = false;
+    std::string _org;
+    std::string _bucket;
+    std::string _token;
     std::function<void()> _overallStatusLogger;
     std::string _realmName;
     std::unordered_map<std::string, int64> _thresholds;

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -812,6 +812,34 @@ Log.Async.Enable = 0
 Metric.Enable = 0
 
 #
+#    Metric.InfluxDB
+#        Description: Connection settings for InfluxDB.
+#
+#        For InfluxDB v1:
+#                     Only fill in Metric.InfluxDB.Connection.
+#
+#        Example:
+#                     Metric.InfluxDB.Connection = "hostname;port;database"
+#
+#        For InfluxDB v2:
+#                     Fill in every field.
+#
+#        Example:
+#                     Metric.InfluxDB.Connection = "hostname;port"
+#                     Metric.InfluxDB.v2 = 0 - (Disabled)
+#                                          1 - (Enabled)
+#                     Metric.InfluxDB.Org = "my-org"
+#                     Metric.InfluxDB.Bucket = "my-bucket"
+#                     Metric.InfluxDB.Token = "my-token"
+#
+
+Metric.InfluxDB.Connection = "127.0.0.1;8086;worldserver"
+Metric.InfluxDB.v2 = 0
+Metric.InfluxDB.Org = ""
+Metric.InfluxDB.Bucket = ""
+Metric.InfluxDB.Token = ""
+
+#
 #    Metric.Interval
 #        Description: Interval between every batch of data sent in seconds.
 #                     Longer interval means larger batch of data. If the batch
@@ -820,15 +848,6 @@ Metric.Enable = 0
 #
 
 Metric.Interval = 1
-
-#
-#    Metric.ConnectionInfo
-#        Description: Connection settings for metric database (currently InfluxDB).
-#        Example:     "hostname;port;database"
-#        Default:     "127.0.0.1;8086;worldserver"
-#
-
-Metric.ConnectionInfo = "127.0.0.1;8086;worldserver"
 
 #
 #    Metric.OverallStatusInterval

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -678,6 +678,7 @@ Appender.Errors=2,5,0,Errors.log,w
 #
 
 Logger.root=2,Console Server
+#Logger.metric=2,Console Server
 #Logger.commands.gm=4,Console GM
 Logger.diff=3,Console Server
 Logger.mmaps=4,Server

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -824,6 +824,9 @@ Metric.Enable = 0
 #        For InfluxDB v2:
 #                     Fill in every field.
 #
+#        NOTE:        Currently, Grafana will not work with the provided json files to visualize
+#                     data from InfluxDB v2.
+#
 #        Example:
 #                     Metric.InfluxDB.Connection = "hostname;port"
 #                     Metric.InfluxDB.v2 = 0 - (Disabled)


### PR DESCRIPTION
### BREAKING CHANGE
- Config setting Metric.ConnectionInfo has been renamed to Metric.InfluxDB.Connection to emphesise that we use InfluxDB

### Notable changes:
- AC Now supports sending data to InfluxDB v2
- Config setting Metric.ConnectionInfo has been renamed to Metric.InfluxDB.Connection to emphesise that we use InfluxDB

By implementing it this way we keep "legacy" support for InfluxDB v1 while also allowing to send data to InfluxDB v2

> [!IMPORTANT]
>  While InfluxDB v2 works, the grafana dashboard is not updated so it will not work with InfluxDB v2

> [!NOTE]
> The following screenshot is taken from the InfluxDB dashboard as proof that the connection works and sends data correctly. (NOT GRAFANA) 
![image](https://github.com/user-attachments/assets/77d01d26-1fbd-495b-9afa-f9194e6fdb38)

* Closes https://github.com/azerothcore/azerothcore-wotlk/issues/20448

### TODO
- The Grafana json files here (https://github.com/azerothcore/azerothcore-wotlk/tree/master/apps/grafana) needs to be updated to use `Flux` queries to be able to access InfluxDB v2.
    - Current implementation uses `InfluxQL` which is only supported by InfluxDB v1