### PR TITLE
fix(Core/Spells): Block SPELL_EFFECT_ENERGIZE_PCT on isolated targets

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1997,6 +1997,12 @@ void Spell::EffectEnergizePct(SpellEffIndex effIndex)
     if (!unitTarget->IsAlive())
         return;
 
+    if (unitTarget->HasUnitState(UNIT_STATE_ISOLATED))
+    {
+        m_caster->SendSpellDamageImmune(unitTarget, GetSpellInfo()->Id);
+        return;
+    }
+
     if (m_spellInfo->Effects[effIndex].MiscValue < 0 || m_spellInfo->Effects[effIndex].MiscValue >= int8(MAX_POWERS))
         return;
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools: **Claude Code (claude-opus-4-6) with azerothMCP** — used to search Spell.dbc for all 48 spells using SPELL_EFFECT_ENERGIZE_PCT to assess impact.

## Description

`EffectEnergizePct()` was missing the `UNIT_STATE_ISOLATED` check that `EffectEnergize()` already has. Shadowfiend's Mana Leech (34650) uses ENERGIZE_PCT, so it bypassed Cyclone/Banish immunity.

Of 48 spells using this effect, only Mana Leech (34650) targets an external unit (`TARGET_OF_TARGET`). The other 47 target self, caster area, or party — none can fire while the caster is banished/stunned.

## Issues Addressed:

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/22536

## SOURCE:

- [ ] Live research
- [ ] Sniffs
- [ ] Video evidence, knowledge databases or other public sources
- [ ] Cherry-pick

## Tests Performed:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing.

1. Priest spends ~50% mana, casts Shadowfiend on a target
2. Druid casts Cyclone on the Priest
3. **Verify**: Priest mana does NOT increase while Cycloned
4. **Verify**: After Cyclone expires, Shadowfiend restores mana normally
5. **Verify**: Without Cyclone, Shadowfiend works as normal

## Known Issues and TODO List:

- [ ] Hymn of Hope (64904) on a Cycloned party member — worth verifying as bonus regression test

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.