### PR TITLE
fix(Scripts/Ulduar): Brundir invincible during Overload if not last boss

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
@@ -121,23 +121,26 @@ enum Misc
     POINT_CHANNEL_STEELBREAKER  = 1
 };
 
+static uint8 CountAliveBosses(InstanceScript* instance)
+{
+    uint8 count = 0;
+    if (!instance)
+        return count;
+
+    for (uint8 i = 0; i < 3; ++i)
+        if (Creature* boss = instance->GetCreature(DATA_STEELBREAKER + i))
+            if (boss->IsAlive())
+                ++count;
+
+    return count;
+}
+
 bool IsEncounterComplete(InstanceScript* pInstance, Creature* me)
 {
     if (!pInstance || !me)
         return false;
 
-    for (uint8 i = 0; i < 3; ++i)
-    {
-        if (Creature* boss = pInstance->GetCreature(DATA_STEELBREAKER + i))
-        {
-            if (boss->IsAlive())
-                return false;
-            continue;
-        }
-        else
-            return false;
-    }
-    return true;
+    return CountAliveBosses(pInstance) == 0;
 }
 
 void RespawnAssemblyOfIron(InstanceScript* pInstance, Creature* me)
@@ -550,6 +553,7 @@ struct boss_stormcaller_brundir : public ScriptedAI
 
     void Reset() override
     {
+        SetInvincibility(false);
         me->SetLootMode(0);
         RespawnAssemblyOfIron(pInstance, me);
 
@@ -665,6 +669,26 @@ struct boss_stormcaller_brundir : public ScriptedAI
     {
         if (type == POINT_MOTION_TYPE && point == POINT_CHANNEL_STEELBREAKER)
             me->CastSpell(me, SPELL_LIGHTNING_CHANNEL_PRE, true);
+    }
+
+    void OnSpellCast(SpellInfo const* spellInfo) override
+    {
+        // When Overload begins, prevent Brundir from dying unless he is the last boss alive
+        if (spellInfo->Id == SPELL_OVERLOAD && CountAliveBosses(pInstance) > 1)
+            SetInvincibility(true);
+    }
+
+    void OnChannelFinished(SpellInfo const* spellInfo) override
+    {
+        if (spellInfo->Id == SPELL_OVERLOAD)
+            SetInvincibility(false);
+    }
+
+    void OnSpellFailed(SpellInfo const* spellInfo) override
+    {
+        // Also lift invincibility if the channel is somehow interrupted
+        if (spellInfo->Id == SPELL_OVERLOAD)
+            SetInvincibility(false);
     }
 
     void UpdateAI(uint32 diff) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
@@ -140,6 +140,10 @@ bool IsEncounterComplete(InstanceScript* pInstance, Creature* me)
     if (!pInstance || !me)
         return false;
 
+    for (uint8 i = 0; i < 3; ++i)
+        if (!pInstance->GetCreature(DATA_STEELBREAKER + i))
+            return false;
+
     return CountAliveBosses(pInstance) == 0;
 }
 


### PR DESCRIPTION
Use the new OnSpellCast/OnChannelFinished/OnSpellFailed AI hooks and SetInvincibility() to prevent Stormcaller Brundir from dying during Overload while other bosses are still alive. Also extracts CountAliveBosses() helper to deduplicate the iteration shared with IsEncounterComplete().

Closes #23872

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23872

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
