### PR TITLE
fix(Core/CLI): Replace fgetws with ReadConsoleW for Windows console UTF-8 input

### DIFF
--- a/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
+++ b/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
@@ -140,6 +140,9 @@ void CliThread()
         fInfo.dwTimeout = 0;
         FlashWindowEx(&fInfo);
     }
+    
+    // Get console input handle once for reading commands
+    HANDLE hStdIn = GetStdHandle(STD_INPUT_HANDLE);
 #endif
 
     ///- As long as the World is running (no World::m_stopEvent), get the command line and handle it
@@ -152,7 +155,6 @@ void CliThread()
 #if AC_PLATFORM == AC_PLATFORM_WINDOWS
         wchar_t commandbuf[256];
         DWORD charsRead = 0;
-        HANDLE hStdIn = GetStdHandle(STD_INPUT_HANDLE);
         
         if (ReadConsoleW(hStdIn, commandbuf, sizeof(commandbuf) / sizeof(wchar_t) - 1, &charsRead, nullptr))
         {

--- a/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
+++ b/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
@@ -143,6 +143,11 @@ void CliThread()
     
     // Get console input handle once for reading commands
     HANDLE hStdIn = GetStdHandle(STD_INPUT_HANDLE);
+    if (hStdIn == INVALID_HANDLE_VALUE)
+    {
+        LOG_ERROR("server.worldserver", "Failed to get console input handle");
+        return;
+    }
 #endif
 
     ///- As long as the World is running (no World::m_stopEvent), get the command line and handle it

--- a/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
+++ b/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
@@ -27,8 +27,6 @@
 
 #if AC_PLATFORM == AC_PLATFORM_WINDOWS
 #include <windows.h>
-#include <io.h>
-#include <fcntl.h>
 #else
 #include "Chat.h"
 #include "ChatCommand.h"
@@ -112,10 +110,8 @@ int kb_hit_return()
 void CliThread()
 {
 #if AC_PLATFORM == AC_PLATFORM_WINDOWS
-    // Set stdin to UTF-16 mode to properly read wide characters
-    _setmode(_fileno(stdin), _O_U16TEXT);
-    
-    // Set console code page to UTF-8 for output
+    // Set console code pages to UTF-8
+    SetConsoleCP(CP_UTF8);
     SetConsoleOutputCP(CP_UTF8);
 
     // print this here the first time

--- a/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
+++ b/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
@@ -140,7 +140,7 @@ void CliThread()
         fInfo.dwTimeout = 0;
         FlashWindowEx(&fInfo);
     }
-    
+
     // Get console input handle once for reading commands
     HANDLE hStdIn = GetStdHandle(STD_INPUT_HANDLE);
     if (hStdIn == INVALID_HANDLE_VALUE)
@@ -160,7 +160,7 @@ void CliThread()
 #if AC_PLATFORM == AC_PLATFORM_WINDOWS
         wchar_t commandbuf[256];
         DWORD charsRead = 0;
-        
+
         if (ReadConsoleW(hStdIn, commandbuf, sizeof(commandbuf) / sizeof(wchar_t) - 1, &charsRead, nullptr))
         {
             if (charsRead > 0)

--- a/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
+++ b/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
@@ -108,6 +108,10 @@ int kb_hit_return()
 void CliThread()
 {
 #if AC_PLATFORM == AC_PLATFORM_WINDOWS
+    // Set console code page to UTF-8 to support full range of characters
+    SetConsoleCP(CP_UTF8);
+    SetConsoleOutputCP(CP_UTF8);
+
     // print this here the first time
     // later it will be printed after command queue updates
     PrintCliPrefix();

--- a/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
+++ b/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
@@ -26,6 +26,7 @@
 #include <fmt/core.h>
 
 #if AC_PLATFORM == AC_PLATFORM_WINDOWS
+#include <windows.h>
 #include <io.h>
 #include <fcntl.h>
 #else

--- a/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
+++ b/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
@@ -151,12 +151,19 @@ void CliThread()
 
 #if AC_PLATFORM == AC_PLATFORM_WINDOWS
         wchar_t commandbuf[256];
-        if (fgetws(commandbuf, sizeof(commandbuf), stdin))
+        DWORD charsRead = 0;
+        HANDLE hStdIn = GetStdHandle(STD_INPUT_HANDLE);
+        
+        if (ReadConsoleW(hStdIn, commandbuf, sizeof(commandbuf) / sizeof(wchar_t) - 1, &charsRead, nullptr))
         {
-            if (!WStrToUtf8(commandbuf, wcslen(commandbuf), command))
+            if (charsRead > 0)
             {
-                PrintCliPrefix();
-                continue;
+                commandbuf[charsRead] = L'\0';
+                if (!WStrToUtf8(commandbuf, charsRead, command))
+                {
+                    PrintCliPrefix();
+                    continue;
+                }
             }
         }
 #else

--- a/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
+++ b/src/server/apps/worldserver/CommandLine/CliRunnable.cpp
@@ -25,7 +25,10 @@
 #include "World.h"
 #include <fmt/core.h>
 
-#if AC_PLATFORM != AC_PLATFORM_WINDOWS
+#if AC_PLATFORM == AC_PLATFORM_WINDOWS
+#include <io.h>
+#include <fcntl.h>
+#else
 #include "Chat.h"
 #include "ChatCommand.h"
 #include <cstring>
@@ -108,8 +111,10 @@ int kb_hit_return()
 void CliThread()
 {
 #if AC_PLATFORM == AC_PLATFORM_WINDOWS
-    // Set console code page to UTF-8 to support full range of characters
-    SetConsoleCP(CP_UTF8);
+    // Set stdin to UTF-16 mode to properly read wide characters
+    _setmode(_fileno(stdin), _O_U16TEXT);
+    
+    // Set console code page to UTF-8 for output
     SetConsoleOutputCP(CP_UTF8);
 
     // print this here the first time


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->

Windows console double-encodes UTF-8 characters: typing `ö` produces `Ã¶`, `懂` produces `æ`. Root cause: `fgetws()` reads from C runtime FILE stream whose encoding is independent of console code page settings. `SetConsoleCP(CP_UTF8)` configures the console but not the FILE stream layer.

**Solution**: Bypass C runtime entirely using Windows API `ReadConsoleW()` to read UTF-16 directly from console buffer.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. Copilot Claude Sonnet 3.7

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13203

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.

<img width="579" height="182" alt="image" src="https://github.com/user-attachments/assets/928e9d3e-fe44-4dc6-b3a0-c32e4f336694" />


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Use any character in the console

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
