### PR TITLE
fix(Core/Spells): Fix Piercing Shots to roll remaining damage on refresh

### DIFF
--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -1581,7 +1581,7 @@ class spell_hun_piercing_shots : public AuraScript
         ASSERT(piercingShots->GetMaxTicks() > 0);
         bp /= piercingShots->GetMaxTicks();
 
-        caster->CastCustomSpell(target, SPELL_HUNTER_PIERCING_SHOTS, &bp, nullptr, nullptr, true, nullptr, aurEff);
+        target->CastDelayedSpellWithPeriodicAmount(caster, SPELL_HUNTER_PIERCING_SHOTS, SPELL_AURA_PERIODIC_DAMAGE, bp);
     }
 
     void Register() override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Piercing Shots (Hunter talent -53234) DoT now carries forward unticked damage into the new application using `CastDelayedSpellWithPeriodicAmount`, matching Ignite and Deep Wounds rolling behavior. Previously used `CastCustomSpell` which overwrote the existing DoT, losing any remaining damage on refresh.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code (claude-opus-4-6) with azerothMCP was used to research spell proc behavior across AzerothCore, TrinityCore, and wotlk-sim, identify the discrepancy, and generate the fix.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9073

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Cross-referenced with [wotlk-sim](https://github.com/wowsims/wotlk) implementation (`sim/hunter/talents.go`) which explicitly rolls remaining Piercing Shots damage forward on refresh. The existing AC implementation (and TC) used `CastCustomSpell` which overwrites the DoT, losing unticked damage. The sim calculates `(outstandingDamage + newDamage) / totalTicks` - this fix achieves the same via `CastDelayedSpellWithPeriodicAmount` which AC already uses for Ignite's rolling behavior.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a hunter with Piercing Shots talent (any rank)
2. Find a target dummy or high-HP mob
3. Land a crit with Aimed Shot/Steady Shot/Chimera Shot to apply the Piercing Shots DoT
4. Land a second crit before the DoT finishes ticking
5. Observe that the new DoT per-tick amount includes the remaining unticked damage from the first application (rolling behavior), rather than simply overwriting

## Known Issues and TODO List:

- [ ] Verify interaction with Ignite munching config (`CONFIG_MUNCHING_BLIZZLIKE`) - `CastDelayedSpellWithPeriodicAmount` uses a 400ms delay queue when caster != target, which is the correct batching behavior

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.