### PR TITLE
fix(DB/CreatureFormations): Add formations to NPCs in the Magister's Terrace

### DIFF
--- a/data/sql/updates/pending_db_world/mgtformations.sql
+++ b/data/sql/updates/pending_db_world/mgtformations.sql
@@ -1,5 +1,4 @@
 DELETE FROM `creature_formations` WHERE `leaderGUID` IN (96764, 96786, 96763, 96776, 96775, 96828, 96825, 96831, 96778, 96777, 96824, 96780, 96767, 96769, 96773, 96779, 96771, 96781);
-
 INSERT INTO `creature_formations` (`leaderGUID`, `memberGUID`, `dist`, `angle`, `groupAI`, `point_1`, `point_2`) VALUES
 (96764, 96764, 0, 0, 3, 0, 0),
 (96764, 96765, 0, 0, 3, 0, 0),


### PR DESCRIPTION
Introduces formations to multiple packs inside Magister's Terrace. 

This omits Selin Fireheart not pulling the whole room if aggroed while other NPCs are alive.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/7905
- Closes https://github.com/chromiecraft/chromiecraft/issues/7906
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/22439

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Go into Magister's Terrace
2. One by one, pull a pack with a taunt and observe the behaviour.
3. In the first room, observe that the two patrolling NPCs stick together and are not spread out after a while. 

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Packs with leaders 96824 and 96780 behave a bit badly with this; they both aggro due to standing too close to each others. I do not know how to fix that. 
- [ ] I am not sure whether Selin Fireheart not aggroing whole room if there are any adds up is in the scope of this PR. 

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
