### PR TITLE
fix(Core/Movement): Revert pet PATHFIND_NOT_USING_PATH teleport (#23494)

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -158,15 +158,6 @@ void PetAI::UpdateAI(uint32 diff)
     else
         m_updateAlliesTimer -= diff;
 
-    if (owner && owner->IsPlayer() && !me->GetVictim() && me->CanNotReachTarget())
-    {
-        if (me->GetDistance(owner) > 40.0f)
-        {
-            me->NearTeleportTo(owner->GetPositionX(), owner->GetPositionY(), owner->GetPositionZ(), me->GetOrientation());
-            me->SetCannotReachTarget(); // Clear flag after teleport
-        }
-    }
-
     if (me->GetVictim() && me->GetVictim()->IsAlive())
     {
         // is only necessary to stop casting, the pet must not exit combat

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -648,16 +648,8 @@ bool FollowMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
             owner->UpdateAllowedPositionZ(x, y, z);
 
         bool success = i_path->CalculatePath(x, y, z, forceDest);
-
-        bool cannotReachTarget = !success || (i_path->GetPathType() & PATHFIND_NOPATH && !followingMaster);
-        if (oPet && followingMaster && !owner->CanFly() && (i_path->GetPathType() & PATHFIND_NOT_USING_PATH))
-            cannotReachTarget = true;
-
-        if (cannotReachTarget)
+        if (!success || (i_path->GetPathType() & PATHFIND_NOPATH && !followingMaster))
         {
-            if (oPet && followingMaster)
-                cOwner->SetCannotReachTarget(target->GetGUID());
-
             if (!owner->IsStopped())
                 owner->StopMoving();
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code (Opus) with AzerothMCP was used to research the regression and draft the revert.

## Issues Addressed:
- Reverts #23494 which introduced a regression where pets cannot move underwater

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

#23494 added a check that treated `PATHFIND_NOT_USING_PATH` as "cannot reach target" for pets following their master. However, `PATHFIND_NOT_USING_PATH` is the **expected, normal** pathfinding result when a unit is swimming or flying — navmesh does not cover water/air areas, so a straight-line shortcut path is generated instead.

This caused pets to stop moving and get stuck whenever they were underwater. Additionally, on login underwater the pet spawns at the water surface while the player is at swimming depth, so the pet would be stuck until the player moved 40+ yards away to trigger the PetAI teleport.

The original issue (#23493 — Orbs of Translocation not including pets) will need a different, more targeted solution.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Summon a pet (hunter pet or warlock demon)
2. Swim into deep water and verify the pet follows and moves normally underwater
3. Log out while underwater, log back in, and verify the pet follows immediately
4. Verify the original #23493 orb issue is NOT fixed by this revert (expected — needs a separate fix)

## Known Issues and TODO List:

- [ ] #23493 (Orbs of Translocation not including pets) needs a separate, targeted fix

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.