### PR TITLE
fix(CMake/Boost): package finding logic + suppress deprecation warnings + support Boost 1.89

### DIFF
--- a/deps/boost/CMakeLists.txt
+++ b/deps/boost/CMakeLists.txt
@@ -10,11 +10,6 @@
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
 
-# Suppress FindBoost deprecation warning in CMake 3.30+
-if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 OLD)
-endif()
-
 if(WIN32)
   if(DEFINED ENV{Boost_ROOT})
     set(Boost_ROOT $ENV{Boost_ROOT})
@@ -36,16 +31,8 @@ else()
   set(BOOST_REQUIRED_VERSION 1.74)
 endif()
 
-# First try to find Boost without system component (for Boost 1.69+)
-find_package(Boost ${BOOST_REQUIRED_VERSION} QUIET COMPONENTS filesystem program_options iostreams regex)
-
-if(NOT Boost_FOUND)
-  # If that fails, try with system component (for Boost < 1.69)
-  find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED COMPONENTS system filesystem program_options iostreams regex)
-else()
-  # Re-run find_package with REQUIRED to get proper error messages if needed
-  find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED COMPONENTS filesystem program_options iostreams regex)
-endif()
+# Boost.System is header-only since 1.69; do not require it explicitly.
+find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED COMPONENTS filesystem program_options iostreams regex)
 
 if(NOT Boost_FOUND)
   if(NOT DEFINED ENV{Boost_ROOT} AND NOT DEFINED Boost_DIR AND NOT DEFINED BOOST_ROOT AND NOT DEFINED BOOSTROOT)

--- a/deps/boost/CMakeLists.txt
+++ b/deps/boost/CMakeLists.txt
@@ -10,6 +10,11 @@
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
 
+# Suppress FindBoost deprecation warning in CMake 3.30+
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 OLD)
+endif()
+
 if(WIN32)
   if(DEFINED ENV{Boost_ROOT})
     set(Boost_ROOT $ENV{Boost_ROOT})
@@ -31,7 +36,16 @@ else()
   set(BOOST_REQUIRED_VERSION 1.74)
 endif()
 
-find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED system filesystem program_options iostreams regex)
+# First try to find Boost without system component (for Boost 1.69+)
+find_package(Boost ${BOOST_REQUIRED_VERSION} QUIET filesystem program_options iostreams regex)
+
+if(NOT Boost_FOUND)
+  # If that fails, try with system component (for Boost < 1.69)
+  find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED system filesystem program_options iostreams regex)
+else()
+  # Re-run find_package with REQUIRED to get proper error messages if needed
+  find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED filesystem program_options iostreams regex)
+endif()
 
 if(NOT Boost_FOUND)
   if(NOT DEFINED ENV{Boost_ROOT} AND NOT DEFINED Boost_DIR AND NOT DEFINED BOOST_ROOT AND NOT DEFINED BOOSTROOT)

--- a/deps/boost/CMakeLists.txt
+++ b/deps/boost/CMakeLists.txt
@@ -37,14 +37,14 @@ else()
 endif()
 
 # First try to find Boost without system component (for Boost 1.69+)
-find_package(Boost ${BOOST_REQUIRED_VERSION} QUIET filesystem program_options iostreams regex)
+find_package(Boost ${BOOST_REQUIRED_VERSION} QUIET COMPONENTS filesystem program_options iostreams regex)
 
 if(NOT Boost_FOUND)
   # If that fails, try with system component (for Boost < 1.69)
-  find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED system filesystem program_options iostreams regex)
+  find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED COMPONENTS system filesystem program_options iostreams regex)
 else()
   # Re-run find_package with REQUIRED to get proper error messages if needed
-  find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED filesystem program_options iostreams regex)
+  find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED COMPONENTS filesystem program_options iostreams regex)
 endif()
 
 if(NOT Boost_FOUND)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

This pull request updates the way Boost dependencies are specified in the `deps/boost/CMakeLists.txt` file to improve compatibility with newer Boost versions. The most important change is the adjustment to the `find_package` command to avoid requiring the `system` component, which is header-only in Boost 1.69 and above.

Dependency management update:

* Modified the `find_package` command to exclude the `system` component and use the `COMPONENTS` keyword, ensuring only necessary Boost libraries are required for builds with Boost 1.74 or newer.

<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/22785

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
