### PR TITLE
fix(Core/Spells): Beacon of Light should not proc from non-Paladin he…

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7940,9 +7940,9 @@ bool Unit::HandleDummyAuraProc(Unit* victim, uint32 damage, AuraEffect* triggere
                     if (!victim)
                         return false;
 
-		    // Only proc from Paladin healing spells
+		        // Only proc from Paladin healing spells
                     if (procSpell->SpellFamilyName != SPELLFAMILY_PALADIN)
-		    {
+		            {
                         return false;
                     }
 


### PR DESCRIPTION
Beacon of Light was incorrectly transferring healing from potions and other non-Paladin healing sources. Added SpellFamilyName check to ensure only Paladin healing spells trigger the beacon transfer.

Closes #23500

## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude was used to help analyze the code and identify the root cause of the issue.

## Issues Addressed:
- Closes #23500

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Beacon of Light tooltip states "Your heals on other party or raid members will also heal the Beacon of Light target" - this refers to Paladin healing spells, not generic healing sources like potions. The original issue triage also confirmed this behavior is not documented anywhere as intended for potion use.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Create a Paladin with Beacon of Light talent
2. Invite someone to party and cast Beacon of Light on them
3. Use a healing potion (e.g., Mad Alchemist's Potion) on yourself
4. Verify the Beacon target does NOT receive healing from the potion
5. Cast Holy Light or Flash of Light on yourself
6. Verify the Beacon target DOES receive healing from Paladin spells

## Known Issues and TODO List:

- [ ] Other Paladin healing interactions should be tested to ensure no regression (Holy Shock, Lay on Hands, Sacred Shield, etc.)