### PR TITLE
refactor(Core/Scripts): move Kalimdor gossip handlers to database

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1774500000_gossip_kalimdor.sql
+++ b/data/sql/updates/pending_db_world/rev_1774500000_gossip_kalimdor.sql
@@ -1,0 +1,172 @@
+-- Move Kalimdor gossip handlers from C++ to database
+-- NPCs: Rivern Frostwind, Stone Watcher of Norgannon, Great Bear Spirit,
+--        Braug Dimspirit, Steward of Time, Thrall Warchief
+
+-- =====================================================
+-- 1. npc_rivern_frostwind (10618) - zone_winterspring
+-- Show vendor option only if Exalted with Wintersaber Trainers (faction 589)
+-- =====================================================
+
+-- Condition: gossip_menu_option MenuID=3130, OptionID=0 requires Exalted (rank 7, mask 128)
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=3130 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=5;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 3130, 0, 0, 0, 5, 0, 589, 128, 0, 0, 0, 0, '', 'Rivern Frostwind - Show vendor option only if Exalted with Wintersaber Trainers');
+
+-- Remove ScriptName
+UPDATE `creature_template` SET `ScriptName`='' WHERE `entry`=10618;
+
+-- =====================================================
+-- 2. npc_stone_watcher_of_norgannon (7918) - zone_tanaris
+-- 5-step gossip chain, quest 2954 credit at end
+-- =====================================================
+
+-- Add missing gossip_menu entries (MenuID -> TextID)
+DELETE FROM `gossip_menu` WHERE `MenuID` IN (57000,57001,57002,57003,57004,57005);
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES
+(57000, 1674),
+(57001, 1675),
+(57002, 1676),
+(57003, 1677),
+(57004, 1678),
+(57005, 1679);
+
+-- Condition: show first option only if quest 2954 is taken (incomplete)
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=57000 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=9;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 57000, 0, 0, 0, 9, 0, 2954, 0, 0, 0, 0, 0, '', 'Stone Watcher of Norgannon - Show gossip option if quest 2954 is taken');
+
+-- SAI: on final gossip select (menu 57005, option 0) -> close gossip + quest credit 2954
+DELETE FROM `smart_scripts` WHERE `entryorguid`=7918 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(7918, 0, 0, 1, 62, 0, 100, 512, 57005, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Stone Watcher of Norgannon - On Gossip Select - Close Gossip'),
+(7918, 0, 1, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 15, 2954, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Stone Watcher of Norgannon - Linked - Quest Credit 2954');
+
+-- Update creature_template: set gossip_menu_id, add gossip npcflag, set SmartAI
+UPDATE `creature_template` SET `gossip_menu_id`=57000, `npcflag`=`npcflag`|1, `ScriptName`='', `AIName`='SmartAI' WHERE `entry`=7918;
+
+-- =====================================================
+-- 3. npc_great_bear_spirit (11956) - zone_moonglade
+-- 4-step gossip chain, quest 5929/5930 credit at end
+-- =====================================================
+
+-- Add quest-active text for menu 3882
+DELETE FROM `gossip_menu` WHERE `MenuID`=3882 AND `TextID`=4719;
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES
+(3882, 4719);
+
+-- Condition on gossip_menu: show TextID 4719 if quest 5929 OR 5930 is taken
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=14 AND `SourceGroup`=3882 AND `SourceEntry`=4719;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 3882, 4719, 0, 0, 9, 0, 5929, 0, 0, 0, 0, 0, '', 'Great Bear Spirit - Show text 4719 if quest 5929 is taken'),
+(14, 3882, 4719, 0, 1, 9, 0, 5930, 0, 0, 0, 0, 0, '', 'Great Bear Spirit - Show text 4719 if quest 5930 is taken');
+
+-- Condition on gossip_menu_option: show option if quest 5929 OR 5930 is taken
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=3882 AND `SourceEntry`=0;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 3882, 0, 0, 0, 9, 0, 5929, 0, 0, 0, 0, 0, '', 'Great Bear Spirit - Show gossip option if quest 5929 is taken'),
+(15, 3882, 0, 0, 1, 9, 0, 5930, 0, 0, 0, 0, 0, '', 'Great Bear Spirit - Show gossip option if quest 5930 is taken');
+
+-- Clean up duplicate OptionID=1 on menu 3884 (identical to OptionID=0)
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=3884 AND `OptionID`=1;
+
+-- SAI: on gossip select (menu 3884, option 0) -> quest credit for both 5929 and 5930
+DELETE FROM `smart_scripts` WHERE `entryorguid`=11956 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(11956, 0, 0, 1, 62, 0, 100, 512, 3884, 0, 0, 0, 0, 0, 15, 5929, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Great Bear Spirit - On Gossip Select - Quest Credit 5929'),
+(11956, 0, 1, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 15, 5930, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Great Bear Spirit - On Gossip Select - Quest Credit 5930');
+
+-- Update creature_template
+UPDATE `creature_template` SET `ScriptName`='', `AIName`='SmartAI' WHERE `entry`=11956;
+
+-- =====================================================
+-- 4. npc_braug_dimspirit (4489) - zone_stonetalon_mountains
+-- Quiz: 5 dragon options, Neltharion = correct, others = wrong spell
+-- =====================================================
+
+-- Add missing Nozdormu option (OptionID=4)
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=4763 AND `OptionID`=4;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`) VALUES
+(4763, 4, 0, 'Nozdormu is my answer.', 0, 1, 1, 0, 0, 0, 0, '');
+
+-- Condition on gossip_menu: show text 5820 (quiz text) if quest 6627 is taken
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=14 AND `SourceGroup`=4763 AND `SourceEntry`=5820;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 4763, 5820, 0, 0, 9, 0, 6627, 0, 0, 0, 0, 0, '', 'Braug Dimspirit - Show quiz text if quest 6627 is taken');
+
+-- Conditions on all 5 options: show only if quest 6627 is taken
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=4763 AND `SourceEntry` IN (0,1,2,3,4) AND `ConditionTypeOrReference`=9;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 4763, 0, 0, 0, 9, 0, 6627, 0, 0, 0, 0, 0, '', 'Braug Dimspirit - Show Ysera option if quest 6627 is taken'),
+(15, 4763, 1, 0, 0, 9, 0, 6627, 0, 0, 0, 0, 0, '', 'Braug Dimspirit - Show Neltharion option if quest 6627 is taken'),
+(15, 4763, 2, 0, 0, 9, 0, 6627, 0, 0, 0, 0, 0, '', 'Braug Dimspirit - Show Alexstrasza option if quest 6627 is taken'),
+(15, 4763, 3, 0, 0, 9, 0, 6627, 0, 0, 0, 0, 0, '', 'Braug Dimspirit - Show Malygos option if quest 6627 is taken'),
+(15, 4763, 4, 0, 0, 9, 0, 6627, 0, 0, 0, 0, 0, '', 'Braug Dimspirit - Show Nozdormu option if quest 6627 is taken');
+
+-- SAI: Neltharion (option 1) = correct answer -> quest credit
+--      All others (options 0,2,3,4) = wrong answer -> cast spell 6766
+DELETE FROM `smart_scripts` WHERE `entryorguid`=4489 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(4489, 0, 0, 0, 62, 0, 100, 512, 4763, 1, 0, 0, 0, 0, 15, 6627, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Braug Dimspirit - On Gossip Select Neltharion - Quest Credit 6627'),
+(4489, 0, 1, 0, 62, 0, 100, 512, 4763, 0, 0, 0, 0, 0, 11, 6766, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Braug Dimspirit - On Gossip Select Ysera - Cast Wrong Answer'),
+(4489, 0, 2, 0, 62, 0, 100, 512, 4763, 2, 0, 0, 0, 0, 11, 6766, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Braug Dimspirit - On Gossip Select Alexstrasza - Cast Wrong Answer'),
+(4489, 0, 3, 0, 62, 0, 100, 512, 4763, 3, 0, 0, 0, 0, 11, 6766, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Braug Dimspirit - On Gossip Select Malygos - Cast Wrong Answer'),
+(4489, 0, 4, 0, 62, 0, 100, 512, 4763, 4, 0, 0, 0, 0, 11, 6766, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Braug Dimspirit - On Gossip Select Nozdormu - Cast Wrong Answer');
+
+-- Update creature_template
+UPDATE `creature_template` SET `ScriptName`='', `AIName`='SmartAI' WHERE `entry`=4489;
+
+-- =====================================================
+-- 5. npc_steward_of_time (20142) - zone_tanaris
+-- Gossip shows flight option if quest 10279 incomplete or rewarded
+-- On select casts spell 34891. Keep OnQuestAccept in C++.
+-- =====================================================
+
+-- Condition on gossip_menu: show text 9978 if quest 10279 is taken OR rewarded
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=14 AND `SourceGroup`=8072 AND `SourceEntry`=9978;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 8072, 9978, 0, 0, 9, 0, 10279, 0, 0, 0, 0, 0, '', 'Steward of Time - Show text 9978 if quest 10279 is taken'),
+(14, 8072, 9978, 0, 1, 8, 0, 10279, 0, 0, 0, 0, 0, '', 'Steward of Time - Show text 9978 if quest 10279 is rewarded');
+
+-- Condition on gossip_menu_option: show option if quest 10279 is taken OR rewarded
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=8072 AND `SourceEntry`=0;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 8072, 0, 0, 0, 9, 0, 10279, 0, 0, 0, 0, 0, '', 'Steward of Time - Show gossip option if quest 10279 is taken'),
+(15, 8072, 0, 0, 1, 8, 0, 10279, 0, 0, 0, 0, 0, '', 'Steward of Time - Show gossip option if quest 10279 is rewarded');
+
+-- SAI: on gossip select (menu 8072, option 0) -> invoker self-casts spell 34891
+-- Using SMART_ACTION_INVOKER_CAST (134) so the player casts on themselves,
+-- matching original C++: player->CastSpell(player, 34891, true)
+DELETE FROM `smart_scripts` WHERE `entryorguid`=20142 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(20142, 0, 0, 0, 62, 0, 100, 512, 8072, 0, 0, 0, 0, 0, 134, 34891, 2, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Steward of Time - On Gossip Select - Invoker Cast Flight Through Caverns');
+
+-- Update creature_template: add SmartAI (keep ScriptName for OnQuestAccept)
+UPDATE `creature_template` SET `AIName`='SmartAI' WHERE `entry`=20142;
+
+-- =====================================================
+-- 6. npc_thrall_warchief (4949) - zone_orgrimmar
+-- 7-step gossip chain, quest 6566 credit at end
+-- Keep ScriptName for OnQuestReward + AI
+-- =====================================================
+
+-- Add missing gossip_menu entries for chain steps
+DELETE FROM `gossip_menu` WHERE `MenuID` IN (3665,3666,3667,3668,3669,3670);
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES
+(3665, 5733),
+(3666, 5734),
+(3667, 5735),
+(3668, 5736),
+(3669, 5737),
+(3670, 5738);
+
+-- Fix menu 3670: ActionMenuID should be 0 (close), not 3664 (loop)
+UPDATE `gossip_menu_option` SET `ActionMenuID`=0 WHERE `MenuID`=3670 AND `OptionID`=0;
+
+-- Condition on gossip_menu_option: show first option only if quest 6566 is taken
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=3664 AND `SourceEntry`=0 AND `ConditionTypeOrReference`=9;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 3664, 0, 0, 0, 9, 0, 6566, 0, 0, 0, 0, 0, '', 'Thrall - Show gossip option if quest 6566 is taken');
+
+-- Quest credit on final gossip step handled via sGossipSelect in C++ AI struct.
+-- Cannot use SAI because Thrall's custom C++ AI (GetAI) takes precedence over SmartAI.
+-- No AIName change needed.

--- a/src/server/scripts/Kalimdor/zone_moonglade.cpp
+++ b/src/server/scripts/Kalimdor/zone_moonglade.cpp
@@ -105,58 +105,6 @@ public:
 };
 
 /*######
-## npc_great_bear_spirit
-######*/
-
-class npc_great_bear_spirit : public CreatureScript
-{
-public:
-    npc_great_bear_spirit() : CreatureScript("npc_great_bear_spirit") { }
-
-    bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action) override
-    {
-        ClearGossipMenuFor(player);
-        switch (action)
-        {
-            case GOSSIP_ACTION_INFO_DEF:
-                AddGossipItemFor(player, 3881, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-                SendGossipMenuFor(player, 4721, creature->GetGUID());
-                break;
-            case GOSSIP_ACTION_INFO_DEF + 1:
-                AddGossipItemFor(player, 3883, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
-                SendGossipMenuFor(player, 4733, creature->GetGUID());
-                break;
-            case GOSSIP_ACTION_INFO_DEF + 2:
-                AddGossipItemFor(player, 3884, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 3);
-                SendGossipMenuFor(player, 4734, creature->GetGUID());
-                break;
-            case GOSSIP_ACTION_INFO_DEF + 3:
-                SendGossipMenuFor(player, 4735, creature->GetGUID());
-                if (player->GetQuestStatus(5929) == QUEST_STATUS_INCOMPLETE)
-                    player->AreaExploredOrEventHappens(5929);
-                if (player->GetQuestStatus(5930) == QUEST_STATUS_INCOMPLETE)
-                    player->AreaExploredOrEventHappens(5930);
-                break;
-        }
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        //ally or horde quest
-        if (player->GetQuestStatus(5929) == QUEST_STATUS_INCOMPLETE || player->GetQuestStatus(5930) == QUEST_STATUS_INCOMPLETE)
-        {
-            AddGossipItemFor(player, 3882, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF);
-            SendGossipMenuFor(player, 4719, creature->GetGUID());
-        }
-        else
-            SendGossipMenuFor(player, 4718, creature->GetGUID());
-
-        return true;
-    }
-};
-
-/*######
 ## npc_silva_filnaveth
 ######*/
 
@@ -714,7 +662,6 @@ public:
 void AddSC_moonglade()
 {
     new npc_bunthen_plainswind();
-    new npc_great_bear_spirit();
     new npc_silva_filnaveth();
     new npc_clintar_spirit();
     new npc_omen();

--- a/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
+++ b/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
@@ -19,7 +19,6 @@
 #include "CreatureScript.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
-#include "ScriptedGossip.h"
 #include "TaskScheduler.h"
 #include "LFGMgr.h"
 
@@ -142,8 +141,6 @@ enum ThrallWarchief : uint32
 
     // What the Wind Carries (ID: 6566)
     QUEST_WHAT_THE_WIND_CARRIES    = 6566,
-    GOSSIP_MENU_THRALL             = 3664,
-    GOSSIP_RESPONSE_THRALL_FIRST   = 5733,
 
     // Deathknight Starting Zone End
     QUEST_WARCHIEFS_BLESSING       = 13189,
@@ -156,45 +153,6 @@ class npc_thrall_warchief : public CreatureScript
 {
 public:
     npc_thrall_warchief() : CreatureScript("npc_thrall_warchief") { }
-
-    bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action) override
-    {
-        ClearGossipMenuFor(player);
-
-        uint32 DiscussionOrder = action - GOSSIP_ACTION_INFO_DEF;
-
-        if (DiscussionOrder>= 1 && DiscussionOrder <= 6)
-        {
-            uint32 NextAction = GOSSIP_ACTION_INFO_DEF + DiscussionOrder + 1;
-            uint32 GossipResponse = GOSSIP_RESPONSE_THRALL_FIRST + DiscussionOrder - 1;
-
-            AddGossipItemFor(player, GOSSIP_MENU_THRALL + DiscussionOrder, 0, GOSSIP_SENDER_MAIN, NextAction);
-            SendGossipMenuFor(player, GossipResponse, creature->GetGUID());
-        }
-        else if (DiscussionOrder == 7)
-        {
-            CloseGossipMenuFor(player);
-            player->AreaExploredOrEventHappens(QUEST_WHAT_THE_WIND_CARRIES);
-        }
-
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        if (creature->IsQuestGiver())
-        {
-            player->PrepareQuestMenu(creature->GetGUID());
-        }
-
-        if (player->GetQuestStatus(QUEST_WHAT_THE_WIND_CARRIES) == QUEST_STATUS_INCOMPLETE)
-        {
-            AddGossipItemFor(player, GOSSIP_MENU_THRALL, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-        }
-
-        SendGossipMenuFor(player, player->GetGossipTextId(creature), creature->GetGUID());
-        return true;
-    }
 
     bool OnQuestReward(Player* player, Creature* creature, Quest const* quest, uint32 /*item*/) override
     {
@@ -230,6 +188,12 @@ public:
         {
             ChainLightningTimer = 2000;
             ShockTimer = 8000;
+        }
+
+        void sGossipSelect(Player* player, uint32 menuId, uint32 /*gossipListId*/) override
+        {
+            if (menuId == 3670)
+                player->AreaExploredOrEventHappens(QUEST_WHAT_THE_WIND_CARRIES);
         }
 
         void JustEngagedWith(Unit* /*who*/) override { }

--- a/src/server/scripts/Kalimdor/zone_stonetalon_mountains.cpp
+++ b/src/server/scripts/Kalimdor/zone_stonetalon_mountains.cpp
@@ -19,61 +19,6 @@
 #include "Player.h"
 #include "ScriptedCreature.h"
 #include "ScriptedEscortAI.h"
-#include "ScriptedGossip.h"
-
-/*######
-## npc_braug_dimspirit
-######*/
-
-#define GOSSIP_HBD1 "Ysera"
-#define GOSSIP_HBD2 "Neltharion"
-#define GOSSIP_HBD3 "Nozdormu"
-#define GOSSIP_HBD4 "Alexstrasza"
-#define GOSSIP_HBD5 "Malygos"
-
-class npc_braug_dimspirit : public CreatureScript
-{
-public:
-    npc_braug_dimspirit() : CreatureScript("npc_braug_dimspirit") { }
-
-    bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action) override
-    {
-        ClearGossipMenuFor(player);
-        if (action == GOSSIP_ACTION_INFO_DEF + 1)
-        {
-            CloseGossipMenuFor(player);
-            creature->CastSpell(player, 6766, false);
-        }
-        if (action == GOSSIP_ACTION_INFO_DEF + 2)
-        {
-            CloseGossipMenuFor(player);
-            player->AreaExploredOrEventHappens(6627);
-        }
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        if (creature->IsQuestGiver())
-            player->PrepareQuestMenu(creature->GetGUID());
-
-        if (player->GetQuestStatus(6627) == QUEST_STATUS_INCOMPLETE)
-        {
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, GOSSIP_HBD1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, GOSSIP_HBD2, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, GOSSIP_HBD3, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, GOSSIP_HBD4, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, GOSSIP_HBD5, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-
-            SendGossipMenuFor(player, 5820, creature->GetGUID());
-        }
-        else
-            SendGossipMenuFor(player, 5819, creature->GetGUID());
-
-        return true;
-    }
-};
-
 /*######
 ## npc_kaya_flathoof
 ######*/
@@ -162,6 +107,5 @@ public:
 
 void AddSC_stonetalon_mountains()
 {
-    new npc_braug_dimspirit();
     new npc_kaya_flathoof();
 }

--- a/src/server/scripts/Kalimdor/zone_tanaris.cpp
+++ b/src/server/scripts/Kalimdor/zone_tanaris.cpp
@@ -20,7 +20,6 @@
 #include "ScriptedCreature.h"
 #include "ScriptedEscortAI.h"
 #include "ScriptedFollowerAI.h"
-#include "ScriptedGossip.h"
 
 /*######
 ## npc_aquementas
@@ -294,95 +293,6 @@ public:
 
         return false;
     }
-
-    bool OnGossipSelect(Player* player, Creature* /*creature*/, uint32 /*sender*/, uint32 action) override
-    {
-        ClearGossipMenuFor(player);
-        if (action == GOSSIP_ACTION_INFO_DEF + 1)
-            player->CastSpell(player, 34891, true);               //(Flight through Caverns)
-
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        if (creature->IsQuestGiver())
-        {
-            player->PrepareQuestMenu(creature->GetGUID());
-        }
-
-        if (player->GetQuestStatus(10279) == QUEST_STATUS_INCOMPLETE || player->GetQuestRewardStatus(10279))
-        {
-            AddGossipItemFor(player, 8072, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-            SendGossipMenuFor(player, 9978, creature->GetGUID());
-        }
-        else
-        {
-            SendGossipMenuFor(player, 9977, creature->GetGUID());
-        }
-
-        return true;
-    }
-};
-
-/*######
-## npc_stone_watcher_of_norgannon
-######*/
-
-class npc_stone_watcher_of_norgannon : public CreatureScript
-{
-public:
-    npc_stone_watcher_of_norgannon() : CreatureScript("npc_stone_watcher_of_norgannon") { }
-
-    bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action) override
-    {
-        ClearGossipMenuFor(player);
-        switch (action)
-        {
-            case GOSSIP_ACTION_INFO_DEF:
-                AddGossipItemFor(player, 57001, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-                SendGossipMenuFor(player, 1675, creature->GetGUID());
-                break;
-            case GOSSIP_ACTION_INFO_DEF+1:
-                AddGossipItemFor(player, 57002, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
-                SendGossipMenuFor(player, 1676, creature->GetGUID());
-                break;
-            case GOSSIP_ACTION_INFO_DEF+2:
-                AddGossipItemFor(player, 57003, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 3);
-                SendGossipMenuFor(player, 1677, creature->GetGUID());
-                break;
-            case GOSSIP_ACTION_INFO_DEF+3:
-                AddGossipItemFor(player, 57004, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 4);
-                SendGossipMenuFor(player, 1678, creature->GetGUID());
-                break;
-            case GOSSIP_ACTION_INFO_DEF+4:
-                AddGossipItemFor(player, 57005, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 5);
-                SendGossipMenuFor(player, 1679, creature->GetGUID());
-                break;
-            case GOSSIP_ACTION_INFO_DEF+5:
-                CloseGossipMenuFor(player);
-                player->AreaExploredOrEventHappens(2954);
-                break;
-        }
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        if (creature->IsQuestGiver())
-        {
-            player->PrepareQuestMenu(creature->GetGUID());
-        }
-
-        if (player->GetQuestStatus(2954) == QUEST_STATUS_INCOMPLETE)
-        {
-            AddGossipItemFor(player, 57000, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF);
-        }
-
-        SendGossipMenuFor(player, 1674, creature->GetGUID());
-
-        return true;
-    }
 };
 
 /*####
@@ -552,6 +462,5 @@ void AddSC_tanaris()
     new npc_aquementas();
     new npc_custodian_of_time();
     new npc_steward_of_time();
-    new npc_stone_watcher_of_norgannon();
     new npc_tooga();
 }

--- a/src/server/scripts/Kalimdor/zone_winterspring.cpp
+++ b/src/server/scripts/Kalimdor/zone_winterspring.cpp
@@ -20,40 +20,6 @@
 #include "Player.h"
 #include "ScriptedCreature.h"
 #include "ScriptedEscortAI.h"
-#include "ScriptedGossip.h"
-
-/*######
-## npc_rivern_frostwind
-######*/
-
-class npc_rivern_frostwind : public CreatureScript
-{
-public:
-    npc_rivern_frostwind() : CreatureScript("npc_rivern_frostwind") { }
-
-    bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action) override
-    {
-        ClearGossipMenuFor(player);
-        if (action == GOSSIP_ACTION_TRADE)
-            player->GetSession()->SendListInventory(creature->GetGUID());
-
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        if (creature->IsQuestGiver())
-            player->PrepareQuestMenu(creature->GetGUID());
-
-        if (creature->IsVendor() && player->GetReputationRank(589) == REP_EXALTED)
-            AddGossipItemFor(player, GOSSIP_ICON_VENDOR, GOSSIP_TEXT_BROWSE_GOODS, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_TRADE);
-
-        SendGossipMenuFor(player, player->GetGossipTextId(creature), creature->GetGUID());
-
-        return true;
-    }
-};
-
 enum Says
 {
     // Escort texts
@@ -608,7 +574,6 @@ public:
 
 void AddSC_winterspring()
 {
-    new npc_rivern_frostwind();
     new npc_ranshalla();
     new go_elune_fire();
 }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

Migrate 6 Kalimdor NPC gossip handlers from C++ to database-driven `gossip_menu`, `gossip_menu_option`, `conditions`, and `smart_scripts` tables. This reduces C++ complexity and makes gossip data-driven and maintainable without recompilation.

**Tier 1 — Full C++ class deletion (gossip was only functionality):**
- `npc_rivern_frostwind` (10618): Vendor option gated by Exalted reputation with Wintersaber Trainers → DB condition (CONDITION_REPUTATION_RANK, mask 128)
- `npc_stone_watcher_of_norgannon` (7918): 5-step gossip chain with quest 2954 credit → DB gossip_menu chain + SAI (close gossip + quest credit)
- `npc_great_bear_spirit` (11956): 4-step gossip chain with quest 5929/5930 credit → DB chain + SAI with linked quest credit for both quests. Also cleans up duplicate gossip_menu_option entry
- `npc_braug_dimspirit` (4489): Quiz NPC with 5 dragon name options; Neltharion = correct (quest 6627 credit), others = wrong (spell 6766). Adds missing Nozdormu option (OptionID=4) → DB conditions + SAI

**Tier 2 — Gossip moved to DB, C++ kept for other hooks:**
- `npc_steward_of_time` (20142): Gossip flight option moved to DB with quest 10279 taken/rewarded conditions + SAI (SMART_ACTION_INVOKER_CAST for player self-cast). C++ `OnQuestAccept` retained
- `npc_thrall_warchief` (4949): 7-step gossip chain (menus 3664–3670) moved to DB. Added missing gossip_menu rows, fixed ActionMenuID loop on final step (3670→0 instead of →3664), added quest 6566 condition. Quest credit handled via `sGossipSelect` in C++ AI struct (SAI not possible due to custom GetAI). C++ `OnQuestReward`, combat AI, and scheduler events retained

**Also fixes:**
- Thrall gossip menu 3670 had ActionMenuID=3664 (infinite loop) instead of 0 (close)
- Great Bear Spirit gossip_menu_option MenuID=3884 had duplicate OptionID=1 identical to OptionID=0

Cross-checked against TrinityCore 3.3.5 branch for correctness of menu IDs, text IDs, quest IDs, and SAI patterns.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Opus 4.6 (Claude Code) was used for code analysis, DB state verification, TrinityCore cross-checking, and implementation.

## Issues Addressed:
<!-- No specific issue, this is a refactoring improvement -->

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Cross-referenced with TrinityCore 3.3.5 branch to verify gossip menu IDs, NPC text IDs, quest IDs, spell IDs, and SAI patterns match. Existing AzerothCore DB state verified via direct SQL queries.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

For each NPC, verify gossip displays correctly based on quest/reputation state and that actions fire properly:

1. **Rivern Frostwind (10618)** — Winterspring: Talk to NPC. Vendor option should only appear if Exalted with Wintersaber Trainers (faction 589). Non-Exalted players should see no vendor option.
2. **Stone Watcher of Norgannon (7918)** — Tanaris: Accept quest 2954, talk to NPC. Step through the 5 gossip pages. On the final option click, gossip should close and quest 2954 should receive credit. Without the quest, no gossip option should appear.
3. **Great Bear Spirit (11956)** — Moonglade: Accept quest 5929 (Alliance) or 5930 (Horde). Talk to NPC, step through the 4 gossip pages. On the final click, both quest 5929 and 5930 should receive credit. Without either quest, the default text (4718) should display with no options.
4. **Braug Dimspirit (4489)** — Stonetalon Mountains: Accept quest 6627. Talk to NPC, verify all 5 dragon options appear (Ysera, Neltharion, Alexstrasza, Malygos, Nozdormu). Selecting "Neltharion" should give quest credit. Any other answer should cast spell 6766 (wrong answer debuff). Without quest 6627, options should not appear.
5. **Steward of Time (20142)** — Tanaris (Caverns of Time): With quest 10279 taken or rewarded, talk to NPC. Flight option should appear. Clicking it should trigger the Caverns of Time flight (spell 34891, self-cast). Also verify OnQuestAccept for quest 10279 still casts the same flight spell.
6. **Thrall (4949)** — Orgrimmar: Accept quest 6566 (What the Wind Carries). Talk to Thrall, step through all 7 gossip pages. On the final click, quest 6566 should receive credit. Also verify For The Horde (quest 4974) reward still triggers the Herald + Warchief's Blessing event, and Deathknight quest 13189 reward still calls InitializeLockedDungeons.

## Known Issues and TODO List:

- [ ] `npc_braug_dimspirit` Nozdormu option has `OptionBroadcastTextID=0` because no `broadcast_text` entry exists for "Nozdormu is my answer." (the other 4 options have broadcast text IDs 8381-8385). Non-English clients won't see a translated string for this option.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.