### PR TITLE
fix(Scripts/Pet): prevent recursive EnterEvadeMode in snake trap AI

### DIFF
--- a/src/server/scripts/Pet/pet_hunter.cpp
+++ b/src/server/scripts/Pet/pet_hunter.cpp
@@ -68,14 +68,13 @@ struct npc_pet_hunter_snake_trap : public ScriptedAI
     void EnterEvadeMode(EvadeReason /*why*/) override
     {
         // _EnterEvadeMode();
+        me->AddUnitState(UNIT_STATE_EVADE);
         me->GetThreatMgr().ClearAllThreat();
         me->CombatStop(true);
         me->LoadCreaturesAddon(true);
         me->SetLootRecipient(nullptr);
         me->ResetPlayerDamageReq();
         me->ClearLastLeashExtensionTimePtr();
-
-        me->AddUnitState(UNIT_STATE_EVADE);
         me->GetMotionMaster()->MoveTargetedHome();
 
         Reset();


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Scripts (bosses, spell scripts, creature scripts).

Moves `AddUnitState(UNIT_STATE_EVADE)` before `CombatStop(true)` in `npc_pet_hunter_snake_trap::EnterEvadeMode()`, mirroring the protection already present in the default `_EnterEvadeMode()`.

### Problem

The snake trap's custom `EnterEvadeMode` calls `CombatStop(true)` at line 72 **before** setting `UNIT_STATE_EVADE` at line 78. This creates a re-entrant loop:

1. `UpdateAI` → `UpdateVictim` → `SelectVictim` → no target → `EnterEvadeMode`
2. `EnterEvadeMode` → `CombatStop(true)` (evade state NOT set yet)
3. → `ClearInCombat` → `EndAllCombat` → `CombatReference::EndCombat`
4. → `JustExitedCombat()` → `CreatureAI::JustExitedCombat` checks `IsInEvadeMode()` → **false**
5. → Calls `EnterEvadeMode` **recursively**
6. Inner `EnterEvadeMode` → `Reset()` → `SelectNearestTarget()` (grid search during combat teardown)
7. Outer `EnterEvadeMode` resumes → calls `Reset()` **again**

This causes `Reset()` to execute twice, with the first call performing a grid search while combat references are still being torn down.

### Fix

Move `me->AddUnitState(UNIT_STATE_EVADE)` before `me->CombatStop(true)`, matching the approach used by `_EnterEvadeMode()` (which this script bypasses). The `IsInEvadeMode()` guard in `CreatureAI::JustExitedCombat` then correctly prevents recursive re-entry.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Opus 4.6 was used for backtrace analysis and TrinityCore comparison.

## Issues Addressed:

Crash/re-entrancy in snake trap pet AI during evade, observed via backtrace from production server.

## SOURCE:

The changes have been validated through:
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). The default `_EnterEvadeMode()` in AzerothCore's own `CreatureAI.cpp` already sets `UNIT_STATE_EVADE` before `CombatStop()` with an explicit comment about preventing this exact recursion. TrinityCore's snake trap does not override `EnterEvadeMode` at all, avoiding the issue entirely.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Use a Hunter with Snake Trap talent
2. Deploy Snake Trap and trigger it with an enemy
3. Have the enemy die or leave combat range so snakes enter evade mode
4. Verify no crash occurs and snakes correctly return to follow behavior
5. Repeat in scenarios where the snake's owner is a player in an instance (the backtrace showed this in an InstanceMap)