### PR TITLE
fix(Scripts/Ulduar): spawn keepers at Observation Ring on defeat

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -285,7 +285,6 @@ const Position KeepersPos[4] =
 
 const uint32 TABLE_KEEPER_ENTRY[4] = {NPC_FREYA_KEEPER, NPC_HODIR_KEEPER, NPC_MIMIRON_KEEPER, NPC_THORIM_KEEPER};
 const uint32 TABLE_GOSSIP_ENTRY[4] = {NPC_FREYA_GOSSIP, NPC_HODIR_GOSSIP, NPC_MIMIRON_GOSSIP, NPC_THORIM_GOSSIP};
-const uint32 TABLE_KEEPER_TYPE[4]  = {BOSS_FREYA,             BOSS_HODIR,       BOSS_MIMIRON,       BOSS_THORIM};
 
 static LocationsXY yoggPortalLoc[] =
 {
@@ -505,8 +504,17 @@ struct boss_yoggsaron_sara : public ScriptedAI
 
     void DespawnGossipKeepers()
     {
+        static uint32 const gossipData[] =
+        {
+            DATA_FREYA_GOSSIP, DATA_HODIR_GOSSIP,
+            DATA_MIMIRON_GOSSIP, DATA_THORIM_GOSSIP
+        };
         for (uint8 i = KEEPER_FREYA; i <= KEEPER_THORIM; i++)
+        {
             summons.DespawnEntry(TABLE_GOSSIP_ENTRY[i]);
+            if (Creature* keeper = m_pInstance->GetCreature(gossipData[i]))
+                keeper->DespawnOrUnsummon();
+        }
     }
 
     void UpdateKeeperSpawns()
@@ -517,11 +525,6 @@ struct boss_yoggsaron_sara : public ScriptedAI
             {
                 if (!summons.HasEntry(TABLE_KEEPER_ENTRY[i]))
                     me->SummonCreature(TABLE_KEEPER_ENTRY[i], KeepersPos[i]);
-            }
-            else if (m_pInstance->GetData(TABLE_KEEPER_TYPE[i]) == DONE)
-            {
-                if (!summons.HasEntry(TABLE_GOSSIP_ENTRY[i]))
-                    me->SummonCreature(TABLE_GOSSIP_ENTRY[i], GossipKeepersPos[i]);
             }
         }
     }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -39,6 +39,32 @@ DoorData const doorData[] =
     { 0,                    0,              DOOR_TYPE_ROOM    }
 };
 
+// Observation Ring keeper positions, indexed by KEEPER_* constants
+static Position const ObservationRingKeepersPos[4] =
+{
+    {1945.6823f,  33.342014f, 411.44083f, 5.270895f}, // Freya
+    {1945.7609f, -81.52171f,  411.4407f,  1.029744f}, // Hodir
+    {2028.7656f,  17.42014f,  411.44458f, 3.857178f}, // Mimiron
+    {2028.8219f, -65.73573f,  411.44257f, 2.460914f}  // Thorim
+};
+
+static uint32 const ObservationRingKeeperEntry[4] =
+{
+    NPC_FREYA_GOSSIP, NPC_HODIR_GOSSIP,
+    NPC_MIMIRON_GOSSIP, NPC_THORIM_GOSSIP
+};
+
+static uint32 const ObservationRingKeeperData[4] =
+{
+    DATA_FREYA_GOSSIP, DATA_HODIR_GOSSIP,
+    DATA_MIMIRON_GOSSIP, DATA_THORIM_GOSSIP
+};
+
+static uint32 const ObservationRingKeeperBoss[4] =
+{
+    BOSS_FREYA, BOSS_HODIR, BOSS_MIMIRON, BOSS_THORIM
+};
+
 ObjectData const creatureData[] =
 {
     { NPC_LEVIATHAN,    BOSS_LEVIATHAN  },
@@ -69,6 +95,11 @@ ObjectData const creatureData[] =
     // Yogg-Saron helpers
     { NPC_SARA,                     DATA_SARA                   },
     { NPC_BRAIN_OF_YOGG_SARON,      DATA_BRAIN_OF_YOGG_SARON    },
+    // Observation Ring Keepers
+    { NPC_FREYA_GOSSIP,             DATA_FREYA_GOSSIP           },
+    { NPC_HODIR_GOSSIP,             DATA_HODIR_GOSSIP           },
+    { NPC_MIMIRON_GOSSIP,           DATA_MIMIRON_GOSSIP         },
+    { NPC_THORIM_GOSSIP,            DATA_THORIM_GOSSIP          },
     // Algalon helpers
     { NPC_BRANN_BRONZBEARD_ALG,     DATA_BRANN_BRONZEBEARD_ALG  },
     { NPC_BRANN_BASE_CAMP,          DATA_BRANN_BASE_CAMP        },
@@ -173,7 +204,6 @@ public:
         // Shared
         EventMap _events;
         bool m_mimironTramUsed;
-        ObjectGuid m_keepersGossipGUID[4];
 
         void Initialize() override
         {
@@ -226,6 +256,15 @@ public:
                             t->AddPassenger(go, true);
                 }
             }
+
+            // Spawn Observation Ring keepers for defeated bosses
+            for (uint8 i = KEEPER_FREYA; i <= KEEPER_THORIM; ++i)
+                if (IsBossDone(ObservationRingKeeperBoss[i])
+                    && !(m_watchersMask & (1 << i))
+                    && !GetObjectGuid(ObservationRingKeeperData[i]))
+                    instance->SummonCreature(
+                        ObservationRingKeeperEntry[i],
+                        ObservationRingKeepersPos[i]);
 
             if (!GetObjectGuid(BOSS_ALGALON) && m_algalonTimer && (m_algalonTimer <= 60 || m_algalonTimer == TIMER_ALGALON_TO_SUMMON))
             {
@@ -303,7 +342,7 @@ public:
                 case BOSS_HODIR:
                 case BOSS_THORIM:
                 case BOSS_FREYA:
-                    if (GetBossState(BOSS_MIMIRON) == DONE && GetBossState(BOSS_FREYA) == DONE && GetBossState(BOSS_HODIR) == DONE && GetBossState(BOSS_THORIM) == DONE)
+                    if (AllBossesDone({BOSS_MIMIRON, BOSS_FREYA, BOSS_HODIR, BOSS_THORIM}))
                     {
                         scheduler.Schedule(45s, [this](TaskContext /*context*/)
                         {
@@ -317,6 +356,13 @@ public:
                     }
                     if (type == BOSS_HODIR && state == DONE)
                         setChestsLootable(BOSS_HODIR);
+                    if (state == DONE)
+                    {
+                        uint8 keeperIdx = type - BOSS_FREYA;
+                        instance->SummonCreature(
+                            ObservationRingKeeperEntry[keeperIdx],
+                            ObservationRingKeepersPos[keeperIdx]);
+                    }
                     break;
                 case BOSS_ALGALON:
                     if (GameObject* go = GetGameObject(DATA_SIGILDOOR_03))
@@ -563,7 +609,7 @@ public:
                     OpenIfDone(BOSS_ASSEMBLY, gameObject, GO_STATE_ACTIVE);
                     break;
                 case GO_KEEPERS_GATE:
-                    if (GetBossState(BOSS_MIMIRON) == DONE && GetBossState(BOSS_FREYA) == DONE && GetBossState(BOSS_HODIR) == DONE && GetBossState(BOSS_THORIM) == DONE)
+                    if (AllBossesDone({BOSS_MIMIRON, BOSS_FREYA, BOSS_HODIR, BOSS_THORIM}))
                         gameObject->RemoveGameObjectFlag(GO_FLAG_LOCKED);
                     break;
                 // Mimiron, Hodir, Vezax

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -143,6 +143,12 @@ enum UlduarData
     DATA_BRANN_MEMOTESAY                    = 801,
     DATA_BRANN_EASY_MODE                    = 802,
     DATA_BRANN_BASE_CAMP                    = 803,
+
+    // Observation Ring Keepers
+    DATA_FREYA_GOSSIP                       = 810,
+    DATA_HODIR_GOSSIP                       = 811,
+    DATA_MIMIRON_GOSSIP                     = 812,
+    DATA_THORIM_GOSSIP                      = 813,
 };
 
 enum UlduarNPCs


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Port TrinityCore's approach to spawning friendly keeper NPCs (Freya, Hodir, Mimiron, Thorim) in the Observation Ring after their boss encounters are defeated.

Previously, gossip keepers were only spawned by Sara's `UpdateKeeperSpawns()`, which required Sara to reset after the boss kill. This meant keepers would not appear until Yogg-Saron's room was reached or Sara happened to reset.

Now the instance script spawns them directly:
- In `SetBossState()` when a keeper boss is killed
- In `OnPlayerEnter()` for saved instance reloads
- Tracked via ObjectData for GUID management
- Sara's `UpdateKeeperSpawns()` no longer handles gossip keepers (only Yogg-Saron room keepers)
- `DespawnGossipKeepers()` updated to handle instance-spawned keepers
- Replaced verbose `GetBossState() == DONE` checks with `AllBossesDone()` / `IsBossDone()`

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code (Claude Opus 4.6) was used to assist with porting and implementing the changes.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25096

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Ported from TrinityCore's `instance_ulduar.cpp` and `boss_yogg_saron.cpp`. Original authors credited via `--author` and `Co-Authored-By`:
- **Shauren** (`shauren.trinity@gmail.com`) — Observation Ring spawning in instance script ([commit 3c2dd7c5ed](https://github.com/TrinityCore/TrinityCore/commit/3c2dd7c5edf7eaee1a7314e390aa2f51f3310687))
- **horn** (`pankrac.ja@seznam.cz`) — Original Yogg-Saron script including keeper positions ([commit 0a0698b1d4](https://github.com/TrinityCore/TrinityCore/commit/0a0698b1d41cca4ae19f84b1c62c97d2964e13a5))

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Ulduar and defeat any keeper boss (Freya, Hodir, Thorim, or Mimiron).
2. Travel to the Observation Ring above Yogg-Saron's room — the defeated keeper's friendly NPC should be present.
3. Optionally click the gossip to send the keeper to help against Yogg-Saron.
4. Leave and re-enter the instance — keepers should respawn in the Observation Ring for any defeated boss whose gossip hasn't been used yet.
5. Start the Yogg-Saron encounter — remaining gossip keepers should despawn.

## Known Issues and TODO List:

- [ ] Needs in-game testing to verify keepers spawn correctly after each boss kill
- [ ] Verify keepers persist correctly across instance reloads