### PR TITLE
fix(DB/Quest): Slaves to Saronite RP scripting improvements

### DIFF
--- a/data/sql/updates/pending_db_world/rev_slaves_to_saronite_rp.sql
+++ b/data/sql/updates/pending_db_world/rev_slaves_to_saronite_rp.sql
@@ -19,42 +19,50 @@
 -- 4. Fix /say messages language from Orcish to Universal
 -- 5. Add unknown voice whispers in Saronite Mines (spell_area 27769, area 4514)
 -- 6. Freedom path and pit coordinates from in-game research (Gultask)
+-- 7. Workaround (Gultask): run random script on gossip first, then cast 5429 on link;
+--    pit outcome sets phase 1 and UPDATE (event 60) picks random pit (no actionlist overlap).
 
 -- ============================================================================
--- 1. Gossip: Cast 5429 on player, then run random script (link chain)
---    Plus MovementInform (event 34, type 8 = Point, pointId 1/2/3): jump then despawn 4000ms
+-- 1. Gossip: Run random script first, then cast 5429 on link (fixes actionlist overlap).
+--    MovementInform (event 34, pointId 1/2/3): jump then despawn 4000ms.
+--    MovementInform pointId 4: freedom reached, despawn instant.
+--    UPDATE phase 1: run random pit (3139703/4/5) so 1/3 chance without nested actionlist.
 -- ============================================================================
-DELETE FROM `smart_scripts` WHERE `entryorguid`=31397 AND `source_type`=0;
-INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`event_param6`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
-(31397,0,0,1,62,0,100,512,10137,0,0,0,0,0,11,5429,0,0,0,0,0,7,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Gossip - Cast 5429 on Player'),
-(31397,0,1,0,61,0,100,0,0,0,0,0,0,0,87,3139700,3139701,3139702,0,0,0,1,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Link - Run Random Script'),
-(31397,0,2,0,0,0,100,0,1000,1000,14000,14000,0,0,11,3148,0,0,0,0,0,2,0,0,0,0,0,0,0,0,'Saronite Mine Slave - IC - Cast Head Crack'),
-(31397,0,3,0,1,0,15,0,10000,30000,50000,70000,0,0,1,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Saronite Mine Slave - OOC - Say text2'),
-(31397,0,4,1,34,0,100,0,8,1,0,0,0,0,97,15,15,0,0,0,0,8,0,0,0,0,6966.75,2067.58,482.553,0,'Saronite Mine Slave - MovementInform Point 1 - Jump to pit'),
-(31397,0,5,0,61,0,100,0,0,0,0,0,0,0,41,4000,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Link - Despawn 4000ms'),
-(31397,0,6,1,34,0,100,0,8,2,0,0,0,0,97,15,15,0,0,0,0,8,0,0,0,0,6904.17,2026.23,482.964,0,'Saronite Mine Slave - MovementInform Point 2 - Jump to pit'),
-(31397,0,7,0,61,0,100,0,0,0,0,0,0,0,41,4000,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Link - Despawn 4000ms'),
-(31397,0,8,1,34,0,100,0,8,3,0,0,0,0,97,15,15,0,0,0,0,8,0,0,0,0,6911.13,1969.18,488.24,0,'Saronite Mine Slave - MovementInform Point 3 - Jump to pit'),
-(31397,0,9,0,61,0,100,0,0,0,0,0,0,0,41,4000,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Link - Despawn 4000ms');
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 31397);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(31397, 0, 0, 1, 62, 0, 100, 512, 10137, 0, 0, 0, 0, 0, 87, 3139700, 3139701, 3139702, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Saronite Mine Slave - On Gossip Option Selected - Run Random Script'),
+(31397, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 5429, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Saronite Mine Slave - On Link - Cast 5429 on Player'),
+(31397, 0, 2, 0, 0, 0, 100, 0, 1000, 1000, 14000, 14000, 0, 0, 11, 3148, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Saronite Mine Slave - IC - Cast Head Crack'),
+(31397, 0, 3, 0, 1, 0, 15, 0, 10000, 30000, 50000, 70000, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Saronite Mine Slave - OOC - Say text2'),
+(31397, 0, 4, 5, 34, 0, 100, 0, 8, 1, 0, 0, 0, 0, 97, 15, 15, 0, 0, 0, 0, 1, 0, 0, 0, 0, 6966.75, 2067.58, 482.553, 0, 'Saronite Mine Slave - On Reached Pit 1 - Jump To Pos'),
+(31397, 0, 5, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 4000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Saronite Mine Slave - On Reached Pit 1 - Despawn In 4000 ms'),
+(31397, 0, 6, 7, 34, 0, 100, 0, 8, 2, 0, 0, 0, 0, 97, 15, 15, 0, 0, 0, 0, 1, 0, 0, 0, 0, 6904.17, 2026.23, 482.964, 0, 'Saronite Mine Slave - On Reached Pit 2 - Jump To Pos'),
+(31397, 0, 7, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 4000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Saronite Mine Slave - On Reached Pit 2 - Despawn In 4000 ms'),
+(31397, 0, 8, 9, 34, 0, 100, 0, 8, 3, 0, 0, 0, 0, 97, 15, 15, 0, 0, 0, 0, 1, 0, 0, 0, 0, 6911.13, 1969.18, 488.24, 0, 'Saronite Mine Slave - On Reached Pit 3 - Jump To Pos'),
+(31397, 0, 9, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 4000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Saronite Mine Slave - On Reached Pit 3 - Despawn In 4000 ms'),
+(31397, 0, 10, 0, 60, 1, 100, 0, 1200, 1200, 0, 0, 0, 0, 87, 3139703, 3139704, 3139705, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Saronite Mine Slave - On Update Phase 1 - Run to Random Pit'),
+(31397, 0, 11, 0, 34, 0, 100, 0, 8, 4, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Saronite Mine Slave - On Reached Freedom - Despawn Instant');
 
 -- ============================================================================
--- 2a. Freedom path: move to exact point (7026.46, 1877.16, 533.62), then despawn
+-- 2a. Freedom path: move to PointId 4 (7026.46, 1877.16, 533.62); MovementInform 4 despawns (31397 id 11).
 -- ============================================================================
-UPDATE `smart_scripts` SET `target_x`=7026.46,`target_y`=1877.1602,`target_z`=533.62744
-WHERE `entryorguid`=3139700 AND `source_type`=9 AND `id`=3;
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 3139700);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(3139700, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Saronite Mine Slave - Actionlist - Close Gossip'),
+(3139700, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Saronite Mine Slave - Actionlist - Remove Npc Flags Gossip'),
+(3139700, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 33, 31866, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 'Saronite Mine Slave - Actionlist - Quest Credit Slaves to Saronite'),
+(3139700, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 4, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 7026.46, 1877.16, 533.627, 0, 'Saronite Mine Slave - Actionlist - Move To Freedom PointId 4');
 
 -- ============================================================================
--- 2b. Pit outcome: yell, then move to one of three pits (PointId 1/2/3).
---    On MovementInform (event 34) creature jumps and despawns (see 31397 id 4-9).
+-- 2b. Pit outcome: yell, set phase 1 (no quest credit; UPDATE event 60 on 31397 runs random pit).
 -- ============================================================================
 DELETE FROM `smart_scripts` WHERE `entryorguid`=3139702 AND `source_type`=9;
 INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`event_param6`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
 (3139702,9,0,0,0,0,100,0,0,0,0,0,0,0,72,0,0,0,0,0,0,7,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Script - Close Gossip'),
 (3139702,9,1,0,0,0,100,0,0,0,0,0,0,0,83,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Script - Remove NPC Flag'),
-(3139702,9,2,0,0,0,100,0,0,0,0,0,0,0,33,31866,0,0,0,0,0,7,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Script - Quest Credit'),
-(3139702,9,3,0,0,0,100,0,0,0,0,0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Script - Yell (GroupID 0)'),
-(3139702,9,4,0,0,0,100,0,500,500,0,0,0,0,59,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Script - Set Run On'),
-(3139702,9,5,0,0,0,100,0,0,0,0,0,0,0,87,3139703,3139704,3139705,0,0,0,1,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Script - Run to Random Pit');
+(3139702,9,2,0,0,0,100,0,0,0,0,0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Script - Yell (GroupID 0)'),
+(3139702,9,3,0,0,0,100,0,0,0,0,0,0,0,59,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Script - Set Run On'),
+(3139702,9,4,0,0,0,100,0,0,0,0,0,0,0,22,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Script - Set Event Phase 1');
 
 -- Pit scripts: only Move to Pos with PointId; MovementInform on 31397 handles jump + despawn
 DELETE FROM `smart_scripts` WHERE `entryorguid` IN (3139703,3139704,3139705) AND `source_type`=9;
@@ -64,7 +72,7 @@ INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type
 (3139705,9,0,0,0,0,100,0,0,0,0,0,0,0,69,3,0,0,0,0,0,8,0,0,0,0,6921.0854,1972.6857,523.33716,0,'Pit 3 - Move to pos PointId 3');
 
 -- ============================================================================
--- 2. Fix hostile behavior: emote "goes into a frenzy!" instead of yelling
+-- 3. Fix hostile behavior: emote "goes into a frenzy!" instead of yelling
 -- ============================================================================
 
 -- Add emote text (Type 16 = CHAT_MSG_MONSTER_EMOTE)
@@ -73,7 +81,6 @@ INSERT INTO `creature_text` (`CreatureID`,`GroupID`,`ID`,`Text`,`Type`,`Language
 (31397,2,0,'%s goes into a frenzy!',16,0,100,0,0,0,36719,0,'Saronite Mine Slave - Frenzy Emote');
 
 -- Update hostile script to use emote (GroupID 2) instead of yell (GroupID 0)
--- Preserves original structure: close gossip, set faction, emote, attack, enrage
 DELETE FROM `smart_scripts` WHERE `entryorguid`=3139701 AND `source_type`=9;
 INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`event_param6`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
 (3139701,9,0,0,0,0,100,0,0,0,0,0,0,0,72,0,0,0,0,0,0,7,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Script - Close Gossip'),
@@ -83,18 +90,13 @@ INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type
 (3139701,9,4,0,0,0,100,0,0,0,0,0,0,0,11,8599,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Saronite Mine Slave - On Script - Cast Enrage');
 
 -- ============================================================================
--- 3. Fix /say messages language from Orcish (1) to Universal (0)
+-- 4. Fix /say messages language from Orcish (1) to Universal (0)
 -- ============================================================================
--- This makes the random ambient /say messages readable by both factions
 UPDATE `creature_text` SET `Language`=0 WHERE `CreatureID`=31397 AND `GroupID`=1;
 
 -- ============================================================================
--- 4. Unknown voice whispers in Saronite Mines (same as Whisper Gulch)
+-- 5. Unknown voice whispers in Saronite Mines (same as Whisper Gulch)
 -- ============================================================================
--- Spell 27769 applies an aura that periodically casts 29072 on the player.
--- NPC 29881 "An Unknown Voice" (already present in the mine at 6964,1979) reacts
--- to spell 29072 and says a random whisper line. Area 4514 = Saronite Mines.
--- Same mechanic as Whisper Gulch (27769 in area 4071).
 DELETE FROM `spell_area` WHERE `spell` = 27769 AND `area` = 4514;
 INSERT INTO `spell_area` (`spell`,`area`,`quest_start`,`quest_end`,`aura_spell`,`racemask`,`gender`,`autocast`,`quest_start_status`,`quest_end_status`) VALUES
 (27769,4514,0,0,0,0,2,1,64,11);


### PR DESCRIPTION
# Pull Request Description

## Changes Proposed

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools used, if any.

**AI Tool Used:** ChatGPT (and/or Windsurf/Cascade per SQL header — specify what you used).

**What AI was used for:**
- Analyzing the existing SmartAI scripts in the codebase
- Generating the SQL update file structure
- Writing comments and documentation

**What I verified manually:**
- Reviewed the 2009 video evidence linked in the issue
- Verified the SmartAI action_type 87 supports up to 6 random scripts (checked `SmartScriptMgr.h`)
- Confirmed the existing creature_text entries for GroupID 0 (yell quotes) and GroupID 1 (say messages)

---

## Issues Addressed

- Closes #24157

---

## SOURCE

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g. Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g. forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

**Video evidence:**
- 2009 video showing blizzlike behavior: https://www.youtube.com/watch?v=QeW_q-24Z28 (pit-jumping at 1:40)
- 2015 Alliance video: https://www.youtube.com/watch?v=eohEUG5vc7s

---

## Tests Performed

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

**CI:** Bats test `test_slaves_to_saronite_rp_sql.bats` added and passing.

---

## How to Test the Changes

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup (e.g. multiple players) please specify it as well.

1. Start the quest "Slaves to Saronite" in Icecrown (Quest ID: 13302).
2. Go to the Saronite Mines and interact with Saronite Mine Slaves (NPC 31397).
3. Verify the three behaviors occur randomly:
   - **Run to freedom:** Slave silently runs away and despawns (gives quest credit).
   - **Frenzy:** Slave emotes "%s goes into a frenzy!" and becomes hostile (no yelling).
   - **Pit jump:** Slave yells one of their quotes, runs to the pit, jumps in, then despawns (quest credit).
4. Test as Alliance to verify /say messages are now readable (no longer Orcish).
5. (Optional) Spend time in Icecrown / Saronite Mines to confirm occasional "unknown voice" whispers (same style as Whisper Gulch).

---

## Known Issues and TODO List

- [x] Pit coordinates (6931, 2014, 519) / (6940, 2020, 450) are from spawn/terrain; may need in-game tweak.
- [ ] Whispers use zone 210 (whole Icecrown); could be narrowed to mine-only if a sub-area ID is desired.

---

## Summary of Changes

1. **Add third random outcome (pit-jumping)**
   - Updated gossip script to include `action_param3=3139702`.
   - New action list 3139702: Close gossip → Remove NPC flag → Quest credit → Yell (GroupID 0) → Set run → Move to pit → Jump → Despawn.

2. **Fix hostile behavior**
   - Current bug: Slave yells before attacking (incorrect per blizzlike).
   - Fix: Slave now emotes "%s goes into a frenzy!" instead (new GroupID 2).
   - Added creature_text entry for frenzy emote (Type 16 = CHAT_MSG_MONSTER_EMOTE).

3. **Fix /say language**
   - Changed GroupID 1 messages from Language 1 (Orcish) to Language 0 (Universal).
   - Both factions can now read the ambient /say messages.

4. **Unknown voice whispers in Saronite Mines**
   - Added `spell_area` entry for spell 27769 in zone 210 (Icecrown), same mechanic as Whisper Gulch.
   - Players in Icecrown (including the mine) can receive occasional "unknown voice" whispers from NPC 29881.

5. **CI test**
   - Added `apps/ci/test/test_slaves_to_saronite_rp_sql.bats` to validate the SQL content (outcomes, emote, language, spell_area).
   - Run: `bats apps/ci/test/test_slaves_to_saronite_rp_sql.bats` or `./acore.sh test bash ci`.
