### PR TITLE
fix(Core/Spells): Prevent friendly spells from breaking stealth

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -2184,7 +2184,7 @@ uint8 Aura::GetProcEffectMask(AuraApplication* aurApp, ProcEventInfo& eventInfo,
     if (m_spellInfo->HasAura(SPELL_AURA_MOD_STEALTH))
     {
         if (SpellInfo const* spellInfo = eventInfo.GetSpellInfo())
-            if (spellInfo->IsPositive())
+            if (spellInfo->IsPositive() || !eventInfo.GetActor()->IsHostileTo(aurApp->GetTarget()))
                 return 0;
     }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

When a shaman casts Bloodlust, the `AfterHit` script applies Sated (57724) to each target via `target->CastSpell(target, SPELL_SHAMAN_SATED, true)`. Sated has `SPELL_ATTR0_AURA_IS_DEBUFF`, making it classify as negative. This generates `PROC_FLAG_TAKEN_SPELL_NONE_DMG_CLASS_NEG` which matches Stealth's DBC proc flags (`0xa22a8`). Because Stealth has `SPELL_ATTR3_CAN_PROC_FROM_PROCS`, the triggered-spell filter is bypassed, and the existing `IsPositive()` guard in `Aura::GetProcEffectMask` doesn't catch Sated since it's a negative debuff. The stealth charge is consumed and stealth breaks.

The same issue applies to Drums of War/Battle/Speed/Restoration which apply Tinnitus (51120) via `spell_linked_spell` — also a negative debuff applied by a friendly actor.

The fix adds a hostility check alongside the existing `IsPositive()` guard: if the proc actor is not hostile to the stealth holder, the stealth proc is skipped. This correctly prevents friendly debuffs (Sated, Tinnitus) from breaking stealth while still allowing hostile spells to consume stealth charges.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Tools used: Claude Code with azerothMCP**

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24873

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

On retail WoW (and Classic WotLK), Bloodlust, Heroism, and Drums buffs do not remove stealth from party members.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a Rogue (or Druid) and a Shaman in the same party
2. Have the Rogue enter Stealth (`.cast 1784`)
3. Have the Shaman cast Bloodlust (`.cast 2825`)
4. Verify the Rogue remains stealthed and receives the Bloodlust buff + Sated debuff without losing stealth
5. Additionally test with Drums: `.cast 35476` (Drums of Battle) on a stealthed party member — verify Tinnitus is applied without breaking stealth
6. Verify that hostile spells still correctly break stealth (e.g. an enemy NPC casting a spell on the stealthed player)

## Known Issues and TODO List:

- [ ] Other negative debuffs applied by friendly spells may exist beyond Sated and Tinnitus — the fix handles all of them generically via the hostility check

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.