### PR TITLE
fix(Core/Spells): Prevent vehicles from receiving party/raid area auras

### DIFF
--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -1005,6 +1005,9 @@ namespace Acore
         AnyGroupedUnitInObjectRangeCheck(WorldObject const* obj, Unit const* funit, float range, bool raid) : _source(obj), _refUnit(funit), _range(range), _raid(raid) {}
         bool operator()(Unit* u)
         {
+            if (u->IsVehicle())
+                return false;
+
             if (_raid)
             {
                 if (!_refUnit->IsInRaidWith(u))


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

Adds an `IsVehicle()` check to `AnyGroupedUnitInObjectRangeCheck` to prevent vehicles from being selected as targets for party/raid area auras. This is an O(1) bitmask check with negligible performance impact.

Previously, vehicles like the Strand of the Ancients Demolisher could receive beneficial area auras such as Fire Resistance Aura, Shadow Resistance Aura, and Frost Resistance Aura from nearby paladins. This caused cannon damage against demolishers to be resisted, which is not correct behavior — vehicles should not benefit from player auras.

The existing `Vehicle::ApplyAllImmunities()` grants immunity to `SPELL_AURA_MOD_RESISTANCE` but not `SPELL_AURA_MOD_RESISTANCE_EXCLUSIVE` (used by paladin resistance auras). Rather than playing whack-a-mole adding individual aura type immunities, this fix prevents vehicles from being selected as area aura targets entirely.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP

## Issues Addressed:

- Closes https://github.com/chromiecraft/chromiecraft/issues/9063

## SOURCE:

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Spawn a Battleground Demolisher: `.npc add 28781`
2. Set it friendly: `.npc set faction temp 35`
3. Cast Fire Resistance Aura (48947) nearby — verify the demolisher does NOT receive the aura
4. Also test Frost Resistance Aura (48945) and Shadow Resistance Aura (48943)
5. Verify the aura still applies to nearby party/raid player members
6. Verify pets (hunter/warlock) in party still receive auras
7. Test in a battleground to confirm auras still work between raid members

## Known Issues and TODO List:

- [ ] Verify Ulduar vehicle encounters (Flame Leviathan) are unaffected
- [ ] Verify Wintergrasp vehicle behavior

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.