### PR TITLE
fix(Core/Spells): Fix iterator invalidation crash in deferred spell mod cleanup

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3992,7 +3992,9 @@ void Spell::_cast(bool skipCheck)
         handle_immediate();
 
         // Clean up deferred 0-charge spell modifier auras
-        for (Aura* aura : m_appliedMods)
+        // Copy to vector first — aura->Remove() can modify m_appliedMods
+        std::vector<Aura*> appliedModsCopy(m_appliedMods.begin(), m_appliedMods.end());
+        for (Aura* aura : appliedModsCopy)
         {
             if (!aura->IsRemoved() && aura->IsUsingCharges()
                 && !aura->GetCharges())


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Fix SIGSEGV crash in `Spell::_cast()` caused by iterator invalidation when iterating `m_appliedMods` (`std::set<Aura*>`) with a range-for loop while `aura->Remove()` modifies the set via `Player::RemoveSpellMods()` → `m_appliedMods.erase()`.

The fix copies the set to a `std::vector` before iterating, matching the pattern already used by the second cleanup loop directly below.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - **Claude Code** with **azerothMCP**

## Issues Addressed:
- Crash at `Spell.cpp:3999` (`aura->Remove()`) during map update thread, reported via debugger showing corrupted `__end2 = 0x3` iterator

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**
  - The second cleanup loop (lines 4004-4019) in the same function already uses a vector copy for safe iteration — this fix applies the same pattern to the first loop

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Use a character with multiple charge-based spell modifier auras active (e.g. Clearcasting, Missile Barrage, Hot Streak)
2. Cast spells that consume those modifiers while multiple are tracked in `m_appliedMods`
3. Verify no crash occurs and modifiers are consumed correctly

## Known Issues and TODO List:

- [ ] The underlying deferral mechanism in `ConsumeProcCharges` (AC-specific, not in TrinityCore) should be reviewed for correctness as a separate effort

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.