### PR TITLE
fix(Core/Spells): Handle SPELL_AURA_DUMMY proc trigger spells

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1254,6 +1254,7 @@ void AuraEffect::HandleProc(AuraApplication* aurApp, ProcEventInfo& eventInfo)
 
     switch (GetAuraType())
     {
+        case SPELL_AURA_DUMMY:
         case SPELL_AURA_PROC_TRIGGER_SPELL:
             HandleProcTriggerSpellAuraProc(aurApp, eventInfo);
             break;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -1788,7 +1788,7 @@ bool InitTriggerAuraData()
         isAlwaysTriggeredAura[i] = false;
         spellTypeMask[i] = PROC_SPELL_TYPE_MASK_ALL;
     }
-    isTriggerAura[SPELL_AURA_DUMMY] = true;                                 // Most dummy auras should require scripting
+    isTriggerAura[SPELL_AURA_DUMMY] = true;                                 // Most dummy auras should require scripting, but there are some exceptions (ie 12311)
     isTriggerAura[SPELL_AURA_MOD_CONFUSE] = true;                           // "Any direct damaging attack will revive targets"
     isTriggerAura[SPELL_AURA_MOD_THREAT] = true;                            // Only one spell: 28762 part of Mage T3 8p bonus
     isTriggerAura[SPELL_AURA_MOD_STUN] = true;                              // Aura does not have charges but needs to be removed on trigger


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

Adds `case SPELL_AURA_DUMMY:` fallthrough to `HandleProcTriggerSpellAuraProc` in `AuraEffect::HandleProc()`, ported from TrinityCore. This allows dummy auras with a `TriggerSpell` defined in DBC to automatically trigger that spell on proc, without needing a dedicated script.

Previously, `HandleProc()` had no case for `SPELL_AURA_DUMMY`, so any dummy aura relying on the generic trigger mechanism silently did nothing when it procced.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP was used to investigate the DBC spell data, cross-reference the spell_proc table, and identify all affected spells.

## Issues Addressed:

- Closes https://github.com/chromiecraft/chromiecraft/issues/9052

## Affected Spells

A full scan of Spell.dbc identified 19 spells with `SPELL_AURA_DUMMY` + non-zero `TriggerSpell` + `ProcFlags`. Of those, 17 already have custom AuraScripts that call `PreventDefaultAction()` and are unaffected by this change. The remaining 2 were broken and are now fixed:

- **12311/12958 - Gag Order** (Warrior talent): Shield Bash and Heroic Throw now correctly apply "Silenced - Gag Order" (spell 18498).
- **70765 - Item - Paladin T10 Retribution 2P Bonus**: 40% chance on melee auto attack to cast "Divine Storm!" (spell 70769) now works, which resets Divine Storm cooldown via the existing `spell_gen_divine_storm_cd_reset` script.
- **68780 - Frozen Visage** (NPC creature spell): Now correctly triggers spell 68781 on proc.

No other spells should be affected.

## SOURCE:

The changes have been validated through:
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Ported from TrinityCore's `AuraEffect::HandleProc` implementation.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Learn Gag Order talent (rank 1 or 2) on a Protection Warrior.
2. Use Shield Bash on an enemy — target should receive "Silenced - Gag Order" debuff (3 sec silence).
3. Use Heroic Throw on an enemy — target should also receive the silence debuff.
4. Equip Paladin T10 Retribution 2-piece set bonus and verify Divine Storm cooldown resets on melee procs.
5. Verify existing SPELL_AURA_DUMMY proc scripts still work correctly (e.g. Sweeping Strikes, Damage Shield, Retaliation, Second Wind).

## Known Issues and TODO List:

- No known issues. All existing SPELL_AURA_DUMMY scripts use `PreventDefaultAction()` and remain unaffected.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.