### PR TITLE
fix(DB/Proc): Restrict on-spellcast procs to damage/heal only

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1773248694866360388.sql
+++ b/data/sql/updates/pending_db_world/rev_1773248694866360388.sql
@@ -1,0 +1,3 @@
+-- Restrict "on spellcast" procs to damage/heal only (SpellTypeMask=3)
+-- Prevents proccing from utility spells like Open Lock (doors with keys)
+UPDATE `spell_proc` SET `SpellTypeMask` = 3 WHERE `SpellId` IN (27521, 27774, 32837, 32980, 32981, 34584, 38334, 55381, 58442, 62114, 71585);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Adds `SpellTypeMask = 3` (PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_HEAL) to all "on spellcast" proc entries modified in #24903. This prevents meta gem and trinket procs (e.g. Insightful Earthsiege Diamond) from triggering on utility spells like Open Lock (opening doors with keys).

Affected spells: 27521, 27774, 32837, 32980, 32981, 34584, 38334, 55381, 58442, 62114, 71585

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request: Claude Code with AzerothMCP

## Issues Addressed:

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Socket Insightful Earthsiege Diamond (`.additem 41401`) into a helm meta slot
2. Open a locked door with a key (e.g. Scarlet Monastery Cathedral) — verify **no** mana restore proc
3. Cast damage/healing spells on targets — verify mana restore **does** proc

## Known Issues and TODO List:

- [ ] Verify no legitimate NONE-damage-class spells are excluded that should proc these effects