### PR TITLE
fix(Scripts/RubySanctum): Halion Corporeality not updating

### DIFF
--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
@@ -598,7 +598,7 @@ public:
 
         void SetData(uint32 id, uint32 value) override
         {
-            if (!events.HasTimeUntilEvent(EVENT_CHECK_CORPOREALITY))
+            if (!_events.HasTimeUntilEvent(EVENT_CHECK_CORPOREALITY))
                 return;
 
             if (id == DATA_MATERIAL_DAMAGE_TAKEN)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Fix typo in `npc_halion_controllerAI::SetData()` where `events` was used instead of `_events`.

This caused the damage tracking condition to always fail, preventing `_materialDamage` and `_twilightDamage` from being updated. As a result, the damage ratio always remained at 1.0, and Corporeality never changed from 50%/50%.

**Before (bugged):**
```cpp
void SetData(uint32 id, uint32 value) override
{
    if (!events.HasTimeUntilEvent(EVENT_CHECK_CORPOREALITY))  // Wrong variable
        return;
```

**After (fixed):**
```cpp
void SetData(uint32 id, uint32 value) override
{
    if (!_events.HasTimeUntilEvent(EVENT_CHECK_CORPOREALITY))  // Correct variable
        return;
```

### AI-assisted Pull Requests
> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.
- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (Anthropic) was used to help identify the bug by analyzing the source code.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24313

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Retail behavior: Corporeality should dynamically change based on damage dealt in each realm (Physical vs Twilight). Reference videos from Paragon and Progress kills show Corporeality changing during Phase 3.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Ruby Sanctum and engage Halion
2. Progress to Phase 3 (Twilight Division - below 50% HP)
3. Have one group (Physical or Twilight realm) deal significantly more damage than the other
4. Observe the Corporeality percentage changing from 50%/50% in the UI
5. Verify emotes appear: "Your efforts force Halion further out of the physical/twilight realm!"

## Known Issues and TODO List:
- [ ] None