### PR TITLE
fix(Core/Combat): Prevent NullCreatureAI creatures from entering combat

### DIFF
--- a/src/server/game/AI/CoreAI/PassiveAI.cpp
+++ b/src/server/game/AI/CoreAI/PassiveAI.cpp
@@ -20,7 +20,11 @@
 
 PassiveAI::PassiveAI(Creature* c) : CreatureAI(c) { me->SetReactState(REACT_PASSIVE); }
 PossessedAI::PossessedAI(Creature* c) : CreatureAI(c) { me->SetReactState(REACT_PASSIVE); }
-NullCreatureAI::NullCreatureAI(Creature* c) : CreatureAI(c) { me->SetReactState(REACT_PASSIVE); }
+NullCreatureAI::NullCreatureAI(Creature* c) : CreatureAI(c)
+{
+    me->SetReactState(REACT_PASSIVE);
+    me->SetIsCombatDisallowed(true);
+}
 
 int32 NullCreatureAI::Permissible(Creature const* creature)
 {


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with AzerothMCP

## Description

NullCreatureAI creatures (triggers, spellclick NPCs, idle fallbacks) have empty handlers for `AttackStart`, `UpdateAI`, `EnterEvadeMode`, and `JustEnteredCombat` — they cannot attack, evade, or resolve combat in any way. After the threat system port (#24715), combat references created by their periodic damage spells persist indefinitely, leaving players stuck in combat.

**Example:** Toxic Tunnel (entry 16400) in Naxxramas uses `NullCreatureAI` and has an aura (spell 28370 "Toxic Gas") that periodically triggers AoE Nature damage (spell 28369). When this damage hits players passing through the pipe to Grobbulus, a PvE combat reference is created. Since `NullCreatureAI::EnterEvadeMode` is a no-op `{}`, the combat reference is never cleared and the player is stuck in combat indefinitely.

**Fix:** Set `IsCombatDisallowed(true)` in the `NullCreatureAI` constructor. The `CombatManager::CanBeginCombat` check already supports this flag — combat references are simply never created. The creatures' spells still deal damage normally, they just don't create unresolvable combat state.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9195

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - Regression from #24715 (threat system port). NullCreatureAI creatures could not previously enter combat as the old threat system did not create persistent combat refs for them.
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Naxxramas and navigate to the pipe/tunnel between Patchwerk's area and Grobbulus
2. Walk through the toxic gas — you should take damage but **not** get stuck in combat
3. After exiting the pipe, verify combat drops normally
4. Verify other NullCreatureAI triggers (spellclick vehicles, invisible triggers) still function correctly

## Known Issues and TODO List:

- [ ] Should audit other NullCreatureAI creatures to ensure none rely on entering combat (unlikely given all combat handlers are no-ops)