### PR TITLE
fix(Core/Spells): Fix Chimera Shot Viper Sting mana cap

### DIFF
--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -492,7 +492,7 @@ class spell_hun_chimera_shot : public SpellScript
 
                         // Amount of one aura tick
                         basePoint = int32(CalculatePct(unitTarget->GetMaxPower(POWER_MANA), aurEff->GetAmount()));
-                        int32 casterBasePoint = aurEff->GetAmount() * unitTarget->GetMaxPower(POWER_MANA) / 50; /// @todo: Caster uses unitTarget?
+                        int32 casterBasePoint = aurEff->GetAmount() * caster->GetMaxPower(POWER_MANA) / 50;
                         if (basePoint > casterBasePoint)
                             basePoint = casterBasePoint;
                         ApplyPct(basePoint, TickCount * 60);


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Scripts (bosses, spell scripts, creature scripts).

Fix the Chimera Shot + Viper Sting mana restoration cap in `spell_hun_chimera_shot`. The `casterBasePoint` cap calculation incorrectly used `unitTarget->GetMaxPower(POWER_MANA)` instead of `caster->GetMaxPower(POWER_MANA)`. Against bosses with large mana pools, this effectively removed the cap entirely, allowing hunters to restore tons of mana
Per the Viper Sting tooltip: *"draining 4% mana over 8 sec (up to a maximum of 8% of the **caster's** maximum mana)"* — the cap must be based on the hunter's mana, not the target's.

Addresses the `@todo: Caster uses unitTarget?` from commit ad4ce0895f (2022).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Tools used:** Claude Code with AzerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/8983

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Spell tooltip confirms the cap is based on the caster's maximum mana. The existing `@todo` comment in the code (`/// @todo: Caster uses unitTarget?`) already flagged this as suspicious.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a hunter and target a boss NPC with a large mana pool
2. Apply Viper Sting to the boss
3. Use Chimera Shot while Viper Sting is active
4. Verify the mana restored is capped based on the hunter's max mana, not the boss's
5. Compare with a PvP target (player) to ensure behavior is consistent

## Known Issues and TODO List:

- [ ] Test against various boss mana pool sizes to confirm cap works correctly
- [ ] Verify Chimera Shot + Viper Sting in PvP scenarios remains unaffected

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.