### PR TITLE
fix(Core/Player): implement Character flag `CHARACTER_FLAG_RESTING`

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -101,7 +101,7 @@ enum CharacterFlags
 {
     CHARACTER_FLAG_NONE                 = 0x00000000,
     CHARACTER_FLAG_UNK1                 = 0x00000001,
-    CHARACTER_FLAG_UNK2                 = 0x00000002,
+    CHARACTER_FLAG_RESTING              = 0x00000002,
     CHARACTER_LOCKED_FOR_TRANSFER       = 0x00000004,
     CHARACTER_FLAG_UNK4                 = 0x00000008,
     CHARACTER_FLAG_UNK5                 = 0x00000010,
@@ -1156,6 +1156,8 @@ bool Player::BuildEnumData(PreparedQueryResult result, WorldPacket* data)
 
     *data << uint32(fields[16].Get<uint32>());                 // guild id
 
+    if (playerFlags & PLAYER_FLAGS_RESTING)
+        playerFlags |= CHARACTER_FLAG_RESTING;
     if (atLoginFlags & AT_LOGIN_RESURRECT)
         playerFlags &= ~PLAYER_FLAGS_GHOST;
     if (playerFlags & PLAYER_FLAGS_HIDE_HELM)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

characterFlag has a corresponding playerFlag `PLAYER_FLAGS_RESTING`. The following fields are related, but are not removable from what I'm seeing.

`characters.restState`
https://github.com/azerothcore/azerothcore-wotlk/blob/d40be8c1d4a4d99ae14be8c4211b84681c8c554f/src/server/game/Entities/Player/Player.cpp#L10176

`characters.is_logout_resting`
https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Entities/Player/PlayerStorage.cpp#L5400

From the mentioned TC PR (see issue), it seems like the flag has no effect

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/18340

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
