### PR TITLE
fix(Core/Spells): Fix Lock and Load proccing from Explosive Trap activation

### DIFF
--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -1195,8 +1195,10 @@ class spell_hun_lock_and_load : public AuraScript
         if (!(eventInfo.GetTypeMask() & PROC_FLAG_DONE_TRAP_ACTIVATION))
             return false;
 
+        // Patch 3.3.3: Lock and Load no longer triggers from Explosive Trap activation,
+        // only from frost trap activation. Fire traps proc via CheckPeriodicProc instead.
         SpellInfo const* spellInfo = eventInfo.GetSpellInfo();
-        if (!spellInfo || !(spellInfo->GetSchoolMask() & (SPELL_SCHOOL_MASK_FROST | SPELL_SCHOOL_MASK_FIRE)))
+        if (!spellInfo || !(spellInfo->GetSchoolMask() & SPELL_SCHOOL_MASK_FROST))
             return false;
 
         // immune to Frost Trap slow (bosses) in WotLK patch 3.2.0


### PR DESCRIPTION
## Changes Proposed:
-  [x] Scripts (bosses, spell scripts, creature scripts).

Lock and Load `CheckTrapProc` allowed fire school traps (Explosive/Immolation) to proc on activation via Effect 0 at 33/66/100% chance. Patch 3.3.3 changed this so fire traps only proc Lock and Load via periodic ticks (Effect 1) at 2/4/6%.

Removed `SPELL_SCHOOL_MASK_FIRE` from `CheckTrapProc` so only frost traps trigger on activation.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP.

## SOURCE:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

https://wowwiki-archive.fandom.com/wiki/Lock_and_Load

## Tests Performed:
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

1. Create a hunter with Lock and Load rank 3
2. Place Explosive Trap and trigger it on a target
3. Confirm LnL does NOT proc on trap activation (no longer 100%)
4. Confirm LnL can proc from periodic ticks at ~6%
5. Place Frost Trap and confirm it still procs on activation at 100%

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR