### PR TITLE
fix(Scripts/EoE): fix Malygos Phase 3 Surge of Power warning

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1710432000000000000.sql
+++ b/data/sql/updates/pending_db_world/rev_1710432000000000000.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (60936, 60939);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(60936, 'spell_malygos_surge_of_power_25'),
+(60939, 'spell_malygos_surge_of_power_warning_selector_25');

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "CombatAI.h"
+#include "Containers.h"
 #include "CreatureScript.h"
 #include "GameObjectAI.h"
 #include "GameObjectScript.h"
@@ -72,7 +73,7 @@ enum MalygosSpells
     SPELL_ARCANE_OVERLOAD_SIZE          = 56435,
     SPELL_ARCANE_OVERLOAD_PROTECTION    = 56438,
 
-    SPELL_SURGE_OF_POWER                = 56505, // no heroic version?
+    SPELL_SURGE_OF_POWER                = 56505,
     SPELL_SURGE_OF_POWER_DMG            = 56548,
 
     SPELL_DESTROY_PLATFORM_EFFECT       = 59099,
@@ -80,6 +81,10 @@ enum MalygosSpells
 
     SPELL_ARCANE_PULSE                  = 57432,
     SPELL_PH3_SURGE_OF_POWER            = 57407,
+    SPELL_PH3_SURGE_OF_POWER_25         = 60936,
+    SPELL_SURGE_OF_POWER_WARN_SELECTOR_25 = 60939,
+
+    SPELL_RIDE_RED_DRAGON_BUDDY         = 56071,
 
     SPELL_STATIC_FIELD_MAIN             = 57430,
     SPELL_STATIC_FIELD_SUMMON           = 57431,
@@ -168,6 +173,12 @@ enum Texts
     SAY_ALEXSTRASZA_FOUR  = 3,
 };
 
+enum MalygosData
+{
+    DATA_FIRST_SURGE_TARGET_GUID = 14,
+    NUM_MAX_SURGE_TARGETS        = 3,
+};
+
 enum Phases
 {
     PHASE_NONE = 0,
@@ -196,12 +207,7 @@ struct boss_malygos : public BossAI
     uint8 IntroCounter;
     bool bLockHealthCheck;
     bool _executingVortex;
-
-    void InitializeAI() override
-    {
-        me->SetDisableGravity(true);
-        Reset();
-    }
+    ObjectGuid _surgeTargetGUID[NUM_MAX_SURGE_TARGETS];
 
     void Reset() override
     {
@@ -212,15 +218,30 @@ struct boss_malygos : public BossAI
         IntroCounter = 0;
         bLockHealthCheck = false;
         _executingVortex = false;
+        for (uint8 i = 0; i < NUM_MAX_SURGE_TARGETS; ++i)
+            _surgeTargetGUID[i].Clear();
 
         SetInvincibility(true);
         me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
         me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_PACIFIED);
         me->RemoveUnitFlag(UNIT_FLAG_DISABLE_MOVE);
-
+        me->SetDisableGravity(true);
         me->SetAnimTier(AnimTier::Fly);
 
         instance->DoStopTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, ACHIEV_YOU_DONT_HAVE_AN_ENTERNITY_EVENT);
+    }
+
+    void SetGUID(ObjectGuid const& guid, int32 id) override
+    {
+        if (id >= DATA_FIRST_SURGE_TARGET_GUID && id < DATA_FIRST_SURGE_TARGET_GUID + NUM_MAX_SURGE_TARGETS)
+            _surgeTargetGUID[id - DATA_FIRST_SURGE_TARGET_GUID] = guid;
+    }
+
+    ObjectGuid GetGUID(int32 id) const override
+    {
+        if (id >= DATA_FIRST_SURGE_TARGET_GUID && id < DATA_FIRST_SURGE_TARGET_GUID + NUM_MAX_SURGE_TARGETS)
+            return _surgeTargetGUID[id - DATA_FIRST_SURGE_TARGET_GUID];
+        return ObjectGuid::Empty;
     }
 
     void MovementInform(uint32 type, uint32 id) override
@@ -653,9 +674,36 @@ struct boss_malygos : public BossAI
             events.Repeat(12s);
             break;
         case EVENT_SPELL_PH3_SURGE_OF_POWER:
-            me->CastSpell((Unit*)nullptr, SPELL_PH3_SURGE_OF_POWER, false);
+        {
+            if (Is25ManRaid())
+            {
+                for (uint8 i = 0; i < NUM_MAX_SURGE_TARGETS; ++i)
+                    _surgeTargetGUID[i].Clear();
+                me->CastSpell((Unit*)nullptr, SPELL_SURGE_OF_POWER_WARN_SELECTOR_25, true);
+                me->m_Events.AddEventAtOffset([this]
+                {
+                    me->CastSpell((Unit*)nullptr, SPELL_PH3_SURGE_OF_POWER_25, true);
+                }, 3s);
+            }
+            else
+            {
+                if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, false, true, SPELL_RIDE_RED_DRAGON_BUDDY))
+                {
+                    if (Vehicle* vehicle = target->GetVehicleKit())
+                        if (Unit* passenger = vehicle->GetPassenger(0))
+                            if (Player* player = passenger->ToPlayer())
+                                Talk(EMOTE_SURGE_OF_POWER_WARNING_P3, player);
+                    ObjectGuid targetGuid = target->GetGUID();
+                    me->m_Events.AddEventAtOffset([this, targetGuid]
+                    {
+                        if (Unit* delayedTarget = ObjectAccessor::GetUnit(*me, targetGuid))
+                            me->CastSpell(delayedTarget, SPELL_PH3_SURGE_OF_POWER, true);
+                    }, 3s);
+                }
+            }
             events.Repeat(7s);
             break;
+        }
         }
 
         DoMeleeAttackIfReady();
@@ -1211,48 +1259,116 @@ class spell_malygos_vortex_visual : public AuraScript
     }
 };
 
+// 57407 - Surge of Power (Phase 3 - 10-man)
 class spell_eoe_ph3_surge_of_power : public SpellScript
 {
     PrepareSpellScript(spell_eoe_ph3_surge_of_power);
 
-    ObjectGuid DrakeGUID[3];
-
-    bool Load() override
-    {
-        if (Unit* caster = GetCaster())
-            if (Creature* creature = caster->ToCreature())
-            {
-                uint8 i = 0;
-                std::list<Unit*> drakes;
-                creature->AI()->SelectTargetList(drakes, (creature->GetMap()->GetSpawnMode() == 0 ? 1 : 3), SelectTargetMethod::Random, 0, 0.0f, false, true, 57403 /*only drakes have this aura*/);
-                for (std::list<Unit*>::iterator itr = drakes.begin(); itr != drakes.end() && i < 3; ++itr)
-                {
-                    DrakeGUID[i++] = (*itr)->GetGUID();
-                    if (Vehicle* vehicle = (*itr)->GetVehicleKit())
-                        if (Unit* passenger = vehicle->GetPassenger(0))
-                            if (Player* player = passenger->ToPlayer())
-                                creature->AI()->Talk(EMOTE_SURGE_OF_POWER_WARNING_P3, player);
-                }
-            }
-
-        return true;
-    }
-
     void FilterTargets(std::list<WorldObject*>& targets)
     {
-        if (Unit* caster = GetCaster())
+        // Target selection and warning are handled in boss AI.
+        // Here we just restrict area targets to the explicit cast target.
+        if (Unit* explTarget = GetExplTargetUnit())
         {
             targets.clear();
-            for (uint8 i = 0; i < 3; ++i)
-                if (DrakeGUID[i])
-                    if (Unit* u = ObjectAccessor::GetUnit(*caster, DrakeGUID[i]))
-                        targets.push_back(u);
+            targets.push_back(explTarget);
         }
     }
 
     void Register() override
     {
         OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_eoe_ph3_surge_of_power::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENEMY);
+    }
+};
+
+// 60939 - Surge of Power (Warning Selector - 25-man)
+class spell_malygos_surge_of_power_warning_selector_25 : public SpellScript
+{
+    PrepareSpellScript(spell_malygos_surge_of_power_warning_selector_25);
+
+    bool Load() override
+    {
+        return GetCaster()->IsCreature();
+    }
+
+    bool Validate(SpellInfo const* /*spell*/) override
+    {
+        return ValidateSpellInfo({ SPELL_PH3_SURGE_OF_POWER_25 });
+    }
+
+    void SendThreeTargets(std::list<WorldObject*>& targets)
+    {
+        Creature* caster = GetCaster()->ToCreature();
+
+        // Keep only creatures with vehicle kits (drakes)
+        targets.remove_if([](WorldObject* target)
+        {
+            Creature* creature = target->ToCreature();
+            return !creature || !creature->GetVehicleKit();
+        });
+
+        if (targets.empty())
+            return;
+
+        Acore::Containers::RandomResize(targets, NUM_MAX_SURGE_TARGETS);
+
+        uint8 guidDataSlot = DATA_FIRST_SURGE_TARGET_GUID;
+        for (WorldObject* obj : targets)
+        {
+            Creature* target = obj->ToCreature();
+            caster->AI()->SetGUID(target->GetGUID(), guidDataSlot++);
+
+            if (Vehicle* vehicle = target->GetVehicleKit())
+                if (Unit* passenger = vehicle->GetPassenger(0))
+                    if (Player* player = passenger->ToPlayer())
+                        caster->AI()->Talk(EMOTE_SURGE_OF_POWER_WARNING_P3, player);
+        }
+    }
+
+    void Register() override
+    {
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_malygos_surge_of_power_warning_selector_25::SendThreeTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENEMY);
+    }
+};
+
+// 60936 - Surge of Power (Phase 3 - 25-man)
+class spell_malygos_surge_of_power_25 : public SpellScript
+{
+    PrepareSpellScript(spell_malygos_surge_of_power_25);
+
+    bool Load() override
+    {
+        return GetCaster()->IsCreature();
+    }
+
+    void FilterTargets(std::list<WorldObject*>& targets)
+    {
+        Creature* caster = GetCaster()->ToCreature();
+
+        for (auto itr = targets.begin(); itr != targets.end();)
+        {
+            bool found = false;
+
+            for (uint8 i = DATA_FIRST_SURGE_TARGET_GUID;
+                i < DATA_FIRST_SURGE_TARGET_GUID + NUM_MAX_SURGE_TARGETS; ++i)
+            {
+                if ((*itr)->GetGUID() == caster->AI()->GetGUID(i))
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+                targets.erase(itr++);
+            else
+                ++itr;
+        }
+    }
+
+    void Register() override
+    {
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_malygos_surge_of_power_25::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENEMY);
     }
 };
 
@@ -1310,6 +1426,8 @@ void AddSC_boss_malygos()
     RegisterSpellScript(spell_wyrmrest_skytalon_ride_red_dragon_buddy_trigger);
 
     RegisterSpellScript(spell_eoe_ph3_surge_of_power);
+    RegisterSpellScript(spell_malygos_surge_of_power_warning_selector_25);
+    RegisterSpellScript(spell_malygos_surge_of_power_25);
     RegisterSpellScript(spell_malygos_vortex_dummy);
     RegisterSpellScript(spell_malygos_vortex_visual);
 }


### PR DESCRIPTION
## Summary
- Ports the Surge of Power Phase 3 mechanic from TrinityCore to fix the warning message not appearing when a drake is targeted
- The old code checked for aura 57403, which drakes don't have, so target selection always failed silently
- 10-man: Target selection moved to boss AI using `SPELL_RIDE_RED_DRAGON_BUDDY` (56071) aura to correctly identify drakes with riders. Warning whisper is sent to the passenger, then the damage spell is cast after a 3-second delay
- 25-man: Added dedicated two-spell approach (spells 60939/60936) with 3-target selection, warning delivery, and delayed filtered damage via `m_Events.AddEventAtOffset()`
- Added `spell_script_names` entries for the two new 25-man spell scripts

Closes https://github.com/chromiecraft/chromiecraft/issues/9142

## Changes
- `src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp` — Core mechanic fix
- `data/sql/updates/pending_db_world/rev_1710432000000000000.sql` — DB script name assignments

## Credits
Original TrinityCore implementation by Trista (attributed via `--author`)

## Test plan
- [x] Test Malygos Phase 3 on 10-man: verify "Malygos fixes his eyes upon you!" whisper appears, and Surge of Power fires on the warned drake 3 seconds later
- [ ] Test Malygos Phase 3 on 25-man: verify up to 3 drakes receive whisper warnings, and Surge of Power hits those 3 targets 3 seconds later
- [ ] Verify no regressions in Phase 1 and Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>