### PR TITLE
fix(Scripts/Dalaran): Prevent Minigob Manabonk from targeting GMs

### DIFF
--- a/src/server/scripts/Northrend/zone_dalaran.cpp
+++ b/src/server/scripts/Northrend/zone_dalaran.cpp
@@ -526,6 +526,7 @@ struct npc_minigob_manabonk : public ScriptedAI
     void Reset() override
     {
         me->SetVisible(false);
+        playerGUID.Clear();
         events.ScheduleEvent(EVENT_SELECT_TARGET, 1s);
     }
 
@@ -579,6 +580,11 @@ struct npc_minigob_manabonk : public ScriptedAI
                 case EVENT_POLYMORPH:
                     if (Player* player = ObjectAccessor::GetPlayer(*me, playerGUID))
                     {
+                        if (player->IsGameMaster())
+                        {
+                            me->DespawnOrUnsummon();
+                            return;
+                        }
                         DoCast(player, SPELL_MANABONKED);
                         SendMailToPlayer(player);
                     }


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code (Claude Opus 4.6) was used to research the issue, implement the fix, and prepare this PR.

## Issues Addressed:

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24731

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Code review of `npc_minigob_manabonk` in `zone_dalaran.cpp` identified two issues:

1. **Missing GM check at polymorph stage**: `SelectTargetInDalaran()` correctly filters out GMs via `IsGameMaster()`, but there is a 30-second window between target selection (`EVENT_SELECT_TARGET`) and the actual spell cast (`EVENT_POLYMORPH`). If a player enables `.gm on` during this window, they would still be polymorphed. A second `IsGameMaster()` check at the polymorph stage prevents this.

2. **Stale `playerGUID` across cycles**: The `playerGUID` member was never cleared in `Reset()`, meaning a GUID from a previous cycle could persist across respawns. Now cleared on reset.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enable GM mode with `.gm on`
2. Teleport to Dalaran with `.tele dalaran`
3. Ensure event 33 is active (`.event start 33` if needed)
4. Wait for Minigob Manabonk to spawn — he should **not** target or polymorph you
5. Disable GM mode with `.gm off` and verify he targets you normally

## Known Issues and TODO List:

- [ ] Needs in-game testing to confirm the fix

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.