### PR TITLE
fix(Core/Combat): Fix guardians not attacking after threat system port

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -236,14 +236,16 @@ void CreatureAI::EnterEvadeMode(EvadeReason why)
     {
         if (Unit* owner = me->GetCharmerOrOwner())
         {
+            // Owned creatures (pets/guardians) follow their owner — clear evade state
+            // so they can re-enter combat immediately via CanBeginCombat
+            me->ClearUnitState(UNIT_STATE_EVADE);
             me->GetMotionMaster()->Clear(false);
             me->GetMotionMaster()->MoveFollow(owner, PET_FOLLOW_DIST, me->GetFollowAngle(), MOTION_SLOT_ACTIVE);
         }
         else
         {
             // Required to prevent attacking creatures that are evading and cause them to reenter combat
-            // Does not apply to MoveFollow
-            me->AddUnitState(UNIT_STATE_EVADE);
+            // Does not apply to MoveFollow — UNIT_STATE_EVADE is already set from _EnterEvadeMode
             me->GetMotionMaster()->MoveTargetedHome();
         }
     }
@@ -378,8 +380,11 @@ bool CreatureAI::_EnterEvadeMode(EvadeReason /*why*/)
         return false;
     }
 
-    // Set evade state early to prevent recursion when CombatStop triggers JustExitedCombat
-    // This will be cleared in MoveTargetedHome for pets/guardians following their owner
+    // Set evade state early to prevent recursion: CombatStop below purges combat
+    // refs, which triggers JustExitedCombat -> EnterEvadeMode -> _EnterEvadeMode.
+    // The IsInEvadeMode() check above will catch it.
+    // EnterEvadeMode will clear this for owned creatures (pets/guardians) that
+    // use MoveFollow instead of MoveTargetedHome.
     me->AddUnitState(UNIT_STATE_EVADE);
 
     // don't remove vehicle auras, passengers aren't supposed to drop off the vehicle

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7333,19 +7333,22 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
     // set position before any AI calls/assistance
     //if (IsCreature())
     //    ToCreature()->SetCombatStartPosition(GetPositionX(), GetPositionY(), GetPositionZ());
-    if (creature && !IsControlledByPlayer())
+    if (creature)
     {
         EngageWithTarget(victim);
 
-        creature->SendAIReaction(AI_REACTION_HOSTILE);
+        if (!IsControlledByPlayer())
+        {
+            creature->SendAIReaction(AI_REACTION_HOSTILE);
 
-        /// @todo: Implement aggro range, detection range and assistance range templates
-        if (!(creature->HasFlagsExtra(CREATURE_FLAG_EXTRA_DONT_CALL_ASSISTANCE)))
-            creature->CallAssistance();
+            /// @todo: Implement aggro range, detection range and assistance range templates
+            if (!(creature->HasFlagsExtra(CREATURE_FLAG_EXTRA_DONT_CALL_ASSISTANCE)))
+                creature->CallAssistance();
 
-        creature->SetAssistanceTimer(sWorld->getIntConfig(CONFIG_CREATURE_FAMILY_ASSISTANCE_PERIOD));
+            creature->SetAssistanceTimer(sWorld->getIntConfig(CONFIG_CREATURE_FAMILY_ASSISTANCE_PERIOD));
 
-        SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
+            SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
+        }
     }
 
     // delay offhand weapon attack by 50% of the base attack time

--- a/src/server/scripts/Pet/pet_dk.cpp
+++ b/src/server/scripts/Pet/pet_dk.cpp
@@ -306,6 +306,8 @@ struct npc_pet_dk_army_of_the_dead : public AggressorAI
 {
     npc_pet_dk_army_of_the_dead(Creature* creature) : AggressorAI(creature) { }
 
+    // Restrict MoveInLineOfSight aggro to targets already fighting our owner,
+    // so ghouls don't pull extra packs on their own.
     bool CanAIAttack(Unit const* target) const override
     {
         if (!target)
@@ -314,6 +316,26 @@ struct npc_pet_dk_army_of_the_dead : public AggressorAI
         if (owner && !target->IsInCombatWith(owner))
             return false;
         return AggressorAI::CanAIAttack(target);
+    }
+
+    // Owner started attacking a target — engage immediately.
+    // We bypass OnOwnerCombatInteraction because CanStartAttack -> CanAIAttack
+    // may reject the target before combat refs are established.
+    void OwnerAttacked(Unit* target) override
+    {
+        if (!target || !me->IsAlive() || me->HasReactState(REACT_PASSIVE))
+            return;
+        if (me->IsValidAttackTarget(target))
+            AttackStart(target);
+    }
+
+    // Owner was attacked — help defend.
+    void OwnerAttackedBy(Unit* attacker) override
+    {
+        if (!attacker || !me->IsAlive() || me->HasReactState(REACT_PASSIVE))
+            return;
+        if (me->IsValidAttackTarget(attacker))
+            AttackStart(attacker);
     }
 };
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Three issues introduced by the threat system port (#24715):

1. **`_EnterEvadeMode` set `UNIT_STATE_EVADE` unconditionally** — but `EnterEvadeMode` only cleared it for ownerless creatures using `MoveTargetedHome`. Owned creatures (pets/guardians) that briefly entered evade got permanently stuck because `CanBeginCombat` rejects units with `UNIT_STATE_EVADE`, preventing new combat references from being created. Fix: explicitly clear `UNIT_STATE_EVADE` in `EnterEvadeMode` for owned creatures that follow their owner.

2. **`Unit::Attack` only called `EngageWithTarget` for non-player-controlled creatures** — Player-controlled guardians (gargoyle, etc.) never got combat references created when attacking, so `_isEngaged` stayed false and `UpdateVictimWithGaze`/`UpdateVictim` always bailed early. Fix: call `EngageWithTarget` for all creatures in `Unit::Attack`, keeping NPC-only behavior (AI reaction, call assistance, emote reset) guarded under `!IsControlledByPlayer()`.

3. **Army of the Dead `CanAIAttack` timing gap** — The `CanAIAttack` override rejects targets not yet `IsInCombatWith(owner)`, but `OwnerAttacked` fires before combat refs exist between the owner and target. Fix: override `OwnerAttacked`/`OwnerAttackedBy` to call `AttackStart` directly, bypassing the `CanAIAttack` gate.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP was used to assist with debugging and preparing this pull request.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25139

## SOURCE:
The changes have been validated through:
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore's `_EnterEvadeMode` does not set `UNIT_STATE_EVADE` — that is only done in `EnterEvadeMode` for ownerless creatures. The AC port incorrectly added it to `_EnterEvadeMode`.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a Death Knight character at level 80
2. Summon Army of the Dead ghouls (spell 42650) **before** entering combat
3. Attack a hostile NPC — ghouls should immediately engage the target
4. Summon Ebon Gargoyle (spell 49206) on a target — gargoyle should begin casting Gargoyle Strike
5. Test with other guardians (e.g. Shaman Fire Elemental) to verify they also engage correctly
6. Verify that Army ghouls do NOT pull extra packs via MoveInLineOfSight (only attack what the owner is fighting)
7. Verify that regular (non-guardian) creatures still evade properly and return home after combat ends

## Known Issues and TODO List:

- [ ] Other classes with guardians should be regression tested (Shaman elementals, etc.)