### PR TITLE
fix(DB/Creature): Drak'aguul now correctly applies debuff to soldiers

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1764470424968150153.sql
+++ b/data/sql/updates/pending_db_world/rev_1764470424968150153.sql
@@ -1,6 +1,4 @@
-UPDATE `conditions` SET `SourceGroup` = 1 WHERE `SourceTypeOrReferenceId` = 13 AND `SourceGroup` = 7 AND `SourceEntry` = 52457;
-
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceEntry` = 52457;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(13, 7, 52457, 0, 0, 31, 0, 3, 26797, 0, 0, 0, 0, '', 'Spell 52457 (Drak\'aguul\'s Soldiers) - Target Drakkari Protector'),
-(13, 7, 52457, 0, 1, 31, 0, 3, 26795, 0, 0, 0, 0, '', 'Spell 52457 (Drak\'aguul\'s Soldiers) - Target Drakkari Oracle');
+(13, 1, 52457, 0, 0, 31, 0, 3, 26797, 0, 0, 0, 0, '', 'Spell 52457 (Drak\'aguul\'s Soldiers) - Target Drakkari Protector'),
+(13, 1, 52457, 0, 1, 31, 0, 3, 26795, 0, 0, 0, 0, '', 'Spell 52457 (Drak\'aguul\'s Soldiers) - Target Drakkari Oracle');


### PR DESCRIPTION
[!] Please Read! This PR comes from AI with [MCP](https://github.com/blinkysc/azerothMCP)

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Adds spell implicit target conditions to spell 52457 (Drak'aguul's Soldiers) so it only affects Drakkari Protector (26797) and Drakkari Oracle (26795), not players.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23948
- Closes https://github.com/chromiecraft/chromiecraft/issues/8724

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://www.youtube.com/watch?v=Nrla9EFDASU - Shows debuff on guards only, not player.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go creature id 26919`
2. Attack Drak'aguul
3. Verify the debuff only appears on the two guards (Drakkari Protector and Drakkari Oracle), not on the player

## Known Issues and TODO List:
- None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.