### PR TITLE
fix(DB/Spell): Elemental Focus proc on hit instead of cast

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1771505895831244753.sql
+++ b/data/sql/updates/pending_db_world/rev_1771505895831244753.sql
@@ -1,0 +1,2 @@
+-- Elemental Focus (16164): change SpellPhaseMask from CAST (0x1) to HIT (0x2)
+UPDATE `spell_proc` SET `SpellPhaseMask` = 2 WHERE `SpellId` = 16164;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Database (SAI, creatures, etc).

Elemental Focus (16164) `SpellPhaseMask` changed from `0x1` (PROC_SPELL_PHASE_CAST) to `0x2` (PROC_SPELL_PHASE_HIT).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools were used: Claude Code (claude-opus-4-6) with AzerothMCP

## Issues Addressed:

## SOURCE:
The changes have been validated through:

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

1. Log in as an Elemental Shaman with Elemental Focus talented
2. Cast fire/nature/frost damage spells at a target
3. Verify Clearcasting procs on critical spell hits, not on cast start

## Known Issues and TODO List:

- [ ] Needs in-game testing