### PR TITLE
refactor(Core/Entities): clean up vendor item removal and add QuaternionData Euler helpers

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -88,7 +88,7 @@ bool VendorItemData::RemoveItem(uint32 item_id)
     {
         if ((*i)->item == item_id)
         {
-            i = m_items.erase(i++);
+            i = m_items.erase(i);
             found = true;
         }
         else

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -43,6 +43,17 @@ bool QuaternionData::IsUnit() const
     return fabs(x * x + y * y + z * z + w * w - 1.0f) < 1e-5f;
 }
 
+void QuaternionData::ToEulerAnglesZYX(float& Z, float& Y, float& X) const
+{
+    G3D::Matrix3(G3D::Quat(x, y, z, w)).toEulerAnglesZYX(Z, Y, X);
+}
+
+QuaternionData QuaternionData::FromEulerAnglesZYX(float Z, float Y, float X)
+{
+    G3D::Quat quat(G3D::Matrix3::fromEulerAnglesZYX(Z, Y, X));
+    return QuaternionData(quat.x, quat.y, quat.z, quat.w);
+}
+
 GameObject::GameObject() : WorldObject(), MovableMapObject(),
     m_model(nullptr), m_goValue(), m_AI(nullptr)
 {

--- a/src/server/game/Entities/GameObject/GameObjectData.h
+++ b/src/server/game/Entities/GameObject/GameObjectData.h
@@ -689,6 +689,8 @@ struct AC_GAME_API QuaternionData
     QuaternionData(float X, float Y, float Z, float W) : x(X), y(Y), z(Z), w(W) { }
 
     [[nodiscard]] bool IsUnit() const;
+    void ToEulerAnglesZYX(float& Z, float& Y, float& X) const;
+    [[nodiscard]] static QuaternionData FromEulerAnglesZYX(float Z, float Y, float X);
 };
 
 // `gameobject_addon` table


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Two small improvements ported from CMaNGOS:

  1. Clean up unnecessary post-increment in VendorItemData::RemoveItem

` i = m_items.erase(i++)` changed to `i = m_items.erase(i)`. The post-increment creates a temporary copy of the iterator that is immediately discarded, since i is overwritten by the return
  value of erase(). Both produce identical results, but the latter is cleaner and avoids the wasted copy. Originally from MaNGOS core.

  2. Add QuaternionData::ToEulerAnglesZYX / FromEulerAnglesZYX utility methods

  AzerothCore already calls G3D::Matrix3::fromEulerAnglesZYX directly in 6+ places (ObjectMgr.cpp, GameObject.cpp, GameObjectModel.cpp, etc.). These new methods on QuaternionData
  encapsulate the G3D dependency and provide a cleaner API, matching what CMaNGOS has. Originally added in CMaNGOS for game object bounding box interaction distance support. Not yet used in AC, but can be useful later.

  Co-Authored-By: VladimirMangos <vladimir@getmangos.com>
  Co-Authored-By: killerwife <killerwife@gmail.com>

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.6

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

 Vendor item removal (iterator fix)

 1. Log in as a GM character
 2. Target any vendor NPC (e.g. innkeeper)
 3. Run .npc info to note the NPC entry
 4. Run .npc additem <itemId> to add a test item (e.g. .npc additem 2589) — add it twice to test multi-removal
 5. Open the vendor window and confirm the item appears
 6. Run .npc delitem <itemId> (e.g. .npc delitem 2589)
 7. Reopen the vendor window — the item should be gone (both copies)
 8. Confirm no server crash or error in the worldserver log


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
