### PR TITLE
Movement: Fix flying in dalaran after disconnect

### DIFF
--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -1170,6 +1170,12 @@ void WorldSession::HandlePlayerLoginToCharInWorld(Player* pCurrChar)
         pCurrChar->RemoveUnitFlag(UNIT_FLAG_STUNNED);
     }
 
+    if (pCurrChar->GetPendingFlightChange() <= pCurrChar->GetMapChangeOrderCounter())
+    {
+        if (!pCurrChar->HasIncreaseMountedFlightSpeedAura() && !pCurrChar->HasFlyAura())
+            pCurrChar->m_movementInfo.RemoveMovementFlag(MOVEMENTFLAG_CAN_FLY);
+    }
+
     pCurrChar->SendInitialPacketsBeforeAddToMap();
 
     // necessary actions from AddPlayerToMap:


### PR DESCRIPTION
@r0m1ntik "Found a new bug with flying mounts: if a player flies into Dalaran on a flying mount and then relogs, after logging back in they appear without the mount but can still fly."

Fixes the issue like previously with arena port.