### PR TITLE
fix(Core/Handlers): potential falling to death on teleport

### DIFF
--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -299,6 +299,8 @@ void WorldSession::HandleMoveTeleportAck(WorldPacket& recvData)
 
     plMover->UpdatePosition(dest, true);
 
+    plMover->SetFallInformation(GameTime::GetGameTime().count(), dest.GetPositionZ());
+
     // xinef: teleport pets if they are not unsummoned
     if (Pet* pet = plMover->GetPet())
     {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Updates fall information in `HandleMoveTeleportAckOpcode`

A similar fix had to be applied in cmangos:
- https://github.com/cmangos/mangos-wotlk/commit/b15729dadd795ef9b39ec8fe7d0b251ea8c8ec6e

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23664

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://github.com/cmangos/mangos-wotlk/commit/b15729dadd795ef9b39ec8fe7d0b251ea8c8ec6e

<details>
<summary>
acore packet log:

Before `MSG_MOVE_FALL_LAND`, after a TP, the old (400+ Z) coordinate will be used, causing the player to fall to death.


</summary>


```cpp
ServerToClient: MSG_MOVE_TELEPORT_ACK (0x00C7) Length: 36 ConnIdx: 0 EP: 127.0.0.1:56568 Time: 11/22/2025 11:53:40.894 Number: 84
Guid: Full: 0x00000003 Type: Player Low: 3
Movement Counter: 24
Movement Flags: 0 (None)
Extra Movement Flags: 0 (None)
Time: 74739
Position: X: 5703.97 Y: -2467.94 Z: 287.55
```

```cpp
ClientToServer: MSG_MOVE_FALL_LAND (0x00C9) Length: 32 ConnIdx: 0 EP: 127.0.0.1:56568 Time: 11/22/2025 11:53:42.954 Number: 120
Guid: Full: 0x00000003 Type: Player Low: 3
Movement Flags: 0 (None)
Extra Movement Flags: 0 (None)
Time: 160561290
Position: X: 5703.97 Y: -2467.94 Z: 287.55
```

</details>


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.




1. `.go xyz  X: 5557.91 Y: -1615.61 Z: 242.247` should not kill
2. `.go c id 28503`, `.die`, release should no longer double kill
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
