### PR TITLE
fix(DB/Spells): Restrict Rime proc to Obliterate only

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1772898413275315909.sql
+++ b/data/sql/updates/pending_db_world/rev_1772898413275315909.sql
@@ -1,5 +1,4 @@
 -- Rime (49188/56822/59057) should only proc from Obliterate (SpellFamilyMask1 = 0x20000)
--- Previously had no spell_proc entry, allowing it to proc from any DK offensive spell
 DELETE FROM `spell_proc` WHERE `SpellId` = -49188;
 INSERT INTO `spell_proc` (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `DisableEffectsMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`)
 VALUES (-49188, 0, 15, 0x00000000, 0x00020000, 0x00000000, 0, 0, 0x2, 0, 0, 0, 0, 0, 0, 0);

--- a/data/sql/updates/pending_db_world/rev_1772898413275315909.sql
+++ b/data/sql/updates/pending_db_world/rev_1772898413275315909.sql
@@ -1,0 +1,5 @@
+-- Rime (49188/56822/59057) should only proc from Obliterate (SpellFamilyMask1 = 0x20000)
+-- Previously had no spell_proc entry, allowing it to proc from any DK offensive spell
+DELETE FROM `spell_proc` WHERE `SpellId` = -49188;
+INSERT INTO `spell_proc` (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `DisableEffectsMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`)
+VALUES (-49188, 0, 15, 0x00000000, 0x00020000, 0x00000000, 0, 0, 0x2, 0, 0, 0, 0, 0, 0, 0);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Rime (49188/56822/59057) procs from both Icy Touch and Obliterate due to the auto-generated `spell_proc` entry pulling in Effect 0's `SpellClassMask` (`{0x2, 0x20000, 0}`). Effect 0 is a cast time modifier targeting Howling Blast (Icy Touch mask `0x2` + Obliterate mask `0x20000`), but the proc system treats it as a proc filter, causing Rime to also proc from Icy Touch.

Added an explicit `spell_proc` entry with `SpellFamilyMask1 = 0x20000` to restrict procs to Obliterate only.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Tools used: **Claude Code** with **azerothMCP**.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9123

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a DK with Rime talent (Rank 3: 59057, 15% chance)
2. Without this fix: spam Icy Touch — Freezing Fog buff (59052) procs
3. With this fix: spam Icy Touch — no Freezing Fog procs; use Obliterate — Freezing Fog procs correctly

## Known Issues and TODO List:

- [ ] None