### PR TITLE
fix(Core/Units): Include charmed creatures in damagedByPlayer check

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1148,7 +1148,8 @@ uint32 Unit::DealDamage(Unit* attacker, Unit* victim, uint32 damage, CleanDamage
         if (!attacker || attacker->IsControlledByPlayer() || attacker->IsCreatedByPlayer())
         {
             uint32 unDamage = health < damage ? health : damage;
-            bool damagedByPlayer = unDamage && attacker && (attacker->IsPlayer() || attacker->m_movedByPlayer != nullptr);
+            bool damagedByPlayer = unDamage && attacker && (attacker->IsPlayer() || attacker->m_movedByPlayer != nullptr
+                || attacker->GetCharmerOrOwnerPlayerOrPlayerItself() != nullptr);
             victim->ToCreature()->LowerPlayerDamageReq(unDamage, damagedByPlayer);
         }
     }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1149,7 +1149,7 @@ uint32 Unit::DealDamage(Unit* attacker, Unit* victim, uint32 damage, CleanDamage
         {
             uint32 unDamage = health < damage ? health : damage;
             bool damagedByPlayer = unDamage && attacker && (attacker->IsPlayer() || attacker->m_movedByPlayer != nullptr
-                || attacker->GetCharmerOrOwnerPlayerOrPlayerItself() != nullptr);
+                || attacker->GetCharmerOrOwnerGUID().IsPlayer());
             victim->ToCreature()->LowerPlayerDamageReq(unDamage, damagedByPlayer);
         }
     }


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Opus 4.6 was used for research and implementation.

## Description

The `_damagedByPlayer` flag in `Creature::LowerPlayerDamageReq()` is an AzerothCore-specific addition (not present in TrinityCore) that gates `IsDamageEnoughForLootingAndReward()`. Its purpose is to prevent pure NPC-vs-NPC kills from granting players loot and quest credit.

The flag is set to `true` only when the attacker is an actual player (`IsPlayer()`) or a unit directly moved by a player (`m_movedByPlayer != nullptr`). However, creatures charmed via `CHARM_TYPE_CHARM` (pet-bar style charm, as opposed to `CHARM_TYPE_POSSESS`) never have `m_movedByPlayer` set — only `CHARM_TYPE_POSSESS` and `CHARM_TYPE_VEHICLE` call `Player::SetMover()`, which assigns `m_movedByPlayer`.

This creates a scenario where:
1. `IsControlledByPlayer()` returns `true` for the charmed creature (set in `Unit::SetCharm()`)
2. The damage correctly reduces `_playerDamageReq` to zero (the 50% threshold counter)
3. But `_damagedByPlayer` stays `false` because neither `IsPlayer()` nor `m_movedByPlayer` is satisfied
4. `IsDamageEnoughForLootingAndReward()` returns `false` (`_playerDamageReq == 0 && _damagedByPlayer` fails on the second condition)
5. No kill credit, loot, or quest completion is granted

This breaks any quest where a player-charmed creature is the sole or primary damage dealer.

### Specific case: Quest "Zero Tolerance" (12686) in Zul'Drak

The player uses the Scepter of Empowerment (item 39206) on a Servant of Drakuru (NPC 28802), which casts spell 52389 (Charm Channel) → triggers spell 52390 (Charm Drakuru Servant). This applies `CHARM_TYPE_CHARM`, giving the player a pet action bar with 3 abilities (Ferocious Enrage, Gut Rip, Stunning Force). The servant transforms into Hand of Drakuru (NPC 28805).

The player **must not attack Darmuk (NPC 28793) directly** — doing so breaks their Scourge disguise. The charmed Hand of Drakuru is the intended sole damage dealer. Because `_damagedByPlayer` is never set to `true`, killing Darmuk with the charmed servant does not fulfill the quest completion requirement.

### The fix

Adds `attacker->GetCharmerOrOwnerPlayerOrPlayerItself() != nullptr` to the `damagedByPlayer` condition in `Unit::DealDamage()`. This means damage from any unit whose charmer or owner is a player correctly sets the `_damagedByPlayer` flag.

The anti-exploit intent of the original check is preserved: pure NPC-vs-NPC kills (where no player is the charmer, owner, or mover) still do not grant credit, since `GetCharmerOrOwnerPlayerOrPlayerItself()` returns `nullptr` for unowned creatures.

## Issues Addressed:

- Closes https://github.com/chromiecraft/chromiecraft/issues/9167

## SOURCE:

The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - [Wowhead: Zero Tolerance quest](https://www.wowhead.com/wotlk/quest=12686/zero-tolerance) — comments confirm the player controls the servant via pet bar and must not attack directly
  - [Wowhead: Charm Drakuru Servant (spell 52390)](https://www.wowhead.com/wotlk/spell=52390/charm-drakuru-servant) — confirms CHARM aura type
  - [TrinityCore source comparison](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Entities/Creature/Creature.h) — `_damagedByPlayer` does not exist in TC
  - [TrinityCore Issue #30286](https://github.com/TrinityCore/TrinityCore/issues/30286) — related charm/pet bar issues with this quest

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Obtain quest "Zero Tolerance" (12686) in Zul'Drak from Drakuru
2. Use disguise amulet to transform into Scourge
3. Use Scepter of Empowerment (item 39206) on a Servant of Drakuru (NPC 28802)
4. Verify pet action bar appears with 3 abilities (Ferocious Enrage, Gut Rip, Stunning Force)
5. Use the charmed Hand of Drakuru to kill Darmuk (NPC 28793) — do NOT attack Darmuk directly
6. Verify quest completion credit is granted upon Darmuk's death

### Regression testing (important — this is a generic code change):
7. Test normal quest mob kills (player attacking directly) — should still grant credit
8. Test pet/guardian kills (e.g. warlock/hunter pets) — should still grant credit
9. Test that pure NPC-vs-NPC kills (no player involvement) do NOT grant credit
10. Test `CHARM_TYPE_POSSESS` (e.g. Mind Control) kills — should still work as before

## Known Issues and TODO List:

- [ ] Other charm-based quests should be tested to confirm they also benefit from this fix
- [ ] Edge case: if a non-player NPC charms another NPC, `GetCharmerOrOwnerPlayerOrPlayerItself()` returns nullptr — this is correct and preserves the anti-exploit behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)