### PR TITLE
fix(Core/Movement): fix creature freeze when switching chase targets

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -73,7 +73,7 @@ void ChaseMovementGenerator<T>::SetOffsetAndAngle(std::optional<ChaseRange> dist
 template<class T>
 void ChaseMovementGenerator<T>::SetNewTarget(Unit* target)
 {
-    i_target.link(target, this);
+    SetTarget(target);
     _lastTargetPosition.reset();
 }
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`ChaseMovementGenerator::SetNewTarget()` called `i_target.link()` directly, bypassing `AbstractFollower::SetTarget()`. This left the cached `_target` pointer stale after #25030 introduced the `AbstractFollower` base class with a dual-pointer system (`i_target` + `_target`).

Because `HasLostTarget()` checks `GetTarget()` (which returns `_target`), it always returned `true` after a target switch, causing the pet to stop movement every tick and freeze in place.

The fix changes `SetNewTarget()` to use `SetTarget()` which updates both `i_target` and `_target`.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with AzerothMCP

## Issues Addressed:

- Closes https://github.com/chromiecraft/chromiecraft/issues/9139
- Closes https://github.com/chromiecraft/chromiecraft/issues/9140

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). TrinityCore's `AbstractFollower` uses a single pointer with `FollowerAdded/FollowerRemoved` callbacks, avoiding this class of bug entirely. AzerothCore's port retained the old `FollowerReference` system alongside the new `_target` pointer, creating the desync.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Haven't tested yet vs NPC's in Naxx

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Summon a pet (hunter pet, warlock demon, etc.)
2. Command pet to attack target A
3. While pet is chasing target A, command pet to attack target B
4. **Before fix**: Pet freezes in place, stuck in "lost target" state
5. **After fix**: Pet correctly switches to chasing target B

## Known Issues and TODO List:

- [ ] The dual-pointer system (`i_target` + `_target`) in `AbstractFollower` is architectural debt from an incomplete port. Ideally AC would adopt TC's simpler callback approach, but that's a larger refactor.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.