### PR TITLE
fix(Scripts/Oculus): Fix Mage-Lord Urom not teleporting between platforms

### DIFF
--- a/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
@@ -213,6 +213,7 @@ public:
             me->LoadCreaturesAddon(true);
             me->SetLootRecipient(nullptr);
             me->ResetPlayerDamageReq();
+            EngagementOver();
         }
 
         void JustDied(Unit* /*killer*/) override
@@ -369,6 +370,10 @@ public:
 
         void EnterEvadeMode(EvadeReason why) override
         {
+            // Block evade during outer platform transitions
+            if (lock)
+                return;
+
             me->SetCanFly(false);
             me->SetDisableGravity(false);
             me->SetControlled(false, UNIT_STATE_ROOT);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with AzerothMCP

## Description

The threat system port (#24715) introduced `EngagementStart`/`EngagementOver` tracking, but Urom's `LeaveCombat()` never called `EngagementOver()`, leaving the boss in a broken engagement state after outer platform transitions. Additionally, `CombatStop` triggering `JustExitedCombat` would fire a full evade chain (`MoveTargetedHome`/`Reset`) mid-transition, interfering with the spell-driven teleport via `spell_target_position`.

**Changes:**
- Add `EngagementOver()` call in `LeaveCombat()` to properly clear engagement state after platform transitions
- Block `EnterEvadeMode` while `lock` is active to prevent the evade chain from firing during scripted platform transitions

**Root cause:** After the threat system port, `UpdateVictim()` checks `IsEngaged()` first. Since `LeaveCombat()` never cleared the engagement flag, the boss was stuck in a state where it was "engaged" but had no victim or threat — preventing both re-engagement and proper evade/home return. The summon menagerie spells (50476/50495/50496) have `spell_target_position` entries that handle the actual teleport between platforms, but the unintended evade chain was disrupting this.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9193

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - TrinityCore reference implementation of `boss_urom` confirmed the same pattern (`EngagementOver()` in `LeaveCombat()`, evade blocked on outer platforms)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Enter The Oculus (map 578) and navigate to Mage-Lord Urom
2. Engage him on the first outer platform — he should summon adds, say his line, and teleport to the second platform
3. Repeat for second and third platforms — after the third, he should teleport to the center platform
4. Engage him at center for the final fight (Frostbomb, Time Bomb, Arcane Explosion teleport cycle)
5. Verify evade works correctly if players wipe during the center fight

## Known Issues and TODO List:

- [ ] The stun-during-cast exploit (stunning Urom during summon menagerie cast leaves `lock = true`) is a pre-existing issue not addressed in this PR