### PR TITLE
fix(Scripts/Commands): inverted display in chat for gm fly

### DIFF
--- a/src/server/scripts/Commands/cs_gm.cpp
+++ b/src/server/scripts/Commands/cs_gm.cpp
@@ -100,8 +100,8 @@ public:
         }
         else
         {
-            canFly = handler->GetSession()->GetPlayer()->CanFly();
-            target->SetCanFly(!canFly);
+            canFly = !handler->GetSession()->GetPlayer()->CanFly();
+            target->SetCanFly(canFly);
         }
 
         handler->PSendSysMessage(LANG_COMMAND_FLYMODE_STATUS, handler->GetNameLink(target), canFly ? "on" : "off");


### PR DESCRIPTION
Per discussion on discord, the toggle option of gm fly shows inverted "on" and "off" after the command refactor.

Functionality was not breaking otherwise in any way.