### PR TITLE
fix(Scripts/Spells): fix Blood Presence not healing for damage dealt

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1771531781265186556.sql
+++ b/data/sql/updates/pending_db_world/rev_1771531781265186556.sql
@@ -1,0 +1,2 @@
+-- Blood Presence (63611): rename script to match new class name
+UPDATE `spell_script_names` SET `ScriptName` = 'spell_dk_improved_blood_presence_triggered' WHERE `spell_id` = 63611;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

The 63611 (Improved Blood Presence Triggered) script was missing `HandleProc` — it only had `CheckProc`. The default proc action tried to cast TriggerSpell=1206 which doesn't exist, so no healing occurred.

Added `HandleProc` that calls `PreventDefaultAction()`, calculates 4% of damage dealt, and casts spell 50475 (Blood Presence heal). Renamed script class and updated `spell_script_names` accordingly.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code (claude-opus-4-6) with AzerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9027

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Cherry-picked from TrinityCore commit 5b8e68ee (mik1893, #17122).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a DK, `.learn 48266` (Blood Presence)
2. Enter Blood Presence, hit a mob
3. Check combat log for 4% healing from damage dealt

## Known Issues and TODO List:

- [ ]
- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.