### PR TITLE
fix(Core/Combat): Fire OnPlayerLeaveCombat hook from CombatManager exit path

### DIFF
--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -427,6 +427,9 @@ bool CombatManager::UpdateOwnerCombatState() const
         _owner->AtExitCombat();
         if (!_owner->IsCreature())
             _owner->AtDisengage();
+
+        if (Player* player = _owner->ToPlayer())
+            sScriptMgr->OnPlayerLeaveCombat(player);
     }
 
     if (Unit* master = _owner->GetCharmerOrOwner())


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Tools used: Claude Code with AzerothMCP**

## Issues Addressed:
- `OnPlayerLeaveCombat` script hook not firing when combat ends via CombatManager (NPC evade/death). The matching `OnPlayerEnterCombat` hook is already present in `UpdateOwnerCombatState()` but the leave hook was missing.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Register a module using the `OnPlayerLeaveCombat` hook
2. Enter combat with an NPC, then let it evade
3. Verify the hook fires on combat exit

## Known Issues and TODO List:

- [ ]
- [ ]