### PR TITLE
fix(Core/Scripts): skip areatrigger scripts for gamemasters

### DIFF
--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -732,7 +732,8 @@ void WorldSession::HandleAreaTriggerOpcode(WorldPacket& recv_data)
     if (player->isDebugAreaTriggers)
         ChatHandler(this).PSendSysMessage(LANG_DEBUG_AREATRIGGER_REACHED, triggerId);
 
-    if (sScriptMgr->OnAreaTrigger(player, atEntry))
+    // Skip areatrigger scripts for GMs unless debug areatriggers is enabled
+    if ((!player->IsGameMaster() || player->isDebugAreaTriggers) && sScriptMgr->OnAreaTrigger(player, atEntry))
         return;
 
     if (player->IsAlive())

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_the_beast.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_the_beast.cpp
@@ -246,9 +246,6 @@ public:
 
     bool OnTrigger(Player* player, AreaTrigger const* /*at*/) override
     {
-        if (player->IsGameMaster())
-            return false;
-
         if (InstanceScript* instance = player->GetInstanceScript())
         {
             if (Creature* beast = ObjectAccessor::GetCreature(*player, instance->GetGuidData(DATA_THE_BEAST)))
@@ -268,9 +265,6 @@ public:
 
     bool OnTrigger(Player* player, AreaTrigger const* /*at*/) override
     {
-        if (player->IsGameMaster())
-            return false;
-
         if (InstanceScript* instance = player->GetInstanceScript())
         {
             if (Creature* beast = ObjectAccessor::GetCreature(*player, instance->GetGuidData(DATA_THE_BEAST)))

--- a/src/server/scripts/Kalimdor/zone_felwood.cpp
+++ b/src/server/scripts/Kalimdor/zone_felwood.cpp
@@ -127,7 +127,7 @@ public:
 
     bool OnTrigger(Player* player, AreaTrigger const* /*trigger*/) override
     {
-        if (player->IsGameMaster() || !player->IsAlive())
+        if (!player->IsAlive())
             return false;
 
         // Handle Call Ancients event start - The area trigger summons 3 ancients

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
@@ -1463,9 +1463,6 @@ public:
 
     bool OnTrigger(Player* player, const AreaTrigger* /*at*/) override
     {
-        if (player->IsGameMaster())
-            return false;
-
         InstanceScript* inst = player->GetInstanceScript();
         if (!inst)
             return false;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
@@ -1176,8 +1176,7 @@ public:
     {
         if (InstanceScript* instance = player->GetInstanceScript())
             if (instance->GetBossState(DATA_LADY_DEATHWHISPER) != DONE)
-                if (!player->IsGameMaster())
-                    if (Creature* ladyDeathwhisper = ObjectAccessor::GetCreature(*player, instance->GetGuidData(DATA_LADY_DEATHWHISPER)))
+                if (Creature* ladyDeathwhisper = ObjectAccessor::GetCreature(*player, instance->GetGuidData(DATA_LADY_DEATHWHISPER)))
                         ladyDeathwhisper->AI()->DoAction(ACTION_START_INTRO);
         return true;
     }

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
@@ -3592,7 +3592,7 @@ public:
     bool OnTrigger(Player* player, AreaTrigger const* /*areaTrigger*/) override
     {
         if (InstanceScript* instance = player->GetInstanceScript())
-            if (instance->GetBossState(DATA_SINDRAGOSA_GAUNTLET) == NOT_STARTED && !player->IsGameMaster())
+            if (instance->GetBossState(DATA_SINDRAGOSA_GAUNTLET) == NOT_STARTED)
                 if (Creature* gauntlet = ObjectAccessor::GetCreature(*player, instance->GetGuidData(NPC_SINDRAGOSA_GAUNTLET)))
                     gauntlet->AI()->DoAction(ACTION_START_GAUNTLET);
         return true;
@@ -3607,7 +3607,7 @@ public:
     bool OnTrigger(Player* player, AreaTrigger const* /*areaTrigger*/) override
     {
         if (InstanceScript* instance = player->GetInstanceScript())
-            if (instance->GetData(DATA_PUTRICIDE_TRAP_STATE) == NOT_STARTED && !player->IsGameMaster())
+            if (instance->GetData(DATA_PUTRICIDE_TRAP_STATE) == NOT_STARTED)
                 if (Creature* trap = ObjectAccessor::GetCreature(*player, instance->GetGuidData(NPC_PUTRICADES_TRAP)))
                     trap->AI()->DoAction(ACTION_START_GAUNTLET);
         return true;


### PR DESCRIPTION
## Changes proposed

- Prevent GMs from firing areatrigger scripts (e.g. encounter starts like Skadi, ICC gauntlet) by adding an `IsGameMaster()` check centrally in `HandleAreaTriggerOpcode`
- GMs with `.debug areatrigger` enabled still fire scripts, allowing intentional testing
- Only areatrigger *scripts* are skipped — tavern rest, quest triggers, battleground/outdoor PvP triggers, and instance teleports still work normally for GMs
- Removed now-redundant per-script `IsGameMaster()` checks from 7 areatrigger scripts

## Issues addressed

GMs walking through areatriggers would unintentionally start encounters and events (e.g. Skadi, Lady Deathwhisper intro, ICC gauntlet, Putricide trap).

## Tests performed

<!-- In-game testing expected per PR requirements -->

## How to test the changes

1. Enable GM mode (`.gm on`)
2. Walk through any areatrigger that starts an encounter (e.g. Skadi in UP, Lady Deathwhisper in ICC)
3. Verify the encounter does **not** start
4. Enable `.debug areatrigger`
5. Walk through the same areatrigger
6. Verify the encounter **does** start
7. Disable GM mode and verify areatriggers work normally for regular players

## AI tool usage disclosure

This PR was developed with assistance from Claude Code (Claude Opus 4.6).