### PR TITLE
fix(Core/Events): Fix multi-stage holiday events ending early on restart

### DIFF
--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1961,21 +1961,22 @@ void GameEventMgr::SetHolidayEventTime(GameEventData& event)
     bool singleDate = ((holiday->Date[0] >> 24) & 0x1F) == 31; // Events with fixed date within year have - 1
 
     time_t curTime = GameTime::GetGameTime().count();
-    for (uint8 i = 0; i < MAX_HOLIDAY_DATES && holiday->Date[i]; ++i)
 
+    if (!singleDate)
+    {
+        time_t start = HolidayDateCalculator::FindStartTimeForStage(
+            holiday->Date, MAX_HOLIDAY_DATES, stageOffset, event.Length, curTime);
+        if (start)
+            event.Start = start;
+        return;
+    }
+
+    for (uint8 i = 0; i < MAX_HOLIDAY_DATES && holiday->Date[i]; ++i)
     {
         uint32 date = holiday->Date[i];
 
-        tm timeInfo;
-        if (singleDate)
-        {
-            timeInfo = Acore::Time::TimeBreakdown(curTime);
-            timeInfo.tm_year -= 1; // First try last year (event active through New Year)
-        }
-        else
-        {
-            timeInfo.tm_year = ((date >> 24) & 0x1F) + 100;
-        }
+        tm timeInfo = Acore::Time::TimeBreakdown(curTime);
+        timeInfo.tm_year -= 1; // First try last year (event active through New Year)
 
         timeInfo.tm_mon = (date >> 20) & 0xF;
         timeInfo.tm_mday = ((date >> 14) & 0x3F) + 1;
@@ -1986,12 +1987,12 @@ void GameEventMgr::SetHolidayEventTime(GameEventData& event)
 
         // try to get next start time (skip past dates)
         time_t startTime = mktime(&timeInfo);
-        if (curTime < startTime + event.Length * MINUTE)
+        if (curTime < startTime + stageOffset + event.Length * MINUTE)
         {
             event.Start = startTime + stageOffset;
             break;
         }
-        else if (singleDate)
+        else
         {
             tm tmCopy = Acore::Time::TimeBreakdown(curTime);
             int year = tmCopy.tm_year; // This year
@@ -1999,11 +2000,6 @@ void GameEventMgr::SetHolidayEventTime(GameEventData& event)
             tmCopy.tm_year = year;
             event.Start = mktime(&tmCopy) + stageOffset;
             break;
-        }
-        else
-        {
-            // date is due and not a singleDate event, try with next DBC date (dynamically calculated or overridden by game_event.start_time)
-            // if none is found we don't modify start date and use the one in game_event
         }
     }
 }

--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1968,6 +1968,7 @@ void GameEventMgr::SetHolidayEventTime(GameEventData& event)
             holiday->Date, MAX_HOLIDAY_DATES, stageOffset, event.Length, curTime);
         if (start)
             event.Start = start;
+
         return;
     }
 

--- a/src/server/game/Events/HolidayDateCalculator.cpp
+++ b/src/server/game/Events/HolidayDateCalculator.cpp
@@ -580,3 +580,27 @@ std::vector<uint32_t> HolidayDateCalculator::GetDarkmoonFaireDates(int locationO
 
     return dates;
 }
+
+time_t HolidayDateCalculator::FindStartTimeForStage(const uint32_t* packedDates, uint8_t numDates,
+    time_t stageOffset, uint32_t stageLengthMinutes, time_t curTime)
+{
+    for (uint8_t i = 0; i < numDates && packedDates[i]; ++i)
+    {
+        uint32_t date = packedDates[i];
+
+        std::tm timeInfo = {};
+        timeInfo.tm_year = static_cast<int>(((date >> 24) & 0x1F)) + 100;
+        timeInfo.tm_mon = static_cast<int>((date >> 20) & 0xF);
+        timeInfo.tm_mday = static_cast<int>(((date >> 14) & 0x3F)) + 1;
+        timeInfo.tm_hour = static_cast<int>((date >> 6) & 0x1F);
+        timeInfo.tm_min = static_cast<int>(date & 0x3F);
+        timeInfo.tm_sec = 0;
+        timeInfo.tm_isdst = -1;
+
+        time_t startTime = mktime(&timeInfo);
+        if (curTime < startTime + stageOffset + static_cast<time_t>(stageLengthMinutes) * 60)
+            return startTime + stageOffset;
+    }
+
+    return 0;
+}

--- a/src/server/game/Events/HolidayDateCalculator.h
+++ b/src/server/game/Events/HolidayDateCalculator.h
@@ -100,6 +100,13 @@ public:
     // Returns packed dates for all occurrences in the year range
     static std::vector<uint32_t> GetDarkmoonFaireDates(int locationOffset, int startYear, int numYears, int dayOffset = 0);
 
+    // Find the correct stage start time from a list of packed holiday dates.
+    // For multi-stage holidays, stageOffset is the cumulative duration (in seconds) of all prior stages.
+    // stageLengthMinutes is the duration of the current stage in minutes.
+    // Returns the computed stage start time (startTime + stageOffset), or 0 if no valid date found.
+    static time_t FindStartTimeForStage(const uint32_t* packedDates, uint8_t numDates,
+        time_t stageOffset, uint32_t stageLengthMinutes, time_t curTime);
+
 private:
     // Julian Date conversions for lunar calculations
     static double DateToJulianDay(int year, int month, double day);

--- a/src/test/server/game/Events/HolidayDateCalculatorTest.cpp
+++ b/src/test/server/game/Events/HolidayDateCalculatorTest.cpp
@@ -1236,3 +1236,156 @@ TEST_F(HolidayDateCalculatorTest, DarkmoonFaire_InHolidayRules)
     EXPECT_TRUE(foundMulgore) << "Darkmoon Faire Mulgore (375) should be in HolidayRules";
     EXPECT_TRUE(foundTerokkar) << "Darkmoon Faire Terokkar (376) should be in HolidayRules";
 }
+
+// ============================================================================
+// FindStartTimeForStage tests
+// ============================================================================
+
+class FindStartTimeForStageTest : public ::testing::Test
+{
+protected:
+    // Helper to create a time_t from year/month/day/hour
+    static time_t MakeTime(int year, int month, int day, int hour = 0)
+    {
+        std::tm t = {};
+        t.tm_year = year - 1900;
+        t.tm_mon = month - 1;
+        t.tm_mday = day;
+        t.tm_hour = hour;
+        t.tm_isdst = -1;
+        return mktime(&t);
+    }
+
+    // Pack two dates into an array (rest zeroed)
+    void PackTwoDates(uint32_t* dates, int y1, int m1, int d1, int y2, int m2, int d2)
+    {
+        std::tm t1 = {};
+        t1.tm_year = y1 - 1900;
+        t1.tm_mon = m1 - 1;
+        t1.tm_mday = d1;
+        t1.tm_isdst = -1;
+        mktime(&t1);
+        dates[0] = HolidayDateCalculator::PackDate(t1);
+
+        std::tm t2 = {};
+        t2.tm_year = y2 - 1900;
+        t2.tm_mon = m2 - 1;
+        t2.tm_mday = d2;
+        t2.tm_isdst = -1;
+        mktime(&t2);
+        dates[1] = HolidayDateCalculator::PackDate(t2);
+
+        for (int i = 2; i < 26; ++i)
+            dates[i] = 0;
+    }
+};
+
+// Stage 1 (no offset): curTime before event starts -> selects first date
+TEST_F(FindStartTimeForStageTest, Stage1_BeforeStart_SelectsFirstDate)
+{
+    uint32_t dates[26] = {};
+    PackTwoDates(dates, 2026, 3, 6, 2026, 4, 3);
+
+    time_t curTime = MakeTime(2026, 3, 1);
+    time_t stageOffset = 0;
+    uint32_t stageLengthMin = 72 * 60; // 72 hours = 3 days
+
+    time_t result = HolidayDateCalculator::FindStartTimeForStage(dates, 26, stageOffset, stageLengthMin, curTime);
+    EXPECT_EQ(result, MakeTime(2026, 3, 6));
+}
+
+// Stage 1 (no offset): curTime during event -> selects current date
+TEST_F(FindStartTimeForStageTest, Stage1_DuringEvent_SelectsCurrentDate)
+{
+    uint32_t dates[26] = {};
+    PackTwoDates(dates, 2026, 3, 6, 2026, 4, 3);
+
+    time_t curTime = MakeTime(2026, 3, 7, 12); // mid-event
+    time_t stageOffset = 0;
+    uint32_t stageLengthMin = 72 * 60; // 3 days
+
+    time_t result = HolidayDateCalculator::FindStartTimeForStage(dates, 26, stageOffset, stageLengthMin, curTime);
+    EXPECT_EQ(result, MakeTime(2026, 3, 6));
+}
+
+// Stage 1 (no offset): curTime after event ends -> selects next date
+TEST_F(FindStartTimeForStageTest, Stage1_AfterEnd_SelectsNextDate)
+{
+    uint32_t dates[26] = {};
+    PackTwoDates(dates, 2026, 3, 6, 2026, 4, 3);
+
+    time_t curTime = MakeTime(2026, 3, 20); // well past first event
+    time_t stageOffset = 0;
+    uint32_t stageLengthMin = 72 * 60; // 3 days
+
+    time_t result = HolidayDateCalculator::FindStartTimeForStage(dates, 26, stageOffset, stageLengthMin, curTime);
+    EXPECT_EQ(result, MakeTime(2026, 4, 3));
+}
+
+// THE BUG: Stage 2 with stageOffset > 0, curTime in the window that the old
+// code would incorrectly skip (between startTime + stageLength and
+// startTime + stageOffset + stageLength). Without the fix, this would
+// return the NEXT occurrence's start instead of the current one.
+TEST_F(FindStartTimeForStageTest, Stage2_DuringLateWindow_SelectsCurrentDate)
+{
+    // Simulate Darkmoon Faire:
+    // Holiday starts Mar 6 (Friday, building phase)
+    // Stage 1 (building): 72 hours = 3 days (Mar 6-9)
+    // Stage 2 (active):  168 hours = 7 days (Mar 9-16)
+    // Total holiday: Mar 6 - Mar 16 (10 days)
+    // Next occurrence: Apr 3
+    uint32_t dates[26] = {};
+    PackTwoDates(dates, 2026, 3, 6, 2026, 4, 3);
+
+    time_t stageOffset = 72 * 3600; // Stage 1 = 72 hours in seconds
+    uint32_t stageLengthMin = 168 * 60; // Stage 2 = 168 hours in minutes
+
+    // curTime = Mar 14 (day 8 of holiday, day 5 of stage 2)
+    // Old bug: startTime(Mar 6) + 168h = Mar 13, so curTime > that -> SKIP to Apr 3!
+    // Fixed:   startTime(Mar 6) + 72h + 168h = Mar 16, so curTime < that -> correct
+    time_t curTime = MakeTime(2026, 3, 14, 12);
+
+    time_t result = HolidayDateCalculator::FindStartTimeForStage(dates, 26, stageOffset, stageLengthMin, curTime);
+    // Should return Mar 6 + stageOffset = Mar 9 (stage 2 start)
+    EXPECT_EQ(result, MakeTime(2026, 3, 6) + stageOffset);
+}
+
+// Stage 2: curTime after entire holiday ends -> selects next occurrence
+TEST_F(FindStartTimeForStageTest, Stage2_AfterHolidayEnds_SelectsNextDate)
+{
+    uint32_t dates[26] = {};
+    PackTwoDates(dates, 2026, 3, 6, 2026, 4, 3);
+
+    time_t stageOffset = 72 * 3600;
+    uint32_t stageLengthMin = 168 * 60;
+
+    // curTime = Mar 20 (well past the entire holiday)
+    time_t curTime = MakeTime(2026, 3, 20);
+
+    time_t result = HolidayDateCalculator::FindStartTimeForStage(dates, 26, stageOffset, stageLengthMin, curTime);
+    EXPECT_EQ(result, MakeTime(2026, 4, 3) + stageOffset);
+}
+
+// No valid dates -> returns 0
+TEST_F(FindStartTimeForStageTest, NoDates_ReturnsZero)
+{
+    uint32_t dates[26] = {};
+    time_t curTime = MakeTime(2026, 6, 1);
+
+    time_t result = HolidayDateCalculator::FindStartTimeForStage(dates, 26, 0, 168 * 60, curTime);
+    EXPECT_EQ(result, 0);
+}
+
+// All dates in the past -> returns 0
+TEST_F(FindStartTimeForStageTest, AllDatesPast_ReturnsZero)
+{
+    uint32_t dates[26] = {};
+    PackTwoDates(dates, 2026, 1, 5, 2026, 2, 6);
+
+    time_t stageOffset = 0;
+    uint32_t stageLengthMin = 72 * 60;
+
+    time_t curTime = MakeTime(2026, 6, 1); // way after both dates
+    time_t result = HolidayDateCalculator::FindStartTimeForStage(dates, 26, stageOffset, stageLengthMin, curTime);
+    EXPECT_EQ(result, 0);
+}


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`SetHolidayEventTime` did not account for `stageOffset` when checking if a `Date[]` entry is still active. For multi-stage holidays (e.g. Darkmoon Faire with building + active phases), a server restart during a later stage would incorrectly skip to the next occurrence, ending the event early.

**Root cause:** The check `curTime < startTime + event.Length * MINUTE` only compared against the current stage's duration from the holiday start, ignoring time consumed by prior stages. The fix changes this to `curTime < startTime + stageOffset + event.Length * MINUTE`.

The date-selection logic was extracted into `HolidayDateCalculator::FindStartTimeForStage()` for testability.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code** with **azerothMCP** were used.

## Issues Addressed:
- Multi-stage holiday events (Darkmoon Faire) ending early when the server restarts during a later stage

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

7 unit tests added covering:
- Stage 1 and Stage 2 date selection (before, during, after event windows)
- The specific regression case where `stageOffset > 0` caused incorrect date skipping
- Edge cases (no dates, all dates past)

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Have a Darkmoon Faire active (building or active phase)
2. Restart the server during the active faire phase (stage 2)
3. Verify the faire remains active after restart and does not jump to the next month's occurrence
4. Run unit tests: `./unit_tests --gtest_filter="FindStartTimeForStage*"`

## Known Issues and TODO List:

- [ ] The `singleDate` path in `SetHolidayEventTime` retains the original inline logic (not extracted) as it depends on `Acore::Time::TimeBreakdown`. It also benefits from the `stageOffset` fix applied inline.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.