### PR TITLE
fix(Core/Scripts): fix Solarian vanish phase evicting encounter

### DIFF
--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_astromancer.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_astromancer.cpp
@@ -198,8 +198,8 @@ struct boss_high_astromancer_solarian : public BossAI
                 });
             }).Schedule(23s, [this](TaskContext)
             {
-                me->GetThreatMgr().ClearAllThreat();
                 me->SetReactState(REACT_AGGRESSIVE);
+                DoResetThreatList();
                 summons.DoForAllSummons([&](WorldObject* summon)
                 {
                     if (Creature* light = summon->ToCreature())


### PR DESCRIPTION
## Changes Proposed:
- Scripts

Fixes a regression introduced by commit 8249ca51 in `boss_astromancer.cpp`.

`ClearAllThreat()` was called during the reappear phase, which emptied the threat table entirely. On the next `UpdateAI` tick, `UpdateVictim()` found no valid victim and triggered evade, resetting the encounter before Solarium Priests could be summoned.

Replaced with `DoResetThreatList()` (which calls `ResetAllThreat()` internally), zeroing all threat values without removing entries from the list. This matches the pattern used by other phase-transition bosses (e.g. Illidan). The boss re-engages the raid and picks a fresh target as intended.

## AI-assisted Pull Requests
AI tools (Claude Sonnet 4.6) were used to assist in identifying and implementing this fix.

## Issues Addressed:
- Closes #25022

## SOURCE:
- Code research and cross-referencing with other boss scripts (boss_illidan.cpp)

## Tests Performed:
- This pull request requires further in-game testing

## Known Issues and TODO List:
- None