### PR TITLE
fix(DB/Quest): Mutiny on the Mercy map tracking points to correct zone

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1764472028716511581.sql
+++ b/data/sql/updates/pending_db_world/rev_1764472028716511581.sql
@@ -1,0 +1,6 @@
+UPDATE `quest_poi` SET `MapID` = 571, `WorldMapAreaId` = 491 WHERE `QuestID` = 11527;
+
+DELETE FROM `quest_poi_points` WHERE `QuestID` = 11527;
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES
+(11527, 0, 0, 118, -3697, 0),
+(11527, 1, 0, 118, -3697, 0);


### PR DESCRIPTION
[!] Please Read! This PR comes from AI with [MCP](https://github.com/blinkysc/azerothMCP)

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Quest 11527 "Mutiny on the Mercy" had incorrect map tracking POI data:
- `MapID` was 0 (Eastern Kingdoms) instead of 571 (Northrend)
- `WorldMapAreaId` was 15 (Alterac Mountains) instead of 491 (Howling Fjord)
- POI coordinates were invalid ship-relative values

Fixed to point to the Sister Mercy ship location at Garvan's Reef in Howling Fjord.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23884
- Closes https://github.com/chromiecraft/chromiecraft/issues/8697

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. `.quest add 11527` (Mutiny on the Mercy)
2. Open quest log → Click on "Mutiny on the Mercy" → Click "Show on Map"
3. Verify the map now correctly points to Howling Fjord (Garvan's Reef area) instead of Alterac Mountains

## Known Issues and TODO List:

- None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.