### PR TITLE
fix(DB/Spell): Arcane Blast and Missile Barrage spell_proc corrections

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1772802828564370448.sql
+++ b/data/sql/updates/pending_db_world/rev_1772802828564370448.sql
@@ -1,1 +1,6 @@
 UPDATE `spell_proc` SET `SpellFamilyMask0` = 4096, `ProcFlags` = 0, `Charges` = 0 WHERE `SpellId` = 36032;
+
+-- Missile Barrage (44401): use PROC_ATTR_REQ_SPELLMOD to consume charges
+-- only when the cast spell is actually modified by the aura (Arcane Missiles),
+-- instead of relying on SpellFamilyMask filtering
+UPDATE `spell_proc` SET `SpellFamilyMask0` = 0, `AttributesMask` = 8 WHERE `SpellId` = 44401;

--- a/data/sql/updates/pending_db_world/rev_1772802828564370448.sql
+++ b/data/sql/updates/pending_db_world/rev_1772802828564370448.sql
@@ -1,6 +1,2 @@
 UPDATE `spell_proc` SET `SpellFamilyMask0` = 4096, `ProcFlags` = 0, `Charges` = 0 WHERE `SpellId` = 36032;
-
--- Missile Barrage (44401): use PROC_ATTR_REQ_SPELLMOD to consume charges
--- only when the cast spell is actually modified by the aura (Arcane Missiles),
--- instead of relying on SpellFamilyMask filtering
 UPDATE `spell_proc` SET `SpellFamilyMask0` = 0, `AttributesMask` = 8 WHERE `SpellId` = 44401;

--- a/data/sql/updates/pending_db_world/rev_1772802828564370448.sql
+++ b/data/sql/updates/pending_db_world/rev_1772802828564370448.sql
@@ -1,0 +1,1 @@
+UPDATE `spell_proc` SET `SpellFamilyMask0` = 4096, `ProcFlags` = 0, `Charges` = 0 WHERE `SpellId` = 36032;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

**Arcane Blast buff (36032):** Updated `spell_proc` entry — set `SpellFamilyMask0 = 4096`, cleared `ProcFlags` and `Charges` so the buff correctly boosts Arcane Missiles damage.

**Missile Barrage buff (44401):** Switched charge consumption from `SpellFamilyMask0` filtering to `PROC_ATTR_REQ_SPELLMOD` (`AttributesMask = 8`). This ensures the charge is only consumed when the cast spell is actually modified by the aura (i.e. Arcane Missiles), rather than relying on family mask matching.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Tools used: **Claude Code** with **azerothMCP**.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9116
- Related https://github.com/chromiecraft/chromiecraft/issues/9118

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). Aligned `spell_proc` entries with TrinityCore `tc_world` database.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a level 80 mage with Arcane Missiles, Arcane Blast, and Missile Barrage talent
2. Cast Arcane Missiles without any Arcane Blast stacks, note damage per wave
3. Cast 4x Arcane Blast to build stacks, then cast Arcane Missiles
4. Verify all missile waves deal ~60% more damage (15% per stack × 4)
5. Spam Arcane Blast on a target and verify Missile Barrage buff is only consumed when casting Arcane Missiles

## Known Issues and TODO List:

- [ ] Verify Arcane Blast buff is still properly consumed by Arcane Explosion and Arcane Barrage