### PR TITLE
fix(Core/Spells): Fix Hungering Cold breaking from disease damage

### DIFF
--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -614,16 +614,18 @@ class spell_dk_hungering_cold : public AuraScript
 {
     PrepareAuraScript(spell_dk_hungering_cold);
 
-    void HandleProc(ProcEventInfo& eventInfo)
+    bool CheckProc(ProcEventInfo& eventInfo)
     {
-        PreventDefaultAction();
-        if (eventInfo.GetDamageInfo() && eventInfo.GetDamageInfo()->GetDamage() > 0 && (!eventInfo.GetSpellInfo() || eventInfo.GetSpellInfo()->Dispel != DISPEL_DISEASE))
-            SetDuration(0);
+        SpellInfo const* spellInfo = eventInfo.GetSpellInfo();
+        if (!spellInfo)
+            return true;
+
+        return spellInfo->Dispel != DISPEL_DISEASE;
     }
 
     void Register() override
     {
-        OnProc += AuraProcFn(spell_dk_hungering_cold::HandleProc);
+        DoCheckProc += AuraCheckProcFn(spell_dk_hungering_cold::CheckProc);
     }
 };
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - **Claude Code** (claude-opus-4-6) with **azerothMCP** for DBC spell data lookup.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9083

## Description

Hungering Cold (spell 51209) was breaking on disease damage ticks despite the spell explicitly exempting diseases. This is a regression introduced by the proc system refactor.

**Root cause:** Spell 51209 has `ProcCharges = 1` in the DBC. The existing `OnProc` handler called `PreventDefaultAction()` to skip `HandleBreakableCCAuraProc`, but `PrepareProcToTrigger()` had already consumed the proc charge (1 → 0) *before* the `OnProc` handler ran. Then `ConsumeProcCharges()` at the end of `TriggerProcOnEvent()` saw 0 charges remaining and removed the aura — even though the script intended to keep it alive for disease damage.

**Fix:** Replace the `OnProc` handler with a `DoCheckProc` handler. `DoCheckProc` runs inside `GetProcEffectMask()`, which is evaluated *before* `PrepareProcToTrigger()`. Returning `false` for disease damage prevents the proc entirely — no charge is consumed and `HandleBreakableCCAuraProc` is never reached. Non-disease damage returns `true`, allowing the normal breakable CC flow.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**
  - TrinityCore [`2ff85505`](https://github.com/TrinityCore/TrinityCore/commit/2ff855054f52bf2dcf81aa7a7da7bab7f8a99686) by ariel-

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Log in as a Death Knight with Hungering Cold talented.
2. Cast Hungering Cold on a regular mob.
3. Do not attack — observe that Frost Fever ticks no longer break the stun.
4. Verify that melee or non-disease spell damage still breaks the stun normally.

## Known Issues and TODO List:

- [ ] Other CC auras with similar disease/DoT exemption patterns should be audited for the same charge-consumption bug.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.