### PR TITLE
fix(Core/GameObject): Handle zero quaternion rotation for dynamically spawned gameobjects

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1770672746227329103.sql
+++ b/data/sql/updates/pending_db_world/rev_1770672746227329103.sql
@@ -1,0 +1,30 @@
+-- Fix gameobject spawns with non-unit rotation quaternions (sniffed values)
+
+-- Barbershop Chairs
+UPDATE `gameobject` SET `rotation0` = 0, `rotation1` = 0, `rotation2` = -0.66261959075927734, `rotation3` = 0.748956084251403808 WHERE `guid` = 4718;   -- 190699
+UPDATE `gameobject` SET `rotation0` = 0, `rotation1` = 0, `rotation2` = -0.99496841430664062, `rotation3` = 0.100189015269279479 WHERE `guid` = 4958;  -- 190697
+UPDATE `gameobject` SET `rotation0` = 0, `rotation1` = 0, `rotation2` = 0.83388519287109375, `rotation3` = 0.55193793773651123 WHERE `guid` = 5136;    -- 190698
+UPDATE `gameobject` SET `rotation0` = 0, `rotation1` = 0, `rotation2` = -0.85035133361816406, `rotation3` = 0.52621537446975708 WHERE `guid` = 5496;   -- 190704
+
+-- Legends of the Earth (2657)
+UPDATE `gameobject` SET `rotation0` = 0.177045822143554687, `rotation1` = -0.68458366394042968, `rotation2` = -0.66014003753662109, `rotation3` = 0.253407031297683715 WHERE `guid` = 12007;
+
+-- Battered Chest (106318)
+UPDATE `gameobject` SET `rotation0` = 0, `rotation1` = 0, `rotation2` = 0.99965667724609375, `rotation3` = 0.026201646775007247 WHERE `guid` = 26916;
+UPDATE `gameobject` SET `rotation0` = 0, `rotation1` = 0, `rotation2` = 0.6883544921875, `rotation3` = 0.725374460220336914 WHERE `guid` = 85745;
+UPDATE `gameobject` SET `rotation0` = 0, `rotation1` = 0, `rotation2` = -0.19936752319335937, `rotation3` = 0.979924798011779785 WHERE `guid` = 85756;
+UPDATE `gameobject` SET `rotation0` = 0, `rotation1` = 0, `rotation2` = 0.477158546447753906, `rotation3` = 0.878817260265350341 WHERE `guid` = 85879;
+
+-- Water Well Cleansing Aura (2904)
+UPDATE `gameobject` SET `rotation0` = 0, `rotation1` = 0, `rotation2` = 0.374606132507324218, `rotation3` = 0.927184045314788818 WHERE `guid` = 46424;
+UPDATE `gameobject` SET `rotation0` = 0, `rotation1` = 0, `rotation2` = 0.034898757934570312, `rotation3` = 0.999390840530395507 WHERE `guid` = 46425;
+UPDATE `gameobject` SET `rotation0` = 0, `rotation1` = 0, `rotation2` = 0.99965667724609375, `rotation3` = 0.026201646775007247 WHERE `guid` = 46429;
+
+-- Frostwyrm Waterfall Door (181225, Naxxramas)
+UPDATE `gameobject` SET `rotation0` = 0, `rotation1` = 0, `rotation2` = -0.77439212799072265, `rotation3` = 0.632705986499786376 WHERE `guid` = 67868;
+
+-- Axxarien Crystal (185056)
+UPDATE `gameobject` SET `rotation0` = 0.045565605163574218, `rotation1` = 0.100982666015625, `rotation2` = 0.293343544006347656, `rotation3` = 0.949566125869750976 WHERE `guid` = 99796;
+
+-- Cage (185474, Serpentshrine Cavern) - normalized from (0, 0, 0.7, -0.7)
+UPDATE `gameobject` SET `rotation0` = 0, `rotation1` = 0, `rotation2` = -0.70710678118654752, `rotation3` = 0.70710678118654752 WHERE `guid` = 265632;

--- a/data/sql/updates/pending_db_world/rev_1770676693634619814.sql
+++ b/data/sql/updates/pending_db_world/rev_1770676693634619814.sql
@@ -1,6 +1,4 @@
 -- Add missing static transport parent_rotation values
--- These were missed by rev_1770210647797541306
-
 DELETE FROM `gameobject_addon` WHERE `guid` IN (2837,6946,18802,18803,18804,18805,18806,18807,56162,56163);
 INSERT INTO `gameobject_addon` (`guid`,`parent_rotation0`,`parent_rotation1`,`parent_rotation2`,`parent_rotation3`,`invisibilityType`,`invisibilityValue`) VALUES
 (2837,0,0,0.996917,-0.078459,0,0),

--- a/data/sql/updates/pending_db_world/rev_1770676693634619814.sql
+++ b/data/sql/updates/pending_db_world/rev_1770676693634619814.sql
@@ -1,0 +1,15 @@
+-- Add missing static transport parent_rotation values
+-- These were missed by rev_1770210647797541306
+
+DELETE FROM `gameobject_addon` WHERE `guid` IN (2837,6946,18802,18803,18804,18805,18806,18807,56162,56163);
+INSERT INTO `gameobject_addon` (`guid`,`parent_rotation0`,`parent_rotation1`,`parent_rotation2`,`parent_rotation3`,`invisibilityType`,`invisibilityValue`) VALUES
+(2837,0,0,0.996917,-0.078459,0,0),
+(6946,0,0,0.992005,-0.126199,0,0),
+(18802,0,0,1,0,0,0),
+(18803,0,0,1,0,0,0),
+(18804,0,0,1,0,0,0),
+(18805,0,0,1,0,0,0),
+(18806,0,0,1,0,0,0),
+(18807,0,0,1,0,0,0),
+(56162,0,0,1,-4.37114e-08,0,0),
+(56163,0,0,1,-4.37114e-08,0,0);

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2209,6 +2209,10 @@ void GameObject::UpdatePackedRotation()
 void GameObject::SetWorldRotation(G3D::Quat const& rot)
 {
     G3D::Quat rotation = rot;
+    // If the quaternion is zero (e.g. dynamically spawned GOs with no rotation),
+    // fall back to computing rotation from orientation to avoid NaN from unitize()
+    if (G3D::fuzzyEq(rotation.magnitude(), 0.0f))
+        rotation = G3D::Quat::fromAxisAngleRotation(G3D::Vector3::unitZ(), GetOrientation());
     rotation.unitize();
     WorldRotation = rotation;
     UpdatePackedRotation();

--- a/src/server/game/Entities/Transport/Transport.cpp
+++ b/src/server/game/Entities/Transport/Transport.cpp
@@ -766,11 +766,13 @@ bool StaticTransport::Create(ObjectGuid::LowType guidlow, uint32 name_id, Map* m
         return false;
     }
 
-    // pussywizard: temporarily calculate WorldRotation from orientation, do so until values in db are correct
-    //SetWorldRotation( /*for StaticTransport we need 2 rotation Quats in db for World- and Path- Rotation*/ );
     SetWorldRotationAngles(NormalizeOrientation(GetOrientation()), 0.0f, 0.0f);
-    // pussywizard: PathRotation for StaticTransport (only StaticTransports have PathRotation)
-    SetTransportPathRotation(rotation.x, rotation.y, rotation.z, rotation.w);
+
+    // Prefer gameobject_addon parent_rotation for path rotation, fall back to gameobject.rotation
+    if (GameObjectAddon const* addon = sObjectMgr->GetGameObjectAddon(GetSpawnId()))
+        SetTransportPathRotation(addon->ParentRotation.x, addon->ParentRotation.y, addon->ParentRotation.z, addon->ParentRotation.w);
+    else
+        SetTransportPathRotation(rotation.x, rotation.y, rotation.z, rotation.w);
 
     SetObjectScale(goinfo->size);
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -2888,6 +2888,13 @@ void ObjectMgr::LoadGameobjects()
             continue;
         }
 
+        if (fabs(data.rotation.x * data.rotation.x + data.rotation.y * data.rotation.y +
+                 data.rotation.z * data.rotation.z + data.rotation.w * data.rotation.w - 1.0f) >= 1e-5f)
+        {
+            LOG_ERROR("sql.sql", "Table `gameobject` has gameobject (GUID: {} Entry: {}) with invalid rotation quaternion (non-unit), defaulting to orientation on Z axis only", guid, data.id);
+            data.rotation = G3D::Quat(G3D::Matrix3::fromEulerAnglesZYX(data.orientation, 0.0f, 0.0f));
+        }
+
         if (!MapMgr::IsValidMapCoord(data.mapid, data.posX, data.posY, data.posZ, data.orientation))
         {
             LOG_ERROR("sql.sql", "Table `gameobject` has gameobject (GUID: {} Entry: {}) with invalid coordinates, skip", guid, data.id);
@@ -3026,6 +3033,13 @@ GameObjectData const* ObjectMgr::LoadGameObjectDataFromDB(ObjectGuid::LowType sp
         LOG_ERROR("sql.sql", "Table `gameobject` has gameobject (GUID: {} Entry: {}) with invalid rotationW ({}) value, skipped.", spawnId, entry, goData.rotation.w);
         _gameObjectDataStore.erase(spawnId);
         return nullptr;
+    }
+
+    if (fabs(goData.rotation.x * goData.rotation.x + goData.rotation.y * goData.rotation.y +
+             goData.rotation.z * goData.rotation.z + goData.rotation.w * goData.rotation.w - 1.0f) >= 1e-5f)
+    {
+        LOG_ERROR("sql.sql", "Table `gameobject` has gameobject (GUID: {} Entry: {}) with invalid rotation quaternion (non-unit), defaulting to orientation on Z axis only", spawnId, entry);
+        goData.rotation = G3D::Quat(G3D::Matrix3::fromEulerAnglesZYX(goData.orientation, 0.0f, 0.0f));
     }
 
     if (!MapMgr::IsValidMapCoord(goData.mapid, goData.posX, goData.posY, goData.posZ, goData.orientation))


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

PR #24617 removed the zero-quaternion fallback from `SetWorldRotation` (formerly `SetLocalRotation`), assuming the SQL migration would cover all cases. However, many gameobjects are spawned dynamically via `SummonGameObject()` with all-zero rotation parameters — these never go through DB loading.

When `G3D::Quat::unitize()` is called on a zero quaternion `(0,0,0,0)`, it produces NaN values. This corrupts the rotation used by `IsAtInteractDistance()` to build the world-space bounding box, causing the `contains()` check to always fail — resulting in "Out of range" errors.

**Fix :**
1. **`SetWorldRotation`**: Detect zero-magnitude quaternions and fall back to computing rotation from orientation, preventing NaN from `unitize()`
2. **`ObjectMgr::LoadGameobjects` / `LoadGameObjectDataFromDB`**: Validate that DB-loaded quaternions are unit-length; if not, default to orientation-based rotation (same as TrinityCore's `ObjectMgr.cpp:2622`)

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with AzerothMCP

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24656
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24668
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24649

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).
  - TrinityCore DB loading validation (commit 02cef6f034, original author: zergtmn)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [x] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.tele gordunnioutpost`
2. `.quest add 2987`
3. `.additem 9466` (Orwin's Shovel, if needed)
4. Use the shovel near a blue cobalt marker on the ground
5. Verify the dirt mound spawns and **can be looted** (no "Out of range")

**Note:** This affects dozens of other `SummonGameObject` calls across scripts (Malygos chest, Eregos spotlight, Obsidian Sanctum portal, Trial of the Crusader chests, Ulduar boss chests, etc.) that all pass zero rotation values.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.