### PR TITLE
fix(Core/Scripts): Move EasternKingdoms gossip to database

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1774395836122258800.sql
+++ b/data/sql/updates/pending_db_world/rev_1774395836122258800.sql
@@ -1,0 +1,116 @@
+-- Move gossip handling from C++ scripts to database for Augustus the Touched,
+-- Parqual Fintallas, and Lokhtos Darkbargainer.
+-- Augustus migration based on TC work by dr-j (commit cefed89c38bc)
+-- Parqual migration based on TC work by offl (issue #24993, commit 7908b00311)
+
+-- =============================================================================
+-- 1. Augustus the Touched (entry 12384)
+--    Conditional vendor option if quest 6164 (Augustus' Receipt Book) rewarded.
+--    Two gossip texts: 4979 before quest, 4980 after quest.
+-- =============================================================================
+
+-- Remove C++ ScriptName
+UPDATE `creature_template` SET `ScriptName` = '' WHERE `entry` = 12384;
+
+-- Add gossip_menu entry for post-quest text 4980
+DELETE FROM `gossip_menu` WHERE `MenuID` = 4085 AND `TextID` = 4980;
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES (4085, 4980);
+
+-- Conditions on gossip_menu text: 4979 before quest, 4980 after quest
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 14 AND `SourceGroup` = 4085;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 4085, 4979, 0, 0, 8, 0, 6164, 0, 0, 1, 0, 0, '', 'Augustus the Touched - Show text 4979 if quest 6164 NOT rewarded'),
+(14, 4085, 4980, 0, 0, 8, 0, 6164, 0, 0, 0, 0, 0, '', 'Augustus the Touched - Show text 4980 if quest 6164 rewarded');
+
+-- Condition: show vendor option (MenuID 4085, OptionID 0) only if quest 6164 rewarded
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` = 4085 AND `SourceEntry` = 0;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 4085, 0, 0, 0, 8, 0, 6164, 0, 0, 0, 0, 0, '', 'Augustus the Touched - Show vendor option only if quest 6164 rewarded');
+
+-- =============================================================================
+-- 2. Parqual Fintallas (entry 4488)
+--    Test of Lore quiz: 4 answers, wrong ones cast Shame, correct completes quest.
+-- =============================================================================
+
+-- Remove C++ ScriptName, set SmartAI
+UPDATE `creature_template` SET `ScriptName` = '', `AIName` = 'SmartAI' WHERE `entry` = 4488;
+
+-- Add gossip_menu entry for quiz text (5822) shown during quiz
+DELETE FROM `gossip_menu` WHERE `MenuID` = 4764 AND `TextID` = 5822;
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES (4764, 5822);
+
+-- Condition on gossip_menu text 5822: quest 6628 taken + no Shame aura
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 14 AND `SourceGroup` = 4764 AND `SourceEntry` = 5822;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 4764, 5822, 0, 0, 9, 0, 6628, 0, 0, 0, 0, 0, '', 'Parqual Fintallas - Show quiz text 5822 if quest 6628 taken'),
+(14, 4764, 5822, 0, 0, 1, 0, 6767, 0, 0, 1, 0, 0, '', 'Parqual Fintallas - Show quiz text 5822 if player does not have Mark of Shame aura');
+
+-- Conditions on quiz options 0, 1, 2, 3: quest 6628 taken + no Shame aura
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` = 4764 AND `SourceEntry` IN (0, 1, 2, 3);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+-- Option 0: Kel'Thuzad (wrong answer)
+(15, 4764, 0, 0, 0, 9, 0, 6628, 0, 0, 0, 0, 0, '', 'Parqual Fintallas - Show option 0 if quest 6628 taken'),
+(15, 4764, 0, 0, 0, 1, 0, 6767, 0, 0, 1, 0, 0, '', 'Parqual Fintallas - Show option 0 if no Mark of Shame aura'),
+-- Option 1: Gul'dan (wrong answer)
+(15, 4764, 1, 0, 0, 9, 0, 6628, 0, 0, 0, 0, 0, '', 'Parqual Fintallas - Show option 1 if quest 6628 taken'),
+(15, 4764, 1, 0, 0, 1, 0, 6767, 0, 0, 1, 0, 0, '', 'Parqual Fintallas - Show option 1 if no Mark of Shame aura'),
+-- Option 2: Kil'jaeden (wrong answer)
+(15, 4764, 2, 0, 0, 9, 0, 6628, 0, 0, 0, 0, 0, '', 'Parqual Fintallas - Show option 2 if quest 6628 taken'),
+(15, 4764, 2, 0, 0, 1, 0, 6767, 0, 0, 1, 0, 0, '', 'Parqual Fintallas - Show option 2 if no Mark of Shame aura'),
+-- Option 3: Ner'zhul (correct answer)
+(15, 4764, 3, 0, 0, 9, 0, 6628, 0, 0, 0, 0, 0, '', 'Parqual Fintallas - Show option 3 if quest 6628 taken'),
+(15, 4764, 3, 0, 0, 1, 0, 6767, 0, 0, 1, 0, 0, '', 'Parqual Fintallas - Show option 3 if no Mark of Shame aura');
+
+-- SAI for Parqual Fintallas
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 4488 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+-- Option 0 (Kel'Thuzad - wrong): close gossip, then cast Mark of Shame
+(4488, 0, 0, 1, 62, 0, 100, 0, 4764, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Parqual Fintallas - On Gossip Select 0 (Kel''Thuzad) - Close Gossip'),
+(4488, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 6767, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Parqual Fintallas - Linked - Cast Mark of Shame on Invoker'),
+-- Option 1 (Gul'dan - wrong): close gossip, then cast Mark of Shame
+(4488, 0, 2, 3, 62, 0, 100, 0, 4764, 1, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Parqual Fintallas - On Gossip Select 1 (Gul''dan) - Close Gossip'),
+(4488, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 6767, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Parqual Fintallas - Linked - Cast Mark of Shame on Invoker'),
+-- Option 2 (Kil'jaeden - wrong): close gossip, then cast Mark of Shame
+(4488, 0, 4, 5, 62, 0, 100, 0, 4764, 2, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Parqual Fintallas - On Gossip Select 2 (Kil''jaeden) - Close Gossip'),
+(4488, 0, 5, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 6767, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Parqual Fintallas - Linked - Cast Mark of Shame on Invoker'),
+-- Option 3 (Ner'zhul - correct): close gossip, then credit quest 6628
+(4488, 0, 6, 7, 62, 0, 100, 0, 4764, 3, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Parqual Fintallas - On Gossip Select 3 (Ner''zhul) - Close Gossip'),
+(4488, 0, 7, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 15, 6628, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Parqual Fintallas - Linked - Area Explored Or Event Happens Quest 6628');
+
+-- =============================================================================
+-- 3. Lokhtos Darkbargainer (entry 12944)
+--    Rep-gated vendor + conditional Thorium Brotherhood contract creation.
+-- =============================================================================
+
+-- Remove C++ ScriptName, set SmartAI
+UPDATE `creature_template` SET `ScriptName` = '', `AIName` = 'SmartAI' WHERE `entry` = 12944;
+
+-- Replace gossip_menu text: remove default 5834, add rep-conditional texts 3673/3677
+DELETE FROM `gossip_menu` WHERE `MenuID` = 4781 AND `TextID` IN (5834, 3673, 3677);
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES
+(4781, 3673),
+(4781, 3677);
+
+-- Condition: show text 3677 only if rep >= Friendly with Thorium Brotherhood (faction 59)
+-- Text 3673 has no condition and serves as the default (unfriendly) text
+-- Friendly(4)=16, Honored(5)=32, Revered(6)=64, Exalted(7)=128 => mask 240
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 14 AND `SourceGroup` = 4781;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 4781, 3677, 0, 0, 5, 0, 59, 240, 0, 0, 0, 0, '', 'Lokhtos Darkbargainer - Show text 3677 if Thorium Brotherhood rep >= Friendly');
+
+-- Condition on vendor option (MenuID 4781, OptionID 0): rep >= Friendly
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` = 4781 AND `SourceEntry` IN (0, 1);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+-- Option 0 (vendor): requires Friendly rep
+(15, 4781, 0, 0, 0, 5, 0, 59, 240, 0, 0, 0, 0, '', 'Lokhtos Darkbargainer - Show vendor option if Thorium Brotherhood rep >= Friendly'),
+-- Option 1 (contract): requires quest 7604 NOT rewarded + no item 18628 (incl. bank) + has item 17203
+(15, 4781, 1, 0, 0, 8, 0, 7604, 0, 0, 1, 0, 0, '', 'Lokhtos Darkbargainer - Show contract option if quest 7604 NOT rewarded'),
+(15, 4781, 1, 0, 0, 2, 0, 18628, 1, 1, 1, 0, 0, '', 'Lokhtos Darkbargainer - Show contract option if player does NOT have Thorium Brotherhood Contract'),
+(15, 4781, 1, 0, 0, 2, 0, 17203, 1, 0, 0, 0, 0, '', 'Lokhtos Darkbargainer - Show contract option if player has Sulfuron Ingot');
+
+-- SAI for Lokhtos Darkbargainer: contract spell on gossip select option 1
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 12944 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+-- Option 1 (Get contract): close gossip, then invoker casts contract creation spell
+(12944, 0, 0, 1, 62, 0, 100, 0, 4781, 1, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Lokhtos Darkbargainer - On Gossip Select 1 (Contract) - Close Gossip'),
+(12944, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 134, 23059, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Lokhtos Darkbargainer - Linked - Invoker Cast Create Thorium Brotherhood Contract');

--- a/data/sql/updates/pending_db_world/rev_1774395836122258800.sql
+++ b/data/sql/updates/pending_db_world/rev_1774395836122258800.sql
@@ -17,7 +17,7 @@ DELETE FROM `gossip_menu` WHERE `MenuID` = 4085 AND `TextID` = 4980;
 INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES (4085, 4980);
 
 -- Conditions on gossip_menu text: 4979 before quest, 4980 after quest
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 14 AND `SourceGroup` = 4085;
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 14 AND `SourceGroup` = 4085 AND `SourceEntry` IN (4979, 4980);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (14, 4085, 4979, 0, 0, 8, 0, 6164, 0, 0, 1, 0, 0, '', 'Augustus the Touched - Show text 4979 if quest 6164 NOT rewarded'),
 (14, 4085, 4980, 0, 0, 8, 0, 6164, 0, 0, 0, 0, 0, '', 'Augustus the Touched - Show text 4980 if quest 6164 rewarded');
@@ -91,11 +91,11 @@ INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES
 (4781, 3673),
 (4781, 3677);
 
--- Condition: show text 3677 only if rep >= Friendly with Thorium Brotherhood (faction 59)
--- Text 3673 has no condition and serves as the default (unfriendly) text
+-- Conditions on gossip_menu text: 3673 below Friendly, 3677 at Friendly+
 -- Friendly(4)=16, Honored(5)=32, Revered(6)=64, Exalted(7)=128 => mask 240
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 14 AND `SourceGroup` = 4781;
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 14 AND `SourceGroup` = 4781 AND `SourceEntry` IN (3673, 3677);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 4781, 3673, 0, 0, 5, 0, 59, 240, 0, 1, 0, 0, '', 'Lokhtos Darkbargainer - Show text 3673 if Thorium Brotherhood rep < Friendly'),
 (14, 4781, 3677, 0, 0, 5, 0, 59, 240, 0, 0, 0, 0, '', 'Lokhtos Darkbargainer - Show text 3677 if Thorium Brotherhood rep >= Friendly');
 
 -- Condition on vendor option (MenuID 4781, OptionID 0): rep >= Friendly

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/blackrock_depths.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/blackrock_depths.cpp
@@ -452,7 +452,6 @@ private:
     uint32 _mightyBlowTimer;
 };
 
-
 // npc_rocknot
 enum RocknotSays
 {

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/blackrock_depths.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/blackrock_depths.cpp
@@ -452,58 +452,6 @@ private:
     uint32 _mightyBlowTimer;
 };
 
-// npc_lokhtos_darkbargainer
-enum LokhtosItems
-{
-    ITEM_THRORIUM_BROTHERHOOD_CONTRACT                     = 18628,
-    ITEM_SULFURON_INGOT                                    = 17203
-};
-
-enum LokhtosQuests
-{
-    QUEST_A_BINDING_CONTRACT                               = 7604
-};
-
-enum LokhtosSpells
-{
-    SPELL_CREATE_THORIUM_BROTHERHOOD_CONTRACT_DND          = 23059
-};
-
-struct npc_lokhtos_darkbargainer : public ScriptedAI
-{
-    npc_lokhtos_darkbargainer(Creature* creature) : ScriptedAI(creature) { }
-
-    void sGossipSelect(Player* player, uint32 /*sender*/, uint32 action) override
-    {
-        ClearGossipMenuFor(player);
-        if (action == GOSSIP_ACTION_INFO_DEF + 1)
-        {
-            CloseGossipMenuFor(player);
-            player->CastSpell(player, SPELL_CREATE_THORIUM_BROTHERHOOD_CONTRACT_DND, false);
-        }
-        if (action == GOSSIP_ACTION_TRADE)
-            player->GetSession()->SendListInventory(me->GetGUID());
-    }
-
-    void sGossipHello(Player* player) override
-    {
-        if (me->IsQuestGiver())
-            player->PrepareQuestMenu(me->GetGUID());
-
-        if (me->IsVendor() && player->GetReputationRank(59) >= REP_FRIENDLY)
-            AddGossipItemFor(player, 4781, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_TRADE);
-
-        if (player->GetQuestRewardStatus(QUEST_A_BINDING_CONTRACT) != 1 &&
-                !player->HasItemCount(ITEM_THRORIUM_BROTHERHOOD_CONTRACT, 1, true) &&
-                player->HasItemCount(ITEM_SULFURON_INGOT))
-            AddGossipItemFor(player, 4781, 1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-
-        if (player->GetReputationRank(59) < REP_FRIENDLY)
-            SendGossipMenuFor(player, 3673, me->GetGUID());
-        else
-            SendGossipMenuFor(player, 3677, me->GetGUID());
-    }
-};
 
 // npc_rocknot
 enum RocknotSays
@@ -641,7 +589,6 @@ void AddSC_blackrock_depths()
     new at_ring_of_law();
     RegisterBlackrockDepthsCreatureAI(npc_grimstone);
     RegisterBlackrockDepthsCreatureAI(npc_phalanx);
-    RegisterBlackrockDepthsCreatureAI(npc_lokhtos_darkbargainer);
     RegisterBlackrockDepthsCreatureAI(npc_rocknot);
     RegisterBlackrockDepthsCreatureAI(brd_ironhand_guardian);
 }

--- a/src/server/scripts/EasternKingdoms/zone_eastern_plaguelands.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_eastern_plaguelands.cpp
@@ -296,39 +296,8 @@ public:
     };
 };
 
-/*######
-## npc_augustus_the_touched
-######*/
-
-class npc_augustus_the_touched : public CreatureScript
-{
-public:
-    npc_augustus_the_touched() : CreatureScript("npc_augustus_the_touched") { }
-
-    bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action) override
-    {
-        ClearGossipMenuFor(player);
-        if (action == GOSSIP_ACTION_TRADE)
-            player->GetSession()->SendListInventory(creature->GetGUID());
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        if (creature->IsQuestGiver())
-            player->PrepareQuestMenu(creature->GetGUID());
-
-        if (creature->IsVendor() && player->GetQuestRewardStatus(6164))
-            AddGossipItemFor(player, GOSSIP_ICON_VENDOR, GOSSIP_TEXT_BROWSE_GOODS, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_TRADE);
-
-        SendGossipMenuFor(player, player->GetGossipTextId(creature), creature->GetGUID());
-        return true;
-    }
-};
-
 void AddSC_eastern_plaguelands()
 {
     new npc_eris_hevenfire();
     new npc_balance_of_light_and_shadow();
-    new npc_augustus_the_touched();
 }

--- a/src/server/scripts/EasternKingdoms/zone_undercity.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_undercity.cpp
@@ -294,63 +294,6 @@ public:
 };
 
 /*######
-## npc_parqual_fintallas
-######*/
-
-enum ParqualFintallas
-{
-    SPELL_MARK_OF_SHAME             = 6767,
-    QUEST_ID_TEST_OF_LORE           = 6628,
-    GOSSIP_MENU_ID_TEST_OF_LORE     = 4764,
-    GOSSIP_TEXTID_PARQUAL_FINTALLAS = 5821,
-    GOSSIP_TEXTID_TEST_OF_LORE      = 5822,
-};
-
-class npc_parqual_fintallas : public CreatureScript
-{
-public:
-    npc_parqual_fintallas() : CreatureScript("npc_parqual_fintallas") { }
-
-    bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action) override
-    {
-        ClearGossipMenuFor(player);
-        if (action == GOSSIP_ACTION_INFO_DEF + 1)
-        {
-            CloseGossipMenuFor(player);
-            creature->CastSpell(player, SPELL_MARK_OF_SHAME, false);
-        }
-        if (action == GOSSIP_ACTION_INFO_DEF + 2)
-        {
-            CloseGossipMenuFor(player);
-            player->AreaExploredOrEventHappens(6628);
-        }
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        if (creature->IsQuestGiver())
-        {
-            player->PrepareQuestMenu(creature->GetGUID());
-        }
-
-        if (player->GetQuestStatus(QUEST_ID_TEST_OF_LORE) == QUEST_STATUS_INCOMPLETE && !player->HasAura(SPELL_MARK_OF_SHAME))
-        {
-            AddGossipItemFor(player, GOSSIP_MENU_ID_TEST_OF_LORE, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-            AddGossipItemFor(player, GOSSIP_MENU_ID_TEST_OF_LORE, 1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-            AddGossipItemFor(player, GOSSIP_MENU_ID_TEST_OF_LORE, 3, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
-            SendGossipMenuFor(player, GOSSIP_TEXTID_TEST_OF_LORE, creature->GetGUID());
-        }
-        else
-        {
-            SendGossipMenuFor(player, GOSSIP_TEXTID_PARQUAL_FINTALLAS, creature->GetGUID());
-        }
-
-        return true;
-    }
-};
-
-/*######
 ## ALLIANCE
 #######*/
 
@@ -4037,7 +3980,6 @@ void AddSC_undercity()
 {
     new npc_lady_sylvanas_windrunner();
     new npc_highborne_lamenter();
-    new npc_parqual_fintallas();
 
     new npc_varian_wrynn();
     new npc_thrall_bfu();


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Move gossip handling from C++ scripts to database-driven gossip (conditions + SmartAI) for 3 NPCs in EasternKingdoms:

- **Augustus the Touched** (12384): Vendor option gated by quest 6164 reward. Two gossip texts (4979/4980) with quest conditions.
- **Parqual Fintallas** (4488): Test of Lore quiz with 4 answer options. Wrong answers cast Mark of Shame, correct answer (Ner'zhul) credits quest 6628. Uses SAI for gossip select actions.
- **Lokhtos Darkbargainer** (12944): Rep-gated vendor (Thorium Brotherhood >= Friendly), conditional contract creation spell. Rep-based gossip text switching (3673/3677). Uses SAI for contract spell cast.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Opus 4.6 was used.

## SOURCE:
The changes have been validated through:
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Augustus migration based on TC work by dr-j (commit cefed89c38bc).
Parqual migration based on TC work by offl (TC issue #24993, commit 7908b00311).
Lokhtos migration is original work (TC still uses C++ for this NPC).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Test Augustus the Touched in Eastern Plaguelands: verify vendor option only appears after completing quest 6164, and gossip text changes from 4979 to 4980.
2. Test Parqual Fintallas in Undercity: pick up quest 6628 (Test of Lore), verify 4 quiz options appear, wrong answers cast Mark of Shame (spell 6767), correct answer (Ner'zhul) credits quest. Options should not appear if quest not taken or if Shame aura is active.
3. Test Lokhtos Darkbargainer in Blackrock Depths: verify vendor option only appears at Friendly+ rep with Thorium Brotherhood. Verify contract option appears only when quest 7604 not rewarded, player has Sulfuron Ingot but not the contract. Verify contract creation spell fires on select.

## Known Issues and TODO List:

- [ ] Gloom'rel (9037) gossip migration skipped - requires multi-step gossip with instance script dependency for Spectral Chalice respawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)