### PR TITLE
fix(Core/Spells): Prevent extra attack abilities from chain-proccing

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1239,6 +1239,29 @@ bool AuraEffect::CheckEffectProc(AuraApplication* aurApp, ProcEventInfo& eventIn
             if (GetCasterGUID() != eventInfo.GetActor()->GetGUID())
                 return false;
             break;
+        case SPELL_AURA_PROC_TRIGGER_SPELL:
+        case SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE:
+        {
+            // Don't proc extra attacks while already processing extra attack spell
+            uint32 triggerSpellId = m_spellInfo->Effects[GetEffIndex()].TriggerSpell;
+            if (SpellInfo const* triggeredSpellInfo = sSpellMgr->GetSpellInfo(triggerSpellId))
+            {
+                if (triggeredSpellInfo->HasEffect(SPELL_EFFECT_ADD_EXTRA_ATTACKS))
+                {
+                    uint32 lastExtraAttackSpell = eventInfo.GetActor()->GetLastExtraAttackSpell();
+
+                    // Patch 1.12.0(?) extra attack abilities can no longer chain proc themselves
+                    if (lastExtraAttackSpell == triggerSpellId)
+                        return false;
+
+                    // Patch 2.2.0 Sword Specialization (Warrior, Rogue) extra attack can no longer proc additional extra attacks
+                    // 3.3.5 Sword Specialization (Warrior), Hack and Slash (Rogue)
+                    if (lastExtraAttackSpell == SPELL_SWORD_SPECIALIZATION || lastExtraAttackSpell == SPELL_HACK_AND_SLASH)
+                        return false;
+                }
+            }
+            break;
+        }
         default:
             break;
     }

--- a/src/test/mocks/ProcChanceTestHelper.h
+++ b/src/test/mocks/ProcChanceTestHelper.h
@@ -283,6 +283,45 @@ public:
     }
 
     // =============================================================================
+    // Extra Attack Chain-Proc Prevention - simulates SpellAuraEffects.cpp:1245-1261
+    // =============================================================================
+
+    /**
+     * @brief Configuration for simulating extra attack chain-proc prevention
+     */
+    struct ExtraAttackProcConfig
+    {
+        bool triggeredSpellHasExtraAttacks = false; // triggeredSpellInfo->HasEffect(SPELL_EFFECT_ADD_EXTRA_ATTACKS)
+        uint32 triggerSpellId = 0;                  // m_spellInfo->Effects[GetEffIndex()].TriggerSpell
+        uint32 lastExtraAttackSpell = 0;            // eventInfo.GetActor()->GetLastExtraAttackSpell()
+    };
+
+    /**
+     * @brief Simulate extra attack chain-proc prevention from CheckEffectProc
+     * Returns true if proc should be blocked
+     *
+     * @param config Extra attack proc configuration
+     * @return true if proc should be blocked
+     */
+    static bool ShouldBlockExtraAttackChainProc(ExtraAttackProcConfig const& config)
+    {
+        // Only applies when the triggered spell grants extra attacks
+        if (!config.triggeredSpellHasExtraAttacks)
+            return false;
+
+        // Patch 1.12.0(?) extra attack abilities can no longer chain proc themselves
+        if (config.lastExtraAttackSpell == config.triggerSpellId)
+            return true;
+
+        // Patch 2.2.0 Sword Specialization (Warrior, Rogue) extra attack can no longer proc additional extra attacks
+        // 3.3.5 Sword Specialization (Warrior), Hack and Slash (Rogue)
+        if (config.lastExtraAttackSpell == 16459 || config.lastExtraAttackSpell == 66923)
+            return true;
+
+        return false;
+    }
+
+    // =============================================================================
     // DisableEffectsMask - simulates SpellAuras.cpp:2244-2258
     // =============================================================================
 

--- a/src/test/server/game/Spells/ExtraAttackChainProcTest.cpp
+++ b/src/test/server/game/Spells/ExtraAttackChainProcTest.cpp
@@ -1,0 +1,149 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file ExtraAttackChainProcTest.cpp
+ * @brief Unit tests for extra attack chain-proc prevention
+ *
+ * Tests the logic from SpellAuraEffects.cpp:1245-1261 (CheckEffectProc):
+ * - Self-chain prevention (same extra attack spell can't proc itself)
+ * - Cross-chain prevention (Sword Specialization / Hack and Slash block all extra attack procs)
+ * - Non-blacklisted extra attack spells allow cross-proccing
+ * - Non-extra-attack procs are unaffected by the guard
+ */
+
+#include "ProcChanceTestHelper.h"
+#include "gtest/gtest.h"
+
+using namespace testing;
+
+// Use existing enum from Unit.h: SPELL_SWORD_SPECIALIZATIONIALIZATION (16459), SPELL_HACK_AND_SLASH (66923)
+constexpr uint32 SPELL_RECKONING       = 32746; // Reckoning (Paladin)
+constexpr uint32 SPELL_HAND_OF_JUSTICE = 15601; // Hand of Justice extra attack
+
+class ExtraAttackChainProcTest : public ::testing::Test
+{
+protected:
+    ProcChanceTestHelper::ExtraAttackProcConfig MakeConfig(
+        bool hasExtraAttacks, uint32 triggerSpellId, uint32 lastExtraAttack)
+    {
+        ProcChanceTestHelper::ExtraAttackProcConfig config;
+        config.triggeredSpellHasExtraAttacks = hasExtraAttacks;
+        config.triggerSpellId = triggerSpellId;
+        config.lastExtraAttackSpell = lastExtraAttack;
+        return config;
+    }
+};
+
+// =============================================================================
+// Normal proc (no extra attack in progress)
+// =============================================================================
+
+TEST_F(ExtraAttackChainProcTest, NormalProc_AllowedWhenNoExtraAttackInProgress)
+{
+    // lastExtraAttackSpell == 0 means no extra attack is executing
+    auto config = MakeConfig(true, SPELL_SWORD_SPECIALIZATION, 0);
+
+    EXPECT_FALSE(ProcChanceTestHelper::ShouldBlockExtraAttackChainProc(config))
+        << "Extra attack proc should be allowed when no extra attack is in progress";
+}
+
+// =============================================================================
+// Self-chain prevention
+// =============================================================================
+
+TEST_F(ExtraAttackChainProcTest, SelfChain_BlockedWhenSameSpell)
+{
+    // Sword Spec trying to proc during its own extra attack
+    auto config = MakeConfig(true, SPELL_SWORD_SPECIALIZATION, SPELL_SWORD_SPECIALIZATION);
+
+    EXPECT_TRUE(ProcChanceTestHelper::ShouldBlockExtraAttackChainProc(config))
+        << "Extra attack spell should not chain-proc itself";
+}
+
+// =============================================================================
+// Cross-chain prevention (blacklisted spells)
+// =============================================================================
+
+TEST_F(ExtraAttackChainProcTest, CrossChain_BlockedBySwordSpecialization)
+{
+    // Reckoning trying to proc during Sword Spec extra attack
+    auto config = MakeConfig(true, SPELL_RECKONING, SPELL_SWORD_SPECIALIZATION);
+
+    EXPECT_TRUE(ProcChanceTestHelper::ShouldBlockExtraAttackChainProc(config))
+        << "Sword Specialization extra attack should block all other extra attack procs";
+}
+
+TEST_F(ExtraAttackChainProcTest, CrossChain_BlockedByHackAndSlash)
+{
+    // Reckoning trying to proc during Hack and Slash extra attack
+    auto config = MakeConfig(true, SPELL_RECKONING, SPELL_HACK_AND_SLASH);
+
+    EXPECT_TRUE(ProcChanceTestHelper::ShouldBlockExtraAttackChainProc(config))
+        << "Hack and Slash extra attack should block all other extra attack procs";
+}
+
+// =============================================================================
+// Non-blacklisted extra attacks allow cross-proccing
+// =============================================================================
+
+TEST_F(ExtraAttackChainProcTest, DifferentExtraAttack_AllowedWhenNotBlacklisted)
+{
+    // Sword Spec trying to proc during Hand of Justice extra attack
+    // Hand of Justice (15601) is not blacklisted, so cross-proc is allowed
+    auto config = MakeConfig(true, SPELL_SWORD_SPECIALIZATION, SPELL_HAND_OF_JUSTICE);
+
+    EXPECT_FALSE(ProcChanceTestHelper::ShouldBlockExtraAttackChainProc(config))
+        << "Non-blacklisted extra attack spells should allow cross-proccing";
+}
+
+// =============================================================================
+// Non-extra-attack procs unaffected
+// =============================================================================
+
+TEST_F(ExtraAttackChainProcTest, NonExtraAttackProc_UnaffectedByExtraAttackState)
+{
+    // A proc that does NOT grant extra attacks should never be blocked,
+    // even during Sword Spec extra attack
+    auto config = MakeConfig(false, 12345, SPELL_SWORD_SPECIALIZATION);
+
+    EXPECT_FALSE(ProcChanceTestHelper::ShouldBlockExtraAttackChainProc(config))
+        << "Non-extra-attack procs should be unaffected by extra attack state";
+}
+
+// =============================================================================
+// Real spell scenarios
+// =============================================================================
+
+TEST_F(ExtraAttackChainProcTest, Reckoning_SelfChainBlocked)
+{
+    // Reckoning (32746) trying to proc during its own extra attack
+    auto config = MakeConfig(true, SPELL_RECKONING, SPELL_RECKONING);
+
+    EXPECT_TRUE(ProcChanceTestHelper::ShouldBlockExtraAttackChainProc(config))
+        << "Reckoning should not chain-proc itself";
+}
+
+TEST_F(ExtraAttackChainProcTest, Reckoning_AllowedDuringHandOfJustice)
+{
+    // Reckoning trying to proc during Hand of Justice extra attack
+    // Hand of Justice is not blacklisted, so Reckoning is allowed
+    auto config = MakeConfig(true, SPELL_RECKONING, SPELL_HAND_OF_JUSTICE);
+
+    EXPECT_FALSE(ProcChanceTestHelper::ShouldBlockExtraAttackChainProc(config))
+        << "Reckoning should be allowed during Hand of Justice extra attack";
+}


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Ports TrinityCore's extra attack chain-prevention guard into `AuraEffect::CheckEffectProc`. When a `SPELL_AURA_PROC_TRIGGER_SPELL` aura would trigger a spell with `SPELL_EFFECT_ADD_EXTRA_ATTACKS`, it now checks `GetLastExtraAttackSpell()` to prevent:

1. **Self-chaining** (patch 1.12.0): An extra attack ability can no longer proc itself during its own extra attack swings (e.g., Reckoning consuming all 4 charges in a single swing instead of 1 per swing)
2. **Cross-chaining** (patch 2.2.0): Sword Specialization and Hack and Slash extra attacks can no longer proc additional extra attacks from other sources

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore commit 084f8f3ded45150a57eabd3ad117f1152d4d046d by trickerer

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Tested Reckoning (Paladin talent) - confirmed charges are now consumed one per swing instead of all at once. Verified TrinityCore does not have this bug.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a Paladin with 5/5 Reckoning talent
2. Get hit by a mob to proc Reckoning buff (4 charges)
3. Melee attack the mob - should consume 1 charge and do 1 extra attack per swing
4. Verify all 4 charges are NOT consumed in a single swing

Additional regression testing recommended:
- Warrior Sword Specialization: extra attacks should not chain-proc more Sword Spec
- Rogue Hack and Slash: extra attacks should not chain-proc more Hack and Slash
- Hand of Justice trinket: extra attacks should not chain-proc
- Creature Thrash ability: should not chain-proc

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Sword Specialization, Hack and Slash, Hand of Justice, Ironfoe, creature Thrash/Windfury are also affected by this change (all correctly per retail patch notes)
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.