### PR TITLE
Improve INSTALL_ARGS handling and update OpenSSL version

### DIFF
--- a/apps/installer/includes/os_configs/windows.sh
+++ b/apps/installer/includes/os_configs/windows.sh
@@ -8,10 +8,10 @@
 # microsoft-build-tools
 # mysql
 
-INSTALL_ARGS=""
+INSTALL_ARGS=()
 
 if [[ $CONTINUOUS_INTEGRATION ]]; then
-    INSTALL_ARGS=" --no-progress "
+    INSTALL_ARGS+=(--no-progress)
 else
     { # try
         choco uninstall -y -n cmake.install cmake # needed to make sure that following install set the env properly
@@ -19,12 +19,12 @@ else
         echo "nothing to do"
     }
 
-    choco install -y --skip-checksums $INSTALL_ARGS  git visualstudio2022community
+    choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  git visualstudio2022community
 fi
 
-choco install -y --skip-checksums $INSTALL_ARGS  cmake.install -y --installargs 'ADD_CMAKE_TO_PATH=System'
-choco install -y --skip-checksums $INSTALL_ARGS  visualstudio2022-workload-nativedesktop
-choco install -y --skip-checksums $INSTALL_ARGS  openssl --force --version=3.5.2
-choco install -y --skip-checksums $INSTALL_ARGS  boost-msvc-14.3 --force --version=1.87.0
-choco install -y --skip-checksums $INSTALL_ARGS  mysql --force --version=8.4.4
+choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  cmake.install -y --installargs 'ADD_CMAKE_TO_PATH=System'
+choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  visualstudio2022-workload-nativedesktop
+choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  openssl --force --version=3.5.3
+choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  boost-msvc-14.3 --force --version=1.87.0
+choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  mysql --force --version=8.4.4
 


### PR DESCRIPTION
Refactor INSTALL_ARGS to use an array for better handling and update the OpenSSL version to 3.5.3.

This pull request updates the Windows installation script to improve argument handling and update a package version. The most important changes are grouped below:

Argument handling improvements:

* Refactored `INSTALL_ARGS` from a string to an array in `windows.sh`, allowing for safer and more flexible argument passing to `choco install` commands. All invocations now use `"${INSTALL_ARGS[@]}"` instead of `$INSTALL_ARGS`.

Dependency updates:

* Updated the `openssl` package version from `3.5.2` to `3.5.3` in the installation commands.