### PR TITLE
feat(Core/Restricted Flight Area): implements verification logic

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5644,7 +5644,25 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                         case 58600: // Restricted Flight Area
                         case 58730: // Restricted Flight Area
                             if (aurApp->GetRemoveMode() == AURA_REMOVE_BY_EXPIRE)
-                                target->CastSpell(target, 58601, true);
+                            {
+                                float posX = target->GetPositionX();
+                                float posY = target->GetPositionY();
+                                float posZ = target->GetPositionZ();
+                                float groundZ = target->GetMapHeight(posX, posY, posZ);
+                                float HeightAboveGround = posZ - groundZ;
+                                float MinParachuteHeight = 8.0f;
+
+                                if (HeightAboveGround >= MinParachuteHeight)
+                                {
+                                    target->CastSpell(target, 58601, true);
+                                }
+
+                                if (HeightAboveGround < MinParachuteHeight)
+                                {
+                                    target->RemoveAurasByType(SPELL_AURA_FLY);
+                                    target->RemoveAurasByType(SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED);
+                                }
+                            }
                             break;
                         case 46374: // quest The Power of the Elements (11893)
                             {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

This commit introduces flight restriction logic to the route planning system, specifically for the zones Dalaran and Wintergrasp.
- When a player falls from a significant height within these restricted areas:
- If they are at a high altitude, a parachute is automatically deployed to prevent fall damage.
- If they are at a low altitude, flight ability is disabled without triggering a fall.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.