### PR TITLE
fix(Core/Battlefield): AddressSanitizer new-delete-type-mismatch

### DIFF
--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -146,6 +146,7 @@ class BfGraveyard
 {
 public:
     BfGraveyard(Battlefield* Bf);
+    virtual ~BfGraveyard() { }
 
     // Method to changing who controls the graveyard
     void GiveControlTo(TeamId team);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Removes an asan error that happens on server shutdown.

```cpp
==999202==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x7ba9fa82a720 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   96 bytes;
  size of the deallocated type: 88 bytes.
    #0 0x0000006015e6 in operator delete(void*, unsigned long) (/home/pc/wd/wow/azerothcore-wotlk/env/dist/bin/worldserver+0x6015e6) (BuildId: e906fb981d240513ce2a62923cb15f7786ed7938)
    #1 0x000001f1bb32 in Battlefield::~Battlefield() /home/pc/wd/wow/azerothcore-wotlk/src/server/game/Battlefield/Battlefield.cpp:76:9
    #2 0x000001f46586 in BattlefieldWG::~BattlefieldWG() /home/pc/wd/wow/azerothcore-wotlk/src/server/game/Battlefield/Zones/BattlefieldWG.cpp:44:1
    #3 0x000001f46638 in BattlefieldWG::~BattlefieldWG() /home/pc/wd/wow/azerothcore-wotlk/src/server/game/Battlefield/Zones/BattlefieldWG.cpp:38:1
    #4 0x000001f3aaaa in BattlefieldMgr::~BattlefieldMgr() /home/pc/wd/wow/azerothcore-wotlk/src/server/game/Battlefield/BattlefieldMgr.cpp:32:9
    #5 0x7f29fbc2a820 in __run_exit_handlers (/lib64/libc.so.6+0x1c820) (BuildId: 48c4b9b1efb1df15da8e787f489128bf31893317)
    #6 0x7f29fbc2a8fd in exit (/lib64/libc.so.6+0x1c8fd) (BuildId: 48c4b9b1efb1df15da8e787f489128bf31893317)
    #7 0x7f29fbc1157b in __libc_start_call_main (/lib64/libc.so.6+0x357b) (BuildId: 48c4b9b1efb1df15da8e787f489128bf31893317)
    #8 0x7f29fbc11627 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3627) (BuildId: 48c4b9b1efb1df15da8e787f489128bf31893317)
    #9 0x000000518454 in _start (/home/pc/wd/wow/azerothcore-wotlk/env/dist/bin/worldserver+0x518454) (BuildId: e906fb981d240513ce2a62923cb15f7786ed7938)

0x7ba9fa82a720 is located 0 bytes inside of 96-byte region [0x7ba9fa82a720,0x7ba9fa82a780)
allocated by thread T0 here:
    #0 0x000000600961 in operator new(unsigned long) (/home/pc/wd/wow/azerothcore-wotlk/env/dist/bin/worldserver+0x600961) (BuildId: e906fb981d240513ce2a62923cb15f7786ed7938)
    #1 0x000001f4784a in BattlefieldWG::SetupBattlefield() /home/pc/wd/wow/azerothcore-wotlk/src/server/game/Battlefield/Zones/BattlefieldWG.cpp:106:36
    #2 0x000001f3c80a in BattlefieldMgr::InitBattlefield() /home/pc/wd/wow/azerothcore-wotlk/src/server/game/Battlefield/BattlefieldMgr.cpp:51:15
    #3 0x000003fb3ae5 in World::SetInitialWorldSettings() /home/pc/wd/wow/azerothcore-wotlk/src/server/game/World/World.cpp:947:22
    #4 0x000000606b58 in main /home/pc/wd/wow/azerothcore-wotlk/src/server/apps/worldserver/Main.cpp:307:13
    #5 0x7f29fbc11574 in __libc_start_call_main (/lib64/libc.so.6+0x3574) (BuildId: 48c4b9b1efb1df15da8e787f489128bf31893317)
    #6 0x7f29fbc11627 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3627) (BuildId: 48c4b9b1efb1df15da8e787f489128bf31893317)
    #7 0x000000518454 in _start (/home/pc/wd/wow/azerothcore-wotlk/env/dist/bin/worldserver+0x518454) (BuildId: e906fb981d240513ce2a62923cb15f7786ed7938)
```


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
