### PR TITLE
fix(Core/Movement): Remove unconditional SetWalk(false) from WaypointMovementGenerator::DoFinalize

### DIFF
--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -95,7 +95,6 @@ void WaypointMovementGenerator<Creature>::DoInitialize(Creature* creature)
 void WaypointMovementGenerator<Creature>::DoFinalize(Creature* creature)
 {
     creature->ClearUnitState(UNIT_STATE_ROAMING | UNIT_STATE_ROAMING_MOVE);
-    creature->SetWalk(false);
 }
 
 void WaypointMovementGenerator<Creature>::DoReset(Creature* creature)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with AzerothMCP

## Description

The smooth waypoint movement port (#25106) added `creature->SetWalk(false)` in `WaypointMovementGenerator::DoFinalize`, which unconditionally forces run mode whenever a waypoint generator is finalized. This breaks creatures that use escort AI with walk mode (e.g. General Bjarngrim in Halls of Lightning), since their DB waypoint generator (MovementType=2) gets finalized when the escort AI takes over, overriding the script's `SetWalk(true)`.

This line did not exist before #25106. Creatures that need to switch to run mode after waypoint movement should handle it in their own scripts.

**Note:** TrinityCore has the same `SetWalk(false)` but guarded behind `if (active)` so it only fires for the currently-running generator. AC's `DoFinalize` doesn't have an `active` parameter, so the line fires for every finalization including idle-slot cleanup. TC also has a TODO comment questioning whether it's needed at all.

## Issues Addressed:
- General Bjarngrim (entry 28586) running instead of walking on his patrol in Halls of Lightning

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - Regression from #25106. Pre-#25106 DoFinalize did not contain SetWalk(false).
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.
  - Should verify other waypoint creatures still behave correctly (walk/run as expected).

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.tele HallsOfLightning`
2. Observe General Bjarngrim patrolling — he should be **walking**, not running
3. Spot-check other waypoint creatures to ensure no regressions

## Known Issues and TODO List:

- [ ] May want to audit other creatures for similar walk/run regressions introduced by #25106