### PR TITLE
fix(Scripts/Karazhan): remove Blood Mirror auras from Mirkblood when mirrored target dies

### DIFF
--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_tenris_mirkblood.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_tenris_mirkblood.cpp
@@ -123,6 +123,15 @@ struct boss_tenris_mirkblood : public BossAI
             return;
 
         DoCast(victim, SPELL_SUMMON_SANGUINE_SPIRIT_ON_KILL);
+
+        if (!_mirrorTarget)
+            return;
+
+        if (victim == _mirrorTarget)
+        {
+            me->RemoveAurasDueToSpell(SPELL_BLOOD_MIRROR0);
+            me->RemoveAurasDueToSpell(SPELL_BLOOD_MIRROR1);
+        }
     }
 
     void DamageTaken(Unit* attacker, uint32& damage, DamageEffectType damageType, SpellSchoolMask damageSchoolMask) override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Scripts (bosses, spell scripts, creature scripts).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes unreported issue.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - https://www.youtube.com/watch?v=W7EQKDu24Js

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
