### PR TITLE
fix(DB/Loot): Add several unobtainable items that should be obtainable

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1768679872082424600.sql
+++ b/data/sql/updates/pending_db_world/rev_1768679872082424600.sql
@@ -51,20 +51,6 @@ DELETE FROM `creature_loot_template` WHERE (`Entry` = 9568) AND (`Item` IN (1316
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (9568, 13164, 0, 1, 0, 1, 0, 1, 1, 'Overlord Wyrmthalak - Heart of the Scale');
 
--- Scourge Invasion Items
-DELETE FROM `creature_loot_template` WHERE (`Entry` = 16143) AND (`Item` IN (23085, 23088, 23087, 23089));
-INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(16143, 23085, 0, 0, 0, 1, 1, 1, 1, 'Shadow of Doom - Robe of Undead Cleansing'),
-(16143, 23088, 0, 0, 0, 1, 1, 1, 1, 'Shadow of Doom - Chestguard of Undead Slaying'),
-(16143, 23087, 0, 0, 0, 1, 1, 1, 1, 'Shadow of Doom - Breastplate of Undead Slaying'),
-(16143, 23089, 0, 0, 0, 1, 1, 1, 1, 'Shadow of Doom - Tunic of Undead Slaying');
-DELETE FROM `reference_loot_template` WHERE (`Entry` = 14697) AND (`Item` IN (23092, 23093, 23091, 23090));
-INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(14697, 23092, 0, 0, 0, 1, 1, 1, 1, 'Wristguards of Undead Slaying'),
-(14697, 23093, 0, 0, 0, 1, 1, 1, 1, 'Wristwraps of Undead Slaying'),
-(14697, 23091, 0, 0, 0, 1, 1, 1, 1, 'Bracers of Undead Cleansing'),
-(14697, 23090, 0, 0, 0, 1, 1, 1, 1, 'Bracers of Undead Slaying');
-
 -- Sack of Spoils and Chest of Spoils (AQ event reward containers)
 DELETE FROM `item_loot_template` WHERE (`Entry` = 20601) AND (`Item` IN (20696, 20698));
 INSERT INTO `item_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

I got curious and looked up which items were not in any loot lists.

Turned out that, after a lot of filtering out profession items, it's a lot of duplicates of existing items and deprecated librams and grimoires. But I did find some hidden gems that were unobtainable.

Nagahide Leggings: from Coilfang Emissary Rare. It's supposed to drop one of 4 pair of pants, one for each type (cloth, leather, etc)
Gruffscale Leggings: from Gruff Rare Elite in Un'Goro. Apparently it used to drop a level 8 Boarhide Leggings green until at some point during WotLK which was changed to the proper item.
Dustbringer: Super Rare fising loot, similar to Sea Turtle, you know? From comments, I set it to the same chance as Sea Turtle (0.01%), although it might be rarer. I actually got Sea Turtle like 3 times in Classic I'm sure it's more than that lmao.
Runed Ring: Old dungeons have BoE Blues (around 0.5% chance, maybe?) but it turns out that this ring, alongside Spellshock Leggings from Zul'Farrak, are too high ilvl to drop from all creatures in the dungeon, except the final bosses.

Several rare endgame dungeon items from Vanilla that drop from select bosses:
War Master Voone: Voone's Twitchbow
Overlord Wyrmthalak: Chillpike
Warchief Rend Blackhand: Bonespike Shoulder
Darkmaster Gandling: Detention Strap
Jandice Barov: Darkshade Gloves
Overlord Wyrmthalak: Heart of the Scale

Scourge Invasion Items with the suffixes: "of Undead Slaying" and "of Undead Cleansing", but only the blues, as the purples were already there.

Sack of Spoils and Chest of Spoils from AQ Event were missing a few items:
Crystal Spiked Maul, Elemental Attuned Blade, Crystal Slugthrower, Band of the Cultist, Dark Whisper Blade

Jin'do was missing Bloodstained Coif
Phalanx was missing Rockfist

Grimoire of Inferno from Scarshield Warlock: Apparently these were still dropping during 3.3.3, and teaches Warlocks an Inferno spell.

One AQ40 trash epic Gloves of the Fallen Prophet. Apparently much rarer than its counterparts

Alterac Valley Bosses Lokholar the Ice Lord and Ivus the Forest Lord were also missing some of their loot.

Additionally, some greens from the 72-74 loot tables have been added to the Loot Normalization PR. Those were also missing. All weapons.

If interested, I have the remaining list here: https://gist.github.com/Gultask/b141f0a2ec7d7fda435e8bdaeb3156c0

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
