### PR TITLE
fix(Core/Combat): Restore pet/owner combat propagation

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -199,7 +199,7 @@ void CreatureAI::OnOwnerCombatInteraction(Unit* target)
         return;
 
     if (!me->HasReactState(REACT_PASSIVE) && me->CanStartAttack(target, true))
-        me->EngageWithTarget(target);
+        AttackStart(target);
 }
 
 // Distract creature, if player gets too close while stealthed/prowling

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11392,6 +11392,8 @@ void Unit::AtTargetAttacked(Unit* target, bool canInitialAggro)
     target->EngageWithTarget(this);
     if (Unit* targetOwner = target->GetCharmerOrOwner())
         targetOwner->EngageWithTarget(this);
+    if (Unit* myOwner = GetCharmerOrOwner())
+        target->EngageWithTarget(myOwner);
 
     // Patch 3.0.8: All player spells which cause a creature to become aggressive
     // to you will now also immediately cause the creature to be tapped.


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP

## Issues Addressed:
Two combat propagation behaviors from the old `CombatStart`/`CombatStartOnCast` system (removed in 5289f3e6d) were not carried over to the new `AtTargetAttacked`/`EngageWithTarget` system:

1. **Pet/summon enters combat, owner remains out of combat.** The old `CombatStart` had explicit owner propagation (`owner->SetInCombatWith(victim)`) that `AtTargetAttacked` lacked. Fix: when a pet attacks a target, also call `target->EngageWithTarget(myOwner)`.

2. **Guardians (Fire/Earth Elemental) don't attack when owner casts spells.** `OnOwnerCombatInteraction` called `EngageWithTarget` which for non-threat-list creatures only created combat refs without starting an attack. `SelectVictim` then failed to find a target via `getAttackerForHelper()` and the guardian immediately evaded. Fix: call `AttackStart` instead, matching what `PetAI::OwnerAttacked` already does.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Fix 1 — Owner combat propagation:**
1. Log in as any class with a pet (Hunter, Warlock, DK ghoul)
2. Set pet to Defensive, send pet to attack a mob
3. Do NOT attack the mob yourself
4. Verify: your character shows combat swords and cannot eat/drink/mount

**Fix 2 — Guardian spell combat:**
1. Log in as Shaman, summon Fire Elemental Totem (out of combat)
2. Target a mob and cast Lightning Bolt (do NOT melee)
3. Verify: Fire Elemental engages and starts attacking the mob
4. Repeat with Earth Elemental

**Regression checks:**
1. Hunter pet on Defensive — attack mob with Auto Shot, pet should assist normally
2. Warlock pet on Passive — should NOT auto-engage when owner attacks
3. DK Army of the Dead — ghouls should still engage owner's targets
4. Pull mob then run far away — mob should still evade properly
5. PvP duel — no weird combat state issues

## Known Issues and TODO List:

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.