### PR TITLE
fix(Core/Spells): Glyph of Polymorph should not remove Shadow Word: Death backlash

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -1219,7 +1219,7 @@ class spell_mage_glyph_of_polymorph : public AuraScript
             return;
 
         // Remove DoTs from target
-        target->RemoveAurasByType(SPELL_AURA_PERIODIC_DAMAGE, ObjectGuid::Empty, nullptr, true);
+        target->RemoveAurasByType(SPELL_AURA_PERIODIC_DAMAGE, ObjectGuid::Empty, target->GetAura(32409), true); // SW:D shall not be removed.
         target->RemoveAurasByType(SPELL_AURA_PERIODIC_DAMAGE_PERCENT, ObjectGuid::Empty, nullptr, true);
         target->RemoveAurasByType(SPELL_AURA_PERIODIC_LEECH, ObjectGuid::Empty, nullptr, true);
     }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP

## Description

The Glyph of Polymorph (56375) calls `RemoveAurasByType(SPELL_AURA_PERIODIC_DAMAGE)` to strip DoTs from the polymorphed target. This incorrectly removes the Shadow Word: Death self-damage backlash aura (32409) from priests.

Spell 32409 is unique among player periodic damage auras — it was explicitly designed to be an unavoidable self-punishment with the following DBC flags:
- `dispel_type = 0` (DISPEL_NONE) — not dispellable
- `SPELL_ATTR0_NO_ACTIVE_DEFENSE` — cannot be dodged/parried/blocked
- `SPELL_ATTR1_NO_REFLECTION` — cannot be reflected
- `SPELL_ATTR1_NO_REDIRECTION` — ignores Grounding Totem
- `SPELL_ATTR1_NO_AURA_ICON` — hidden from aura bar
- `SPELL_ATTR3_IGNORE_CASTER_MODIFIERS` — damage unaffected by modifiers
- `SPELL_ATTR4_NO_CAST_LOG` — cannot be resisted

A generic filter (e.g. checking `dispel_type`) was considered but is not viable because legitimate DoTs like Rend, Rake, Rip, Rupture, Deep Wounds, and Garrote also have `dispel_type=0` and should be removed by the glyph. SW:D backlash (32409) is the only player self-inflicted `SPELL_AURA_PERIODIC_DAMAGE` with `dispel_type=0` that can exist on a polymorph target — Warlock Hellfire shares similar properties but its channel breaks on polymorph, removing the aura. This makes the explicit exclusion the approach.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9122

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**
  - TrinityCore commit `99d34bde1b` by Vincent-Michael

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a Mage with Glyph of Polymorph equipped
2. Create a Shadow Priest
3. Have the Priest cast Shadow Word: Death on a target that survives (so the backlash aura 32409 is applied)
4. Immediately Polymorph the Priest
5. Verify the SW:D backlash damage still ticks on the Priest after being polymorphed

## Known Issues and TODO List:

- [ ]