### PR TITLE
fix(DB/Loot): Fireproof Satchel will now always drop the Ritual of Torch 

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1762695074553179900.sql
+++ b/data/sql/updates/pending_db_world/rev_1762695074553179900.sql
@@ -1,3 +1,3 @@
 -- Makes sure the Shaman player gets the required ritual toch item and that requires the quest to drop
 UPDATE `item_loot_template` SET `Chance` = 0, `QuestRequired` = 1, `GroupId` = 1 WHERE `Entry` = 24336 AND `Item` = 23682;
-UPDATE `item_loot_template` SET `Chance` = 0 WHERE `Entry` = 24336, `GroupId` = 2 AND `Item` = 24335;
+UPDATE `item_loot_template` SET `Chance` = 0, `GroupId` = 2 WHERE `Entry` = 24336 AND `Item` = 24335;


### PR DESCRIPTION
Ritual Torch from 96.1% to 100%
Orb of Returning from 99.8% to 85%

Also Ritual Torch now only drops people welding the quest, I have not validated it, but you only can get these Satchel by having the same quest. The important part this fixes the CHANCE of a shamna player not getting the ritual torch.

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes N/A

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.
- [x] No tested just ran the SQL with no errors


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
