### PR TITLE
fix(Core/Spells): Refresh duration for ENCHANT_PROC_ATTR_EXCLUSIVE auras

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7366,6 +7366,7 @@ void Player::CastItemCombatSpell(Unit* target, WeaponAttackType attType, uint32 
                 Unit* checkTarget = spellInfo->IsPositive() ? this : target;
                 if (checkTarget->HasAura(spellInfo->Id, GetGUID()))
                 {
+		    aura->RefreshDuration();
                     continue;
                 }
             }


### PR DESCRIPTION
Fixes the regression introduced in #15476 where exclusive enchant procs (like Executioner) would not refresh their duration when re-proccing.

The ENCHANT_PROC_ATTR_EXCLUSIVE flag should prevent stacking but still allow duration refresh on subsequent procs.

Closes #18324

## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude was used to help analyze the code and identify the root cause of the regression.

## Issues Addressed:
- Closes #18324

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Executioner tooltip states the effect lasts "for 15 sec" and should refresh on re-proc. WotLK Classic confirms this behavior.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Enchant two 1H weapons with Executioner
2. Attack a target dummy to trigger the proc
3. Continue attacking and verify the buff duration refreshes on subsequent procs
4. Verify only one stack of the buff is active at any time

## Known Issues and TODO List:

- [ ] Other enchants with ENCHANT_PROC_ATTR_EXCLUSIVE should be tested to ensure they also benefit from this fix