### PR TITLE
fix(scripts/ICC): Fix raging spirit visual clone

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -2220,7 +2220,7 @@ public:
             me->CastSpell(me, SPELL_RAGING_SPIRIT_VISUAL, true);
             if (TempSummon* summon = me->ToTempSummon())
                 if (Unit* summoner = summon->GetSummonerUnit())
-                    if (summoner->IsPlayer() && summoner->IsAlive() && !summoner->ToPlayer()->IsBeingTeleported() && summoner->FindMap() == me->GetMap())
+                    if (summoner->IsPlayer() && summoner->IsAlive() && summoner->FindMap() == me->GetMap())
                     {
                         valid = true;
                         summoner->CastSpell(me, SPELL_RAGING_SPIRIT_VISUAL_CLONE, true);
@@ -2281,7 +2281,7 @@ public:
                             bool valid = false;
                             if (TempSummon* summon = me->ToTempSummon())
                                 if (Unit* summoner = summon->GetSummonerUnit())
-                                    if (summoner->IsPlayer() && summoner->IsAlive() && !summoner->ToPlayer()->IsBeingTeleported() && summoner->FindMap() == me->GetMap())
+                                    if (summoner->IsPlayer() && summoner->IsAlive() && summoner->FindMap() == me->GetMap())
                                     {
                                         valid = true;
                                         AttackStart(summoner);


### PR DESCRIPTION
## Changes Proposed:
Remove `IsBeingTeleported()` check from Raging Spirit visual clone validation that causes the first spirit to fail visual clone application during the second transition of the Lich King encounter.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude was used to assist with code analysis and comparison with TrinityCore's implementation.

## Issues Addressed:
- Closes #24171

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore's implementation does not include the `IsBeingTeleported()` check:
https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Icecrown Citadel and engage the Lich King
2. Reach the second transition (phase 5)
3. Observe the first Raging Spirit - it should now display the player clone visual correctly
4. Verify subsequent spirits also display correctly
5. Test on both 10/25 man normal and heroic if possible

## Known Issues and TODO List:
- [ ] Verify no regressions on first transition
- [ ] Test all raid sizes and difficulties