### PR TITLE
fix(Core/Scripts): Fix Missile Barrage and Clearcasting proc with Arcane Missiles

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1772406444785733446.sql
+++ b/data/sql/updates/pending_db_world/rev_1772406444785733446.sql
@@ -1,0 +1,9 @@
+-- Fix Missile Barrage / Clearcasting proc interaction with Arcane Missiles
+-- 1) PROC_ATTR_REQ_SPELLMOD was incorrectly blocking Missile Barrage from
+--    proccing because the channel spell (42846) is not in m_appliedMods.
+--    Restrict via SpellFamilyMask to Arcane Missiles (0x800) instead.
+-- 2) Register Clearcasting script to give Missile Barrage priority
+UPDATE `spell_proc` SET `AttributesMask` = 0, `SpellFamilyMask0` = 0x800 WHERE `SpellId` = 44401;
+
+DELETE FROM `spell_script_names` WHERE `spell_id` = 12536 AND `ScriptName` = 'spell_mage_clearcasting';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (12536, 'spell_mage_clearcasting');

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -10027,9 +10027,10 @@ bool Player::HasSpellModApplied(SpellModifier* mod, Spell* spell)
 
 void Player::SetSpellModTakingSpell(Spell* spell, bool apply)
 {
-    if (apply && m_spellModTakingSpell && m_spellModTakingSpell != spell)
+    if (apply && m_spellModTakingSpell != nullptr)
         return;
-    else if (!apply && m_spellModTakingSpell != spell)
+
+    if (!apply && (!m_spellModTakingSpell || m_spellModTakingSpell != spell))
         return;
 
     m_spellModTakingSpell = apply ? spell : nullptr;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3911,9 +3911,6 @@ void Spell::_cast(bool skipCheck)
     // we must send smsg_spell_go packet before m_castItem delete in TakeCastItem()...
     SendSpellGo();
 
-    if (modOwner)
-        modOwner->SetSpellModTakingSpell(this, true);
-
     bool resetAttackTimers = IsAutoActionResetSpell() && !m_spellInfo->HasAttribute(SPELL_ATTR2_DO_NOT_RESET_COMBAT_TIMERS);
     if (resetAttackTimers)
     {

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -71,7 +71,8 @@ enum MageSpells
     SPELL_MAGE_CHILLED_R3                        = 12486,
     SPELL_MAGE_MANA_SURGE                        = 37445,
     SPELL_MAGE_FROST_NOVA                        = 122,
-    SPELL_MAGE_LIVING_BOMB_R1                    = 44457
+    SPELL_MAGE_LIVING_BOMB_R1                    = 44457,
+    SPELL_MAGE_MISSILE_BARRAGE_PROC              = 44401
 };
 
 enum MageSpellIcons
@@ -1504,6 +1505,31 @@ class spell_mage_ice_block : public SpellScript
     }
 };
 
+// 12536 - Clearcasting
+class spell_mage_clearcasting : public AuraScript
+{
+    PrepareAuraScript(spell_mage_clearcasting);
+
+    bool CheckProc(ProcEventInfo& eventInfo)
+    {
+        SpellInfo const* spellInfo = eventInfo.GetSpellInfo();
+        if (!spellInfo)
+            return true;
+
+        // Missile Barrage has priority over Clearcasting for Arcane Missiles
+        if (spellInfo->SpellFamilyName == SPELLFAMILY_MAGE && (spellInfo->SpellFamilyFlags[0] & 0x800))
+            if (GetTarget()->HasAura(SPELL_MAGE_MISSILE_BARRAGE_PROC))
+                return false;
+
+        return true;
+    }
+
+    void Register() override
+    {
+        DoCheckProc += AuraCheckProcFn(spell_mage_clearcasting::CheckProc);
+    }
+};
+
 // 44401 - Missile Barrage (proc buff)
 class spell_mage_missile_barrage_proc : public AuraScript
 {
@@ -1575,6 +1601,7 @@ void AddSC_mage_spell_scripts()
     RegisterSpellScript(spell_mage_ice_block);
     RegisterSpellScript(spell_mage_imp_blizzard);
     RegisterSpellScript(spell_mage_imp_mana_gems);
+    RegisterSpellScript(spell_mage_clearcasting);
     RegisterSpellScript(spell_mage_missile_barrage);
     RegisterSpellScript(spell_mage_missile_barrage_proc);
     RegisterSpellScript(spell_mage_blast_wave);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

### Summary
- Fix Missile Barrage (44401) not being consumed when casting Arcane Missiles. The `PROC_ATTR_REQ_SPELLMOD` attribute in `spell_proc` was incorrectly rejecting the proc because the Arcane Missiles channel spell (42846) was not present in the aura's `m_appliedMods` set. Replaced with `SpellFamilyMask0 = 0x800` to target Arcane Missiles directly.
- Add `spell_mage_clearcasting` AuraScript to give Missile Barrage consumption priority over Clearcasting (12536) when casting Arcane Missiles. Without this, both buffs are consumed simultaneously due to proc iteration order (by spell ID).
- Align `SetSpellModTakingSpell` guards with TrinityCore (fb5c07ffe8) and remove redundant duplicate call in `Spell::_cast()`.

Fixed regression from https://github.com/azerothcore/azerothcore-wotlk/pull/24948

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.

- [x] AI tools were used in preparing this pull request: **Claude Code** with **azerothMCP**

## SOURCE:
The changes have been validated through:
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). SetSpellModTakingSpell aligned with TrinityCore commit fb5c07ffe8.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

1. Create a level 80 Mage with Arcane spec (Missile Barrage and Arcane Concentration talents)
2. Cast Arcane Blast on a target dummy until both Missile Barrage and Clearcasting buffs are active
3. Cast Arcane Missiles — verify Missile Barrage is consumed and Clearcasting is preserved
4. Cast another spell — verify Clearcasting is now consumed normally
5. Verify Arcane Blast does NOT consume Missile Barrage (only Arcane Missiles should)

## Known Issues and TODO List:

- [ ] The proc system iterates auras by spell ID which creates implicit priority ordering. A proper priority field in `spell_proc` would be a better long-term solution.