### PR TITLE
chore(Scripts/Spells): Remove duplicate Shaman T8 Electrified script

### DIFF
--- a/data/sql/updates/pending_db_world/fix_shaman_t8_electrified_double_proc.sql
+++ b/data/sql/updates/pending_db_world/fix_shaman_t8_electrified_double_proc.sql
@@ -1,5 +1,2 @@
 -- Remove stale spell_script_names entry for spell_sha_t8_electrified.
--- Spell 64928 (Shaman T8 Elemental 4P Bonus) had two script registrations
--- causing Electrified to proc twice per Lightning Bolt crit.
--- The surviving script is spell_sha_t8_elemental_4p_bonus.
 DELETE FROM `spell_script_names` WHERE `spell_id` = 64928 AND `ScriptName` = 'spell_sha_t8_electrified';

--- a/data/sql/updates/pending_db_world/fix_shaman_t8_electrified_double_proc.sql
+++ b/data/sql/updates/pending_db_world/fix_shaman_t8_electrified_double_proc.sql
@@ -1,0 +1,5 @@
+-- Remove stale spell_script_names entry for spell_sha_t8_electrified.
+-- Spell 64928 (Shaman T8 Elemental 4P Bonus) had two script registrations
+-- causing Electrified to proc twice per Lightning Bolt crit.
+-- The surviving script is spell_sha_t8_elemental_4p_bonus.
+DELETE FROM `spell_script_names` WHERE `spell_id` = 64928 AND `ScriptName` = 'spell_sha_t8_electrified';


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP was used for discovery and code changes.

## Issues Addressed:
Spell 64928 (Shaman T8 Elemental 4P Bonus / Electrified) had two spell scripts registered simultaneously:
- `spell_sha_t8_electrified` (from `spell_script_names` base table)
- `spell_sha_t8_elemental_4p_bonus` (from `2026_02_18_01.sql` update)

Both C++ classes were also registered via `RegisterSpellScript`. This removes the duplicate `spell_sha_t8_electrified` class and its stale DB entry, and ports the Lightning Overload exclusion check into the surviving `spell_sha_t8_elemental_4p_bonus` script.

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Cross-referenced with TrinityCore (single script, no duplicate) and WoWSim/wotlk (single implementation with LO exclusion).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Equip Shaman T8 Elemental 4-piece set bonus on an Elemental Shaman.
2. Cast Lightning Bolt on a target dummy until it crits.
3. Verify Electrified DoT ticks for 8% of the LB crit damage (divided over 2 ticks).
4. Trigger Lightning Overload crits and verify they do NOT apply Electrified.

## Known Issues and TODO List:
- [ ] The `spell_script_names` base SQL file still contains the stale `spell_sha_t8_electrified` entry and should be cleaned up when the base is next regenerated.