### PR TITLE
fix(DB/Conditions): update quest conditions to drop chokers

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1762804136169898506.sql
+++ b/data/sql/updates/pending_db_world/rev_1762804136169898506.sql
@@ -1,5 +1,9 @@
 --
--- Writhing Choker
-UPDATE `conditions` SET `Comment` = 'must have completed quest \'Cleansing Drak\'Tharon\'' WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceGroup` = 28519) AND (`SourceEntry` = 38673) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 8) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12238) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
--- Unliving Choker
+-- Unliving Chocker
 UPDATE `conditions` SET `ConditionTypeOrReference` = 8, `NegativeCondition` = 1, `Comment` = 'must not have completed quest \'Cleansing Drak\'Tharon\'' WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceGroup` = 28519) AND (`SourceEntry` = 38660) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 14) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 12238) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
+-- Writhing Choker
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceGroup` = 28519) AND (`SourceEntry` = 38673) AND (`SourceId` = 0) AND (`ElseGroup` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(1, 28519, 38673, 0, 0, 8, 0, 12238, 0, 0, 0, 0, 0, '', 'must have completed quest \'Cleansing Drak\'Tharon\''),
+(1, 28519, 38673, 0, 0, 2, 0, 38660, 1, 1, 1, 0, 0, '', 'must not have item \'Unliving Chocker\''),
+(1, 28519, 38673, 0, 0, 8, 0, 12631, 0, 0, 1, 0, 0, '', 'must not have completed quest \'An Invitation, of Sorts...\'');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/8446

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

ac: https://wowgaming.altervista.org/aowow/?npc=28519#drops


https://www.wowhead.com/wotlk/item=38660/unliving-choker#comments

https://www.wowhead.com/wotlk/item=38673/writhing-choker#comments

> Precisely. All of the objectives and rewards for both chains are equal; the difference is in whether you did the chain from Grizzly Hills through to Drak'Tharon Keep prior to begining this chain. If yes, you get the Writhing Choker and its chain; if not, you get the Unliving Choker. You can never have both.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

```
withered troll
.npc add temp 28519
unliving choker
.add 38660
invitation
.quest reward 12631
cleansing
.quest add 12238
.quest complete 12238
.quest reward 12238
```


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

On a fresh character, kill Withered Troll and see if a choker drops

The choker will either be Unliving or Writhing depending if the player has completed the Cleansing Drak'Tharon quest.

Once an Unliving choker or its quest has been done, Writhing should no longer drop

1. 
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
