### PR TITLE
fix(Core/Scripts): Remove duplicate spell scripts causing double-firing

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1772139853408206022.sql
+++ b/data/sql/updates/pending_db_world/rev_1772139853408206022.sql
@@ -1,0 +1,8 @@
+-- Remove duplicate spell scripts that caused handlers to fire twice
+DELETE FROM `spell_script_names` WHERE `spell_id` = 54937 AND `ScriptName` = 'spell_pal_glyph_of_holy_light_proc';
+DELETE FROM `spell_script_names` WHERE `spell_id` = 41404 AND `ScriptName` = 'spell_black_temple_dementia_aura';
+DELETE FROM `spell_script_names` WHERE `spell_id` = 64440 AND `ScriptName` = 'spell_item_blade_ward_enchant';
+DELETE FROM `spell_script_names` WHERE `spell_id` = 37594 AND `ScriptName` = 'spell_pri_item_greater_heal_refund';
+DELETE FROM `spell_script_names` WHERE `spell_id` = 69483 AND `ScriptName` = 'spell_icc_dark_reckoning_aura';
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_warl_demonic_pact_aura';
+DELETE FROM `spell_script_names` WHERE `spell_id` = 72176 AND `ScriptName` = 'spell_deathbringer_blood_link_blood_beast_aura';

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
@@ -1096,48 +1096,6 @@ class spell_deathbringer_blood_link_aura : public AuraScript
     }
 };
 
-class spell_deathbringer_blood_link_blood_beast_aura : public AuraScript
-{
-    PrepareAuraScript(spell_deathbringer_blood_link_blood_beast_aura);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_BLOOD_LINK_DUMMY });
-    }
-
-    bool CheckProc(ProcEventInfo& eventInfo)
-    {
-        DamageInfo* damageInfo = eventInfo.GetDamageInfo();
-        SpellInfo const* procSpell = eventInfo.GetSpellInfo();
-        return eventInfo.GetActor() && eventInfo.GetActionTarget() && ((damageInfo && damageInfo->GetDamage()) || eventInfo.GetHitMask() & PROC_EX_ABSORB) && (!procSpell || procSpell->SpellIconID != 2731); // Xinef: Mark of the Fallen Champion
-    }
-
-    void HandleProc(AuraEffect const*  /*aurEff*/, ProcEventInfo& eventInfo)
-    {
-        PreventDefaultAction();
-
-        /*
-        uint32 markCount = 0;
-        if (Map* map = eventInfo.GetActor()->FindMap())
-            if (InstanceMap* imap = map->ToInstanceMap())
-                if (InstanceScript* isc = imap->GetInstanceScript())
-                    if (ObjectGuid sguid = isc->GetGuidData(3) //DATA_DEATHBRINGER_SAURFANG
-                        if (Creature* saurfang = ObjectAccessor::GetCreature(*eventInfo.GetActor(), sguid))
-                            markCount = saurfang->IsAIEnabled ? saurfang->AI()->GetData(123456) : 0; //FALLEN_CHAMPION_CAST_COUNT
-        */
-        int32 basepoints = int32(3.0f /*+ 0.5f + 0.5f*markCount*/);
-
-        eventInfo.GetActor()->CastCustomSpell(SPELL_BLOOD_LINK_DUMMY, SPELLVALUE_BASE_POINT0, basepoints, eventInfo.GetActionTarget(), true);
-        return;
-    }
-
-    void Register() override
-    {
-        DoCheckProc += AuraCheckProcFn(spell_deathbringer_blood_link_blood_beast_aura::CheckProc);
-        OnEffectProc += AuraEffectProcFn(spell_deathbringer_blood_link_blood_beast_aura::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
-    }
-};
-
 class spell_deathbringer_blood_link : public SpellScript
 {
     PrepareSpellScript(spell_deathbringer_blood_link);
@@ -1371,7 +1329,6 @@ void AddSC_boss_deathbringer_saurfang()
     new npc_muradin_bronzebeard_icc();
     new npc_saurfang_event();
     RegisterSpellScript(spell_deathbringer_blood_link_aura);
-    RegisterSpellScript(spell_deathbringer_blood_link_blood_beast_aura);
     RegisterSpellScript(spell_deathbringer_blood_beast_blood_link);
     RegisterSpellScript(spell_deathbringer_blood_link);
     RegisterSpellAndAuraScriptPair(spell_deathbringer_blood_power, spell_deathbringer_blood_power_aura);

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
@@ -2295,27 +2295,6 @@ class spell_icc_web_wrap_aura : public AuraScript
     }
 };
 
-class spell_icc_dark_reckoning_aura : public AuraScript
-{
-    PrepareAuraScript(spell_icc_dark_reckoning_aura);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ 69482 });
-    }
-
-    void OnPeriodic(AuraEffect const* /*aurEff*/)
-    {
-        if (Unit* caster = GetCaster())
-            caster->CastSpell(GetTarget(), 69482, true);
-    }
-
-    void Register() override
-    {
-        OnEffectPeriodic += AuraEffectPeriodicFn(spell_icc_dark_reckoning_aura::OnPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY);
-    }
-};
-
 class spell_stinky_precious_decimate : public SpellScript
 {
     PrepareSpellScript(spell_stinky_precious_decimate);
@@ -3681,7 +3660,6 @@ void AddSC_icecrown_citadel()
 
     // pussywizard below:
     RegisterSpellScript(spell_icc_web_wrap_aura);
-    RegisterSpellScript(spell_icc_dark_reckoning_aura);
     RegisterSpellScript(spell_stinky_precious_decimate);
     RegisterSpellScript(spell_icc_yf_frozen_orb_aura);
     RegisterSpellScript(spell_icc_yh_volley_aura);

--- a/src/server/scripts/Outland/BlackTemple/instance_black_temple.cpp
+++ b/src/server/scripts/Outland/BlackTemple/instance_black_temple.cpp
@@ -446,29 +446,6 @@ class spell_black_temple_curse_of_vitality_aura : public AuraScript
     }
 };
 
-class spell_black_temple_dementia_aura : public AuraScript
-{
-    PrepareAuraScript(spell_black_temple_dementia_aura);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_DEMENTIA1, SPELL_DEMENTIA2 });
-    }
-
-    void OnPeriodic(AuraEffect const*  /*aurEff*/)
-    {
-        if (roll_chance_i(50))
-            GetTarget()->CastSpell(GetTarget(), SPELL_DEMENTIA1, true);
-        else
-            GetTarget()->CastSpell(GetTarget(), SPELL_DEMENTIA2, true);
-    }
-
-    void Register() override
-    {
-        OnEffectPeriodic += AuraEffectPeriodicFn(spell_black_temple_dementia_aura::OnPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY);
-    }
-};
-
 // 39649 - Summon Shadowfiends
 class spell_black_temple_summon_shadowfiends : public SpellScript
 {
@@ -525,7 +502,6 @@ void AddSC_instance_black_temple()
     RegisterSpellScript(spell_black_temple_bloodbolt);
     RegisterSpellScript(spell_black_temple_consuming_strikes_aura);
     RegisterSpellScript(spell_black_temple_curse_of_vitality_aura);
-    RegisterSpellScript(spell_black_temple_dementia_aura);
     RegisterSpellScript(spell_black_temple_summon_shadowfiends);
     RegisterSpellScript(spell_black_temple_l5_arcane_charge);
 }

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -1206,31 +1206,6 @@ class spell_item_trauma : public AuraScript
     }
 };
 
-class spell_item_blade_ward_enchant : public AuraScript
-{
-    PrepareAuraScript(spell_item_blade_ward_enchant);
-
-    void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
-    {
-        PreventDefaultAction();
-        if (!eventInfo.GetActionTarget())
-        {
-            return;
-        }
-
-        if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(64442 /*SPELL_BLADE_WARDING*/))
-        {
-            int32 basepoints = spellInfo->Effects[EFFECT_0].CalcValue() * this->GetStackAmount();
-            eventInfo.GetActionTarget()->CastCustomSpell(spellInfo->Id, SPELLVALUE_BASE_POINT0, basepoints, eventInfo.GetActor(), true);
-        }
-    }
-
-    void Register() override
-    {
-        OnEffectProc += AuraEffectProcFn(spell_item_blade_ward_enchant::HandleProc, EFFECT_1, SPELL_AURA_PROC_TRIGGER_SPELL);
-    }
-};
-
 class spell_item_blood_draining_enchant : public AuraScript
 {
     PrepareAuraScript(spell_item_blood_draining_enchant);
@@ -6236,7 +6211,6 @@ void AddSC_item_spell_scripts()
     RegisterSpellScript(spell_item_fetch_ball);
     RegisterSpellScript(spell_item_oracle_ablutions);
     RegisterSpellScript(spell_item_trauma);
-    RegisterSpellScript(spell_item_blade_ward_enchant);
     RegisterSpellScript(spell_item_blood_draining_enchant);
     RegisterSpellScript(spell_item_dragon_kite_summon_lightning_bunny);
     RegisterSpellScript(spell_item_enchanted_broom_periodic);

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -1404,33 +1404,6 @@ class spell_pal_spiritual_attunement : public AuraScript
     }
 };
 
-// 54937 - Glyph of Holy Light (proc trigger)
-class spell_pal_glyph_of_holy_light_proc : public AuraScript
-{
-    PrepareAuraScript(spell_pal_glyph_of_holy_light_proc);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_PALADIN_GLYPH_OF_HOLY_LIGHT_HEAL });
-    }
-
-    void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
-    {
-        PreventDefaultAction();
-        HealInfo* healInfo = eventInfo.GetHealInfo();
-        if (!healInfo || !healInfo->GetHeal())
-            return;
-
-        int32 bp = CalculatePct(int32(healInfo->GetHeal()), aurEff->GetAmount());
-        GetTarget()->CastCustomSpell(SPELL_PALADIN_GLYPH_OF_HOLY_LIGHT_HEAL, SPELLVALUE_BASE_POINT0, bp, eventInfo.GetActionTarget(), true, nullptr, aurEff);
-    }
-
-    void Register() override
-    {
-        OnEffectProc += AuraEffectProcFn(spell_pal_glyph_of_holy_light_proc::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
-    }
-};
-
 // 1022 - Hand of Protection
 class spell_pal_hand_of_protection : public SpellScript
 {
@@ -2209,7 +2182,6 @@ void AddSC_paladin_spell_scripts()
     RegisterSpellScript(spell_pal_judgement_of_light_heal);
     RegisterSpellScript(spell_pal_judgement_of_wisdom_mana);
     RegisterSpellScript(spell_pal_spiritual_attunement);
-    RegisterSpellScript(spell_pal_glyph_of_holy_light_proc);
     RegisterSpellScript(spell_pal_t3_6p_bonus);
     RegisterSpellScript(spell_pal_t8_2p_bonus);
     RegisterSpellScript(spell_pal_glyph_of_divinity);

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -360,38 +360,6 @@ class spell_pri_hymn_of_hope : public SpellScript
     }
 };
 
-// 37594 - Greater Heal Refund
-class spell_pri_item_greater_heal_refund : public AuraScript
-{
-    PrepareAuraScript(spell_pri_item_greater_heal_refund);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_PRIEST_ITEM_EFFICIENCY });
-    }
-
-    bool CheckProc(ProcEventInfo& eventInfo)
-    {
-        if (HealInfo* healInfo = eventInfo.GetHealInfo())
-            if (Unit* healTarget = healInfo->GetTarget())
-                if (eventInfo.GetHitMask() & PROC_EX_NO_OVERHEAL && healTarget->IsFullHealth())
-                    return true;
-        return false;
-    }
-
-    void HandleProc(AuraEffect const* aurEff, ProcEventInfo& /*eventInfo*/)
-    {
-        PreventDefaultAction();
-        GetTarget()->CastSpell(GetTarget(), SPELL_PRIEST_ITEM_EFFICIENCY, true, nullptr, aurEff);
-    }
-
-    void Register() override
-    {
-        DoCheckProc += AuraCheckProcFn(spell_pri_item_greater_heal_refund::CheckProc);
-        OnEffectProc += AuraEffectProcFn(spell_pri_item_greater_heal_refund::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
-    }
-};
-
 // 60123 - Lightwell
 class spell_pri_lightwell : public SpellScript
 {
@@ -1448,7 +1416,6 @@ void AddSC_priest_spell_scripts()
     RegisterSpellScript(spell_pri_glyph_of_prayer_of_healing);
     RegisterSpellScript(spell_pri_guardian_spirit);
     RegisterSpellScript(spell_pri_hymn_of_hope);
-    RegisterSpellScript(spell_pri_item_greater_heal_refund);
     RegisterSpellScript(spell_pri_lightwell);
     RegisterSpellScript(spell_pri_lightwell_renew);
     RegisterSpellScript(spell_pri_mana_burn);

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -1306,54 +1306,6 @@ class spell_warl_voidwalker_pet_passive : public AuraScript
     }
 };
 
-// 54909, 53646 - Demonic Pact
-class spell_warl_demonic_pact_aura : public AuraScript
-{
-    PrepareAuraScript(spell_warl_demonic_pact_aura);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_WARLOCK_DEMONIC_PACT_PROC });
-    }
-
-    bool AfterCheckProc(ProcEventInfo& eventInfo, bool isTriggeredAtSpellProcEvent)
-    {
-        return isTriggeredAtSpellProcEvent && eventInfo.GetActor() && eventInfo.GetActor()->IsPet();
-    }
-
-    void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
-    {
-        PreventDefaultAction();
-
-        if (eventInfo.GetActor()->HasSpellCooldown(aurEff->GetId()))
-            return;
-
-        if (Unit* owner = eventInfo.GetActor()->GetOwner())
-        {
-            int32 currentBonus = 0;
-            if (AuraEffect* demonicAurEff = owner->GetAuraEffect(SPELL_WARLOCK_DEMONIC_PACT_PROC, EFFECT_0))
-            {
-                currentBonus = demonicAurEff->GetAmount();
-            }
-
-            if (AuraEffect* talentAurEff = owner->GetDummyAuraEffect(SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_DEMONIC_PACT, EFFECT_0))
-            {
-                int32 spellDamageMinusBonus = owner->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_MAGIC) - currentBonus;
-                if (spellDamageMinusBonus < 0)
-                    return;
-                int32 bp = int32((talentAurEff->GetAmount() / 100.0f) * spellDamageMinusBonus);
-                owner->CastCustomSpell((Unit*)nullptr, SPELL_WARLOCK_DEMONIC_PACT_PROC, &bp, &bp, 0, true, nullptr, talentAurEff);
-                eventInfo.GetActor()->AddSpellCooldown(aurEff->GetId(), 0, eventInfo.GetProcCooldown());
-            }
-        }
-    }
-
-    void Register() override
-    {
-        OnEffectProc += AuraEffectProcFn(spell_warl_demonic_pact_aura::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
-    }
-};
-
 // -980 - Curse of Agony
 class spell_warl_curse_of_agony : public AuraScript
 {
@@ -1861,7 +1813,6 @@ void AddSC_warlock_spell_scripts()
     RegisterSpellScript(spell_warl_drain_soul);
     RegisterSpellScript(spell_warl_shadowburn);
     RegisterSpellScript(spell_warl_voidwalker_pet_passive);
-    RegisterSpellScript(spell_warl_demonic_pact_aura);
     RegisterSpellScript(spell_warl_curse_of_agony);
     RegisterSpellScript(spell_warl_glyph_of_corruption_nightfall);
     RegisterSpellScript(spell_warl_nightfall);


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Multiple spells had two AuraScripts registered on the same spell ID with overlapping hooks, causing handlers to fire twice per proc/tick. Each removed script was verified against TrinityCore, which only has a single script for each spell.

| Spell | Name | Removed (AC-only duplicate) | Kept (matches TC) |
|-------|------|-----------------------------|--------------------|
| 54937 | Glyph of Holy Light | `spell_pal_glyph_of_holy_light_proc` | `spell_pal_glyph_of_holy_light_dummy` |
| 41404 | Dementia | `spell_black_temple_dementia_aura` | `spell_item_dementia` |
| 64440 | Blade Warding | `spell_item_blade_ward_enchant` | `spell_gen_blade_warding` |
| 37594 | Priest T5 2P Bonus | `spell_pri_item_greater_heal_refund` | `spell_pri_t5_heal_2p_bonus` |
| 69483 | Dark Reckoning | `spell_icc_dark_reckoning_aura` | `spell_deathwhisper_dark_reckoning` |
| 53646/54909 | Demonic Pact | `spell_warl_demonic_pact_aura` | `spell_warl_demonic_pact` |
| 72176 | Blood Beast Blood Link | `spell_deathbringer_blood_link_blood_beast_aura` | `spell_deathbringer_blood_beast_blood_link` |

In each case, two AuraScripts were registered for the same spell and same aura effect hook (e.g. both on `OnEffectProc EFFECT_0 SPELL_AURA_PROC_TRIGGER_SPELL`), causing the handler logic to execute twice. This resulted in double damage, double healing, double buff application, or double blood power gain depending on the spell.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP

## SOURCE:

The changes have been validated through:
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Each duplicate was cross-referenced against TrinityCore's source. In all 7 cases, TC has only the single script that we kept.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. **Glyph of Holy Light (54937)**: Cast Holy Light with glyph, verify nearby allies receive AoE heal once (not twice)
2. **Dementia (41404)**: On Reliquary of Souls (BT), verify Dementia buff/debuff applies once per tick
3. **Blade Warding (64440)**: Equip Blade Ward enchant, take melee hits, verify damage proc fires once per proc
4. **Priest T5 2P (37594)**: Wear T5 2pc, cast Greater Heal on full-health target, verify single mana refund
5. **Dark Reckoning (69483)**: Pull ICC Deathwhisper trash with Dark Reckoning, verify single damage cast per tick
6. **Demonic Pact (53646/54909)**: Warlock pet deals spell damage, verify buff applies once per proc
7. **Blood Beast Blood Link (72176)**: Deathbringer Saurfang encounter, verify blood beasts grant normal blood power (not double)

## Known Issues and TODO List:

- [ ] Needs in-game testing for all 7 affected spells