### PR TITLE
fix(Core/SmartAI): Remove REACT_PASSIVE check from CanAIAttack

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -755,7 +755,7 @@ void SmartAI::MoveInLineOfSight(Unit* who)
 
 bool SmartAI::CanAIAttack(Unit const* /*who*/) const
 {
-    return !(me->GetReactState() == REACT_PASSIVE);
+    return true;
 }
 
 bool SmartAI::AssistPlayerInCombatAgainst(Unit* who)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`SmartAI::CanAIAttack()` returns `false` for `REACT_PASSIVE` creatures. After the threat system port (#24715), this causes `ShouldBeOffline()` to return `true` via `CanCreatureAttack`, keeping threat refs permanently offline and preventing `SMART_EVENT_AGGRO` from ever firing.

TrinityCore does not override `CanAIAttack` in SmartAI. `REACT_PASSIVE` already prevents combat initiation via `MoveInLineOfSight` and `UpdateVictim`.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with [azerothMCP](https://github.com/blinkysc/azerothMCP) were used.

## Issues Addressed:
- Fixes REACT_PASSIVE SmartAI creatures not firing SMART_EVENT_AGGRO after threat system port

## SOURCE:
The changes have been validated through:
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). TrinityCore does not override `CanAIAttack` in SmartAI.

## Tests Performed:
- [x] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request requires further testing.

1. `.go creature 128910` (Citizen of Havenshire, DK starting zone) → attack → verify On Aggro scripts fire
2. Verify REACT_PASSIVE creatures still don't initiate combat via line of sight

## Known Issues and TODO List:
- [x] Audit other REACT_PASSIVE SmartAI creatures with SMART_EVENT_AGGRO

Only 2 others and tested; they look good now too

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.