### PR TITLE
fix(Core/Spells): Fix ranged spell minimum range incorrectly applying leeway

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -7090,7 +7090,7 @@ SpellCastResult Spell::CheckRange(bool strict)
             if (m_caster->IsWithinRange(target, minRangeCombined))
                 return SPELL_FAILED_TOO_CLOSE;
         }
-        else if (min_range && m_caster->IsWithinCombatRange(target, min_range)) // skip this check if min_range = 0
+        else if (min_range > 0 && m_caster->IsWithinCombatRange(target, min_range))
             return SPELL_FAILED_TOO_CLOSE;
     }
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -7079,18 +7079,18 @@ SpellCastResult Spell::CheckRange(bool strict)
             else if (!m_caster->IsWithinCombatRange(target, max_range))
                 return SPELL_FAILED_OUT_OF_RANGE; //0x5A;
 
-            if (m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_RANGED && range_type == SPELL_RANGE_RANGED)
-            {
-                if (m_caster->IsWithinMeleeRange(target))
-                    return SPELL_FAILED_TOO_CLOSE;
-            }
-
             if (m_caster->IsPlayer() && (m_spellInfo->FacingCasterFlags & SPELL_FACING_FLAG_INFRONT) && !m_caster->HasInArc(static_cast<float>(M_PI), target) && !m_caster->IsWithinBoundaryRadius(target))
                 return SPELL_FAILED_UNIT_NOT_INFRONT;
         }
 
-        // Xinef: check min range for self casts
-        if (min_range && range_type != SPELL_RANGE_RANGED && m_caster->IsWithinCombatRange(target, min_range)) // skip this check if min_range = 0
+        // Check min range - for ranged spells, min range is the spell's min range + melee range (no leeway)
+        if (range_type == SPELL_RANGE_RANGED)
+        {
+            float minRangeCombined = min_range + m_caster->GetMeleeRange(target);
+            if (m_caster->IsWithinRange(target, minRangeCombined))
+                return SPELL_FAILED_TOO_CLOSE;
+        }
+        else if (min_range && m_caster->IsWithinCombatRange(target, min_range)) // skip this check if min_range = 0
             return SPELL_FAILED_TOO_CLOSE;
     }
 


### PR DESCRIPTION
## Changes Proposed:

`Spell::CheckRange` used `IsWithinMeleeRange()` for the ranged spell too-close check, which adds `LEEWAY_BONUS_RANGE` (2.66yd) when both caster and target are moving. This made the minimum range (deadzone) significantly larger while kiting, causing `SPELL_FAILED_TOO_CLOSE` at distances where the ability should be castable.

Aligned with TrinityCore's approach: minimum range for ranged spells is computed as `spell min_range + GetMeleeRange()` and checked with `IsWithinRange()` (no leeway). Leeway should only affect maximum range, never minimum range.

**Before:** Hunter kiting a mob, both moving → deadzone extends ~2.66yd further than intended
**After:** Deadzone is consistent whether standing still or moving

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code** with **azerothMCP** was used to analyze the issue and compare with TrinityCore's implementation.

## Issues Addressed:

- Ranged spell minimum range (deadzone) grows when both caster and target are moving due to leeway being applied to the min range check

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore reference: `Spell::GetMinMaxRange()` by Chaouki Dhib ([d7600f1126d](https://github.com/TrinityCore/TrinityCore/commit/d7600f1126d)) — leeway (`rangeMod`) is only added to `maxRange`, not `minRange`.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Log in as a Hunter
2. `.npc add temp 31146` (Training Dummy)
3. Stand at melee range, confirm ranged abilities show "Too Close"
4. Back up until ranged abilities work, note the distance
5. Have a friend run alongside you toward a moving target — minimum range should be the **same** as when stationary
6. Before this fix, the moving deadzone was ~2.66yd larger due to leeway
7. Verify max range still benefits from leeway when both targets are moving
8. Test with a non-ranged spell that has min_range (e.g. Feral Charge) to confirm no regression

## Known Issues and TODO List:

- [ ] N/A

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.