### PR TITLE
fix(DB/ReputationRewardRate): Patch 3.0.0 gain for Northrend factions

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1762772818391236393.sql
+++ b/data/sql/updates/pending_db_world/rev_1762772818391236393.sql
@@ -1,0 +1,20 @@
+--
+SET @ARGENT_CRUSADE := 1106;
+SET @KIRIN_TOR := 1090;
+SET @KNIGHTS_OF_THE_EBON_BLADE := 1098;
+SET @WYRMREST_ACCORD := 1091;
+SET @ALLIANCE_VANGUARD := 1037;
+SET @HORDE_EXPEDITION := 1052;
+SET @SONS_OF_HODIR := 1119;
+
+UPDATE `quest_template` SET `RewardFactionOverride1`=2200000 WHERE `ID` IN (12915, 12956);
+UPDATE `quest_template` SET `RewardFactionOverride1`=0 WHERE `ID` IN (12924, 12975, 12976, 12977, 12981, 12985, 12987, 12994, 13001, 13003, 13010, 13011, 13046, 13108, 13420, 13421, 13559);
+UPDATE `quest_template` SET `RewardFactionID1` = 0, `RewardFactionValue1` = 0, `RewardFactionOverride1` = 0 WHERE `ID` IN (12966, 12967);
+
+UPDATE `reputation_reward_rate` SET `quest_rate`=1.3,`quest_daily_rate`=1.3,`quest_weekly_rate`=1.3,`quest_monthly_rate`=1.3,`quest_repeatable_rate`=1.3 WHERE `faction` IN (@ARGENT_CRUSADE, @KNIGHTS_OF_THE_EBON_BLADE, @KIRIN_TOR, @WYRMREST_ACCORD);
+
+DELETE FROM `reputation_reward_rate` WHERE `faction` IN (@SONS_OF_HODIR, @ALLIANCE_VANGUARD, @HORDE_EXPEDITION);
+INSERT INTO `reputation_reward_rate` (`faction`, `quest_rate`, `quest_daily_rate`, `quest_weekly_rate`, `quest_monthly_rate`, `quest_repeatable_rate`, `creature_rate`, `spell_rate`) VALUES
+(@SONS_OF_HODIR, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3),
+(@ALLIANCE_VANGUARD, 1.0, 1.0, 1.0, 1.0, 1.0, 1.3, 1.3),
+(@HORDE_EXPEDITION, 1.0, 1.0, 1.0, 1.0, 1.0, 1.3, 1.3);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Patch 3.0.0 sped up reputation gains from some Northrend Factions by 30%. This updates the current implementation:
- Quest reputation bonuses are now applied (in addition to kill bonuses) for Argent Crusade, Kirin Tor, Ebon Blade, and Wyrmrest Accord
- Horde Expedition and Alliance Vanguard now grant bonus reputation from kills
- Refactor Sons of Hodir rep from `quest_template` overrides to `reputation_reward_rate`. Reputation gains remain unchanged.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**



> The following reputations have been sped up by roughly 30%:
> Argent Crusade
> Alliance Vanguard
> Horde Expedition
> Kirin Tor
> Knights of the Ebon Blade
> Sons of Hodir
> Wyrmrest Accord
> Sons of Hodir quests now give more reputation overall.
> 3.3.0 https://wowwiki-archive.fandom.com/wiki/Patch_3.3.0


Quest XP Bonus (+30%) should be applied to Argent Crusade, Kirin Tor, Ebon Blade, Wyrmrest Accord, Sons of Hodir factions
retail: 325 https://youtu.be/s08BW_ngPsk&t=62
Ebon Blade
retail: 325 https://youtu.be/kn5VttPB3hY&t=133
Kirin Tor
retail: 455 https://www.youtube.com/watch?v=3EgoUK9WuPA

Sons of Hodir bonus applied 28600 rep
https://www.youtube.com/watch?v=XqokTxlDvXs

Quest XP Bonus (+30%) should **not** be applied to Horde Expedition, Alliance Vanguard, or their sub-factions
Horde Expedition: https://www.youtube.com/watch?v=FjZE-VoUleI
The Taunka: https://www.youtube.com/watch?v=eIoKnt6P5q4

Sons of Hodir quests:

|                   Quest ID                   | RewardFactionOverride1 | Reputation (Wowhead) | QuestFactionReward DBC | Corrected RewardFactionOverride1 |
| :------------------------------------------: | :--------------------: | -------------------- | ---------------------- | -------------------------------- |
| [12915](https://www.wowhead.com/quest=12915) |         2860000        | 22,000               | NA                     | 2200000                          |
| [12924](https://www.wowhead.com/quest=12924) |          32500         | 250                  | 5                      | 0                                |
| [12956](https://www.wowhead.com/quest=12956) |         2860000        | 22,000               | NA                     | 2200000                          |
| [12966](https://www.wowhead.com/quest=12966) |          9700          | 0                    | 0                      | 0                                |
| [12967](https://www.wowhead.com/quest=12967) |          9700          | 0                    | 0                      | 0                                |
| [12975](https://www.wowhead.com/quest=12975) |          32500         | 250                  | 5                      | 0                                |
| [12976](https://www.wowhead.com/quest=12976) |          9700          | 75                   | 3                      | 0                                |
| [12977](https://www.wowhead.com/quest=12977) |          45500         | 350                  | 6                      | 0                                |
| [12981](https://www.wowhead.com/quest=12981) |          45500         | 350                  | 6                      | 0                                |
| [12985](https://www.wowhead.com/quest=12985) |          32500         | 250                  | 5                      | 0                                |
| [12987](https://www.wowhead.com/quest=12987) |          19500         | 150                  | 4                      | 0                                |
| [12994](https://www.wowhead.com/quest=12994) |          45500         | 350                  | 6                      | 0                                |
| [13001](https://www.wowhead.com/quest=13001) |          32500         | 250                  | 5                      | 0                                |
| [13003](https://www.wowhead.com/quest=13003) |          65000         | 500                  | 7                      | 0                                |
| [13006](https://www.wowhead.com/quest=13006) |          45500         | 350                  | 6                      | 0                                |
| [13010](https://www.wowhead.com/quest=13010) |          45500         | 350                  | 6                      | 0                                |
| [13011](https://www.wowhead.com/quest=13011) |          32500         | 250                  | 5                      | 0                                |
| [13046](https://www.wowhead.com/quest=13046) |          45500         | 350                  | 6                      | 0                                |
| [13108](https://www.wowhead.com/quest=13108) |          65000         | 500                  | 7                      | 0                                |
| [13420](https://www.wowhead.com/quest=13420) |          45500         | 350                  | 6                      | 0                                |
| [13421](https://www.wowhead.com/quest=13421) |          45500         | 350                  | 6                      | 0                                |
| [13559](https://www.wowhead.com/quest=13559) |          65000         | 500                  | 7                      | 0                                |




## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.


```
Argent Crusade
.q add 12503
.q complete 12503
.go c id 28059
default: 250 rep
post 3.3: 325 = 250 rep * 1.3
```

Sons of Hodir
```
spark of hope
.q add 12956
28600 rep
```


1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
