### PR TITLE
fix(Core/DB): Fix Malygos not engaging due to IMMUNE_TO_PC spawn flag

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1773882866738187733.sql
+++ b/data/sql/updates/pending_db_world/rev_1773882866738187733.sql
@@ -1,0 +1,2 @@
+-- Remove incorrect IMMUNE_TO_PC from Malygos spawn flags
+UPDATE `creature` SET `unit_flags` = 0 WHERE `guid` = 132313 AND `id1` = 28859;

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2758,10 +2758,6 @@ void Creature::AtEngage(Unit* target)
 {
     Unit::AtEngage(target);
 
-    // If we somehow engage in combat with a player while immune, remove immunity so they can fight back
-    if (target && IsImmuneToPC() && target->GetCharmerOrOwnerPlayerOrPlayerItself())
-        SetImmuneToPC(false);
-
     if (!IsStandState())
         SetStandState(UNIT_STAND_STATE_STAND);
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Malygos (entry 28859) would enter combat but never engage. The creature spawn had `unit_flags=320` which includes `UNIT_FLAG_IMMUNE_TO_PC` (0x100). This caused `ThreatReference::ShouldBeOffline()` to return true via `FlagsAllowFighting`, keeping the threat ref permanently OFFLINE and preventing `JustStartedThreateningMe` → `EngagementStart` → `JustEngagedWith` from firing.

The old threat system masked this with a runtime hack in `SetInCombatState` that stripped `IMMUNE_TO_PC` on combat entry. That hack (moved to `Creature::AtEngage` during the threat port) is removed here since the correct fix is removing the wrong flag from spawn data.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP were used.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). TrinityCore creature spawn for Malygos has `unit_flags=0`. **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Eye of Eternity
2. Activate the Focusing Iris to start the Malygos encounter
3. Malygos should engage and begin Phase 1 (fly to center, land, start attacking)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [x] Audit other creature spawns with IMMUNE_TO_PC in spawn data (265 spawns across 40 creature types)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.