### PR TITLE
fix(Core/Arena): Fix inverted OnBeforeArenaTeamMemberUpdate hook

### DIFF
--- a/src/server/game/Battlegrounds/Arena.cpp
+++ b/src/server/game/Battlegrounds/Arena.cpp
@@ -353,13 +353,13 @@ void Arena::EndBattleground(TeamId winnerTeamId)
                         if (GetArenaType() == ARENA_TYPE_5v5 && aliveWinners == 1 && player->IsAlive())
                             player->CastSpell(player, SPELL_LAST_MAN_STANDING, true);
 
-                        if (!sScriptMgr->OnBeforeArenaTeamMemberUpdate(winnerArenaTeam, player, true, loserMatchmakerRating, winnerMatchmakerChange))
+                        if (sScriptMgr->OnBeforeArenaTeamMemberUpdate(winnerArenaTeam, player, true, loserMatchmakerRating, winnerMatchmakerChange))
                             winnerArenaTeam->MemberWon(player, loserMatchmakerRating, winnerMatchmakerChange);
                     }
                 }
                 else
                 {
-                    if (!sScriptMgr->OnBeforeArenaTeamMemberUpdate(loserArenaTeam, player, false, winnerMatchmakerRating, loserMatchmakerChange))
+                    if (sScriptMgr->OnBeforeArenaTeamMemberUpdate(loserArenaTeam, player, false, winnerMatchmakerRating, loserMatchmakerChange))
                         loserArenaTeam->MemberLost(player, winnerMatchmakerRating, loserMatchmakerChange);
 
                     // Arena lost => reset the win_rated_arena having the "no_lose" condition

--- a/src/test/server/game/Battlegrounds/ArenaHookDefaultsTest.cpp
+++ b/src/test/server/game/Battlegrounds/ArenaHookDefaultsTest.cpp
@@ -1,0 +1,129 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ScriptMgr.h"
+#include "ScriptDefines/ArenaScript.h"
+#include "ScriptDefines/AllBattlegroundScript.h"
+#include "ArenaTeam.h"
+#include "ObjectGuid.h"
+#include "WorldMock.h"
+#include "gtest/gtest.h"
+
+/**
+ * Tests that ArenaScript and AllBattlegroundScript hooks return
+ * safe defaults when no scripts are registered, ensuring core
+ * game logic (MemberWon/MemberLost, SaveToDB, etc.) is not
+ * accidentally skipped.
+ */
+class ArenaHookDefaultsTest : public ::testing::Test
+{
+protected:
+    static void EnsureScriptRegistriesInitialized()
+    {
+        static bool initialized = false;
+        if (!initialized)
+        {
+            ScriptRegistry<ArenaScript>::InitEnabledHooksIfNeeded(ARENAHOOK_END);
+            ScriptRegistry<BGScript>::InitEnabledHooksIfNeeded(ALLBATTLEGROUNDHOOK_END);
+            initialized = true;
+        }
+    }
+
+    void SetUp() override
+    {
+        previousWorld_ = std::move(sWorld);
+        auto* mock = new ::testing::NiceMock<WorldMock>();
+        ON_CALL(*mock, getIntConfig(::testing::_))
+            .WillByDefault(::testing::Return(0));
+        ON_CALL(*mock, getIntConfig(CONFIG_LEGACY_ARENA_START_RATING))
+            .WillByDefault(::testing::Return(1500));
+        ON_CALL(*mock, getIntConfig(CONFIG_ARENA_START_RATING))
+            .WillByDefault(::testing::Return(0));
+        sWorld.reset(mock);
+
+        EnsureScriptRegistriesInitialized();
+    }
+
+    void TearDown() override
+    {
+        sWorld = std::move(previousWorld_);
+    }
+
+    std::unique_ptr<IWorld> previousWorld_;
+};
+
+// CanSaveToDB must return true by default so ArenaTeam::SaveToDB
+// proceeds to write team and member stats to the database.
+TEST_F(ArenaHookDefaultsTest, CanSaveToDBDefaultsTrue)
+{
+    ArenaTeam team;
+    EXPECT_TRUE(sScriptMgr->CanSaveToDB(&team));
+}
+
+// OnBeforeArenaTeamMemberUpdate must return true by default so that
+// MemberWon/MemberLost execute. A false return would skip personal
+// rating and game count updates for all arena participants.
+TEST_F(ArenaHookDefaultsTest, OnBeforeArenaTeamMemberUpdateDefaultsTrue)
+{
+    ArenaTeam team;
+    EXPECT_TRUE(sScriptMgr->OnBeforeArenaTeamMemberUpdate(&team, nullptr, true, 1500, 0));
+    EXPECT_TRUE(sScriptMgr->OnBeforeArenaTeamMemberUpdate(&team, nullptr, false, 1500, 0));
+}
+
+// CanSaveArenaStatsForMember must return true by default so that
+// character_arena_stats (MMR, MaxMMR) are written to the database.
+TEST_F(ArenaHookDefaultsTest, CanSaveArenaStatsForMemberDefaultsTrue)
+{
+    ArenaTeam team;
+    EXPECT_TRUE(sScriptMgr->CanSaveArenaStatsForMember(&team, ObjectGuid::Empty));
+}
+
+// OnBeforeArenaCheckWinConditions must return true by default so
+// the normal win condition check proceeds.
+TEST_F(ArenaHookDefaultsTest, OnBeforeArenaCheckWinConditionsDefaultsTrue)
+{
+    EXPECT_TRUE(sScriptMgr->OnBeforeArenaCheckWinConditions(nullptr));
+}
+
+// CanAddGroupToMatchingPool must return true by default so groups
+// are not filtered out of the BG matchmaking pool.
+TEST_F(ArenaHookDefaultsTest, CanAddGroupToMatchingPoolDefaultsTrue)
+{
+    EXPECT_TRUE(sScriptMgr->CanAddGroupToMatchingPool(nullptr, nullptr, 0, nullptr, BattlegroundBracketId(0)));
+}
+
+// Verify the calling convention used in Arena::EndBattleground:
+//   if (sScriptMgr->OnBeforeArenaTeamMemberUpdate(...))
+//       team->MemberWon/MemberLost(...)
+//
+// The hook returns true when no scripts override it.
+// The caller must NOT negate the result, or MemberWon/MemberLost
+// will never execute and arena stats will silently stop saving.
+TEST_F(ArenaHookDefaultsTest, MemberUpdateCallingConventionAllowsByDefault)
+{
+    ArenaTeam team;
+    bool hookResult = sScriptMgr->OnBeforeArenaTeamMemberUpdate(
+        &team, nullptr, true, 1500, 0);
+
+    // This simulates the condition in Arena::EndBattleground.
+    // MemberWon must be called when no scripts are registered.
+    bool memberWonWouldExecute = hookResult; // NOT !hookResult
+    EXPECT_TRUE(memberWonWouldExecute)
+        << "MemberWon/MemberLost must execute when no scripts override "
+           "OnBeforeArenaTeamMemberUpdate. Check Arena.cpp is using "
+           "if(sScriptMgr->OnBeforeArenaTeamMemberUpdate(...)) without negation.";
+}


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->

The `OnBeforeArenaTeamMemberUpdate` hook condition in `Arena::EndBattleground` was negated (`!sScriptMgr->OnBeforeArenaTeamMemberUpdate(...)`), causing `MemberWon`/`MemberLost` to never execute when no scripts override the hook. `CALL_ENABLED_BOOLEAN_HOOKS` returns `true` when no scripts are registered, so `!true = false` silently skipped all personal rating and game count updates for arena participants.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Arena stats (personal rating, week/season games, MMR) not saving to the database after merging #23543.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Unit tests added and passing (6 tests in `ArenaHookDefaultsTest`).

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Build with `-DBUILD_TESTING=ON` and run `unit_tests --gtest_filter="ArenaHookDefaults*"` — all 6 tests should pass.
2. Queue a rated arena match with two teams (requires 2 clients).
3. After the match ends, verify `arena_team_member.weekGames` incremented and `personalRating` changed.
4. Verify `character_arena_stats.matchmakerRating` updated.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Needs in-game verification with a rated arena match.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.