### PR TITLE
fix(DB/Spell): Fix Killing Machine PPM values for ranks 3-5

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1771990265346528243.sql
+++ b/data/sql/updates/pending_db_world/rev_1771990265346528243.sql
@@ -1,0 +1,8 @@
+-- Fix Killing Machine PPM values for ranks 3-5
+-- Previous values (1, 2, 4, 6, 8) used non-linear scaling
+-- Correct values (1, 2, 3, 4, 5) use linear scaling matching tooltip
+-- Formula: attackSpeed * talentRank / 60, yielding talentRank PPM
+
+UPDATE `spell_proc` SET `ProcsPerMinute` = 3 WHERE `SpellId` = 51128; -- Killing Machine Rank 3
+UPDATE `spell_proc` SET `ProcsPerMinute` = 4 WHERE `SpellId` = 51129; -- Killing Machine Rank 4
+UPDATE `spell_proc` SET `ProcsPerMinute` = 5 WHERE `SpellId` = 51130; -- Killing Machine Rank 5


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Killing Machine ranks 3-5 had incorrect non-linear PPM scaling in the `spell_proc` table:

| Rank | Spell ID | Before | After |
|------|----------|--------|-------|
| 1 | 51123 | 1 PPM | 1 PPM (unchanged) |
| 2 | 51127 | 2 PPM | 2 PPM (unchanged) |
| 3 | 51128 | **4 PPM** | **3 PPM** |
| 4 | 51129 | **6 PPM** | **4 PPM** |
| 5 | 51130 | **8 PPM** | **5 PPM** |

At rank 5 with a 3.5s weapon this gave 46.7% chance per swing instead of the correct 29.2% — a 60% overproc rate.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code with azerothMCP** was used to identify the discrepancy by comparing AzerothCore proc data against the WoWSim reference implementation.

## Issues Addressed:
- Frost DK Killing Machine proccing significantly more often than intended at ranks 3-5.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

WoWSim (https://github.com/wowsims/wotlk) uses the formula `procChance = attackSpeed * talentRank / 60.0` in `sim/deathknight/talents_frost.go:167`, which yields exactly `talentRank` PPM — linear scaling of 1, 2, 3, 4, 5 PPM across ranks 1-5.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a level 80 Frost DK with 5/5 Killing Machine.
2. Equip a slow 2H weapon (e.g. 3.5s speed) and attack a target dummy.
3. Track Killing Machine (51124) proc rate over several minutes.
4. Expected: ~5 procs per minute (was ~8 procs per minute before fix).
5. Repeat with rank 3 (3/5 talent) — expect ~3 PPM (was ~4 PPM).

## Known Issues and TODO List:

- [ ] None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.