### PR TITLE
fix(Scripts/Naxx): Thaddius Ball Lightning should check all players i…

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
@@ -129,6 +129,15 @@ public:
         uint32 resetTimer{};
         bool ballLightningEnabled;
 
+        bool IsAnyPlayerInMeleeRange() const
+        {
+            for (auto const& ref : me->GetThreatMgr().GetThreatList())
+                if (Unit* target = ref->getTarget())
+                    if (target->IsPlayer() && me->IsWithinMeleeRange(target))
+                        return true;
+            return false;
+        }
+
         void DoAction(int32 param) override
         {
             if (param == ACTION_SUMMON_DIED)
@@ -327,17 +336,11 @@ public:
                     break;
             }
 
-            if (me->IsWithinMeleeRange(me->GetVictim()))
-            {
+            if (IsAnyPlayerInMeleeRange())
                 DoMeleeAttackIfReady();
-            }
-            else if (ballLightningEnabled)
-            {
+            else if (ballLightningEnabled && !IsAnyPlayerInMeleeRange())
                 if (Unit* target = SelectTarget(SelectTargetMethod::MaxThreat))
-                {
                     me->CastSpell(target, SPELL_BALL_LIGHTNING, false);
-                }
-            }
         }
     };
 };


### PR DESCRIPTION
Ball Lightning was being cast even when melee players (other than the tank) were in range of the boss. Added IsAnyPlayerInMeleeRange() helper function to check if any player on the threat list is within melee range.

Closes #24372

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude was used to help analyze the code and identify the root cause of the issue.

## Issues Addressed:
- Closes #24372

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Sources from the issue:
- https://warcraft.wiki.gg/wiki/Thaddius?oldid=127160
- https://www.warcrafttavern.com/wotlk/guides/thaddius-10/

Both sources confirm Ball Lightning should only be cast when no players are in melee range.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Start Thaddius encounter with at least 2 players
2. Have one player (tank) move away from melee range
3. Keep another player in melee range of Thaddius
4. Verify Thaddius does NOT cast Ball Lightning while any player is in melee range
5. Have all players move out of melee range
6. Verify Thaddius now casts Ball Lightning

## Known Issues and TODO List:

- [ ] The issue mentions pets/summons should possibly be checked too - this may need additional testing/confirmation