### PR TITLE
fix(DB/Spell): Correct Demonic Pact ICD to 20 seconds

### DIFF
--- a/data/sql/updates/pending_db_world/rev_fix_demonic_pact_icd.sql
+++ b/data/sql/updates/pending_db_world/rev_fix_demonic_pact_icd.sql
@@ -1,0 +1,3 @@
+-- Fix Demonic Pact ICD: should be 20 seconds in 3.3.5, not 5 seconds
+-- Also ensure both ranks (53646, 54909) have consistent cooldown
+UPDATE `spell_proc` SET `Cooldown` = 20000 WHERE `SpellId` IN (53646, 54909);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Updates the `spell_proc` table to set the Internal Cooldown (ICD) for Demonic Pact (spells 53646 and 54909) from 5 seconds to 20 seconds, matching the correct 3.3.5a behavior.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Tools used:** Claude Code with AzerothMCP

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/9151

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://warcraft.wiki.gg/wiki/Demonic_Pact — Demonic Pact had a 20 second ICD in patch 3.3.3+. The `spell_proc` table currently has `Cooldown = 5000` (5s) for spell 53646 and `Cooldown = 0` for spell 54909. Both are corrected to 20000 (20s).

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Play a Warlock with Demonic Pact talent
2. Have pet attack a target dummy (use Demonic Empowerment for more crits)
3. Observe the Demonic Pact buff — it should only refresh when remaining duration is less than 25 seconds (45s duration - 20s ICD = 25s), not at 40 seconds remaining

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] In 3.3.5a, a weaker Demonic Pact can still overwrite a stronger one (this was only changed in WotLK Classic 3.4.3)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.