### PR TITLE
fix(Core/Scripts): Fix GetVictim() returning null during JustEngagedWith

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -225,7 +225,7 @@ bool AssistDelayEvent::Execute(uint64 /*e_time*/, uint32 /*p_time*/)
 
                 // When nearby mobs aggro from another mob's initial call for assistance
                 // their leash timers become linked and attacking one will keep the rest from evading.
-                if (assistant->GetVictim())
+                if (assistant->IsEngaged())
                     assistant->SetLastLeashExtensionTimePtr(m_owner->GetLastLeashExtensionTimePtr());
             }
         }
@@ -2394,20 +2394,18 @@ void Creature::CallAssistance(Unit* target /*= nullptr*/)
 
 void Creature::CallForHelp(float radius, Unit* target /*= nullptr*/)
 {
-    if (radius <= 0.0f || IsPet() || IsCharmed())
-    {
+    if (radius <= 0.0f || !IsEngaged() || !IsAlive() || IsPet() || IsCharmed())
         return;
-    }
 
     if (!target)
-    {
-        target = GetVictim();
-    }
+        target = GetThreatMgr().GetCurrentVictim();
+    if (!target)
+        target = GetThreatMgr().GetAnyTarget();
+    if (!target)
+        target = GetCombatManager().GetAnyTarget();
 
     if (!target)
-    {
         return;
-    }
 
     if (m_alreadyCallForHelp) // avoid recursive call for help for any reason
         return;

--- a/src/server/scripts/Northrend/Naxxramas/boss_grobbulus.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_grobbulus.cpp
@@ -82,20 +82,22 @@ public:
             dropSludgeTimer = 0;
         }
 
-        void PullChamberAdds()
+        void PullChamberAdds(Unit* target)
         {
+            if (!target)
+                return;
             std::list<Creature*> StichedGiants;
             me->GetCreaturesWithEntryInRange(StichedGiants, 300.0f, NPC_STICHED_GIANT);
             for (std::list<Creature*>::const_iterator itr = StichedGiants.begin(); itr != StichedGiants.end(); ++itr)
             {
-                (*itr)->ToCreature()->AI()->AttackStart(me->GetVictim());
+                (*itr)->ToCreature()->AI()->AttackStart(target);
             }
         }
 
         void JustEngagedWith(Unit* who) override
         {
             BossAI::JustEngagedWith(who);
-            PullChamberAdds();
+            PullChamberAdds(who);
             me->SetInCombatWithZone();
             events.ScheduleEvent(EVENT_POISON_CLOUD, 15s);
             events.ScheduleEvent(EVENT_MUTATING_INJECTION, 20s);

--- a/src/server/scripts/Northrend/Naxxramas/instance_naxxramas.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/instance_naxxramas.cpp
@@ -516,11 +516,14 @@ public:
                 // pull all the trash if not killed
                 if (Creature* patchwerk = GetCreature(DATA_PATCHWERK_BOSS))
                 {
-                    for (auto& itr : _patchwerkRoomTrash)
+                    if (Unit* target = patchwerk->GetThreatMgr().GetCurrentVictim())
                     {
-                        Creature* trash = ObjectAccessor::GetCreature(*patchwerk, itr);
-                        if (trash && trash->IsAlive() && !trash->IsInCombat())
-                            trash->AI()->AttackStart(patchwerk->GetVictim());
+                        for (auto& itr : _patchwerkRoomTrash)
+                        {
+                            Creature* trash = ObjectAccessor::GetCreature(*patchwerk, itr);
+                            if (trash && trash->IsAlive() && !trash->IsInCombat())
+                                trash->AI()->AttackStart(target);
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP was used.

## Description

The threat system port (984baa92d) changed the engagement flow so that `Attack()` (which sets `m_attacking`) is no longer called before `JustEngagedWith`. In the old system, `CombatStart` called `AttackStart()` before triggering `JustEngagedWith`, so `GetVictim()` always returned a valid target during engagement callbacks. In the new system, engagement goes through `EngageWithTarget` → `ThreatManager::AddThreat` → `JustStartedThreateningMe` → `JustEngagedWith` without ever calling `AttackStart`, so `GetVictim()` returns `nullptr`.

This broke:
- **`Creature::CallForHelp()`** — used `GetVictim()` as fallback target, silently returning without calling for help. Affected all bosses using `callForHelpRange` (e.g. Sartharion, and any boss with configured call-for-help range).
- **`AssistDelayEvent`** — checked `GetVictim()` for leash timer linking, which always failed, causing assist-pulled mobs to evade independently.
- **Patchwerk trash pull** — `instance_naxxramas.cpp` passed `patchwerk->GetVictim()` (null) to trash `AttackStart`, so trash never pulled.
- **Grobbulus chamber adds** — `PullChamberAdds()` used `me->GetVictim()` (null) during `JustEngagedWith`.

### Fixes applied:
- `CallForHelp()`: Use `GetThreatMgr().GetCurrentVictim()` with fallbacks to `GetAnyTarget()` and `GetCombatManager().GetAnyTarget()`, matching TrinityCore.
- `AssistDelayEvent`: Check `IsEngaged()` instead of `GetVictim()` for leash timer linking.
- `instance_naxxramas.cpp`: Use `patchwerk->GetThreatMgr().GetCurrentVictim()` for trash pull target.
- `boss_grobbulus.cpp`: Pass `who` parameter from `JustEngagedWith` directly to `PullChamberAdds()`.

### Audit of other `GetVictim()` → `AttackStart` patterns:
All other instances (~28 cases across scripts) were audited and confirmed safe — they are called during mid-combat events (`UpdateAI` after `UpdateVictim`, `SetData` during combat, phase transitions, summon handlers) where `m_attacking` is already set.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9170

## SOURCE:
The changes have been validated through:
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore's `Creature::CallForHelp()` implementation was used as reference for the correct victim resolution pattern.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Obsidian Sanctum and pull Sartharion — all trash in the instance should aggro
2. Enter Naxxramas Construct Quarter, pull Patchwerk — all room trash should aggro
3. Pull Grobbulus — Stitched Giants in the chamber should aggro
4. Pull any regular outdoor mob — nearby same-faction mobs should assist and share leash timers

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.