### PR TITLE
fix(Scripts/ICC): guard gunship reset against missing transports

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
@@ -520,12 +520,20 @@ public:
     bool Execute(uint64, uint32) override
     {
         _caster->CastSpell(_caster, _spellId, true);
-        _caster->GetTransport()->ToMotionTransport()->UnloadNonStaticPassengers();
-        _caster->GetTransport()->AddObjectToRemoveList();
+
+        if (TransportBase* casterTransport = _caster->GetTransport())
+        {
+            if (MotionTransport* motionTransport = casterTransport->ToMotionTransport())
+                motionTransport->UnloadNonStaticPassengers();
+
+            casterTransport->AddObjectToRemoveList();
+        }
 
         if (Transport* transport = ObjectAccessor::GetTransport(*_caster, _otherTransport))
         {
-            transport->ToMotionTransport()->UnloadNonStaticPassengers();
+            if (MotionTransport* motionTransport = transport->ToMotionTransport())
+                motionTransport->UnloadNonStaticPassengers();
+
             transport->AddObjectToRemoveList();
         }
 


### PR DESCRIPTION
## Summary
- restore the gunship script to its original logic while tightening ResetEncounterEvent
- check for missing transports before unloading passengers during encounter reset to avoid crashes