### PR TITLE
chore(Core/Player): Change player setting index type from uint8 to ui…

### DIFF
--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2641,8 +2641,8 @@ public:
     std::string GetPlayerName();
 
     // Settings
-    [[nodiscard]] PlayerSetting GetPlayerSetting(std::string const& source, uint8 index);
-    void UpdatePlayerSetting(std::string const& source, uint8 index, uint32 value);
+    [[nodiscard]] PlayerSetting GetPlayerSetting(std::string const& source, uint32 index);
+    void UpdatePlayerSetting(std::string const& source, uint32 index, uint32 value);
 
     void SendSystemMessage(std::string_view msg, bool escapeCharacters = false);
 

--- a/src/server/game/Entities/Player/PlayerSettings.cpp
+++ b/src/server/game/Entities/Player/PlayerSettings.cpp
@@ -80,7 +80,7 @@ namespace PlayerSettingsStore
         return result;
     }
 
-    void UpdateSetting(uint32 playerLowGuid, std::string const& source, uint8 index, uint32 value)
+    void UpdateSetting(uint32 playerLowGuid, std::string const& source, uint32 index, uint32 value)
     {
         if (!sWorld->getBoolConfig(CONFIG_PLAYER_SETTINGS_ENABLED))
             return;
@@ -129,7 +129,7 @@ void Player::_LoadCharacterSettings(PreparedQueryResult result)
     } while (result->NextRow());
 }
 
-PlayerSetting Player::GetPlayerSetting(std::string const& source, uint8 index)
+PlayerSetting Player::GetPlayerSetting(std::string const& source, uint32 index)
 {
     auto it = m_charSettingsMap.find(source);
     if (it == m_charSettingsMap.end() || static_cast<size_t>(index) >= it->second.size())
@@ -156,7 +156,7 @@ void Player::_SavePlayerSettings(CharacterDatabaseTransaction trans)
     }
 }
 
-void Player::UpdatePlayerSetting(std::string const& source, uint8 index, uint32 value)
+void Player::UpdatePlayerSetting(std::string const& source, uint32 index, uint32 value)
 {
     auto it = m_charSettingsMap.find(source);
     size_t const requiredSize = static_cast<size_t>(index) + 1;

--- a/src/server/game/Entities/Player/PlayerSettings.h
+++ b/src/server/game/Entities/Player/PlayerSettings.h
@@ -57,7 +57,7 @@ namespace PlayerSettingsStore
 {
     // Update a single setting value for any player by GUID (works for online or offline players).
     // This reads the existing "source" row from character_settings, adjusts the index, and REPLACE's it back.
-    void UpdateSetting(uint32 playerLowGuid, std::string const& source, uint8 index, uint32 value);
+    void UpdateSetting(uint32 playerLowGuid, std::string const& source, uint32 index, uint32 value);
 
     // Common helpers for parsing and serializing settings data
     PlayerSettingVector ParseSettingsData(std::string const& data);


### PR DESCRIPTION
…nt32

Updated the index parameter type from uint8 to uint32 in Player and PlayerSettings methods to support a larger range of setting indices. This affects GetPlayerSetting, UpdatePlayerSetting, and PlayerSettingsStore::UpdateSetting, as well as their declarations and usages.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
