### PR TITLE
fix(Core/Spells): Fix SetSpellModTakingSpell assert from re-entrant calls

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -10027,10 +10027,10 @@ bool Player::HasSpellModApplied(SpellModifier* mod, Spell* spell)
 
 void Player::SetSpellModTakingSpell(Spell* spell, bool apply)
 {
-    if (apply && m_spellModTakingSpell)
-        ASSERT(m_spellModTakingSpell == nullptr);
-    else if (!apply)
-        ASSERT(m_spellModTakingSpell && m_spellModTakingSpell == spell);
+    if (apply && m_spellModTakingSpell && m_spellModTakingSpell != spell)
+        return;
+    else if (!apply && m_spellModTakingSpell != spell)
+        return;
 
     m_spellModTakingSpell = apply ? spell : nullptr;
 }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`_cast()` calls `SetSpellModTakingSpell(this, true)` at lines 3901 and 3911 without clearing between them for immediate spells (e.g. triggered procs like Defensive State), causing the ASSERT to fire. Replace asserts with defensive guards that allow same-spell re-sets and skip mismatched clears from nested triggered spell casts.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP

## Issues Addressed:
- Fixes assert introduced in #24862

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Play a Rogue with Turn The Tables or any class with frequent triggered proc spells (e.g. Defensive State from block/dodge/parry)
2. Engage in combat where procs fire rapidly
3. Server should no longer assert in `SetSpellModTakingSpell`

## Known Issues and TODO List:

- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.