### PR TITLE
fix(Core/Handlers): Handle vehicle and possess spells in CMSG_REQUEST_PET_INFO

### DIFF
--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1560,8 +1560,15 @@ void WorldSession::HandleRequestPetInfo(WorldPackets::Pet::RequestPetInfo& /*pac
 
     if (_player->GetPet())
         _player->PetSpellInitialize();
-    else if (_player->GetCharm())
-        _player->CharmSpellInitialize();
+    else if (Unit* charm = _player->GetCharm())
+    {
+        if (charm->HasUnitState(UNIT_STATE_POSSESSED))
+            _player->PossessSpellInitialize();
+        else if (charm->HasUnitFlag(UNIT_FLAG_PLAYER_CONTROLLED) && charm->HasUnitFlag(UNIT_FLAG_POSSESSED))
+            _player->VehicleSpellInitialize();
+        else
+            _player->CharmSpellInitialize();
+    }
 }
 
 void WorldSession::HandleSetTaxiBenchmarkOpcode(WorldPacket& recv_data)


### PR DESCRIPTION
## Changes Proposed:
Correctly respond to pet spell bar requests (CMSG_REQUEST_PET_INFO) based on charm type:
- `UNIT_STATE_POSSESSED` → `PossessSpellInitialize()`
- `UNIT_FLAG_PLAYER_CONTROLLED` + `UNIT_FLAG_POSSESSED` → `VehicleSpellInitialize()`
- Otherwise → `CharmSpellInitialize()`

Previously all charm cases incorrectly used `CharmSpellInitialize()`, causing missing or wrong spell bars for vehicles and possessed units.

-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP/GhidraMCP

## Issues Addressed:
- Fixes missing/incorrect spell bars when controlling vehicles or possessed units

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

### Client Verification (Ghidra)
| Address | Purpose |
|---------|---------|
| 0x005d6e60 | Sends CMSG_REQUEST_PET_INFO (opcode 0x279) |
| 0x005d6b90 | Handles SMSG_PET_SPELLS response |
| 0x005d62a0 | Checks aura effects 2/6/0x80/0xEC to determine pet mode |
| 0x006124a0 | Returns true when possess bar should show |
| 0x005eae90 | Returns true when vehicle action bar active |

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter a vehicle with a spell bar (e.g. Wintergrasp siege vehicles, Ulduar vehicles)
2. Verify the vehicle spell bar appears correctly with all abilities
3. Cast Mind Control on a target (Priest spell)
4. Verify the possess bar appears correctly with the possessed unit's abilities

## Known Issues and TODO List:

- [x] Needs in-game testing

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.