### PR TITLE
Dockerfile: TZ ARG was not applied because it was put before FROM

### DIFF
--- a/apps/docker/Dockerfile
+++ b/apps/docker/Dockerfile
@@ -1,10 +1,10 @@
 ARG UBUNTU_VERSION=22.04 # lts
-ARG TZ=Etc/UTC
 
 # This target lays out the general directory skeleton for AzerothCore,
 # This target isn't intended to be directly used
 FROM ubuntu:$UBUNTU_VERSION AS skeleton
 
+ARG TZ=Etc/UTC
 ARG DOCKER=1
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Sorry I skipped all the lenghty standard stuff here. I hope this is ok as this i a very simple one line change to fix a problem.

Problem:
Docker build do not recognize timezone (TZ) arg.

Reason:
ARG in Dockerfile before FROM is not usable.
(See here for official doc: https://docs.docker.com/reference/dockerfile/#understand-how-arg-and-from-interact)

Test:\
docker-compose.override.yml:
```
services:
  ac-worldserver:
    environment:
      TZ: "Europe/Copenhagen"
```
Before fix: Time in game was always UTC. Also in the container `/etc/localtime` linked to the dir `/usr/share/zoneinfo` and not a timezone file as the $TZ reference gave an empty string.\
Efter fix: Time in game is the correct one according to my timezone setting.