### PR TITLE
fix(Core/Movement): DAMAGE_FALL_TO_VOID bypasses all immunities

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -769,7 +769,9 @@ bool Player::IsImmuneToEnvironmentalDamage()
 
 uint32 Player::EnvironmentalDamage(EnviromentalDamage type, uint32 damage)
 {
-    if (IsImmuneToEnvironmentalDamage())
+    // DAMAGE_FALL_TO_VOID bypasses all immunities (e.g. Divine Shield) to prevent
+    // players from being stuck infinitely falling below the map
+    if (type != DAMAGE_FALL_TO_VOID && IsImmuneToEnvironmentalDamage())
         return 0;
 
     // Absorb, resist some environmental damage type


### PR DESCRIPTION
## Summary
- `DAMAGE_FALL_TO_VOID` now bypasses all immunities (Divine Shield, etc.) in `EnvironmentalDamage()`
- Previously, casting Divine Shield while falling below the map caused infinite falling since `IsImmuneToEnvironmentalDamage()` returned `true`, `EnvironmentalDamage()` returned 0, and the `KillPlayer()` fallback resulted in an incomplete death state with the corpse stranded below the map

## How to reproduce
1. Enter Eye of Eternity and reach Phase 3 (dragon phase)
2. Let your drake die
3. Cast Divine Shield while falling
4. Character falls infinitely and cannot die, log out, or be summoned

Also reproducible in Eye of the Storm, Outland zones (Nagrand, Blade's Edge), and anywhere with void falls.

## Changes
One-line change in `Player::EnvironmentalDamage()`: skip the immunity check when the damage type is `DAMAGE_FALL_TO_VOID`.

Closes https://github.com/chromiecraft/chromiecraft/issues/9187

## Test plan
- [ ] Cast Divine Shield and fall off the map in Eye of the Storm — player should die
- [ ] Cast Divine Shield during Eye of Eternity Phase 3 drake death — player should die
- [ ] Verify regular environmental immunities (lava, slime) still work with Divine Shield
- [ ] Verify GMs still get killed by void fall (KillPlayer fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)