### PR TITLE
fix(Core/Scripts): Fix Obsidian Sanctum lava waves disappearing mid-room

### DIFF
--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
@@ -166,8 +166,6 @@ enum Events
     EVENT_SARTHARION_CAST_FLAME_BREATH          = 11,
     EVENT_SARTHARION_CAST_TAIL_LASH             = 12,
     EVENT_SARTHARION_SUMMON_LAVA                = 13,
-    EVENT_SARTHARION_START_LAVA                 = 14,
-    EVENT_SARTHARION_FINISH_LAVA                = 15,
     EVENT_SARTHARION_LAVA_STRIKE                = 16,
     EVENT_SARTHARION_BERSERK                    = 17,
 
@@ -451,7 +449,9 @@ struct boss_sartharion : public BossAI
         {
             case NPC_FLAME_TSUNAMI:
             {
-                summon->SetSpeed(MOVE_FLIGHT, 1.5f);
+                summon->SetReactState(REACT_PASSIVE);
+                summon->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
+                summon->CastSpell(summon, SPELL_FLAME_TSUNAMI_DAMAGE_AURA, true);
                 break;
             }
             case NPC_FIRE_CYCLONE:
@@ -516,16 +516,6 @@ struct boss_sartharion : public BossAI
 
                     SummonLavaWaves();
                     extraEvents.Repeat(25s);
-                    return;
-                }
-                case EVENT_SARTHARION_START_LAVA:
-                {
-                    SendLavaWaves(true);
-                    return;
-                }
-                case EVENT_SARTHARION_FINISH_LAVA:
-                {
-                    SendLavaWaves(false);
                     return;
                 }
                 // Handling of Drakes Events
@@ -625,18 +615,19 @@ private:
     {
         summons.RemoveNotExisting();
         Talk(WHISPER_LAVA_CHURN);
-        extraEvents.ScheduleEvent(EVENT_SARTHARION_START_LAVA, 3600ms);
-        extraEvents.ScheduleEvent(EVENT_SARTHARION_FINISH_LAVA, 11s);
 
         // Send wave from left
         if (lastLavaSide == LAVA_RIGHT_SIDE)
         {
             for (uint8 i = 0; i < MAX_LEFT_LAVA_TSUNAMIS; ++i)
             {
-                Creature* tsunami = me->SummonCreature(NPC_FLAME_TSUNAMI, 3211.0f, FlameTsunamiLeftOffsets[i], 57.083332f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 13500);
+                if (Creature* tsunami = me->SummonCreature(NPC_FLAME_TSUNAMI, 3211.0f, FlameTsunamiLeftOffsets[i], 57.083332f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 13500))
+                {
+                    if ((i - 2) % 3 == 0) // If center of wave
+                        tsunami->CastSpell(tsunami, SPELL_FLAME_TSUNAMI_VISUAL, true);
 
-                if (((i - 2) % 3 == 0) && tsunami) // If center of wave
-                    tsunami->CastSpell(tsunami, SPELL_FLAME_TSUNAMI_VISUAL, true);
+                    tsunami->GetMotionMaster()->MovePoint(0, 3286.0f, FlameTsunamiLeftOffsets[i], 57.083332f);
+                }
             }
 
             lastLavaSide = LAVA_LEFT_SIDE;
@@ -646,37 +637,16 @@ private:
         {
             for (uint8 i = 0; i < MAX_RIGHT_LAVA_TSUNAMIS; ++i)
             {
-                Creature* tsunami = me->SummonCreature(NPC_FLAME_TSUNAMI, 3286.0f, FlameTsunamiRightOffsets[i], 57.083332f, 3.14f, TEMPSUMMON_TIMED_DESPAWN, 13500);
+                if (Creature* tsunami = me->SummonCreature(NPC_FLAME_TSUNAMI, 3286.0f, FlameTsunamiRightOffsets[i], 57.083332f, 3.14f, TEMPSUMMON_TIMED_DESPAWN, 13500))
+                {
+                    if ((i - 2) % 3 == 0) // If center of wave
+                        tsunami->CastSpell(tsunami, SPELL_FLAME_TSUNAMI_VISUAL, true);
 
-                if (((i - 2) % 3 == 0) && tsunami) // If center of wave
-                    tsunami->CastSpell(tsunami, SPELL_FLAME_TSUNAMI_VISUAL, true);
+                    tsunami->GetMotionMaster()->MovePoint(0, 3211.0f, FlameTsunamiRightOffsets[i], 57.083332f);
+                }
             }
 
             lastLavaSide = LAVA_RIGHT_SIDE;
-        }
-    }
-
-    void SendLavaWaves(bool start)
-    {
-        if (summons.empty())
-            return;
-
-        for (ObjectGuid const& guid : summons)
-        {
-            Creature* tsunami = ObjectAccessor::GetCreature(*me, guid);
-            if (!tsunami || tsunami->GetEntry() != NPC_FLAME_TSUNAMI)
-                continue;
-
-            if (start) // Movement possibly simplified from official, ideally reevaluate in the future.
-            {
-                tsunami->CastSpell(tsunami, SPELL_FLAME_TSUNAMI_DAMAGE_AURA, true);
-                tsunami->GetMotionMaster()->MovePoint(0, ((tsunami->GetPositionX() < 3250.0f) ? 3286.0f : 3211.0f), tsunami->GetPositionY(), tsunami->GetPositionZ());
-            }
-            else
-            {
-                tsunami->RemoveAura(SPELL_FLAME_TSUNAMI_DAMAGE_AURA);
-                tsunami->SetObjectScale(0.1f);
-            }
         }
     }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Opus 4.6 (Claude Code) was used for implementation assistance.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15428
- Closes https://github.com/chromiecraft/chromiecraft/issues/9168

## Description

Flame Tsunami (lava waves) in Obsidian Sanctum disappeared halfway across the room from one direction.

**Root cause:** The old code used a 3-phase approach:
1. Spawn tsunami NPCs (t=0)
2. Start movement + apply damage aura after a 3.6s delay (`EVENT_SARTHARION_START_LAVA`)
3. Remove aura + `SetObjectScale(0.1f)` at t=11s (`EVENT_SARTHARION_FINISH_LAVA`) — making waves invisible

With only ~7.4s of actual movement to cross 75 units, the waves were shrunk to invisible before completing their traversal.

**Fix:** Cherry-picked the TrinityCore approach:
- Spawn waves and **immediately** start `MovePoint` to the explicit destination coordinates
- Apply damage aura and defensive flags (`REACT_PASSIVE`, `NON_ATTACKABLE`, `NOT_SELECTABLE`) on summon via `JustSummoned`
- Removed the `SendLavaWaves()` function and the delayed `EVENT_SARTHARION_START_LAVA` / `EVENT_SARTHARION_FINISH_LAVA` events entirely
- Waves now naturally despawn via their existing `TEMPSUMMON_TIMED_DESPAWN` (13.5s) instead of being artificially shrunk

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**
  - TrinityCore 3.3.5 branch: `boss_sartharion.cpp` (Malcrom) and `obsidian_sanctum.cpp` (joschiwald)

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Obsidian Sanctum (10 or 25 player)
2. Engage Sartharion
3. Observe lava waves from both directions — verify they traverse the full width of the room without disappearing mid-way
4. Verify the waves deal damage and knock back players properly when crossing through them
5. Verify safe spots between wave groups still function correctly

## Known Issues and TODO List:

- [ ] Needs in-game testing to confirm both wave directions traverse fully
- [ ] Verify wave speed feels appropriate (using NPC default run speed instead of previous flight speed override)