### PR TITLE
fix(Scripts/Gundrak): Fix Drakkari Colossus not activating when Living Mojo is attacked

### DIFF
--- a/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
@@ -363,7 +363,7 @@ public:
             ScriptedAI::MoveInLineOfSight(who);
         }
 
-        void AttackStart(Unit* who) override
+        void JustEngagedWith(Unit* who) override
         {
             if (me->ToTempSummon())
             {
@@ -372,6 +372,14 @@ public:
                         summoner->GetAI()->DoAction(ACTION_INFORM);
                 return;
             }
+
+            ScriptedAI::JustEngagedWith(who);
+        }
+
+        void AttackStart(Unit* who) override
+        {
+            if (me->ToTempSummon())
+                return;
 
             ScriptedAI::AttackStart(who);
         }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

After the threat system port (#24715), the Living Mojo temp summons surrounding the Drakkari Colossus boss no longer trigger the encounter when attacked. This causes the boss to remain permanently inactive, softlocking the Gundrak instance.

**Root cause:** The boss notification logic in `npc_living_mojo` relied on `AttackStart` being called when a player attacked a temp-summoned mojo. The new combat system no longer calls `AttackStart` through the old combat-start path — it uses `JustStartedThreateningMe` → `EngagementStart` → `JustEngagedWith` instead. Since the temp-summoned mojos' `UpdateAI` returns early (before `UpdateVictim`), `AttackStart` is never reached through that path either.

**Fix:** Move the boss activation logic from `AttackStart` to `JustEngagedWith`, which is the correct engagement hook in the new threat system. `AttackStart` is kept as an override to prevent temp-summoned mojos from starting melee chase behavior.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Opus 4.6 (Claude Code) was used for codebase analysis and authoring the fix.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9189

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore's implementation was compared for reference. TC uses normal world spawns (not temp summons) for boss-area mojos, so their `AttackStart` is still reached via `UpdateVictim`. AC's temp-summon design requires using `JustEngagedWith` instead.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Gundrak on Normal or Heroic difficulty.
2. Approach the Drakkari Colossus area and attack any of the 5 Living Mojo mobs surrounding the inactive boss.
3. Verify the mojos surge into the boss and the Drakkari Colossus encounter activates correctly.
4. Complete the encounter and verify phase transitions (elemental summon at 51% and 2%) work normally.

## Known Issues and TODO List:

- [ ] Regression test: verify non-boss-area Living Mojos (regular spawns in the dungeon) still fight normally when pulled.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.