### PR TITLE
fix(Core/Spells): Turn the Tables buff only applies to the rogue

### DIFF
--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -1046,13 +1046,19 @@ class spell_rog_turn_the_tables : public AuraScript
 };
 
 // 52910, 52914, 52915 - Turn the Tables (proc)
-class spell_rog_turn_the_tables_proc : public AuraScript
+class spell_rog_turn_the_tables_proc : public SpellScript
 {
-    PrepareAuraScript(spell_rog_turn_the_tables_proc);
+    PrepareSpellScript(spell_rog_turn_the_tables_proc);
+
+    void FilterTargets(std::list<WorldObject*>& targets)
+    {
+        targets.clear();
+        targets.push_back(GetCaster());
+    }
 
     void Register() override
     {
-        // No special handling needed - default behavior
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_rog_turn_the_tables_proc::FilterTargets, EFFECT_0, TARGET_UNIT_CASTER_AREA_RAID);
     }
 };
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

The Turn the Tables proc buff spells (52910, 52914, 52915) use `TARGET_UNIT_CASTER_AREA_RAID` in the DBC, causing the buff to be applied to all nearby party/raid members instead of just the rogue. While the `SPELL_AURA_FLAT_MODIFIER` with `SPELLFAMILY_ROGUE` means the buff is mechanically harmless on non-rogues, it still incorrectly appears on their buff bars.

This fix changes the `spell_rog_turn_the_tables_proc` script from an empty `AuraScript` to a `SpellScript` that filters the area targets down to only the caster.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP

## Issues Addressed:

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Log in as a Rogue with Turn the Tables talented (any rank: 51627/51628/51629), or use `.aura 51627`
2. Group up with at least one other player and stack them on the rogue
3. Let a melee mob attack the rogue until a dodge/parry triggers the proc
4. Verify only the rogue receives the Turn the Tables buff — party members should NOT see it on their buff bar
5. Verify the buff still grants the crit bonus and lasts 8 seconds

## Known Issues and TODO List:

- [ ] N/A