### PR TITLE
fix(Core/Spells): Fix Cut to the Chase S&D duration

### DIFF
--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -844,19 +844,22 @@ class spell_rog_cut_to_the_chase : public AuraScript
 {
     PrepareAuraScript(spell_rog_cut_to_the_chase);
 
-    void HandleProc(ProcEventInfo& /*eventInfo*/)
+    void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
     {
         PreventDefaultAction();
-        // Refresh Slice and Dice to 5 combo point max duration
-        if (AuraEffect const* snDEffect = GetTarget()->GetAuraEffect(SPELL_AURA_MOD_MELEE_HASTE, SPELLFAMILY_ROGUE, 0x40000, 0, 0))
+        // Refresh Slice and Dice to its 5 combo point maximum duration
+        Unit* caster = eventInfo.GetActor();
+        if (AuraEffect const* snd = caster->GetAuraEffect(SPELL_AURA_MOD_MELEE_HASTE, SPELLFAMILY_ROGUE, 0x40000, 0, 0, caster->GetGUID()))
         {
-            snDEffect->GetBase()->SetDuration(snDEffect->GetSpellInfo()->GetMaxDuration(), true);
+            int32 maxDuration = snd->GetSpellInfo()->GetMaxDuration();
+            snd->GetBase()->SetDuration(maxDuration, true);
+            snd->GetBase()->SetMaxDuration(snd->GetBase()->GetDuration());
         }
     }
 
     void Register() override
     {
-        OnProc += AuraProcFn(spell_rog_cut_to_the_chase::HandleProc);
+        OnEffectProc += AuraEffectProcFn(spell_rog_cut_to_the_chase::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
     }
 };
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP

## Description

Cut to the Chase was missing a `SetMaxDuration()` call after refreshing Slice and Dice. When S&D was cast with fewer than 5 combo points and then refreshed by the talent, `m_duration` was updated to the 5 CP max but `m_maxDuration` stayed at the original lower value. The client receives both in `SMSG_AURA_UPDATE`, causing incorrect duration display.

Also switched from `OnProc` to `OnEffectProc` and added caster GUID filtering.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Play a rogue with Cut to the Chase rank 5 (`.learn 51669`)
2. Cast Slice and Dice with 1-2 combo points
3. Use Eviscerate to proc Cut to the Chase
4. Verify S&D duration refreshes to 5 CP max and displays correctly

## Known Issues and TODO List:

- [ ] Needs in-game testing with Improved Slice and Dice and Glyph of Slice and Dice to verify duration modifiers apply correctly after refresh