### PR TITLE
fix(Core/Arena): Make personal rating season-aware on team join

### DIFF
--- a/src/server/game/Battlegrounds/ArenaTeam.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeam.cpp
@@ -132,6 +132,8 @@ bool ArenaTeam::AddMember(ObjectGuid playerGuid)
 
     if (sWorld->getIntConfig(CONFIG_ARENA_START_PERSONAL_RATING) > 0)
         personalRating = sWorld->getIntConfig(CONFIG_ARENA_START_PERSONAL_RATING);
+    else if (sArenaSeasonMgr->GetCurrentSeason() < 6)
+        personalRating = 1500;
     else if (GetRating() >= 1000)
         personalRating = 1000;
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

`ArenaTeam::AddMember()` personal rating logic was not season-aware. In seasons before S6, personal rating was not a separate concept — new members should start at 1500. Current code caps at 1000 or gives 0, which is the S6+ behavior.

Added a season check so pre-S6 members get a flat 1500 personal rating. `CONFIG_ARENA_START_PERSONAL_RATING` still overrides everything if set > 0.

| Season | Personal Rating on Join |
|--------|------------------------|
| < 6    | 1500 (hardcoded) |
| >= 6   | 1000 if team >= 1000, else 0 |

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - **Claude Code** (claude-opus-4-6) with **AzerothMCP** for database research and source navigation.

## Issues Addressed:

## SOURCE:
The changes have been validated through:
- Code inspection: follows the existing season-aware pattern used for team rating initialization at ArenaTeam.cpp line 39-41.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Set arena season < 6 (e.g. Season 5)
2. Create an arena team and invite a new member
3. Verify the new member's personal rating is 1500
4. Set arena season >= 6 (e.g. Season 8), create a team with rating >= 1000
5. Invite a new member — personal rating should be 1000
6. Create a team with rating < 1000, invite a member — personal rating should be 0

## Known Issues and TODO List:

- [ ] Needs in-game verification across season boundaries

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.