### PR TITLE
fix(Core/Spells): Fix ADD_TARGET_TRIGGER duration overwrite

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3255,7 +3255,7 @@ void Spell::DoTriggersOnSpellHit(Unit* unit, uint8 effMask)
                             Aura* aur = unit->GetAura(m_spellInfo->Id, m_caster->GetGUID());
                             _duration = aur ? aur->GetDuration() : -1;
                         }
-                        triggeredAur->SetDuration(_duration);
+                        triggeredAur->SetDuration(std::max(triggeredAur->GetDuration(), _duration));
                     }
                 }
             }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

When multiple spells trigger the same aura via `SPELL_AURA_ADD_TARGET_TRIGGER`, shorter-duration sources would overwrite longer-duration ones. This caused Blood Frenzy to drop when Deep Wounds expired, even when Rend was still active on the target.

The fix uses `std::max` to preserve the longest remaining duration when syncing triggered aura durations.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/6579

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create an Arms Warrior with Blood Frenzy 2/2 and Deep Wounds 3/3
2. Apply Rend on a target dummy
3. Get a melee crit to proc Deep Wounds
4. Observe that Blood Frenzy persists after Deep Wounds expires, as long as Rend is still active

## Known Issues and TODO List:

- [x] Other spells using `SPELL_AURA_ADD_TARGET_TRIGGER` with multiple sources should be regression tested

Only 4 triggered spells qualify
[30069] Blood Frenzy R1  [29836] Blood Frenzy R1  Fix target 
[30070] Blood Frenzy R2  [29859] Blood Frenzy R2  Fix target  
[28815] Revealed Flaw   [28814] Rogue set bonus  None - single source (Eviscerate only) 
[28820] Lightning Shield  [28821] Shaman set bonus None - single source (Lightning Shield only) 

All other spells (Frostbite, Shadow Weaving, Chilblains, Predatory Strikes, PvP relics, etc.) have finite DBC durations and never enter the affected code path. No regression risk.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.