### PR TITLE
fix(DB): Reference loot table 4001/4000

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1764777696518855406.sql
+++ b/data/sql/updates/pending_db_world/rev_1764777696518855406.sql
@@ -1,1 +1,2 @@
+UPDATE `reference_loot_template` SET `Chance` = 0.5 WHERE `Entry` = 6010 AND `Item` = 1 AND `Reference` = 4000;
 UPDATE `reference_loot_template` SET `Chance` = 0.5 WHERE `Entry` = 6010 AND `Item` = 2 AND `Reference` = 4001;

--- a/data/sql/updates/pending_db_world/rev_1764777696518855406.sql
+++ b/data/sql/updates/pending_db_world/rev_1764777696518855406.sql
@@ -1,2 +1,2 @@
-UPDATE `reference_loot_template` SET `Chance` = 0.5 WHERE `Entry` = 6010 AND `Item` = 1 AND `Reference` = 4000;
-UPDATE `reference_loot_template` SET `Chance` = 0.5 WHERE `Entry` = 6010 AND `Item` = 2 AND `Reference` = 4001;
+UPDATE `reference_loot_template` SET `Chance` = 5 WHERE `Entry` = 6010 AND `Item` = 1 AND `Reference` = 4000;
+UPDATE `reference_loot_template` SET `Chance` = 5 WHERE `Entry` = 6010 AND `Item` = 2 AND `Reference` = 4001;

--- a/data/sql/updates/pending_db_world/rev_1764777696518855406.sql
+++ b/data/sql/updates/pending_db_world/rev_1764777696518855406.sql
@@ -1,0 +1,1 @@
+UPDATE `reference_loot_template` SET `Chance` = 0.5 WHERE `Entry` = 6010 AND `Item` = 2 AND `Reference` = 4001;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
[!] Please Read! This PR comes from AI with MCP

Note: This fix modifies reference_loot_template entry 6010, which is shared by 27 Zangamarsh creatures:

```sql
SELECT ct.entry, ct.name
  FROM creature_template ct
  JOIN creature_loot_template clt ON ct.lootid = clt.Entry
  WHERE clt.Reference = 6010
  ORDER BY ct.entry;
```

  - 4 Giants (from issue): Bog Lord, Fungal Giant, Starving Bog Lord, Starving Fungal Giant
  - 7 Naga: Bloodscale Enchantress, Slavedriver, Overseer, Wavecaller, Rajis Fyashe, Rajah Haghazed, Ssslith
  - 6 Ogres: Ango'rosh Ogre, Mauler, Souleater, Shadowmage, Captain Krosh, Overlord Gorefist, Mal'druk, Chieftain Mummaki
  - 4 Lost Ones: Daggerfen Muckdweller, Assassin
  - 6 Beasts/Elementals: Marsh Walker, Lagoon Walker, Ironspine Threshalisk, Ironspine Gazer, "Count" Ungula, Mragesh

  All will have grey weapon "effective" drop rate reduced from ~3% to ~0.05% per item. Green/blue rates remain unchanged.

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/14606
- Closes https://github.com/chromiecraft/chromiecraft/issues/4791 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Following sql query should show effective %0.05

```sql
  SELECT
      clt.Entry as creature_entry,
      ct.name as creature_name,
      clt.Chance as chance1,
      rlt1.Chance as chance2,
      (SELECT COUNT(*) FROM reference_loot_template WHERE Entry = rlt1.Reference AND GroupId = 1) as items_in_group,
      (clt.Chance / 100.0) * (rlt1.Chance / 100.0) /
          (SELECT COUNT(*) FROM reference_loot_template WHERE Entry = rlt1.Reference AND GroupId = 1) * 100 as effective_per_item_pct
  FROM creature_loot_template clt
  JOIN creature_template ct ON ct.entry = clt.Entry
  JOIN reference_loot_template rlt1 ON rlt1.Entry = clt.Reference
  WHERE clt.Entry IN (18125, 18127, 19519, 19734)
  AND clt.Reference = 6010
  AND rlt1.Reference = 4001;
```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
