### PR TITLE
fix(DB/SQL): Do not give all permissions to user "acore" upon creation via the sql file

### DIFF
--- a/data/sql/create/create_mysql.sql
+++ b/data/sql/create/create_mysql.sql
@@ -1,8 +1,6 @@
 DROP USER IF EXISTS 'acore'@'localhost';
 CREATE USER 'acore'@'localhost' IDENTIFIED BY 'acore' WITH MAX_QUERIES_PER_HOUR 0 MAX_CONNECTIONS_PER_HOUR 0 MAX_UPDATES_PER_HOUR 0;
 
-GRANT USAGE ON * . * TO 'acore'@'localhost' WITH GRANT OPTION;
-
 -- Create databases for AzerothCore, only if they do not exist
 CREATE DATABASE IF NOT EXISTS `acore_world` DEFAULT CHARACTER SET UTF8MB4 COLLATE utf8mb4_unicode_ci;
 

--- a/data/sql/create/create_mysql.sql
+++ b/data/sql/create/create_mysql.sql
@@ -1,7 +1,7 @@
 DROP USER IF EXISTS 'acore'@'localhost';
 CREATE USER 'acore'@'localhost' IDENTIFIED BY 'acore' WITH MAX_QUERIES_PER_HOUR 0 MAX_CONNECTIONS_PER_HOUR 0 MAX_UPDATES_PER_HOUR 0;
 
-GRANT ALL PRIVILEGES ON * . * TO 'acore'@'localhost' WITH GRANT OPTION;
+GRANT USAGE ON * . * TO 'acore'@'localhost' WITH GRANT OPTION;
 
 -- Create databases for AzerothCore, only if they do not exist
 CREATE DATABASE IF NOT EXISTS `acore_world` DEFAULT CHARACTER SET UTF8MB4 COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
Upon creation of the user and databases the `acore` user gets ALL PERMISSIONS for all the databases, instead of only the `acore` related ones, after the user is created it still grants all permissions to each respective database being created.

Current AC:

`Root User`
<img width="442" height="329" alt="image" src="https://github.com/user-attachments/assets/eaff5d7f-d42a-4ed3-8976-80df5ee43ef5" />

`Acore User`
<img width="446" height="335" alt="image" src="https://github.com/user-attachments/assets/b39d3318-be9f-427f-8a4d-cbb5852835e8" />

Current PR:

`Root User`
<img width="445" height="393" alt="image" src="https://github.com/user-attachments/assets/b1243721-aae6-4d97-982a-0fc810a0f502" />

`Acore User`
<img width="462" height="191" alt="image" src="https://github.com/user-attachments/assets/b03b8573-52ad-44bb-89f1-791d09d814a0" />


## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes N/A

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
