### PR TITLE
fix(bash): Exit simple-restarter script if shutdown is requested

### DIFF
--- a/apps/startup-scripts/src/simple-restarter
+++ b/apps/startup-scripts/src/simple-restarter
@@ -66,7 +66,7 @@ while true; do
     echo "$(basename "$BINARY") terminated after $DIFFERENCE seconds, restart count: $_restart_count"
 
     # Crash loop detection
-    if [ $DIFFERENCE -lt 10 ]; then
+    if [ "$DIFFERENCE" -lt 10 ]; then
         # Increment instant crash count if runtime is lower than 10 seconds
         ((_instant_crash_count++))
         echo "Warning: Quick restart detected ($DIFFERENCE seconds) - instant crash count: $_instant_crash_count"
@@ -76,14 +76,14 @@ while true; do
     fi
 
     # Prevent infinite crash loops
-    if [ $_instant_crash_count -gt 5 ]; then
+    if [ "$_instant_crash_count" -gt 5 ]; then
         echo "Error: $(basename "$BINARY") restarter exited. Infinite crash loop prevented (6 crashes in under 10 seconds each)"
         echo "Please check your system configuration and logs"
         exit 1
     fi
 
     # Exit cleanly if shutdown was requested by command or SIGINT (exit code 0)
-    if [ $_exit_code -eq 0 ]; then
+    if [ "$_exit_code" -eq 0 ]; then
         echo "$(basename "$BINARY") shutdown safely"
         exit 0
     fi

--- a/apps/startup-scripts/src/simple-restarter
+++ b/apps/startup-scripts/src/simple-restarter
@@ -81,6 +81,12 @@ while true; do
         echo "Please check your system configuration and logs"
         exit 1
     fi
+
+    # Exit cleanly if shutdown was requested by command or SIGINT (exit code 0)
+    if [ $_exit_code -eq 0 ]; then
+        echo "$(basename "$BINARY") shutdown safely"
+        exit 0
+    fi
     
     echo "$(basename "$BINARY") will restart in 3 seconds..."
     sleep 3


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
Unlike starting through the binaries, if you start through acore.sh and then try to shutdown worldserver with `server shutdown 1` or SIGINT, you don't stop after shutdown. Instead you remain in the starter script loop, and end up with a restart. This change ensures that you get out of the loop if you have requested a shutdown.
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
Before trying this fix, if you only run AC through the binaries and have never seen this issue, run the server through acore.sh at the AC directory with these commands:
```
./acore.sh run-authserver
./acore.sh run-worldserver
```
Then try to shutdown worldserver with ctrl+c or `server shutdown 1` you should get
```
worldserver terminated with exit code: 0
worldserver terminated after <###> seconds, restart count: 1
will restart in 3 seconds...
```
Then worldserver proceeds to restart instead of staying shutdown. After applying this fix, you would get the following after the shutdown request
```
worldserver terminated with exit code: 0
worldserver terminated after <###> seconds, restart count: 1
worldserver shutdown safely
```
And that's it. The server stays shutdown. It should only restart if you request `server restart 1`.

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
