### PR TITLE
fix(Core/Spells): Beacon of Light no longer copies target healing modifiers

### DIFF
--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -386,6 +386,7 @@ private:
     Unit* const m_healer;
     Unit* const m_target;
     uint32 m_heal;
+    uint32 m_healBeforeTakenMods;
     uint32 m_effectiveHeal;
     uint32 m_absorb;
     SpellInfo const* const m_spellInfo;
@@ -393,7 +394,7 @@ private:
     uint32 m_hitMask;
 public:
     explicit HealInfo(Unit* _healer, Unit* _target, uint32 _heal, SpellInfo const* _spellInfo, SpellSchoolMask _schoolMask)
-        : m_healer(_healer), m_target(_target), m_heal(_heal), m_spellInfo(_spellInfo), m_schoolMask(_schoolMask), m_hitMask(0)
+        : m_healer(_healer), m_target(_target), m_heal(_heal), m_healBeforeTakenMods(0), m_spellInfo(_spellInfo), m_schoolMask(_schoolMask), m_hitMask(0)
     {
         m_absorb = 0;
         m_effectiveHeal = 0;
@@ -414,6 +415,11 @@ public:
         m_heal = amount;
     }
 
+    void SetHealBeforeTakenMods(uint32 amount)
+    {
+        m_healBeforeTakenMods = amount;
+    }
+
     void SetEffectiveHeal(uint32 amount)
     {
         m_effectiveHeal = amount;
@@ -422,6 +428,7 @@ public:
     [[nodiscard]] Unit* GetHealer() const { return m_healer; }
     [[nodiscard]] Unit* GetTarget() const { return m_target; }
     [[nodiscard]] uint32 GetHeal() const { return m_heal; }
+    [[nodiscard]] uint32 GetHealBeforeTakenMods() const { return m_healBeforeTakenMods; }
     [[nodiscard]] uint32 GetEffectiveHeal() const { return m_effectiveHeal; }
     [[nodiscard]] uint32 GetAbsorb() const { return m_absorb; }
     [[nodiscard]] SpellInfo const* GetSpellInfo() const { return m_spellInfo; };

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -273,6 +273,7 @@ struct TargetInfo
     bool   crit:1;
     bool   scaleAura:1;
     int32  damage;
+    int32  damageBeforeTakenMods;
 };
 
 static const uint32 SPELL_INTERRUPT_NONPLAYER = 32747;
@@ -683,6 +684,7 @@ public:
     // Damage and healing in effects need just calculate
     int32 m_damage;           // Damge   in effects count here
     int32 m_healing;          // Healing in effects count here
+    int32 m_damageBeforeTakenMods;
 
     // ******************************************
     // Spell trigger system

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1557,11 +1557,13 @@ void Spell::EffectHeal(SpellEffIndex effIndex)
         else if (m_spellInfo->SpellFamilyName == SPELLFAMILY_DEATHKNIGHT && m_spellInfo->SpellFamilyFlags[0] & 0x00080000)
         {
             addhealth = caster->SpellHealingBonusDone(unitTarget, m_spellInfo, int32(caster->CountPctFromMaxHealth(damage)), HEAL, effIndex);
+            m_damageBeforeTakenMods -= addhealth;
             addhealth = unitTarget->SpellHealingBonusTaken(caster, m_spellInfo, addhealth, HEAL);
         }
         else if (m_spellInfo->Id != 33778) // not lifebloom
         {
             addhealth = caster->SpellHealingBonusDone(unitTarget, m_spellInfo, addhealth, HEAL, effIndex);
+            m_damageBeforeTakenMods -= addhealth;
             addhealth = unitTarget->SpellHealingBonusTaken(caster, m_spellInfo, addhealth, HEAL);
         }
 
@@ -1593,6 +1595,7 @@ void Spell::EffectHealPct(SpellEffIndex effIndex)
         return;
 
     uint32 heal = m_originalCaster->SpellHealingBonusDone(unitTarget, m_spellInfo, unitTarget->CountPctFromMaxHealth(damage), HEAL, effIndex);
+    m_damageBeforeTakenMods -= heal;
     heal = unitTarget->SpellHealingBonusTaken(m_originalCaster, m_spellInfo, heal, HEAL);
 
     m_damage -= heal;
@@ -1611,6 +1614,7 @@ void Spell::EffectHealMechanical(SpellEffIndex effIndex)
         return;
 
     uint32 heal = m_originalCaster->SpellHealingBonusDone(unitTarget, m_spellInfo, uint32(damage), HEAL, effIndex);
+    m_damageBeforeTakenMods -= heal;
 
     m_damage -= unitTarget->SpellHealingBonusTaken(m_originalCaster, m_spellInfo, heal, HEAL);
 }

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -2148,7 +2148,10 @@ class spell_pal_light_s_beacon : public AuraScript
         // Holy Light heals for 100%, Flash of Light heals for 50%
         uint32 healSpellId = procSpell->IsRankOf(sSpellMgr->AssertSpellInfo(SPELL_PALADIN_HOLY_LIGHT_R1)) ?
             SPELL_PALADIN_BEACON_OF_LIGHT_FLASH : SPELL_PALADIN_BEACON_OF_LIGHT_HOLY;
-        int32 heal = CalculatePct(healInfo->GetHeal(), aurEff->GetAmount());
+
+        // Use heal amount before target-specific modifiers to avoid copying them
+        uint32 healAmount = healInfo->GetHealBeforeTakenMods();
+        int32 heal = CalculatePct(healAmount, aurEff->GetAmount());
 
         Unit* beaconTarget = GetCaster();
         if (!beaconTarget || !beaconTarget->HasAura(SPELL_PALADIN_BEACON_OF_LIGHT_AURA, eventInfo.GetActor()->GetGUID()))


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### Description

Beacon of Light was incorrectly copying the original heal target's individual healing modifiers (e.g. Mortal Strike -50%, Divinity +5%) into the beacon transfer amount. Blizzlike behavior is that each target's modifiers apply independently — the beacon should transfer the raw heal amount before target-specific modifiers, then the beacon target's own modifiers apply when the beacon heal spell lands.

**Root cause:** The beacon proc handler used `healInfo->GetHeal()` which returns the heal amount *after* `SpellHealingBonusTaken` was applied on the original target, baking in that target's modifiers.

**Fix:** Store the heal amount between `SpellHealingBonusDone` and `SpellHealingBonusTaken` in a new `HealInfo` field (`m_healBeforeTakenMods`), and use that in the beacon proc handler. The beacon heal spells (53652/53654) already have `SPELL_ATTR3_IGNORE_CASTER_MODIFIERS` which skips `SpellHealingBonusDone`, while `SpellHealingBonusTaken` naturally applies the beacon target's own modifiers when the spell lands.

**Files changed (5):**
- `Unit.h` — Added `m_healBeforeTakenMods` field, getter/setter to `HealInfo`
- `Spell.h` — Added `damageBeforeTakenMods` to `TargetInfo` and `m_damageBeforeTakenMods` to `Spell`
- `SpellEffects.cpp` — Capture intermediate value in `EffectHeal`, `EffectHealPct`, `EffectHealMechanical`
- `Spell.cpp` — Plumb value through launch → hit → HealInfo with crit applied
- `spell_paladin.cpp` — Beacon proc uses `GetHealBeforeTakenMods()` instead of `GetHeal()`

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Tools used: Claude Code with azerothMCP**

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13912
- Closes https://github.com/chromiecraft/chromiecraft/issues/9056

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create two characters: a Paladin healer (Testpala) and a heal target (Atest)
2. Testpala casts Beacon of Light on self
3. Apply NPC Mortal Strike on Atest: `.aura 13737` (-50% healing received, 5 sec duration)
4. Testpala casts Holy Light on Atest within 5 seconds
5. **Expected:** Beacon heal on Testpala should be based on the pre-MS heal amount (~7000), not the MS-reduced amount (~3700)
6. **Before fix:** Beacon transfer was based on the MS-reduced value, incorrectly halving the beacon heal
7. **After fix:** Beacon transfers the clean value; each target's modifiers apply independently

## Known Issues and TODO List:

- [ ] Other spells/procs that use `HealInfo::GetHeal()` may also want to consider using `GetHealBeforeTakenMods()` depending on their intended behavior