### PR TITLE
fix(Scripts/ObsidianSanctum): remove Sartharion's boss boundary

### DIFF
--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
@@ -145,7 +145,6 @@ enum Misc
     MAX_AREA_TRIGGER_COUNT                      = 2,
     MAX_CYCLONE_COUNT                           = 5,
     MAX_TENEBORN_EGGS_SUMMONS                   = 6,
-    MAX_BOUNDARY_POSITIONS                      = 4,
 };
 
 enum Events
@@ -173,7 +172,6 @@ enum Events
     EVENT_SARTHARION_CALL_SHADRON               = 31,
     EVENT_SARTHARION_CALL_VESPERON              = 32,
 
-    EVENT_SARTHARION_BOUNDARY                   = 33,
     EVENT_MINIDRAKE_SPEECH                      = 34,
 };
 
@@ -222,14 +220,6 @@ const Position AreaTriggerSummonPos[MAX_AREA_TRIGGER_COUNT] =
 {
     { 3244.14f, 512.597f, 58.6534f, 0.0f },
     { 3242.84f, 553.979f, 58.8272f, 0.0f },
-};
-
-float const SartharionBoundary[MAX_BOUNDARY_POSITIONS] =
-{
-    3218.86f,   // South X
-    3275.69f,   // North X
-    484.68f,    // East Y
-    572.4f      // West Y
 };
 
 float const FlameTsunamiLeftOffsets[MAX_LEFT_LAVA_TSUNAMIS] =
@@ -282,14 +272,8 @@ struct boss_sartharion : public BossAI
             DoCastSelf(SPELL_SARTHARION_TWILIGHT_REVENGE, true);
     }
 
-    void JustEngagedWith(Unit* who) override
+    void JustEngagedWith(Unit* /*who*/) override
     {
-        if (who && !IsTargetInBounds(who))
-        {
-            EnterEvadeMode();
-            return;
-        }
-
         _JustEngagedWith();
         DoCastSelf(SPELL_SARTHARION_PYROBUFFET, true);
         Talk(SAY_SARTHARION_AGGRO);
@@ -303,7 +287,6 @@ struct boss_sartharion : public BossAI
         extraEvents.ScheduleEvent(EVENT_SARTHARION_SUMMON_LAVA, 20s);
         extraEvents.ScheduleEvent(EVENT_SARTHARION_LAVA_STRIKE, 5s);
         extraEvents.ScheduleEvent(EVENT_SARTHARION_BERSERK, 15min);
-        extraEvents.ScheduleEvent(EVENT_SARTHARION_BOUNDARY, 250ms);
 
         // Store dragons
         for (uint8 i = 0; i < MAX_DRAGONS; ++i)
@@ -449,14 +432,6 @@ struct boss_sartharion : public BossAI
         {
             switch (eventId)
             {
-                case EVENT_SARTHARION_BOUNDARY:
-                {
-                    if (!IsTargetInBounds(me->GetVictim()))
-                        EnterEvadeMode();
-                    else
-                        extraEvents.Repeat(250ms);
-                    break;
-                }
                 case EVENT_SARTHARION_SUMMON_LAVA:
                 {
                     if (!urand(0, 3))
@@ -660,18 +635,6 @@ private:
         }
 
         dragonsCount = 0;
-    }
-
-    bool IsTargetInBounds(Unit const* victim) const
-    {
-        if (!victim || victim->GetPositionX() < SartharionBoundary[0] || victim->GetPositionX() > SartharionBoundary[1] || victim->GetPositionY() > SartharionBoundary[3])
-            return false;
-
-        // Big island handling
-        if (victim->GetPositionY() < SartharionBoundary[2])
-            return victim->GetDistance(bigIslandMiddlePos) <= 6.0f;
-
-        return true;
     }
 
     EventMap extraEvents;

--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/instance_obsidian_sanctum.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/instance_obsidian_sanctum.cpp
@@ -15,17 +15,11 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "AreaBoundary.h"
 #include "CreatureAIImpl.h"
 #include "InstanceMapScript.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
 #include "obsidian_sanctum.h"
-
-BossBoundaryData const boundaries =
-{
-    { DATA_SARTHARION, new RectangleBoundary(3218.86f, 3275.69f, 484.68f, 572.4f) }
-};
 
 class instance_obsidian_sanctum : public InstanceMapScript
 {
@@ -43,7 +37,6 @@ public:
         {
             SetHeaders(DataHeader);
             SetBossNumber(MAX_ENCOUNTERS);
-            LoadBossBoundaries(boundaries);
         }
 
         void OnCreatureCreate(Creature* pCreature) override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

credit to @TheSCREWEDSoftware for verifying boundary behavior

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
