### PR TITLE
fix(DB/Conditions): Restrict holiday items to their events

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1768263336435146350.sql
+++ b/data/sql/updates/pending_db_world/rev_1768263336435146350.sql
@@ -1,0 +1,13 @@
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 1 AND `SourceEntry` = 20400 AND `ConditionTypeOrReference` = 12;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(1, 27830, 20400, 0, 0, 12, 0, 12, 0, 0, 0, 0, 0, '', 'Pumpkin Bag - Venture Co. Evacuee - Requires Hallow''s End'),
+(1, 29330, 20400, 0, 0, 12, 0, 12, 0, 0, 0, 0, 0, '', 'Pumpkin Bag - Onslaught Harbor Guard - Requires Hallow''s End'),
+(1, 29722, 20400, 0, 0, 12, 0, 12, 0, 0, 0, 0, 0, '', 'Pumpkin Bag - Rabid Cannibal - Requires Hallow''s End'),
+(1, 30243, 20400, 0, 0, 12, 0, 12, 0, 0, 0, 0, 0, '', 'Pumpkin Bag - Njorndar Spear-Sister - Requires Hallow''s End'),
+(1, 30687, 20400, 0, 0, 12, 0, 12, 0, 0, 0, 0, 0, '', 'Pumpkin Bag - Skeletal Constructor - Requires Hallow''s End'),
+(1, 31738, 20400, 0, 0, 12, 0, 12, 0, 0, 0, 0, 0, '', 'Pumpkin Bag - Cultist Corrupter - Requires Hallow''s End'),
+(1, 32259, 20400, 0, 0, 12, 0, 12, 0, 0, 0, 0, 0, '', 'Pumpkin Bag - Void Summoner - Requires Hallow''s End');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 1 AND `SourceEntry` = 21235 AND `ConditionTypeOrReference` = 12;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(1, 11459, 21235, 0, 0, 12, 0, 2, 0, 0, 0, 0, 0, '', 'Winter Veil Roast - Ironbark Protector - Requires Winter Veil');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->

Add CONDITION_ACTIVE_EVENT conditions to restrict holiday items to only drop during their respective events:

- **Pumpkin Bag (20400)** - Now requires Hallow's End (event 12) to drop from 7 Northrend creatures
- **Winter Veil Roast (21235)** - Now requires Winter Veil (event 2) to drop from Ironbark Protector

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Database investigation confirmed these items were dropping year-round without event restrictions.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply the SQL and reload conditions (`.reload conditions`)
2. Enable Hallow's End event (`.event start 12`)
3. Kill one of the affected creatures (e.g. `.go creature id 27830` - Venture Co. Evacuee) and verify Pumpkin Bag can drop
4. Disable Hallow's End (`.event stop 12`) and verify Pumpkin Bag no longer drops
5. Repeat for Winter Veil (event 2) with Ironbark Protector (`.go creature id 11459`)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.