### PR TITLE
fix(CORE/SmartScripts): Remove Invoker in SMART_EVENT_EVENT_PHASE_CHANGE

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -4500,14 +4500,7 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
                 if (!IsInPhase(e.event.eventPhaseChange.phasemask))
                     return;
 
-                WorldObject* templastInvoker = GetLastInvoker();
-                if (!templastInvoker)
-                    return;
-
-                if (!IsUnit(templastInvoker))
-                    return;
-
-                ProcessAction(e, templastInvoker->ToUnit());
+                ProcessAction(e);
                 break;
             }
         case SMART_EVENT_GAME_EVENT_START:


### PR DESCRIPTION
## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

SMART_EVENT_EVENT_PHASE_CHANGE currently exits early if the previous event that led to its trigger did not have an invoker. I believe this behavior to be incorrect since ProcessEventsFor(SMART_EVENT_EVENT_PHASE_CHANGE); is called directly by the core whenever SetPhase is executed and even when trying to use target type 7 (invoker) in a smart script which uses this event type results in a worldserver error about this event not using invoker. Additionally, the invoker is often not present (cases where the event which led to this one did not have an invoker), resulting in this event exiting early despite a phase change occurring. 

This change restores proper functionality by removing the invoker check entirely, as it doesn't seem to be necessary. 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
This smart event currently does nothing.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

This smart event is unused in the db currently so to test
1. Create a simple smart script that uses SMART_ACTION_SET_EVENT_PHASE and set a creatures event phase to 2
2. Create another simple smart script that uses SMART_EVENT_EVENT_PHASE_CHANGE with parameter 2 
3. Ensure that 2nd script has its event_phase_mask set to 2 as well or it won't run!
4. Have this 2nd script perform any action, who cares.
5. You should see that when your first script's event triggers, the mob will perform whatever action you specify in the 2nd script.

Here are some test scripts people could use:

```
DELETE FROM `smart_scripts` WHERE `entryorguid` = 197 AND `id` IN (2, 3, 4, 5, 6);
INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `event_phase_mask`, `event_type`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `comment`) VALUES
(197, 0, 2, 0, 11, 0, 0, 0, 0, 0, 0, 22, 1, 0, 0, 0, 0, 0, 1, 'Marshal McBride - On Respawn - Set Event Phase to 1'),
(197, 0, 3, 1, 101, 1, 10, 0, 250, 250, 0, 22, 2, 0, 0, 0, 0, 0, 1, 'Marshal McBride - On Near Player - Set Event Phase to 2'),
(197, 0, 4, 2, 66, 2, 0, 0, 0, 0, 0, 5, 11, 0, 0, 0, 0, 0, 1, 'Marshal McBride - On Event Phase Change - Play Emote Laugh'),
(197, 0, 5, 2, 64, 0, 0, 0, 0, 0, 0, 22, 3, 0, 0, 0, 0, 0, 1, 'Marshal McBride - On GossipHello - Set Event Phase to 3 (Phase Mask 4)'),
(197, 0, 6, 4, 66, 4, 0, 0, 0, 0, 0, 11, 68037, 2, 0, 0, 0, 0, 1, 'Marshal McBride - On Event Phase Change - Cast Renew on Self');
```
These will add smart events to Marshal McBride in Northshire Valley. When the player approaches him, he will laugh once. This will not repeat. Then, when right clicking him to speak to him, he will cast renew on himself. This will not repeat either.

.tele northshirevalley 
walk into the building and approach Marshal McBride, see him laugh, then right click him and see him cast renew.

Prior to this PR, the above scripts would not play the laugh emote, as SMART_EVENT_NEAR_PLAYER does not have an invoker, but the renew cast would still happen on gossip hello since that does have an invoker. After the PR, both actions will work on their respective phase changes.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
