### PR TITLE
fix(Core/Spells): Fix Entrapment not proccing from trap activation

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2247,7 +2247,7 @@ void Spell::prepareDataForTriggerSystem(AuraEffect const* /*triggeredByAura*/)
     // Hunter trap spells - activation proc for Lock and Load, Entrapment and Misdirection
     if (m_spellInfo->SpellFamilyName == SPELLFAMILY_HUNTER &&
             (m_spellInfo->SpellFamilyFlags[0] & 0x18 ||              // Freezing and Frost Trap, Freezing Arrow
-             m_spellInfo->Id == 57879 || m_spellInfo->Id == 45145 ||  // Snake Trap - done this way to avoid double proc
+             m_spellInfo->Id == 57879 ||                               // Snake Trap - done this way to avoid double proc
              m_spellInfo->SpellFamilyFlags[2] & 0x00024000))          // Explosive and Immolation Trap
     {
         m_procAttacker |= PROC_FLAG_DONE_TRAP_ACTIVATION;
@@ -4307,7 +4307,13 @@ void Spell::_handle_finish_phase()
             break;
         }
 
-        Unit::ProcSkillsAndAuras(m_originalCaster, nullptr, procAttacker, PROC_FLAG_NONE, hitMask, 1, BASE_ATTACK, m_spellInfo, m_triggeredByAuraSpell.spellInfo,
+        // For trap activation, pass the original target (trap triggerer) so proc trigger spells
+        // like Entrapment can find a valid target to cast on
+        Unit* finishVictim = nullptr;
+        if (procAttacker & PROC_FLAG_DONE_TRAP_ACTIVATION)
+            finishVictim = GetOriginalTarget();
+
+        Unit::ProcSkillsAndAuras(m_originalCaster, finishVictim, procAttacker, PROC_FLAG_NONE, hitMask, 1, BASE_ATTACK, m_spellInfo, m_triggeredByAuraSpell.spellInfo,
             m_triggeredByAuraSpell.effectIndex, this, nullptr, nullptr, PROC_SPELL_PHASE_FINISH);
     }
 }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code** with **AzerothMCP**

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/22202

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - TrinityCore 3.3.5 branch uses the same approach (only spell 57879 for Snake Trap, no 45145)
  - TrinityCore has the same `nullptr` victim bug in FINISH phase procs (unfixed)
  - Wowpedia Entrapment description: "When your Frost Trap or Snake Trap are triggered you entrap all afflicted targets"

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a Hunter with Entrapment talent (`.learn 19184` for rank 1, `.learn 19388` for rank 3)
2. Get a second player character as a PvP target
3. Go to a PvP area (e.g. `.tele gurubashi`)
4. Place **Frost Trap** under the opponent — verify the target gets rooted (Entrapment debuff, cannot move) for the correct duration (2/3/4s based on rank)
5. Wait for DR to expire (~18 seconds)
6. Place **Snake Trap** under the opponent — verify the target gets rooted with the same full duration
7. Verify subsequent trap roots apply correct DR: 2nd application = half duration, 3rd = quarter duration

### What was broken:
- **Entrapment did not proc at all** for either Frost Trap or Snake Trap. The FINISH phase proc passed `nullptr` as victim, so the triggered root spell (19185) had no target to cast on.
- **Snake Trap caused double DR** because both spells 45145 and 57879 set `PROC_FLAG_DONE_TRAP_ACTIVATION`, causing Entrapment to proc twice per activation.

### What this PR fixes:
1. Pass the trap triggerer (`GetOriginalTarget()`) as victim for trap activation FINISH procs, so Entrapment's root spell has a valid target
2. Remove spell 45145 from the trap activation check (matching TrinityCore), so only 57879 triggers the proc for Snake Trap

## Known Issues and TODO List:


## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.