### PR TITLE
fix(DB/Proc): Add missing NONE DmgClass proc flags to Blue Dragon

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1772086971482356750.sql
+++ b/data/sql/updates/pending_db_world/rev_1772086971482356750.sql
@@ -1,2 +1,2 @@
--- Darkmoon Card: Blue Dragon - add NONE DmgClass proc flags to match "on successful spellcast"
-UPDATE `spell_proc` SET `ProcFlags` = 0x15400 WHERE `SpellId` = 23688;
+-- Darkmoon Card: Blue Dragon - add NONE DmgClass proc flags and fix phase to CAST
+UPDATE `spell_proc` SET `ProcFlags` = 0x15400, `SpellPhaseMask` = 1 WHERE `SpellId` = 23688;

--- a/data/sql/updates/pending_db_world/rev_1772086971482356750.sql
+++ b/data/sql/updates/pending_db_world/rev_1772086971482356750.sql
@@ -1,6 +1,2 @@
--- Add PROC_FLAG_DONE_SPELL_NONE_DMG_CLASS_POS/NEG to Darkmoon Card: Blue Dragon (spell 23688)
--- The DBC ProcFlags (0x14000) only cover magic damage class spells, missing spells with
--- DmgClass=0 (NONE) like Prayer of Mending's initial cast, buffs, and other utility spells.
--- The tooltip says "2% chance on successful spellcast" which should include all direct casts.
--- Mirrors the approach used for Soul Preserver (60510) which also adds 0x400 to its spell_proc.
+-- Darkmoon Card: Blue Dragon - add NONE DmgClass proc flags to match "on successful spellcast"
 UPDATE `spell_proc` SET `ProcFlags` = 0x15400 WHERE `SpellId` = 23688;

--- a/data/sql/updates/pending_db_world/rev_1772086971482356750.sql
+++ b/data/sql/updates/pending_db_world/rev_1772086971482356750.sql
@@ -1,0 +1,6 @@
+-- Add PROC_FLAG_DONE_SPELL_NONE_DMG_CLASS_POS/NEG to Darkmoon Card: Blue Dragon (spell 23688)
+-- The DBC ProcFlags (0x14000) only cover magic damage class spells, missing spells with
+-- DmgClass=0 (NONE) like Prayer of Mending's initial cast, buffs, and other utility spells.
+-- The tooltip says "2% chance on successful spellcast" which should include all direct casts.
+-- Mirrors the approach used for Soul Preserver (60510) which also adds 0x400 to its spell_proc.
+UPDATE `spell_proc` SET `ProcFlags` = 0x15400 WHERE `SpellId` = 23688;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Fix `spell_proc` for Darkmoon Card: Blue Dragon (spell 23688):
- Add `PROC_FLAG_DONE_SPELL_NONE_DMG_CLASS_POS` and `PROC_FLAG_DONE_SPELL_NONE_DMG_CLASS_NEG` so spells with `DmgClass=0` (NONE) like Prayer of Mending's initial cast can proc it.
- Change `SpellPhaseMask` from HIT (2) to CAST (1) to match the tooltip "2% chance on successful spellcast".

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP

## Issues Addressed:

- Closes https://github.com/chromiecraft/chromiecraft/issues/9082

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Equip Darkmoon Card: Blue Dragon on a priest
2. Cast Prayer of Mending on a friendly target
3. Verify the trinket has a chance to proc Aura of the Blue Dragon from the initial cast
4. Verify that PoM bounce heals do NOT proc it (triggered spells are still filtered)

## Known Issues and TODO List:

- [ ]