### PR TITLE
fix(Scripts/Spells): throttle Shadowmourne soul fragments & chaos bane.

### DIFF
--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -2442,6 +2442,8 @@ class spell_item_shadowmourne : public AuraScript
     void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
     {
         PreventDefaultAction();
+        if (GetTarget()->HasAura(SPELL_SHADOWMOURNE_CHAOS_BANE_BUFF))
+            return;
 
         // Throttle fragment procs to avoid high-frequency spam.
         if (GetTarget()->HasSpellCooldown(SPELL_SHADOWMOURNE_SOUL_FRAGMENT))


### PR DESCRIPTION
# Shadowmourne DoS Proc Findings and Fix

## Findings
- Shadowmourne (spell 71903) procs too often because the DBC `ProcFlags` include melee spell hits.
- Debug logs showed **10 Soul Fragment procs in the same millisecond**, meaning multiple proc events fire in a single server tick.

## Current Fix (Code)
- Prevent Soul Fragment stacking while Chaos Bane buff is active.
- Add a per-target throttle (200ms) to prevent multiple proc events per server tick from stacking fragments instantly.

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

I used OpenAI codex with gpt-5.2-codex high to triage the issue and find potential fix in the code.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.). I tested on my own local private server
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

My own videos (unlisted on YT), showing the condition before the proposed fix:


- [Video 1 - Better version, less server hang](https://youtu.be/KPwB-SLPcmA)
- [Video 2 - Worse, server hangs on proc](https://youtu.be/_fc-YPOo4ns)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Video after the issue is fixed: [link](https://youtu.be/dn6WTpQ9gbM).

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a lvl 80 paladin and obtain Shadowmourne, GM can use `.additem 49623` 
2. Try attacking any mob in any place. I tested in Ymirheim (Icecrown), Naxx, and ICC. 
3. See if the chaos bane/soul fragments being continuously stacked. If soul fragments stack1 properly from 1 to 10 and then release the chaos bane, then the fragments start stacking from 1 again after chaos bane buff expire, then there should be no issue.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
