### PR TITLE
fix(Scripts/Spells): killing with Victory Rush grants Victory Rush

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7205,16 +7205,6 @@ bool Unit::HandleDummyAuraProc(Unit* victim, uint32 damage, AuraEffect* triggere
             }
         case SPELLFAMILY_WARRIOR:
             {
-                switch (dummySpell->Id)
-                {
-                    // Victorious
-                    case 32216:
-                        {
-                            RemoveAura(dummySpell->Id);
-                            return false;
-                        }
-                }
-
                 // Second Wind
                 if (dummySpell->SpellIconID == 1697)
                 {

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -102,23 +102,15 @@ class spell_warr_victory_rush : public SpellScript
 {
     PrepareSpellScript(spell_warr_victory_rush);
 
-    void VictoryRushHit()
+    void HandleCast()
     {
-        if (Unit* player = GetCaster())
-        {
-            if (Unit* victim = GetHitUnit())
-            {
-                if (victim->isDead())
-                {
-                    player->CastSpell(player, SPELL_VICTORIOUS, true);
-                }
-            }
-        }
+        if (Unit* caster = GetCaster())
+            caster->RemoveAurasDueToSpell(SPELL_VICTORIOUS);
     }
 
     void Register() override
     {
-        AfterHit += SpellHitFn(spell_warr_victory_rush::VictoryRushHit);
+        OnCast += SpellCastFn(spell_warr_victory_rush::HandleCast);
     }
 };
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Previously, killing a creature with Victory Rush procs Victory Rush, then removes the aura.

This change allows a player to kill a creature with Victory Rush and keep Victory Rush.

previous bugs reported for this spell:
- https://github.com/azerothcore/azerothcore-wotlk/issues/5156
- https://github.com/azerothcore/azerothcore-wotlk/issues/6657
- https://github.com/azerothcore/azerothcore-wotlk/issues/7628


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/8146

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Warrior character with Victory Rush learned

target a creature and grant immunity
```
.cast self 71550
```

Add dummy aura, enabling Victory Rush to be cast
```
.cast 32216
```

1. Casting Victory Rush and killing the target with the spell should allow Victory Rush to be cast again

Regression testing:
1. Casting Victory Rush without killing the target should not allow Victory Rush to be cast again
2. Casting Victory Rush with a failed result (e.g., immunity or parry/dodge) should not allow Victory Rush to be cast again

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
