### PR TITLE
fix(Core/Spells): Fix Explosive Trap crit bonus multiplier

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -652,6 +652,19 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AttributesEx3 |= SPELL_ATTR3_ALWAYS_HIT;
     });
 
+    // Explosive Trap Effect
+    ApplySpellFix({
+        13812, // Explosive Trap Effect (Rank 1)
+        14314, // Explosive Trap Effect (Rank 2)
+        14315, // Explosive Trap Effect (Rank 3)
+        27026, // Explosive Trap Effect (Rank 4)
+        49064, // Explosive Trap Effect (Rank 5)
+        49065  // Explosive Trap Effect (Rank 6)
+        }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+    });
+
     // Kill Command
     // Kill Command, Overpower
     ApplySpellFix({ 34027, 37529 }, [](SpellInfo* spellInfo)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Explosive Trap Effect (all 6 ranks) has `DmgClass = SPELL_DAMAGE_CLASS_RANGED` in the DBC. In `Unit::SpellCriticalDamageBonus()`, RANGED damage class receives a 100% crit bonus (2x damage), but as a Fire spell it should receive the standard 50% spell crit bonus (1.5x damage).

The fix adds a SpellInfoCorrections entry to change DmgClass to `SPELL_DAMAGE_CLASS_MAGIC` for all ranks of Explosive Trap Effect (13812, 14314, 14315, 27026, 49064, 49065).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Tools used:** Claude Code with azerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9093

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Blizzard developer Aggrend confirmed the 50% crit bonus was the original Wrath behavior: https://github.com/ClassicWoWCommunity/mop-classic-bugs/issues/474

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Log in as a Hunter with Explosive Trap
2. Cast Explosive Trap on a target, note crit
3. Verify crit damage is ~1.5x non-crit (50% bonus), not ~2x (100% bonus)

## Known Issues and TODO List:

- [ ] Verify no regression on other hunter trap spells (Immolation Trap, etc.)