### PR TITLE
fix(Core/Spells): Fix negative SPELL_AURA_MOD_DAMAGE_DONE client display

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5340,11 +5340,10 @@ void AuraEffect::HandleModDamageDone(AuraApplication const* aurApp, uint8 mode, 
     // This information for client side use only
     if (target->IsPlayer())
     {
-
         uint16 baseField = GetAmount() >= 0 ? PLAYER_FIELD_MOD_DAMAGE_DONE_POS : PLAYER_FIELD_MOD_DAMAGE_DONE_NEG;
         for (uint16 i = 0; i < MAX_SPELL_SCHOOL; ++i)
             if (GetMiscValue() & (1 << i))
-                target->ApplyModUInt32Value(baseField + i, GetAmount(), apply);
+                target->ApplyModInt32Value(baseField + i, GetAmount(), apply);
 
         if (Guardian* pet = target->ToPlayer()->GetGuardianPet())
             pet->UpdateAttackPowerAndDamage();


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

`HandleModDamageDone` uses `ApplyModUInt32Value` to update `PLAYER_FIELD_MOD_DAMAGE_DONE_NEG` for negative spell power modifiers. `ApplyModUInt32Value` clamps to 0, so applying -300 does nothing, but removing it adds +300 permanently to the client field. `ApplyModInt32Value` (signed, no clamping) 

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24838

## SOURCE:
The changes have been validated through:
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). TrinityCore already uses `ApplyModInt32Value` for this code path.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.go creature id 26828` (Magister Keldonus)
2. Fight until he casts Power Siphon (spell 51804) — spell power should decrease by 300
3. Wait for debuff to expire — spell power should return to normal (not gain +300)