### PR TITLE
fix(Core/Skills): Remove profession passive auras on skill removal

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5366,7 +5366,10 @@ void Player::SetSkill(uint16 id, uint16 step, uint16 newVal, uint16 maxVal)
 
             // remove all spells that related to this skill
             for (SkillLineAbilityEntry const* pAbility : GetSkillLineAbilitiesBySkillLine(id))
+            {
                 removeSpell(sSpellMgr->GetFirstSpellInChain(pAbility->Spell), SPEC_MASK_ALL, false);
+                RemoveAurasDueToSpell(pAbility->Spell);
+            }
         }
     }
     else if (newVal)                                        //add


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9099

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Learn Skinning + Leatherworking and max both:
```
.learn 8613
.learn 8617
.learn 8618
.learn 10768
.learn 32678
.learn 50305
.setskill 393 450 450
.learn 2108
.learn 3104
.learn 3811
.learn 10662
.learn 32549
.learn 51302
.setskill 165 450 450
```
2. Verify Master of Anatomy R6 is in buffs
3. Unlearn Leatherworking from Spellbook (K) → Professions tab → unlearn icon
4. Learn Herbalism:
```
.learn 2366
.learn 2368
.learn 3570
.learn 11993
.learn 28695
.learn 50300
.setskill 182 450 450
```
5. Unlearn Skinning from Spellbook → Professions tab → unlearn icon
6. Learn Alchemy:
```
.learn 2259
.learn 3101
.learn 3464
.learn 11611
.learn 28596
.learn 51304
.setskill 171 450 450
```
7. Verify Master of Anatomy is **gone** from buffs

## Known Issues and TODO List:

- [ ] Test with Mining/Toughness and Herbalism/Lifeblood