### PR TITLE
fix(DB/Quest): Judgment Day Comes! breadcrumb for Honor Above All Else

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1764453323364883724.sql
+++ b/data/sql/updates/pending_db_world/rev_1764453323364883724.sql
@@ -2,7 +2,6 @@
 -- Judgment Day Comes! should not be available if Honor Above All Else is taken/complete/rewarded
 -- Uses CONDITION_QUESTSTATE (47) with state_mask 74 (2+8+64 = Completed+InProgress+Rewarded)
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 19) AND (`SourceEntry` IN (13226, 13227)) AND (`ConditionTypeOrReference` = 47) AND (`ConditionValue1` = 13036);
-
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (19, 0, 13226, 0, 0, 47, 0, 13036, 74, 0, 1, 0, 0, '', 'Judgment Day Comes! - NOT have Honor Above All Else (taken/complete/rewarded)'),
 (19, 0, 13227, 0, 0, 47, 0, 13036, 74, 0, 1, 0, 0, '', 'Judgment Day Comes! - NOT have Honor Above All Else (taken/complete/rewarded)');


### PR DESCRIPTION
[!] Please Read! This PR comes from AI with MCP

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Judgment Day Comes! (13226/13227) can be accepted while the player is in a phase incompatible with the turn-in NPC (Highlord Tirion Fordring). This quest should be a breadcrumb to Honor Above All Else (13036) and should not be obtainable if you have the quest or have completed Honor Above All Else.

**Fix:** Added CONDITION_QUESTSTATE (47) conditions to make Judgment Day Comes! unavailable if Honor Above All Else is taken, completed, or rewarded.

**Note:** Players can still technically be locked with the quest if they choose not to turn in to Tirion right away and Tirion phases out. This is a blizzlike bug.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23794
- Closes https://github.com/chromiecraft/chromiecraft/issues/8651

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. `.quest remove 13036` (if you have Honor Above All Else)
2. `.go creature id 31261` (Brother Keltan - Horde) or `.go creature id 31259` (Absalan the Pious - Alliance)
3. Verify **Judgment Day Comes!** IS available
4. `.quest add 13036`
5. Go back to quest giver - **Judgment Day Comes!** should NOT be available now
6. `.quest remove 13036`
7. Accept **Judgment Day Comes!** from the quest giver
8. `.go creature id 28179` (Tirion Fordring)
9. Verify BOTH turn-in for Judgment Day Comes! AND Honor Above All Else are available

## Known Issues and TODO List:

- [ ] None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.