### PR TITLE
fix(DB/Spell): Piercing Howl should break stealth

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1772987652770167121.sql
+++ b/data/sql/updates/pending_db_world/rev_1772987652770167121.sql
@@ -1,0 +1,2 @@
+-- Remove SPELL_ATTR0_CU_DONT_BREAK_STEALTH (0x40) from Piercing Howl
+UPDATE `spell_custom_attr` SET `attributes` = `attributes` & ~(64) WHERE `spell_id` = 12323;


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Remove `SPELL_ATTR0_CU_DONT_BREAK_STEALTH` (0x40) from Piercing Howl (spell 12323) in `spell_custom_attr`. This flag was incorrectly preventing the spell from breaking stealth on hit.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP was used for investigation and fix preparation.

## Issues Addressed:

- Closes https://github.com/chromiecraft/chromiecraft/issues/9021
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24740

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://www.wowhead.com/wotlk/spell=12323/piercing-howl#english-comments

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Have a Rogue enter Stealth
2. Have a Warrior cast Piercing Howl in range of the stealthed Rogue
3. Verify the Rogue's stealth is broken

## Known Issues and TODO List:

- [ ] Other NPC Piercing Howl variants (10576, 23600, 38256, 43530, 52744) also have this flag but may be intentional for those NPCs