### PR TITLE
fix(Core/Movement): Fire WaypointReached before PathEndReached

### DIFF
--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -187,10 +187,11 @@ void WaypointMovementGenerator<Creature>::ProcessWaypointArrival(Creature* creat
         creature->UpdateCurrentWaypointInfo(0, 0);
 
         if (CreatureAI* AI = creature->AI())
-        {
             AI->PathEndReached(i_path->Id);
+
+        // Re-fetch AI — PathEndReached may have despawned the creature or swapped its AI
+        if (CreatureAI* AI = creature->AI())
             AI->WaypointPathEnded(waypoint.Id, i_path->Id);
-        }
     }
 
     // All hooks called and infos updated. Time to increment the waypoint node id
@@ -426,10 +427,11 @@ bool WaypointMovementGenerator<Creature>::DoUpdate(Creature* creature, uint32 di
                 _smoothSplineLaunched = false;
                 creature->UpdateCurrentWaypointInfo(0, 0);
                 if (CreatureAI* AI = creature->AI())
-                {
                     AI->PathEndReached(i_path->Id);
+
+                // Re-fetch AI — PathEndReached may have despawned the creature or swapped its AI
+                if (CreatureAI* AI = creature->AI())
                     AI->WaypointPathEnded(i_path->Nodes.at(i_currentNode).Id, i_path->Id);
-                }
             }
             else
             {

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -143,18 +143,9 @@ void WaypointMovementGenerator<Creature>::ProcessWaypointArrival(Creature* creat
         _waypointDelay = waypoint.Delay;
     }
 
-    // Check if the waypoint path has reached its end and may not repeat. Inform AI.
-    if ((i_currentNode == i_path->Nodes.size() - 1) && !_repeating && !_done)
-    {
+    bool pathEnded = (i_currentNode == i_path->Nodes.size() - 1) && !_repeating && !_done;
+    if (pathEnded)
         _done = true;
-        creature->UpdateCurrentWaypointInfo(0, 0);
-
-        if (CreatureAI* AI = creature->AI())
-        {
-            AI->PathEndReached(i_path->Id);
-            AI->WaypointPathEnded(waypoint.Id, i_path->Id);
-        }
-    }
 
     UpdateHomePosition(creature, waypoint);
 
@@ -187,6 +178,19 @@ void WaypointMovementGenerator<Creature>::ProcessWaypointArrival(Creature* creat
             if (Unit* owner2 = tempSummon->GetSummonerUnit())
                 if (UnitAI* AI = owner2->GetAI())
                     AI->SummonMovementInform(creature, WAYPOINT_MOTION_TYPE, i_currentNode);
+    }
+
+    // Path end notifications fire after WaypointReached so that m_path_id
+    // is still valid when SmartAI checks it for SMART_EVENT_WAYPOINT_REACHED.
+    if (pathEnded)
+    {
+        creature->UpdateCurrentWaypointInfo(0, 0);
+
+        if (CreatureAI* AI = creature->AI())
+        {
+            AI->PathEndReached(i_path->Id);
+            AI->WaypointPathEnded(waypoint.Id, i_path->Id);
+        }
     }
 
     // All hooks called and infos updated. Time to increment the waypoint node id


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

Fixes callback ordering in `WaypointMovementGenerator::ProcessWaypointArrival`. Previously, `PathEndReached` (which calls `LoadPath(0)`, clearing `m_path_id`) fired **before** `WaypointReached`. This meant `SMART_EVENT_WAYPOINT_REACHED` on the last waypoint of a non-repeating path could never match the `pathId`, since `me->GetWaypointPath()` returned 0 by the time the event was checked.

This was a regression from #25106. The fix moves the path-end notifications (`PathEndReached`/`WaypointPathEnded`) to fire after `WaypointReached`, restoring the original callback order.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with AzerothMCP was used for analysis and authoring the fix.

## Issues Addressed:
- Related to #25236
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25244

## SOURCE:
The changes have been validated through:
- [x] Code analysis tracing the regression from #25106

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Go to the DK starting zone: `.go xyz 2229.51 -5826.64 101.553 609`
2. Find the Havenshire Stallion (guid 129210) and watch it complete its waypoint path
3. At the last waypoint (point 8), it should stop and run the fence-jumping script
4. Verify other creatures with `SMART_EVENT_WAYPOINT_REACHED` on their final waypoint still trigger correctly

## Known Issues and TODO List:

- [ ] Other NPCs using `SMART_EVENT_WAYPOINT_REACHED` on their last waypoint may have had workarounds applied that are now unnecessary