### PR TITLE
fix(Core/Spells): Fully absorbed periodic damage should not break stealth

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -6756,7 +6756,9 @@ void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, Unit* caster) const
     // Set trigger flag
     uint32 procAttacker = PROC_FLAG_DONE_PERIODIC;
     uint32 procVictim   = PROC_FLAG_TAKEN_PERIODIC;
-    uint32 procEx = (crit ? PROC_EX_CRITICAL_HIT : PROC_EX_NORMAL_HIT) | PROC_EX_INTERNAL_DOT;
+    uint32 procEx = PROC_EX_INTERNAL_DOT;
+    if (damage)
+        procEx |= crit ? PROC_EX_CRITICAL_HIT : PROC_EX_NORMAL_HIT;
     if (absorb > 0)
         procEx |= PROC_EX_ABSORB;
 
@@ -6770,6 +6772,7 @@ void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, Unit* caster) const
     SpellPeriodicAuraLogInfo pInfo(this, damage, overkill, absorb, resist, 0.0f, crit);
     target->SendPeriodicAuraLog(&pInfo);
 
+    cleanDamage.absorbed_damage = absorb;
     Unit::DealDamage(caster, target, damage, &cleanDamage, DOT, GetSpellInfo()->GetSchoolMask(), GetSpellInfo(), true);
 
     Unit::ProcSkillsAndAuras(caster, target, caster ? procAttacker : 0, procVictim, procEx, damage, BASE_ATTACK, GetSpellInfo(), nullptr, GetEffIndex(), nullptr, &dmgInfo);
@@ -6843,7 +6846,9 @@ void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) c
     // Set trigger flag
     uint32 procAttacker = PROC_FLAG_DONE_PERIODIC;
     uint32 procVictim   = PROC_FLAG_TAKEN_PERIODIC;
-    uint32 procEx = (crit ? PROC_EX_CRITICAL_HIT : PROC_EX_NORMAL_HIT) | PROC_EX_INTERNAL_DOT;
+    uint32 procEx = PROC_EX_INTERNAL_DOT;
+    if (dmgInfo.GetDamage())
+        procEx |= crit ? PROC_EX_CRITICAL_HIT : PROC_EX_NORMAL_HIT;
     if (absorb > 0)
         procEx |= PROC_EX_ABSORB;
 
@@ -6864,6 +6869,7 @@ void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) c
 
     int32 new_damage;
 
+    cleanDamage.absorbed_damage = absorb;
     new_damage = Unit::DealDamage(caster, target, damage, &cleanDamage, DOT, GetSpellInfo()->GetSchoolMask(), GetSpellInfo(), false);
 
     Unit::ProcSkillsAndAuras(caster, target, caster ? procAttacker : 0, procVictim, procEx, damage, BASE_ATTACK, GetSpellInfo(), nullptr, GetEffIndex(), nullptr, &dmgInfo);

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -6772,7 +6772,6 @@ void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, Unit* caster) const
     SpellPeriodicAuraLogInfo pInfo(this, damage, overkill, absorb, resist, 0.0f, crit);
     target->SendPeriodicAuraLog(&pInfo);
 
-    cleanDamage.absorbed_damage = absorb;
     Unit::DealDamage(caster, target, damage, &cleanDamage, DOT, GetSpellInfo()->GetSchoolMask(), GetSpellInfo(), true);
 
     Unit::ProcSkillsAndAuras(caster, target, caster ? procAttacker : 0, procVictim, procEx, damage, BASE_ATTACK, GetSpellInfo(), nullptr, GetEffIndex(), nullptr, &dmgInfo);
@@ -6869,7 +6868,6 @@ void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) c
 
     int32 new_damage;
 
-    cleanDamage.absorbed_damage = absorb;
     new_damage = Unit::DealDamage(caster, target, damage, &cleanDamage, DOT, GetSpellInfo()->GetSchoolMask(), GetSpellInfo(), false);
 
     Unit::ProcSkillsAndAuras(caster, target, caster ? procAttacker : 0, procVictim, procEx, damage, BASE_ATTACK, GetSpellInfo(), nullptr, GetEffIndex(), nullptr, &dmgInfo);

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3073,9 +3073,7 @@ SpellMissInfo Spell::DoSpellHitOnUnit(Unit* unit, uint32 effectMask, bool scaleA
     }
 
     if (m_caster != unit && m_caster->IsHostileTo(unit) && !m_spellInfo->IsPositive() && !m_triggeredByAuraSpell && !m_spellInfo->HasAttribute(SPELL_ATTR0_CU_DONT_BREAK_STEALTH))
-    {
         unit->RemoveAurasByType(SPELL_AURA_MOD_STEALTH);
-    }
 
     if (aura_effmask)
     {

--- a/src/test/server/game/Spells/PeriodicAbsorbStealthProcTest.cpp
+++ b/src/test/server/game/Spells/PeriodicAbsorbStealthProcTest.cpp
@@ -1,0 +1,156 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ProcEventInfoHelper.h"
+#include "SpellMgr.h"
+#include "WorldMock.h"
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+using namespace testing;
+
+/**
+ * @brief Tests for fully absorbed periodic damage not triggering TAKEN procs
+ *
+ * When periodic damage (e.g. Consecration ticks) is fully absorbed by an
+ * absorb shield (e.g. Power Word: Shield), the hit mask should only contain
+ * PROC_HIT_ABSORB (no PROC_HIT_NORMAL/CRITICAL). Since TAKEN procs default
+ * to requiring PROC_HIT_NORMAL | PROC_HIT_CRITICAL, fully absorbed ticks
+ * should not trigger victim procs like stealth charge consumption.
+ *
+ * This aligns with TrinityCore behavior where hitMask only gets NORMAL/CRITICAL
+ * added when damage > 0 in HandlePeriodicDamageAurasTick.
+ */
+class PeriodicAbsorbStealthProcTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        _originalWorld = sWorld.release();
+        _worldMock = new NiceMock<WorldMock>();
+        sWorld.reset(_worldMock);
+
+        static std::string emptyString;
+        ON_CALL(*_worldMock, GetDataPath()).WillByDefault(ReturnRef(emptyString));
+    }
+
+    void TearDown() override
+    {
+        IWorld* currentWorld = sWorld.release();
+        delete currentWorld;
+        _worldMock = nullptr;
+
+        sWorld.reset(_originalWorld);
+        _originalWorld = nullptr;
+    }
+
+    IWorld* _originalWorld = nullptr;
+    NiceMock<WorldMock>* _worldMock = nullptr;
+};
+
+// Stealth-like TAKEN periodic proc with default HitMask (0) should NOT
+// trigger when the only hit flag is PROC_HIT_ABSORB (fully absorbed tick)
+TEST_F(PeriodicAbsorbStealthProcTest, FullyAbsorbedPeriodicDoesNotTriggerTakenProc)
+{
+    // Stealth has ProcFlags including PROC_FLAG_TAKEN_PERIODIC, HitMask=0
+    // Default TAKEN HitMask = PROC_HIT_NORMAL | PROC_HIT_CRITICAL (no ABSORB)
+    auto procEntry = SpellProcEntryBuilder()
+        .WithProcFlags(PROC_FLAG_TAKEN_PERIODIC)
+        .WithHitMask(0)
+        .Build();
+
+    // Fully absorbed periodic tick: hitMask = PROC_HIT_ABSORB only
+    // (damage=0 so PROC_EX_NORMAL_HIT is NOT set)
+    auto eventInfo = ProcEventInfoBuilder()
+        .WithTypeMask(PROC_FLAG_TAKEN_PERIODIC)
+        .WithHitMask(PROC_HIT_ABSORB)
+        .Build();
+
+    EXPECT_FALSE(sSpellMgr->CanSpellTriggerProcOnEvent(procEntry, eventInfo));
+}
+
+// Non-absorbed periodic tick (damage > 0) SHOULD trigger TAKEN procs
+TEST_F(PeriodicAbsorbStealthProcTest, NonAbsorbedPeriodicTriggersTakenProc)
+{
+    auto procEntry = SpellProcEntryBuilder()
+        .WithProcFlags(PROC_FLAG_TAKEN_PERIODIC)
+        .WithHitMask(0)
+        .Build();
+
+    // Normal periodic tick: hitMask includes PROC_HIT_NORMAL
+    auto eventInfo = ProcEventInfoBuilder()
+        .WithTypeMask(PROC_FLAG_TAKEN_PERIODIC)
+        .WithHitMask(PROC_HIT_NORMAL)
+        .Build();
+
+    EXPECT_TRUE(sSpellMgr->CanSpellTriggerProcOnEvent(procEntry, eventInfo));
+}
+
+// Critical periodic tick SHOULD trigger TAKEN procs
+TEST_F(PeriodicAbsorbStealthProcTest, CriticalPeriodicTriggersTakenProc)
+{
+    auto procEntry = SpellProcEntryBuilder()
+        .WithProcFlags(PROC_FLAG_TAKEN_PERIODIC)
+        .WithHitMask(0)
+        .Build();
+
+    auto eventInfo = ProcEventInfoBuilder()
+        .WithTypeMask(PROC_FLAG_TAKEN_PERIODIC)
+        .WithHitMask(PROC_HIT_CRITICAL)
+        .Build();
+
+    EXPECT_TRUE(sSpellMgr->CanSpellTriggerProcOnEvent(procEntry, eventInfo));
+}
+
+// Partially absorbed periodic tick (damage > 0, some absorbed) SHOULD trigger
+// because PROC_HIT_NORMAL is set alongside PROC_HIT_ABSORB
+TEST_F(PeriodicAbsorbStealthProcTest, PartiallyAbsorbedPeriodicTriggersTakenProc)
+{
+    auto procEntry = SpellProcEntryBuilder()
+        .WithProcFlags(PROC_FLAG_TAKEN_PERIODIC)
+        .WithHitMask(0)
+        .Build();
+
+    // Partial absorb: both NORMAL and ABSORB flags set
+    auto eventInfo = ProcEventInfoBuilder()
+        .WithTypeMask(PROC_FLAG_TAKEN_PERIODIC)
+        .WithHitMask(PROC_HIT_NORMAL | PROC_HIT_ABSORB)
+        .Build();
+
+    EXPECT_TRUE(sSpellMgr->CanSpellTriggerProcOnEvent(procEntry, eventInfo));
+}
+
+// DONE procs (attacker side) SHOULD trigger on fully absorbed damage
+// because DONE default HitMask includes PROC_HIT_ABSORB
+TEST_F(PeriodicAbsorbStealthProcTest, FullyAbsorbedPeriodicTriggersDoneProc)
+{
+    auto procEntry = SpellProcEntryBuilder()
+        .WithProcFlags(PROC_FLAG_DONE_PERIODIC)
+        .WithSpellPhaseMask(PROC_SPELL_PHASE_HIT)
+        .WithHitMask(0)
+        .Build();
+
+    // Fully absorbed: only PROC_HIT_ABSORB
+    auto eventInfo = ProcEventInfoBuilder()
+        .WithTypeMask(PROC_FLAG_DONE_PERIODIC)
+        .WithSpellPhaseMask(PROC_SPELL_PHASE_HIT)
+        .WithHitMask(PROC_HIT_ABSORB)
+        .Build();
+
+    // DONE default includes ABSORB, so this SHOULD trigger
+    EXPECT_TRUE(sSpellMgr->CanSpellTriggerProcOnEvent(procEntry, eventInfo));
+}


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Fully absorbed periodic AoE ticks (Consecration, Blizzard, etc.) no longer break stealth. Initial application still breaks stealth as expected.

- **DealDamage**: Skip `AURA_INTERRUPT_FLAG_TAKE_DAMAGE` when damage is fully absorbed
- **HandlePeriodicDamageAurasTick/LeechTick**: Populate `CleanDamage.absorbed_damage` before `DealDamage`
- **GetProcEffectMask**: Skip stealth charge consumption on fully absorbed damage

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP was used.

## Issues Addressed:
- Stealthed players with absorb shields broken by fully absorbed periodic AoE ticks

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - https://youtu.be/ftPAhpLv0zs?si=d3W36wWacVmE1y7W&t=123
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Stealth a rogue with Power Word: Shield, walk into enemy Consecration
2. Stealth should break on initial hit but not on absorbed periodic ticks

## Known Issues and TODO List:

- [ ]
- [ ]