### PR TITLE
fix(Scripts/Pets): Shaman elementals follow totem instead of player

### DIFF
--- a/src/server/scripts/Pet/pet_shaman.cpp
+++ b/src/server/scripts/Pet/pet_shaman.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "CreatureScript.h"
+#include "MotionMaster.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
 
@@ -46,13 +47,34 @@ struct npc_pet_shaman_earth_elemental : public ScriptedAI
 {
     npc_pet_shaman_earth_elemental(Creature* creature) : ScriptedAI(creature), _initAttack(true) { }
 
+    void InitializeAI() override
+    {
+        MoveToTotem();
+    }
+
     void JustEngagedWith(Unit*) override
     {
         _events.Reset();
         _events.ScheduleEvent(EVENT_SHAMAN_ANGEREDEARTH, 0ms);
     }
 
-    void InitializeAI() override { }
+    void EnterEvadeMode(EvadeReason why) override
+    {
+        if (!_EnterEvadeMode(why))
+            return;
+
+        MoveToTotem();
+    }
+
+    void MoveToTotem()
+    {
+        if (Unit* owner = me->GetCharmerOrOwner())
+            if (Creature* totem = ObjectAccessor::GetCreature(*me, owner->m_SummonSlot[SUMMON_SLOT_TOTEM_EARTH]))
+            {
+                me->GetMotionMaster()->Clear(false);
+                me->GetMotionMaster()->MoveFollow(totem, PET_FOLLOW_DIST, me->GetFollowAngle(), MOTION_SLOT_ACTIVE);
+            }
+    }
 
     void UpdateAI(uint32 diff) override
     {
@@ -89,7 +111,10 @@ struct npc_pet_shaman_fire_elemental : public ScriptedAI
 {
     npc_pet_shaman_fire_elemental(Creature* creature) : ScriptedAI(creature), _initAttack(true) { }
 
-    void InitializeAI() override { }
+    void InitializeAI() override
+    {
+        MoveToTotem();
+    }
 
     void JustEngagedWith(Unit*) override
     {
@@ -100,6 +125,24 @@ struct npc_pet_shaman_fire_elemental : public ScriptedAI
 
         me->RemoveAurasDueToSpell(SPELL_SHAMAN_FIRESHIELD);
         me->CastSpell(me, SPELL_SHAMAN_FIRESHIELD, true);
+    }
+
+    void EnterEvadeMode(EvadeReason why) override
+    {
+        if (!_EnterEvadeMode(why))
+            return;
+
+        MoveToTotem();
+    }
+
+    void MoveToTotem()
+    {
+        if (Unit* owner = me->GetCharmerOrOwner())
+            if (Creature* totem = ObjectAccessor::GetCreature(*me, owner->m_SummonSlot[SUMMON_SLOT_TOTEM_FIRE]))
+            {
+                me->GetMotionMaster()->Clear(false);
+                me->GetMotionMaster()->MoveFollow(totem, PET_FOLLOW_DIST, me->GetFollowAngle(), MOTION_SLOT_ACTIVE);
+            }
     }
 
     void UpdateAI(uint32 diff) override


### PR DESCRIPTION
Closes #19514

Fire and Earth elementals now follow their respective totems instead of the shaman player. This is achieved by:
- Adding MoveToTotem() that finds the nearby totem and follows it
- Calling MoveToTotem() in InitializeAI() when elemental spawns
- Overriding EnterEvadeMode() to return to totem after combat

This approach keeps the elemental's ownership with the player (avoiding faction issues from reverted PR #19599) while fixing the movement behavior.

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
PR #19599 previously attempted to fix this by changing elemental ownership to the totem. However, this caused a regression (#19658) where elementals became hostile to opposite faction players, so it was reverted in #19664.

The root cause is that many pet-related checks assume the owner is a player. Changing ownership to the totem broke faction handling.

This PR takes a different approach: keep the elemental owned by the player but only change its follow behavior to target the totem. This is done in the elemental's AI script (`pet_shaman.cpp`) by:
- Finding the nearby totem using `FindNearestCreature()`
- Using `MoveFollow()` to follow the totem in `InitializeAI()`
- Overriding `EnterEvadeMode()` to return to the totem after combat

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [X] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude was used to analyze the codebase and help develop the solution.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/19514

## SOURCE:
The changes have been validated through:
- [X] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - Video: https://www.youtube.com/watch?v=U9bm6I9G1_4&t=459s (Wrath retail)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [X] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. `.learn 2894` (Fire Elemental Totem) or `.learn 2062` (Earth Elemental Totem)
2. Cast the totem
3. Observe the elemental stays near the totem instead of following the player
4. Move away from the totem - elemental should remain near totem
5. Enter combat and exit - elemental should return to totem, not to the player

## Known Issues and TODO List:

- None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.