### PR TITLE
fix(Core/Battlefield): fix stale queue/invite entries and wrong-team kicks

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -130,6 +130,7 @@ void Battlefield::HandlePlayerLeaveZone(Player* player, uint32 /*zone*/)
         cp->HandlePlayerLeave(player);
 
     InvitedPlayers[player->GetTeamId()].erase(player->GetGUID());
+    PlayersInQueue[player->GetTeamId()].erase(player->GetGUID());
     PlayersWillBeKick[player->GetTeamId()].erase(player->GetGUID());
     Players[player->GetTeamId()].erase(player->GetGUID());
     SendRemoveWorldStates(player);
@@ -290,7 +291,8 @@ void Battlefield::KickAfkPlayers()
 void Battlefield::KickPlayerFromBattlefield(ObjectGuid guid)
 {
     if (Player* player = ObjectAccessor::FindPlayer(guid))
-        if (player->GetZoneId() == GetZoneId() && !player->IsGameMaster())
+        if (player->GetZoneId() == GetZoneId() && !player->IsGameMaster()
+            && !PlayersInWar[player->GetTeamId()].count(guid))
             player->TeleportTo(KickPosition);
 }
 
@@ -416,7 +418,7 @@ void Battlefield::PlayerAcceptInviteToWar(Player* player)
     {
         player->GetSession()->SendBfEntered(BattleId);
         PlayersInWar[player->GetTeamId()].insert(player->GetGUID());
-        InvitedPlayers[player->GetTeamId(true)].erase(player->GetGUID());
+        InvitedPlayers[player->GetTeamId()].erase(player->GetGUID());
 
         if (player->isAFK())
             player->ToggleAFK();


### PR DESCRIPTION
## Summary
- **HandlePlayerLeaveZone** was missing `PlayersInQueue` cleanup — queue entries persisted after leaving the zone
- **PlayerAcceptInviteToWar** erased the invite from `GetTeamId(true)` (original team) instead of `GetTeamId()` (effective team), which is the bucket it was stored under — the erase silently missed when these differ (e.g. crossfaction)
- **KickPlayerFromBattlefield** now skips players already in `PlayersInWar` as a safety net against stale invite/kick timer entries

Crossfaction-specific entry migration (queue/invite/kick buckets from original → new team on zone enter) is left to mod-cfbg's `OnBattlefieldPlayerEnterZone` hook.

## Test plan
- [ ] Queue for Wintergrasp, enter via portal, accept invite — verify no unexpected kick
- [ ] Leave Wintergrasp zone while queued — verify queue entry is cleaned
- [ ] With crossfaction: get assigned opposite team, accept war invite — verify invite entry is removed and player stays in battle

🤖 Generated with [Claude Code](https://claude.com/claude-code)