### PR TITLE
fix(Scripts/Spells): Fix Retaliation self-damage and charge loss on activation

### DIFF
--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -47,7 +47,7 @@ enum WarriorSpells
     SPELL_WARRIOR_JUGGERNAUT_CRIT_BONUS_BUFF        = 65156,
     SPELL_WARRIOR_JUGGERNAUT_CRIT_BONUS_TALENT      = 64976,
     SPELL_WARRIOR_LAST_STAND_TRIGGERED              = 12976,
-    SPELL_WARRIOR_RETALIATION_DAMAGE                = 22858,
+    SPELL_WARRIOR_RETALIATION_DAMAGE                = 20240,
     SPELL_WARRIOR_SLAM                              = 50783,
     SPELL_WARRIOR_SUNDER_ARMOR                      = 58567,
     SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_1   = 12723,
@@ -884,19 +884,14 @@ class spell_warr_retaliation : public AuraScript
 
     bool CheckProc(ProcEventInfo& eventInfo)
     {
-        if (!eventInfo.GetActor() || !eventInfo.GetProcTarget())
-        {
-            return false;
-        }
-
         // check attack comes not from behind and warrior is not stunned
-        return GetTarget()->isInFront(eventInfo.GetActor(), M_PI) && !GetTarget()->HasUnitState(UNIT_STATE_STUNNED);
+        return eventInfo.GetActionTarget()->isInFront(eventInfo.GetActor(), float(M_PI)) && !GetTarget()->HasUnitState(UNIT_STATE_STUNNED);
     }
 
     void HandleEffectProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
     {
         PreventDefaultAction();
-        GetTarget()->CastSpell(eventInfo.GetProcTarget(), SPELL_WARRIOR_RETALIATION_DAMAGE, true, nullptr, aurEff);
+        eventInfo.GetActionTarget()->CastSpell(eventInfo.GetActor(), SPELL_WARRIOR_RETALIATION_DAMAGE, true, nullptr, aurEff);
     }
 
     void Register() override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Aligns the Warrior Retaliation (20230) spell script with TrinityCore:
- Changed triggered counter-attack spell from 22858 to **20240** (which has `SPELL_ATTR3_NOT_A_PROC`)
- Changed target resolution to use `GetActionTarget()`/`GetActor()` instead of `GetTarget()`/`GetProcTarget()`
- Removed redundant null checks (TC doesn't have them)

**Root cause**: Retaliation has `DmgClass = SPELL_DAMAGE_CLASS_MELEE`. When cast as a self-buff, `prepareDataForTriggerSystem` generates `procVictim = PROC_FLAG_TAKEN_SPELL_MELEE_DMG_CLASS`. Since the warrior is both caster and target, these victim flags match Retaliation's own ProcFlags (0x28), causing it to proc from its own application — counter-attacking the warrior and consuming a charge on activation.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Claude Code** with **azerothMCP**

## Issues Addressed:
- Warriors Retaliation consuming 1-2 stacks of buff and damaging yourself on activation

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore reference: [6c21bba](https://github.com/TrinityCore/TrinityCore/commit/6c21bbaaa47ba0701790dbcbdc34c9794a9bd7d9), [5715ed0](https://github.com/TrinityCore/TrinityCore/commit/5715ed009d380fcf45674fd66037fdc63bdb6ee0)

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a warrior at level 20+ with Retaliation ability
2. Cast Retaliation — verify no self-damage occurs and no charges are consumed on activation
3. Engage a melee mob — verify Retaliation counter-attacks the mob correctly (1 charge per hit taken from the front)
4. Verify Retaliation does NOT proc from attacks from behind
5. Verify all 20 charges can be consumed normally before the buff expires

## Known Issues and TODO List:

- [ ] If the self-proc still occurs after this change, an explicit `eventInfo.GetActor() == GetTarget()` guard in CheckProc may be needed