### PR TITLE
fix(DB/Quest): Fix breadcrumb for Find Sage Mistwalker and The Artifacts of Steel Gate

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1765321067916530574.sql
+++ b/data/sql/updates/pending_db_world/rev_1765321067916530574.sql
@@ -13,4 +13,4 @@
   (19, 0, 11287, 0, 0, 9, 0, 11286, 0, 0, 1, 0, 0, '', 'Find Sage Mistwalker - Not available if The Artifacts of Steel Gate is taken'),
   (19, 0, 11287, 0, 0, 8, 0, 11286, 0, 0, 1, 0, 0, '', 'Find Sage Mistwalker - Not available if The Artifacts of Steel Gate is rewarded'),
   (19, 0, 11286, 0, 0, 9, 0, 11287, 0, 0, 1, 0, 0, '', 'The Artifacts of Steel Gate - Not available if Find Sage Mistwalker is in progress'),
-  (19, 0, 11286, 0, 0, 28, 0, 11287, 0, 0, 1, 0, 0, '', 'The Artifacts of Steel Gate - Not available if Find Sage Mistwalker is complete but not turned in');\
+  (19, 0, 11286, 0, 0, 28, 0, 11287, 0, 0, 1, 0, 0, '', 'The Artifacts of Steel Gate - Not available if Find Sage Mistwalker is complete but not turned in');


### PR DESCRIPTION
[!] Please Read! This PR comes from AI with [MCP](https://github.com/blinkysc/azerothMCP)

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Uses conditions instead of ExclusiveGroup to properly handle the breadcrumb quest interaction:
- Remove `PrevQuestID` and `ExclusiveGroup` from 11286 (The Artifacts of Steel Gate)
- Remove `ExclusiveGroup` from 11287 (Find Sage Mistwalker)
- Add conditions so 11287 (breadcrumb) is unavailable if 11286 is taken or completed

This fixes the regression where taking the breadcrumb first would block the quest chain (11317 The Cleansing requires 11286 to be completed).

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23846

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Test Path 1 - Direct to main quest:**
1. `.quest remove 11286` and `.quest remove 11287`
2. `.go creature id 24186` (Sage Mistwalker) - should offer 11286 (The Artifacts of Steel Gate)
3. Accept 11286
4. `.go creature id 24135` (Greatmother Ankha) - should NOT offer 11287 (Find Sage Mistwalker)
5. `.quest complete 11286` then `.quest reward 11286`
6. `.go creature id 24186` - should offer 11317 (The Cleansing)

**Test Path 2 - Breadcrumb first (regression test):**
1. `.quest remove 11286` and `.quest remove 11287` and `.quest remove 11317`
2. `.go creature id 24135` (Greatmother Ankha) - should offer 11287 (Find Sage Mistwalker)
3. Accept and complete: `.quest complete 11287` then `.quest reward 11287`
4. `.go creature id 24186` (Sage Mistwalker) - should offer 11286 (The Artifacts of Steel Gate)
5. `.quest complete 11286` then `.quest reward 11286`
6. Sage Mistwalker should offer 11317 (The Cleansing)

## Known Issues and TODO List:

- [ ]
- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.