### PR TITLE
fix(Core/Spells): Judgement of Wisdom should restore 2% base mana per proc

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -1374,7 +1374,8 @@ class spell_pal_judgement_of_wisdom_mana : public AuraScript
         if (!attacker)
             return;
 
-        int32 bp = int32(CalculatePct(attacker->GetCreateMana(), aurEff->GetAmount()));
+        SpellInfo const* spellInfo = sSpellMgr->AssertSpellInfo(SPELL_PALADIN_JUDGEMENT_OF_WISDOM_MANA);
+        int32 bp = int32(CalculatePct(attacker->GetCreateMana(), spellInfo->Effects[EFFECT_0].CalcValue()));
         attacker->CastCustomSpell(attacker, SPELL_PALADIN_JUDGEMENT_OF_WISDOM_MANA, &bp, nullptr, nullptr, true, nullptr, aurEff, GetCasterGUID());
     }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Judgement of Wisdom was restoring 1% of the attacker's base mana per proc instead of the correct 2%. The script was reading the mana percentage from the aura's effect amount (`aurEff->GetAmount()` = 1) instead of the triggered spell 20268's effect value (`CalcValue()` = 2).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Tools used:** Claude Code with azerothMCP

- Closes https://github.com/chromiecraft/chromiecraft/issues/9120

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Reference: TrinityCore `spell_pal_judgement_of_wisdom_mana::HandleProc` uses `spellInfo->GetEffect(EFFECT_0).CalcValue()` which evaluates to 2% from spell 20268.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

1. Create a paladin and a target dummy or hostile mob
2. Apply Judgement of Wisdom to the target
3. Attack the target with a mana-using class and observe mana restored
4. Verify the mana restored equals 2% of the attacker's base mana