### PR TITLE
fix(db/Quest) - Necklace Recovery no longer can be shared to alliance members

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1751964417164296900.sql
+++ b/data/sql/updates/pending_db_world/rev_1751964417164296900.sql
@@ -1,0 +1,2 @@
+-- From 0 (all) to 690 (only horde)
+UPDATE `quest_template` SET `AllowableRaces` = 690 WHERE `ID` = 2283;

--- a/data/sql/updates/pending_db_world/rev_1751964417164296900.sql
+++ b/data/sql/updates/pending_db_world/rev_1751964417164296900.sql
@@ -1,2 +1,0 @@
--- From 0 (all) to 690 (only horde)
-UPDATE `quest_template` SET `AllowableRaces` = 690 WHERE `ID` = 2283;

--- a/data/sql/updates/pending_db_world/rev_1752257729299358400.sql
+++ b/data/sql/updates/pending_db_world/rev_1752257729299358400.sql
@@ -1,0 +1,4 @@
+-- Only allows HORDE players to pick Necklace Recovery quest (and not be able to share with alliance)
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceGroup` = 0) AND (`SourceEntry` = 2283) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 16) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 690) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(19, 0, 2283, 0, 0, 16, 0, 690, 0, 0, 0, 0, 0, '', 'Only HORDE faction pick up quest "Necklace Recovery"');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/8136

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

- Make 2 characters, 1 alliance and 1 horde
- `.level 39` 
- `.quest add 2283` // Necklace Recovery to the horde character
- Teleport both characters to `.tele uldaman` (dont enter) and be in a group
- Try to share the quest

Before this PR
![image](https://github.com/user-attachments/assets/df0a54c0-a6b3-4e54-9f12-dbca04bc6bc6)

With this PR
![image](https://github.com/user-attachments/assets/f2fd83bf-c922-4556-811c-5e5ba2cd4b7d)


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
