### PR TITLE
fix(DB/Spells): Fix Soul Preserver trinket proccing from non-healing spells

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1771685416037009585.sql
+++ b/data/sql/updates/pending_db_world/rev_1771685416037009585.sql
@@ -1,0 +1,1 @@
+UPDATE `spell_proc` SET `SpellTypeMask` = 2 WHERE `SpellId` = 60510;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9051

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Item tooltip states: "Each time you heal, there is a chance the mana cost of your healing spell will be reduced by 800 on your next cast."

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Equip Soul Preserver (item 37111) on a Paladin.
2. Cast non-healing spells (Beacon of Light, Judgement, Blessing of Kings) — verify the trinket does NOT proc.
3. Cast healing spells (Holy Light, Flash of Light) — verify the trinket CAN proc (2% chance per cast).

## Known Issues and TODO List:

- [ ] N/A