### PR TITLE
fix(Core/Spells): Fix Frozen Power talent using wrong effect for proc chance

### DIFF
--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -1384,7 +1384,7 @@ class spell_sha_frozen_power : public AuraScript
         if (GetTarget()->GetDistance(target) < 15.0f)
             return false;
 
-        return roll_chance_i(GetEffect(EFFECT_0)->GetAmount());
+        return roll_chance_i(GetEffect(EFFECT_1)->GetAmount());
     }
 
     void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

The `spell_sha_frozen_power::CheckProc` was reading `GetEffect(EFFECT_0)->GetAmount()` which returns the damage modifier (5 for rank 1, 10 for rank 2) instead of `GetEffect(EFFECT_1)->GetAmount()` which holds the actual proc chance (50% for rank 1, 100% for rank 2).

This caused the freeze/root (spell 63685) to trigger only ~10% of the time at rank 2 instead of the intended 100%.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code (claude-opus-4-6) with azerothMCP for DBC spell data lookup and database queries.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9098

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

https://www.wowhead.com/wotlk/spell=63374/frozen-power — Rank 2 states 100% chance to freeze targets beyond 15 yards.

DBC data confirms:
- Effect 0 (SPELL_AURA_ADD_FLAT_MODIFIER): BasePoints 4/9 → amounts 5/10 (damage bonus)
- Effect 1 (SPELL_AURA_DUMMY): BasePoints 49/99 → amounts 50/100 (proc chance)

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a Shaman and grant talents (`.mod talents 50`), spec into Frozen Power 2/2
2. Stand **> 15 yards** from a duel partner or mob, cast Frost Shock — target should be rooted (spell 63685) **100% of the time**
3. Test with rank 1 (1/2) — should root ~50% of the time at > 15 yards
4. Stand **< 15 yards** and cast Frost Shock — should **never** root (only slow)

## Known Issues and TODO List:

- [ ] N/A

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.