### PR TITLE
fix(DB/Spells): Fix Darkmoon Card: Illusion restoring double mana

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1771802367872480571.sql
+++ b/data/sql/updates/pending_db_world/rev_1771802367872480571.sql
@@ -1,0 +1,2 @@
+-- Darkmoon Card: Illusion - remove duplicate mana restore (handled by C++ script)
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = -57350 AND `spell_effect` = 60242;


### PR DESCRIPTION
## Changes Proposed:
-  [x] Database (SAI, creatures, etc).

Remove duplicate `spell_linked_spell` entry for Illusionary Barrier (57350 → 60242). The mana energize on shield removal is already handled by the C++ script `spell_item_darkmoon_card_illusion`, causing double mana restore (3000 instead of 1500).

### AI-assisted Pull Requests

- [x] AI tools were used in preparing this pull request: Claude Code with azerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9064

## SOURCE:


## Tests Performed:
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
1. Equip Darkmoon Card: Illusion (42988)
2. Note current mana
3. Use the trinket
4. `/cancelaura Illusionary Barrier`
5. Combat log should show 1500 mana gained, not 3000