### PR TITLE
fix(DB/Spell): Add internal cooldown to Spirit Burn proc

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1773945980134291128.sql
+++ b/data/sql/updates/pending_db_world/rev_1773945980134291128.sql
@@ -1,3 +1,3 @@
 -- Spirit Burn (54647) - Add 10s internal cooldown
 DELETE FROM `spell_proc` WHERE `SpellId` = 54647;
-INSERT INTO `spell_proc` (`SpellId`, `Cooldown`) VALUES (54647, 10000);
+INSERT INTO `spell_proc` (`SpellId`, `Cooldown`) VALUES (54647, 8000);

--- a/data/sql/updates/pending_db_world/rev_1773945980134291128.sql
+++ b/data/sql/updates/pending_db_world/rev_1773945980134291128.sql
@@ -1,0 +1,3 @@
+-- Spirit Burn (54647) - Add 10s internal cooldown
+DELETE FROM `spell_proc` WHERE `SpellId` = 54647;
+INSERT INTO `spell_proc` (`SpellId`, `Cooldown`) VALUES (54647, 10000);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code** with **AzerothMCP** was used for database research and analysis.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9166

## Description:
Enchanted Tiki Warriors (entry 28882) in Zul'Drak self-cast Spirit Burn aura (54647) on respawn. This aura triggers Spirit Burn (54651) on being hit with a 75% proc chance and no internal cooldown, causing the damage + stat reduction debuff to fire on nearly every hit taken.

This adds a 8 second internal cooldown via `spell_proc`, matching the duration of the triggered debuff (54651). This prevents the proc from firing excessively while still keeping it as a meaningful mechanic.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

The source for this fix isn't very clear right now. The DBC data shows 75% proc chance with no cooldown, and neither AC nor TrinityCore have a `spell_proc` entry for this spell. The reference video in the issue shows Spirit Burn proccing far less frequently than the current behavior on AC. A 8s ICD matching the debuff duration is a reasonable correction.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go creature id 28882` to teleport to an Enchanted Tiki Warrior
2. Engage in melee combat and observe Spirit Burn proc frequency
3. Verify Spirit Burn no longer fires on nearly every hit, with roughly 10 seconds between procs

## Known Issues and TODO List:

- [ ] Source evidence could be stronger - further retail video/sniff comparison welcome

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.