### PR TITLE
fix(Core/Spells): Allow Mutilate offhand to proc Focused Attacks

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1772144945706318839.sql
+++ b/data/sql/updates/pending_db_world/rev_1772144945706318839.sql
@@ -1,0 +1,7 @@
+-- Replace generic no-offhand-proc with Focused Attacks-specific script
+-- that only blocks Fan of Knives offhand from proccing, allowing Mutilate
+-- offhand and other offhand attacks to proc normally
+DELETE FROM `spell_script_names` WHERE `spell_id` = -51634 AND `ScriptName` = 'spell_gen_no_offhand_proc';
+DELETE FROM `spell_script_names` WHERE `spell_id` = -51634 AND `ScriptName` = 'spell_rog_focused_attacks';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(-51634, 'spell_rog_focused_attacks');

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -1056,6 +1056,30 @@ class spell_rog_turn_the_tables_proc : public AuraScript
     }
 };
 
+// -51634 - Focused Attacks
+// Block Fan of Knives offhand from proccing
+class spell_rog_focused_attacks : public AuraScript
+{
+    PrepareAuraScript(spell_rog_focused_attacks);
+
+    bool CheckProc(ProcEventInfo& eventInfo)
+    {
+        // Block Fan of Knives offhand (0x40000) from proccing
+        SpellInfo const* spellInfo = eventInfo.GetSpellInfo();
+        if (spellInfo && spellInfo->SpellFamilyName == SPELLFAMILY_ROGUE
+            && (spellInfo->SpellFamilyFlags[1] & 0x40000)
+            && (eventInfo.GetTypeMask() & PROC_FLAG_DONE_OFFHAND_ATTACK))
+            return false;
+
+        return true;
+    }
+
+    void Register() override
+    {
+        DoCheckProc += AuraCheckProcFn(spell_rog_focused_attacks::CheckProc);
+    }
+};
+
 void AddSC_rogue_spell_scripts()
 {
     RegisterSpellScript(spell_rog_savage_combat);
@@ -1086,4 +1110,5 @@ void AddSC_rogue_spell_scripts()
     RegisterSpellAndAuraScriptPair(spell_rog_honor_among_thieves_proc, spell_rog_honor_among_thieves_proc_aura);
     RegisterSpellScript(spell_rog_turn_the_tables);
     RegisterSpellScript(spell_rog_turn_the_tables_proc);
+    RegisterSpellScript(spell_rog_focused_attacks);
 }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

PR #24870 used the generic `spell_gen_no_offhand_proc` script to prevent Focused Attacks from proccing on offhand Fan of Knives. However, this also blocked Mutilate's offhand component (spell 27576, which has `SPELL_ATTR3_REQUIRES_OFF_HAND_WEAPON`) from proccing Focused Attacks.

This replaces the generic script with a targeted `spell_rog_focused_attacks` AuraScript that only blocks Fan of Knives offhand (`SPELLFAMILY_ROGUE`, `SpellFamilyFlags[1] & 0x40000` + `PROC_FLAG_DONE_OFFHAND_ATTACK`) from proccing. All other procs (Mutilate offhand, offhand auto-attacks, mainhand abilities) work normally.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code (claude-opus-4-6) with azerothMCP was used for DBC spell data lookup and database verification.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a Rogue with Focused Attacks (rank 3) and equip mainhand + offhand weapons
2. Use Mutilate on a target dummy — verify offhand crits grant 2 energy from Focused Attacks
3. Use Fan of Knives on training dummies — verify offhand FoK crits do NOT grant energy
4. Verify mainhand auto-attack and ability crits still proc Focused Attacks normally

## Known Issues and TODO List:

- [ ] N/A

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.