### PR TITLE
fix(DB/Quest): A Sister's Pledge spawning multiple Sasha

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1764469571769780167.sql
+++ b/data/sql/updates/pending_db_world/rev_1764469571769780167.sql
@@ -1,0 +1,5 @@
+-- Fix A Sister's Pledge (12411) spawning multiple Sasha when turned in by multiple players
+-- Add condition to prevent Sasha spawn if she already exists nearby
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 27646 AND `SourceId` = 0;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(22, 1, 27646, 0, 0, 29, 1, 26935, 50, 0, 1, 0, 0, '', 'Anya - Quest reward chain only if Sasha is not already nearby');


### PR DESCRIPTION
[!] Please Read! This PR comes from AI with [MCP](https://github.com/blinkysc/azerothMCP)

## Changes Proposed:
Adds a condition to Anya's (27646) SmartAI script that prevents spawning Sasha (26935) if she already exists within 50 yards. This fixes the issue where multiple players turning in quest "A Sister's Pledge" (12411) would each spawn their own copy of Sasha.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23962

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

From [Wowhead comments](https://www.wowhead.com/wotlk/quest=12411/a-sisters-pledge#comments:id=556959): A player mentioned Sasha despawning because somebody else did the quest before them, meaning it did not spawn a new Sasha for that person.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Get two Alliance characters
2. `.quest add 12411` on both characters
3. `.go creature id 27646` to go to Anya
4. Turn in quest with first player - Sasha should spawn and RP plays
5. Turn in quest with second player - Sasha should NOT spawn again (existing one remains)

## Known Issues and TODO List:

- [ ] None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.