### PR TITLE
fix(Core/OutdoorPvP): Fix use-after-free in DelCapturePoint

### DIFF
--- a/src/server/game/OutdoorPvP/OutdoorPvP.cpp
+++ b/src/server/game/OutdoorPvP/OutdoorPvP.cpp
@@ -215,14 +215,14 @@ bool OPvPCapturePoint::DelObject(uint32 type)
 
 bool OPvPCapturePoint::DelCapturePoint()
 {
-    sObjectMgr->DeleteGOData(m_capturePointSpawnId);
-    m_capturePointSpawnId = 0;
-
     if (_capturePoint)
     {
         _capturePoint->SetRespawnTime(0);                                 // not save respawn time
         _capturePoint->Delete();
     }
+
+    sObjectMgr->DeleteGOData(m_capturePointSpawnId);
+    m_capturePointSpawnId = 0;
 
     return true;
 }


### PR DESCRIPTION
## Changes Proposed:

Minor shutdown-only use-after-free: `OPvPCapturePoint::DelCapturePoint()` called `DeleteGOData()` before `_capturePoint->Delete()`, freeing the `GameObjectData` while `Delete()` → `SetLootState()` → `GetScriptId()` still accesses it.

Reorders to match `DelObject()` directly above, which already has the correct order (delete GO first, then erase data).

Only triggers during server shutdown via `OutdoorPvPMgr::Die()` — no gameplay impact.

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code** with **azerothMCP** was used to analyze the ASAN trace and identify the fix.

## Issues Addressed:

- Found via AddressSanitizer during shutdown (OutdoorPvPGH)

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Build with AddressSanitizer (`-DCMAKE_CXX_FLAGS="-fsanitize=address"`)
2. Start worldserver, then shut it down cleanly
3. Verify no ASAN heap-use-after-free in `GameObject::GetScriptId` during `OutdoorPvPMgr::Die()`

## Known Issues and TODO List:

- [ ] N/A

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.