### PR TITLE
fix(DB/spell_custom_attr): Allow Poison Bolt to stack

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1754910707047949800.sql
+++ b/data/sql/updates/pending_db_world/rev_1754910707047949800.sql
@@ -1,0 +1,8 @@
+--
+-- Anub'ar Venomancer - Poison Bolt, Poison Bolt(H)
+DELETE FROM `spell_custom_attr` WHERE `spell_id` IN (53617, 59359);
+
+INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (53617, 4194304);
+INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (59359, 4194304);
+
+

--- a/data/sql/updates/pending_db_world/rev_1754910707047949800.sql
+++ b/data/sql/updates/pending_db_world/rev_1754910707047949800.sql
@@ -1,8 +1,9 @@
---
--- Anub'ar Venomancer - Poison Bolt, Poison Bolt(H)
-DELETE FROM `spell_custom_attr` WHERE `spell_id` IN (53617, 59359);
-
+-- Anub'ar Venomancer - Poison Bolt
+DELETE FROM `spell_custom_attr` WHERE `spell_id` = (53617);
 INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (53617, 4194304);
+
+-- Anub'ar Venomancer - Poison Bolt(H)
+DELETE FROM `spell_custom_attr` WHERE `spell_id` = (59359);
 INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (59359, 4194304);
 
 

--- a/data/sql/updates/pending_db_world/rev_1754910707047949800.sql
+++ b/data/sql/updates/pending_db_world/rev_1754910707047949800.sql
@@ -3,5 +3,5 @@ DELETE FROM `spell_custom_attr` WHERE `spell_id` = 53617;
 INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (53617, 4194304);
 
 -- Anub'ar Venomancer - Poison Bolt(H)
-DELETE FROM `spell_custom_attr` WHERE `spell_id` = (59359);
+DELETE FROM `spell_custom_attr` WHERE `spell_id` = 59359;
 INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (59359, 4194304);

--- a/data/sql/updates/pending_db_world/rev_1754910707047949800.sql
+++ b/data/sql/updates/pending_db_world/rev_1754910707047949800.sql
@@ -5,5 +5,3 @@ INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (53617, 419430
 -- Anub'ar Venomancer - Poison Bolt(H)
 DELETE FROM `spell_custom_attr` WHERE `spell_id` = (59359);
 INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (59359, 4194304);
-
-

--- a/data/sql/updates/pending_db_world/rev_1754910707047949800.sql
+++ b/data/sql/updates/pending_db_world/rev_1754910707047949800.sql
@@ -1,5 +1,5 @@
 -- Anub'ar Venomancer - Poison Bolt
-DELETE FROM `spell_custom_attr` WHERE `spell_id` = (53617);
+DELETE FROM `spell_custom_attr` WHERE `spell_id` = 53617;
 INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (53617, 4194304);
 
 -- Anub'ar Venomancer - Poison Bolt(H)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/22653

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .go c id 29120
2. Start [Anub'arak](https://wowgaming.altervista.org/aowow/?npc=29120) encounter
3. Deal damage to [Anub'arak](https://wowgaming.altervista.org/aowow/?npc=29120) until it submerge at 75%
4. Do not kill [Anub'ar Venomancer](https://wowgaming.altervista.org/aowow/?npc=29217) and wait for [Anub'arak](https://wowgaming.altervista.org/aowow/?npc=29120) to emerge
5.  Deal damage to [Anub'arak](https://wowgaming.altervista.org/aowow/?npc=29120) until it submerge again at 50%
6. .  Wait for the 2nd [Anub'ar Venomancer](https://wowgaming.altervista.org/aowow/?npc=29217) to spawn and watch both [Anub'ar Venomancer](https://wowgaming.altervista.org/aowow/?npc=29217) adds a new debuff icon for [Poison Bolt](https://wowgaming.altervista.org/aowow/?spell=53617) instead of stacking

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
