### PR TITLE
fix(Scripts/Icecrown): Fix idle scourge NPCs in The Battle For Crusaders' Pinnacle

### DIFF
--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -1771,18 +1771,18 @@ public:
 
         void MoveInLineOfSight(Unit* /*who*/) override { }
 
-        void JustSummoned(Creature* Summoned) override
+        void JustSummoned(Creature* summon) override
         {
-            Summons.Summon(Summoned);
-            if (Summoned->GetEntry() == NPC_SCOURGE_DRUDGE || Summoned->GetEntry() == NPC_REANIMATED_CAPTAIN ||
-                Summoned->GetEntry() == NPC_HIDEOUS_PLAGUEBRINGER || Summoned->GetEntry() == NPC_HALOF_THE_DEATHBRINGER)
+            Summons.Summon(summon);
+            if (summon->GetEntry() == NPC_SCOURGE_DRUDGE || summon->GetEntry() == NPC_REANIMATED_CAPTAIN ||
+                summon->GetEntry() == NPC_HIDEOUS_PLAGUEBRINGER || summon->GetEntry() == NPC_HALOF_THE_DEATHBRINGER)
             {
-                Summoned->SetHomePosition(DalforsPos[2]);
-                Summoned->SetReactState(REACT_PASSIVE);
-                Summoned->EngageWithTarget(me);
-                Summoned->m_Events.AddEventAtOffset([Summoned]()
+                summon->SetHomePosition(DalforsPos[2]);
+                summon->SetReactState(REACT_PASSIVE);
+                summon->EngageWithTarget(me);
+                summon->m_Events.AddEventAtOffset([summon]()
                 {
-                    Summoned->SetReactState(REACT_AGGRESSIVE);
+                    summon->SetReactState(REACT_AGGRESSIVE);
                 }, 2s);
             }
         }

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -1774,6 +1774,17 @@ public:
         void JustSummoned(Creature* Summoned) override
         {
             Summons.Summon(Summoned);
+            if (Summoned->GetEntry() == NPC_SCOURGE_DRUDGE || Summoned->GetEntry() == NPC_REANIMATED_CAPTAIN ||
+                Summoned->GetEntry() == NPC_HIDEOUS_PLAGEBRINGER || Summoned->GetEntry() == NPC_HALOF_THE_DEATHBRINGER)
+            {
+                Summoned->SetHomePosition(DalforsPos[2]);
+                Summoned->SetReactState(REACT_PASSIVE);
+                Summoned->EngageWithTarget(me);
+                Summoned->m_Events.AddEventAtOffset([Summoned]()
+                {
+                    Summoned->SetReactState(REACT_AGGRESSIVE);
+                }, 2s);
+            }
         }
 
         void JustDied(Unit* /*killer*/) override
@@ -1926,36 +1937,16 @@ public:
                             if (Creature* LK = GetClosestCreatureWithEntry(me, NPC_LK, 100))
                                 LK->AI()->Talk(LK_TALK_3);
                         }
-                        if (Creature* tempsum = DoSummon(NPC_SCOURGE_DRUDGE, Mason3Pos[0]))
-                        {
-                            tempsum->SetHomePosition(DalforsPos[2]);
-                            tempsum->AI()->AttackStart(GetClosestCreatureWithEntry(me, NPC_BLESSED_BANNER, 100));
-                        }
+                        DoSummon(NPC_SCOURGE_DRUDGE, Mason3Pos[0]);
                         if (urand(0, 1) == 0)
                         {
-                            if (Creature* tempsum = DoSummon(NPC_HIDEOUS_PLAGEBRINGER, Mason1Pos[0]))
-                            {
-                                tempsum->SetHomePosition(DalforsPos[2]);
-                                tempsum->AI()->AttackStart(GetClosestCreatureWithEntry(me, NPC_BLESSED_BANNER, 100));
-                            }
-                            if (Creature* tempsum = DoSummon(NPC_HIDEOUS_PLAGEBRINGER, Mason2Pos[0]))
-                            {
-                                tempsum->SetHomePosition(DalforsPos[2]);
-                                tempsum->AI()->AttackStart(GetClosestCreatureWithEntry(me, NPC_BLESSED_BANNER, 100));
-                            }
+                            DoSummon(NPC_HIDEOUS_PLAGEBRINGER, Mason1Pos[0]);
+                            DoSummon(NPC_HIDEOUS_PLAGEBRINGER, Mason2Pos[0]);
                         }
                         else
                         {
-                            if (Creature* tempsum = DoSummon(NPC_REANIMATED_CAPTAIN, Mason1Pos[0]))
-                            {
-                                tempsum->SetHomePosition(DalforsPos[2]);
-                                tempsum->AI()->AttackStart(GetClosestCreatureWithEntry(me, NPC_BLESSED_BANNER, 100));
-                            }
-                            if (Creature* tempsum = DoSummon(NPC_REANIMATED_CAPTAIN, Mason2Pos[0]))
-                            {
-                                tempsum->SetHomePosition(DalforsPos[2]);
-                                tempsum->AI()->AttackStart(GetClosestCreatureWithEntry(me, NPC_BLESSED_BANNER, 100));
-                            }
+                            DoSummon(NPC_REANIMATED_CAPTAIN, Mason1Pos[0]);
+                            DoSummon(NPC_REANIMATED_CAPTAIN, Mason2Pos[0]);
                         }
 
                         PhaseCount++;
@@ -1970,22 +1961,12 @@ public:
                     {
                         if (Creature* LK = GetClosestCreatureWithEntry(me, NPC_LK, 100))
                             LK->AI()->Talk(LK_TALK_4);
-                        if (Creature* tempsum = DoSummon(NPC_SCOURGE_DRUDGE, Mason1Pos[0]))
-                        {
-                            tempsum->SetHomePosition(DalforsPos[2]);
-                            tempsum->AI()->AttackStart(GetClosestCreatureWithEntry(me, NPC_BLESSED_BANNER, 100));
-                        }
-                        if (Creature* tempsum = DoSummon(NPC_SCOURGE_DRUDGE, Mason2Pos[0]))
-                        {
-                            tempsum->SetHomePosition(DalforsPos[2]);
-                            tempsum->AI()->AttackStart(GetClosestCreatureWithEntry(me, NPC_BLESSED_BANNER, 100));
-                        }
+                        DoSummon(NPC_SCOURGE_DRUDGE, Mason1Pos[0]);
+                        DoSummon(NPC_SCOURGE_DRUDGE, Mason2Pos[0]);
                         if (Creature* tempsum = DoSummon(NPC_HALOF_THE_DEATHBRINGER, DalforsPos[0]))
                         {
                             HalofSpawned = true;
                             guidHalof = tempsum->GetGUID();
-                            tempsum->SetHomePosition(DalforsPos[2]);
-                            tempsum->AI()->AttackStart(GetClosestCreatureWithEntry(me, NPC_BLESSED_BANNER, 100));
                         }
                     }
                     break;

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -1659,7 +1659,7 @@ enum BlessedBanner
     NPC_ARGENT_MASON                    = 30900,
     NPC_REANIMATED_CAPTAIN              = 30986,
     NPC_SCOURGE_DRUDGE                  = 30984,
-    NPC_HIDEOUS_PLAGEBRINGER            = 30987,
+    NPC_HIDEOUS_PLAGUEBRINGER           = 30987,
     NPC_HALOF_THE_DEATHBRINGER          = 30989,
     NPC_LK                              = 31013,
 
@@ -1775,7 +1775,7 @@ public:
         {
             Summons.Summon(Summoned);
             if (Summoned->GetEntry() == NPC_SCOURGE_DRUDGE || Summoned->GetEntry() == NPC_REANIMATED_CAPTAIN ||
-                Summoned->GetEntry() == NPC_HIDEOUS_PLAGEBRINGER || Summoned->GetEntry() == NPC_HALOF_THE_DEATHBRINGER)
+                Summoned->GetEntry() == NPC_HIDEOUS_PLAGUEBRINGER || Summoned->GetEntry() == NPC_HALOF_THE_DEATHBRINGER)
             {
                 Summoned->SetHomePosition(DalforsPos[2]);
                 Summoned->SetReactState(REACT_PASSIVE);
@@ -1940,8 +1940,8 @@ public:
                         DoSummon(NPC_SCOURGE_DRUDGE, Mason3Pos[0]);
                         if (urand(0, 1) == 0)
                         {
-                            DoSummon(NPC_HIDEOUS_PLAGEBRINGER, Mason1Pos[0]);
-                            DoSummon(NPC_HIDEOUS_PLAGEBRINGER, Mason2Pos[0]);
+                            DoSummon(NPC_HIDEOUS_PLAGUEBRINGER, Mason1Pos[0]);
+                            DoSummon(NPC_HIDEOUS_PLAGUEBRINGER, Mason2Pos[0]);
                         }
                         else
                         {
@@ -1983,7 +1983,7 @@ public:
                     if (Halof->isDead())
                     {
                         DoCast(me, SPELL_CRUSADERS_SPIRE_VICTORY, true);
-                        Summons.DespawnEntry(NPC_HIDEOUS_PLAGEBRINGER);
+                        Summons.DespawnEntry(NPC_HIDEOUS_PLAGUEBRINGER);
                         Summons.DespawnEntry(NPC_REANIMATED_CAPTAIN);
                         Summons.DespawnEntry(NPC_SCOURGE_DRUDGE);
                         Summons.DespawnEntry(NPC_HALOF_THE_DEATHBRINGER);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - **Claude Code** (claude-opus-4-6) with **AzerothMCP** for database research

## Issues Addressed:
- Scourge NPCs during quest "The Battle For Crusaders' Pinnacle" (13141) stand idle instead of attacking

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Referenced TrinityCore's `npc_blessed_banner` implementation for the `JustSummoned` + `EngageWithTarget` approach.

## Description

During quest 13141 "The Battle For Crusaders' Pinnacle", scourge wave NPCs (Scourge Drudge, Reanimated Captain, Hideous Plaguebringer, Halof the Deathbringer) would spawn and stand idle instead of attacking.

**Root cause:** The old code used `AttackStart(GetClosestCreatureWithEntry(me, NPC_BLESSED_BANNER, 100))` inline for each summoned scourge mob in `EVENT_WAVE_SPAWN` and `EVENT_HALOF`. This search could fail to properly engage the mobs with the banner.

**Fix:** Ports TrinityCore's approach — moves all scourge mob setup into `JustSummoned`:
1. Sets home position to the fight area
2. Sets `REACT_PASSIVE` initially
3. Uses `EngageWithTarget(me)` to put the mob directly in combat with the banner
4. After a 2s delay, switches to `REACT_AGGRESSIVE` so the mob naturally selects the nearest hostile target

This ensures scourge mobs properly path to the fight area and engage defenders/banner.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.quest add 13141`
2. `.additem 43243` (Blessed Banner of the Crusade, if not auto-given)
3. `.go gameobject 100145` — teleport to the Pile of Crusader Skulls at Crusaders' Pinnacle
4. Use the Blessed Banner item on the pile to start the event
5. Verify scourge waves spawn and actively fight (not standing idle)
6. Verify Dalfors and priests engage the scourge
7. After 8 waves, Halof the Deathbringer spawns — verify he also fights
8. Kill Halof, verify Dalfors yells victory line and quest completes

## Known Issues and TODO List:


## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.