### PR TITLE
fix(Core/LFG): prevent RDF anti-kick exploit via loot rolls

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13022,7 +13022,7 @@ PartyResult Player::CanUninviteFromGroup(ObjectGuid targetPlayerGUID) const
         if (state == lfg::LFG_STATE_FINISHED_DUNGEON)
             return ERR_PARTY_LFG_BOOT_DUNGEON_COMPLETE;
 
-        if (grp->isRollLootActive())
+        if (grp->isRollLootActive() && ObjectAccessor::FindConnectedPlayer(targetPlayerGUID))
             return ERR_PARTY_LFG_BOOT_LOOT_ROLLS;
 
         /// @todo: Should also be sent when anyone has recently left combat, with an aprox ~5 seconds timer.

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -600,35 +600,7 @@ bool Group::RemoveMember(ObjectGuid guid, const RemoveMethod& method /*= GROUP_R
         }
 
         // Remove player from loot rolls
-        for (Rolls::iterator it = RollId.begin(); it != RollId.end();)
-        {
-            Roll* roll = *it;
-            Roll::PlayerVote::iterator itr2 = roll->playerVote.find(guid);
-            if (itr2 == roll->playerVote.end())
-            {
-                ++it;
-                continue;
-            }
-
-            if (itr2->second == GREED || itr2->second == DISENCHANT)
-                --roll->totalGreed;
-            else if (itr2->second == NEED)
-                --roll->totalNeed;
-            else if (itr2->second == PASS)
-                --roll->totalPass;
-
-            if (itr2->second != NOT_VALID)
-                --roll->totalPlayersRolling;
-
-            roll->playerVote.erase(itr2);
-
-            // Xinef: itr can be erased inside
-            // Xinef: player is removed from all vote lists so it will not pass above playerVote == playerVote.end statement during second iteration
-            if (CountRollVote(guid, roll->itemGUID, MAX_ROLL_TYPE))
-                it = RollId.begin();
-            else
-                ++it;
-        }
+        RemovePlayerFromRolls(guid);
 
         // Update subgroups
         member_witerator slot = _getMemberWSlot(guid);
@@ -1419,6 +1391,37 @@ void Group::EndRoll(Loot* pLoot, Map* allowedMap)
         }
         else
             ++itr;
+    }
+}
+
+void Group::RemovePlayerFromRolls(ObjectGuid guid)
+{
+    for (Rolls::iterator it = RollId.begin(); it != RollId.end();)
+    {
+        Roll* roll = *it;
+        Roll::PlayerVote::iterator itr2 = roll->playerVote.find(guid);
+        if (itr2 == roll->playerVote.end())
+        {
+            ++it;
+            continue;
+        }
+
+        if (itr2->second == GREED || itr2->second == DISENCHANT)
+            --roll->totalGreed;
+        else if (itr2->second == NEED)
+            --roll->totalNeed;
+        else if (itr2->second == PASS)
+            --roll->totalPass;
+
+        if (itr2->second != NOT_VALID)
+            --roll->totalPlayersRolling;
+
+        roll->playerVote.erase(itr2);
+
+        if (CountRollVote(guid, roll->itemGUID, MAX_ROLL_TYPE))
+            it = RollId.begin();
+        else
+            ++it;
     }
 }
 

--- a/src/server/game/Groups/Group.h
+++ b/src/server/game/Groups/Group.h
@@ -299,6 +299,7 @@ public:
     void CountTheRoll(Rolls::iterator roll, Map* allowedMap);
     bool CountRollVote(ObjectGuid playerGUID, ObjectGuid Guid, uint8 Choise);
     void EndRoll(Loot* loot, Map* allowedMap);
+    void RemovePlayerFromRolls(ObjectGuid guid);
 
     // related to disenchant rolls
     void ResetMaxEnchantingLevel();

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -702,6 +702,10 @@ void WorldSession::LogoutPlayer(bool save)
         // a) in group; b) not in raid group; c) logging out normally (not being kicked or disconnected) d) LeaveGroupOnLogout is enabled
         if (_player->GetGroup() && !_player->GetGroup()->isRaidGroup() && !_player->GetGroup()->isLFGGroup() && m_Socket && sWorld->getBoolConfig(CONFIG_LEAVE_GROUP_ON_LOGOUT))
             _player->RemoveFromGroup();
+        // Remove player from active loot rolls in LFG groups (player stays in group but should not block rolls)
+        else if (Group* group = _player->GetGroup())
+            if (group->isLFGGroup())
+                group->RemovePlayerFromRolls(_player->GetGUID());
 
         // pussywizard: checked second time after being removed from a group
         if (!_player->IsBeingTeleportedFar() && !_player->m_InstanceValid && !_player->IsGameMaster())


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

When a player in an LFG group logs off during an active loot roll, they remain in the group but cannot vote on the roll. This blocks kick votes for the full 60-second roll timer via the `isRollLootActive()` check in `CanUninviteFromGroup`, creating a griefing exploit.

This PR fixes the issue by:
1. Extracting roll cleanup from `Group::RemoveMember` into a new `Group::RemovePlayerFromRolls()` method (no behavior change for existing callers)
2. Calling `RemovePlayerFromRolls()` during `LogoutPlayer` for LFG groups — the player stays in the group but is immediately removed from active rolls, allowing remaining players to resolve rolls without waiting the full 60s timer
3. As a safety net, `CanUninviteFromGroup` now allows kick votes targeting disconnected players (`FindConnectedPlayer` returns nullptr) even during active rolls

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Opus 4.6 was used for code analysis and implementation.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9156

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Existing code evidence supports that offline players should not participate in loot rolls:
- `GroupLoot` already excludes sessionless players from new rolls (`!member->GetSession()`)
- `RemoveMember` already removes departing players from active rolls
- `EndRoll` treats non-voters as passes

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Queue for RDF with two or more players
2. Kill a mob that drops loot requiring a roll (Need/Greed)
3. Have one player log off while the roll is active
4. Verify the roll resolves immediately for remaining players (not blocked for 60s)
5. Verify the remaining players can initiate a kick vote against the offline player
6. Also test that kicking is still blocked during active rolls when the target is online (normal behavior preserved)

## Known Issues and TODO List:

- [ ] Verify no regressions with normal (non-LFG) group loot roll behavior
- [ ] Verify no regressions with the `RemoveMember` refactor (should be identical behavior)