### PR TITLE
fix(DB/Spell): Fix Threat of Thassarian not proccing on MH miss/dodge/parry

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1771984985196552455.sql
+++ b/data/sql/updates/pending_db_world/rev_1771984985196552455.sql
@@ -1,0 +1,7 @@
+-- Threat of Thassarian: OH attack should fire even when MH misses/dodges/parries
+-- SpellTypeMask 0 = don't filter by spell type (miss/dodge/parry have no damage, so
+--   PROC_SPELL_TYPE_DAMAGE won't match - need to allow PROC_SPELL_TYPE_NO_DMG_HEAL too)
+-- HitMask 0x477 = PROC_HIT_NORMAL | PROC_HIT_CRITICAL | PROC_HIT_MISS | PROC_HIT_DODGE | PROC_HIT_PARRY | PROC_HIT_BLOCK | PROC_HIT_ABSORB
+DELETE FROM `spell_proc` WHERE `SpellId` = -65661;
+INSERT INTO `spell_proc` (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `DisableEffectsMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`) VALUES
+(-65661, 0, 15, 4194321, 537001988, 0, 0x10, 0, 2, 0x477, 0, 0, 0, 100, 0, 0);

--- a/data/sql/updates/pending_db_world/rev_1771984985196552455.sql
+++ b/data/sql/updates/pending_db_world/rev_1771984985196552455.sql
@@ -1,6 +1,3 @@
--- Threat of Thassarian: OH attack should fire even when MH misses/dodges/parries
--- SpellTypeMask 0 = don't filter by spell type (miss/dodge/parry have no damage, so
---   PROC_SPELL_TYPE_DAMAGE won't match - need to allow PROC_SPELL_TYPE_NO_DMG_HEAL too)
 -- HitMask 0x477 = PROC_HIT_NORMAL | PROC_HIT_CRITICAL | PROC_HIT_MISS | PROC_HIT_DODGE | PROC_HIT_PARRY | PROC_HIT_BLOCK | PROC_HIT_ABSORB
 DELETE FROM `spell_proc` WHERE `SpellId` = -65661;
 INSERT INTO `spell_proc` (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `DisableEffectsMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`) VALUES


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code** with **azerothMCP** were used for research, diagnosis, and fix preparation.

## Description

Threat of Thassarian (talent 65661/66191/66192) should cause the off-hand version of DK strikes to fire even when the main-hand attack misses, is dodged, or is parried. Currently the OH attack only fires on MH hit/crit.

**Root cause:** The proc system's default `SpellTypeMask` for DONE procs requires `PROC_SPELL_TYPE_DAMAGE`, but when a spell misses/dodges/parries it deals no damage, so the event gets classified as `PROC_SPELL_TYPE_NO_DMG_HEAL` — which doesn't match, and the proc is filtered out before reaching the aura handler.

**Fix:** Add a `spell_proc` entry for Threat of Thassarian (`SpellId = -65661`, covering all 3 ranks) with:
- `SpellTypeMask = 0` — disables spell type filtering so the proc fires regardless of whether damage was dealt
- `HitMask = 0x477` — explicitly allows NORMAL, CRITICAL, MISS, DODGE, PARRY, BLOCK, and ABSORB hit results

The OH spells already have `SPELL_ATTR3_ALWAYS_HIT` in DBC data, so they will always land once triggered.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9077

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

- Confirmed via [wotlk wowsim](https://github.com/wowsims/wotlk) source code that OH always fires regardless of MH outcome, and OH uses `OutcomeMeleeSpecialCritOnly` (cannot miss).
- [Elitist Jerks DW DK discussion](https://web.archive.org/web/20100817174147/http://elitistjerks.com/f72/t94207-dk_mechanics_discussion/p2/) confirms OH strikes always fire on MH use regardless of hit result.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:

1. Create a DK with Threat of Thassarian 3/3 and dual wield weapons
2. `.npc add temp 23519` (Big Shirl, level 83 elite — high avoidance)
3. Use Obliterate, Death Strike, Plague Strike, Blood Strike repeatedly
4. Observe combat log: on MH miss/dodge/parry, OH attack should still fire
5. Without this fix, OH only fires on MH hit/crit

## Known Issues and TODO List:

- [ ] PARRY case was not directly observed during testing (MISS and DODGE confirmed), but the HitMask correctly includes it and the proc system path is identical for all three miss types