### PR TITLE
fix(Scripts/DraktharonKeep): chain King Dred claw emote with slash sequence

### DIFF
--- a/src/server/scripts/Northrend/DraktharonKeep/boss_dred.cpp
+++ b/src/server/scripts/Northrend/DraktharonKeep/boss_dred.cpp
@@ -66,37 +66,42 @@ public:
 
         void ScheduleTasks() override
         {
-            ScheduleTimedEvent(20s, [&] {
-                DoCastVictim(SPELL_GRIEVOUS_BITE);
-            }, 20s);
-
-            ScheduleTimedEvent(18s + 500ms, [&] {
-                DoCastVictim(SPELL_MANGLING_SLASH);
-            }, 20s);
-
             ScheduleTimedEvent(10s, 20s, [&] {
                 DoCastAOE(SPELL_FEARSOME_ROAR);
             }, 17s);
 
-            ScheduleTimedEvent(17s, [&] {
-                DoCastVictim(SPELL_PIERCING_SLASH);
-            }, 20s);
+            // Claw emote followed by Piercing Slash, Mangling Slash, Grievous Bite sequence
+            scheduler.Schedule(13s, 18s, [this](TaskContext context)
+            {
+                Talk(SAY_CLAW_EMOTE);
+                me->setAttackTimer(BASE_ATTACK, 2000);
+                me->AttackerStateUpdate(me->GetVictim());
+                if (me->GetVictim())
+                    me->AttackerStateUpdate(me->GetVictim());
+                if (me->GetVictim())
+                    me->AttackerStateUpdate(me->GetVictim());
+
+                context.Schedule(1500ms, [this](TaskContext context)
+                {
+                    DoCastVictim(SPELL_PIERCING_SLASH);
+                    context.Schedule(1500ms, [this](TaskContext context)
+                    {
+                        DoCastVictim(SPELL_MANGLING_SLASH);
+                        context.Schedule(1500ms, [this](TaskContext /*context*/)
+                        {
+                            DoCastVictim(SPELL_GRIEVOUS_BITE);
+                        });
+                    });
+                });
+
+                context.Repeat(18s, 35s);
+            });
 
             if (IsHeroic())
             {
                 ScheduleTimedEvent(16s, [&] {
                     DoCastSelf(SPELL_RAPTOR_CALL);
                 }, 30s);
-
-                ScheduleTimedEvent(21s, [&] {
-                    Talk(SAY_CLAW_EMOTE);
-                    me->setAttackTimer(BASE_ATTACK, 2000);
-                    me->AttackerStateUpdate(me->GetVictim());
-                    if (me->GetVictim())
-                        me->AttackerStateUpdate(me->GetVictim());
-                    if (me->GetVictim())
-                        me->AttackerStateUpdate(me->GetVictim());
-                }, 20s);
             }
         }
 

--- a/src/server/scripts/Northrend/DraktharonKeep/boss_dred.cpp
+++ b/src/server/scripts/Northrend/DraktharonKeep/boss_dred.cpp
@@ -74,12 +74,15 @@ public:
             scheduler.Schedule(13s, 18s, [this](TaskContext context)
             {
                 Talk(SAY_CLAW_EMOTE);
-                me->setAttackTimer(BASE_ATTACK, 2000);
-                me->AttackerStateUpdate(me->GetVictim());
-                if (me->GetVictim())
-                    me->AttackerStateUpdate(me->GetVictim());
-                if (me->GetVictim())
-                    me->AttackerStateUpdate(me->GetVictim());
+                if (Unit* victim = me->GetVictim())
+                {
+                    me->setAttackTimer(BASE_ATTACK, 2000);
+                    me->AttackerStateUpdate(victim);
+                    if (me->GetVictim())
+                        me->AttackerStateUpdate(me->GetVictim());
+                    if (me->GetVictim())
+                        me->AttackerStateUpdate(me->GetVictim());
+                }
 
                 context.Schedule(1500ms, [this](TaskContext context)
                 {


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Opus 4.6 was used to assist with the implementation.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23526

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - WoW Classic Normal: https://youtu.be/S6VzcZXU5dE?t=1824
  - WoW Classic Normal: https://youtu.be/ce06G8IO3cM?t=685
  - WoW Classic Heroic+: https://youtu.be/G9JWQ3HALns?t=1353
  - WoW Classic Heroic+: https://youtu.be/7dtlXab3oOk?t=2138
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go c id 27483` to teleport to King Dred in Drak'Tharon Keep
2. Fight King Dred on **normal** difficulty — verify the claw emote (`%s raises his claws menacingly!`) fires and is followed by Piercing Slash → Mangling Slash → Grievous Bite in sequence ~1.5s apart
3. Fight King Dred on **heroic** difficulty — verify the same claw sequence fires, plus Raptor Call still works as a separate heroic-only mechanic
4. Verify the first claw sequence starts 13-18s into the fight and repeats every 18-35s
5. Verify Fearsome Roar and Bellowing Roar (at 67%/34% HP) still fire independently

## Known Issues and TODO List:

- [ ] Raptor Call or Bellowing Roar may still interrupt the claw sequence mid-chain (matches retail behavior per issue reporter)

## Summary of Changes

King Dred's claw attack sequence was heroic-only and each ability (Piercing Slash, Mangling Slash, Grievous Bite) fired on independent timers unrelated to the claw emote. Per WoW Classic video evidence, these should be a linked combo chain on both difficulties:

1. Claw emote → Piercing Slash (1.5s) → Mangling Slash (1.5s) → Grievous Bite (1.5s)
2. First sequence at 13-18s, repeating every 18-35s
3. Moved claw emote + triple melee attack outside `IsHeroic()` block
4. Chained the three slash abilities off the claw emote using `TaskContext` scheduling
5. Raptor Call remains heroic-only (separate mechanic)

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.