### PR TITLE
fix(DB/Conditions): Fix Ruthless Cunning banner target conditions

### DIFF
--- a/data/sql/updates/pending_db_world/rev_ruthless_cunning_conditions.sql
+++ b/data/sql/updates/pending_db_world/rev_ruthless_cunning_conditions.sql
@@ -1,0 +1,14 @@
+--
+-- Fix Quest 9927 (Ruthless Cunning): banner spell 32307 conditions only checked for Kil'sorrow Deathsworn (17148)
+-- Each ElseGroup should check a different Kil'sorrow creature so banners work on all applicable mobs
+-- No double-banner check needed: SpellEffects.cpp already removes corpse after banner placement
+
+-- Remove old conditions for spell 32307
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 17 AND `SourceEntry` = 32307;
+
+-- Insert corrected conditions: CONDITION_NEAR_CREATURE (29) per mob
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(17, 0, 32307, 0, 0, 29, 0, 17148, 5, 1, 0, 12, 0, '', 'Spell Place Kil''sorrow Banner requires nearby Kil''sorrow Deathsworn'),
+(17, 0, 32307, 0, 1, 29, 0, 17147, 5, 1, 0, 12, 0, '', 'Spell Place Kil''sorrow Banner requires nearby Kil''sorrow Cultist'),
+(17, 0, 32307, 0, 2, 29, 0, 17146, 5, 1, 0, 12, 0, '', 'Spell Place Kil''sorrow Banner requires nearby Kil''sorrow Spellbinder'),
+(17, 0, 32307, 0, 3, 29, 0, 18391, 5, 1, 0, 12, 0, '', 'Spell Place Kil''sorrow Banner requires nearby Giselda the Crone');

--- a/data/sql/updates/pending_db_world/rev_ruthless_cunning_conditions.sql
+++ b/data/sql/updates/pending_db_world/rev_ruthless_cunning_conditions.sql
@@ -3,10 +3,8 @@
 -- Each ElseGroup should check a different Kil'sorrow creature so banners work on all applicable mobs
 -- No double-banner check needed: SpellEffects.cpp already removes corpse after banner placement
 
--- Remove old conditions for spell 32307
+-- Remove old conditions for spell 32307 and insert corrected ones: CONDITION_NEAR_CREATURE (29) per mob
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 17 AND `SourceEntry` = 32307;
-
--- Insert corrected conditions: CONDITION_NEAR_CREATURE (29) per mob
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (17, 0, 32307, 0, 0, 29, 0, 17148, 5, 1, 0, 12, 0, '', 'Spell Place Kil''sorrow Banner requires nearby Kil''sorrow Deathsworn'),
 (17, 0, 32307, 0, 1, 29, 0, 17147, 5, 1, 0, 12, 0, '', 'Spell Place Kil''sorrow Banner requires nearby Kil''sorrow Cultist'),


### PR DESCRIPTION
## Changes Proposed:
- Fix spell 32307 (Place Kil'sorrow Banner) conditions so banners can be placed on all applicable Kil'sorrow mobs, not just Deathsworn
- All 5 ElseGroups previously referenced only creature 17148 (Kil'sorrow Deathsworn). Each ElseGroup now checks a different creature:
  - ElseGroup 0: Kil'sorrow Deathsworn (17148)
  - ElseGroup 1: Kil'sorrow Cultist (17147)
  - ElseGroup 2: Kil'sorrow Spellbinder (17146)
  - ElseGroup 3: Giselda the Crone (18391)
- Removed redundant 5th ElseGroup (duplicate) and CONDITION_NEAR_GAMEOBJECT (30) check (corpse removal is already handled in SpellEffects.cpp)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24268

## SOURCE:
1. Quest description specifies "Kil'sorrow members at Kil'sorrow Fortress"
2. [Wowhead comments confirming all Kil'sorrow mobs are valid targets](https://www.wowhead.com/wotlk/quest=9927/ruthless-cunning#comments:id=16941)
3. [Wowhead comment confirming Giselda the Crone is a valid target](https://www.wowhead.com/wotlk/quest=9927/ruthless-cunning#comments:id=16941:reply=32939)

## Tests Performed:
- Tested in-game by the author.

## How to Test the Changes:
1. Pick up quest [Ruthless Cunning](https://www.wowhead.com/wotlk/quest=9927/ruthless-cunning) from Warlord Goretooth at Kil'sorrow Fortress
2. Kill Kil'sorrow Deathsworn, Cultists, Spellbinders, and Giselda the Crone
3. Use the Warmaul Ogre Banner on each type of corpse
4. Verify that banners can be placed on all four creature types, not just Deathsworn

## Known Issues and TODO List:

- [ ] N/A

<!-- AI Disclosure: This PR was developed with assistance from Claude Code (AI). -->

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.