### PR TITLE
fix(DB/Quest): Where Dragons Fell available with Cradle/Sindragosa

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1764206535501749673.sql
+++ b/data/sql/updates/pending_db_world/rev_1764206535501749673.sql
@@ -1,0 +1,2 @@
+UPDATE `quest_template_addon` SET `PrevQuestID` = 13348 WHERE `ID` = 13359;
+UPDATE `quest_template_addon` SET `PrevQuestID` = 13396 WHERE `ID` = 13398;


### PR DESCRIPTION
[!] Please Read! This PR comes from AI with MCP

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23894
- Closes https://github.com/chromiecraft/chromiecraft/issues/8684

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Wowhead comment confirms blizzlike behavior: "dunno if i'd really call this a 'follow up' though as i picked it up before i even started killing stuff for the Cradle for the Frostblood quest."

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Horde:**
1. `.quest complete 13348` (complete "Futility")
2. `.go creature 142849` (teleport to Koltira Deathweaver on Orgrim's Hammer) - Note: if teleport fails, manually fly to Orgrim's Hammer airship in Icecrown
3. Verify quest 13349 "Cradle of the Frostbrood" is available
4. `.go creature id 32423` (teleport to Matthias Lehner at Sindragosa's Fall)
5. Verify quest 13359 "Where Dragons Fell" is also available

**Alliance:**
1. `.quest complete 13396` (complete "Futility")
2. Fly to The Skybreaker airship in Icecrown
3. Verify quest 13397 "Sindragosa's Fall" is available from Thassarian
4. `.go creature id 32423` (teleport to Matthias Lehner at Sindragosa's Fall)
5. Verify quest 13398 "Where Dragons Fell" is also available

Both quests should now be available simultaneously after completing "Futility".

## Known Issues and TODO List:

- [ ] None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.