### PR TITLE
fix(Core/Spells): No longer add a signature to items created by NPCs

### DIFF
--- a/src/server/game/Entities/Item/ItemTemplate.h
+++ b/src/server/game/Entities/Item/ItemTemplate.h
@@ -700,8 +700,7 @@ struct ItemTemplate
         return GetMaxStackSize() == 1 &&
                Class != ITEM_CLASS_CONSUMABLE &&
                Class != ITEM_CLASS_QUEST &&
-               !HasFlag(ITEM_FLAG_NO_CREATOR) &&
-               ItemId != 6948; /*Hearthstone*/
+               !HasFlag(ITEM_FLAG_NO_CREATOR);
     }
 
     [[nodiscard]] bool CanChangeEquipStateInCombat() const

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1759,7 +1759,7 @@ void Spell::DoCreateItem(uint8 /*effIndex*/, uint32 itemId)
         }
 
         // set the "Crafted by ..." property of the item
-        if (pItem->GetTemplate()->HasSignature())
+        if (m_caster->IsPlayer() && pItem->GetTemplate()->HasSignature())
             pItem->SetGuidValue(ITEM_FIELD_CREATOR, player->GetGUID());
 
         // send info to the client


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Some creatures cast a spell with `SPELL_EFFECT_CREATE_ITEM`, which can mistakenly add an item with a signature "Created by" to the player. For example, a list below shows smartAI actions that will result in a Signature when it shouldn't. 

<details><summary>table of ~100 SmartAI/Items that should no longer give a "Created by" signature</summary>

| entryorguid | id | spell_id | item_entry | item_name                            | 
|-------------|----|----------|------------|--------------------------------------| 
| -98174      | 0  | 61457    | 44738      | Kirin Tor Familiar                   | 
| 5049        | 0  | 54974    | 25549      | Blood Knight Tabard                  | 
| 5049        | 1  | 54976    | 24344      | Tabard of the Hand                   | 
| 5049        | 2  | 55008    | 28788      | Tabard of the Protector              | 
| 5049        | 3  | 54977    | 31404      | Green Trophy Tabard of the Illidari  | 
| 5049        | 4  | 54982    | 31405      | Purple Trophy Tabard of the Illidari | 
| 5049        | 5  | 62768    | 35279      | Tabard of Summer Skies               | 
| 5049        | 6  | 62769    | 35280      | Tabard of Summer Flames              | 
| 5049        | 7  | 58194    | 43300      | Loremaster's Colors                  | 
| 5049        | 8  | 58224    | 43348      | Tabard of the Explorer               | 
| 5049        | 9  | 55006    | 40643      | Tabard of the Achiever               | 
| 5188        | 0  | 54974    | 25549      | Blood Knight Tabard                  | 
| 5188        | 1  | 54976    | 24344      | Tabard of the Hand                   | 
| 5188        | 2  | 55008    | 28788      | Tabard of the Protector              | 
| 5188        | 3  | 54977    | 31404      | Green Trophy Tabard of the Illidari  | 
| 5188        | 4  | 54982    | 31405      | Purple Trophy Tabard of the Illidari | 
| 5188        | 5  | 62768    | 35279      | Tabard of Summer Skies               | 
| 5188        | 6  | 62769    | 35280      | Tabard of Summer Flames              | 
| 5188        | 7  | 58194    | 43300      | Loremaster's Colors                  | 
| 5188        | 8  | 58224    | 43348      | Tabard of the Explorer               | 
| 5188        | 9  | 55006    | 40643      | Tabard of the Achiever               | 
| 5189        | 0  | 54974    | 25549      | Blood Knight Tabard                  | 
| 5189        | 1  | 54976    | 24344      | Tabard of the Hand                   | 
| 5189        | 2  | 55008    | 28788      | Tabard of the Protector              | 
| 5189        | 3  | 54977    | 31404      | Green Trophy Tabard of the Illidari  | 
| 5189        | 4  | 54982    | 31405      | Purple Trophy Tabard of the Illidari | 
| 5189        | 5  | 62768    | 35279      | Tabard of Summer Skies               | 
| 5189        | 6  | 62769    | 35280      | Tabard of Summer Flames              | 
| 5189        | 7  | 58194    | 43300      | Loremaster's Colors                  | 
| 5189        | 8  | 58224    | 43348      | Tabard of the Explorer               | 
| 5189        | 9  | 55006    | 40643      | Tabard of the Achiever               | 
| 5190        | 0  | 54974    | 25549      | Blood Knight Tabard                  | 
| 5190        | 1  | 54976    | 24344      | Tabard of the Hand                   | 
| 5190        | 2  | 55008    | 28788      | Tabard of the Protector              | 
| 5190        | 3  | 54977    | 31404      | Green Trophy Tabard of the Illidari  | 
| 5190        | 4  | 54982    | 31405      | Purple Trophy Tabard of the Illidari | 
| 5190        | 5  | 62768    | 35279      | Tabard of Summer Skies               | 
| 5190        | 6  | 62769    | 35280      | Tabard of Summer Flames              | 
| 5190        | 7  | 58194    | 43300      | Loremaster's Colors                  | 
| 5190        | 8  | 58224    | 43348      | Tabard of the Explorer               | 
| 5190        | 9  | 55006    | 40643      | Tabard of the Achiever               | 
| 5191        | 0  | 54974    | 25549      | Blood Knight Tabard                  | 
| 5191        | 1  | 54976    | 24344      | Tabard of the Hand                   | 
| 5191        | 2  | 55008    | 28788      | Tabard of the Protector              | 
| 5191        | 3  | 54977    | 31404      | Green Trophy Tabard of the Illidari  | 
| 5191        | 4  | 54982    | 31405      | Purple Trophy Tabard of the Illidari | 
| 5191        | 5  | 62768    | 35279      | Tabard of Summer Skies               | 
| 5191        | 6  | 62769    | 35280      | Tabard of Summer Flames              | 
| 5191        | 7  | 58194    | 43300      | Loremaster's Colors                  | 
| 5191        | 8  | 58224    | 43348      | Tabard of the Explorer               | 
| 5191        | 9  | 55006    | 40643      | Tabard of the Achiever               | 
| 6566        | 0  | 9949     | 5060       | Thieves' Tools                       | 
| 6566        | 1  | 9949     | 5060       | Thieves' Tools                       | 
| 7166        | 3  | 9949     | 5060       | Thieves' Tools                       | 
| 7572        | 5  | 15247    | 11582      | Fel Salve                            | 
| 8479        | 2  | 19797    | 10515      | Torch of Retribution                 | 
| 9117        | 1  | 15211    | 11482      | Crystal Pylon User's Manual          | 
| 11035       | 4  | 24179    | 13209      | Seal of the Dawn                     | 
| 11035       | 6  | 24201    | 19812      | Rune of the Dawn                     | 
| 11536       | 0  | 17777    | 12846      | Argent Dawn Commission               | 
| 14450       | 0  | 23124    | 18598      | Human Orphan Whistle                 | 
| 14451       | 0  | 23125    | 18597      | Orcish Orphan Whistle                | 
| 15180       | 2  | 24727    | 20402      | Agent of Nozdormu                    | 
| 16610       | 0  | 54974    | 25549      | Blood Knight Tabard                  | 
| 16610       | 1  | 54976    | 24344      | Tabard of the Hand                   | 
| 16610       | 2  | 55008    | 28788      | Tabard of the Protector              | 
| 16610       | 3  | 54977    | 31404      | Green Trophy Tabard of the Illidari  | 
| 16610       | 4  | 54982    | 31405      | Purple Trophy Tabard of the Illidari | 
| 16610       | 5  | 62768    | 35279      | Tabard of Summer Skies               | 
| 16610       | 6  | 62769    | 35280      | Tabard of Summer Flames              | 
| 16610       | 7  | 58194    | 43300      | Loremaster's Colors                  | 
| 16610       | 8  | 58224    | 43348      | Tabard of the Explorer               | 
| 16610       | 9  | 55006    | 40643      | Tabard of the Achiever               | 
| 16766       | 0  | 54974    | 25549      | Blood Knight Tabard                  | 
| 16766       | 1  | 54976    | 24344      | Tabard of the Hand                   | 
| 16766       | 2  | 55008    | 28788      | Tabard of the Protector              | 
| 16766       | 3  | 54977    | 31404      | Green Trophy Tabard of the Illidari  | 
| 16766       | 4  | 54982    | 31405      | Purple Trophy Tabard of the Illidari | 
| 16766       | 5  | 62768    | 35279      | Tabard of Summer Skies               | 
| 16766       | 6  | 62769    | 35280      | Tabard of Summer Flames              | 
| 16766       | 7  | 58194    | 43300      | Loremaster's Colors                  | 
| 16766       | 8  | 58224    | 43348      | Tabard of the Explorer               | 
| 16766       | 9  | 55006    | 40643      | Tabard of the Achiever               | 
| 16994       | 0  | 16994    | 12784      | Arcanite Reaper                      | 
| 21772       | 0  | 37602    | 30719      | Spectrecles                          | 
| 21772       | 1  | 37700    | 30721      | Spectrecles                          | 
| 21774       | 0  | 37602    | 30719      | Spectrecles                          | 
| 21774       | 1  | 37700    | 30721      | Spectrecles                          | 
| 22819       | 1  | 39512    | 31880      | Blood Elf Orphan Whistle             | 
| 22819       | 2  | 39513    | 31881      | Draenei Orphan Whistle               | 
| 23486       | 0  | 66592    | 46735      | Synthebrew Goggles                   | 
| 23486       | 2  | 66592    | 46735      | Synthebrew Goggles                   | 
| 23559       | 1  | 42540    | 33105      | Budd's Guise of Zul'aman             | 
| 24657       | 3  | 66592    | 46735      | Synthebrew Goggles                   | 
| 24657       | 5  | 66592    | 46735      | Synthebrew Goggles                   | 
| 28776       | 0  | 54974    | 25549      | Blood Knight Tabard                  | 
| 28776       | 1  | 54976    | 24344      | Tabard of the Hand                   | 
| 28776       | 2  | 55008    | 28788      | Tabard of the Protector              | 
| 28776       | 3  | 54977    | 31404      | Green Trophy Tabard of the Illidari  | 
| 28776       | 4  | 54982    | 31405      | Purple Trophy Tabard of the Illidari | 
| 28776       | 5  | 62768    | 35279      | Tabard of Summer Skies               | 
| 28776       | 6  | 62769    | 35280      | Tabard of Summer Flames              | 
| 28776       | 7  | 58194    | 43300      | Loremaster's Colors                  | 
| 28776       | 8  | 58224    | 43348      | Tabard of the Explorer               | 
| 28776       | 9  | 55006    | 40643      | Tabard of the Achiever               | 
| 34365       | 0  | 65359    | 46397      | Oracle Orphan Whistle                | 
| 34365       | 1  | 65360    | 46396      | Wolvar Orphan Whistle                | 
| 37120       | 0  | 72995    | 49888      | Shadow's Edge                        | 
</details>

link to static Python notebook to generate the above table https://static.marimo.app/static/signatureitems-9ziw
with conditions based on
- https://github.com/azerothcore/azerothcore-wotlk/blob/f0a38b30916dae2560af36693c6b84e255829712/src/server/game/Entities/Item/ItemTemplate.h#L698

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
reported as part of 
- https://github.com/azerothcore/azerothcore-wotlk/pull/22338

> - SAI for the tabard vendors were changed from CAST to ADD_ITEM because casting the spell that creates the item makes this:
![image](https://github.com/user-attachments/assets/74b6edd9-ed49-41c4-b019-641a88fc4e9c)
> Instead of this:
![image](https://github.com/user-attachments/assets/4aac43fb-6aa9-4a06-bc1c-b226f5070006)


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Thieves' Tools
```
.go c id 6566
.quest add 1999
```

Hearthstone
delete hearthstone
Talk to an innkeeper

Kirin Tor Familiar
```
.achi add 1956
.go c 98174
```

Tabard create spell when cast by a NPC
select NPC
```
.cast back 62769
```


1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
