### PR TITLE
fix(Core/Tests): Add missing GetDataPath mock to combat tests

### DIFF
--- a/src/test/server/game/Combat/CombatManagerTest.cpp
+++ b/src/test/server/game/Combat/CombatManagerTest.cpp
@@ -42,6 +42,8 @@ protected:
         ON_CALL(*_worldMock, getIntConfig(_)).WillByDefault(Return(0));
         ON_CALL(*_worldMock, getFloatConfig(_)).WillByDefault(Return(1.0f));
         ON_CALL(*_worldMock, getBoolConfig(_)).WillByDefault(Return(false));
+        static std::string emptyString;
+        ON_CALL(*_worldMock, GetDataPath()).WillByDefault(ReturnRef(emptyString));
 
         sWorld.reset(_worldMock);
 

--- a/src/test/server/game/Combat/ThreatManagerTest.cpp
+++ b/src/test/server/game/Combat/ThreatManagerTest.cpp
@@ -42,6 +42,8 @@ protected:
         ON_CALL(*_worldMock, getIntConfig(_)).WillByDefault(Return(0));
         ON_CALL(*_worldMock, getFloatConfig(_)).WillByDefault(Return(1.0f));
         ON_CALL(*_worldMock, getBoolConfig(_)).WillByDefault(Return(false));
+        static std::string emptyString;
+        ON_CALL(*_worldMock, GetDataPath()).WillByDefault(ReturnRef(emptyString));
 
         sWorld.reset(_worldMock);
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

After #25049 refactored collision data to be stored on the map context, the `Map` constructor now calls `sWorld->GetDataPath()` during initialization. This causes a segfault in `CombatManagerTest` and `ThreatManagerTest` since the `WorldMock` had no default action set for `GetDataPath()`.

This PR adds the missing `GetDataPath()` mock default to both test fixtures, matching the pattern used in other tests (e.g. `SpellProcTest`, `GmVisibleCommandTest`).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code was used to identify the root cause and prepare the fix.

## Issues Addressed:
- Fixes unit test segfault introduced by #25049

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Build with `-DBUILD_TESTING=ON`
2. Run `ctest --output-on-failure`
3. All tests should pass (previously segfaulted on CombatManagerIntegrationTest)

## Known Issues and TODO List:

- None

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.