### PR TITLE
fix(DB/SpellGroups): stacking rules of Power Infusion with Haste effects

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1766152313494877642.sql
+++ b/data/sql/updates/pending_db_world/rev_1766152313494877642.sql
@@ -1,0 +1,7 @@
+--
+-- Temporary Haste Buffs (PI, Heroism, Bloodlust)
+-- 3	SPELL_GROUP_STACK_RULE_EXCLUSIVE_SAME_EFFECT	Same effects of spells will not stack, yet auras will remain on a target
+UPDATE `spell_group_stack_rules` SET `stack_rule`=3 WHERE `group_id`=1122;
+-- Power Infusion and Arcane Power
+-- 4	SPELL_GROUP_STACK_RULE_EXCLUSIVE_HIGHEST	Only Highest effect will remain on target
+UPDATE `spell_group_stack_rules` SET `stack_rule`=4 WHERE `group_id`=1123;


### PR DESCRIPTION

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

article http://talesofapriest.com/re-revisiting-power-infusion-in-wrath/

> If you cast PI when AP is already active, you receive “A more powerful
spell is already active” error. If you cast PI and THEN the mage casts AP, PI is over written.

> Heroism/Bloodlust are considered External, and therefor DO NOT stack
with PI. You can, of course, still cast PI during a Heroism/BL, but the only benefit received will be the mana reduction – quite the waste of a powerful spell.


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Mage + Priest

Shaman + Priest

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Observe if the stacking behavior matches the source

1. Mage AP + Priest PI stacks
2. Shaman BL/Hero + Priest PI
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
