### PR TITLE
fix(Core/Player): Prevent player gaining client control when charmed

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -12843,9 +12843,21 @@ void Player::ResurectUsingRequestData()
 
 void Player::SetClientControl(Unit* target, bool allowMove, bool packetOnly /*= false*/)
 {
+    ASSERT(target);
+    // refuse to grant control if target has UNIT_STATE_CHARMED
+    if (target->HasUnitState(UNIT_STATE_CHARMED) && (GetGUID() != target->GetCharmerGUID()))
+    {
+        LOG_ERROR("entities.player", "Player '{}' attempt to client control '{}', which is charmed by GUID {}", GetName(), target->GetName(), target->GetCharmerGUID().ToString());
+        return;
+    }
+
+    // still affected by some aura that shouldn't allow control, only allow on last such aura to be removed
+    if (target->HasUnitState(UNIT_STATE_FLEEING | UNIT_STATE_CONFUSED))
+        allowMove = false;
+
     WorldPacket data(SMSG_CLIENT_CONTROL_UPDATE, target->GetPackGUID().size() + 1);
     data << target->GetPackGUID();
-    data << uint8((allowMove && !target->HasUnitState(UNIT_STATE_FLEEING | UNIT_STATE_CONFUSED)) ? 1 : 0);
+    data << uint8(allowMove ? 1 : 0);
     SendDirectMessage(&data);
 
     // We want to set the packet only

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11118,6 +11118,8 @@ void Unit::SetCharm(Unit* charm, bool apply)
     }
     else
     {
+        charm->ClearUnitState(UNIT_STATE_CHARMED);
+
         if (IsPlayer())
         {
             if (!RemoveGuidValue(UNIT_FIELD_CHARM, charm->GetGUID()))
@@ -18790,6 +18792,8 @@ bool Unit::SetCharmedBy(Unit* charmer, CharmType type, AuraApplication const* au
     }
     else if (IsPlayer())
         RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
+
+    AddUnitState(UNIT_STATE_CHARMED);
 
     if (Creature* creature = ToCreature())
         creature->RefreshSwimmingFlag();

--- a/src/server/game/Entities/Unit/UnitDefines.h
+++ b/src/server/game/Entities/Unit/UnitDefines.h
@@ -169,7 +169,7 @@ enum UnitState
 {
     UNIT_STATE_DIED                     = 0x00000001,       // player has fake death aura
     UNIT_STATE_MELEE_ATTACKING          = 0x00000002,       // player is melee attacking someone
-    //UNIT_STATE_MELEE_ATTACK_BY        = 0x00000004,       // player is melee attack by someone
+    UNIT_STATE_CHARMED                  = 0x00000004,       // having any kind of charm aura on self
     UNIT_STATE_STUNNED                  = 0x00000008,
     UNIT_STATE_ROAMING                  = 0x00000010,
     UNIT_STATE_CHASE                    = 0x00000020,
@@ -201,7 +201,7 @@ enum UnitState
     UNIT_STATE_NO_COMBAT_MOVEMENT       = 0x40000000,       // should not be changed outside the core and should be placed at the end
     UNIT_STATE_LOGOUT_TIMER             = 0x80000000,       // Unit is logging out
 
-    UNIT_STATE_ALL_STATE_SUPPORTED = UNIT_STATE_DIED | UNIT_STATE_MELEE_ATTACKING | UNIT_STATE_STUNNED | UNIT_STATE_ROAMING | UNIT_STATE_CHASE
+    UNIT_STATE_ALL_STATE_SUPPORTED = UNIT_STATE_DIED | UNIT_STATE_MELEE_ATTACKING | UNIT_STATE_CHARMED | UNIT_STATE_STUNNED | UNIT_STATE_ROAMING | UNIT_STATE_CHASE
     | UNIT_STATE_FLEEING | UNIT_STATE_IN_FLIGHT | UNIT_STATE_FOLLOW | UNIT_STATE_ROOT | UNIT_STATE_CONFUSED
     | UNIT_STATE_DISTRACTED | UNIT_STATE_ISOLATED | UNIT_STATE_ATTACK_PLAYER | UNIT_STATE_CASTING
     | UNIT_STATE_POSSESSED | UNIT_STATE_CHARGING | UNIT_STATE_JUMPING | UNIT_STATE_MOVE | UNIT_STATE_ROTATING


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Previously, when a player is charmed by a creature (spell: 28410) and a confuse CC effect is removed (spell: 12826), the player will incorrectly gain control. This adds a guard to prevent this from happening.

Add `UNIT_STATE_CHARMED` from [PATCH] Core/Entities: unit states cleanup
[1]: https://github.com/TrinityCore/TrinityCore/commit/ba27711145d1b015578aedb48ea8532b4f0bec75

Add guard to not allow possession to be overridden from [PATCH] Entities/Player: Clean up client control handling behavior [2]: https://github.com/TrinityCore/TrinityCore/commit/f6f1c48aa592ea10c99fd23f46e94934b2f0cef2


### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

mentioned in 
- https://github.com/chromiecraft/PTR-review/issues/46

> Mechanics comments on Kel'Thuzad
When Mind-controlled; after you received a CC (sheep) and when the CC expires; you are able to move your character, despite still being under the MC spell... so you can just run away from other players and avoid the mechanic.



## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Polymorph expiring will cause the player to gain client control here:

https://github.com/azerothcore/azerothcore-wotlk/blob/5710567d05eeba5c0817f28e0af068c6278ff005/src/server/game/Entities/Unit/Unit.cpp#L18595

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

test with a mage and another character
```
spawn patchwerk
.npc add temp 38386
target patch and cast chains
.cast back 28410
cast polymorph on MC'd target
Try to move after the sheep expires
```


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
