### PR TITLE
fix(Core/Scripts): Fix Judgement and Judgements of the Just seal interactions

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -96,12 +96,15 @@ enum PaladinSpells
     SPELL_PALADIN_HOLY_VENGEANCE                 = 31803,
     SPELL_PALADIN_BLOOD_CORRUPTION               = 53742,
     SPELL_PALADIN_SEAL_OF_VENGEANCE_EFFECT       = 42463,
-    SPELL_PALADIN_SEAL_OF_CORRUPTION_EFFECT      = 53739
+    SPELL_PALADIN_SEAL_OF_CORRUPTION_EFFECT      = 53739,
+
+    SPELL_PALADIN_SEAL_OF_COMMAND                = 20375
 };
 
 enum PaladinSpellIcons
 {
     PALADIN_ICON_ID_RETRIBUTION_AURA             = 555,
+    PALADIN_ICON_JUDGEMENTS_OF_THE_JUST          = 3015,
     PALADIN_ICON_JUDGEMENTS_OF_THE_WISE          = 3017,
     PALADIN_ICON_HAMMER_OF_THE_RIGHTEOUS         = 3023,
     PALADIN_ICON_RIGHTEOUS_VENGEANCE             = 3025,
@@ -147,6 +150,20 @@ enum PaladinProcSpells
     SPELL_PALADIN_SACRED_SHIELD_TRIGGER          = 58597,
     SPELL_PALADIN_T8_HOLY_4P_BONUS               = 64895
 };
+
+static bool IsJudgementDamageSpell(SpellInfo const* spellInfo)
+{
+    return spellInfo &&
+        spellInfo->SpellFamilyName == SPELLFAMILY_PALADIN &&
+        (spellInfo->SpellFamilyFlags[0] & 0x800000);
+}
+
+static bool HasJudgementsOfTheJust(Unit const* caster)
+{
+    return caster && caster->GetAuraEffect(
+        SPELL_AURA_ADD_FLAT_MODIFIER, SPELLFAMILY_PALADIN,
+        PALADIN_ICON_JUDGEMENTS_OF_THE_JUST, 0) != nullptr;
+}
 
 class spell_pal_seal_of_command_aura : public AuraScript
 {
@@ -959,27 +976,26 @@ public:
             GetCaster()->CastSpell(GetCaster(), SPELL_IMPROVED_JUDGEMENT_ENERGIZE, true);
         }
 
-        // Judgement of the Just
-        if (GetCaster()->GetAuraEffect(SPELL_AURA_ADD_FLAT_MODIFIER, SPELLFAMILY_PALADIN, 3015, 0))
+        // Judgements of the Just
+        if (HasJudgementsOfTheJust(GetCaster()))
         {
-            if (GetCaster()->CastSpell(GetHitUnit(), SPELL_JUDGEMENTS_OF_THE_JUST, true) && (spellId2 == SPELL_JUDGEMENT_OF_VENGEANCE_EFFECT || spellId2 == SPELL_JUDGEMENT_OF_CORRUPTION_EFFECT))
-            {
-                //hidden effect only cast when spellcast of judgements of the just is succesful
-                GetCaster()->CastSpell(GetHitUnit(), SealApplication(spellId2), true); //add hidden seal apply effect for vengeance and corruption
-            }
-        }
-    }
+            GetCaster()->CastSpell(GetHitUnit(), SPELL_JUDGEMENTS_OF_THE_JUST, true);
 
-    uint32 SealApplication(uint32 correspondingSpellId)
-    {
-        switch (correspondingSpellId)
-        {
-            case SPELL_JUDGEMENT_OF_VENGEANCE_EFFECT:
-                return SPELL_HOLY_VENGEANCE;
-            case SPELL_JUDGEMENT_OF_CORRUPTION_EFFECT:
-                return SPELL_BLOOD_CORRUPTION;
-            default:
-                return 0;
+            // JotJ makes Judgements trigger Seal of Command's
+            // cleave effect
+            if (AuraEffect const* socEff =
+                GetCaster()->GetAuraEffect(
+                    SPELL_PALADIN_SEAL_OF_COMMAND, EFFECT_0))
+            {
+                if (GetHitUnit()->IsAlive())
+                {
+                    GetCaster()->CastCustomSpell(
+                        socEff->GetSpellInfo()->Effects[EFFECT_0]
+                            .TriggerSpell,
+                        SPELLVALUE_MAX_TARGETS, 3,
+                        GetHitUnit(), true, nullptr, socEff);
+                }
+            }
         }
     }
 
@@ -1164,11 +1180,15 @@ class spell_pal_seal_of_righteousness : public AuraScript
         DamageInfo* damageInfo = eventInfo.GetDamageInfo();
 
         if (!damageInfo || !damageInfo->GetDamage())
-        {
             return false;
-        }
 
-        return target->IsAlive() && !eventInfo.GetTriggerAuraSpell() && (damageInfo->GetDamage() || (eventInfo.GetHitMask() & PROC_EX_ABSORB));
+        if (IsJudgementDamageSpell(eventInfo.GetSpellInfo()))
+            return target->IsAlive() &&
+                HasJudgementsOfTheJust(eventInfo.GetActor());
+
+        return target->IsAlive() && !eventInfo.GetTriggerAuraSpell() &&
+            (damageInfo->GetDamage() ||
+            (eventInfo.GetHitMask() & PROC_EX_ABSORB));
     }
 
     void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
@@ -1187,6 +1207,16 @@ class spell_pal_seal_of_righteousness : public AuraScript
 
         int32 bp = std::max<int32>(0, int32((ap * 0.022f + 0.044f * holy) * GetTarget()->GetAttackTime(BASE_ATTACK) / 1000));
         GetTarget()->CastCustomSpell(SPELL_PALADIN_SEAL_OF_RIGHTEOUSNESS, SPELLVALUE_BASE_POINT0, bp, eventInfo.GetProcTarget(), true, nullptr, aurEff);
+
+        // Judgements of the Just: Seal of Righteousness procs
+        // twice from Judgements
+        if (IsJudgementDamageSpell(eventInfo.GetSpellInfo()))
+        {
+            GetTarget()->CastCustomSpell(
+                SPELL_PALADIN_SEAL_OF_RIGHTEOUSNESS,
+                SPELLVALUE_BASE_POINT0, bp,
+                eventInfo.GetProcTarget(), true, nullptr, aurEff);
+        }
     }
 
     void Register() override
@@ -1884,6 +1914,25 @@ class spell_pal_seal_of_vengeance_aura : public AuraScript
         return true;
     }
 
+    bool CheckProc(ProcEventInfo& eventInfo)
+    {
+        SpellInfo const* procSpell = eventInfo.GetSpellInfo();
+        if (procSpell &&
+            procSpell->SpellFamilyName == SPELLFAMILY_PALADIN)
+        {
+            // Block re-proc from seal damage effects
+            if ((procSpell->SpellFamilyFlags[1] & 0x800) &&
+                !(procSpell->SpellFamilyFlags[0] & 0x800000))
+                return false;
+
+            // Judgements only trigger seal procs with JotJ
+            if (procSpell->SpellFamilyFlags[0] & 0x800000)
+                return HasJudgementsOfTheJust(eventInfo.GetActor());
+        }
+
+        return true;
+    }
+
     void HandleApplyDoT(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
     {
         PreventDefaultAction();
@@ -1925,6 +1974,7 @@ class spell_pal_seal_of_vengeance_aura : public AuraScript
 
     void Register() override
     {
+        DoCheckProc += AuraCheckProcFn(spell_pal_seal_of_vengeance_aura::CheckProc);
         OnEffectProc += AuraEffectProcFn(spell_pal_seal_of_vengeance_aura::HandleApplyDoT, EFFECT_0, SPELL_AURA_DUMMY);
         OnEffectProc += AuraEffectProcFn(spell_pal_seal_of_vengeance_aura::HandleSeal, EFFECT_0, SPELL_AURA_DUMMY);
     }

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -1183,8 +1183,7 @@ class spell_pal_seal_of_righteousness : public AuraScript
             return false;
 
         if (IsJudgementDamageSpell(eventInfo.GetSpellInfo()))
-            return target->IsAlive() &&
-                HasJudgementsOfTheJust(eventInfo.GetActor());
+            return target->IsAlive();
 
         return target->IsAlive() && !eventInfo.GetTriggerAuraSpell() &&
             (damageInfo->GetDamage() ||
@@ -1210,7 +1209,8 @@ class spell_pal_seal_of_righteousness : public AuraScript
 
         // Judgements of the Just: Seal of Righteousness procs
         // twice from Judgements
-        if (IsJudgementDamageSpell(eventInfo.GetSpellInfo()))
+        if (IsJudgementDamageSpell(eventInfo.GetSpellInfo()) &&
+            HasJudgementsOfTheJust(GetTarget()))
         {
             GetTarget()->CastCustomSpell(
                 SPELL_PALADIN_SEAL_OF_RIGHTEOUSNESS,


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Tools used:** Claude Code with azerothMCP

## Issues Addressed:
- Closes #24949

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

DBC spell data analysis confirmed:
- Judgement damage spells (54158, 31804, 53733, 20187) are DmgClass=MELEE, SchoolMask=Holy, SpellFamilyFlags[0] & 0x800000
- SoC spell_proc has SchoolMask=1 (Physical only), which blocks Holy Judgement damage from proccing through the proc system
- Seal damage effects (42463/53739) have SpellFamilyFlags[1] & 0x800, used to identify and block re-procs
- JotJ talent (53695/53696) has SpellFamilyFlags=[0,0,0] requiring icon-based detection (icon 3015)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

All tests use a level 80 Paladin (Blood Elf for Seal of Corruption variant). Use `.damage 0` on test mobs so they don't die.

**Test 1 - SoV/SoC without JotJ (Bug #1 fix):**
1. Spec without Judgements of the Just talent
2. Apply Seal of Vengeance (`.cast 31801`) or Seal of Corruption (`.cast 53736`)
3. Auto-attack a target - should add DoT stacks and deal seal damage (working as before)
4. Cast Judgement - should NOT trigger additional seal damage or add DoT stacks

**Test 2 - SoV/SoC with JotJ (Bug #3 fix):**
1. Spec with Judgements of the Just talent
2. Apply Seal of Vengeance/Corruption, build 5 stacks on target via auto-attack
3. Cast Judgement - should trigger seal damage once but NOT add a DoT stack

**Test 3 - SoC cleave with JotJ (Bug #2 fix):**
1. Spec with Judgements of the Just talent
2. Apply Seal of Command (`.cast 20375`)
3. Pull 3+ mobs close together
4. Cast Judgement on one mob - should cleave to 2 additional nearby targets

**Test 4 - SoR double proc with JotJ (Bug #4 fix):**
1. Spec with Judgements of the Just talent
2. Equip a 1H weapon + shield
3. Apply Seal of Righteousness (`.cast 21084`)
4. Cast Judgement - should proc SoR damage twice (visible in combat log)

**Test 5 - SoR single proc without JotJ:**
1. Spec without Judgements of the Just talent
2. Equip a 1H weapon + shield
3. Apply Seal of Righteousness, auto-attack to confirm normal procs
4. Cast Judgement - should proc SoR damage once (Judgement always triggers SoR, JotJ adds a second proc)

## Known Issues and TODO List:

- [x] Hammer of the Righteous interaction with JotJ seal procs has not been tested

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.