### PR TITLE
fix(Core/Spells): Check DONT_BREAK_STEALTH in stealth proc guard

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -2184,7 +2184,7 @@ uint8 Aura::GetProcEffectMask(AuraApplication* aurApp, ProcEventInfo& eventInfo,
     if (m_spellInfo->HasAura(SPELL_AURA_MOD_STEALTH))
     {
         if (SpellInfo const* spellInfo = eventInfo.GetSpellInfo())
-            if (spellInfo->IsPositive() || !eventInfo.GetActor()->IsHostileTo(aurApp->GetTarget()))
+            if (spellInfo->IsPositive() || !eventInfo.GetActor()->IsHostileTo(aurApp->GetTarget()) || spellInfo->HasAttribute(SPELL_ATTR0_CU_DONT_BREAK_STEALTH))
                 return 0;
     }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

I derp...

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code** with **azerothMCP** were used.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:

1. Create a Horde shaman with Storm, Earth and Fire talent (51483)
2. Create an Alliance rogue, cast Stealth (1784)
3. Have the shaman place Earthbind Totem near the stealthed rogue
4. Without fix: stealth breaks on Earthgrab proc
5. With fix: stealth remains active