### PR TITLE
fix(Scripts/Spells): Fix Toughness (Mining) applying incorrect stamin…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1769912467681831000.sql
+++ b/data/sql/updates/pending_db_world/rev_1769912467681831000.sql
@@ -1,0 +1,10 @@
+-- Fix Toughness (Mining) applying incorrect stamina after relogin
+-- Issue: https://github.com/azerothcore/azerothcore-wotlk/issues/10097
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_gen_toughness';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(53040, 'spell_gen_toughness'),  -- Rank 6: +60 Stamina
+(53120, 'spell_gen_toughness'),  -- Rank 1: +3 Stamina
+(53121, 'spell_gen_toughness'),  -- Rank 2: +5 Stamina
+(53122, 'spell_gen_toughness'),  -- Rank 3: +7 Stamina
+(53123, 'spell_gen_toughness'),  -- Rank 4: +10 Stamina
+(53124, 'spell_gen_toughness');  -- Rank 5: +30 Stamina

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2422,6 +2422,30 @@ class spell_gen_lifeblood : public AuraScript
     }
 };
 
+// -53120 - Toughness (Mining)
+// Spell IDs: 53120 (Rank 1), 53121 (Rank 2), 53122 (Rank 3), 53123 (Rank 4), 53124 (Rank 5), 53040 (Rank 6)
+class spell_gen_toughness : public AuraScript
+{
+    PrepareAuraScript(spell_gen_toughness);
+
+    void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& canBeRecalculated)
+    {
+        // Force recalculation on load to fix incorrect stamina after relogin
+        canBeRecalculated = true;
+
+        // Get the base amount from spell info to ensure correct value
+        if (SpellInfo const* spellInfo = GetSpellInfo())
+        {
+            amount = spellInfo->Effects[EFFECT_0].BasePoints + 1;
+        }
+    }
+
+    void Register() override
+    {
+        DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_gen_toughness::CalculateAmount, EFFECT_0, SPELL_AURA_MOD_STAT);
+    }
+};
+
 /* 4073 - Mechanical Dragonling
    12749 - Mithril Mechanical Dragonling
    13166 - Battle Chicken
@@ -5773,6 +5797,7 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_seaforium_blast);
     RegisterSpellScript(spell_gen_turkey_marker);
     RegisterSpellScript(spell_gen_lifeblood);
+    RegisterSpellScript(spell_gen_toughness);
     RegisterSpellScript(spell_gen_allow_cast_from_item_only);
     RegisterSpellAndAuraScriptPair(spell_gen_vehicle_scaling, spell_gen_vehicle_scaling_aura);
     RegisterSpellScript(spell_gen_oracle_wolvar_reputation);


### PR DESCRIPTION
Adds a spell script for Toughness that forces recalculation of the stamina amount on aura load, ensuring the correct value is applied based on the spell's base points.

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude was used for fix this, using 4.5 Opus

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/10097

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Learn Mining from an NPC trainer or use `.learn 2575`
2. Set skill level to 450 using `.setskill 186 450 450`
3. Observe the spell provides the correct 60 stamina bonus
4. Log out of the game
5. Log back in and verify the bonus still shows 60 stamina (not 30)

## Known Issues and TODO List:

- [ ] None
