### PR TITLE
feat(DB): decouple item GUIDs to BIGINT UNSIGNED for future-proof database integrity

### DIFF
--- a/data/sql/updates/pending_db_characters/rev_decouple_item_guids.sql
+++ b/data/sql/updates/pending_db_characters/rev_decouple_item_guids.sql
@@ -1,0 +1,40 @@
+-- Decouple item GUIDs: widen to BIGINT UNSIGNED for persistent DB IDs
+-- Item instance primary key to BIGINT
+ALTER TABLE `item_instance`
+  MODIFY COLUMN `guid` BIGINT UNSIGNED NOT NULL,
+  DROP PRIMARY KEY,
+  ADD PRIMARY KEY (`guid`);
+
+-- Character inventory references
+ALTER TABLE `character_inventory`
+  MODIFY COLUMN `item` BIGINT UNSIGNED NOT NULL;
+
+-- Mail items references
+ALTER TABLE `mail_items`
+  MODIFY COLUMN `item_guid` BIGINT UNSIGNED NOT NULL;
+
+-- Auctionhouse references
+ALTER TABLE `auctionhouse`
+  MODIFY COLUMN `itemguid` BIGINT UNSIGNED NOT NULL,
+  DROP INDEX `item_guid`,
+  ADD UNIQUE KEY `item_guid` (`itemguid`);
+
+-- Guild bank references
+ALTER TABLE `guild_bank_item`
+  MODIFY COLUMN `item_guid` BIGINT UNSIGNED NOT NULL,
+  DROP INDEX `Idx_item_guid`,
+  ADD KEY `Idx_item_guid` (`item_guid`);
+
+-- Refund/trade/gift tables referencing items by guid
+ALTER TABLE `item_refund_instance`
+  MODIFY COLUMN `item_guid` BIGINT UNSIGNED NOT NULL;
+
+ALTER TABLE `item_soulbound_trade_data`
+  MODIFY COLUMN `itemGuid` BIGINT UNSIGNED NOT NULL,
+  DROP PRIMARY KEY,
+  ADD PRIMARY KEY (`itemGuid`);
+
+ALTER TABLE `character_gifts`
+  MODIFY COLUMN `item_guid` BIGINT UNSIGNED NOT NULL,
+  DROP PRIMARY KEY,
+  ADD PRIMARY KEY (`item_guid`);

--- a/src/server/game/Entities/Item/Item.h
+++ b/src/server/game/Entities/Item/Item.h
@@ -239,11 +239,18 @@ public:
     [[nodiscard]] bool IsBoundByEnchant() const;
     [[nodiscard]] bool IsBoundByTempEnchant() const;
     virtual void SaveToDB(CharacterDatabaseTransaction trans);
+    // Legacy: Load by low-guid (pre-decoupling)
     virtual bool LoadFromDB(ObjectGuid::LowType guid, ObjectGuid owner_guid, Field* fields, uint32 entry);
+    // Decoupled: Load by persistent db-guid (64-bit), will map to a transient low-guid
+    virtual bool LoadFromDB64(uint64 dbGuid, ObjectGuid owner_guid, Field* fields, uint32 entry);
     static void DeleteFromDB(CharacterDatabaseTransaction trans, ObjectGuid::LowType itemGuid);
     virtual void DeleteFromDB(CharacterDatabaseTransaction trans);
     static void DeleteFromInventoryDB(CharacterDatabaseTransaction trans, ObjectGuid::LowType itemGuid);
     void DeleteFromInventoryDB(CharacterDatabaseTransaction trans);
+
+    // Decoupled: DB GUID accessors
+    uint64 GetDbGuid() const { return m_dbGuid; }
+    void SetDbGuid(uint64 v) { m_dbGuid = v; }
     void SaveRefundDataToDB();
     void DeleteRefundDataFromDB(CharacterDatabaseTransaction* trans);
 
@@ -376,5 +383,6 @@ private:
     uint32 m_paidMoney;
     uint32 m_paidExtendedCost;
     AllowedLooterSet allowedGUIDs;
+    uint64 m_dbGuid = 0;                                // Persistent DB identifier (64-bit)
 };
 #endif

--- a/src/server/game/Entities/Item/ItemGuidMap.cpp
+++ b/src/server/game/Entities/Item/ItemGuidMap.cpp
@@ -1,0 +1,59 @@
+/*
+ * Lightweight runtime mapper for Items: DB GUID (uint64) <-> transient Low GUID (uint32)
+ */
+
+#include "ItemGuidMap.h"
+
+ItemGuidMap* ItemGuidMap::instance()
+{
+    // Function-local static to respect the private constructor
+    static ItemGuidMap s_Instance;
+    return &s_Instance;
+}
+
+uint32_t ItemGuidMap::NextLow()
+{
+    // Simple monotonically increasing counter with free-list reuse
+    if (!_free.empty())
+    {
+        uint32_t id = _free.front();
+        _free.pop();
+        return id;
+    }
+    // wrap-around protection is not handled here; upper layers should ensure recyclable usage
+    return _next++;
+}
+
+uint32_t ItemGuidMap::Acquire(uint64_t dbGuid)
+{
+    std::lock_guard<std::mutex> g(_mtx);
+    auto it = _dbToLow.find(dbGuid);
+    if (it != _dbToLow.end())
+        return it->second;
+    uint32_t low = NextLow();
+    _dbToLow.emplace(dbGuid, low);
+    return low;
+}
+
+uint32_t ItemGuidMap::AcquireForNew()
+{
+    std::lock_guard<std::mutex> g(_mtx);
+    return NextLow();
+}
+
+void ItemGuidMap::Bind(uint64_t dbGuid, uint32_t lowGuid)
+{
+    std::lock_guard<std::mutex> g(_mtx);
+    _dbToLow[dbGuid] = lowGuid;
+}
+
+void ItemGuidMap::Release(uint64_t dbGuid)
+{
+    std::lock_guard<std::mutex> g(_mtx);
+    auto it = _dbToLow.find(dbGuid);
+    if (it != _dbToLow.end())
+    {
+        _free.push(it->second);
+        _dbToLow.erase(it);
+    }
+}

--- a/src/server/game/Entities/Item/ItemGuidMap.h
+++ b/src/server/game/Entities/Item/ItemGuidMap.h
@@ -1,0 +1,56 @@
+/*
+ * Lightweight runtime mapper for Items: DB GUID (uint64) <-> transient Low GUID (uint32)
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include <queue>
+#include <mutex>
+#include <atomic>
+
+class ItemGuidMap
+{
+public:
+    static ItemGuidMap* instance();
+
+    // Acquire or create a low-guid for a persistent db-guid
+    uint32_t Acquire(uint64_t dbGuid);
+
+    // Reserve a new low-guid for a brand new, unsaved item (dbGuid not known yet)
+    uint32_t AcquireForNew();
+
+    // Bind a db-guid to an already reserved low-guid (used after first save assigns dbGuid)
+    void Bind(uint64_t dbGuid, uint32_t lowGuid);
+
+    // Release mapping and recycle low-guid
+    void Release(uint64_t dbGuid);
+
+    // Initialize the starting value for persistent DB GUID generator
+    void InitDbGuidSeed(uint64_t start)
+    {
+        std::lock_guard<std::mutex> g(_mtx);
+        if (_nextDbGuid.load() == 0 || start > _nextDbGuid.load())
+            _nextDbGuid.store(start);
+    }
+
+    // Get next persistent DB GUID
+    uint64_t AcquireDbGuid()
+    {
+        return _nextDbGuid.fetch_add(1, std::memory_order_relaxed);
+    }
+
+private:
+    ItemGuidMap() = default;
+
+    uint32_t NextLow();
+
+    std::unordered_map<uint64_t, uint32_t> _dbToLow;
+    std::queue<uint32_t> _free;
+    uint32_t _next{1};
+    std::mutex _mtx;
+    std::atomic<uint64_t> _nextDbGuid{0};
+};
+
+#define sItemGuidMap ItemGuidMap::instance()

--- a/src/server/game/Entities/Player/PlayerStorage.cpp
+++ b/src/server/game/Entities/Player/PlayerStorage.cpp
@@ -63,6 +63,7 @@
 #include "Util.h"
 #include "World.h"
 #include "WorldPacket.h"
+#include "Entities/Item/ItemGuidMap.h"
 
 /// @todo: this import is not necessary for compilation and marked as unused by the IDE
 //  however, for some reasons removing it would cause a damn linking issue
@@ -2561,7 +2562,7 @@ Item* Player::StoreNewItem(ItemPosCountVec const& dest, uint32 item, bool update
                 ss << ' ' << (*itr).GetCounter();
 
             CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_ITEM_BOP_TRADE);
-            stmt->SetData(0, pItem->GetGUID().GetCounter());
+            stmt->SetData(0, static_cast<uint64>(pItem->GetDbGuid()));
             stmt->SetData(1, ss.str());
             CharacterDatabase.Execute(stmt);
         }
@@ -3032,7 +3033,7 @@ void Player::DestroyItem(uint8 bag, uint8 slot, bool update)
         if (pItem->IsWrapped())
         {
             CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_GIFT);
-            stmt->SetData(0, pItem->GetGUID().GetCounter());
+            stmt->SetData(0, static_cast<uint64>(pItem->GetDbGuid()));
             CharacterDatabase.Execute(stmt);
         }
 
@@ -5969,20 +5970,21 @@ void Player::_LoadInventory(PreparedQueryResult result, uint32 timeDiff)
 Item* Player::_LoadItem(CharacterDatabaseTransaction trans, uint32 zoneId, uint32 timeDiff, Field* fields)
 {
     Item* item = nullptr;
-    ObjectGuid::LowType itemGuid  = fields[13].Get<uint32>();
+    uint64 itemGuidDb  = fields[13].Get<uint64>();
     uint32 itemEntry = fields[14].Get<uint32>();
     if (ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemEntry))
     {
         bool remove = false;
         item = NewItemOrBag(proto);
-        if (item->LoadFromDB(itemGuid, GetGUID(), fields, itemEntry))
+        bool ok = item->LoadFromDB64(itemGuidDb, GetGUID(), fields, itemEntry);
+        if (ok)
         {
             CharacterDatabasePreparedStatement* stmt = nullptr;
 
             // Do not allow to have item limited to another map/zone in alive state
             if (IsAlive() && item->IsLimitedToAnotherMapOrZone(GetMapId(), zoneId))
             {
-                LOG_DEBUG("entities.player.loading", "Player::_LoadInventory: player ({}, name: '{}', map: {}) has item ({}, entry: {}) limited to another map ({}). Deleting item.",
+                        LOG_DEBUG("entities.player.loading", "Player::_LoadInventory: player ({}, name: '{}', map: {}) has item ({}, entry: {}) limited to another map ({}). Deleting item.",
                           GetGUID().ToString(), GetName(), GetMapId(), item->GetGUID().ToString(), item->GetEntry(), zoneId);
                 remove = true;
             }
@@ -6000,7 +6002,7 @@ Item* Player::_LoadItem(CharacterDatabaseTransaction trans, uint32 zoneId, uint3
                     LOG_DEBUG("entities.player.loading", "Player::_LoadInventory: player ({}, name: '{}') has item ({}, entry: {}) with expired refund time ({}). Deleting refund data and removing refundable flag.",
                               GetGUID().ToString(), GetName(), item->GetGUID().ToString(), item->GetEntry(), item->GetPlayedTime());
                     stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_ITEM_REFUND_INSTANCE);
-                    stmt->SetData(0, item->GetGUID().GetCounter());
+                    stmt->SetData(0, static_cast<uint64>(item->GetDbGuid()));
                     trans->Append(stmt);
 
                     item->RemoveFlag(ITEM_FIELD_FLAGS, ITEM_FIELD_FLAG_REFUNDABLE);
@@ -6009,7 +6011,7 @@ Item* Player::_LoadItem(CharacterDatabaseTransaction trans, uint32 zoneId, uint3
                 {
                     // xinef: sync query
                     stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_ITEM_REFUNDS);
-                    stmt->SetData(0, item->GetGUID().GetCounter());
+                    stmt->SetData(0, static_cast<uint64>(item->GetDbGuid()));
                     stmt->SetData(1, GetGUID().GetCounter());
                     if (PreparedQueryResult result = CharacterDatabase.Query(stmt))
                     {
@@ -6029,7 +6031,7 @@ Item* Player::_LoadItem(CharacterDatabaseTransaction trans, uint32 zoneId, uint3
             else if (item->IsBOPTradable())
             {
                 stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_ITEM_BOP_TRADE);
-                stmt->SetData(0, item->GetGUID().GetCounter());
+                stmt->SetData(0, static_cast<uint64>(item->GetDbGuid()));
 
                 if (PreparedQueryResult result = CharacterDatabase.Query(stmt))
                 {
@@ -6079,13 +6081,15 @@ Item* Player::_LoadItem(CharacterDatabaseTransaction trans, uint32 zoneId, uint3
         else
         {
             LOG_ERROR("entities.player", "Player::_LoadInventory: player ({}, name: '{}') has broken item (GUID: {}, entry: {}) in inventory. Deleting item.",
-                      GetGUID().ToString(), GetName(), itemGuid, itemEntry);
+                      GetGUID().ToString(), GetName(), itemGuidDb, itemEntry);
             remove = true;
         }
         // Remove item from inventory if necessary
         if (remove)
         {
-            Item::DeleteFromInventoryDB(trans, itemGuid);
+            CharacterDatabasePreparedStatement* delStmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_CHAR_INVENTORY_BY_ITEM);
+            delStmt->SetData(0, static_cast<uint64>(item->GetDbGuid()));
+            trans->Append(delStmt);
             item->FSetState(ITEM_REMOVED);
             item->SaveToDB(trans);                           // it also deletes item object!
             item = nullptr;
@@ -6095,8 +6099,12 @@ Item* Player::_LoadItem(CharacterDatabaseTransaction trans, uint32 zoneId, uint3
     {
         LOG_ERROR("entities.player", "Player::_LoadInventory: player ({}, name: '{}') has unknown item (entry: {}) in inventory. Deleting item.",
                   GetGUID().ToString(), GetName(), itemEntry);
-        Item::DeleteFromInventoryDB(trans, itemGuid);
-        Item::DeleteFromDB(trans, itemGuid);
+        CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_CHAR_INVENTORY_BY_ITEM);
+        stmt->SetData(0, static_cast<uint64>(itemGuidDb));
+        trans->Append(stmt);
+        stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_ITEM_INSTANCE);
+        stmt->SetData(0, static_cast<uint64>(itemGuidDb));
+        trans->Append(stmt);
     }
     return item;
 }
@@ -6104,19 +6112,19 @@ Item* Player::_LoadItem(CharacterDatabaseTransaction trans, uint32 zoneId, uint3
 // load mailed item which should receive current player
 Item* Player::_LoadMailedItem(ObjectGuid const& playerGuid, Player* player, uint32 mailId, Mail* mail, Field* fields)
 {
-    ObjectGuid::LowType itemGuid = fields[11].Get<uint32>();
+    uint64 itemGuidDb = fields[11].Get<uint64>();
     uint32 itemEntry = fields[12].Get<uint32>();
 
     ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemEntry);
     if (!proto)
     {
         LOG_ERROR("entities.player", "Player {} ({}) has unknown item in mailed items (GUID: {}, Entry: {}) in mail ({}), deleted.",
-            player ? player->GetName() : "<unknown>", playerGuid.ToString(), itemGuid, itemEntry, mailId);
+            player ? player->GetName() : "<unknown>", playerGuid.ToString(), itemGuidDb, itemEntry, mailId);
 
         CharacterDatabaseTransaction trans = CharacterDatabase.BeginTransaction();
 
         CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_INVALID_MAIL_ITEM);
-        stmt->SetData(0, itemGuid);
+        stmt->SetData(0, static_cast<uint64>(itemGuidDb));
         trans->Append(stmt);
 
         CharacterDatabase.CommitTransaction(trans);
@@ -6126,12 +6134,12 @@ Item* Player::_LoadMailedItem(ObjectGuid const& playerGuid, Player* player, uint
     Item* item = NewItemOrBag(proto);
 
     ObjectGuid ownerGuid = fields[13].Get<uint32>() ? ObjectGuid::Create<HighGuid::Player>(fields[13].Get<uint32>()) : ObjectGuid::Empty;
-    if (!item->LoadFromDB(itemGuid, ownerGuid, fields, itemEntry))
+    if (!item->LoadFromDB64(itemGuidDb, ownerGuid, fields, itemEntry))
     {
-        LOG_ERROR("entities.player", "Player::_LoadMailedItems: Item (GUID: {}) in mail ({}) doesn't exist, deleted from mail.", itemGuid, mailId);
+        LOG_ERROR("entities.player", "Player::_LoadMailedItems: Item (GUID: {}) in mail ({}) doesn't exist, deleted from mail.", itemGuidDb, mailId);
 
         CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_MAIL_ITEM);
-        stmt->SetData(0, itemGuid);
+        stmt->SetData(0, static_cast<uint64>(itemGuidDb));
         CharacterDatabase.Execute(stmt);
 
         item->FSetState(ITEM_REMOVED);
@@ -6143,7 +6151,7 @@ Item* Player::_LoadMailedItem(ObjectGuid const& playerGuid, Player* player, uint
 
     if (mail)
     {
-        mail->AddItem(itemGuid, itemEntry);
+        mail->AddItem(item->GetGUID().GetCounter(), itemEntry);
     }
 
     if (player)
@@ -7267,11 +7275,11 @@ void Player::_SaveInventory(CharacterDatabaseTransaction trans)
         }
 
         stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_CHAR_INVENTORY_BY_ITEM);
-        stmt->SetData(0, item->GetGUID().GetCounter());
+        stmt->SetData(0, static_cast<uint64>(item->GetDbGuid()));
         trans->Append(stmt);
 
         stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_ITEM_INSTANCE);
-        stmt->SetData(0, item->GetGUID().GetCounter());
+        stmt->SetData(0, static_cast<uint64>(item->GetDbGuid()));
         trans->Append(stmt);
         m_items[i]->FSetState(ITEM_NEW);
 
@@ -7365,16 +7373,23 @@ void Player::_SaveInventory(CharacterDatabaseTransaction trans)
         {
             case ITEM_NEW:
             case ITEM_CHANGED:
+                // Ensure a DB GUID is assigned before writing character_inventory
+                if (item->GetDbGuid() == 0)
+                {
+                    uint64 newDbGuid = sItemGuidMap->AcquireDbGuid();
+                    sItemGuidMap->Bind(newDbGuid, item->GetGUID().GetCounter());
+                    item->SetDbGuid(newDbGuid);
+                }
                 stmt = CharacterDatabase.GetPreparedStatement(CHAR_REP_INVENTORY_ITEM);
                 stmt->SetData(0, lowGuid);
                 stmt->SetData(1, bag_guid);
                 stmt->SetData (2, item->GetSlot());
-                stmt->SetData(3, item->GetGUID().GetCounter());
+                stmt->SetData(3, static_cast<uint64>(item->GetDbGuid()));
                 trans->Append(stmt);
                 break;
             case ITEM_REMOVED:
                 stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_CHAR_INVENTORY_BY_ITEM);
-                stmt->SetData(0, item->GetGUID().GetCounter());
+                stmt->SetData(0, static_cast<uint64>(item->GetDbGuid()));
                 trans->Append(stmt);
             case ITEM_UNCHANGED:
                 break;

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -27,6 +27,7 @@
 #include "DBCStructure.h"
 #include "DatabaseEnv.h"
 #include "DisableMgr.h"
+#include "Entities/Item/ItemGuidMap.h"
 #include "GameEventMgr.h"
 #include "GameObjectAIFactory.h"
 #include "GameTime.h"
@@ -6316,7 +6317,7 @@ void ObjectMgr::ReturnOrDeleteOldMails(bool serverUp)
         do
         {
             Field* fields = items->Fetch();
-            item.item_guid = fields[0].Get<uint32>();
+            item.item_guid = fields[0].Get<uint64>();
             item.item_template = fields[1].Get<uint32>();
             uint32 mailId = fields[2].Get<uint32>();
             itemsCache[mailId].push_back(item);
@@ -7184,14 +7185,11 @@ void ObjectMgr::SetHighestGuids()
         GetGuidSequenceGenerator<HighGuid::Player>().Set((*result)[0].Get<uint32>() + 1);
 
     result = CharacterDatabase.Query("SELECT MAX(guid) FROM item_instance");
-    if (result)
-        GetGuidSequenceGenerator<HighGuid::Item>().Set((*result)[0].Get<uint32>() + 1);
+    // Initialize persistent item DB GUID starting point (64-bit)
+    // NOTE: In decoupled mode, item low GUIDs are process-local and not persisted.
+    if (QueryResult itemMax = CharacterDatabase.Query("SELECT MAX(guid) FROM item_instance"))
+        sItemGuidMap->InitDbGuidSeed((*itemMax)[0].Get<uint64>() + 1u);
 
-    // Cleanup other tables from not existed guids ( >= _hiItemGuid)
-    CharacterDatabase.Execute("DELETE FROM character_inventory WHERE item >= '{}'", GetGuidSequenceGenerator<HighGuid::Item>().GetNextAfterMaxUsed());     // One-time query
-    CharacterDatabase.Execute("DELETE FROM mail_items WHERE item_guid >= '{}'", GetGuidSequenceGenerator<HighGuid::Item>().GetNextAfterMaxUsed());         // One-time query
-    CharacterDatabase.Execute("DELETE FROM auctionhouse WHERE itemguid >= '{}'", GetGuidSequenceGenerator<HighGuid::Item>().GetNextAfterMaxUsed());        // One-time query
-    CharacterDatabase.Execute("DELETE FROM guild_bank_item WHERE item_guid >= '{}'", GetGuidSequenceGenerator<HighGuid::Item>().GetNextAfterMaxUsed());    // One-time query
 
     result = WorldDatabase.Query("SELECT MAX(guid) FROM transports");
     if (result)

--- a/src/server/game/Guilds/Guild.cpp
+++ b/src/server/game/Guilds/Guild.cpp
@@ -387,25 +387,26 @@ void Guild::BankTab::LoadFromDB(Field* fields)
 bool Guild::BankTab::LoadItemFromDB(Field* fields)
 {
     uint8 slotId = fields[13].Get<uint8>();
-    ObjectGuid::LowType itemGuid = fields[14].Get<uint32>();
+    uint64 itemGuidDb = fields[14].Get<uint64>();
     uint32 itemEntry = fields[15].Get<uint32>();
     if (slotId >= GUILD_BANK_MAX_SLOTS)
     {
-        LOG_ERROR("guild", "Invalid slot for item (GUID: {}, id: {}) in guild bank, skipped.", itemGuid, itemEntry);
+        LOG_ERROR("guild", "Invalid slot for item (GUID: {}, id: {}) in guild bank, skipped.", itemGuidDb, itemEntry);
         return false;
     }
 
     ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemEntry);
     if (!proto)
     {
-        LOG_ERROR("guild", "Unknown item (GUID: {}, id: {}) in guild bank, skipped.", itemGuid, itemEntry);
+        LOG_ERROR("guild", "Unknown item (GUID: {}, id: {}) in guild bank, skipped.", itemGuidDb, itemEntry);
         return false;
     }
 
     Item* pItem = NewItemOrBag(proto);
-    if (!pItem->LoadFromDB(itemGuid, ObjectGuid::Empty, fields, itemEntry))
+    bool ok = pItem->LoadFromDB64(itemGuidDb, ObjectGuid::Empty, fields, itemEntry);
+    if (!ok)
     {
-        LOG_ERROR("guild", "Item (GUID {}, id: {}) not found in item_instance, deleting from guild bank!", itemGuid, itemEntry);
+        LOG_ERROR("guild", "Item (GUID {}, id: {}) not found in item_instance, deleting from guild bank!", itemGuidDb, itemEntry);
 
         CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_NONEXISTENT_GUILD_BANK_ITEM);
         stmt->SetData(0, m_guildId);

--- a/src/server/game/Handlers/MailHandler.cpp
+++ b/src/server/game/Handlers/MailHandler.cpp
@@ -31,6 +31,7 @@
 #include "ScriptMgr.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
+#include "Entities/Item/ItemGuidMap.h"
 
 #define MAX_INBOX_CLIENT_CAPACITY 50
 
@@ -73,13 +74,13 @@ void WorldSession::HandleSendMail(WorldPacket& recvData)
 
     recvData >> subject;
 
+    recvData >> body;
+
     // prevent client crash
     if (subject.find("| |") != std::string::npos || body.find("| |") != std::string::npos)
     {
         return;
     }
-
-    recvData >> body;
 
     recvData >> unk1;                                      // stationery?
     recvData >> unk2;                                      // 0x00000000
@@ -712,7 +713,7 @@ void WorldSession::HandleGetMailList(WorldPacket& recvData)
 
         for (uint8 i = 0; i < item_count; ++i)
         {
-            Item* item = player->GetMItem(mail->items[i].item_guid);
+            Item* item = player->GetMItem(static_cast<ObjectGuid::LowType>(mail->items[i].item_guid));
             // item index (0-6?)
             data << uint8(i);
             // item guid low?
@@ -775,7 +776,7 @@ void WorldSession::HandleMailCreateTextItem(WorldPacket& recvData)
     }
 
     Item* bodyItem = new Item;                              // This is not bag and then can be used new Item.
-    if (!bodyItem->Create(sObjectMgr->GetGenerator<HighGuid::Item>().Generate(), MAIL_BODY_ITEM_TEMPLATE, player))
+    if (!bodyItem->Create(sItemGuidMap->AcquireForNew(), MAIL_BODY_ITEM_TEMPLATE, player))
     {
         delete bodyItem;
         return;

--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -273,7 +273,7 @@ void WorldSession::HandleOpenItemOpcode(WorldPacket& recvPacket)
         if (item->IsWrapped())// wrapped?
         {
             CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_CHARACTER_GIFT_BY_ITEM);
-            stmt->SetData(0, item->GetGUID().GetCounter());
+            stmt->SetData(0, static_cast<uint64>(item->GetDbGuid()));
             _queryProcessor.AddCallback(CharacterDatabase.AsyncQuery(stmt)
                 .WithPreparedCallback(std::bind(&WorldSession::HandleOpenWrappedItemCallback, this, bagIndex, slot, item->GetGUID().GetCounter(), std::placeholders::_1)));
         }
@@ -318,7 +318,7 @@ void WorldSession::HandleOpenWrappedItemCallback(uint8 bagIndex, uint8 slot, Obj
     GetPlayer()->SaveInventoryAndGoldToDB(trans);
 
     CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_GIFT);
-    stmt->SetData(0, item->GetGUID().GetCounter());
+    stmt->SetData(0, static_cast<uint64>(item->GetDbGuid()));
     trans->Append(stmt);
 
     CharacterDatabase.CommitTransaction(trans);

--- a/src/server/game/Mails/Mail.cpp
+++ b/src/server/game/Mails/Mail.cpp
@@ -246,7 +246,7 @@ void MailDraft::SendMailTo(CharacterDatabaseTransaction trans, MailReceiver cons
     {
         stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_MAIL_ITEM);
         stmt->SetData(0, mailId);
-        stmt->SetData(1, mailItemIter->second->GetGUID().GetCounter());
+        stmt->SetData(1, static_cast<uint64>(mailItemIter->second->GetDbGuid()));
         stmt->SetData(2, receiver.GetPlayerGUIDLow());
         trans->Append(stmt);
     }

--- a/src/server/game/Mails/Mail.h
+++ b/src/server/game/Mails/Mail.h
@@ -158,7 +158,7 @@ private:
 
 struct MailItemInfo
 {
-    ObjectGuid::LowType item_guid;
+    uint64 item_guid;
     uint32 item_template;
 };
 typedef std::vector<MailItemInfo> MailItemInfoVec;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

This pull request introduces a major refactor to how item GUIDs are handled in the database and game code. The main change is the decoupling of transient in-memory item GUIDs (low GUIDs) from persistent database GUIDs (now 64-bit unsigned integers), enabling safer and more scalable item tracking. A new `ItemGuidMap` system is implemented to map between DB GUIDs and runtime low GUIDs, and all relevant database tables, queries, and code paths are updated to use this new system.

Out of scope: Characters GUIDs etc.

**Database schema changes:**

* All tables referencing item GUIDs (`item_instance`, `character_inventory`, `mail_items`, `auctionhouse`, `guild_bank_item`, `item_refund_instance`, `item_soulbound_trade_data`, `character_gifts`) now use `BIGINT UNSIGNED` for item GUIDs, supporting 64-bit persistent DB IDs. Indexes and primary keys are updated accordingly.

**Item GUID mapping system:**

* Added new files `ItemGuidMap.h` and `ItemGuidMap.cpp` implementing a runtime mapping between persistent DB GUIDs (`uint64`) and transient low GUIDs (`uint32`). Provides methods for acquiring, binding, and releasing GUIDs, and for generating new persistent DB GUIDs. [[1]](diffhunk://#diff-751b37c9624356cff55549923afa5ca89474bc0d33837de034cbb4e46f0f83c4R1-R56) [[2]](diffhunk://#diff-4c9af30888a247c182b4c11878291db59f75c696e0eb9c78f432315191515ea5R1-R59)

**Core item logic changes:**

* The `Item` class now stores its persistent DB GUID (`m_dbGuid`) and provides accessors. Item creation, saving, loading, and deletion are refactored to use the new DB GUID system, including new method `LoadFromDB64`. All DB operations (save, delete, refund, soulbound trade, etc.) now use the persistent DB GUID instead of the low GUID. [[1]](diffhunk://#diff-cc5f95fe4dcdf4b27d97dbfb4b4fa3b81082e50621d7c57e0bde65f0a01a0a2cL377-R413) [[2]](diffhunk://#diff-cc5f95fe4dcdf4b27d97dbfb4b4fa3b81082e50621d7c57e0bde65f0a01a0a2cR525-R623) [[3]](diffhunk://#diff-cc5f95fe4dcdf4b27d97dbfb4b4fa3b81082e50621d7c57e0bde65f0a01a0a2cL1177-R1283) [[4]](diffhunk://#diff-cc5f95fe4dcdf4b27d97dbfb4b4fa3b81082e50621d7c57e0bde65f0a01a0a2cL1195-R1297) [[5]](diffhunk://#diff-cc5f95fe4dcdf4b27d97dbfb4b4fa3b81082e50621d7c57e0bde65f0a01a0a2cL1273-R1375) [[6]](diffhunk://#diff-4f28e9665111595b9c64021f23316ff5bfac616c670c96128d6191259f7ad8a6R242-R253) [[7]](diffhunk://#diff-4f28e9665111595b9c64021f23316ff5bfac616c670c96128d6191259f7ad8a6R386)

**Auction house and player inventory integration:**

* `AuctionHouseMgr.cpp` and `PlayerStorage.cpp` are updated to use the new DB GUID system for item references, saving, loading, and deletion. Auction entries now store and retrieve the persistent DB GUID, mapping it to a low GUID at runtime. Player inventory loading and item destruction also use the new GUID system. [[1]](diffhunk://#diff-f4f8437f4c37733502345d304c41c008bdcf9a91cc66ef269ece3a5e29b4ba44L583-R588) [[2]](diffhunk://#diff-f4f8437f4c37733502345d304c41c008bdcf9a91cc66ef269ece3a5e29b4ba44L598-R607) [[3]](diffhunk://#diff-e8d54c0ff22e7231aeca437b54b589d2c527d1d9e9fb42ece815792d63567e77L2564-R2565) [[4]](diffhunk://#diff-e8d54c0ff22e7231aeca437b54b589d2c527d1d9e9fb42ece815792d63567e77L3035-R3036) [[5]](diffhunk://#diff-e8d54c0ff22e7231aeca437b54b589d2c527d1d9e9fb42ece815792d63567e77L5972-R5980) [[6]](diffhunk://#diff-e8d54c0ff22e7231aeca437b54b589d2c527d1d9e9fb42ece815792d63567e77L6003-R6005)

**Codebase updates and imports:**

* Includes necessary imports of `ItemGuidMap.h` in affected files to enable the new mapping system. [[1]](diffhunk://#diff-f4f8437f4c37733502345d304c41c008bdcf9a91cc66ef269ece3a5e29b4ba44R32) [[2]](diffhunk://#diff-cc5f95fe4dcdf4b27d97dbfb4b4fa3b81082e50621d7c57e0bde65f0a01a0a2cR31) [[3]](diffhunk://#diff-e8d54c0ff22e7231aeca437b54b589d2c527d1d9e9fb42ece815792d63567e77R66)

This refactor lays the foundation for scalable, persistent item tracking and prepares the codebase for future features that require reliable item identification across server restarts and migrations.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- https://github.com/azerothcore/azerothcore-wotlk/issues/22777 (partially)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] 
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
