### PR TITLE
fix(Core/Spells): Fix Prayer of Mending not bouncing to full-HP members

### DIFF
--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -1539,7 +1539,7 @@ namespace Acore
                 return false;
             }
 
-            if (u->IsAlive() && !i_obj->IsHostileTo(u) && i_obj->IsWithinDistInMap(u, i_range) && u->GetMaxHealth() - u->GetHealth() > i_hp)
+            if (u->IsAlive() && !i_obj->IsHostileTo(u) && i_obj->IsWithinDistInMap(u, i_range) && u->GetMaxHealth() - u->GetHealth() >= i_hp)
             {
                 i_hp = u->GetMaxHealth() - u->GetHealth();
                 return true;

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -18,7 +18,6 @@
 #include "SpellAuraEffects.h"
 #include "AreaDefines.h"
 #include "BattlefieldMgr.h"
-#include "Group.h"
 #include "Battleground.h"
 #include "CellImpl.h"
 #include "CharmInfo.h"
@@ -7352,92 +7351,43 @@ void AuraEffect::HandleRaidProcFromChargeWithValueAuraProc(AuraApplication* aurA
     Unit* target = aurApp->GetTarget();
 
     // Currently only Prayer of Mending
-    if (!(GetSpellInfo()->SpellFamilyName == SPELLFAMILY_PRIEST
-        && GetSpellInfo()->SpellFamilyFlags[1] & 0x20))
+    if (!(GetSpellInfo()->SpellFamilyName == SPELLFAMILY_PRIEST && GetSpellInfo()->SpellFamilyFlags[1] & 0x20))
     {
-        LOG_DEBUG("spells.aura",
-            "AuraEffect::HandleRaidProcFromChargeWithValueAuraProc:"
-            " received not handled spell: {}", GetId());
+        LOG_DEBUG("spells.aura", "AuraEffect::HandleRaidProcFromChargeWithValueAuraProc: received not handled spell: {}", GetId());
         return;
     }
 
     int32 value = GetAmount();
-    ObjectGuid casterGUID = GetCasterGUID();
 
     int32 jumps = GetBase()->GetCharges();
 
-    // Current aura expires on proc finish
+    // current aura expire on proc finish
     GetBase()->SetCharges(0);
     GetBase()->SetUsingCharges(true);
 
-    // Next target selection
+    // next target selection
     if (jumps > 0)
     {
         if (Unit* caster = GetCaster())
         {
             float radius = GetSpellInfo()->Effects[GetEffIndex()].CalcRadius(caster);
 
-            // AC uses a unified grid (AllMapGridStoredObjectTypes includes
-            // Player) so MostHPMissingGroupInRange's grid searcher can
-            // find players, but it also requires IsInCombat() and missing
-            // HP > 0 which prevents bouncing to full-HP or out-of-combat
-            // group members. Use direct group iteration instead.
-            std::list<Unit*> nearMembers;
+            Unit*                                                         triggerTarget = nullptr;
+            Acore::MostHPMissingGroupInRange                              u_check(target, radius, 0);
+            Acore::UnitLastSearcher<Acore::MostHPMissingGroupInRange>     searcher(target, triggerTarget, u_check);
+            Cell::VisitObjects(target, searcher, radius);
 
-            Player* player = nullptr;
-            if (target->IsPlayer())
-                player = target->ToPlayer();
-            else if (target->GetOwner())
-                player = target->GetOwner()->ToPlayer();
-
-            if (player)
+            if (triggerTarget)
             {
-                Group* group = player->GetGroup();
-                if (!group)
-                {
-                    // Solo: bounce between player and pet
-                    if (player != target)
-                    {
-                        if (player->IsAlive() && target->IsWithinDistInMap(player, radius))
-                            nearMembers.push_back(player);
-                    }
-                    else if (Unit* pet = player->GetGuardianPet())
-                    {
-                        if (pet->IsAlive() && target->IsWithinDistInMap(pet, radius))
-                            nearMembers.push_back(pet);
-                    }
-                }
-                else
-                {
-                    for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
-                    {
-                        if (Player* member = itr->GetSource())
-                        {
-                            if (member != target && member->IsAlive() && !target->IsHostileTo(member) && target->IsWithinDistInMap(member, radius))
-                                nearMembers.push_back(member);
-
-                            if (Unit* pet = member->GetGuardianPet())
-                                if (pet != target && pet->IsAlive() && !target->IsHostileTo(pet) && target->IsWithinDistInMap(pet, radius))
-                                    nearMembers.push_back(pet);
-                        }
-                    }
-                }
-
-                if (!nearMembers.empty())
-                {
-                    nearMembers.sort(Acore::HealthPctOrderPred());
-                    Unit* triggerTarget = nearMembers.front();
-
-                    target->CastSpell(triggerTarget, SPELL_PRAYER_OF_MENDING_VISUAL, true);
-                    target->CastCustomSpell(triggerTarget, GetId(), &value, nullptr, nullptr, true, nullptr, this, casterGUID);
-                    if (Aura* aura = triggerTarget->GetAura(GetId(), casterGUID))
-                        aura->SetCharges(jumps);
-                }
+                target->CastSpell(triggerTarget, SPELL_PRAYER_OF_MENDING_VISUAL, true);
+                target->CastCustomSpell(triggerTarget, GetId(), &value, nullptr, nullptr, true, nullptr, this, GetCasterGUID());
+                if (Aura* aura = triggerTarget->GetAura(GetId(), GetCasterGUID()))
+                    aura->SetCharges(jumps);
             }
         }
     }
 
-    target->CastCustomSpell(target, SPELL_PRAYER_OF_MENDING_HEAL, &value, nullptr, nullptr, true, nullptr, this, casterGUID);
+    target->CastCustomSpell(target, SPELL_PRAYER_OF_MENDING_HEAL, &value, nullptr, nullptr, true, nullptr, this, GetCasterGUID());
 }
 
 int32 AuraEffect::GetTotalTicks() const

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -18,6 +18,7 @@
 #include "SpellAuraEffects.h"
 #include "AreaDefines.h"
 #include "BattlefieldMgr.h"
+#include "Group.h"
 #include "Battleground.h"
 #include "CellImpl.h"
 #include "CharmInfo.h"
@@ -7342,47 +7343,101 @@ void AuraEffect::HandleRaidProcFromChargeAuraProc(AuraApplication* aurApp, ProcE
 
 void AuraEffect::HandleRaidProcFromChargeWithValueAuraProc(AuraApplication* aurApp, ProcEventInfo& /*eventInfo*/)
 {
+    enum
+    {
+        SPELL_PRAYER_OF_MENDING_HEAL   = 33110,
+        SPELL_PRAYER_OF_MENDING_VISUAL = 41637
+    };
+
     Unit* target = aurApp->GetTarget();
 
     // Currently only Prayer of Mending
-    if (!(GetSpellInfo()->SpellFamilyName == SPELLFAMILY_PRIEST && GetSpellInfo()->SpellFamilyFlags[1] & 0x20))
+    if (!(GetSpellInfo()->SpellFamilyName == SPELLFAMILY_PRIEST
+        && GetSpellInfo()->SpellFamilyFlags[1] & 0x20))
     {
-        LOG_DEBUG("spells.aura", "AuraEffect::HandleRaidProcFromChargeWithValueAuraProc: received not handled spell: {}", GetId());
+        LOG_DEBUG("spells.aura",
+            "AuraEffect::HandleRaidProcFromChargeWithValueAuraProc:"
+            " received not handled spell: {}", GetId());
         return;
     }
-    uint32 triggerSpellId = 33110;
 
     int32 value = GetAmount();
+    ObjectGuid casterGUID = GetCasterGUID();
 
     int32 jumps = GetBase()->GetCharges();
 
-    // current aura expire on proc finish
+    // Current aura expires on proc finish
     GetBase()->SetCharges(0);
     GetBase()->SetUsingCharges(true);
 
-    // next target selection
+    // Next target selection
     if (jumps > 0)
     {
         if (Unit* caster = GetCaster())
         {
             float radius = GetSpellInfo()->Effects[GetEffIndex()].CalcRadius(caster);
 
-            Unit*                                                         triggerTarget = nullptr;
-            Acore::MostHPMissingGroupInRange                              u_check(target, radius, 0);
-            Acore::UnitLastSearcher<Acore::MostHPMissingGroupInRange>     searcher(target, triggerTarget, u_check);
-            Cell::VisitObjects(target, searcher, radius);
+            // AC uses a unified grid (AllMapGridStoredObjectTypes includes
+            // Player) so MostHPMissingGroupInRange's grid searcher can
+            // find players, but it also requires IsInCombat() and missing
+            // HP > 0 which prevents bouncing to full-HP or out-of-combat
+            // group members. Use direct group iteration instead.
+            std::list<Unit*> nearMembers;
 
-            if (triggerTarget)
+            Player* player = nullptr;
+            if (target->IsPlayer())
+                player = target->ToPlayer();
+            else if (target->GetOwner())
+                player = target->GetOwner()->ToPlayer();
+
+            if (player)
             {
-                target->CastCustomSpell(triggerTarget, GetId(), &value, nullptr, nullptr, true, nullptr, this, GetCasterGUID());
-                if (Aura* aura = triggerTarget->GetAura(GetId(), GetCasterGUID()))
-                    aura->SetCharges(jumps);
+                Group* group = player->GetGroup();
+                if (!group)
+                {
+                    // Solo: bounce between player and pet
+                    if (player != target)
+                    {
+                        if (player->IsAlive() && target->IsWithinDistInMap(player, radius))
+                            nearMembers.push_back(player);
+                    }
+                    else if (Unit* pet = player->GetGuardianPet())
+                    {
+                        if (pet->IsAlive() && target->IsWithinDistInMap(pet, radius))
+                            nearMembers.push_back(pet);
+                    }
+                }
+                else
+                {
+                    for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+                    {
+                        if (Player* member = itr->GetSource())
+                        {
+                            if (member != target && member->IsAlive() && !target->IsHostileTo(member) && target->IsWithinDistInMap(member, radius))
+                                nearMembers.push_back(member);
+
+                            if (Unit* pet = member->GetGuardianPet())
+                                if (pet != target && pet->IsAlive() && !target->IsHostileTo(pet) && target->IsWithinDistInMap(pet, radius))
+                                    nearMembers.push_back(pet);
+                        }
+                    }
+                }
+
+                if (!nearMembers.empty())
+                {
+                    nearMembers.sort(Acore::HealthPctOrderPred());
+                    Unit* triggerTarget = nearMembers.front();
+
+                    target->CastSpell(triggerTarget, SPELL_PRAYER_OF_MENDING_VISUAL, true);
+                    target->CastCustomSpell(triggerTarget, GetId(), &value, nullptr, nullptr, true, nullptr, this, casterGUID);
+                    if (Aura* aura = triggerTarget->GetAura(GetId(), casterGUID))
+                        aura->SetCharges(jumps);
+                }
             }
         }
     }
 
-    LOG_DEBUG("spells.aura", "AuraEffect::HandleRaidProcFromChargeWithValueAuraProc: Triggering spell {} from aura {} proc", triggerSpellId, GetId());
-    target->CastCustomSpell(target, triggerSpellId, &value, nullptr, nullptr, true, nullptr, this, GetCasterGUID());
+    target->CastCustomSpell(target, SPELL_PRAYER_OF_MENDING_HEAL, &value, nullptr, nullptr, true, nullptr, this, casterGUID);
 }
 
 int32 AuraEffect::GetTotalTicks() const


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`MostHPMissingGroupInRange` (the grid searcher used by the Prayer of Mending bounce handler) used strict greater-than (`> 0`) when comparing missing HP. This meant full-HP group members were never eligible as bounce targets — when all group members are at full HP, PoM loses all remaining charges instantly with no bounce.

The fix changes `>` to `>=` so targets at full health are included. Also adds the missing visual bounce spell (41637) and replaces magic numbers with named constants.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP was used.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/9062

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a Priest and a Warlock (or Hunter), group them together
2. On the Warlock, summon a pet (`.additem 6265` for soul shard, `.cast 688` for Imp)
3. Cast Prayer of Mending on any group member while everyone is at **full HP**
4. Apply a DoT to the PoM target (`.aura 47813` for Corruption)
5. Verify PoM bounces between players and pets with charges decrementing 1 at a time
6. Without the fix, all charges are lost on the first proc when everyone is at full HP

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] The NPC/boss version of Prayer of Mending (spell 44586, aura type 222) uses a separate handler (`HandleRaidProcFromChargeAuraProc`) which was not modified

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.