### PR TITLE
fix(Core/Scripting): fix Defias Thug waypoint errors

### DIFF
--- a/src/server/game/Scripting/MapScripts.cpp
+++ b/src/server/game/Scripting/MapScripts.cpp
@@ -880,7 +880,6 @@ void Map::ScriptsProcess()
                     if (!cSource->IsAlive())
                         return;
 
-                    cSource->GetMotionMaster()->MovementExpired();
                     cSource->GetMotionMaster()->MoveIdle();
 
                     switch (step.script->Movement.MovementType)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

error is caused by:
https://github.com/azerothcore/azerothcore-wotlk/blob/1430d4c2c96096610435ea3cb2c7868c45593b82/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp#L42
The waypoint movement is initialized when the path is set to 0 due to `SCRIPT_COMMAND_MOVEMENT`

https://github.com/azerothcore/azerothcore-wotlk/blob/1430d4c2c96096610435ea3cb2c7868c45593b82/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp#L145

`SCRIPT_COMMAND_MOVEMENT` was implemented here:
- https://github.com/azerothcore/azerothcore-wotlk/pull/1721

When comparing with TC335:
- https://github.com/TrinityCore/TrinityCore/blob/982643cd96790ffc54e7a3e507469649f3b074d2/src/server/game/Maps/MapScripts.cpp#L876
The line `cSource->GetMotionMaster()->MovementExpired();` was removed, so I removed it in AC, and the error no longer appears
https://github.com/TrinityCore/TrinityCore/pull/21888

The WP command 35 of `acore_world.waypoint_scripts` is limited to Defias Thugs only

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/19810

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

`.go c 80149`
Wait for the mob to complete its waypoint and start wandering. There should be no error in the console


1. 
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] refactor: port Defias Thugs to smartAI as proposed by https://github.com/azerothcore/azerothcore-wotlk/issues/19810#issuecomment-2551633862 
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
