### PR TITLE
fix(DB/SAI): Image of Stone Giant now despawns after The Lodestone quest event

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1764211813526262504.sql
+++ b/data/sql/updates/pending_db_world/rev_1764211813526262504.sql
@@ -1,2 +1,35 @@
--- Fixes https://github.com/azerothcore/azerothcore-wotlk/issues/23803
+-- Update SAI Comments (Image of Megalith)
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 24381;
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 24381);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(24381, 0, 0, 0, 54, 0, 100, 512, 0, 0, 0, 0, 0, 0, 80, 2438100, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Image of Megalith - On Just Summoned - Run Script');
+
+-- Update Action List (Image of Megalith)
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 2438100);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2438100, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 24385, 7, 0, 0, 0, 0, 8, 0, 0, 0, 0, 2410.14, -5727.26, 270.986, 4.28769, 'Image of Megalith - Actionlist - Summon Creature \'Image of Stone Giant\''),
+(2438100, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 24385, 7, 0, 0, 0, 0, 8, 0, 0, 0, 0, 2414.86, -5729.5, 272.095, 3.98296, 'Image of Megalith - Actionlist - Summon Creature \'Image of Stone Giant\''),
+(2438100, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 24385, 7, 0, 0, 0, 0, 8, 0, 0, 0, 0, 2417.34, -5733.23, 273.029, 3.60361, 'Image of Megalith - Actionlist - Summon Creature \'Image of Stone Giant\''),
+(2438100, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 24385, 7, 0, 0, 0, 0, 8, 0, 0, 0, 0, 2419.4, -5738.03, 274.121, 3.24154, 'Image of Megalith - Actionlist - Summon Creature \'Image of Stone Giant\''),
+(2438100, 9, 4, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Image of Megalith - Actionlist - Say Line 0'),
+(2438100, 9, 5, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Image of Megalith - Actionlist - Say Line 1'),
+(2438100, 9, 6, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Image of Megalith - Actionlist - Say Line 2'),
+(2438100, 9, 7, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 223, 45, 0, 0, 0, 0, 0, 204, 24385, 0, 0, 0, 0, 0, 0, 0, 'Image of Megalith - Actionlist - Do Action ID 45'), -- Action Changed with do action / target summoned creatures
+(2438100, 9, 8, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 43693, 0, 0, 0, 0, 0, 21, 40, 0, 0, 0, 0, 0, 0, 0, 'Image of Megalith - Actionlist - Cast \'Image of Megalith Kill Credit\''),
+(2438100, 9, 9, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Image of Megalith - Actionlist - Say Line 3'),
+(2438100, 9, 10, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Image of Megalith - Actionlist - Despawn Instant');
+
+-- Add SAI (Image of Stone Giant)
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 24385;
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 24385);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(24385, 0, 0, 0, 72, 0, 100, 0, 45, 0, 0, 0, 0, 0, 80, 2438500, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Image of Stone Giant - On Action 45 Done - Run Script'); -- Added this event.
+
+-- Update Action List comments (Image of Stone Giant)
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 2438500);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2438500, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Image of Stone Giant - Actionlist - Set Run Off'),
+(2438500, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 2515.45, -5670.36, 298.778, 0.618311, 'Image of Stone Giant - Actionlist - Move To Position'),
+(2438500, 9, 2, 0, 0, 0, 100, 0, 7000, 7000, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Image of Stone Giant - Actionlist - Despawn Instant');


### PR DESCRIPTION
[!] Please Read! This PR comes from AI with MCP

## Changes Proposed:
Set `AIName = 'SmartAI'` on Image of Stone Giant (24385) so it can process the despawn action list called by Image of Megalith.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23803
- Closes https://github.com/chromiecraft/chromiecraft/issues/8660

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go gameobject 66102` (Broken Tablet in Howling Fjord)
2. `.quest add 11358` (Alliance) or `.quest add 11366` (Horde)
3. Use the Rune Sample item near the tablet
4. Observe the 4 Stone Giant images spawn, walk away, and despawn after ~7 seconds
5. Repeat to confirm no duplicate images remain

## Known Issues and TODO List:
- None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.