### PR TITLE
fix(Scripts/Gundrak): Eck the Ferocious wrong enrage timing

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1764224411866335544.sql
+++ b/data/sql/updates/pending_db_world/rev_1764224411866335544.sql
@@ -1,0 +1,4 @@
+-- Add creature_text for Eck the Ferocious "grows increasingly crazed" emote
+DELETE FROM `creature_text` WHERE `CreatureID` = 29932 AND `GroupID` = 1;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`)
+VALUES (29932, 1, 0, '%s grows increasingly crazed!', 16, 0, 100, 0, 0, 0, 30727, 0, 'Eck the Ferocious - Crazed Warning');

--- a/src/server/scripts/Northrend/Gundrak/boss_eck.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_eck.cpp
@@ -36,7 +36,8 @@ enum Misc
     EVENT_ECK_BITE                      = 2,
     EVENT_ECK_SPIT                      = 3,
     EVENT_ECK_SPRING                    = 4,
-    EVENT_ECK_HEALTH                    = 5
+    EVENT_ECK_CRAZED_EMOTE              = 5,
+    EMOTE_CRAZED                        = 1
 };
 
 class boss_eck : public CreatureScript
@@ -89,7 +90,8 @@ public:
         void JustEngagedWith(Unit* who) override
         {
             BossAI::JustEngagedWith(who);
-            events.ScheduleEvent(EVENT_ECK_BERSERK, 60s, 90s);
+            events.ScheduleEvent(EVENT_ECK_CRAZED_EMOTE, 76s, 78s);
+            events.ScheduleEvent(EVENT_ECK_BERSERK, 90s);
             events.ScheduleEvent(EVENT_ECK_BITE, 5s);
             events.ScheduleEvent(EVENT_ECK_SPIT, 10s, 37s);
             events.ScheduleEvent(EVENT_ECK_SPRING, 10s, 24s);
@@ -111,18 +113,11 @@ public:
 
             switch (events.ExecuteEvent())
             {
-                case EVENT_ECK_HEALTH:
-                    if (me->HealthBelowPct(21))
-                    {
-                        events.CancelEvent(EVENT_ECK_BERSERK);
-                        me->CastSpell(me, SPELL_ECK_BERSERK, false);
-                        break;
-                    }
-                    events.ScheduleEvent(EVENT_ECK_HEALTH, 1s);
+                case EVENT_ECK_CRAZED_EMOTE:
+                    Talk(EMOTE_CRAZED);
                     break;
                 case EVENT_ECK_BERSERK:
                     me->CastSpell(me, SPELL_ECK_BERSERK, false);
-                    events.CancelEvent(EVENT_ECK_HEALTH);
                     break;
                 case EVENT_ECK_BITE:
                     me->CastSpell(me->GetVictim(), SPELL_ECK_BITE, false);


### PR DESCRIPTION
[!] Please Read! This PR comes from AI with MCP

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

**Changes:**
- Change berserk timer from random 60-90s to exactly 90s
- Add "grows increasingly crazed" emote at 76-78s before berserk (using BroadcastTextId 30727)
- Remove incorrect 21% health berserk trigger (EVENT_ECK_HEALTH)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23084

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Video evidence from the issue:
- [Wotlk Classic Heroic](https://youtu.be/vFxq3WJwj-I?t=4940) - Multiple attempts showing 90s enrage timing
- [Wotlk Classic Heroic+](https://youtu.be/Zug9Gy5YSZc?t=1728) - Shows emote at ~78s and enrage at 90s
- [Wotlk Classic Heroic+](https://youtu.be/HfjyU5hCtyY?t=1290) - Shows emote at ~76s
- [Wotlk Classic Heroic+](https://youtu.be/aznzk4YTZ0w?t=393) - Shows emote at ~77s

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.tele Gundrak`
2. Set instance to Heroic mode
3. `.go c id 29305` (go to Moorabi)
4. Kill Moorabi to spawn Eck
5. `.reload creature_text`
6. Engage Eck and verify:
   - At 76-78 seconds: Raid boss emote "Eck the Ferocious grows increasingly crazed!" appears
   - At exactly 90 seconds: Berserk triggers
   - Below 21% health: Should NOT trigger early berserk (old bugged behavior removed)

## Known Issues and TODO List:

- [ ] None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.