### PR TITLE
fix(Core/Unit): Fix duplicate sending of hitinfo in SMSG_SPELLNONMELEEDAMAGELOG 

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6569,7 +6569,6 @@ void Unit::SendSpellNonMeleeDamageLog(SpellNonMeleeDamage* log)
     data << uint8 (log->unused);                            // unused
     data << uint32(log->blocked);                           // blocked
     data << uint32(log->HitInfo);
-    data << uint32(log->HitInfo);
     data << uint8(log->HitInfo & (SPELL_HIT_TYPE_CRIT_DEBUG | SPELL_HIT_TYPE_HIT_DEBUG | SPELL_HIT_TYPE_ATTACK_TABLE_DEBUG));
     //if (log->HitInfo & SPELL_HIT_TYPE_CRIT_DEBUG)
     //{


### PR DESCRIPTION
Packet SMSG_SPELLNONMELEEDAMAGELOG has a double copy paste typo sending it twice.

Second usecase of sending this packet is correct in the core, feel free to check for verification 