### PR TITLE
fix(DB/Spell): Fix Omen of Clarity not proccing from utility spells

### DIFF
--- a/data/sql/updates/pending_db_world/rev_11390035128862920444.sql
+++ b/data/sql/updates/pending_db_world/rev_11390035128862920444.sql
@@ -1,0 +1,2 @@
+-- Omen of Clarity: revert SpellTypeMask to 0 to match TrinityCore
+UPDATE `spell_proc` SET `SpellTypeMask` = 0 WHERE `SpellId` = 16864;

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -238,44 +238,32 @@ class spell_dru_omen_of_clarity : public AuraScript
     {
         SpellInfo const* spellInfo = eventInfo.GetSpellInfo();
         if (!spellInfo)
-        {
             return true;
-        }
 
-        // Prevent passive spells to proc. (I.e shapeshift passives & passive talents)
         if (spellInfo->IsPassive())
-        {
             return false;
-        }
 
-        // Don't proc on crafting items.
         if (spellInfo->HasEffect(SPELL_EFFECT_CREATE_ITEM))
-        {
             return false;
-        }
+
+        // Reject energize spells (e.g. Furor) - they are not real casts
+        if (spellInfo->HasEffect(SPELL_EFFECT_ENERGIZE))
+            return false;
 
         if (eventInfo.GetTypeMask() & PROC_FLAG_DONE_SPELL_MELEE_DMG_CLASS)
-        {
             return spellInfo->HasAttribute(SPELL_ATTR0_ON_NEXT_SWING) || spellInfo->HasAttribute(SPELL_ATTR0_ON_NEXT_SWING_NO_DAMAGE);
-        }
 
         // Non-damaged/Non-healing spells - only druid abilities
         if (!spellInfo->HasAttribute(SpellCustomAttributes(SPELL_ATTR0_CU_DIRECT_DAMAGE | SPELL_ATTR0_CU_NO_INITIAL_THREAT)))
         {
             if (spellInfo->SpellFamilyName == SPELLFAMILY_DRUID)
-            {
-                // Exclude shapeshifting
                 return !spellInfo->HasAura(SPELL_AURA_MOD_SHAPESHIFT);
-            }
 
             return false;
         }
 
-        // Revitalize
         if (spellInfo->SpellIconID == SPELL_ICON_REVITALIZE)
-        {
             return false;
-        }
 
         return true;
     }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Reverts `SpellTypeMask` from 3 to 0 for Omen of Clarity (16864), matching TrinityCore. `SpellTypeMask=3` blocked magic-class utility spells like Gift of the Wild and Mark of the Wild from triggering OoC.

Regression from #24233.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). TrinityCore `spell_proc` for 16864 uses `SpellTypeMask=0`.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Learn Omen of Clarity on a druid
2. Cast Gift of the Wild or Mark of the Wild on a target
3. Verify Clearcasting can proc

## Known Issues and TODO List:

- [ ] Verify no unintended triggered spells proc OoC

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.