### PR TITLE
fix(Core/Movement): Prevent vehicles from following their own passenger on evade

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -246,8 +246,11 @@ void CreatureAI::EnterEvadeMode(EvadeReason why)
             // Owned creatures (pets/guardians) follow their owner — clear evade state
             // so they can re-enter combat immediately via CanBeginCombat
             me->ClearUnitState(UNIT_STATE_EVADE);
-            me->GetMotionMaster()->Clear(false);
-            me->GetMotionMaster()->MoveFollow(owner, PET_FOLLOW_DIST, me->GetFollowAngle(), MOTION_SLOT_ACTIVE);
+            if (!me->IsVehicle()) // vehicles should not follow their owner (passenger)
+            {
+                me->GetMotionMaster()->Clear(false);
+                me->GetMotionMaster()->MoveFollow(owner, PET_FOLLOW_DIST, me->GetFollowAngle(), MOTION_SLOT_ACTIVE);
+            }
         }
         else
         {


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - **Claude Code** (claude-opus-4-6) with **AzerothMCP** for database research

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25202
- Closes https://github.com/chromiecraft/chromiecraft/issues/9198

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Description

When a vehicle creature with an owner (summoned by a player) exits combat, `CreatureAI::EnterEvadeMode` calls `MoveFollow(owner)` — the owner being the passenger riding the vehicle. This causes the vehicle to chase its own rider, producing uncontrollable spiraling movement.

**Root cause:** In `EnterEvadeMode`, owned creatures (pets/guardians) follow their owner after evading. This logic doesn't account for vehicle creatures where the "owner" is the passenger sitting on the vehicle itself.

**Fix:** Skip `MoveFollow` for vehicles (`me->IsVehicle()`) in the evade path. Vehicles should not chase their passenger.

**Affected encounters:**
- Malygos Phase 3 — drakes spiral downward after kill
- Trial of the Champion — vehicle mounts freeze/behave oddly
- Aces High! quest — drake spirals after exiting combat

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.quest add 13413` — Add "Aces High!" quest
2. `.go creature id 32548` — Go to Corastrasza
3. Talk to Corastrasza and request a Wyrmrest Skytalon
4. Engage combat with a drake
5. `.gm on` to exit combat
6. Verify the drake does NOT spiral or behave erratically — it should remain stable and controllable

## Known Issues and TODO List:

- [ ] SmartAI has a similar `MoveFollow(owner)` in its evade path (`SmartAI.cpp:723`) that may need the same vehicle check for SmartAI-based vehicles

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.