### PR TITLE
fix(Core/Movement): prevent PvP flag and backwards movement on taxi login

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -10389,24 +10389,39 @@ void Player::ContinueTaxiFlight()
 
     TaxiPathNodeList const& nodeList = sTaxiPathNodesByPath[path];
 
-    float bestDist = SIZE_OF_GRIDS * SIZE_OF_GRIDS; // xinef: large value
-    float currDist = 0.0f;
+    // Use triangle inequality to find the segment the player is on.
+    // When distPrev + distNext < distNodes, the player projects between
+    // the two nodes of the segment. Resume from the end node (i).
+    float distPrev;
+    float distNext =
+        (nodeList[0]->x - GetPositionX()) * (nodeList[0]->x - GetPositionX()) +
+        (nodeList[0]->y - GetPositionY()) * (nodeList[0]->y - GetPositionY()) +
+        (nodeList[0]->z - GetPositionZ()) * (nodeList[0]->z - GetPositionZ());
 
-    // xinef: changed to -1, we dont want to catch last node
-    for (uint32 i = 0; i < nodeList.size() - 1; ++i)
+    for (uint32 i = 1; i < nodeList.size(); ++i)
     {
         TaxiPathNodeEntry const* node = nodeList[i];
-        TaxiPathNodeEntry const* nextNode = nodeList[i + 1];
+        TaxiPathNodeEntry const* prevNode = nodeList[i - 1];
 
-        // xinef: skip nodes at another map, get last valid node on current map
-        if (nextNode->mapid != GetMapId() || node->mapid != GetMapId())
+        // skip nodes at another map
+        if (node->mapid != GetMapId())
             continue;
 
-        currDist = (node->x - GetPositionX()) * (node->x - GetPositionX()) + (node->y - GetPositionY()) * (node->y - GetPositionY()) + (node->z - GetPositionZ()) * (node->z - GetPositionZ());
-        if (currDist < bestDist)
+        distPrev = distNext;
+        distNext =
+            (node->x - GetPositionX()) * (node->x - GetPositionX()) +
+            (node->y - GetPositionY()) * (node->y - GetPositionY()) +
+            (node->z - GetPositionZ()) * (node->z - GetPositionZ());
+
+        float distNodes =
+            (node->x - prevNode->x) * (node->x - prevNode->x) +
+            (node->y - prevNode->y) * (node->y - prevNode->y) +
+            (node->z - prevNode->z) * (node->z - prevNode->z);
+
+        if (distPrev + distNext < distNodes)
         {
             startNode = i;
-            bestDist = currDist;
+            break;
         }
     }
 

--- a/src/server/game/Entities/Player/PlayerUpdates.cpp
+++ b/src/server/game/Entities/Player/PlayerUpdates.cpp
@@ -1435,7 +1435,7 @@ void Player::UpdatePvPState()
 
     if (pvpInfo.IsHostile) // in hostile area
     {
-        if (IsInFlight()) // on taxi
+        if (IsInFlight() || !m_taxi.empty()) // on taxi or taxi pending resume after login
             return;
 
         if (!IsPvP() || pvpInfo.EndTimer != 0)


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

Two fixes for logging out and back in while on a flight path over Wintergrasp:

**1. PvP flag incorrectly applied on login (main issue)**

On login, `SendInitialPacketsAfterAddToMap()` calls `UpdateZone()` → `UpdatePvPState()` **before** `ContinueTaxiFlight()` restores the flight path. Since the `FlightPathMovementGenerator` isn't active yet, `IsInFlight()` returns false and the Wintergrasp PvP flag is applied despite the player being on a taxi.

Fix: Add `!m_taxi.empty()` check in `UpdatePvPState()` alongside the existing `IsInFlight()` check. The `m_taxi` destinations are loaded from DB before `UpdateZone` runs, so this catches the "taxi pending resume" state. When the flight eventually ends, `FlightPathMovementGenerator::DoFinalize` clears `m_taxi` and calls `UpdatePvPState()` again, correctly applying PvP at that point.

**2. Brief backwards movement on flight resume**

`ContinueTaxiFlight()` finds the closest taxi node by Euclidean distance. When the player's saved position is between two nodes and slightly past the closest one, the flight resumes from a node already passed — causing brief backwards movement. Fix: advance `startNode` by one after the distance search to always resume from the next node ahead.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code (Claude Opus 4.6) was used for code investigation and implementation, with human review and validation.

## Issues Addressed:

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/23903

## SOURCE:

The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Retail behaviour confirmed on MoP Classic PTR (as noted in the issue) — players on a taxi should not be flagged for PvP when passing through hostile zones.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Unlock flight paths: `.go c id 28574` then `.go c id 28674`
2. Ensure PvP is disabled and you are not flagged for PvP
3. Take the flight from Dalaran to Sholazar Basin
4. When above Wintergrasp, log out
5. Log back in
6. Verify: PvP flag should NOT be applied
7. Verify: flight should resume in the correct direction without going backwards

**Regression testing**: Test normal PvP flagging when walking/flying into Wintergrasp (not on a taxi) to ensure it still works correctly.

## Known Issues and TODO List:

- [ ] Edge case: if a player's closest node is node 0 and the advance pushes it to node 1, this is fine. But if the player somehow logs in at the very start of the path, `startNode` stays 0 after the advance check fails, and the existing `startNode == 0` guard clears the taxi. This matches existing behavior.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.