### PR TITLE
fix(Core/Spells): fix PPM proc chance calculation for healing spells

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1771524241618710557.sql
+++ b/data/sql/updates/pending_db_world/rev_1771524241618710557.sql
@@ -2,10 +2,10 @@
 -- Auto-generated entry had SpellFamilyName=10 (Paladin) which blocked other classes
 -- ProcFlags 0x4400: DONE_SPELL_MAGIC_DMG_CLASS_POS + DONE_SPELL_NONE_DMG_CLASS_POS (direct heals + HoTs)
 -- SpellTypeMask 6: HEAL + NO_DMG_HEAL (HoT applications)
-DELETE FROM spell_proc WHERE SpellId = 60510;
-INSERT INTO spell_proc (SpellId, SchoolMask, SpellFamilyName, SpellFamilyMask0, SpellFamilyMask1, SpellFamilyMask2, ProcFlags, SpellTypeMask, SpellPhaseMask, HitMask, AttributesMask, DisableEffectsMask, ProcsPerMinute, Chance, Cooldown, Charges)
+DELETE FROM `spell_proc` WHERE `SpellId` = 60510;
+INSERT INTO `spell_proc` (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `DisableEffectsMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`)
 VALUES (60510, 0, 0, 0, 0, 0, 0x4400, 6, 2, 0, 0, 0, 0, 0, 0, 0);
 
 -- Spark of Life (60519): add DONE_SPELL_NONE_DMG_CLASS_POS (0x400) and NO_DMG_HEAL to SpellTypeMask
 -- Allows HoT casts to trigger the proc
-UPDATE spell_proc SET ProcFlags = 0x14400, SpellTypeMask = 7 WHERE SpellId = 60519;
+UPDATE `spell_proc` SET `ProcFlags` = 0x14400, `SpellTypeMask` = 7 WHERE `SpellId` = 60519;

--- a/data/sql/updates/pending_db_world/rev_1771524241618710557.sql
+++ b/data/sql/updates/pending_db_world/rev_1771524241618710557.sql
@@ -1,0 +1,11 @@
+-- Soul Preserver (60510): add spell_proc entry to fix proc for non-Paladin healers
+-- Auto-generated entry had SpellFamilyName=10 (Paladin) which blocked other classes
+-- ProcFlags 0x4400: DONE_SPELL_MAGIC_DMG_CLASS_POS + DONE_SPELL_NONE_DMG_CLASS_POS (direct heals + HoTs)
+-- SpellTypeMask 6: HEAL + NO_DMG_HEAL (HoT applications)
+DELETE FROM spell_proc WHERE SpellId = 60510;
+INSERT INTO spell_proc (SpellId, SchoolMask, SpellFamilyName, SpellFamilyMask0, SpellFamilyMask1, SpellFamilyMask2, ProcFlags, SpellTypeMask, SpellPhaseMask, HitMask, AttributesMask, DisableEffectsMask, ProcsPerMinute, Chance, Cooldown, Charges)
+VALUES (60510, 0, 0, 0, 0, 0, 0x4400, 6, 2, 0, 0, 0, 0, 0, 0, 0);
+
+-- Spark of Life (60519): add DONE_SPELL_NONE_DMG_CLASS_POS (0x400) and NO_DMG_HEAL to SpellTypeMask
+-- Allows HoT casts to trigger the proc
+UPDATE spell_proc SET ProcFlags = 0x14400, SpellTypeMask = 7 WHERE SpellId = 60519;

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -2280,13 +2280,14 @@ float Aura::CalcProcChance(SpellProcEntry const& procEntry, ProcEventInfo& event
     if (Unit* caster = GetCaster())
     {
         // If PPM exists calculate chance from PPM
-        if (eventInfo.GetDamageInfo() && procEntry.ProcsPerMinute != 0)
+        if ((eventInfo.GetDamageInfo() || eventInfo.GetHealInfo()) && procEntry.ProcsPerMinute != 0)
         {
             SpellInfo const* procSpell = eventInfo.GetSpellInfo();
             uint32 attackSpeed = 0;
             if (!procSpell || procSpell->DmgClass == SPELL_DAMAGE_CLASS_MELEE || procSpell->IsRangedWeaponSpell())
             {
-                attackSpeed = caster->GetAttackTime(eventInfo.GetDamageInfo()->GetAttackType());
+                if (eventInfo.GetDamageInfo())
+                    attackSpeed = caster->GetAttackTime(eventInfo.GetDamageInfo()->GetAttackType());
             }
             else // spells use their cast time for PPM calculations
             {

--- a/src/test/mocks/ProcChanceTestHelper.h
+++ b/src/test/mocks/ProcChanceTestHelper.h
@@ -79,6 +79,7 @@ public:
      * @param chanceModifier Talent/aura modifier to chance
      * @param ppmModifier Talent/aura modifier to PPM
      * @param hasDamageInfo Whether a DamageInfo is present (enables PPM)
+     * @param hasHealInfo Whether a HealInfo is present (also enables PPM)
      * @return Calculated proc chance
      */
     static float SimulateCalcProcChance(
@@ -87,12 +88,13 @@ public:
         uint32 weaponSpeed = 2500,
         float chanceModifier = 0.0f,
         float ppmModifier = 0.0f,
-        bool hasDamageInfo = true)
+        bool hasDamageInfo = true,
+        bool hasHealInfo = false)
     {
         float chance = procEntry.Chance;
 
-        // PPM calculation overrides base chance if PPM > 0 and we have DamageInfo
-        if (hasDamageInfo && procEntry.ProcsPerMinute > 0.0f)
+        // PPM calculation overrides base chance if PPM > 0 and we have DamageInfo or HealInfo
+        if ((hasDamageInfo || hasHealInfo) && procEntry.ProcsPerMinute > 0.0f)
         {
             chance = CalculatePPMChance(weaponSpeed, procEntry.ProcsPerMinute, ppmModifier);
         }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

`CalcProcChance` only checked `GetDamageInfo()` to enter the PPM branch. Healing events only have `HealInfo`, so the PPM calculation was skipped and chance fell through to the base `Chance` field. For Omen of Clarity (PPM=3.5, Chance=0), this meant 0% proc rate on all healing spells.

Fix: also check `GetHealInfo()` to enter the PPM branch, guard `GetAttackTime()` since `DamageInfo` can be null for heals.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with AzerothMCP.

## Issues Addressed:

- Closes https://github.com/chromiecraft/chromiecraft/issues/9028

## SOURCE:
The changes have been validated through:

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:

1. Create a druid with Omen of Clarity talent
2. Cast healing spells (Healing Touch, Rejuvenation, etc.)
3. Verify Clearcasting (16870) procs at ~3.5 PPM rate
4. Verify melee OoC procs still work in feral forms