### PR TITLE
Player: Fix two uninitialized variables causing bad fall damage

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -420,6 +420,8 @@ Player::Player(WorldSession* session): Unit(), m_mover(this)
     sScriptMgr->OnConstructPlayer(this);
 
     _expectingChangeTransport = false;
+    _pendingFlightChangeCounter = 0;
+    _mapChangeOrderCounter = 0;
 }
 
 Player::~Player()


### PR DESCRIPTION
Should fix 

<img width="296" height="279" alt="image" src="https://github.com/user-attachments/assets/4aa823bf-d3dd-4dd1-810f-d1530ad0f2fe" />
