### PR TITLE
fix(DB/Proc): Add missing NONE DmgClass flags and fix SpellPhaseMask for on-cast procs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1772134223874742153.sql
+++ b/data/sql/updates/pending_db_world/rev_1772134223874742153.sql
@@ -17,10 +17,12 @@ UPDATE `spell_proc` SET `ProcFlags` = 0x15400, `SpellPhaseMask` = 1 WHERE `Spell
 
 -- [32980] Arcane Might - "2% chance on successful spellcast to increase spell power"
 -- No spell_proc entry existed. Add with NONE flags and CAST phase.
+DELETE FROM `spell_proc` WHERE `SpellId` = 32980;
 INSERT INTO `spell_proc` (`SpellId`, `ProcFlags`, `SpellPhaseMask`) VALUES (32980, 0x15400, 1);
 
 -- [32981] Verdant Flame - "Chance on successful spellcast to restore Mana"
 -- No spell_proc entry existed. Add with NONE flags and CAST phase.
+DELETE FROM `spell_proc` WHERE `SpellId` = 32981;
 INSERT INTO `spell_proc` (`SpellId`, `ProcFlags`, `SpellPhaseMask`) VALUES (32981, 0x15400, 1);
 
 -- [34584] Love Struck - "Chance on spell cast to increase your Spirit"

--- a/data/sql/updates/pending_db_world/rev_1772134223874742153.sql
+++ b/data/sql/updates/pending_db_world/rev_1772134223874742153.sql
@@ -1,0 +1,48 @@
+-- Fix "on cast" procs: add missing NONE DmgClass flags and correct SpellPhaseMask
+-- These spells have tooltips like "chance on successful spellcast" but were missing
+-- DONE_SPELL_NONE_DMG_CLASS_POS/NEG flags, preventing NONE-DmgClass spells from
+-- proccing them. Some also had SpellPhaseMask=2 (HIT) instead of 1 (CAST).
+
+-- [27521] Mana Restore - "2% chance on successful spellcast to restore mana"
+-- Phase HIT->CAST, add NONE flags: 0x14000 -> 0x15400
+UPDATE `spell_proc` SET `ProcFlags` = 0x15400, `SpellPhaseMask` = 1 WHERE `SpellId` = 27521;
+
+-- [27774] The Furious Storm - "Chance on spell cast to increase your spell power"
+-- Phase HIT->CAST, add NONE flags: 0x14000 -> 0x15400
+UPDATE `spell_proc` SET `ProcFlags` = 0x15400, `SpellPhaseMask` = 1 WHERE `SpellId` = 27774;
+
+-- [32837] Spell Focus Trigger - "Chance on successful spellcast to grant Spell Haste"
+-- Phase HIT->CAST, add NONE flags: 0x14000 -> 0x15400
+UPDATE `spell_proc` SET `ProcFlags` = 0x15400, `SpellPhaseMask` = 1 WHERE `SpellId` = 32837;
+
+-- [32980] Arcane Might - "2% chance on successful spellcast to increase spell power"
+-- No spell_proc entry existed. Add with NONE flags and CAST phase.
+INSERT INTO `spell_proc` (`SpellId`, `ProcFlags`, `SpellPhaseMask`) VALUES (32980, 0x15400, 1);
+
+-- [32981] Verdant Flame - "Chance on successful spellcast to restore Mana"
+-- No spell_proc entry existed. Add with NONE flags and CAST phase.
+INSERT INTO `spell_proc` (`SpellId`, `ProcFlags`, `SpellPhaseMask`) VALUES (32981, 0x15400, 1);
+
+-- [34584] Love Struck - "Chance on spell cast to increase your Spirit"
+-- Phase HIT->CAST, add NONE flags: 0x14000 -> 0x15400
+UPDATE `spell_proc` SET `ProcFlags` = 0x15400, `SpellPhaseMask` = 1 WHERE `SpellId` = 34584;
+
+-- [38334] Proc Mana Regen - "Your spell casts have a chance to allow mana regen"
+-- Phase HIT->CAST, add NONE flags: 0x14000 -> 0x15400
+UPDATE `spell_proc` SET `ProcFlags` = 0x15400, `SpellPhaseMask` = 1 WHERE `SpellId` = 38334;
+
+-- [55381] Mana Restore - "2% chance on successful spellcast to restore mana"
+-- Phase HIT->CAST, add NONE flags: 0x14000 -> 0x15400
+UPDATE `spell_proc` SET `ProcFlags` = 0x15400, `SpellPhaseMask` = 1 WHERE `SpellId` = 55381;
+
+-- [58442] Airy Pale Ale - "Chance on successful spellcast to restore mana"
+-- Phase HIT->CAST, add NONE flags: 0x14000 -> 0x15400
+UPDATE `spell_proc` SET `ProcFlags` = 0x15400, `SpellPhaseMask` = 1 WHERE `SpellId` = 58442;
+
+-- [62114] Flow of Knowledge - "Your spell casts have a chance to increase spell power"
+-- Phase HIT->CAST, add NONE flags: 0x54000 -> 0x55400
+UPDATE `spell_proc` SET `ProcFlags` = 0x55400, `SpellPhaseMask` = 1 WHERE `SpellId` = 62114;
+
+-- [71585] Item - Icecrown 25 Emblem Healer Trinket - "Your spell casts have a chance to grant mana per 5 sec"
+-- Phase already CAST, just add NONE flags: 0x14000 -> 0x15400
+UPDATE `spell_proc` SET `ProcFlags` = 0x15400 WHERE `SpellId` = 71585;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Fix `spell_proc` for 11 spells with "chance on successful spellcast" (or similar) tooltips:

**Phase fix (HIT → CAST) + add NONE DmgClass flags (8 spells):**
- `27521` Mana Restore (Darkmoon Card: Crusade proc)
- `27774` The Furious Storm
- `32837` Spell Focus Trigger
- `34584` Love Struck
- `38334` Proc Mana Regen
- `55381` Mana Restore (Pendant of the Violet Eye)
- `58442` Airy Pale Ale
- `62114` Flow of Knowledge

**Add NONE DmgClass flags only (3 spells):**
- `32980` Arcane Might (new `spell_proc` INSERT)
- `32981` Verdant Flame (new `spell_proc` INSERT)
- `71585` Item - Icecrown 25 Emblem Healer Trinket

All 11 share the same root cause as #24890 (Blue Dragon): their DBC `ProcFlags` only include `DONE_SPELL_MAGIC_DMG_CLASS_POS/NEG` but not `DONE_SPELL_NONE_DMG_CLASS_POS/NEG`, so spells with `DmgClass=NONE` (e.g. Prayer of Mending initial cast, Penance, Arcane Missiles) cannot proc them. The 8 spells with `SpellPhaseMask=2` (HIT) also contradict their tooltip which says "on spellcast" not "on spell hit".

Full audit report: https://gist.github.com/blinkysc/fb2cbd157d9de580e30d018e6abd3c95

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP

## Issues Addressed:

Followup to #24890 — systematic audit of all "on cast" procs for the same class of bug.

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Spell DBC tooltip analysis — all affected spells explicitly state "chance on successful spellcast" / "chance on spell cast" / "your spell casts have a chance".

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

For each affected spell:
1. Equip/apply the item/buff that grants the proc aura
2. Cast a spell with `DmgClass=NONE` (e.g. Prayer of Mending, Penance)
3. Verify the proc can trigger from the cast
4. Cast a spell with `DmgClass=MAGIC` (e.g. Flash Heal, Frostbolt)
5. Verify the proc still triggers normally

## Known Issues and TODO List:
