### PR TITLE
fix(Core/WorldState): Start boss activation event when starting Scourge Invasion.

### DIFF
--- a/src/server/game/World/WorldState.cpp
+++ b/src/server/game/World/WorldState.cpp
@@ -1312,6 +1312,8 @@ void WorldState::StartScourgeInvasion(bool sendMail)
         Acore::Containers::RandomShuffle(randomIds);
         for (uint32 id : randomIds)
             OnEnable(m_siData.m_activeInvasions[id]);
+
+        sGameEventMgr->StartEvent(GAME_EVENT_SCOURGE_INVASION_BOSSES);
     }
 }
 

--- a/src/server/game/World/WorldState.h
+++ b/src/server/game/World/WorldState.h
@@ -65,6 +65,7 @@ enum WorldStateGameEvents
 {
     // Scourge Invasion
     GAME_EVENT_SCOURGE_INVASION                         = 17,
+    GAME_EVENT_SCOURGE_INVASION_BOSSES                  = 120,
     GAME_EVENT_SCOURGE_INVASION_WINTERSPRING            = 121,
     GAME_EVENT_SCOURGE_INVASION_TANARIS                 = 122,
     GAME_EVENT_SCOURGE_INVASION_AZSHARA                 = 123,


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR:
- [X] Has not been tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
- [X] This pull request requires further testing.
1. `.worldstate scourgeinvasion state 1`
2. Verify that bosses have spawned in instances.
3. Restart server.
4. Verify that bosses remain spawned in instances.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
