### PR TITLE
DB/Item: Fix missing damage values for various ILVL 146, 232, and 264…

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1772058780233384995.sql
+++ b/data/sql/updates/pending_db_world/rev_1772058780233384995.sql
@@ -31,3 +31,24 @@ UPDATE `item_template` SET `dmg_min1` = 339, `dmg_max1` = 632, `dmg_type1` = 0 W
 
 -- Wand of the Drowned Contessa (ILVL 264 Epic Wand)
 UPDATE `item_template` SET `dmg_min1` = 583, `dmg_max1` = 1083, `dmg_type1` = 4 WHERE `entry` = 50204;
+
+UPDATE `item_template` SET `MaxDurability`=55, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36477;
+UPDATE `item_template` SET `MaxDurability`=75, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36491;
+UPDATE `item_template` SET `MaxDurability`=85, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36505;
+UPDATE `item_template` SET `MaxDurability`=75, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36519;
+UPDATE `item_template` SET `MaxDurability`=85, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36533;
+UPDATE `item_template` SET `MaxDurability`=85, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36547;
+UPDATE `item_template` SET `MaxDurability`=75, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36575;
+UPDATE `item_template` SET `MaxDurability`=85, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36589;
+UPDATE `item_template` SET `MaxDurability`=85, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36603;
+UPDATE `item_template` SET `MaxDurability`=65, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36617;
+UPDATE `item_template` SET `MaxDurability`=65, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36631;
+UPDATE `item_template` SET `MaxDurability`=65, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36645;
+UPDATE `item_template` SET `MaxDurability`=55, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36659;
+UPDATE `item_template` SET `MaxDurability`=55, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36673;
+UPDATE `item_template` SET `MaxDurability`=75, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36687;
+UPDATE `item_template` SET `MaxDurability`=85, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36701;
+UPDATE `item_template` SET `MaxDurability`=0, `DisenchantID`=15, `RequiredDisenchantSkill`=325 WHERE `entry`=36715;
+
+UPDATE `item_template` SET `MaxDurability`=105 WHERE `entry`=42238;
+UPDATE `item_template` SET `MaxDurability`=75, `DisenchantID`=68, `RequiredDisenchantSkill`=375 WHERE `entry`=50204;


### PR DESCRIPTION
… weapons

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

This PR fixes missing damage values (`dmg_min1` and `dmg_max1` were `0`) for a specific batch of legitimate ILVL 146 Rare player weapons, as well as two Epic items (ILVL 232 and 264). These items are now usable by players with their correct Blizz-like stats.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Google Gemini was used to assist in writing the SQL filters to exclude non-player/developer items and format the final UPDATE statements.**

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- None

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

* [Moonlit Katana (ILVL 146 1H)](https://www.wowhead.com/wotlk/item=36519/moonlit-katana)
* [Furious Gladiator's Waraxe (ILVL 232 2H)](https://www.wowhead.com/wotlk/item=42238/furious-gladiators-waraxe)
* [Wand of the Drowned Contessa (ILVL 264 Wand)](https://www.wowhead.com/wotlk/item=50204/wand-of-the-drowned-contessa)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Run `SELECT entry, name, dmg_min1, dmg_max1 FROM item_template WHERE entry IN (36519, 42238);` on the master branch and verify the damage values are `0`.
2. Apply the SQL update provided in this PR.
3. Close your WoW client and delete your `Cache` folder (or specifically `Cache/WDB/enUS/itemcache.wdb`) to ensure the client downloads the fresh item stats from the server.
4. Log in on a GM character and run `.additem 36519` (Moonlit Katana) and `.additem 42238` (Furious Gladiator's Waraxe).
5. Hover over the items in your inventory to verify the tooltip displays the correct weapon damage range. Equip the items to verify the damage applies to your character's stats.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
