### PR TITLE
fix(DB/SpellGroup): feral Faerie Fire can apply with imp Faerie Fire

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1765899873993557813.sql
+++ b/data/sql/updates/pending_db_world/rev_1765899873993557813.sql
@@ -1,0 +1,4 @@
+--
+-- Faerie Fire group
+-- SPELL_GROUP_STACK_RULE_EXCLUSIVE_SAME_EFFECT	'Same effects of spells will not stack, yet auras will remain on a target'
+UPDATE `spell_group_stack_rules` SET `stack_rule`=3 WHERE `group_id`=1016;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Change Faerie Fire spell group stack rule from:
> 4	SPELL_GROUP_STACK_RULE_EXCLUSIVE_HIGHEST	Only Highest effect will remain on target

to 

> 3	SPELL_GROUP_STACK_RULE_EXCLUSIVE_SAME_EFFECT	Same effects of spells will not stack, yet auras will remain on a target

This causes both icons to show up on the target, but this is blizzlike according to source linked.

> Don't think we need a source for this but this thread talks about them both showing up:
https://www.mmo-champion.com/threads/646710-Faerie-Fire

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24094

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

double checked that this does not apply armor twice 
- https://github.com/azerothcore/azerothcore-wotlk/blob/558da9d39e3e22932b82191f9c10cd65d4d337b7/src/server/game/Spells/Auras/SpellAuraEffects.cpp#L4410

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Feral druid, balance druid (with improved faerie fire talent 33602)

cast feral ff (16857)
cast balance ff (770)

expect to cast feral faerie fire with balance ff applied

expect both icons to appear

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
