### PR TITLE
fix(Core/Spells): Prevent Flexweave Underlay use on ground

### DIFF
--- a/data/sql/updates/pending_db_world/rev_flexweave_underlay_script.sql
+++ b/data/sql/updates/pending_db_world/rev_flexweave_underlay_script.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` = 55002;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (55002, 'spell_item_flexweave_underlay');

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -3565,6 +3565,24 @@ class spell_item_rocket_boots : public SpellScript
     }
 };
 
+// 55002 - Flexweave Underlay
+class spell_item_flexweave_underlay : public SpellScript
+{
+    PrepareSpellScript(spell_item_flexweave_underlay);
+
+    SpellCastResult CheckCast()
+    {
+        if (GetCaster()->IsFlying() || GetCaster()->IsFalling())
+            return SPELL_CAST_OK;
+        return SPELL_FAILED_NOT_FLYING;
+    }
+
+    void Register() override
+    {
+        OnCheckCast += SpellCheckCastFn(spell_item_flexweave_underlay::CheckCast);
+    }
+};
+
 class spell_item_healing_injector : public SpellScript
 {
     PrepareSpellScript(spell_item_healing_injector);
@@ -6327,6 +6345,7 @@ void AddSC_item_spell_scripts()
     RegisterSpellScript(spell_item_deathbringers_will_normal);
     RegisterSpellScript(spell_item_deathbringers_will_heroic);
     RegisterSpellScript(spell_item_discerning_eye_beast_dummy);
+    RegisterSpellScript(spell_item_flexweave_underlay);
     RegisterSpellScript(spell_item_frozen_shadoweave);
     RegisterSpellScript(spell_item_healing_touch_refund);
     RegisterSpellScript(spell_item_heartpierce);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

Adds a `CheckCast` spell script for spell 55002 (Flexweave Underlay) that prevents the parachute from being activated while the player is on the ground. The spell now only succeeds if the caster `IsFlying()` or `IsFalling()`, returning `SPELL_FAILED_NOT_FLYING` otherwise.

A DB condition was considered but no existing condition type supports checking movement flags (flying/falling state), so a C++ spell script is required.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code was used to assist with preparing this pull request.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24477

## SOURCE:
The changes have been validated through:
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Wowhead comments confirm the parachute should only work while airborne:
- https://www.wowhead.com/wotlk/spell=55002/flexweave-underlay#comments:id=446985
- https://www.wowhead.com/wotlk/spell=55002/flexweave-underlay#comments:id=470914

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Have a character with 350+ Engineering
2. Enchant a cloak with Flexweave Underlay
3. While standing on the ground, use the cloak enchant — should fail with "You are not flying" error
4. Mount a flying mount and fly up, then use the enchant — should succeed and apply the parachute
5. Jump off a ledge/cliff and use the enchant while falling — should succeed

## Known Issues and TODO List:

- [ ] Needs in-game testing to confirm error message is appropriate