### PR TITLE
fix(Core/Spells): Restrict Beacon of Light proc to intended heals

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1772207125325046.sql
+++ b/data/sql/updates/pending_db_world/rev_1772207125325046.sql
@@ -1,9 +1,10 @@
--- Beacon of Light (53651): restrict proc to Holy Light, Flash of Light, Holy Shock
+-- Beacon of Light (53651): restrict proc to Holy Light, Flash of Light, Holy Shock, Lay on Hands
 -- Previously had no SpellFamily filter, allowing unintended heals to transfer:
--- Glyph of Holy Light (54968), Lay on Hands (633), Seal of Light (20167), JoL (20267)
+-- Glyph of Holy Light (54968), Seal of Light (20167), JoL (20267)
 -- SpellFamilyName=10 (PALADIN) blocks Glyph of Holy Light (GENERIC family)
--- SpellFamilyMask 0xC0000000/0x00010000 allows only:
---   Holy Light (635)      Flags[0]=0x80000000
---   Flash of Light (19750) Flags[0]=0x40000000
+-- SpellFamilyMask 0xC0008000/0x00010000 allows only:
+--   Holy Light (635)        Flags[0]=0x80000000
+--   Flash of Light (19750)  Flags[0]=0x40000000
+--   Lay on Hands (633)      Flags[0]=0x00008000
 --   Holy Shock heal (25914) Flags[1]=0x00010000
-UPDATE `spell_proc` SET `SpellFamilyName` = 10, `SpellFamilyMask0` = 0xC0000000, `SpellFamilyMask1` = 0x00010000 WHERE `SpellId` = 53651;
+UPDATE `spell_proc` SET `SpellFamilyName` = 10, `SpellFamilyMask0` = 0xC0008000, `SpellFamilyMask1` = 0x00010000 WHERE `SpellId` = 53651;

--- a/data/sql/updates/pending_db_world/rev_1772207125325046.sql
+++ b/data/sql/updates/pending_db_world/rev_1772207125325046.sql
@@ -1,0 +1,9 @@
+-- Beacon of Light (53651): restrict proc to Holy Light, Flash of Light, Holy Shock
+-- Previously had no SpellFamily filter, allowing unintended heals to transfer:
+-- Glyph of Holy Light (54968), Lay on Hands (633), Seal of Light (20167), JoL (20267)
+-- SpellFamilyName=10 (PALADIN) blocks Glyph of Holy Light (GENERIC family)
+-- SpellFamilyMask 0xC0000000/0x00010000 allows only:
+--   Holy Light (635)      Flags[0]=0x80000000
+--   Flash of Light (19750) Flags[0]=0x40000000
+--   Holy Shock heal (25914) Flags[1]=0x00010000
+UPDATE `spell_proc` SET `SpellFamilyName` = 10, `SpellFamilyMask0` = 0xC0000000, `SpellFamilyMask1` = 0x00010000 WHERE `SpellId` = 53651;

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -2088,18 +2088,12 @@ class spell_pal_light_s_beacon : public AuraScript
             SPELL_PALADIN_BEACON_OF_LIGHT_AURA,
             SPELL_PALADIN_BEACON_OF_LIGHT_FLASH,
             SPELL_PALADIN_BEACON_OF_LIGHT_HOLY,
-            SPELL_PALADIN_HOLY_LIGHT_R1,
-            SPELL_PALADIN_JUDGEMENT_OF_LIGHT_HEAL
+            SPELL_PALADIN_HOLY_LIGHT_R1
         });
     }
 
     bool CheckProc(ProcEventInfo& eventInfo)
     {
-        // Don't proc from Judgement of Light heals — JoL sets originalCaster to
-        // the paladin for combat log, but the heal is actually cast by the attacker.
-        if (eventInfo.GetSpellInfo() && eventInfo.GetSpellInfo()->Id == SPELL_PALADIN_JUDGEMENT_OF_LIGHT_HEAL)
-            return false;
-
         // Don't proc if the heal target is the beacon target (no double heal)
         if (GetTarget()->HasAura(SPELL_PALADIN_BEACON_OF_LIGHT_AURA, eventInfo.GetActor()->GetGUID()))
             return false;


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

Adds SpellFamilyName and SpellFamilyMask filtering to the `spell_proc` entry for Light's Beacon (53651) so only the intended healing spells can trigger beacon heal transfer:
- **Holy Light** (SpellFamilyFlags[0] = 0x80000000)
- **Flash of Light** (SpellFamilyFlags[0] = 0x40000000)
- **Lay on Hands** (SpellFamilyFlags[0] = 0x00008000)
- **Holy Shock heal** (SpellFamilyFlags[1] = 0x00010000)

This fixes a regression where the following heals could incorrectly proc beacon:
- **Glyph of Holy Light** (54968) — blocked by SpellFamilyName=10 (PALADIN) since the glyph is GENERIC family
- **Seal of Light** (20167) — blocked by SpellFamilyMask (flags 0x40000 not in mask)
- **Judgement of Light** (20267) — blocked by SpellFamilyMask (flags[1] 0x1 not in mask)

The explicit JoL spell ID check in CheckProc is removed since the mask now handles all exclusions.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - **Claude Code** with **azerothMCP** — used for DBC spell family flag lookups and database queries to verify the mask approach.

## SOURCE:

The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Reference: The old (pre-proc-migration) implementation in `Unit::HandleDummyAuraProc` explicitly blocked Glyph of Holy Light (54968) and Judgement of Light (20267) by spell ID. The new spell_proc system's SpellFamilyMask approach is a more robust equivalent that also correctly excludes Seal of Light.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Cast Beacon of Light on Target A
2. Cast Holy Light on Target B → Target A should receive beacon heal (100%)
3. Cast Flash of Light on Target B → Target A should receive beacon heal (50%)
4. Cast Holy Shock on Target B → Target A should receive beacon heal
5. Cast Lay on Hands on Target B → Target A should receive beacon heal
6. With Glyph of Holy Light, cast Holy Light near Target A → Glyph AoE heal should NOT trigger beacon
7. Proc Seal of Light → should NOT trigger beacon
8. Proc Judgement of Light → should NOT trigger beacon

## Known Issues and TODO List:

- [ ] N/A