### PR TITLE
fix(Core/Movement): skip TriggerAlert for creatures immune to players

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -211,6 +211,9 @@ void CreatureAI::TriggerAlert(Unit const* who) const
     // If this unit isn't an NPC, is already distracted, is in combat, is confused, stunned or fleeing, do nothing
     if (!me->IsCreature() || me->IsEngaged() || me->HasUnitState(UNIT_STATE_CONFUSED | UNIT_STATE_STUNNED | UNIT_STATE_FLEEING | UNIT_STATE_DISTRACTED))
         return;
+    // If the creature is immune to players, it should not be alerted by them
+    if (me->IsImmuneToPC())
+        return;
     // Only alert for hostiles!
     if (me->IsCivilian() || me->HasReactState(REACT_PASSIVE) || !me->IsHostileTo(who) || !me->_IsTargetAcceptable(who))
         return;


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).

Adds an `IsImmuneToPC()` check to `CreatureAI::TriggerAlert()`. Creatures with `UNIT_FLAG_IMMUNE_TO_PC` (set via `SetImmuneToAll(true)` or `SetImmuneToPC(true)`) will no longer be alerted by stealthed players.

**Root cause:** `TriggerAlert` calls `StopMoving()` and `MoveDistract(5s)`, which destroys any active spline movement. For creatures on scripted spline paths while immune (e.g. Captain Skarloc's approach in Old Hillsbrad), this prevents `MovementInform` from firing for the final waypoint, so the combat initiation timer is never scheduled and the encounter softlocks.

`TriggerAlert` already checks for `REACT_PASSIVE`, engagement state, and various unit states, but had no immunity check — a creature that cannot attack a player has no reason to stop and alert toward them.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude (Opus) was used to trace the code path and identify the root cause.

## Issues Addressed:

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/17146
- Closes https://github.com/azerothcore/azerothcore-wotlk/pull/25122

## SOURCE:

The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Code path analysis: `CreatureUnitRelocationWorker` (GridNotifiers.cpp:140) calls `TriggerAlert` when a stealthed player is within alert detection range. `TriggerAlert` had no immunity check, so it would call `StopMoving()` on immune creatures mid-spline, destroying the scripted movement path.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Old Hillsbrad Foothills dungeon and progress Thrall's escort to the Captain Skarloc encounter.
2. Use stealth (Rogue/Druid) and position yourself close to Captain Skarloc's spawn/approach path before he arrives.
3. Verify Skarloc completes his approach spline without stopping, dismounts, and initiates combat normally.
4. Additionally verify that non-immune creatures still react to stealthed players with the alert animation as expected.

## Known Issues and TODO List:

- [ ] Verify no regression on other encounters using ImmuneToPC during scripted movement phases.


🤖 Generated with [Claude Code](https://claude.com/claude-code)