### PR TITLE
fix(Core/CMAKE) - Include mmaps-config. yaml with mmaps_generator for Windows

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -184,7 +184,7 @@ foreach(TOOL_NAME ${TOOLS_BUILD_LIST})
           COMMAND ${CMAKE_COMMAND} -E copy_if_different "${SOURCE_TOOL_PATH}/mmaps-config.yaml" "${CMAKE_BINARY_DIR}/bin/mmaps-config.yaml")
       endif()
     endif()
-  
+
     if (UNIX)
       install(FILES ${SOURCE_TOOL_PATH}/mmaps-config.yaml DESTINATION bin)
     elseif (WIN32)


### PR DESCRIPTION
Currently  (AC) windows users have to manually get `mmaps-config.yaml` if they build their tools (mmaps in this case), unlike Linux which always created those tools in `bin` folder. and this PR makes sure that it has the same behaviour as Linux, and MMAPS always comes with the required  mmaps-config.yaml (also if enabled the mmaps config it will always update the yaml file if it has any changes vs the existing one)

This shouldn't affect any Linux users BUT i would appreicate if it was tested in linux before being merged just to be 100% sure

All Tools
<img width="1051" height="159" alt="image" src="https://github.com/user-attachments/assets/f8057b15-f94a-4d9d-80bd-749b4733cdef" />
<img width="815" height="525" alt="image" src="https://github.com/user-attachments/assets/ae91fe90-c0d0-4d37-a6ff-b9e629882c4a" />

No MMAPS
<img width="1048" height="166" alt="image" src="https://github.com/user-attachments/assets/85890444-4690-412d-8016-d8ff82076e0c" />
<img width="856" height="272" alt="image" src="https://github.com/user-attachments/assets/b7907b8e-4f43-4627-8743-9c825f48cb6c" />

Only MMAPS
<img width="1036" height="145" alt="image" src="https://github.com/user-attachments/assets/cff9f2f0-48b1-4daf-91ab-832f85874660" />
<img width="799" height="160" alt="image" src="https://github.com/user-attachments/assets/d69855a5-6a1f-4d1c-a0af-69be56447cf5" />


