### PR TITLE
fix(DB/Quest): Remove duplicate Kaskala Supplies spawn

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1764202397289333755.sql
+++ b/data/sql/updates/pending_db_world/rev_1764202397289333755.sql
@@ -1,0 +1,1 @@
+DELETE FROM `gameobject` WHERE `guid` = 21197;


### PR DESCRIPTION
[!] Please Read! This PR comes from AI with MCP

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Removes duplicate Kaskala Supplies gameobject spawn (GUID 21197) that was stacked at identical coordinates with GUID 21196.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23910
- Closes https://github.com/chromiecraft/chromiecraft/issues/8714

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. `.quest add 11945`
2. `.go gameobj 21196`
3. Verify only one Kaskala Supplies crate exists at this location (not two stacked)

## Known Issues and TODO List:

- None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.