### PR TITLE
fix(DB/SmartAI): Scorn spawns after Bloodmage Thalnos dies

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1759592050712749074.sql
+++ b/data/sql/updates/pending_db_world/rev_1759592050712749074.sql
@@ -4,3 +4,18 @@ DELETE FROM `creature` WHERE (`id1` = 14693);
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 4543) AND (`source_type` = 0) AND (`id` IN (7));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (4543, 0, 7, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 14693, 8, 0, 0, 0, 0, 8, 0, 0, 0, 0, 1797.84, 1233.68, 18.3153, 1.58286, 'Bloodmage Thalnos - On Just Died - Summon Creature \'Scorn\'');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 14693;
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 14693) AND (`source_type` = 0) AND (`id` IN (4));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(14693, 0, 4, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 53, 0, 1469300, 1, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scorn - On Just Summoned - Start Patrol Path 1469300');
+
+SET @ENTRY := 14693;
+DELETE FROM `waypoints` WHERE `entry` = @ENTRY * 100;
+INSERT INTO `waypoints` (`entry`, `pointid`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `point_comment`) VALUES
+(@ENTRY*100, 1, 1798.01, 1312.39, 18.69,  NULL, 0, 'Scorn'),
+(@ENTRY*100, 2, 1805.39, 1323.66, 18.91,  NULL, 0, 'Scorn'),
+(@ENTRY*100, 3, 1797.70, 1383.27, 18.76,  NULL, 0, 'Scorn'),
+(@ENTRY*100, 4, 1805.39, 1323.66, 18.91,  NULL, 0, 'Scorn'),
+(@ENTRY*100, 5, 1798.01, 1312.39, 18.69,  NULL, 0, 'Scorn'),
+(@ENTRY*100, 6, 1798.01, 1223.17, 18.274, NULL, 0, 'Scorn - spawn point');

--- a/data/sql/updates/pending_db_world/rev_1759592050712749074.sql
+++ b/data/sql/updates/pending_db_world/rev_1759592050712749074.sql
@@ -10,6 +10,10 @@ DELETE FROM `smart_scripts` WHERE (`entryorguid` = 14693) AND (`source_type` = 0
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (14693, 0, 4, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 53, 0, 1469300, 1, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Scorn - On Just Summoned - Start Patrol Path 1469300');
 
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 22) AND (`SourceGroup` = 8) AND (`SourceEntry` = 4543) AND (`SourceId` = 0) AND (`ElseGroup` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(22, 8, 4543, 0, 0, 12, 0, 120, 0, 0, 0, 0, 0, '', 'Scourge Invasion - Boss in instance activation event must be active');
+
 SET @ENTRY := 14693;
 DELETE FROM `waypoints` WHERE `entry` = @ENTRY * 100;
 INSERT INTO `waypoints` (`entry`, `pointid`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `point_comment`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1759592050712749074.sql
+++ b/data/sql/updates/pending_db_world/rev_1759592050712749074.sql
@@ -1,0 +1,6 @@
+--
+DELETE FROM `creature` WHERE (`id1` = 14693);
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 4543) AND (`source_type` = 0) AND (`id` IN (7));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(4543, 0, 7, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 14693, 8, 0, 0, 0, 0, 8, 0, 0, 0, 0, 1797.84, 1233.68, 18.3153, 1.58286, 'Bloodmage Thalnos - On Just Died - Summon Creature \'Scorn\'');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Scorn in SM GY is currently perma-spawned during the event, but should spawn only after defeating Bloodmage Thalnos

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

classic SI footage
https://www.twitch.tv/flamytv/clip/SpikyAgreeableKoalaGivePLZ-oKKrx4VWbxf6xanw

waypoints: spawn -> crypt  -> spawn. Possibly not accurate
https://github.com/cmangos/classic-db/commit/fc956e3ddf0e4a845ddd297c9a1a744765d10028

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

```
.go c id 4543
.die
check if spawned, boss should not be spawned

.instance unbind all
.worldstate scourgeinvasion 1
.go c id 4543
.die
check if spawned, boss should be spawned
```

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
