### PR TITLE
fix(Scripts/WorldState): defeated scourge zone invasions not restarting after a defeat

### DIFF
--- a/src/server/game/World/WorldState.cpp
+++ b/src/server/game/World/WorldState.cpp
@@ -1420,8 +1420,13 @@ void ScourgeInvasionData::Reset()
 std::string ScourgeInvasionData::GetData()
 {
     std::string output = std::to_string(m_state) + " ";
-    for (auto& timer : m_timers)
-        output += std::to_string(timer.time_since_epoch().count()) + " ";
+    for (TimePoint& timer : m_timers)
+    {
+        if (timer == TimePoint())
+            output += "0 ";
+        else
+            output += std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(timer.time_since_epoch()).count()) + " ";
+    }
     output += std::to_string(m_battlesWon) + " " + std::to_string(m_lastAttackZone) + " ";
     for (uint32& remaining : m_remaining)
         output += std::to_string(remaining) + " ";


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

SI timers are stored in the wrong format. The load expect timers to be in ms
https://github.com/azerothcore/azerothcore-wotlk/blob/d5d8256bc5f733477966f70d0802abdedde0cd2d/src/server/game/World/WorldState.cpp#L109

But we're storing it by mistake in 'ticks', which are 1e6 times too large

after logging
```cpp
std::string ScourgeInvasionData::GetData()
    for (TimePoint& timer : m_timers)
        auto tick = std::to_string(timer.time_since_epoch().count());
        auto ms = std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(timer.time_since_epoch()).count());
```
`tick: 30425131150684, ms: 30425131`

Note:
for an event in progress the `acore_characters.world_state` with id 3. The timer entries should be trimmed by 6 digits (/1_000_000) for the timers to be converted from ticks to ms

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

`.worldstate scourgeinvasion state 1`

`.die` on crystals to defeat the zone invasion

`.worldstate scourgeinvasion show` to display timers

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

see above

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
