### PR TITLE
fix(Scripts/Naxx): Fix Heigan evading and regenerating HP at end of Phase 2

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/boss_heigan.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_heigan.cpp
@@ -42,19 +42,20 @@ enum Spells
 enum Events
 {
     EVENT_DISRUPTION                = 1,
-    EVENT_DECREPIT_FEVER            = 2,
+    EVENT_DECEPIT_FEVER             = 2,
     EVENT_ERUPT_SECTION             = 3,
-    EVENT_DANCE                     = 4,
-    EVENT_DANCE_END                 = 5,
-    EVENT_SAFETY_DANCE              = 6,
-    EVENT_PLAGUE_CLOUD              = 7
+    EVENT_SWITCH_PHASE              = 4,
+    EVENT_SAFETY_DANCE              = 5,
+    EVENT_PLAGUE_CLOUD              = 6
 };
 
-enum Phases
+enum Misc
 {
-    PHASE_FIGHT                     = 1,
-    PHASE_DANCE                     = 2
+    PHASE_SLOW_DANCE                = 0,
+    PHASE_FAST_DANCE                = 1
 };
+
+float const heiganFastDanceFaceDirection = 2.40f;
 
 struct boss_heigan : public BossAI
 {
@@ -63,9 +64,10 @@ struct boss_heigan : public BossAI
     void Reset() override
     {
         BossAI::Reset();
-        me->SetReactState(REACT_AGGRESSIVE);
+        _currentPhase = 0;
         _currentSection = 3;
         _moveRight = true;
+        _eruptionScheduler.CancelAll();
     }
 
     void KilledUnit(Unit* who) override
@@ -79,6 +81,7 @@ struct boss_heigan : public BossAI
 
     void JustDied(Unit*  killer) override
     {
+        _eruptionScheduler.CancelAll();
         BossAI::JustDied(killer);
         Talk(EMOTE_DEATH);
     }
@@ -88,14 +91,69 @@ struct boss_heigan : public BossAI
         BossAI::JustEngagedWith(who);
         me->SetInCombatWithZone();
         Talk(SAY_AGGRO);
+        StartFightPhase(PHASE_SLOW_DANCE);
+    }
 
+    void StartFightPhase(uint8 phase)
+    {
         _currentSection = 3;
-        events.SetPhase(PHASE_FIGHT);
-        events.ScheduleEvent(EVENT_DISRUPTION, randtime(12s, 15s), 0, PHASE_FIGHT);
-        events.ScheduleEvent(EVENT_DECREPIT_FEVER, 17s, 0, PHASE_FIGHT);
-        events.ScheduleEvent(EVENT_DANCE, 90s, 0, PHASE_FIGHT);
-        events.ScheduleEvent(EVENT_ERUPT_SECTION, 15s);
-        events.ScheduleEvent(EVENT_SAFETY_DANCE, 5s);
+        _currentPhase = phase;
+        scheduler.CancelAll();
+        _eruptionScheduler.CancelAll();
+        if (phase == PHASE_SLOW_DANCE)
+        {
+            me->CastStop();
+            me->SetReactState(REACT_AGGRESSIVE);
+            DoZoneInCombat();
+            ScheduleTimedEvent(12s, 15s, [&] {
+                DoCastSelf(SPELL_SPELL_DISRUPTION);
+            }, 10s);
+            ScheduleTimedEvent(17s, [&] {
+                DoCastSelf(SPELL_DECREPIT_FEVER);
+            }, 22s, 25s);
+            _eruptionScheduler.Schedule(15s, [this](TaskContext context){
+                instance->SetData(DATA_HEIGAN_ERUPTION, _currentSection);
+                if (_currentSection == 3)
+                    _moveRight = false;
+                else if (_currentSection == 0)
+                    _moveRight = true;
+
+                _moveRight ? _currentSection++ : _currentSection--;
+                Talk(SAY_TAUNT);
+                context.Repeat(10s);
+            }).Schedule(90s, [this](TaskContext /*context*/) {
+                StartFightPhase(PHASE_FAST_DANCE);
+            });
+        }
+        else // if (phase == PHASE_FAST_DANCE)
+        {
+            Talk(EMOTE_DANCE);
+            Talk(SAY_DANCE);
+            me->AttackStop();
+            me->StopMoving();
+            me->SetReactState(REACT_PASSIVE);
+            me->CastSpell(me, SPELL_TELEPORT_SELF, false);
+            me->SetFacingTo(heiganFastDanceFaceDirection);
+            scheduler.Schedule(1s, [this](TaskContext /*context*/) {
+                DoCastSelf(SPELL_PLAGUE_CLOUD);
+            });
+            _eruptionScheduler.Schedule(7s, [this](TaskContext context){
+                instance->SetData(DATA_HEIGAN_ERUPTION, _currentSection);
+                if (_currentSection == 3)
+                    _moveRight = false;
+                else if (_currentSection == 0)
+                    _moveRight = true;
+
+                _moveRight ? _currentSection++ : _currentSection--;
+                context.Repeat(4s);
+            }).Schedule(45s, [this](TaskContext /*context*/) {
+                StartFightPhase(PHASE_SLOW_DANCE);
+                Talk(EMOTE_DANCE_END); // avoid play the emote on aggro
+            });
+        }
+        ScheduleTimedEvent(5s, [&] {
+            CheckSafetyDance();
+        }, 5s);
     }
 
     void UpdateAI(uint32 diff) override
@@ -103,69 +161,9 @@ struct boss_heigan : public BossAI
         if (!UpdateVictim())
             return;
 
-        events.Update(diff);
+        _eruptionScheduler.Update(diff);
 
-        while (uint32 eventId = events.ExecuteEvent())
-        {
-            switch (eventId)
-            {
-                case EVENT_DISRUPTION:
-                    DoCastSelf(SPELL_SPELL_DISRUPTION);
-                    events.Repeat(10s);
-                    break;
-                case EVENT_DECREPIT_FEVER:
-                    DoCastSelf(SPELL_DECREPIT_FEVER);
-                    events.Repeat(randtime(22s, 25s));
-                    break;
-                case EVENT_DANCE:
-                    events.SetPhase(PHASE_DANCE);
-                    Talk(SAY_DANCE);
-                    Talk(EMOTE_DANCE);
-                    _currentSection = 3;
-                    me->SetReactState(REACT_PASSIVE);
-                    me->AttackStop();
-                    me->StopMoving();
-                    me->CastSpell(me, SPELL_TELEPORT_SELF, false);
-                    me->SetFacingTo(2.40f);
-                    events.ScheduleEvent(EVENT_PLAGUE_CLOUD, 1s, 0, PHASE_DANCE);
-                    events.ScheduleEvent(EVENT_DANCE_END, 45s, 0, PHASE_DANCE);
-                    events.RescheduleEvent(EVENT_ERUPT_SECTION, 7s);
-                    break;
-                case EVENT_PLAGUE_CLOUD:
-                    DoCastSelf(SPELL_PLAGUE_CLOUD);
-                    break;
-                case EVENT_DANCE_END:
-                    events.SetPhase(PHASE_FIGHT);
-                    Talk(EMOTE_DANCE_END);
-                    _currentSection = 3;
-                    me->CastStop();
-                    me->SetReactState(REACT_AGGRESSIVE);
-                    DoZoneInCombat();
-                    events.ScheduleEvent(EVENT_DISRUPTION, randtime(12s, 15s), 0, PHASE_FIGHT);
-                    events.ScheduleEvent(EVENT_DECREPIT_FEVER, 17s, 0, PHASE_FIGHT);
-                    events.ScheduleEvent(EVENT_DANCE, 90s, 0, PHASE_FIGHT);
-                    events.RescheduleEvent(EVENT_ERUPT_SECTION, 15s);
-                    break;
-                case EVENT_ERUPT_SECTION:
-                    instance->SetData(DATA_HEIGAN_ERUPTION, _currentSection);
-                    if (_currentSection == 3)
-                        _moveRight = false;
-                    else if (_currentSection == 0)
-                        _moveRight = true;
-
-                    _moveRight ? _currentSection++ : _currentSection--;
-                    Talk(SAY_TAUNT);
-                    events.Repeat(events.IsInPhase(PHASE_DANCE) ? 4s : 10s);
-                    break;
-                case EVENT_SAFETY_DANCE:
-                    CheckSafetyDance();
-                    events.Repeat(5s);
-                    break;
-            }
-
-            if (me->HasUnitState(UNIT_STATE_CASTING))
-                return;
-        }
+        scheduler.Update(diff);
 
         DoMeleeAttackIfReady();
     }
@@ -186,8 +184,10 @@ struct boss_heigan : public BossAI
         }
     }
 private:
-    uint8 _currentSection{3};
+    uint8 _currentPhase{};
+    uint8 _currentSection{};
     bool _moveRight{true};
+    TaskScheduler _eruptionScheduler;
 };
 
 void AddSC_boss_heigan()

--- a/src/server/scripts/Northrend/Naxxramas/boss_heigan.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_heigan.cpp
@@ -42,20 +42,19 @@ enum Spells
 enum Events
 {
     EVENT_DISRUPTION                = 1,
-    EVENT_DECEPIT_FEVER             = 2,
+    EVENT_DECREPIT_FEVER            = 2,
     EVENT_ERUPT_SECTION             = 3,
-    EVENT_SWITCH_PHASE              = 4,
-    EVENT_SAFETY_DANCE              = 5,
-    EVENT_PLAGUE_CLOUD              = 6
+    EVENT_DANCE                     = 4,
+    EVENT_DANCE_END                 = 5,
+    EVENT_SAFETY_DANCE              = 6,
+    EVENT_PLAGUE_CLOUD              = 7
 };
 
-enum Misc
+enum Phases
 {
-    PHASE_SLOW_DANCE                = 0,
-    PHASE_FAST_DANCE                = 1
+    PHASE_FIGHT                     = 1,
+    PHASE_DANCE                     = 2
 };
-
-float const heiganFastDanceFaceDirection = 2.40f;
 
 struct boss_heigan : public BossAI
 {
@@ -64,10 +63,9 @@ struct boss_heigan : public BossAI
     void Reset() override
     {
         BossAI::Reset();
-        _currentPhase = 0;
+        me->SetReactState(REACT_AGGRESSIVE);
         _currentSection = 3;
         _moveRight = true;
-        _eruptionScheduler.CancelAll();
     }
 
     void KilledUnit(Unit* who) override
@@ -81,7 +79,6 @@ struct boss_heigan : public BossAI
 
     void JustDied(Unit*  killer) override
     {
-        _eruptionScheduler.CancelAll();
         BossAI::JustDied(killer);
         Talk(EMOTE_DEATH);
     }
@@ -91,81 +88,86 @@ struct boss_heigan : public BossAI
         BossAI::JustEngagedWith(who);
         me->SetInCombatWithZone();
         Talk(SAY_AGGRO);
-        StartFightPhase(PHASE_SLOW_DANCE);
-    }
 
-    void StartFightPhase(uint8 phase)
-    {
         _currentSection = 3;
-        _currentPhase = phase;
-        scheduler.CancelAll();
-        _eruptionScheduler.CancelAll();
-        if (phase == PHASE_SLOW_DANCE)
-        {
-            me->CastStop();
-            me->SetReactState(REACT_AGGRESSIVE);
-            DoZoneInCombat();
-            ScheduleTimedEvent(12s, 15s, [&] {
-                DoCastSelf(SPELL_SPELL_DISRUPTION);
-            }, 10s);
-            ScheduleTimedEvent(17s, [&] {
-                DoCastSelf(SPELL_DECREPIT_FEVER);
-            }, 22s, 25s);
-            _eruptionScheduler.Schedule(15s, [this](TaskContext context){
-                instance->SetData(DATA_HEIGAN_ERUPTION, _currentSection);
-                if (_currentSection == 3)
-                    _moveRight = false;
-                else if (_currentSection == 0)
-                    _moveRight = true;
-
-                _moveRight ? _currentSection++ : _currentSection--;
-                Talk(SAY_TAUNT);
-                context.Repeat(10s);
-            }).Schedule(90s, [this](TaskContext /*context*/) {
-                StartFightPhase(PHASE_FAST_DANCE);
-            });
-        }
-        else // if (phase == PHASE_FAST_DANCE)
-        {
-            Talk(EMOTE_DANCE);
-            Talk(SAY_DANCE);
-            me->AttackStop();
-            me->StopMoving();
-            me->SetReactState(REACT_PASSIVE);
-            me->CastSpell(me, SPELL_TELEPORT_SELF, false);
-            me->SetFacingTo(heiganFastDanceFaceDirection);
-            scheduler.Schedule(1s, [this](TaskContext /*context*/) {
-                DoCastSelf(SPELL_PLAGUE_CLOUD);
-            });
-            _eruptionScheduler.Schedule(7s, [this](TaskContext context){
-                instance->SetData(DATA_HEIGAN_ERUPTION, _currentSection);
-                if (_currentSection == 3)
-                    _moveRight = false;
-                else if (_currentSection == 0)
-                    _moveRight = true;
-
-                _moveRight ? _currentSection++ : _currentSection--;
-                context.Repeat(4s);
-            }).Schedule(45s, [this](TaskContext /*context*/) {
-                StartFightPhase(PHASE_SLOW_DANCE);
-                Talk(EMOTE_DANCE_END); // avoid play the emote on aggro
-            });
-        }
-        ScheduleTimedEvent(5s, [&] {
-            CheckSafetyDance();
-        }, 5s);
+        events.SetPhase(PHASE_FIGHT);
+        events.ScheduleEvent(EVENT_DISRUPTION, randtime(12s, 15s), 0, PHASE_FIGHT);
+        events.ScheduleEvent(EVENT_DECREPIT_FEVER, 17s, 0, PHASE_FIGHT);
+        events.ScheduleEvent(EVENT_DANCE, 90s, 0, PHASE_FIGHT);
+        events.ScheduleEvent(EVENT_ERUPT_SECTION, 15s);
+        events.ScheduleEvent(EVENT_SAFETY_DANCE, 5s);
     }
 
     void UpdateAI(uint32 diff) override
     {
         if (!UpdateVictim())
-        {
             return;
+
+        events.Update(diff);
+
+        while (uint32 eventId = events.ExecuteEvent())
+        {
+            switch (eventId)
+            {
+                case EVENT_DISRUPTION:
+                    DoCastSelf(SPELL_SPELL_DISRUPTION);
+                    events.Repeat(10s);
+                    break;
+                case EVENT_DECREPIT_FEVER:
+                    DoCastSelf(SPELL_DECREPIT_FEVER);
+                    events.Repeat(randtime(22s, 25s));
+                    break;
+                case EVENT_DANCE:
+                    events.SetPhase(PHASE_DANCE);
+                    Talk(SAY_DANCE);
+                    Talk(EMOTE_DANCE);
+                    _currentSection = 3;
+                    me->SetReactState(REACT_PASSIVE);
+                    me->AttackStop();
+                    me->StopMoving();
+                    me->CastSpell(me, SPELL_TELEPORT_SELF, false);
+                    me->SetFacingTo(2.40f);
+                    events.ScheduleEvent(EVENT_PLAGUE_CLOUD, 1s, 0, PHASE_DANCE);
+                    events.ScheduleEvent(EVENT_DANCE_END, 45s, 0, PHASE_DANCE);
+                    events.RescheduleEvent(EVENT_ERUPT_SECTION, 7s);
+                    break;
+                case EVENT_PLAGUE_CLOUD:
+                    DoCastSelf(SPELL_PLAGUE_CLOUD);
+                    break;
+                case EVENT_DANCE_END:
+                    events.SetPhase(PHASE_FIGHT);
+                    Talk(EMOTE_DANCE_END);
+                    _currentSection = 3;
+                    me->CastStop();
+                    me->SetReactState(REACT_AGGRESSIVE);
+                    DoZoneInCombat();
+                    events.ScheduleEvent(EVENT_DISRUPTION, randtime(12s, 15s), 0, PHASE_FIGHT);
+                    events.ScheduleEvent(EVENT_DECREPIT_FEVER, 17s, 0, PHASE_FIGHT);
+                    events.ScheduleEvent(EVENT_DANCE, 90s, 0, PHASE_FIGHT);
+                    events.RescheduleEvent(EVENT_ERUPT_SECTION, 15s);
+                    break;
+                case EVENT_ERUPT_SECTION:
+                    instance->SetData(DATA_HEIGAN_ERUPTION, _currentSection);
+                    if (_currentSection == 3)
+                        _moveRight = false;
+                    else if (_currentSection == 0)
+                        _moveRight = true;
+
+                    _moveRight ? _currentSection++ : _currentSection--;
+                    Talk(SAY_TAUNT);
+                    events.Repeat(events.IsInPhase(PHASE_DANCE) ? 4s : 10s);
+                    break;
+                case EVENT_SAFETY_DANCE:
+                    CheckSafetyDance();
+                    events.Repeat(5s);
+                    break;
+            }
+
+            if (me->HasUnitState(UNIT_STATE_CASTING))
+                return;
         }
 
-        _eruptionScheduler.Update(diff);
-
-        BossAI::UpdateAI(diff);
+        DoMeleeAttackIfReady();
     }
 
     void CheckSafetyDance()
@@ -184,10 +186,8 @@ struct boss_heigan : public BossAI
         }
     }
 private:
-    uint8 _currentPhase{};
-    uint8 _currentSection{};
+    uint8 _currentSection{3};
     bool _moveRight{true};
-    TaskScheduler _eruptionScheduler;
 };
 
 void AddSC_boss_heigan()


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - **Claude Code** (claude-opus-4-6) with **AzerothMCP** for database research

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9196

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Referenced TrinityCore's boss_heigan implementation for the EventMap-based approach.

## Description

At the end of Phase 2 (fast dance), Heigan would briefly evade, regenerate HP, and cause warlock pets to go idle.

**Root cause:** The old code used a dual-scheduler pattern (`scheduler` + `_eruptionScheduler`) with a custom `UpdateAI` override that called `UpdateVictim()`, then fired the `_eruptionScheduler` (which transitioned the phase to `REACT_AGGRESSIVE`), then called `BossAI::UpdateAI` which called `UpdateVictim()` **a second time**. This second call ran `SelectVictim()` while the boss was still physically on the platform, causing `CanCreatureAttack()` to fail and triggering an evade.

**Fix:** Rewrites to use a single `EventMap` with phase filtering (`PHASE_FIGHT`/`PHASE_DANCE`), matching TrinityCore's approach. This ensures only one `UpdateVictim()` call per tick. The phase transition happens inside the event loop after `UpdateVictim()` has already passed, so the boss isn't evade-checked until the next tick — by which time the movement system is already chasing a target.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.tele naxxramas` then `.go creature id 15936` to reach Heigan the Unclean
2. Pull Heigan and fight through Phase 1 (90s slow dance eruptions)
3. When Phase 2 starts (boss teleports to platform, plague cloud, fast eruptions), survive for 45s
4. At the end of Phase 2, verify boss transitions back to Phase 1 without evading or regenerating HP
5. Verify warlock pets continue attacking normally through the transition
6. Repeat for at least 2 full phase cycles (P1→P2→P1→P2→P1)

## Known Issues and TODO List:

- [ ] Needs in-game testing to confirm eruption timings match expected behavior across phase transitions

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.