### PR TITLE
fix(Core/Spells): Fix Swift Hand of Justice healing for 0

### DIFF
--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -5903,7 +5903,10 @@ class spell_item_swift_hand_justice_dummy : public AuraScript
     void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
     {
         PreventDefaultAction();
-        eventInfo.GetActor()->CastSpell(nullptr, SPELL_SWIFT_HAND_OF_JUSTICE_HEAL, true, nullptr, aurEff);
+
+        Unit* caster = eventInfo.GetActor();
+        int32 bp0 = static_cast<int32>(caster->CountPctFromMaxHealth(aurEff->GetAmount()));
+        caster->CastCustomSpell(SPELL_SWIFT_HAND_OF_JUSTICE_HEAL, SPELLVALUE_BASE_POINT0, bp0, nullptr, true, nullptr, aurEff);
     }
 
     void Register() override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - **Claude Code** with **azerothMCP**

## Description

The Swift Hand of Justice heirloom trinket (item 42991) proc was healing for 0.

Spell 59906 applies a `SPELL_AURA_DUMMY` with `GetAmount() = 2` (2% of max health). On proc, it casts spell 59913 (`SPELL_EFFECT_HEAL`), which has `BasePoints = 0` in DBC. The old code called `CastSpell` directly without overriding the base points, so the heal was always 0.

The fix calculates `CountPctFromMaxHealth(aurEff->GetAmount())` and passes it as `SPELLVALUE_BASE_POINT0` via `CastCustomSpell`, matching TrinityCore's implementation.

## Issues Addressed:
- Swift Hand of Justice trinket heal proc doing no healing

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**
  - TrinityCore commit b7bf703737 by ariel-

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Equip Swift Hand of Justice (item 42991) on a character
2. Attack and kill mobs that grant XP
3. Observe that the trinket proc now heals for 2% of max health instead of 0

## Known Issues and TODO List:

- [ ] None