### PR TITLE
fix(installer/windows): update OpenSSL version to 3.5.1 to fix gh build errors

### DIFF
--- a/apps/installer/includes/os_configs/windows.sh
+++ b/apps/installer/includes/os_configs/windows.sh
@@ -24,7 +24,7 @@ fi
 
 choco install -y --skip-checksums $INSTALL_ARGS  cmake.install -y --installargs 'ADD_CMAKE_TO_PATH=System'
 choco install -y --skip-checksums $INSTALL_ARGS  visualstudio2022-workload-nativedesktop
-choco install -y --skip-checksums $INSTALL_ARGS  openssl --force --version=3.4.1
+choco install -y --skip-checksums $INSTALL_ARGS  openssl --force --version=3.5.1
 choco install -y --skip-checksums $INSTALL_ARGS  boost-msvc-14.3 --force --version=1.87.0
 choco install -y --skip-checksums $INSTALL_ARGS  mysql --force --version=8.4.4
 


### PR DESCRIPTION
Chocolatey on windows cannot download openssl 3.4.1 since the source has been removed. 

3.5.1 is available instead. However, this must be tested