### PR TITLE
fix(DB/creature): Howling Fjord Rope Swing Invisible Vehicle Stalker visibility

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1765697713697231306.sql
+++ b/data/sql/updates/pending_db_world/rev_1765697713697231306.sql
@@ -1,7 +1,7 @@
 --
 SET @ENTRY := 24705;
 
-UPDATE `creature_template` SET `flags_extra` = 128 WHERE `entry` = @ENTRY;
+UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 128 WHERE `entry` = @ENTRY;
 
 DELETE FROM `creature_template_model` WHERE `CreatureID` = @ENTRY;
 INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES


### PR DESCRIPTION
## Changes Proposed:

The Rope Swing Invisible Vehicle Stalker creature/prop/trigger is visible to regular players. 

It appears that this is caused by:

1. The creature template is missing the `128` value for the `flags_extra` field in the database. This appears to be set for similar creature templates such as the `Whisper Gulch Ore Bunnies` that the linked issue originally indicated was the cause of the visible infernals.
2. The secondary model for the Rope Swing Invisible Vehicle Stalker in the `creature_template_model` table differs from the infernal model used for other invisible creatures. While it is an infernal model it is not a non-trigger infernal model, which appears to cause an issue with proper visibility both with `.gm on` and `.gm off`. Updating this secondary infernal to `17612` to match the other invisible creatures in the area solves it.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

## Issues Addressed:

- Closes #24001 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:

This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

1. Teleport to creature location, `.go xyz 1634 -3265 72 571 3`
3. Observe they are no longer visible as infernals with `.gm off`
4. Observe they are visible as infernals with `.gm on` the same way that other helper creatures/triggers are

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
