### PR TITLE
fix(CORE/lfg): Correct random LFG reward bug

### DIFF
--- a/src/server/game/Entities/Player/PlayerQuest.cpp
+++ b/src/server/game/Entities/Player/PlayerQuest.cpp
@@ -1272,7 +1272,7 @@ bool Player::SatisfyQuestDay(Quest const* qInfo, bool msg) const
 
     if (qInfo->IsDFQuest())
     {
-        if (!m_DFQuests.empty())
+        if (m_DFQuests.find(qInfo->GetQuestId()) != m_DFQuests.end())
             return false;
 
         return true;


### PR DESCRIPTION
## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Currently, doing either the daily random heroic dungeon or daily random normal dungeon locks you out of the other's reward. 

Random daily heroic dungeon reward (2 emblem of frost) and random daily normal dungeon reward (2 emblem triumph) are currently shared rewards. Meaning you cannot do both in one day. This PR alters the dungeon quest check to ensure both can be completed in the same day.

This is how it works on TrinityCore, and using resources such as: https://www.bluetracker.gg/wow/topic/us-en/20677351931-can-you-do-the-random-daily-with-a-non-pug/ seems to imply that both rewards can be obtained once per day.

This also corrects the seemingly wrong behavior of completing a random normal dungeon, receiving 2 emblems of triumph, and then being locked out of being eligible for your random daily heroic reward of 2 emblems of frost. This pre-pr behavior seems wrong, as anyone who runs a random normal dungeon to help out a friend would then have locked themselves out of their daily heroic reward.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore line for SatisfyQuestDay function (same function used by azerothcore, just different location) https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Entities/Player/Player.cpp/#L15630

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.  .debug lfg
2.  Observe random normal dungeon reward and random heroic dungeon reward.
3.  Queue and complete a heroic dungeon.
4.  Pre-pr, you will now see that after earning the daily heroic reward of 2 emblems of frost, you can no longer earn the daily normal reward.
5.  Post-pr, you will see that after earning the daily heroic reward, you are still eligible for the daily normal reward.
6.  Test in reverse as well, i.e. clear a random normal dungeon and claim the daily reward, then make sure you are still eligible for the daily heroic reward of 2 emblems of frost.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
