### PR TITLE
Fix: Add safeguards against recursion and race condition crashes

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -43,6 +43,15 @@
 //  see: https://github.com/azerothcore/azerothcore-wotlk/issues/9766
 #include "GridNotifiersImpl.h"
 
+// Definition of some variables / structs for the recursion railguard
+thread_local bool g_smartScriptProcessing = false;
+
+struct SmartScriptProcessorGuard
+{
+    SmartScriptProcessorGuard() { g_smartScriptProcessing = true; }
+    ~SmartScriptProcessorGuard() { g_smartScriptProcessing = false; }
+};
+
 SmartScript::SmartScript()
 {
     go = nullptr;
@@ -4037,6 +4046,12 @@ void SmartScript::GetWorldObjectsInDist(ObjectVector& targets, float dist) const
 
 void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, uint32 var1, bool bvar, SpellInfo const* spell, GameObject* gob)
 {
+	// A recursion protection
+	if (g_smartScriptProcessing)
+        return;
+
+    SmartScriptProcessorGuard guard;
+	
     if (!e.active && e.GetEventType() != SMART_EVENT_LINK)
         return;
 

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -4046,10 +4046,10 @@ void SmartScript::GetWorldObjectsInDist(ObjectVector& targets, float dist) const
 
 void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, uint32 var1, bool bvar, SpellInfo const* spell, GameObject* gob)
 {
-	// A recursion protection
-	if (g_smartScriptProcessing)
+    // A recursion protection
+    if (g_smartScriptProcessing)
         return;
-
+    
     SmartScriptProcessorGuard guard;
 	
     if (!e.active && e.GetEventType() != SMART_EVENT_LINK)

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -4049,9 +4049,9 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
     // A recursion protection
     if (g_smartScriptProcessing)
         return;
-    
+
     SmartScriptProcessorGuard guard;
-	
+
     if (!e.active && e.GetEventType() != SMART_EVENT_LINK)
         return;
 

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -1141,10 +1141,10 @@ namespace Acore
         {}
         void operator()(Creature* u)
         {
-			// Prevents Chain Reactions to mobs - causing a cascade error
-			if (u->IsInCombat())
-				return;
-			
+            // Prevents Chain Reactions to mobs - causing a cascade error
+            if (u->IsInCombat())
+                return;
+
             if (u == i_funit)
                 return;
 

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -1141,6 +1141,10 @@ namespace Acore
         {}
         void operator()(Creature* u)
         {
+			// Prevents Chain Reactions to mobs - causing a cascade error
+			if (u->IsInCombat())
+				return;
+			
             if (u == i_funit)
                 return;
 

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -650,7 +650,7 @@ template<class T>
 void Map::RemoveFromMap(T* obj, bool remove)
 {
     obj->RemoveFromWorld();
-	
+
     // This should prevent double removals and therefore crashes under heavy-load
     if (!obj->IsInGrid())
         return;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -650,6 +650,10 @@ template<class T>
 void Map::RemoveFromMap(T* obj, bool remove)
 {
     obj->RemoveFromWorld();
+	
+    // This should prevent double removals and therefore crashes under heavy-load
+    if (!obj->IsInGrid())
+        return;
 
     obj->RemoveFromGrid();
 


### PR DESCRIPTION
This commit introduces three key stability fixes: 1. A re-entrancy guard in SmartScript::ProcessEvent to prevent stack overflows from recursive event calls. 2. An idempotency check in Map::RemoveFromMap to prevent assertion failures from double-removal race conditions. 3. An in-combat check in GridNotifiers.h to prevent call-for-help chainreactions.

## Changes Proposed:
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
https://github.com/azerothcore/azerothcore-wotlk/issues/22675

## Tests Performed:
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
- [X] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Compile
2. Start the server and play
3. Check your Tracelogs for far less SmartScript calls and crashes

## Known Issues and TODO List:
None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
