### PR TITLE
fix(Scripts/WorldState): zone invasion marks self as defeated when ti…

### DIFF
--- a/src/server/scripts/World/scourge_invasion.cpp
+++ b/src/server/scripts/World/scourge_invasion.cpp
@@ -92,6 +92,7 @@ struct npc_herald_of_the_lich_king : public ScriptedAI
             Talk(HERALD_OF_THE_LICH_KING_SAY_ATTACK_END);
             ChangeZoneEventStatus(false);
             UpdateWeather(false);
+            me->DespawnOrUnsummon();
         }
     }
 


### PR DESCRIPTION
…mer ends

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Necropolis Health script `JustDied` lowers the count of remaining necropoli, which is checked on the next world update.

https://github.com/azerothcore/azerothcore-wotlk/blob/d5d8256bc5f733477966f70d0802abdedde0cd2d/src/server/game/World/WorldState.cpp#L1797

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

missed a line when porting:

https://github.com/cmangos/mangos-wotlk/blob/ee8f5e5776c7ed11bbb8228ddfffc64701f4c802/src/game/AI/ScriptDevAI/scripts/world/scourge_invasion.cpp#L335


Add the missing line to despawn the Herald of the Lich King


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

defeat zones with
```
/target necropolis health
.die
```


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
