### PR TITLE
fix(SERVER/Main): Implementation for version param

### DIFF
--- a/src/server/apps/authserver/Main.cpp
+++ b/src/server/apps/authserver/Main.cpp
@@ -29,6 +29,7 @@
 #include "Config.h"
 #include "DatabaseEnv.h"
 #include "DatabaseLoader.h"
+#include "GitRevision.h"
 #include "IPLocation.h"
 #include "IoContext.h"
 #include "Log.h"
@@ -75,7 +76,7 @@ int main(int argc, char** argv)
     auto vm = GetConsoleArguments(argc, argv, configFile);
 
     // exit if help or version is enabled
-    if (vm.count("help"))
+    if (vm.count("help") || vm.count("version"))
         return 0;
 
     // Add file and args in config
@@ -294,6 +295,10 @@ variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile)
     if (variablesMap.count("help"))
     {
         std::cout << all << "\n";
+    }
+    else if (variablesMap.count("version"))
+    {
+        std::cout << GitRevision::GetFullVersion() << "\n";
     }
     else if (variablesMap.count("dry-run"))
     {

--- a/src/server/apps/worldserver/Main.cpp
+++ b/src/server/apps/worldserver/Main.cpp
@@ -127,7 +127,7 @@ int main(int argc, char** argv)
     auto vm = GetConsoleArguments(argc, argv, configFile, configService);
 
     // exit if help or version is enabled
-    if (vm.count("help"))
+    if (vm.count("help") || vm.count("version"))
         return 0;
 
 #if AC_PLATFORM == AC_PLATFORM_WINDOWS
@@ -735,6 +735,10 @@ variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, [
     if (vm.count("help"))
     {
         std::cout << all << "\n";
+    }
+    else if (vm.count("version"))
+    {
+        std::cout << GitRevision::GetFullVersion() << "\n";
     }
     else if (vm.count("dry-run"))
     {


### PR DESCRIPTION
**Implementation for -v/--version parameters were missing**

IssueId: #22706

On branch fix-issue-22706
  Changes to be committed:
	modified:   src/server/apps/authserver/Main.cpp
	modified:   src/server/apps/worldserver/Main.cpp

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
**-  [ ] Core (units, players, creatures, game systems).**
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
https://github.com/azerothcore/azerothcore-wotlk/issues/22706

## SOURCE:

## Tests Performed:
This PR has been:
**- [ ] Tested in-game by the author.**
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
Built and start any of the servers (auth/world) with -v commandline parameter.

**- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue**

## Known Issues and TODO List:

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
