### PR TITLE
fix(DB/Quest): Implement Event for Killing Two Scourge With One Skeleton and phasing for following quests

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1767905979492678700.sql
+++ b/data/sql/updates/pending_db_world/rev_1767905979492678700.sql
@@ -59,7 +59,7 @@ DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 3143201
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (3143201, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 5, 460, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ghostwing - Actionlist - Play Emote 460 (OneShotFlyDragonSpit)'),
 (3143201, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ghostwing - Actionlist - Say Line 0'),
-(3143201, 9, 2, 0, 0, 0, 100, 0, 6470, 6470, 0, 0, 0, 0, 5, 452, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ghostwing - Actionlist - Play Emote 452 (OneShotFlyDragonSpit)'),
+(3143201, 9, 2, 0, 0, 0, 100, 0, 6470, 6470, 0, 0, 0, 0, 5, 452, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ghostwing - Actionlist - Play Emote 452 (OneShotFlyGrab)'),
 (3143201, 9, 3, 0, 0, 0, 100, 0, 400, 400, 0, 0, 0, 0, 86, 59091, 2, 19, 31428, 40, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ghostwing - Actionlist - Cross Cast \'Ride Ghostwing\''),
 (3143201, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 64, 1, 0, 0, 0, 0, 0, 19, 30631, 40, 0, 0, 0, 0, 0, 0, 'Ghostwing - Actionlist - Store Arly as Target'),
 (3143201, 9, 5, 0, 0, 0, 100, 0, 2840, 2840, 0, 0, 0, 0, 69, 2, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 6690.6504, 3177.2793, 860.5705, 0, 'Ghostwing - Actionlist - Move To Position'),


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

Implementation based on a 50664 sniff

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [X] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Had trouble with the quest_end_status but it was a misunderstanding on my part. I was setting it to 66 (completed or rewarded), when I should've done the opposite 9.
Claude helped me.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/8903

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [X] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [X] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .quest add 13144
2. .quest complete 13144
3. .go quest ender 13144
4. complete the following quests until Olakin is phased back in:
5. .quest complete 13212
6. .quest complete 13220

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
