### PR TITLE
fix(Core/Spells): Use correct beacon copy spell for Flash of Light

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -130,9 +130,11 @@ enum PaladinProcSpells
     SPELL_PALADIN_SPIRITUAL_ATTUNEMENT_MANA      = 31786,
     SPELL_PALADIN_BEACON_OF_LIGHT_AURA           = 53563,
     SPELL_PALADIN_LIGHTS_BEACON                  = 53651,
-    SPELL_PALADIN_BEACON_OF_LIGHT_FLASH          = 53652,
-    SPELL_PALADIN_BEACON_OF_LIGHT_HOLY           = 53654,
+    SPELL_PALADIN_BEACON_OF_LIGHT_HL             = 53652,
+    SPELL_PALADIN_BEACON_OF_LIGHT_FOL            = 53653,
+    SPELL_PALADIN_BEACON_OF_LIGHT_HS             = 53654,
     SPELL_PALADIN_HOLY_LIGHT_R1                  = 635,
+    SPELL_PALADIN_FLASH_OF_LIGHT_R1              = 19750,
     SPELL_PALADIN_GLYPH_OF_HOLY_LIGHT_HEAL       = 54968,
     SPELL_PALADIN_SACRED_SHIELD                  = 53601,
     SPELL_PALADIN_T9_HOLY_4P_BONUS               = 67191,
@@ -2132,6 +2134,9 @@ private:
 };
 
 // 53651 - Light's Beacon - Beacon of Light
+// Each source heal has a dedicated beacon copy spell:
+//   53652 - Holy Light, 53653 - Flash of Light, 53654 - Holy Shock
+// Reference: https://kurn.info/blog/holy-how-to-5-to-beacon-or-not-to-beacon/
 class spell_pal_light_s_beacon : public AuraScript
 {
     PrepareAuraScript(spell_pal_light_s_beacon);
@@ -2141,9 +2146,11 @@ class spell_pal_light_s_beacon : public AuraScript
         return ValidateSpellInfo(
         {
             SPELL_PALADIN_BEACON_OF_LIGHT_AURA,
-            SPELL_PALADIN_BEACON_OF_LIGHT_FLASH,
-            SPELL_PALADIN_BEACON_OF_LIGHT_HOLY,
-            SPELL_PALADIN_HOLY_LIGHT_R1
+            SPELL_PALADIN_BEACON_OF_LIGHT_HL,
+            SPELL_PALADIN_BEACON_OF_LIGHT_FOL,
+            SPELL_PALADIN_BEACON_OF_LIGHT_HS,
+            SPELL_PALADIN_HOLY_LIGHT_R1,
+            SPELL_PALADIN_FLASH_OF_LIGHT_R1
         });
     }
 
@@ -2167,9 +2174,13 @@ class spell_pal_light_s_beacon : public AuraScript
         if (!healInfo || !healInfo->GetHeal())
             return;
 
-        // Holy Light heals for 100%, Flash of Light heals for 50%
-        uint32 healSpellId = procSpell->IsRankOf(sSpellMgr->AssertSpellInfo(SPELL_PALADIN_HOLY_LIGHT_R1)) ?
-            SPELL_PALADIN_BEACON_OF_LIGHT_FLASH : SPELL_PALADIN_BEACON_OF_LIGHT_HOLY;
+        uint32 healSpellId;
+        if (procSpell->IsRankOf(sSpellMgr->AssertSpellInfo(SPELL_PALADIN_HOLY_LIGHT_R1)))
+            healSpellId = SPELL_PALADIN_BEACON_OF_LIGHT_HL;
+        else if (procSpell->IsRankOf(sSpellMgr->AssertSpellInfo(SPELL_PALADIN_FLASH_OF_LIGHT_R1)))
+            healSpellId = SPELL_PALADIN_BEACON_OF_LIGHT_FOL;
+        else
+            healSpellId = SPELL_PALADIN_BEACON_OF_LIGHT_HS;
 
         // Use heal amount before target-specific modifiers to avoid copying them
         uint32 healAmount = healInfo->GetHealBeforeTakenMods();


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - **Claude Code** with **AzerothMCP** for DBC spell lookups and proc table analysis.

## Issues Addressed:
- Closes 

## Summary

Beacon of Light (53651) has three dedicated copy spells in DBC, one per source heal:
- **53652** — Holy Light
- **53653** — Flash of Light
- **53654** — Holy Shock

Previously only 53652 and 53654 were used in a binary check (Holy Light vs everything else), causing Flash of Light beacon heals to incorrectly use the Holy Shock copy spell (53654) instead of its own (53653).

Also cleans up misleading enum names to match their actual purpose.

Reference: https://kurn.info/blog/holy-how-to-5-to-beacon-or-not-to-beacon/

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - DBC spell data analysis (53652, 53653, 53654)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a Holy Paladin with Beacon of Light
2. Place Beacon on a target
3. Cast Flash of Light on a different target — verify beacon copy uses spell 53653
4. Cast Holy Light — verify copy uses 53652
5. Cast Holy Shock heal — verify copy uses 53654

## Known Issues and TODO List:

- [ ] Functional behavior is identical since all three copy spells are the same direct heal — this is a correctness fix for combat log accuracy