### PR TITLE
fix(CORE/DBUpdater): Use stdin instead of -e SOURCE

### DIFF
--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -496,17 +496,13 @@ void DBUpdater<T>::ApplyFile(DatabaseWorkerPool<T>& pool, std::string const& hos
     if (ssl == "ssl")
         args.emplace_back("--ssl-mode=REQUIRED");
 
-    // Execute sql file
-    args.emplace_back("-e");
-    args.emplace_back(Acore::StringFormat("BEGIN; SOURCE {}; COMMIT;", path.generic_string()));
-
     // Database
     if (!database.empty())
         args.emplace_back(database);
 
     // Invokes a mysql process which doesn't leak credentials to logs
     int const ret = Acore::StartProcess(DBUpdaterUtil::GetCorrectedMySQLExecutable(), args,
-        "sql.updates", "", true);
+        "sql.updates", path.generic_string(), true);
 
     if (ret != EXIT_SUCCESS)
     {


### PR DESCRIPTION
DBUpdater previously always used `-e "SOURCE file.sql"`, which is unsupported in non-interactive mode and caused errors like:

ERROR 1064 (42000) at line 1: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'SOURCE ...'

- Changed DBUpdater<T>::ApplyFile to pass the SQL file via stdin
- Removed usage of `-e SOURCE` when stdin is provided
- Verified that SQL updates apply successfully on macOS/Homebrew MySQL as well as on Linux

<img width="1512" height="853" alt="Error 2025-09-11 в 01 18 02" src="https://github.com/user-attachments/assets/1b05b3f8-bb7c-433a-ad14-211c1ee21db5" />

