### PR TITLE
fix(Scripts/Oculus): preserve warrior stances when boarding drakes

### DIFF
--- a/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
@@ -817,7 +817,8 @@ class spell_oculus_rider_aura : public AuraScript
                 _drakeGUID = drake->GetGUID();
                 caster->AddAura(SPELL_DRAKE_FLAG_VISUAL, caster);
                 caster->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
-                caster->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
+                if (caster->IsInDisallowedMountForm())
+                    caster->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
                 drake->CastSpell(drake, SPELL_SOAR_TRIGGER);
                 if (drake->GetEntry() == NPC_RUBY_DRAKE)
                     drake->CastSpell(drake, SPELL_RUBY_EVASIVE_AURA);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

The Oculus drake boarding script (`spell_oculus_rider_aura`) unconditionally removes all `SPELL_AURA_MOD_SHAPESHIFT` auras when a player boards a drake. This strips warrior stances (Battle/Defensive/Berserker Stance), which should persist through vehicle use.

The fix adds an `IsInDisallowedMountForm()` check before removing shapeshift auras, so only actual shapeshifts that conflict with mounting (druid forms, ghost wolf) are removed, while stance-flagged forms (warrior stances, shadow form, stealth) are preserved. This matches the pattern already used by Trial of the Champion vehicle scripts.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code (Claude Opus 4.6) was used to research the issue, identify the fix, and prepare the PR.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24500 (warrior stances portion only)

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Video evidence from the issue shows warrior stances persisting through vehicle use on retail/classic:
- https://youtu.be/nAX7B80Gu84?si=Ud66dYfBzlgQjxW2&t=342

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a warrior character, enter a stance (e.g. Battle Stance)
2. `.go gameobject 2368` to teleport to Oculus
3. `.add 37859` to get a drake essence, use it to board the drake
4. Verify the warrior stance is still active while on the drake and after dismounting
5. Repeat with a druid in bear/cat form — verify the druid form IS removed upon boarding

## Known Issues and TODO List:

- [ ] The other two issues from #24500 (orientation reset and parachute) are separate and not addressed by this PR.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.