### PR TITLE
fix(Core/Spells): Fix Swift Hand of Justice using wrong proc spell

### DIFF
--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -246,7 +246,7 @@ enum SunwellExaltedNeck
 
 enum SwiftHandOfJustice
 {
-    SPELL_SWIFT_HAND_OF_JUSTICE_HEAL = 59914
+    SPELL_SWIFT_HAND_OF_JUSTICE_HEAL = 59913
 };
 
 enum TinyAbominationInAJar


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`SPELL_SWIFT_HAND_OF_JUSTICE_HEAL` was incorrectly set to spell `59914` (Discerning Eye of the Beast - 2% mana restore via `SPELL_EFFECT_ENERGIZE_PCT`) instead of spell `59913` (Swift Hand of Justice - 2% health restore via `SPELL_EFFECT_HEAL`).

This caused the Swift Hand of Justice heirloom trinket (item 42991) to restore mana on kill instead of health, and display "Discerning Eye of the Beast" in the combat log.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9059

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Spell 59913 (Swift Hand of Justice) in Spell.dbc has Effect 10 (`SPELL_EFFECT_HEAL`) — health restore. Spell 59914 (Discerning Eye of the Beast) has Effect 137 (`SPELL_EFFECT_ENERGIZE_PCT`) — mana restore. The Discerning Eye of the Beast script correctly uses 59914; only Swift Hand of Justice had the wrong ID.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Equip Swift Hand of Justice (item 42991)
2. Kill a mob that grants experience or honor
3. Verify 2% health is restored (not mana) and the combat log shows "Swift Hand of Justice"

## Known Issues and TODO List:

- None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.