### PR TITLE
fix(Core/Spells): Implement Honor Among Thieves spell scripts

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1771742446580585.sql
+++ b/data/sql/updates/pending_db_world/rev_1771742446580585.sql
@@ -1,0 +1,7 @@
+-- Honor Among Thieves spell script registration
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (51698, 51700, 51701, 52916);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(51698, 'spell_rog_honor_among_thieves'),
+(51700, 'spell_rog_honor_among_thieves'),
+(51701, 'spell_rog_honor_among_thieves'),
+(52916, 'spell_rog_honor_among_thieves_proc');

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -713,12 +713,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_SCRIPT_EFFECT;
     });
 
-    // Honor Among Thieves
-    ApplySpellFix({ 51698, 51700, 51701 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->Effects[EFFECT_0].TriggerSpell = 51699;
-    });
-
     ApplySpellFix({
         5171,   // Slice and Dice
         6774    // Slice and Dice
@@ -4386,6 +4380,12 @@ void SpellMgr::LoadSpellInfoCorrections()
     ApplySpellFix({ 18278 }, [](SpellInfo* spellInfo)
     {
         spellInfo->AttributesEx4 |= SPELL_ATTR4_NOT_IN_ARENA_OR_RATED_BATTLEGROUND;
+    });
+
+    // Honor Among Thieves - allow area aura from different casters to coexist
+    ApplySpellFix({ 51698, 51700, 51701 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_DOT_STACKING_RULE;
     });
 
     // Absorb Life

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -51,7 +51,9 @@ enum RogueSpells
     SPELL_ROGUE_TURN_THE_TABLES_R1              = 52910,
     SPELL_ROGUE_TURN_THE_TABLES_R2              = 52914,
     SPELL_ROGUE_TURN_THE_TABLES_R3              = 52915,
-    SPELL_ROGUE_OVERKILL_TRIGGERED              = 58427
+    SPELL_ROGUE_OVERKILL_TRIGGERED              = 58427,
+    SPELL_ROGUE_HONOR_AMONG_THIEVES_PROC        = 52916,
+    SPELL_ROGUE_HONOR_AMONG_THIEVES_TRIGGERED   = 51699
 };
 
 enum RogueSpellIcons
@@ -932,6 +934,91 @@ class spell_rog_setup : public AuraScript
     }
 };
 
+// 51698, 51700, 51701 - Honor Among Thieves
+class spell_rog_honor_among_thieves : public AuraScript
+{
+    PrepareAuraScript(spell_rog_honor_among_thieves);
+
+    bool Validate(SpellInfo const* spellInfo) override
+    {
+        return ValidateSpellInfo(
+        {
+            SPELL_ROGUE_HONOR_AMONG_THIEVES_TRIGGERED,
+            spellInfo->Effects[EFFECT_0].TriggerSpell
+        });
+    }
+
+    bool CheckProc(ProcEventInfo& /*eventInfo*/)
+    {
+        Unit* caster = GetCaster();
+        if (!caster || caster->HasAura(SPELL_ROGUE_HONOR_AMONG_THIEVES_TRIGGERED))
+            return false;
+
+        return true;
+    }
+
+    void HandleProc(AuraEffect const* aurEff, ProcEventInfo& /*eventInfo*/)
+    {
+        PreventDefaultAction();
+
+        Unit* caster = GetCaster();
+        if (!caster)
+            return;
+
+        Unit* target = GetTarget();
+        target->CastSpell(target, GetSpellInfo()->Effects[aurEff->GetEffIndex()].TriggerSpell, true, nullptr, aurEff, caster->GetGUID());
+    }
+
+    void Register() override
+    {
+        DoCheckProc += AuraCheckProcFn(spell_rog_honor_among_thieves::CheckProc);
+        OnEffectProc += AuraEffectProcFn(spell_rog_honor_among_thieves::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
+    }
+};
+
+// 52916 - Honor Among Thieves (Proc)
+class spell_rog_honor_among_thieves_proc : public SpellScript
+{
+    PrepareSpellScript(spell_rog_honor_among_thieves_proc);
+
+    void FilterTargets(std::list<WorldObject*>& targets)
+    {
+        targets.clear();
+
+        Unit* target = GetOriginalCaster();
+        if (!target)
+            return;
+
+        targets.push_back(target);
+    }
+
+    void Register() override
+    {
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_rog_honor_among_thieves_proc::FilterTargets, EFFECT_0, TARGET_UNIT_CASTER_AREA_PARTY);
+    }
+};
+
+// 52916 - Honor Among Thieves (Proc Aura)
+class spell_rog_honor_among_thieves_proc_aura : public AuraScript
+{
+    PrepareAuraScript(spell_rog_honor_among_thieves_proc_aura);
+
+    void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* caster = GetCaster();
+        if (!caster)
+            return;
+
+        if (Player* player = caster->ToPlayer())
+            player->CastSpell(static_cast<Unit*>(nullptr), SPELL_ROGUE_HONOR_AMONG_THIEVES_TRIGGERED, true);
+    }
+
+    void Register() override
+    {
+        AfterEffectApply += AuraEffectApplyFn(spell_rog_honor_among_thieves_proc_aura::HandleEffectApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL_OR_REAPPLY_MASK);
+    }
+};
+
 // -51627 - Turn the Tables
 class spell_rog_turn_the_tables : public AuraScript
 {
@@ -996,6 +1083,8 @@ void AddSC_rogue_spell_scripts()
     RegisterSpellScript(spell_rog_deadly_brew);
     RegisterSpellScript(spell_rog_quick_recovery);
     RegisterSpellScript(spell_rog_setup);
+    RegisterSpellScript(spell_rog_honor_among_thieves);
+    RegisterSpellAndAuraScriptPair(spell_rog_honor_among_thieves_proc, spell_rog_honor_among_thieves_proc_aura);
     RegisterSpellScript(spell_rog_turn_the_tables);
     RegisterSpellScript(spell_rog_turn_the_tables_proc);
 }

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -939,13 +939,9 @@ class spell_rog_honor_among_thieves : public AuraScript
 {
     PrepareAuraScript(spell_rog_honor_among_thieves);
 
-    bool Validate(SpellInfo const* spellInfo) override
+    bool Validate(SpellInfo const* /*spellInfo*/) override
     {
-        return ValidateSpellInfo(
-        {
-            SPELL_ROGUE_HONOR_AMONG_THIEVES_TRIGGERED,
-            spellInfo->Effects[EFFECT_0].TriggerSpell
-        });
+        return ValidateSpellInfo({ SPELL_ROGUE_HONOR_AMONG_THIEVES_TRIGGERED });
     }
 
     bool CheckProc(ProcEventInfo& /*eventInfo*/)


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### Description

Port TrinityCore's 3-class approach for Honor Among Thieves (51698/51700/51701):

- **`spell_rog_honor_among_thieves`** (AuraScript for 51698/51700/51701): Handles the talent area aura proc. `CheckProc` enforces the 1-second ICD by checking for the 51699 aura on the rogue. `HandleProc` uses `PreventDefaultAction()` and manually triggers spell 52916 with the rogue's GUID as the original caster, ensuring the combo point is routed back to the correct player.
- **`spell_rog_honor_among_thieves_proc`** (SpellScript for 52916): `FilterTargets` clears the default area party targets and redirects the spell to only hit `GetOriginalCaster()` (the rogue who owns the talent).
- **`spell_rog_honor_among_thieves_proc_aura`** (AuraScript for 52916): On aura apply, the rogue casts 51699 (Add Combo Point) on their current target.

Additionally:
- **Removed** the old `SpellInfoCorrection` hack that replaced TriggerSpell from 52916 to 51699, which bypassed the intermediate spell entirely and broke the targeting chain.
- **Added** `SPELL_ATTR3_DOT_STACKING_RULE` to 51698/51700/51701 so that area auras from different rogues with Honor Among Thieves can coexist on the same party member (the `CanStackWith` check in `UpdateTargetMap` otherwise blocks same-rank area auras from different casters).
- **Added** `spell_script_names` DB entries for 51698/51700/51701/52916.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP were used.

## Issues Addressed:

- Closes https://github.com/chromiecraft/chromiecraft/issues/9058

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore commit: https://github.com/TrinityCore/TrinityCore/commit/7672ca194552704eacf0fa49c7c28e91ade64399

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create two characters in a party (at least one must be a Rogue with Honor Among Thieves rank 3).
2. Have the non-rogue (or second rogue) critically hit a target with a spell or ability.
3. Verify the rogue with HoAT gains a combo point on their current target.
4. For multi-rogue testing: both rogues should have HoAT, verify each rogue gains combo points from the other's crits.
5. Verify the 1-second ICD is respected (rapid crits should not grant more than 1 CP per second).

## Known Issues and TODO List:

- [ ] Melee auto-attack crits do not proc HoAT (matches DBC ProcFlags which exclude `PROC_FLAG_DONE_MELEE_AUTO_ATTACK` — needs verification against retail behavior)