### PR TITLE
fix(Core/Scripts): Fix Seal of Command cleave for Crusader Strike and ShoR

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -190,10 +190,16 @@ class spell_pal_seal_of_command_aura : public AuraScript
     void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
     {
         PreventDefaultAction();
-        // Only auto-attacks (no spell info) should trigger SoC's cleave.
-        // Spells like HotR/ShoR should proc SoC but not cleave.
+        // All melee procs should cleave except Hammer of the Righteous.
         // Judgement cleave is handled separately via JotJ code path.
-        int32 targets = eventInfo.GetSpellInfo() ? 1 : 3;
+        int32 targets = 3;
+        if (SpellInfo const* procSpell = eventInfo.GetSpellInfo())
+        {
+            // HotR: flag1 0x40000, DS: flag1 0x20000
+            if (procSpell->SpellFamilyName == SPELLFAMILY_PALADIN &&
+                (procSpell->SpellFamilyFlags[1] & 0x60000))
+                targets = 1;
+        }
 
         Unit* target = eventInfo.GetActionTarget();
         if (target->IsAlive())


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Fixes a regression from PR #24986 where Crusader Strike and Shield of the Righteous no longer cleave when proccing Seal of Command.

The previous fix used a blanket check that blocked all spells from cleaving. This PR reverses the logic: default to cleave (3 targets), and only filter out Hammer of the Righteous using its DBC SpellFamilyFlags (`SPELLFAMILY_PALADIN` flag1 `0x40000`).

- **Auto-attacks**: cleave (3 targets)
- **Crusader Strike**: cleave (3 targets)
- **Shield of the Righteous**: cleave (3 targets)
- **Hammer of the Righteous**: single-target (1 target), procs per target hit
- **Judgement**: handled separately via JotJ code path (unchanged)

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with AzerothMCP was used.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24984

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Reference video from original issue showing SoC cleave behavior with HotR and ShoR: https://youtu.be/30FaiRL7fS8?t=65
Maintankadin forum source: https://web.archive.org/web/20100117163718/http://maintankadin.failsafedesign.com/forum/index.php?p=522485&rb_v=viewtopic#p522485

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Create a paladin with Protection and Retribution talents (Hammer of the Righteous + Seal of Command)
2. Equip 1h + shield, activate Seal of Command
3. Pull multiple mobs and verify:
   - Auto-attacks proc SoC with cleave (hits nearby enemies)
   - Crusader Strike procs SoC with cleave
   - Shield of the Righteous procs SoC with cleave
   - Hammer of the Righteous procs SoC per target hit but does NOT cleave

## Known Issues and TODO List:

- [ ] None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.