### PR TITLE
fix(Core/Conditions): Limit Oculus' Cache drop to Random Heroic

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1766404520085093714.sql
+++ b/data/sql/updates/pending_db_world/rev_1766404520085093714.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `conditions` SET `ConditionTypeOrReference` = 105, `ConditionValue1` = 1, `ConditionValue2` = 0, `ConditionValue3` = 0, `Comment` = 'Loot Cache of the Ley-Guardian only when the player is queued via Random Heroic' WHERE `SourceTypeOrReferenceId` = 4 AND `SourceGroup` = 24524 AND `SourceEntry` = 52676 AND `SourceId` = 0 AND `ElseGroup` = 0 AND `ConditionTarget` = 0 AND `ConditionTypeOrReference` = 1;

--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -542,6 +542,23 @@ bool Condition::Meets(ConditionSourceInfo& sourceInfo)
         condMeets = object->GetMap()->GetDifficulty() == ConditionValue1;
         break;
     }
+    case CONDITION_RANDOM_DUNGEON:
+    {
+        if (Unit* unit = object->ToUnit())
+        {
+            if (Player* player = unit->GetCharmerOrOwnerPlayerOrPlayerItself())
+            {
+                if (sLFGMgr->selectedRandomLfgDungeon(player->GetGUID()))
+                {
+                    if (!ConditionValue1)
+                        condMeets = true;
+                    else if (Map* map = player->GetMap())
+                        condMeets = map->GetDifficulty() == Difficulty(ConditionValue1);
+                }
+            }
+        }
+        break;
+    }
     case CONDITION_PET_TYPE:
     {
         if (Unit* unit = object->ToUnit())
@@ -785,6 +802,9 @@ uint32 Condition::GetSearcherTypeMaskForCondition()
         break;
     case CONDITION_CHARMED:
         mask |= GRID_MAP_TYPE_MASK_CREATURE | GRID_MAP_TYPE_MASK_PLAYER;
+        break;
+    case CONDITION_RANDOM_DUNGEON:
+        mask |= GRID_MAP_TYPE_MASK_PLAYER;
         break;
     case CONDITION_WORLD_SCRIPT:
         mask |= GRID_MAP_TYPE_MASK_ALL;
@@ -2465,6 +2485,17 @@ bool ConditionMgr::isConditionTypeValid(Condition* cond)
             LOG_ERROR("sql.sql", "CONDITION_DIFFICULTY_ID has non existing difficulty in value1 ({}), skipped.", cond->ConditionValue1);
             return false;
         }
+        break;
+    case CONDITION_RANDOM_DUNGEON:
+        if (cond->ConditionValue1 >= MAX_DIFFICULTY)
+        {
+            LOG_ERROR("sql.sql", "RandomDungeon condition has invalid difficulty in value1 ({}).", cond->ConditionValue1);
+            return false;
+        }
+        if (cond->ConditionValue2)
+            LOG_ERROR("sql.sql", "RandomDungeon condition has useless data in value2 ({}).", cond->ConditionValue2);
+        if (cond->ConditionValue3)
+            LOG_ERROR("sql.sql", "RandomDungeon condition has useless data in value3 ({}).", cond->ConditionValue3);
         break;
     case CONDITION_PET_TYPE:
         if (cond->ConditionValue1 >= (1 << MAX_PET_TYPE))

--- a/src/server/game/Conditions/ConditionMgr.h
+++ b/src/server/game/Conditions/ConditionMgr.h
@@ -88,8 +88,9 @@ enum ConditionTypes
     CONDITION_HAS_AURA_TYPE            = 102,           // aura_type        0              0                  true if has aura type
     CONDITION_WORLD_SCRIPT             = 103,           // conditionId      state          0                  true if WorldState::IsConditionFulfilled returns true
     CONDITION_AI_DATA                  = 104,           // dataId           value          0                  true if AI::GetData returns value
+    CONDITION_RANDOM_DUNGEON           = 105,           // difficulty (0 = any) 0          0                  true if player is queued for a random dungeon via RDF (param1 = Difficulty)
 
-    CONDITION_AC_END                   = 105            // placeholder
+    CONDITION_AC_END                   = 106            // placeholder
 };
 
 /*! Documentation on implementing a new ConditionSourceType:


### PR DESCRIPTION

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Previously, the Luck of the Draw aura was checked as a condition. This incorrectly allows the "Cache of the Ley-Guardian" to be looted by players who queue for The Oculus by using "Specific Dungeons".

This allows the Cache to be looted only by players who queue via "Random Lich King Heroic".


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

> This only drops when you do the instance as the result of putting yourself in the queue for a random heroic: it will not drop if you choose to do the Oculus.

https://www.wowhead.com/wotlk/item=52676/cache-of-the-ley-guardian#comments

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Queue LFG Heroic with a group of mixed  "Specific Dungeons" and "Random Lich King Heroic"

Spawn the cache: `.gobject add temp 191349`

The Cache only drops for players who queue for "Random Lich King Heroic"


1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
