### PR TITLE
fix(Scripts/Spells): Add missing Druid T10 Balance 2P bonus

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1771984985196552455.sql
+++ b/data/sql/updates/pending_db_world/rev_1771984985196552455.sql
@@ -1,0 +1,7 @@
+-- Threat of Thassarian: OH attack should fire even when MH misses/dodges/parries
+-- SpellTypeMask 0 = don't filter by spell type (miss/dodge/parry have no damage, so
+--   PROC_SPELL_TYPE_DAMAGE won't match - need to allow PROC_SPELL_TYPE_NO_DMG_HEAL too)
+-- HitMask 0x477 = PROC_HIT_NORMAL | PROC_HIT_CRITICAL | PROC_HIT_MISS | PROC_HIT_DODGE | PROC_HIT_PARRY | PROC_HIT_BLOCK | PROC_HIT_ABSORB
+DELETE FROM `spell_proc` WHERE `SpellId` = -65661;
+INSERT INTO `spell_proc` (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `DisableEffectsMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`) VALUES
+(-65661, 0, 15, 4194321, 537001988, 0, 0x10, 0, 2, 0x477, 0, 0, 0, 100, 0, 0);

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -88,6 +88,8 @@ enum DruidSpells
     SPELL_DRUID_GLYPH_OF_RIP                = 54818,
     SPELL_DRUID_RIP_DURATION_LACERATE_DMG   = 60141,
     SPELL_DRUID_REJUVENATION_T10_PROC       = 70691,
+    SPELL_DRUID_BALANCE_T10_BONUS           = 70718,
+    SPELL_DRUID_BALANCE_T10_BONUS_PROC      = 70721,
     SPELL_DRUID_LANGUISH                    = 71023,
     // T9 Feral Relic
     SPELL_DRUID_T9_FERAL_RELIC_BEAR         = 67354,
@@ -234,6 +236,11 @@ class spell_dru_omen_of_clarity : public AuraScript
 {
     PrepareAuraScript(spell_dru_omen_of_clarity);
 
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_DRUID_BALANCE_T10_BONUS, SPELL_DRUID_BALANCE_T10_BONUS_PROC });
+    }
+
     bool CheckProc(ProcEventInfo& eventInfo)
     {
         SpellInfo const* spellInfo = eventInfo.GetSpellInfo();
@@ -268,9 +275,17 @@ class spell_dru_omen_of_clarity : public AuraScript
         return true;
     }
 
+    void HandleProc(AuraEffect const* aurEff, ProcEventInfo& /*eventInfo*/)
+    {
+        Unit* target = GetTarget();
+        if (target->HasAura(SPELL_DRUID_BALANCE_T10_BONUS))
+            target->CastSpell(nullptr, SPELL_DRUID_BALANCE_T10_BONUS_PROC, true, nullptr, aurEff);
+    }
+
     void Register() override
     {
         DoCheckProc += AuraCheckProcFn(spell_dru_omen_of_clarity::CheckProc);
+        OnEffectProc += AuraEffectProcFn(spell_dru_omen_of_clarity::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
     }
 };
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Port the T10 Balance 2P set bonus from TrinityCore. When Omen of Clarity procs Clearcasting, players with the Lasherweave Regalia 2-piece bonus (spell 70718) now receive "Omen of Doom" (spell 70721), granting +15% Nature and Arcane damage for 6 seconds.

Previously, spell 70718 was a `SPELL_AURA_DUMMY` with no proc flags, no `spell_proc` entry, and no script — making the bonus completely non-functional.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code with azerothMCP** was used to identify the missing implementation by comparing against WowSim and TrinityCore, and to port the fix.

## Issues Addressed:
- T10 Balance 2P set bonus (Lasherweave Regalia) was non-functional — no +15% Nature/Arcane damage buff on Clearcasting proc.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). TrinityCore `spell_dru_omen_of_clarity` implementation.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a level 80 Balance Druid with Lasherweave Regalia 2-piece equipped.
2. Learn Omen of Clarity and engage a target dummy.
3. Cast Wrath/Starfire/melee until Clearcasting (spell 16870) procs.
4. Verify that "Omen of Doom" (spell 70721) buff appears, granting +15% Nature and Arcane damage for 6 seconds.
5. Verify the buff does NOT appear without 2-piece equipped.

## Known Issues and TODO List:

- [ ] None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.