### PR TITLE
fix(Core/Spells): Remove modifier auras from isTriggerAura proc generation

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -9963,9 +9963,7 @@ void Player::RemoveSpellMods(Spell* spell)
             // don't handle spells with spell_proc entry defined
             // this is a temporary workaround, because all spellmods should be handled like that
             if (sSpellMgr->GetSpellProcEntry(mod->spellId))
-            {
                 continue;
-            }
 
             // spellmods without aura set cannot be charged
             if (!mod->ownerAura || !mod->ownerAura->IsUsingCharges())


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Port TrinityCore's improved default proc generation ([efaa33b599](https://github.com/TrinityCore/TrinityCore/commit/efaa33b599)). Removes `SPELL_AURA_ADD_FLAT_MODIFIER` and `SPELL_AURA_ADD_PCT_MODIFIER` from `isTriggerAura` so modifier auras no longer get auto-generated proc entries that consume charges on the spell's own cast. Charges are now correctly consumed via `Player::RemoveSpellMods`.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with AzerothMCP.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore [efaa33b599](https://github.com/TrinityCore/TrinityCore/commit/efaa33b599)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Inner Focus (the reported bug):**
1. Learn Inner Focus on a Priest (`.learn 14751`)
2. Cast Inner Focus — buff should persist until next spell
3. Cast a spell (e.g. Greater Heal) — Inner Focus consumed, mana cost reduction + crit applied
4. Verify buff is gone after one spell cast

**Other modifier-charge spells to regression test:**

| Spell | Class | Command | Test |
|-------|-------|---------|------|
| Cold Blood | Rogue | `.learn 14177` | Should persist until next offensive ability |
| Divine Favor | Paladin | `.learn 20216` | Should persist until next Holy Light/Flash of Light |
| Presence of Mind | Mage | `.learn 12043` | Should make next cast instant (has explicit `spell_proc`, safe) |
| Nature's Swiftness | Shaman | `.learn 16188` | Should make next heal instant |
| Predator's Swiftness | Druid | `.learn 69369` | Should proc on finishing move crit |
| Surge of Light | Priest | `.learn 33151` | Should proc from healing crit |
| Sword and Board | Warrior | `.learn 50227` | Should proc from Devastate/Revenge |

Full list of all 137 affected spells (highest rank, deduped): https://gist.github.com/blinkysc/8877bd84f9d89b4225ea1f2e344cd73f

## Known Issues and TODO List:

- [ ] Regression test modifier-charge spells (Presence of Mind, Nature's Swiftness, etc.)

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.