### PR TITLE
fix(DB/Creature): Add missing texts for Doomclaw

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1760910926559529300.sql
+++ b/data/sql/updates/pending_db_world/rev_1760910926559529300.sql
@@ -10,4 +10,4 @@ UPDATE `creature_template` SET `AIName`='SmartAI', `ScriptName`='' WHERE `entry`
 DELETE FROM `smart_scripts` WHERE `entryorguid`=19738 AND `source_type`=0 AND `id` IN (4, 5);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (19738, 0, 4, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Doomclaw - On Death - Say Line 0'),
-(19738, 0, 5, 0, 1, 0, 100, 0, 30000, 120000, 60000, 120000, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Doomclaw - OOC - Say Random Text');
+(19738, 0, 5, 0, 1, 0, 100, 0, 10000, 15000, 12000, 25000, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Doomclaw - OOC - Say Random Text');


### PR DESCRIPTION
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/21985
- Closes https://github.com/chromiecraft/chromiecraft/issues/7933

![WoWScrnShot_101925_193146](https://github.com/user-attachments/assets/2f61b9d3-d696-4bdb-bd94-f3e50b986888)

![WoWScrnShot_101925_195206](https://github.com/user-attachments/assets/82aa5bcb-8f30-479e-a67f-7f4e9db74bfe)

Tests:
1. Go to the NPC's location. `.go c 70616`
2. Outside of combat, they will randomly say 3 dialogs.
3. Upon death, they should say one phrase.