### PR TITLE
fix(Core/GameObject): Fix fishing bobber immediate expiration

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5451,6 +5451,16 @@ void Spell::EffectTransmitted(SpellEffIndex effIndex)
                 // Duration of the fishing bobber can't be higher than the Fishing channeling duration
                 duration = std::min(duration, duration - lastSec*IN_MILLISECONDS + FISHING_BOBBER_READY_TIME*IN_MILLISECONDS);
 
+                // Ensure duration is at least FISHING_BOBBER_READY_TIME to prevent negative/immediate splash
+                // The splash happens at (duration - FISHING_BOBBER_READY_TIME), so if duration < READY_TIME,
+                // splash would happen at a negative time or immediately, giving player no time to react
+                if (duration < FISHING_BOBBER_READY_TIME * IN_MILLISECONDS)
+                {
+                    LOG_WARN("spells.effect", "Fishing bobber duration calculated as {}ms (too short for {}s click window). Base spell duration: {}ms, lastSec: {}. Setting to minimum {}ms to prevent immediate expiration.",
+                              duration, FISHING_BOBBER_READY_TIME, m_spellInfo->GetDuration(), lastSec, FISHING_BOBBER_READY_TIME * IN_MILLISECONDS);
+                    duration = FISHING_BOBBER_READY_TIME * IN_MILLISECONDS;
+                }
+
                 break;
             }
         case GAMEOBJECT_TYPE_SUMMONING_RITUAL:


### PR DESCRIPTION
Bobbers were expiring immediately after splash due to duration calculation producing values shorter than the 5-second click window.

- Add minimum duration validation (5 seconds) in SpellEffects.cpp
- Fix splash timing operator (> to >=) for correct window
- Always reset respawn time to now+6s on splash for consistency

This ensures players always have 6 seconds to click after splash while preserving random splash timing (3-13 seconds).

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

These changes were created with the help of Claude Code.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Set fishing skill if needed: .setskill 356 1
2. Give a basic Fishing Pole if needed: .additem 6256
3. Try fishing, there should be no cases where the bobber expires too quickly

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
