### PR TITLE
fix(Scripts/Spells): Remove duplicate Sacred Shield script with wrong caster attribution

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1771684443067867140.sql
+++ b/data/sql/updates/pending_db_world/rev_1771684443067867140.sql
@@ -1,0 +1,1 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_pal_sacred_shield_base';


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Removes the `spell_pal_sacred_shield_base` AuraScript and its `spell_script_names` registration. This script was an accidental duplicate of `spell_pal_sacred_shield_dummy` — both handled the Sacred Shield (53601) damage proc on `EFFECT_0 SPELL_AURA_DUMMY`, causing double absorb creation with independent ICD tracking.

The base script also had a critical bug: it set `originalCaster` to `eventInfo.GetActionTarget()->GetGUID()` (the target wearing Sacred Shield) instead of the paladin who cast it. This caused the triggered absorb (58597) to be incorrectly attributed to the target in combat logs rather than the original caster.

TrinityCore only uses `spell_pal_sacred_shield_dummy` for this spell, which correctly attributes the absorb via `caster->CastSpell(GetTarget(), ...)` where `caster = GetCaster()` (the paladin).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP was used to investigate the caster attribution issue across paladin spells and compare against TrinityCore's implementation.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9050

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore's `spell_pal_sacred_shield_dummy` is the reference implementation. The removed `spell_pal_sacred_shield_base` does not exist in TrinityCore.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Have a Paladin cast Sacred Shield on another player.
2. Have the buffed player take damage to trigger the absorb proc.
3. Check combat logs — the Sacred Shield absorb should be attributed to the Paladin caster, not the target.
4. Verify the absorb amount and ICD (6s) remain correct.
5. If T8 Holy 4P bonus is available, verify the reduced ICD still works.

## Known Issues and TODO List:

- [ ] The Infusion of Light interaction with Sacred Shield (spell 66922 HoT from Flash of Light heals) that was in the removed script does not exist in TrinityCore and may need separate investigation if needed.