### PR TITLE
fix(Core/Unit): Fix infinite loop in RemoveAllControlled

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8102,6 +8102,8 @@ void Unit::RemoveAllControlled(bool onDeath /*= false*/)
                 target->ToTempSummon()->UnSummon();
                 it = m_Controlled.erase(it);
             }
+            else
+                ++it;
         }
         else
         {


### PR DESCRIPTION
The iterator was not incremented when a TempSummon was not unsummoned, causing an infinite loop.

Introduced in fda5093e5.

## Changes Proposed:

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

In `Unit::RemoveAllControlled`, when iterating over `m_Controlled`, the branch handling `TempSummon` that are guardians during `onDeath` (where `!(onDeath && !IsPlayer() && target->IsGuardian())` is false) did not increment the iterator, causing the loop to spin forever on the same element.

Added the missing `else ++it;` to advance the iterator when the summon is kept alive.

This is purely a code logic fix — every other branch in the loop either calls `it = m_Controlled.erase(it)` or `++it`, this one was simply missing. No in-game testing is strictly necessary to validate it, but steps are provided below for completeness.

### AI-assisted Pull Requests

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:

- Closes fda5093e5 regression (infinite loop in `RemoveAllControlled` when a guardian TempSummon is not unsummoned on owner death)

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Code review of the iterator logic in the while loop. The bug is apparent from reading the code: every other branch either calls `it = m_Controlled.erase(it)` or `++it`, except this one.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

I recommend starting the server with waypoints and creature activity enabled to stress test the summon/guardian paths, but given this is a straightforward iterator logic fix, simple reproduction should suffice:

1. Have a player with a guardian-type summon active (e.g. a Warlock pet flagged as guardian).
2. Kill the player (`.kill` GM command).
3. Verify the server does not hang/freeze in `RemoveAllControlled`.
4. Also test with a Lightwell active on owner death to ensure it still stays alive as intended by fda5093e5.

## Known Issues and TODO List:

- [ ] Regression test with all summon types (Lightwell, guardians, totems, standard pets) on owner death to ensure no other iterator issue exists.
