### PR TITLE
fix(Core/Movement): Clear CanNotReachTarget when chase spline finishes

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -259,12 +259,7 @@ bool ChaseMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
         owner->SetInFront(target);
 
         if (cOwner)
-        {
-            if (cOwner->IsWithinMeleeRange(target))
-                cOwner->SetCannotReachTarget();
-            else
-                cOwner->SetCannotReachTarget(target->GetGUID());
-        }
+            cOwner->SetCannotReachTarget();
 
         MovementInform(owner);
     }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

When a creature's chase spline completes, unconditionally clear the `CanNotReachTarget` flag instead of conditionally setting it based on melee range. This aligns with TrinityCore's approach.

The previous logic set `CanNotReachTarget` when the spline finished but the target was not in melee range. This caused creatures to get stuck showing "Evade" on all attacks when their own knockback abilities launched targets into the air — the creature would reach the target's XY, but the Z difference from the knockup caused `IsWithinMeleeRange` to fail, permanently setting the unreachable flag.

Most commonly observed with Anub'Rekhan's Impale in Naxxramas, but affects any creature with knockback/knockup abilities.

Genuinely unreachable targets are still handled by other code paths in `DoUpdate`: `isInAccessiblePlaceFor` and `DispatchSplineToPosition` path failure checks.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with AzerothMCP was used for debugging and preparing this fix.

## Issues Addressed:
- Creatures getting stuck in "Evade" state after using knockback abilities on their target

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). TrinityCore's `ChaseMovementGenerator` unconditionally clears `CanNotReachTarget` when the spline finishes.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Naxxramas and engage Anub'Rekhan (`.go creature id 15956`)
2. Tank the boss and get hit by Impale (knockback/knockup)
3. Observe that the boss no longer gets stuck showing "Evade" after the knockup
4. Test other bosses with knockback mechanics to verify no regressions

## Known Issues and TODO List:

- [ ] Should be tested with other knockback bosses (e.g. Onyxia tail swipe, Sartharion) to verify no regressions

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.