### PR TITLE
fix(Core/Spells): Make haunted memento blizzlike

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -1020,3 +1020,11 @@ bool MotionMaster::GetDestination(float& x, float& y, float& z)
     z = dest.z;
     return true;
 }
+
+void MotionMaster::MoveHaunt(Unit* target)
+{
+    if (!target)
+        return;
+
+    Mutate(new HauntMovementGenerator<Creature>(target), MOTION_SLOT_CONTROLLED);
+}

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -262,6 +262,7 @@ public:
     void MoveDistract(uint32 time);
     void MoveWaypoint(uint32 path_id, bool repeatable, PathSource pathSource = PathSource::WAYPOINT_MGR);
     void MoveRotate(uint32 time, RotateDirection direction);
+    void MoveHaunt(Unit* target);
 
     [[nodiscard]] MovementGeneratorType GetCurrentMovementGeneratorType() const;
     [[nodiscard]] MovementGeneratorType GetMotionSlotType(int slot) const;

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -677,6 +677,105 @@ void FollowMovementGenerator<T>::MovementInform(T* owner)
         AI->MovementInform(FOLLOW_MOTION_TYPE, i_target.getTarget()->GetGUID().GetCounter());
 }
 
+template<class T>
+bool HauntMovementGenerator<T>::DoUpdate(T* owner, uint32 /*time_diff*/)
+{
+    if (!i_target.isValid() || !i_target->IsInWorld() || !owner || !owner->IsInMap(i_target.getTarget()))
+       return false;
+
+    Unit* target = i_target.getTarget();
+    Position targetPos = target->GetPosition();
+
+    float distance = owner->GetDistance(target);
+
+    if (distance <= 4.0f)
+    {
+        if (owner->HasUnitState(UNIT_STATE_FOLLOW_MOVE))
+        {
+            owner->ClearUnitState(UNIT_STATE_FOLLOW_MOVE);
+            i_path = nullptr;
+        }
+
+        owner->SetFacingToObject(target);
+        return true;
+    }
+
+    if (distance < 9.0f && !owner->HasUnitState(UNIT_STATE_FOLLOW_MOVE))
+    {
+        owner->SetFacingToObject(target);
+        return true;
+    }
+
+    if (!i_path)
+        i_path = std::make_unique<PathGenerator>(owner);
+    else
+        i_path->Clear();
+
+    bool targetIsMoving = target->m_movementInfo.HasMovementFlag(MOVEMENTFLAG_FORWARD | MOVEMENTFLAG_BACKWARD | MOVEMENTFLAG_STRAFE_LEFT | MOVEMENTFLAG_STRAFE_RIGHT);
+
+    if (targetIsMoving)
+        targetPos = PredictPosition(target);
+
+    target->MovePositionToFirstCollision(targetPos, 5.0f, 0.0f);
+
+    float x, y, z;
+    targetPos.GetPosition(x, y, z);
+
+    bool success = i_path->CalculatePath(x, y, z, false);
+    if (!success || (i_path->GetPathType() & PATHFIND_NOPATH))
+    {
+        if (!owner->IsStopped())
+            owner->StopMoving();
+
+        return true;
+    }
+
+    owner->AddUnitState(UNIT_STATE_FOLLOW_MOVE);
+
+    Movement::MoveSplineInit init(owner);
+    init.SetFacing(target);
+
+    // Catch up if too far away
+    if (distance > 100.0f)
+        init.SetVelocity(owner->GetSpeed(MOVE_RUN) * 3);
+    else
+        init.SetVelocity(owner->GetSpeed(MOVE_RUN) * 0.5);
+
+    init.MovebyPath(i_path->GetPath());
+    init.Launch();
+    return true;
+}
+
+template<class T>
+void HauntMovementGenerator<T>::DoInitialize(T* owner)
+{
+    i_path = nullptr;
+    owner->AddUnitState(UNIT_STATE_FOLLOW);
+}
+
+template<class T>
+void HauntMovementGenerator<T>::DoFinalize(T* owner)
+{
+    owner->ClearUnitState(UNIT_STATE_FOLLOW | UNIT_STATE_FOLLOW_MOVE);
+}
+
+template<class T>
+void HauntMovementGenerator<T>::DoReset(T* owner)
+{
+    DoInitialize(owner);
+}
+
+template<class T>
+void HauntMovementGenerator<T>::MovementInform(T* owner)
+{
+    if (!owner->IsCreature())
+        return;
+
+    // Pass back the GUIDLow of the target
+    if (CreatureAI* AI = owner->ToCreature()->AI())
+        AI->MovementInform(FOLLOW_MOTION_TYPE, i_target.getTarget()->GetGUID().GetCounter());
+}
+
 //-----------------------------------------------//
 
 template void ChaseMovementGenerator<Player>::DoFinalize(Player*);
@@ -702,3 +801,9 @@ template void FollowMovementGenerator<Player>::DoReset(Player*);
 template void FollowMovementGenerator<Creature>::DoReset(Creature*);
 template bool FollowMovementGenerator<Player>::DoUpdate(Player*, uint32);
 template bool FollowMovementGenerator<Creature>::DoUpdate(Creature*, uint32);
+
+template void HauntMovementGenerator<Creature>::DoInitialize(Creature*);
+template void HauntMovementGenerator<Creature>::DoFinalize(Creature*);
+template void HauntMovementGenerator<Creature>::DoReset(Creature*);
+template bool HauntMovementGenerator<Creature>::DoUpdate(Creature*, uint32);
+template void HauntMovementGenerator<Creature>::MovementInform(Creature*);

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.h
@@ -126,4 +126,24 @@ private:
     bool _inheritSpeed;
 };
 
+template<class T>
+class HauntMovementGenerator : public MovementGeneratorMedium<T, HauntMovementGenerator<T>>, public TargetedMovementGeneratorBase
+{
+public:
+    HauntMovementGenerator(Unit* target) : TargetedMovementGeneratorBase(target), i_path(nullptr) {}
+    ~HauntMovementGenerator() {}
+
+    MovementGeneratorType GetMovementGeneratorType() { return FOLLOW_MOTION_TYPE; }
+
+    bool DoUpdate(T*, uint32);
+    void DoInitialize(T*);
+    void DoFinalize(T*);
+    void DoReset(T*);
+    void MovementInform(T*);
+
+    Unit* GetTarget() const { return i_target.getTarget(); }
+
+private:
+    std::unique_ptr<PathGenerator> i_path;
+};
 #endif


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

In Wrath of the Lich King the Haunted Memento followed the player around everywhere and was a permanent ghost. In Azerothcore it disappears after a few seconds. It was nerfed several expansions later.

I had one of these from the WotLK scourge invasion until I stopped playing in MoP and it was by my side the whole time so I'm pretty familiar with it..

The original behavior in Azerothcore just has it spawn the creature then follow the player using the pet follow logic. That is definitely incorrect.

In WotLK the creature would:

- Permanently follow the player
- Stop when it got within a certain distance
- Walk slowly
- Keep facing the player when you walked around it

I have guessed on some of the numbers and implementation here but it's a lot closer than the current approach which is completely incorrect for several reasons: it uses the `movefollow` logic so follows like a pet behind the player, then when it reaches the player faces the same direction as the player in the pet spot and it only lasts a few seconds

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Used claude to generate a preliminary movement generator based on the existing FollowMovementGenerator but ended up rewriting most of its work, it was good to have a base to work from though

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**


See comments on WoWHead: https://www.wowhead.com/item=40110/haunted-memento#comments

>  finally got my hands on one of these today, paid 11k for the thing. Only to find out the buff isn't permanant anymore. Needless to say I'm incredibly pissed off about it

video: https://www.youtube.com/watch?v=iVIBMREHZiU

comment from that video:

>  +chaosdream1 it's worthless now. The ghost only shows up for 15 seconds and then disappears every once and a while now rather than permanently following you around.  

Article about it being nerfed: https://www.engadget.com/2015-01-09-haunted-memento-nerfed-for-server-stability.html

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


Test log

1. haunt spawns on log in :+1: 
2. haunt spawns when recieving the item (.additem 40110) :+1: 
3. haunt despawns when item is destroyed/removed from bag :+1:
4. haunt is despawned when player logs off/teleports to a different map :+1:
5. haunt is recreated after teleporting between maps :+1:
6. haunt follows player :+1: 
7. haunt turns to face player when player moves :+1: 
8. haunt stops moving when close to player :+1: 
9. haunt starts following again when player gets far enough away :+1: 

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
10.
11.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
