### PR TITLE
fix(Core/Spells): Exempt kill/death events from triggered-spell proc filter

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -2164,9 +2164,12 @@ uint8 Aura::GetProcEffectMask(AuraApplication* aurApp, ProcEventInfo& eventInfo,
             return 0;
 
         // check if aura can proc when spell is triggered (exception for hunter auto shot & wands)
+        // Kill/killed/death events should not be blocked by the triggered-spell check -
+        // the kill itself is the proc trigger, not the spell that dealt the killing blow
         if (!GetSpellInfo()->HasAttribute(SPELL_ATTR3_CAN_PROC_FROM_PROCS) &&
             !(procEntry->AttributesMask & PROC_ATTR_TRIGGERED_CAN_PROC) &&
-            !(eventInfo.GetTypeMask() & AUTO_ATTACK_PROC_FLAG_MASK))
+            !(eventInfo.GetTypeMask() & AUTO_ATTACK_PROC_FLAG_MASK) &&
+            !(eventInfo.GetTypeMask() & (PROC_FLAG_KILL | PROC_FLAG_KILLED | PROC_FLAG_DEATH)))
         {
             if (spell->IsTriggered() && !spell->GetSpellInfo()->HasAttribute(SPELL_ATTR3_NOT_A_PROC))
                 return 0;

--- a/src/test/mocks/ProcChanceTestHelper.h
+++ b/src/test/mocks/ProcChanceTestHelper.h
@@ -268,9 +268,13 @@ public:
 
         // Check if triggered spell filtering applies
         // SpellAuras.cpp:2195-2208
+        static constexpr uint32 KILL_DEATH_PROC_FLAG_MASK =
+            PROC_FLAG_KILL | PROC_FLAG_KILLED | PROC_FLAG_DEATH;
+
         if (!config.auraHasCanProcFromProcs &&
             !(procEntry.AttributesMask & PROC_ATTR_TRIGGERED_CAN_PROC) &&
-            !(eventTypeMask & AUTO_ATTACK_PROC_FLAG_MASK))
+            !(eventTypeMask & AUTO_ATTACK_PROC_FLAG_MASK) &&
+            !(eventTypeMask & KILL_DEATH_PROC_FLAG_MASK))
         {
             // Filter triggered spells unless they have NOT_A_PROC
             if (config.isTriggered && !config.spellHasNotAProc)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code with azerothMCP**

## Description

`Aura::GetProcEffectMask` has a triggered-spell filter that blocks auras from proccing when the triggering spell is marked as `IsTriggered()`. This filter has exemptions for auto-attack proc flags (`AUTO_ATTACK_PROC_FLAG_MASK`) and spells with `SPELL_ATTR3_CAN_PROC_FROM_PROCS` / `PROC_ATTR_TRIGGERED_CAN_PROC`.

However, `PROC_FLAG_KILL`, `PROC_FLAG_KILLED`, and `PROC_FLAG_DEATH` were not exempted. When `Unit::Kill()` calls `ProcSkillsAndAuras`, it passes the killing spell object. If that spell is a triggered spell (e.g., Auto Shot repeated casts are internally marked `IsTriggered=true`), all proc-on-kill auras were incorrectly blocked.

**The kill itself is the proc trigger, not the spell that dealt the killing blow.** Whether the killing blow came from a normal cast or a triggered spell should not matter for kill/death proc events.

### Root cause:
- Auto Shot (spell 75) repeated casts are marked `IsTriggered=true`
- `PROC_FLAG_KILL` (0x2) is NOT in `AUTO_ATTACK_PROC_FLAG_MASK`, so the existing auto-attack exemption doesn't help
- The triggered-spell filter blocks the kill proc event

### Fix:
Add `PROC_FLAG_KILL | PROC_FLAG_KILLED | PROC_FLAG_DEATH` to the exemption alongside `AUTO_ATTACK_PROC_FLAG_MASK`.

### Regression analysis:
Analyzed all `spell_proc` entries with kill/death flags against the Spell.dbc:
- Only 2 entries exist: one already has `SPELL_ATTR3_CAN_PROC_FROM_PROCS` (no change), the other is a group entry for Improved Drain Soul (not affected since `CanSpellTriggerProcOnEvent` returns true immediately for kill events, bypassing school/family checks)
- **Zero regressions expected**

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9072
- Closes https://github.com/chromiecraft/chromiecraft/issues/9074

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Rapid Killing should proc on any kill that yields XP or honor, regardless of the attack type used.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:

1. Create a Hunter with Rapid Killing talent (Rank 2, spell 34949)
2. Find a creature that gives XP (non-gray, non-critter)
3. Kill it using only Auto Shot (ranged auto-attack)
4. **Expected**: Rapid Killing buff (35099) should appear after the kill
5. **Before fix**: Buff does not appear when killing with Auto Shot
6. **After fix**: Buff appears correctly regardless of attack type

## Known Issues and TODO List:

- [x] Regression analysis completed - no adverse effects found