### PR TITLE
Stop spawned mobs from Lich King fight from attacking totems and pets over players

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -1832,6 +1832,8 @@ public:
 
         bool CanAIAttack(Unit const* target) const override
         {
+            if (!target->IsPlayer()) //Ignore non-players such as totems and pets.
+                return false;
             return IsValidPlatformTarget(target) && !target->GetVehicle();
         }
     };
@@ -3381,6 +3383,8 @@ public:
 
         bool CanAIAttack(Unit const* target) const override
         {
+            if (!target->IsPlayer()) //Ignore non-players such as totems and pets.
+                return false;
             return IsValidPlatformTarget(target) && !target->GetVehicle();
         }
     };


### PR DESCRIPTION
Added to npc_scripts "npc_shambling_horror_icc" and "npc_icc_lk_checktarget" a check to only target players, and skip non players.



<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/22048
- Related to https://github.com/azerothcore/azerothcore-wotlk/issues/18882

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

See video evidence below. Current behavior is that the affected creatures target the nearest target and kill totems and pets first before going after players. Blizzard like behavior is to attack players first.

Video of [issue](https://www.youtube.com/watch?v=b7POiVKbwwI&ab_channel=Morningstars)


[Video of blizzlike behavior](https://www.youtube.com/watch?v=_QcuB8zCpu4&ab_channel=TheAscardia) of the first lich king kill in 2010
Timeline with blizzlike behaviour:
2:08 - Drudge Ghoul spawn and stays still
2:16 - Shambling Horror spawn and stays still
12:33 - Vile Spirits spawns and stays in the air

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Before (Most obvious at 50 seconds)

https://github.com/user-attachments/assets/03f78573-771a-4fba-8d8d-2af801f4ab5c




After

https://github.com/user-attachments/assets/2e39c6a0-eebf-4a15-be20-ac76a7b09f09




## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .go c 36597
2. Start fight
3. Lay down totems

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
