### PR TITLE
fix(Core/Spells): Fix Lock and Load procs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1740153600000000000.sql
+++ b/data/sql/updates/pending_db_world/rev_1740153600000000000.sql
@@ -1,0 +1,3 @@
+-- Lock and Load: allow periodic tick procs (Black Arrow, Explosive Trap)
+-- SpellPhaseMask 6 = PROC_SPELL_PHASE_HIT | PROC_SPELL_PHASE_FINISH
+UPDATE `spell_proc` SET `SpellPhaseMask` = 6 WHERE `SpellId` = -56342;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -718,6 +718,7 @@ Spell::~Spell()
 void Spell::InitExplicitTargets(SpellCastTargets const& targets)
 {
     m_targets = targets;
+    m_originalTargetGUID = targets.GetObjectTargetGUID();
     // this function tries to correct spell explicit targets for spell
     // client doesn't send explicit targets correctly sometimes - we need to fix such spells serverside
     // this also makes sure that we correctly send explicit targets to client (removes redundant data)
@@ -7840,6 +7841,11 @@ void Spell::DelayedChannel()
         dynObj->Delay(delaytime);
 
     SendChannelUpdate(m_timer);
+}
+
+Unit* Spell::GetOriginalTarget() const
+{
+    return ObjectAccessor::GetUnit(*m_caster, m_originalTargetGUID);
 }
 
 bool Spell::UpdatePointers()

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -584,6 +584,7 @@ public:
 
     Unit* GetCaster() const { return m_caster; }
     Unit* GetOriginalCaster() const { return m_originalCaster; }
+    Unit* GetOriginalTarget() const;
     SpellInfo const* GetSpellInfo() const { return m_spellInfo; }
     int32 GetPowerCost() const { return m_powerCost; }
 
@@ -619,6 +620,8 @@ public:
     ObjectGuid m_originalCasterGUID;                    // real source of cast (aura caster/etc), used for spell targets selection
     // e.g. damage around area spell trigered by victim aura and damage enemies of aura caster
     Unit* m_originalCaster;                             // cached pointer for m_originalCaster, updated at Spell::UpdatePointers()
+
+    ObjectGuid m_originalTargetGUID;                    // unit target saved before InitExplicitTargets strips it
 
     Spell** m_selfContainer;                            // pointer to our spell container (if applicable)
 

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -67,6 +67,7 @@ enum HunterSpells
     SPELL_HUNTER_GLYPH_OF_ARCANE_SHOT               = 61389,
     SPELL_LOCK_AND_LOAD_TRIGGER                     = 56453,
     SPELL_LOCK_AND_LOAD_MARKER                      = 67544,
+    SPELL_FROST_TRAP_SLOW                           = 67035,
     SPELL_HUNTER_PET_LEGGINGS_OF_BEAST_MASTERY      = 38297, // Leggings of Beast Mastery
 
     // Proc system spells
@@ -1177,7 +1178,8 @@ class spell_hun_lock_and_load : public AuraScript
         return ValidateSpellInfo(
         {
             SPELL_LOCK_AND_LOAD_TRIGGER,
-            SPELL_LOCK_AND_LOAD_MARKER
+            SPELL_LOCK_AND_LOAD_MARKER,
+            SPELL_FROST_TRAP_SLOW
         });
     }
 
@@ -1197,6 +1199,13 @@ class spell_hun_lock_and_load : public AuraScript
         SpellInfo const* spellInfo = eventInfo.GetSpellInfo();
         if (!spellInfo || !(spellInfo->GetSchoolMask() & SPELL_SCHOOL_MASK_FROST))
             return false;
+
+        // TODO: Research whether Lock and Load should proc on targets
+        // immune to Frost Trap slow (bosses) in WotLK 3.3.5a.
+        // if (Spell const* procSpell = eventInfo.GetProcSpell())
+        //     if (Unit* target = procSpell->GetOriginalTarget())
+        //         if (target->IsImmunedToSpell(sSpellMgr->GetSpellInfo(SPELL_FROST_TRAP_SLOW)))
+        //             return false;
 
         return roll_chance_i(aurEff->GetAmount());
     }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code with azerothMCP** was used.

## Issues Addressed:
- Progress https://github.com/chromiecraft/chromiecraft/issues/9053
- Ref https://github.com/chromiecraft/chromiecraft/issues/9054
- Closes https://github.com/chromiecraft/chromiecraft/issues/9055

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Description

**SpellPhaseMask fix (SQL):** `spell_proc` for Lock and Load had `SpellPhaseMask=4` (`PROC_SPELL_PHASE_FINISH`), which only allowed trap activation procs. Periodic damage ticks from Black Arrow and Explosive Trap fire with `PROC_SPELL_PHASE_HIT` (2) and were blocked. Changed to `SpellPhaseMask=6` (HIT | FINISH).

**Boss immunity check (C++/Core):** Frost Trap should not proc Lock and Load on targets immune to its snare (e.g. bosses with `mechanic_immune_mask` including `MECHANIC_SNARE`). The proc target is null for persistent area aura spells at `PROC_SPELL_PHASE_FINISH` because the explicit unit target is stripped by `Spell::InitExplicitTargets`. Added `Spell::GetOriginalTarget()` which preserves the original unit target GUID before it is stripped, allowing the Lock and Load script to check immunity.

**Scope of SpellFamilyMask:** Verified that only the intended spells match the proc mask `[0x18, 0x8000000, 0x24000]`:
- Frost Trap Aura (13810) via Mask0 bit 4
- Explosive Trap Effect (49065) via Mask2 bit 14
- Black Arrow (3674) via Mask1 bit 27
- Immolation Trap Effect (51740) does **not** match

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a hunter with Lock and Load talent (rank 3, Survival tree)
2. `.npc add temp 9938` (Magmus — boss, snare immune) and `.npc add temp 26829` (Frenzied Worgen — no immunities)
3. Test Frost Trap on both: should proc LnL on Worgen (100% at rank 3, 22s ICD), should NOT proc on Magmus
4. Test Explosive Trap periodic damage: should proc LnL from ticks
5. Test Black Arrow periodic damage: should proc LnL from ticks

## Known Issues and TODO List: