### PR TITLE
fix(Core/Spells): Fix Cobra Strikes stack consumption

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1772186400000000000.sql
+++ b/data/sql/updates/pending_db_world/rev_1772186400000000000.sql
@@ -1,0 +1,5 @@
+-- Cobra Strikes spell script bindings
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (-53256, 53257);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(-53256, 'spell_hun_cobra_strikes'),
+(53257, 'spell_hun_cobra_strikes_triggered');

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13040,6 +13040,23 @@ void Unit::TriggerAurasProcOnEvent(std::list<AuraApplication*>* myProcAuras, std
     AuraApplicationProcContainer myAurasTriggeringProc;
     GetProcAurasTriggeredOnEvent(myAurasTriggeringProc, myProcAuras, myProcEventInfo);
 
+    // needed for example for Cobra Strikes, pet does the attack, but aura is on owner
+    if (Player* modOwner = GetSpellModOwner())
+    {
+        if (modOwner != this && spell)
+        {
+            std::list<AuraApplication*> modAuras;
+            for (auto itr = modOwner->GetAppliedAuras().begin(); itr != modOwner->GetAppliedAuras().end(); ++itr)
+            {
+                if (spell->m_appliedMods.count(itr->second->GetBase()) != 0)
+                    modAuras.push_back(itr->second);
+            }
+
+            if (!modAuras.empty())
+                modOwner->GetProcAurasTriggeredOnEvent(myAurasTriggeringProc, &modAuras, myProcEventInfo);
+        }
+    }
+
     // prepare data for target trigger
     ProcEventInfo targetProcEventInfo = ProcEventInfo(this, actionTarget, this, typeMaskActionTarget, spellTypeMask, spellPhaseMask, hitMask, spell, damageInfo, healInfo);
     AuraApplicationProcContainer targetAurasTriggeringProc;

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1313,10 +1313,10 @@ bool SpellInfo::IsAffectedBySpellMod(SpellModifier const* mod) const
     if (affectSpell->SpellFamilyName != SpellFamilyName)
         return false;
 
-    if (mod->mask & SpellFamilyFlags)
-        return true;
+    if (mod->mask && !(mod->mask & SpellFamilyFlags))
+        return false;
 
-    return false;
+    return true;
 }
 
 bool SpellInfo::CanPierceImmuneAura(SpellInfo const* aura) const

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -652,13 +652,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AttributesEx3 |= SPELL_ATTR3_ALWAYS_HIT;
     });
 
-    // Cobra Strikes
-    ApplySpellFix({ 53257 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->ProcCharges = 2;
-        spellInfo->StackAmount = 0;
-    });
-
     // Kill Command
     // Kill Command, Overpower
     ApplySpellFix({ 34027, 37529 }, [](SpellInfo* spellInfo)

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -78,7 +78,8 @@ enum HunterSpells
     SPELL_HUNTER_RAPID_RECUPERATION_MANA_R1         = 56654,
     SPELL_HUNTER_RAPID_RECUPERATION_MANA_R2         = 58882,
     SPELL_HUNTER_PIERCING_SHOTS                     = 63468,
-    SPELL_HUNTER_T9_4P_GREATNESS                    = 68130
+    SPELL_HUNTER_T9_4P_GREATNESS                    = 68130,
+    SPELL_HUNTER_COBRA_STRIKES_TRIGGERED            = 53257
 };
 
 enum HunterSpellIcons
@@ -934,6 +935,49 @@ class spell_hun_misdirection_proc : public AuraScript
     }
 };
 
+// -53256 - Cobra Strikes (talent)
+class spell_hun_cobra_strikes : public AuraScript
+{
+    PrepareAuraScript(spell_hun_cobra_strikes);
+
+    bool Validate(SpellInfo const* spellInfo) override
+    {
+        return ValidateSpellInfo({ spellInfo->Effects[EFFECT_0].TriggerSpell });
+    }
+
+    void HandleProc(AuraEffect const* aurEff, ProcEventInfo& /*eventInfo*/)
+    {
+        PreventDefaultAction();
+
+        SpellInfo const* triggeredSpellInfo = sSpellMgr->GetSpellInfo(aurEff->GetSpellInfo()->Effects[aurEff->GetEffIndex()].TriggerSpell);
+        if (!triggeredSpellInfo)
+            return;
+
+        GetTarget()->CastCustomSpell(triggeredSpellInfo->Id, SPELLVALUE_AURA_STACK, triggeredSpellInfo->StackAmount, GetTarget(), true);
+    }
+
+    void Register() override
+    {
+        OnEffectProc += AuraEffectProcFn(spell_hun_cobra_strikes::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
+    }
+};
+
+// 53257 - Cobra Strikes (triggered buff)
+class spell_hun_cobra_strikes_triggered : public AuraScript
+{
+    PrepareAuraScript(spell_hun_cobra_strikes_triggered);
+
+    void HandleStackDrop(AuraEffect const* /*aurEff*/, ProcEventInfo& /*eventInfo*/)
+    {
+        ModStackAmount(-1);
+    }
+
+    void Register() override
+    {
+        OnEffectProc += AuraEffectProcFn(spell_hun_cobra_strikes_triggered::HandleStackDrop, EFFECT_0, SPELL_AURA_ADD_FLAT_MODIFIER);
+    }
+};
+
 // 781 - Disengage
 class spell_hun_disengage : public SpellScript
 {
@@ -1633,6 +1677,8 @@ void AddSC_hunter_spell_scripts()
     RegisterSpellScript(spell_hun_aspect_of_the_beast);
     RegisterSpellScript(spell_hun_ascpect_of_the_viper);
     RegisterSpellScript(spell_hun_chimera_shot);
+    RegisterSpellScript(spell_hun_cobra_strikes);
+    RegisterSpellScript(spell_hun_cobra_strikes_triggered);
     RegisterSpellScript(spell_hun_disengage);
     RegisterSpellScript(spell_hun_improved_mend_pet);
     RegisterSpellScript(spell_hun_invigoration);


### PR DESCRIPTION
## Changes Proposed:

Fix Hunter talent "Cobra Strikes" (53256) buff (53257) never being consumed when pet attacks. The +100% pet crit chance buff was applied but stacks were never decremented.

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

**Root causes fixed:**

1. **`SpellInfo::IsAffectedBySpellMod` empty mask logic** — AC returned false for empty SpellClassMask (no spells match). TC's `IsAffected` returns true (all same-family spells match). This prevented the +100% crit spell modifier from 53257 from applying to pet abilities like Bite/Claw/Smack.

2. **No pet-to-owner proc forwarding** — The buff is on the hunter but the pet does the attacking. Ported TC's explicit forwarding code in `TriggerAurasProcOnEvent` so pet attacks can trigger procs on owner auras that were applied as spell mods.

3. **Missing spell scripts for stack management** — Added scripts for the talent (-53256) to set correct initial stack count (2) and for the triggered buff (53257) to consume one stack per pet special attack proc.

4. **Removed incorrect SpellInfoCorrections** — Removed the workaround that converted 53257 from stacks to charges (ProcCharges=2, StackAmount=0). The DBC defaults (StackAmount=2, ProcCharges=0) are correct.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Tools used: Claude Code with azerothMCP**

## Issues Addressed:

- Closes https://github.com/chromiecraft/chromiecraft/issues/9087

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Ported from TrinityCore:
- `SpellInfo::IsAffected` empty mask logic
- Pet-to-owner proc forwarding in `Unit::TriggerAurasProcOnEvent`
- `spell_hun_cobra_strikes` and `spell_hun_cobra_strikes_triggered` spell scripts

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Unit tests pass (5431/5431).

**Regression testing performed:**

Of the 24 spells using `PROC_ATTR_REQ_SPELLMOD` (0x8) in `spell_proc`, all were audited against DBC per-effect `SpellClassMask` values. Only Cobra Strikes (53257) has an empty mask on its active modifier effect — all others have explicit non-zero masks, meaning the `IsAffectedBySpellMod` change has no behavioral impact on them (the `mod->mask && !(mod->mask & flags)` check is logically identical to the old `mod->mask & flags` check when mask is non-zero).

The one exception besides Cobra Strikes is **Molten Core (47383)** which has empty masks on effects 0 (damage) and 2 (cast time), while effect 1 (crit) has a non-zero mask. Tested in-game:

- `.aura 47383` — applied 3 charges
- Cast **Incinerate** — correctly consumed charges, received damage/cast time bonuses
- Cast **Shadow Bolt** — no regression, did not incorrectly receive bonuses or consume charges
- Cast **Immolate** — no regression

Additional in-game regression tests performed:

| Spell | ID | Class | Test | Result |
|-------|----|-------|------|--------|
| Hot Streak | 48108 | Mage | `.aura 48108` → cast Pyroblast (instant), cast Fireball (not affected) | OK — mask (4194304,0,0) non-zero |
| Killing Machine | 51124 | DK | `.aura 51124` → Icy Touch/Frost Strike auto-crit, consumed correctly | OK — mask (2,0,0) non-zero |
| Molten Core | 47383 | Warlock | `.aura 47383` → Incinerate consumes, Shadow Bolt does not | OK — no regression |
| Backdraft | 54274 | Warlock | `.aura 54274` → Destruction spells consume charges correctly | OK — mask (293,293,0) non-zero |
| Presence of Mind | 12043 | Mage | `.aura 12043` → next spell instant, consumed on cast | OK — mask (1631584309,0,0) non-zero |
| Recklessness | 1719 | Warrior | `.aura 1719` → special attacks crit, 3 charges consumed | OK — mask (778044484,0,0) non-zero |
| Elemental Mastery | 16166 | Shaman | `.aura 16166` → next spell instant+crit, consumed | OK — mask (2416967683,3,2416967683) non-zero |
| Maelstrom Weapon | 53817 | Shaman | `.aura 53817` → 5 stacks, Lightning Bolt instant | OK — mask (451,451,0) non-zero |
| Deathchill | 49796 | DK | `.aura 49796` → next Frost spell auto-crit, consumed | OK — mask (2,0,0) non-zero |

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Cobra Strikes (primary fix):**
1. Create a Beast Mastery hunter with Cobra Strikes talent (rank 2 for 60% proc chance, or rank 1 for 20%)
2. Use `.aura 53257` to force-apply Cobra Strikes buff (should show 2 stacks)
3. Have pet use a special ability (Bite/Claw/Smack) on a target — each special attack should consume one stack
4. After 2 pet special attacks, the buff should disappear from the hunter
5. Pet auto-attacks should NOT consume stacks
6. Verify other hunter pet abilities (Kill Command) still work normally

**Regression testing (PROC_ATTR_REQ_SPELLMOD spells):**
1. `.aura 48108` (Hot Streak) on a Mage — Pyroblast should be instant, consumed on cast. Other spells should not consume it.
2. `.aura 51124` (Killing Machine) on a DK — Icy Touch/Frost Strike should auto-crit and consume. Non-Frost abilities should not.
3. `.aura 47383` (Molten Core) on a Warlock — Incinerate should get faster cast/more damage and consume charges. Shadow Bolt should NOT consume or benefit.
4. `.aura 54274` (Backdraft) on a Warlock — Destruction spell casts should consume charges correctly.
5. `.aura 12043` (Presence of Mind) on a Mage — next spell should be instant, buff consumed.
6. `.aura 1719` (Recklessness) on a Warrior — special attacks should crit, 3 charges consumed correctly.

## Known Issues and TODO List:

- [ ] Talent script binding via negative spell_id (-53256) depends on `spell_ranks` chain entries existing for spell 53256. If chain is missing, initial stack count may be 1 instead of 2. Needs verification.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.