### PR TITLE
fix(DB/Reputation): Implement Violet Hold heroic reputation

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1768963044843954200.sql
+++ b/data/sql/updates/pending_db_world/rev_1768963044843954200.sql
@@ -3,7 +3,7 @@ SET @REPPORTALKEEPER := 30;
 SET @REPREGULAR := 18;
 SET @REPBOSS := 275;
 
-DELETE FROM `creature_onkill_reputation` WHERE `creature_id` IN (31503, 31501, 31493, 31490, 31513, 32191, 31486, 31507, 31509, 31510, 31512, 31508, 31506);
+DELETE FROM `creature_onkill_reputation` WHERE `creature_id` IN (31503, 31501, 31493, 31490, 31513, 32191, 31486, 31507, 31509, 31510, 31511, 31512, 31508, 31506);
 INSERT INTO `creature_onkill_reputation` (`creature_id`,`RewOnKillRepFaction1`,`RewOnKillRepFaction2`,`MaxStanding1`,`IsTeamAward1`,`RewOnKillRepValue1`,`MaxStanding2`,`IsTeamAward2`,`RewOnKillRepValue2`,`TeamDependent`) VALUES
 (31503,1037,1052,7,0,@REPPORTALKEEPER,7,0,@REPPORTALKEEPER,1), -- Portal Keeper
 (31501,1037,1052,7,0,@REPPORTALKEEPER,7,0,@REPPORTALKEEPER,1),  -- Portal Guardian
@@ -15,6 +15,7 @@ INSERT INTO `creature_onkill_reputation` (`creature_id`,`RewOnKillRepFaction1`,`
 (31507,1037,1052,7,0,@REPBOSS,7,0,@REPBOSS,1), -- Erekem
 (31509,1037,1052,7,0,@REPBOSS,7,0,@REPBOSS,1), -- Lavanthor
 (31510,1037,1052,7,0,@REPBOSS,7,0,@REPBOSS,1), -- Moragg
+(31511,1037,1052,7,0,@REPBOSS,7,0,@REPBOSS,1), -- Zevoxx
 (31512,1037,1052,7,0,@REPBOSS,7,0,@REPBOSS,1), -- Zuramat
 (31508,1037,1052,7,0,@REPBOSS,7,0,@REPBOSS,1), -- Ichoron
 (31506,1037,1052,7,0,@REPBOSS,7,0,@REPBOSS,1); -- Cyanigosa


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/6329

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
