### PR TITLE
Feature/windows setup

### DIFF
--- a/apps/installer/includes/functions.sh
+++ b/apps/installer/includes/functions.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
 # Set SUDO variable - one liner
-SUDO=$([ "$EUID" -ne 0 ] && echo "sudo" || echo "")
+if [[ "$OSTYPE" == "msys"* ]]; then
+    SUDO=""
+else
+    SUDO=$([ "$EUID" -ne 0 ] && echo "sudo" || echo "")
+fi
 
 function inst_configureOS() {
     echo "Platform: $OSTYPE"
@@ -67,7 +71,7 @@ function inst_dbCreate() {
     # In CI environments or when no password is set, try without password first
     if [[ "$CONTINUOUS_INTEGRATION" == "true" ]]; then
         echo "CI environment detected, attempting connection without password..."
-        
+
         if $SUDO mysql -u root < "$AC_PATH_ROOT/data/sql/create/create_mysql.sql" 2>/dev/null; then
             echo "Database created successfully."
             return 0
@@ -75,7 +79,7 @@ function inst_dbCreate() {
             echo "Failed to connect without password, falling back to interactive mode..."
         fi
     fi
-    
+
     # Try with password (interactive mode)
     echo "Please enter your sudo and your MySQL root password if prompted."
     $SUDO mysql -u root -p < "$AC_PATH_ROOT/data/sql/create/create_mysql.sql"

--- a/apps/installer/main.sh
+++ b/apps/installer/main.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
 # AzerothCore Dashboard Script
-# 
+#
 # This script provides an interactive menu system for AzerothCore management
 # using the unified menu system library.
-# 
+#
 # Usage:
 #   ./acore.sh                    - Interactive mode with numeric and text selection
 #   ./acore.sh <command> [args]   - Direct command execution (only text commands, no numbers)
 #
 # Interactive Mode:
-#   - Select options by number (1, 2, 3...), command name (init, compiler, etc.), 
+#   - Select options by number (1, 2, 3...), command name (init, compiler, etc.),
 #     or short alias (i, c, etc.)
 #   - All selection methods work in interactive mode
 #
@@ -35,6 +35,7 @@ menu_items=(
     "install-deps|d|Configure OS dep"
     "pull|u|Update Repository"
     "reset|r|Reset & Clean Repository"
+    "setup-db|r|Install db only"
     "compiler|c|Run compiler tool"
     "module|m|Module manager (search/install/update/remove)"
     "client-data|gd|download client data from github repository (beta)"
@@ -51,52 +52,55 @@ menu_items=(
 function handle_menu_command() {
     local key="$1"
     shift
-    
+
     case "$key" in
-        "init") 
-            inst_allInOne 
+        "init")
+            inst_allInOne
             ;;
-        "install-deps") 
-            inst_configureOS 
+        "install-deps")
+            inst_configureOS
             ;;
-        "pull") 
-            inst_updateRepo 
+        "pull")
+            inst_updateRepo
             ;;
-        "reset") 
-            inst_resetRepo 
+        "reset")
+            inst_resetRepo
             ;;
-        "compiler") 
-            bash "$AC_PATH_APPS/compiler/compiler.sh" "$@" 
+        "setup-db")
+            inst_dbCreate
             ;;
-        "module") 
-            bash "$AC_PATH_APPS/installer/includes/modules-manager/module-main.sh" "$@" 
+        "compiler")
+            bash "$AC_PATH_APPS/compiler/compiler.sh" "$@"
             ;;
-        "client-data") 
-            inst_download_client_data 
+        "module")
+            bash "$AC_PATH_APPS/installer/includes/modules-manager/module-main.sh" "$@"
             ;;
-        "run-worldserver") 
-            inst_simple_restarter worldserver 
+        "client-data")
+            inst_download_client_data
             ;;
-        "run-authserver") 
-            inst_simple_restarter authserver 
+        "run-worldserver")
+            inst_simple_restarter worldserver
             ;;
-        "docker") 
+        "run-authserver")
+            inst_simple_restarter authserver
+            ;;
+        "docker")
             DOCKER=1 bash "$AC_PATH_ROOT/apps/docker/docker-cmd.sh" "$@"
-            exit 
+            exit
             ;;
-        "version") 
+        "version")
             printf "AzerothCore Rev. %s\n" "$ACORE_VERSION"
-            exit 
+            exit
             ;;
-        "service-manager") 
+        "service-manager")
             bash "$AC_PATH_APPS/startup-scripts/src/service-manager.sh" "$@"
-            exit 
+            exit
             ;;
-        "quit") 
+        "quit")
             echo "Goodbye!"
-            exit 
+            exit
             ;;
-        *) 
+        *)
             echo "Invalid option. Use --help to see available commands."
             return 1
             ;;


### PR DESCRIPTION
Introduces two features for development on windows outside of WSL:

Enables only setting up DB using setup-db (rather than whole installation, which isnt compatible with windows anyway)

Also my IDE kinda fixed whitespaces all over the place.

Also fixes sudo not existing on some windows shells, and its not needed in the first place