### PR TITLE
refactor(Core/Spells): Pass nullptr as victim for PROC_SPELL_PHASE_CAST

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4016,7 +4016,7 @@ void Spell::_cast(bool skipCheck)
             break;
         }
 
-        Unit::ProcSkillsAndAuras(m_originalCaster, m_originalCaster, procAttacker, PROC_FLAG_NONE, hitMask, 1, BASE_ATTACK, m_spellInfo, m_triggeredByAuraSpell.spellInfo,
+        Unit::ProcSkillsAndAuras(m_originalCaster, nullptr, procAttacker, PROC_FLAG_NONE, hitMask, 1, BASE_ATTACK, m_spellInfo, m_triggeredByAuraSpell.spellInfo,
             m_triggeredByAuraSpell.effectIndex, this, nullptr, nullptr, PROC_SPELL_PHASE_CAST);
     }
 

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -1556,6 +1556,10 @@ class spell_mage_missile_barrage_proc : public AuraScript
     {
         Unit* caster = eventInfo.GetActor();
 
+        // Prevent double proc for Arcane Missiles
+        if (caster == eventInfo.GetActionTarget())
+            return false;
+
         // T8 4P bonus: chance to not consume the proc
         if (AuraEffect const* aurEff = caster->GetAuraEffect(SPELL_MAGE_T8_4P_BONUS, EFFECT_0))
             if (roll_chance_i(aurEff->GetAmount()))


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

At CAST phase, no target has been hit yet. Pass `nullptr` as the victim instead of `m_originalCaster` to better align with TrinityCore's proc system behavior.

This is a no-op behavioral change — all code paths that use `actionTarget` at CAST phase are already null-safe:

- `ProcSkillsAndReactives` (line 6897): guarded by `target &&` before use
- `ProcSkillsAndAuras` victim path (line 6704): guarded by `victim &&`
- `TriggerAurasProcOnEvent` target proc path (lines 13050/13055): guarded by `actionTarget &&`
- `CanSpellTriggerProcOnEvent` PROC_ATTR_REQ_EXP_OR_HONOR check (line 805): guarded by `eventInfo.GetActionTarget() &&`
- `GetProcEffectMask` ConditionSourceInfo (line 2214): `nullptr` is the default for target1
- No spell scripts in the codebase dereference `GetActionTarget()` at CAST phase without null checks

This change also enables porting TrinityCore's `spell_mage_missile_barrage_proc` double-proc self-target guard (`caster == eventInfo.GetActionTarget()`), which was previously incompatible because AC set `actionTarget` to self at CAST phase, causing the guard to block all procs.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with AzerothMCP were used.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore `Spell.cpp` - commit fccf1a8c62820004df92b9ac567ba75f7281e6e2 by ariel-

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Test spells that proc at CAST phase (e.g. Missile Barrage consumption when casting Arcane Missiles)
2. Verify Arcane Potency and other charge-based proc auras still consume correctly
3. Verify no regressions with general spell proc behavior

## Known Issues and TODO List:

- [ ]
- [ ]