### PR TITLE
feat(Core/SAI): enhance movement actions with force destination option

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1846,6 +1846,8 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
             WorldObject* target = nullptr;
 
+            SAIBool isForced = !e.action.moveToPos.disableForceDestination;
+
             switch (e.GetTargetType())
             {
                 case SMART_TARGET_POSITION:
@@ -1855,7 +1857,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                         if (TransportBase* trans = me->GetDirectTransport())
                             trans->CalculatePassengerPosition(dest.x, dest.y, dest.z);
 
-                    me->GetMotionMaster()->MovePoint(e.action.moveToPos.pointId, dest.x, dest.y, dest.z, true, true,
+                    me->GetMotionMaster()->MovePoint(e.action.moveToPos.pointId, dest.x, dest.y, dest.z, true, isForced,
                         isControlled ? MOTION_SLOT_CONTROLLED : MOTION_SLOT_ACTIVE, e.target.o);
 
                     break;
@@ -1873,7 +1875,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                             randomPoint.m_positionY,
                             randomPoint.m_positionZ,
                             true,
-                            true,
+                            isForced,
                             isControlled ? MOTION_SLOT_CONTROLLED : MOTION_SLOT_ACTIVE
                         );
 
@@ -1898,7 +1900,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                     else if (e.action.moveToPos.ContactDistance)
                         target->GetNearPoint(me, x, y, z, e.action.moveToPos.ContactDistance, 0, target->GetAngle(me));
 
-                    me->GetMotionMaster()->MovePoint(e.action.moveToPos.pointId, x + e.target.x, y + e.target.y, z + e.target.z, true, true, isControlled ? MOTION_SLOT_CONTROLLED : MOTION_SLOT_ACTIVE);
+                    me->GetMotionMaster()->MovePoint(e.action.moveToPos.pointId, x + e.target.x, y + e.target.y, z + e.target.z, true, isForced, isControlled ? MOTION_SLOT_CONTROLLED : MOTION_SLOT_ACTIVE);
 
                     break;
                 }
@@ -1912,8 +1914,11 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             {
                 if (IsCreature(target))
                 {
+
+                    SAIBool isForced = !e.action.moveToPosTarget.disableForceDestination;
+
                     Creature* ctarget = target->ToCreature();
-                    ctarget->GetMotionMaster()->MovePoint(e.action.moveToPos.pointId, e.target.x, e.target.y, e.target.z, true, true, isControlled ? MOTION_SLOT_CONTROLLED : MOTION_SLOT_ACTIVE);
+                    ctarget->GetMotionMaster()->MovePoint(e.action.moveToPosTarget.pointId, e.target.x, e.target.y, e.target.z, true, isForced, isControlled ? MOTION_SLOT_CONTROLLED : MOTION_SLOT_ACTIVE);
                 }
             }
 

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1914,7 +1914,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             {
                 if (IsCreature(target))
                 {
-
                     SAIBool isForced = !e.action.moveToPosTarget.disableForceDestination;
 
                     Creature* ctarget = target->ToCreature();

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -855,7 +855,7 @@ bool SmartAIMgr::CheckUnusedActionParams(SmartScriptHolder const& e)
             case SMART_ACTION_SET_HOVER: return sizeof(SmartAction::setHover);
             case SMART_ACTION_SET_HEALTH_PCT: return sizeof(SmartAction::setHealthPct);
             // case SMART_ACTION_CREATE_CONVERSATION: return sizeof(SmartAction::raw);
-            case SMART_ACTION_MOVE_TO_POS_TARGET: return sizeof(SmartAction::moveToPos);
+            case SMART_ACTION_MOVE_TO_POS_TARGET: return sizeof(SmartAction::moveToPosTarget);
             case SMART_ACTION_EXIT_VEHICLE: return NO_PARAMS;
             case SMART_ACTION_SET_UNIT_MOVEMENT_FLAGS: return sizeof(SmartAction::movementFlag);
             case SMART_ACTION_SET_COMBAT_DISTANCE: return sizeof(SmartAction::combatDistance);

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -1216,7 +1216,14 @@ struct SmartAction
             uint32 controlled;
             uint32 ContactDistance;
             uint32 combatReach;
+            SAIBool disableForceDestination;
         } moveToPos;
+
+        struct
+        {
+            uint32 pointId;
+            SAIBool disableForceDestination;
+        } moveToPosTarget;
 
         struct
         {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->

This pull request refactors how the "force destination" behavior is controlled for movement actions in SmartScripts. It introduces a new `disableForceDestination` parameter to both the `moveToPos` and `moveToPosTarget` structs, and updates relevant logic to utilize this flag, allowing more granular control over movement commands.

**SmartScript movement logic improvements:**

* Added a `disableForceDestination` field to the `moveToPos` struct in `SmartAction`, enabling scripts to specify whether the force destination behavior should be disabled for position-based movement actions.
* Introduced a new `moveToPosTarget` struct in `SmartAction` with its own `disableForceDestination` field and updated related logic to use this struct for target-based movement actions.
* Updated all calls to `MovePoint` in `SmartScript::ProcessAction` to use the new `isForced` variable, which is derived from the `disableForceDestination` field, ensuring the force destination logic respects script configuration. [[1]](diffhunk://#diff-6d3483b74df32d157a6f8f227dacec1496d15fadfa8da3300e87fe5f6166e213R1849-R1850) [[2]](diffhunk://#diff-6d3483b74df32d157a6f8f227dacec1496d15fadfa8da3300e87fe5f6166e213L1858-R1860) [[3]](diffhunk://#diff-6d3483b74df32d157a6f8f227dacec1496d15fadfa8da3300e87fe5f6166e213L1876-R1878) [[4]](diffhunk://#diff-6d3483b74df32d157a6f8f227dacec1496d15fadfa8da3300e87fe5f6166e213L1901-R1903) [[5]](diffhunk://#diff-6d3483b74df32d157a6f8f227dacec1496d15fadfa8da3300e87fe5f6166e213R1917-R1921)

**Parameter size and action handling updates:**

* Changed the action parameter size calculation for `SMART_ACTION_MOVE_TO_POS_TARGET` to use `sizeof(SmartAction::moveToPosTarget)` instead of `moveToPos`, ensuring correct memory handling for the new struct.


This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- It solves the known issue here: https://github.com/azerothcore/azerothcore-wotlk/pull/22970

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Go to  Borean Tundra
2. Wait for  the ships to come
3. The Kvaldir Raider are flying towards the targets (or falling into the textures)

If you set the param6 of the action to 1, they can now follow the proper path

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- We should check all the creatures that use those actions to make sure they are not bugged, otherwise we need to set the parameter accordingly

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
