### PR TITLE
fix(DB/SmartAI): Sindragosa's Fall Wyrm Reanimator despawns

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1764179503855062953.sql
+++ b/data/sql/updates/pending_db_world/rev_1764179503855062953.sql
@@ -1,0 +1,46 @@
+--
+-- Increase despawn timer
+UPDATE `smart_scripts` SET `action_param3`=180000 WHERE `entryorguid` IN (-125414, -123669, -123663, -123660) AND `source_type`=0 AND `id`=0;
+
+-- Spawn only when there's a  Wyrm Reanimator nearby
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 22) AND (`SourceGroup` = 1) AND (`SourceEntry` IN (-125414, -123669, -123663, -123660)) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 29) AND (`ConditionTarget` = 1) AND (`ConditionValue1` = 31731) AND (`ConditionValue2` = 30) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(22, 1, -125414, 0, 0, 29, 1, 31731, 30, 0, 0, 0, 0, '', 'must be near \'Wyrm Reanimator\''),
+(22, 1, -123669, 0, 0, 29, 1, 31731, 30, 0, 0, 0, 0, '', 'must be near \'Wyrm Reanimator\''),
+(22, 1, -123663, 0, 0, 29, 1, 31731, 30, 0, 0, 0, 0, '', 'must be near \'Wyrm Reanimator\''),
+(22, 1, -123660, 0, 0, 29, 1, 31731, 30, 0, 0, 0, 0, '', 'must be near \'Wyrm Reanimator\'');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 31702);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(31702, 0, 0, 1, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 64, 1, 0, 0, 0, 0, 0, 19, 31731, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - On Just Summoned - Store Targetlist'),
+(31702, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 3170200, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - On Just Summoned - Run Script'),
+(31702, 0, 2, 0, 34, 0, 100, 0, 8, 1, 0, 0, 0, 0, 80, 3170201, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - On Reached Point 1 - Run Script'),
+(31702, 0, 3, 0, 0, 0, 100, 0, 0, 5000, 5000, 15000, 0, 0, 11, 60667, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - In Combat - Cast \'Frost Breath\''),
+(31702, 0, 4, 0, 17, 0, 100, 0, 31731, 0, 0, 0, 0, 0, 64, 1, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - On Summoned Unit - Store Targetlist');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 3170200);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(3170200, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 60, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - Actionlist - Set Fly On'),
+(3170200, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 0, 30, 0, 0, 0, 0, 12, 1, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - Actionlist - Despawn Instant'),
+(3170200, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 31731, 1, 120000, 0, 0, 0, 12, 1, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - Actionlist - Summon Creature \'Wyrm Reanimator\''),
+(3170200, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 48, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - Actionlist - Set Active On'),
+(3170200, 9, 4, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 69, 1, 0, 0, 0, 0, 0, 12, 1, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - Actionlist - Move To Stored');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 3170201);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(3170201, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 36380, 2, 0, 0, 0, 0, 12, 1, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - Actionlist - Cast \'Special Unarmed\''),
+(3170201, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 86, 52391, 2, 12, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - Actionlist - Cross Cast \'Ride Vehicle\''),
+(3170201, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 53, 2, 317020, 0, 0, 0, 1, 8, 0, 0, 0, 0, 7326.43, 1289.52, 611.652, 0, 'Frostbrood Spawn - Actionlist - Start Waypoint Path 317020'),
+(3170201, 9, 3, 0, 0, 0, 100, 0, 30000, 30000, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 12, 1, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - Actionlist - Despawn Instant'),
+(3170201, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Frostbrood Spawn - Actionlist - Despawn Instant');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 31731);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(31731, 0, 0, 0, 0, 0, 100, 0, 5000, 9000, 15000, 15000, 0, 0, 11, 32063, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Wyrm Reanimator - In Combat - Cast \'Corruption\''),
+(31731, 0, 1, 0, 0, 0, 100, 0, 1000, 1000, 3000, 4000, 0, 0, 11, 9613, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Wyrm Reanimator - In Combat - Cast \'Shadow Bolt\''),
+(31731, 0, 2, 0, 0, 0, 100, 0, 4000, 7000, 16000, 22000, 0, 0, 11, 11443, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Wyrm Reanimator - In Combat - Cast \'Cripple\''),
+(31731, 0, 3, 0, 1, 1, 100, 0, 0, 0, 30000, 30000, 0, 0, 11, 59661, 0, 0, 0, 0, 0, 19, 27047, 0, 0, 0, 0, 0, 0, 0, 'Wyrm Reanimator - Out of Combat - Cast \'Icecrown Purple Beam\' (Phase 1)'),
+(31731, 0, 4, 5, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 92, 0, 59661, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Wyrm Reanimator - On Just Summoned - Interrupt Spell \'Icecrown Purple Beam\''),
+(31731, 0, 5, 6, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 52385, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Wyrm Reanimator - On Just Summoned - Cast \'Cosmetic - Periodic Cower\''),
+(31731, 0, 6, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 22, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Wyrm Reanimator - On Just Summoned - Set Event Phase 2'),
+(31731, 0, 7, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 22, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Wyrm Reanimator - On Respawn - Set Event Phase 1');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Currently, Frostbrood Spawn is mounting a Wyrm Reanimator and moving it away from its spawn location
When the Wyrm Reanimators respawns, it isn't returned to their initial spawn position.

Now, Frostbrood Spawn summons a temporary summon of Wyrm Reanimator instead of targeting the original. 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23804

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

speed up the event
```sql
UPDATE smart_scripts SET event_param1=1000, event_param2=5000, event_param3=10000, event_param4=10000 WHERE entryorguid IN (-125414, -123669, -123663, -123660) AND source_type=0 AND id=0 AND link=0;
```

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Reanimators should no longer appear in the valley as seen in screenshots:
- https://github.com/chromiecraft/chromiecraft/issues/8634#issue-3639577019

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
