### PR TITLE
fix(Core/Spells): Fix item use macro breaking melee auto-attack

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7459,6 +7459,15 @@ void Player::CastItemUseSpell(Item* item, SpellCastTargets const& targets, uint8
 
         if (HasSpellCooldown(spellInfo->Id))
         {
+            // Client-side bug: silently skipping here orphans a pending spell cast that
+            // permanently blocks melee auto-attack. The client's SMSG_CAST_FAILED handler
+            // won't clean it up (broken lookup), so send a no-op SMSG_SPELL_GO instead.
+            if (cast_count
+                && (spellInfo->InterruptFlags
+                    & SPELL_INTERRUPT_FLAG_INTERRUPT))
+                Spell::SendEmptySpellGo(item->GetGUID(),
+                    GetGUID(), cast_count,
+                    spellInfo->Id, this);
             continue;
         }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7459,15 +7459,10 @@ void Player::CastItemUseSpell(Item* item, SpellCastTargets const& targets, uint8
 
         if (HasSpellCooldown(spellInfo->Id))
         {
-            // Client-side bug: silently skipping here orphans a pending spell cast that
-            // permanently blocks melee auto-attack. The client's SMSG_CAST_FAILED handler
-            // won't clean it up (broken lookup), so send a no-op SMSG_SPELL_GO instead.
-            if (cast_count
-                && (spellInfo->InterruptFlags
-                    & SPELL_INTERRUPT_FLAG_INTERRUPT))
-                Spell::SendEmptySpellGo(item->GetGUID(),
-                    GetGUID(), cast_count,
-                    spellInfo->Id, this);
+            // Notify client so it can clean up the pending spell cast.
+            // Without this the client orphans the cast and blocks auto-attack.
+            Spell::SendCastResult(ToPlayer(), spellInfo, cast_count,
+                SPELL_FAILED_NOT_READY);
             continue;
         }
 
@@ -7514,7 +7509,11 @@ void Player::CastItemUseSpell(Item* item, SpellCastTargets const& targets, uint8
             }
 
             if (HasSpellCooldown(spellInfo->Id))
+            {
+                Spell::SendCastResult(ToPlayer(), spellInfo, cast_count,
+                    SPELL_FAILED_NOT_READY);
                 continue;
+            }
 
             Spell* spell = new Spell(this, spellInfo, (count > 0) ? TRIGGERED_FULL_MASK : TRIGGERED_NONE);
             spell->m_CastItem = item;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4879,6 +4879,21 @@ void Spell::SendSpellGo()
     m_caster->SendMessageToSet(&data, true);
 }
 
+void Spell::SendEmptySpellGo(ObjectGuid castItemGuid, ObjectGuid casterGuid, uint8 castCount, uint32 spellId, Player* target)
+{
+    WorldPacket data(SMSG_SPELL_GO, 50);
+    data << castItemGuid.WriteAsPacked();
+    data << casterGuid.WriteAsPacked();
+    data << uint8(castCount);
+    data << uint32(spellId);
+    data << uint32(CAST_FLAG_UNKNOWN_9);
+    data << uint32(GameTime::GetGameTimeMS().count());
+    data << uint8(0);  // hit count
+    data << uint8(0);  // miss count
+    data << uint32(0); // target flags
+    target->SendDirectMessage(&data);
+}
+
 void Spell::WriteAmmoToPacket(WorldPacket* data)
 {
     uint32 ammoInventoryType = 0;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4879,21 +4879,6 @@ void Spell::SendSpellGo()
     m_caster->SendMessageToSet(&data, true);
 }
 
-void Spell::SendEmptySpellGo(ObjectGuid castItemGuid, ObjectGuid casterGuid, uint8 castCount, uint32 spellId, Player* target)
-{
-    WorldPacket data(SMSG_SPELL_GO, 50);
-    data << castItemGuid.WriteAsPacked();
-    data << casterGuid.WriteAsPacked();
-    data << uint8(castCount);
-    data << uint32(spellId);
-    data << uint32(CAST_FLAG_UNKNOWN_9);
-    data << uint32(GameTime::GetGameTimeMS().count());
-    data << uint8(0);  // hit count
-    data << uint8(0);  // miss count
-    data << uint32(0); // target flags
-    target->SendDirectMessage(&data);
-}
-
 void Spell::WriteAmmoToPacket(WorldPacket* data)
 {
     uint32 ammoInventoryType = 0;

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -509,7 +509,7 @@ public:
     void SendPetCastResult(SpellCastResult result);
     void SendSpellStart();
     void SendSpellGo();
-    static void SendEmptySpellGo(ObjectGuid castItemGuid, ObjectGuid casterGuid, uint8 castCount, uint32 spellId, Player* target);
+
     void SendSpellCooldown();
     void SendLogExecute();
     void ExecuteLogEffectTakeTargetPower(uint8 effIndex, Unit* target, uint32 PowerType, uint32 powerTaken, float gainMultiplier);

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -509,6 +509,7 @@ public:
     void SendPetCastResult(SpellCastResult result);
     void SendSpellStart();
     void SendSpellGo();
+    static void SendEmptySpellGo(ObjectGuid castItemGuid, ObjectGuid casterGuid, uint8 castCount, uint32 spellId, Player* target);
     void SendSpellCooldown();
     void SendLogExecute();
     void ExecuteLogEffectTakeTargetPower(uint8 effIndex, Unit* target, uint32 PowerType, uint32 powerTaken, float gainMultiplier);


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude was used for Ghidra reverse engineering analysis of the WoW 3.3.5a client to understand the root cause.

## Description

When a player uses an item spell (e.g. healing potion) via macro while the spell is on cooldown, `CastItemUseSpell` silently skips the cast without notifying the client. The client never receives `SMSG_CAST_FAILED`, so it orphans the pending spell cast state, which permanently blocks melee auto-attack until the player manually casts another spell.

### Root Cause

AzerothCore's `CastItemUseSpell` has a `HasSpellCooldown` optimization that `continue`s without sending any packet to the client. TrinityCore doesn't have this optimization — the spell always goes through `prepare()` → `CheckCast()` → `SendCastResult()`, which naturally sends `SMSG_CAST_FAILED` and allows the client to clean up its pending cast state.

### Fix

Send `SMSG_CAST_FAILED` with `SPELL_FAILED_NOT_READY` when skipping cooldown-blocked item spells

## SOURCE:

The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). Original TrinityCore behavior by QAston credited via Co-Authored-By.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

1. Equip a melee weapon and engage a target dummy with auto-attack
2. Create a macro: `/use Super Healing Potion`
3. Spam the macro twice quickly (second use hits cooldown)
4. Verify melee auto-attack continues swinging without interruption

## Known Issues and TODO List:

- None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.