### PR TITLE
fix(Core/Scripts): Fix boss scripts resetting during death/defeat RP after threat system port

### DIFF
--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -472,7 +472,7 @@ void ScriptedAI::DoResetThreat(Unit* unit)
 
 void ScriptedAI::DoResetThreatList()
 {
-    if (!me->CanHaveThreatList() || me->GetThreatMgr().IsThreatListEmpty())
+    if (!me->CanHaveThreatList() || me->GetThreatMgr().IsThreatListEmpty(true))
     {
         LOG_ERROR("entities.unit.ai", "DoResetThreatList called for creature that either cannot have threat list or has empty threat list (me entry = {})", me->GetEntry());
         return;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11419,12 +11419,8 @@ Unit* Creature::SelectVictim()
 
     Unit* target = nullptr;
 
-    // Taunt handling is now done inside ThreatManager via TauntState
     if (CanHaveThreatList())
-    {
-        if (!m_threatManager.IsThreatListEmpty())
-            target = m_threatManager.GetCurrentVictim();
-    }
+        target = m_threatManager.GetCurrentVictim();
     else if (!HasReactState(REACT_PASSIVE))
     {
         // we have player pet probably

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
@@ -193,6 +193,7 @@ struct boss_felblood_kaelthas : public BossAI
                 me->CastStop();
                 me->SetRegeneratingHealth(false);
                 me->SetUnitFlag(UNIT_FLAG_DISABLE_MOVE);
+                me->SetImmuneToAll(true, true);
                 me->SetReactState(REACT_PASSIVE);
                 LapseAction(ACTION_REMOVE_FLY);
                 scheduler.CancelAll();

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
@@ -190,11 +190,9 @@ struct boss_felblood_kaelthas : public BossAI
             damage = me->GetHealth() - 1;
             if (me->isRegeneratingHealth())
             {
-                me->CombatStop();
                 me->CastStop();
                 me->SetRegeneratingHealth(false);
                 me->SetUnitFlag(UNIT_FLAG_DISABLE_MOVE);
-                me->SetImmuneToAll(true);
                 me->SetReactState(REACT_PASSIVE);
                 LapseAction(ACTION_REMOVE_FLY);
                 scheduler.CancelAll();

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kalecgos.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kalecgos.cpp
@@ -161,7 +161,6 @@ struct boss_kalecgos : public BossAI
 
             me->m_Events.AddEventAtOffset([&] {
                 me->SetReactState(REACT_PASSIVE);
-                me->CombatStop();
                 me->RemoveAllAuras();
                 me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                 Talk(SAY_EVIL_ENRAGE);

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
@@ -95,7 +95,7 @@ struct boss_skeram : public BossAI
         creature->CastSpell(creature, SPELL_BIRTH, true);
         creature->SetControlled(true, UNIT_STATE_ROOT);
         creature->SetReactState(REACT_PASSIVE);
-        creature->SetImmuneToAll(true);
+        creature->SetImmuneToAll(true, true);
 
         _copiesGUIDs.push_back(creature->GetGUID());
     }

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
@@ -211,7 +211,7 @@ struct boss_skeram : public BossAI
             _copiesGUIDs.clear();
             DoCast(me, SPELL_SUMMON_IMAGES, true);
             me->SetReactState(REACT_PASSIVE);
-            me->SetImmuneToAll(true);
+            me->SetImmuneToAll(true, true);
             me->SetControlled(true, UNIT_STATE_ROOT);
             Talk(SAY_SPLIT);
             _hpct -= 25.0f;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -217,6 +217,14 @@ struct boss_hodir : public BossAI
     const Position ENTRANCE_DOOR{ 1999.160034f, -297.792999f, 431.960999f, 0 };
     const Position EXIT_DOOR{ 1999.709961f, -166.259003f, 432.822998f, 0 };
 
+    void JustExitedCombat() override
+    {
+        EngagementOver();
+        if (me->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE))
+            return;
+        EnterEvadeMode(EVADE_REASON_NO_HOSTILES);
+    }
+
     void Reset() override
     {
         _Reset();

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -399,6 +399,14 @@ struct boss_thorim : public BossAI
             go->SetGoState(GO_STATE_ACTIVE);
     }
 
+    void JustExitedCombat() override
+    {
+        EngagementOver();
+        if (_encounterFinished)
+            return;
+        EnterEvadeMode(EVADE_REASON_NO_HOSTILES);
+    }
+
     void EnterEvadeMode(EvadeReason why) override
     {
         DisableThorim(false);

--- a/src/server/scripts/Outland/BlackTemple/boss_illidan.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_illidan.cpp
@@ -1101,16 +1101,29 @@ struct npc_maiev_illidan : public ScriptedAI
         instance = creature->GetInstanceScript();
     }
 
+    bool _outroActive{ false };
+
     void Reset() override
     {
+        if (_outroActive)
+            return;
         scheduler.CancelAll();
         me->m_Events.KillAllEvents(false);
+    }
+
+    void JustExitedCombat() override
+    {
+        EngagementOver();
+        if (_outroActive)
+            return;
+        EnterEvadeMode(EVADE_REASON_NO_HOSTILES);
     }
 
     void DoAction(int32 param) override
     {
         if (param == ACTION_MAIEV_ENDING)
         {
+            _outroActive = true;
             scheduler.CancelAll();
             me->SetReactState(REACT_PASSIVE);
             DoStopAttack();


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

After the threat system port (#24715) and the `IMMUNE_TO_PC` hack removal (#25121), several boss scripts trigger premature evade during scripted death/defeat sequences. Three root causes:

1. **`CombatStop()`** now fires `JustExitedCombat()` → `EnterEvadeMode()` when the creature is still alive
2. **`SetImmuneToAll(true)`** calls `SetImmuneToPC(true)` with default `keepCombat=false`, which directly ends all player combat references → triggers evade
3. **`Creature::SelectVictim()`** had an `IsThreatListEmpty()` guard (added during the port but not present in TrinityCore) that skipped `GetCurrentVictim()` when all refs were offline — preventing `UpdateOffline()` from ever transitioning refs back to online after temporary immunity

### Core fixes:

**`Creature::SelectVictim()` (Unit.cpp):** Remove the `IsThreatListEmpty()` guard to match TrinityCore. This allows `GetCurrentVictim()` → `UpdateVictim()` → `ReselectVictim()` → `UpdateOffline()` to run, giving offline threat refs a chance to transition back to online when conditions change (e.g. immunity clears).

**`DoResetThreatList()` (ScriptedCreature.cpp):** Change `IsThreatListEmpty()` to `IsThreatListEmpty(true)` so the error guard includes offline refs. TrinityCore has no guard here at all; this preserves the safety check but only errors on truly empty lists.

### Script fixes:

| Boss | Fix |
|------|-----|
| **Kael'thas (MT)** | Remove `CombatStop()`, change `SetImmuneToAll(true)` → `SetImmuneToAll(true, true)` to preserve sniffed immune flags while keeping combat refs |
| **Kalecgos (SWP)** | Remove `CombatStop()` from `ACTION_KALEC_DIED` handler — intentional `EnterEvadeMode()` at 9s handles it |
| **Hodir** | Add `JustExitedCombat()` override — skip evade when `UNIT_FLAG_NON_ATTACKABLE` (encounter done) |
| **Thorim** | Add `JustExitedCombat()` override — skip evade when `_encounterFinished` |
| **Skeram (AQ40)** | Pass `keepCombat=true` to `SetImmuneToAll()` on boss and images during split phase |
| **Maiev (BT)** | Add `_outroActive` flag + `JustExitedCombat()` override + `Reset()` guard to protect outro RP |

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with [azerothMCP](https://github.com/blinkysc/azerothMCP) were used.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25180

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). `Creature::SelectVictim()` pattern ported from [TrinityCore](https://github.com/TrinityCore/TrinityCore) — their implementation does not have the `IsThreatListEmpty()` guard. **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. **Kael'thas (MT)**: `.go creature 96762` → engage and DPS to 0 HP → verify death RP plays for 11s → boss dies and is lootable (does not reset/disappear)
2. **Kalecgos (SWP)**: `.go creature 54810` → engage and kill Sathrovarr → verify Kalecgos RP plays (SAY_EVIL_ENRAGE at 1s, liftoff at 4s, evade at 9s) without premature reset
3. **Hodir**: `.go creature 136262` → defeat Hodir → verify he becomes friendly, spawns loot chest, and does not reset back to hostile
4. **Thorim**: `.go creature 136384` → complete encounter → verify he becomes friendly, spawns loot chest, and does not reset
5. **Skeram (AQ40)**: `.go creature 88075` → engage and DPS to 75%/50%/25% → verify split phase works without boss evading, images appear and teleport correctly
6. **Maiev (BT)**: `.go creature 148736` → engage Illidan → kill Illidan after Maiev spawns at 30% → verify Maiev's full outro dialogue plays (~41s sequence)

**Regression checks:**
- Wipe on each boss → should still reset normally
- Leash/evade each boss → should evade home normally
- General creature combat — verify no changes to normal threat/evade behavior

## Known Issues and TODO List:

- [ ] Other scripts with `CombatStop()` or `SetImmuneToAll(true)` mid-combat may have similar issues — this PR covers the most impactful encounters

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.