### PR TITLE
fix(Core/ObjectMgr): Remove deprecated stat types warnings from items 13113 and 34967

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -3174,9 +3174,8 @@ void ObjectMgr::LoadItemTemplates()
                 case ITEM_MOD_SPELL_DAMAGE_DONE:
                     // Skip warning for specific items: 13113 (Feathermoon Headdress - Blizzard oversight), 34967 (test item)
                     if (entry != 13113 && entry != 34967)
-                    {
                         LOG_WARN("sql.sql", "Item (Entry: {}) has deprecated stat_type{} ({})", entry, j + 1, itemTemplate.ItemStat[j].ItemStatType);
-                    }
+
                     break;
                 default:
                     break;


### PR DESCRIPTION
  ## Changes Proposed:
  -  [X] Core (units, players, creatures, game systems).
  -  [ ] Scripts (bosses, spell scripts, creature scripts).
  -  [ ] Database (SAI, creatures, etc).

  ## Issues Addressed:
  - Closes #24305

  ## SOURCE:
  The changes have been validated through:
  - [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
    - Item 13113 (Feathermoon Headdress): Blizzard overlooked this item when converting spell damage/healing to spell power in patch 3.0. Keeping deprecated stat for 3.3.5 authenticity. See: https://www.wowhead.com/wotlk/item=13113/feathermoon-headdress#comments
    - Item 34967 (Juno's Test Gem): Test item not available to players.

  ## Tests Performed:
  - [ ] Tested in-game by the author.
  - [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
  - [X] This pull request requires further testing and may have edge cases to be tested.

  ## How to Test the Changes:
  - [X] This pull request can be tested by following the reproduction steps provided in the linked issue

  1. Enable warning for sql logger in `worldserver.conf`: `Logger.sql.sql=3,Console Errors`
  2. Start worldserver
  3. Verify no warnings appear for items 13113 and 34967

  ## Known Issues and TODO List:
  - [ ] None

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=148254234