### PR TITLE
fix(Core/Combat): Re-enable combat for training dummies

### DIFF
--- a/src/server/game/AI/CoreAI/PassiveAI.cpp
+++ b/src/server/game/AI/CoreAI/PassiveAI.cpp
@@ -23,6 +23,7 @@ PossessedAI::PossessedAI(Creature* c) : CreatureAI(c) { me->SetReactState(REACT_
 NullCreatureAI::NullCreatureAI(Creature* c) : CreatureAI(c)
 {
     me->SetReactState(REACT_PASSIVE);
+    // TODO: Remove once WorldObject casting is ported (triggers won't create combat refs from spell casts)
     me->SetIsCombatDisallowed(true);
 }
 

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -314,7 +314,11 @@ public:
 
 struct npc_training_dummy : NullCreatureAI
 {
-    npc_training_dummy(Creature* creature) : NullCreatureAI(creature) { }
+    npc_training_dummy(Creature* creature) : NullCreatureAI(creature)
+    {
+        // TODO: Remove once WorldObject casting is ported
+        me->SetIsCombatDisallowed(false);
+    }
 
     void JustEnteredCombat(Unit* who) override
     {
@@ -359,6 +363,8 @@ struct npc_target_dummy : NullCreatureAI
 {
     npc_target_dummy(Creature* creature) : NullCreatureAI(creature)
     {
+        // TODO: Remove once WorldObject casting is ported
+        me->SetIsCombatDisallowed(false);
         _deathTimer = 15s;
     }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code (claude-opus-4-6) with AzerothMCP for database research

## Description

PR #25222 added `SetIsCombatDisallowed(true)` to the `NullCreatureAI` constructor to fix players getting stuck in combat with triggers in Naxxramas. However, both `npc_training_dummy` and `npc_target_dummy` extend `NullCreatureAI` and need combat references to function properly:

- `npc_training_dummy` uses `JustEnteredCombat()` and `GetPvECombatRefs()` to manage per-attacker combat timers
- Pets (e.g. DK Ebon Gargoyle) cannot attack training dummies because `CombatManager::CanBeginCombat()` returns false when either unit has `IsCombatDisallowed`

This fix re-enables combat in both training dummy constructors, since they handle their own combat lifecycle (timeout after 5s of no damage for training dummies, death timer for target dummies).

TODO comments added for removal once WorldObject casting is ported.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9202

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Spawn a training dummy: `.npc add temp 31146`
2. On a Death Knight, use Summon Gargoyle (spell 49206) targeting the dummy
3. Verify the gargoyle attacks the dummy instead of sitting idle
4. Verify combat drops after 5 seconds of not attacking the dummy

## Known Issues and TODO List:

- [ ] `IsCombatDisallowed` workaround should be removed once WorldObject casting is ported (triggers won't create combat refs from spell casts)

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.