### PR TITLE
fix(Scripts/EoE): Cross-faction Wyrmrest Skytalon support in Eye of Eternity

### DIFF
--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/eye_of_eternity.h
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/eye_of_eternity.h
@@ -49,6 +49,7 @@ enum NPCs
     NPC_SURGE_OF_POWER          = 30334,
     NPC_STATIC_FIELD            = 30592,
     NPC_ALEXSTRASZA             = 32295,
+    NPC_WYRMREST_SKYTALON       = 30161,
 };
 
 enum Data

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/instance_eye_of_eternity.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/instance_eye_of_eternity.cpp
@@ -56,6 +56,10 @@ struct instance_eye_of_eternity : public InstanceScript
 
         if (creature->GetEntry() == NPC_VORTEX)
             _vortexTriggers.push_back(creature->GetGUID());
+
+        if (sWorld->getBoolConfig(CONFIG_ALLOW_TWO_SIDE_INTERACTION_GROUP))
+            if (creature->GetEntry() == NPC_WYRMREST_SKYTALON)
+                creature->SetFaction(FACTION_FRIENDLY);
     }
 
     ObjectGuid GetGuidData(uint32 data) const override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

When `CONFIG_ALLOW_TWO_SIDE_INTERACTION_GROUP` is enabled, Wyrmrest Skytalons summoned during Phase 3 of the Malygos encounter inherit the summoning player's faction. This prevents opposite-faction players in cross-faction groups from interacting with each other's dragons.

This adds the same handling already present in the Oculus instance for its drakes: on creature creation, if the cross-faction group config is enabled, the skytalon's faction is set to `FACTION_FRIENDLY`.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Opus 4.6 was used.

## Issues Addressed:

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Mirrors existing cross-faction handling from the Oculus instance script (`instance_oculus.cpp`).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enable `AllowTwoSide.Interaction.Group` in worldserver config.
2. Create a cross-faction group (one Alliance, one Horde player).
3. Enter Eye of Eternity and reach Phase 3 of the Malygos encounter.
4. Verify both players can interact with all summoned Wyrmrest Skytalons regardless of faction.

## Known Issues and TODO List:

- [ ] N/A