### PR TITLE
fix(Core/Spells): Use base mana cost for Illumination and Thrill of the Hunt

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1771519000000000000.sql
+++ b/data/sql/updates/pending_db_world/rev_1771519000000000000.sql
@@ -1,0 +1,3 @@
+-- Fix spell_pal_illumination bound to wrong spell (-20234 = Improved Lay on Hands instead of -20210 = Illumination)
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_pal_illumination';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (-20210, 'spell_pal_illumination');

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -1349,10 +1349,13 @@ class spell_hun_thrill_of_the_hunt : public AuraScript
                 return;
             }
             if (AuraEffect const* pEff = victim->GetAuraEffect(SPELL_AURA_PERIODIC_DUMMY, SPELLFAMILY_HUNTER, 0x0, 0x80000000, 0x0, caster->GetGUID()))
-                mana = pEff->GetSpellInfo()->CalcPowerCost(caster, SpellSchoolMask(pEff->GetSpellInfo()->SchoolMask)) * 4 / 10 / 3;
+            {
+                SpellInfo const* expSpell = pEff->GetSpellInfo();
+                mana = (expSpell->ManaCost + int32(CalculatePct(caster->GetCreateMana(), expSpell->ManaCostPercentage))) * 4 / 10 / 3;
+            }
         }
         else
-            mana = procSpell->CalcPowerCost(caster, SpellSchoolMask(procSpell->SchoolMask)) * 4 / 10;
+            mana = (procSpell->ManaCost + int32(CalculatePct(caster->GetCreateMana(), procSpell->ManaCostPercentage))) * 4 / 10;
 
         if (spell)
             caster->ToPlayer()->SetSpellModTakingSpell(spell, true);

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -2063,7 +2063,7 @@ private:
     bool _isVengeance = true;
 };
 
-// -20234 - Illumination
+// -20210 - Illumination
 class spell_pal_illumination : public AuraScript
 {
     PrepareAuraScript(spell_pal_illumination);
@@ -2095,7 +2095,8 @@ class spell_pal_illumination : public AuraScript
             if (originalSpell && aurEff->GetSpellInfo())
             {
                 Unit* target = eventInfo.GetActor(); // Paladin is the target of the energize
-                int32 bp = CalculatePct(static_cast<int32>(originalSpell->CalcPowerCost(target, originalSpell->GetSchoolMask())), aurEff->GetSpellInfo()->Effects[EFFECT_1].CalcValue());
+                int32 baseCost = originalSpell->ManaCost + int32(CalculatePct(target->GetCreateMana(), originalSpell->ManaCostPercentage));
+                int32 bp = CalculatePct(baseCost, aurEff->GetSpellInfo()->Effects[EFFECT_1].CalcValue());
                 target->CastCustomSpell(target, SPELL_PALADIN_ILLUMINATION_ENERGIZE, &bp, nullptr, nullptr, true, nullptr, aurEff);
             }
         }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### Description

`CalcPowerCost()` applies spell mods (cost reduction talents, Clearcasting) which can reduce the calculated mana cost to zero. Both **Illumination** and **Thrill of the Hunt** talent descriptions specify refunding based on "base mana cost", meaning the unmodified cost.

This PR replaces `CalcPowerCost()` with direct base mana calculation (`ManaCost + ManaCostPercentage * baseMana`) for both talents.

Additionally fixes `spell_script_names` binding for `spell_pal_illumination` — it was bound to spell -20234 (Improved Lay on Hands) instead of -20210 (Illumination), making the script completely non-functional.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with AzerothMCP.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/9040

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a Paladin, `.learn 20215` (Illumination R5), `.cheat power on`
2. Spam Holy Light on a target — verify mana refund procs on every crit (30% of base mana cost)
3. Create a Hunter, `.learn 34499` (Thrill of the Hunt R3), `.cheat power on`
4. Use Arcane Shot / Aimed Shot / Explosive Shot — verify mana refund procs on every crit (40% of base mana cost)
5. Learn cost reduction talents (e.g. Paladin's Seal of Wisdom Glyph) and verify refund stays consistent based on base cost, not reduced cost

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.