### PR TITLE
fix(Core/Spells): prevent aura rank downranking based on hostile target level

### DIFF
--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -530,14 +530,16 @@ void WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket)
     }
 
     // auto-selection buff level base at target level (in spellInfo)
-    if (targets.GetUnitTarget())
-    {
-        SpellInfo const* actualSpellInfo = spellInfo->GetAuraRankForLevel(targets.GetUnitTarget()->GetLevel());
+    if (spellInfo->IsPositive())
+        if (Unit* target = targets.GetUnitTarget())
+            if (mover->IsFriendlyTo(target))
+            {
+                SpellInfo const* actualSpellInfo = spellInfo->GetAuraRankForLevel(target->GetLevel());
 
-        // if rank not found then function return nullptr but in explicit cast case original spell can be casted and later failed with appropriate error message
-        if (actualSpellInfo)
-            spellInfo = actualSpellInfo;
-    }
+                // if rank not found then function return nullptr but in explicit cast case original spell can be casted and later failed with appropriate error message
+                if (actualSpellInfo)
+                    spellInfo = actualSpellInfo;
+            }
 
     Spell* spell = new Spell(mover, spellInfo, triggerFlag, ObjectGuid::Empty, false);
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Self-buff spells like Slice and Dice that target an enemy (for combo points) but apply their aura to the caster were incorrectly downranked based on the enemy's level. For example, casting Slice and Dice Rank 2 (spell 6774, SpellLevel 42) on a level 30 creature would downrank it to Rank 1 (spell 5171), giving only 20% haste instead of 40%.

The `GetAuraRankForLevel` check in `HandleCastSpellOpcode` used the hostile target's level for rank selection, even though the aura is applied to the caster. This fix adds `IsPositive()` and `IsFriendlyTo()` guards so that aura rank downranking only occurs when casting positive spells on friendly targets (e.g., buffing a low-level ally), which is the intended use case.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with AzerothMCP 

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9132

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). TrinityCore has a partial fix (`IsPositive()` check) but still has the same underlying bug. The `IsFriendlyTo()` guard is a further improvement.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a Rogue character level 42+ and learn Slice and Dice Rank 2
2. Find or spawn a low-level hostile creature (e.g. level 30: `.go creature 5066`)
3. Build combo points on the creature and cast Slice and Dice Rank 2
4. Verify the buff tooltip shows 40% haste and the character sheet attack speed reflects the full 40% increase
5. Also test buffing a low-level friendly player (e.g. with Fort) to verify downranking still works correctly for that case

## Known Issues and TODO List:

- [x] Other combo point finisher self-buffs should be verified (e.g. Savage Roar for Druids)

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.