### PR TITLE
fix(Scripts/Desolance): use correct gossip hook for kodo kombo quest

### DIFF
--- a/src/server/scripts/Kalimdor/zone_desolace.cpp
+++ b/src/server/scripts/Kalimdor/zone_desolace.cpp
@@ -469,9 +469,9 @@ struct npc_aged_dying_ancient_kodo : public ScriptedAI
         }
     }
 
-    bool OnGossipHello(Player* player, Creature* creature)
+    void sGossipHello(Player* player) override
     {
-        if (creature->HasAura(SPELL_KODO_KOMBO_DESPAWN_BUFF))
+        if (me->HasAura(SPELL_KODO_KOMBO_DESPAWN_BUFF))
         {
             if (Group* group = player->GetGroup())
             {
@@ -479,18 +479,17 @@ struct npc_aged_dying_ancient_kodo : public ScriptedAI
                 {
                     Player* grpPlayer = itr->GetSource();
                     if (grpPlayer->HasAura(SPELL_KODO_KOMBO_PLAYER_BUFF))
-                        grpPlayer->TalkedToCreature(creature->GetEntry(), ObjectGuid::Empty);
+                        grpPlayer->TalkedToCreature(me->GetEntry(), ObjectGuid::Empty);
                 }
             }
             else
                 if (player->HasAura(SPELL_KODO_KOMBO_PLAYER_BUFF))
-                    player->TalkedToCreature(creature->GetEntry(), ObjectGuid::Empty);
+                    player->TalkedToCreature(me->GetEntry(), ObjectGuid::Empty);
 
             player->RemoveAurasDueToSpell(SPELL_KODO_KOMBO_PLAYER_BUFF);
         }
 
-        SendGossipMenuFor(player, NPC_TEXT_KODO, creature->GetGUID());
-        return true;
+        SendGossipMenuFor(player, NPC_TEXT_KODO, me->GetGUID());
     }
 };
 


### PR DESCRIPTION
## Summary
- `npc_aged_dying_ancient_kodo` inherits from `ScriptedAI` but defined `OnGossipHello(Player*, Creature*)`, which is a `CreatureScript` method — never called in the `UnitAI` hierarchy
- Replaced with `sGossipHello(Player*)` override, which is the correct virtual in `UnitAI`
- Changed `creature->` references to `me->` to match the new signature

## Test plan
- [ ] Verify Kodo Kombo quest (ID 5561) gossip interaction works with tamed kodo in Desolace
- [ ] Verify quest credit is granted to player (and group members with the buff)
- [ ] Verify `SPELL_KODO_KOMBO_PLAYER_BUFF` is removed after gossip

🤖 Generated with [Claude Code](https://claude.com/claude-code)