### PR TITLE
fix(Core/Spells): Do not set proc SpellFamilyName without SpellFamilyMask

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2040,13 +2040,17 @@ void SpellMgr::LoadSpellProcs()
         // Generate default proc entry from DBC data
         SpellProcEntry procEntry;
         procEntry.SchoolMask      = 0;
-        procEntry.SpellFamilyName = spellInfo->SpellFamilyName;
         procEntry.SpellFamilyMask[0] = 0;
         procEntry.SpellFamilyMask[1] = 0;
         procEntry.SpellFamilyMask[2] = 0;
         for (uint32 i = 0; i < MAX_SPELL_EFFECTS; ++i)
             if (spellInfo->Effects[i].IsEffect() && isTriggerAura[spellInfo->Effects[i].ApplyAuraName])
                 procEntry.SpellFamilyMask |= spellInfo->Effects[i].SpellClassMask;
+
+        if (procEntry.SpellFamilyMask)
+            procEntry.SpellFamilyName = spellInfo->SpellFamilyName;
+        else
+            procEntry.SpellFamilyName = 0;
 
         procEntry.ProcFlags = spellInfo->ProcFlags;
         procEntry.SpellTypeMask   = procSpellTypeMask;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9060
- Closes https://github.com/chromiecraft/chromiecraft/issues/9057

## Description

Auto-generated proc entries in `LoadSpellProcs()` unconditionally set `SpellFamilyName` from DBC data. This caused auras like Rogue Stealth (1784) and Druid Prowl (5215) to only break from same-family spells, because `CanSpellTriggerProcOnEvent` rejects proc events where the triggering spell's family doesn't match.

For example, a Warlock DoT (SPELLFAMILY_WARLOCK=5) ticking on a stealthed Rogue (proc entry SpellFamilyName=SPELLFAMILY_ROGUE=8) would fail the family check and stealth would not break.

Shadowmeld (58984) was unaffected because its SpellFamilyName is 0 (SPELLFAMILY_GENERIC), which skips the check entirely.

The fix only sets `SpellFamilyName` when `SpellFamilyMask` is non-zero, matching TrinityCore behavior (56be2b47ce).

## SOURCE:
The changes have been validated through:
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**
  - TrinityCore commit `56be2b47ce` by `ariel-`

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Stealth break on DoT ticks:**
1. On a Rogue, `.aura 172` (Corruption) then cast Stealth — stealth should break on next tick
2. Repeat with `.aura 589` (SW:Pain), `.aura 55078` (Blood Plague), `.aura 1978` (Serpent Sting)
3. Repeat steps 1-2 on a Druid with Prowl

**Regression — CC break on damage:**
4. Polymorph a target → any damage should still break it
5. Fear a target → any damage should still break it

**Regression — proc auras with SpellFamilyMask (should be unaffected):**
6. Talent procs that filter by spell family (e.g. Hot Streak, Combat Potency) should still work correctly

**Regression — direct damage stealth break:**
7. Direct melee/spell hits should still break Rogue Stealth and Druid Prowl

## Known Issues and TODO List:

- [ ] Druid Prowl likely had the same bug (only breaking on SPELLFAMILY_DRUID spells) but was not reported separately