### PR TITLE
fix(DB/Spell): Add spell_proc entry for Inner Focus

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1771623224005229683.sql
+++ b/data/sql/updates/pending_db_world/rev_1771623224005229683.sql
@@ -1,0 +1,8 @@
+-- Inner Focus (14751) - Add spell_proc entry with PROC_ATTR_REQ_SPELLMOD
+-- Without this, the proc system consumes the charge on the spell's own cast
+-- because Inner Focus's SpellFamilyFlags overlap with its EffectSpellClassMask.
+-- PROC_ATTR_REQ_SPELLMOD (0x8) ensures charges are only consumed when the
+-- modifier is actually applied to the triggering spell.
+DELETE FROM `spell_proc` WHERE `SpellId` = 14751;
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`ProcFlags`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(14751, 0, 6, 3755474943, 14521847, 8256, 0, 7, 2, 0, 8, 0, 0, 0, 0, 0);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Adds an explicit `spell_proc` entry for Inner Focus (14751) with `PROC_ATTR_REQ_SPELLMOD` (0x8). This ensures the charge is only consumed when the modifier is actually applied to the triggering spell, preventing the buff from being consumed on its own cast.

This is a DB-only interim fix. The broader core fix is in #24779.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with AzerothMCP.

## Issues Addressed:
- Closes chromiecraft/chromiecraft#9042

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create or use a Priest character
2. Learn Inner Focus: `.learn 14751`
3. Cast Inner Focus — buff should appear and persist
4. Cast a spell (e.g. Greater Heal) — Inner Focus should be consumed, applying mana cost reduction + crit bonus
5. Verify the buff is gone after one spell cast (not immediately on activation)

## Known Issues and TODO List:

None. This is a targeted DB fix for Inner Focus only.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.