### PR TITLE
fix(World/WorldState): SI main event can only be disabled manually

### DIFF
--- a/src/server/game/World/WorldState.cpp
+++ b/src/server/game/World/WorldState.cpp
@@ -1579,7 +1579,8 @@ void WorldState::HandleDefendedZones()
     }
     else if (m_siData.m_battlesWon >= 150)
     {
-        sGameEventMgr->StopEvent(GAME_EVENT_SCOURGE_INVASION);
+        // The event is enabled via command, so we expect it to be disabled via command as well.
+        // sGameEventMgr->StopEvent(GAME_EVENT_SCOURGE_INVASION);
         sGameEventMgr->StopEvent(GAME_EVENT_SCOURGE_INVASION_50_INVASIONS);
         sGameEventMgr->StopEvent(GAME_EVENT_SCOURGE_INVASION_100_INVASIONS);
         sGameEventMgr->StartEvent(GAME_EVENT_SCOURGE_INVASION_INVASIONS_DONE);

--- a/src/server/game/World/WorldState.cpp
+++ b/src/server/game/World/WorldState.cpp
@@ -1442,6 +1442,8 @@ void WorldState::StopScourgeInvasion()
     sGameEventMgr->StopEvent(GAME_EVENT_SCOURGE_INVASION_BLASTED_LANDS);
     sGameEventMgr->StopEvent(GAME_EVENT_SCOURGE_INVASION_EASTERN_PLAGUELANDS);
     sGameEventMgr->StopEvent(GAME_EVENT_SCOURGE_INVASION_BURNING_STEPPES);
+    sGameEventMgr->StopEvent(GAME_EVENT_SCOURGE_INVASION_INVASIONS_DONE);
+    sGameEventMgr->StopEvent(GAME_EVENT_SCOURGE_INVASION_BOSSES);
     BroadcastSIWorldstates();
     m_siData.Reset();
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

After 150 battles are won, the main NPCs (quest givers + vendors) will remain active

`.worldstate scourgeinvasion state 0` should disable all events without requiring a restart.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

After 150 battles are won, the main NPCs (quest givers + vendors) disappear early

`.worldstate scourgeinvasion state 0`  left some events active.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

`.worldstate scourgeinvasion state 1`

If battleswon >=150 the vendors should still be accessible.  
`.worldstate scourgeinvasion battleswon 50`  

`.worldstate scourgeinvasion state 0`  stops all events without requiring a restart

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
