### PR TITLE
fix(DB/Spells): Fix Seal of Light and Flame Cap proc rates

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1772383094683558026.sql
+++ b/data/sql/updates/pending_db_world/rev_1772383094683558026.sql
@@ -1,0 +1,7 @@
+-- Seal of Light (20165): Fix PPM 20 -> 10
+UPDATE `spell_proc` SET `ProcsPerMinute` = 10 WHERE `SpellId` = 20165;
+
+-- Flame Cap (28714): Add 6 PPM (was 100% with no spell_proc entry)
+DELETE FROM `spell_proc` WHERE `SpellId` = 28714;
+INSERT INTO `spell_proc` (`SpellId`, `ProcsPerMinute`, `SpellTypeMask`, `SpellPhaseMask`)
+VALUES (28714, 6, 1, 2);

--- a/data/sql/updates/pending_db_world/rev_1772383094683558026.sql
+++ b/data/sql/updates/pending_db_world/rev_1772383094683558026.sql
@@ -3,5 +3,4 @@ UPDATE `spell_proc` SET `ProcsPerMinute` = 10 WHERE `SpellId` = 20165;
 
 -- Flame Cap (28714): Add 6 PPM (was 100% with no spell_proc entry)
 DELETE FROM `spell_proc` WHERE `SpellId` = 28714;
-INSERT INTO `spell_proc` (`SpellId`, `ProcsPerMinute`, `SpellTypeMask`, `SpellPhaseMask`)
-VALUES (28714, 6, 1, 2);
+INSERT INTO `spell_proc` (`SpellId`, `ProcsPerMinute`, `SpellTypeMask`, `SpellPhaseMask`) VALUES (28714, 6, 1, 2);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

- Seal of Light (20165): PPM restored from 20 to 10 (was doubled during spell_proc migration).
- Flame Cap (28714): Added spell_proc entry with 6 PPM (DBC ProcChance=101 caused 100% proc rate).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code** with **azerothMCP** was used.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply Seal of Light, auto attack with various weapon speeds — should proc roughly 10 times per minute.
2. Use Flame Cap, auto attack — fireball should proc ~6 times per minute, not every hit.

## Known Issues and TODO List:

- [ ] Judgement of Light/Wisdom proc rates may also need investigation (separate fix).

How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.