### PR TITLE
fix(Core/Spells): Register missing Ice Barrier AuraScript for Incanter's Absorption

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1773420510836357829.sql
+++ b/data/sql/updates/pending_db_world/rev_1773420510836357829.sql
@@ -1,0 +1,3 @@
+--
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(-11426, 'spell_mage_ice_barrier_aura');

--- a/data/sql/updates/pending_db_world/rev_1773420510836357829.sql
+++ b/data/sql/updates/pending_db_world/rev_1773420510836357829.sql
@@ -1,3 +1,4 @@
 --
+DELETE FROM `spell_script_names` WHERE `spell_id` = -11426 AND `ScriptName` = 'spell_mage_ice_barrier_aura';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (-11426, 'spell_mage_ice_barrier_aura');

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -1614,6 +1614,7 @@ void AddSC_mage_spell_scripts()
     RegisterSpellScript(spell_mage_glyph_of_polymorph);
     RegisterSpellScript(spell_mage_hot_streak);
     RegisterSpellScript(spell_mage_ice_barrier);
+    RegisterSpellScript(spell_mage_ice_barrier_aura);
     RegisterSpellScript(spell_mage_ice_block);
     RegisterSpellScript(spell_mage_imp_blizzard);
     RegisterSpellScript(spell_mage_imp_mana_gems);


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

The `spell_mage_ice_barrier_aura` AuraScript (which handles Incanter's Absorption proc from Ice Barrier absorbs) was never registered after commit ef0bbc4c7 (Nov 2021) refactored `spell_mage` from the old `SpellScriptLoader` system to the new `RegisterSpellScript` system. The old single class was split into:
- `spell_mage_ice_barrier` (SpellScript — cast check) ✓ registered
- `spell_mage_ice_barrier_aura` (AuraScript — absorb handler + Incanter's Absorption trigger) ✗ **never registered**

This PR adds:
1. `RegisterSpellScript(spell_mage_ice_barrier_aura)` in C++
2. `spell_script_names` DB entry binding it to spell -11426 (Ice Barrier, all ranks)

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Tools used:** Claude Code with AzerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9002

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a mage with Incanter's Absorption (talent 44394/44395/44396) and Ice Barrier
2. Cast Ice Barrier
3. Take damage that is absorbed by Ice Barrier
4. Verify Incanter's Absorption buff (44413) is applied with correct spell power bonus
5. Verify Mana Shield and Fire/Frost Ward still proc Incanter's Absorption correctly (regression check)

## Known Issues and TODO List:

- [ ] Verify interaction with Glyph of Ice Barrier

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.