### PR TITLE
fix(Core/Combat): Suppress combat refs on Feign Death in dungeons

### DIFF
--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -331,6 +331,15 @@ void CombatManager::SuppressPvPCombat()
             ownerAI->JustExitedCombat();
 }
 
+void CombatManager::SuppressPvECombat()
+{
+    for (auto const& pair : _pveRefs)
+        pair.second->Suppress(_owner);
+    if (UpdateOwnerCombatState())
+        if (UnitAI* ownerAI = _owner->GetAI())
+            ownerAI->JustExitedCombat();
+}
+
 void CombatManager::EndAllPvECombat()
 {
     // cannot have threat without combat

--- a/src/server/game/Combat/CombatManager.h
+++ b/src/server/game/Combat/CombatManager.h
@@ -141,6 +141,8 @@ public:
     void EndCombatBeyondRange(float range, bool includingPvP = false);
     // flags any pvp refs for suppression on owner's side - these refs will not generate combat until refreshed
     void SuppressPvPCombat();
+    // flags any pve refs for suppression on owner's side - used by feign death in dungeons
+    void SuppressPvECombat();
     void EndAllPvECombat();
     void RevalidateCombat();
     void EndAllPvPCombat();

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2990,6 +2990,8 @@ void AuraEffect::HandleFeignDeath(AuraApplication const* aurApp, uint8 mode, boo
         if (target->GetMap()->IsDungeon()) // feign death does not remove combat in dungeons
         {
             target->AttackStop();
+            target->GetCombatManager().SuppressPvECombat();
+            target->GetCombatManager().SuppressPvPCombat(); // edge case: PvP combat in dungeons (e.g. cross-faction mods)
             if (Player* targetPlayer = target->ToPlayer())
                 targetPlayer->SendAttackSwingCancelAttack();
         }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code with AzerothMCP** was used for codebase analysis, database queries, and cross-referencing with TrinityCore.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9205

## Description

After the TrinityCore threat system port (#24715), Feign Death in dungeons no longer properly dropped the player out of combat. The old code called `RemoveAllAttackers()` and `ResetAllMyThreatOnOthers()` which immediately cleared the player's combat state. The new code only scales threat to zero via `ScaleThreat(0.0f)` but leaves PvE combat references active, keeping the player stuck in combat until creatures independently process evade through their AI.

### Fix

- Add `CombatManager::SuppressPvECombat()` (mirrors the existing `SuppressPvPCombat()`)
- Call both `SuppressPvECombat()` and `SuppressPvPCombat()` during the dungeon Feign Death path
- This suppresses combat refs on the **player side** so they immediately appear out of combat (can eat, drink, etc.)
- The creature retains the ref and processes evade asynchronously via `SelectVictim() → EnterEvadeMode()`
- When Feign Death ends early (player acts), creature re-attack calls `SetInCombatWith` → `Refresh()`, which unsuppresses the ref and restores combat normally

The `CombatReference` header already documents this as intended behavior:
```cpp
// suppressed combat refs do not generate a combat state for one side of the relation
// (used by: vanish, feign death and launched out of combat but not yet landed spell missiles)
```

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- Code analysis cross-referenced with TrinityCore Cata branch

## Tests Performed:
This PR has been:
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter any dungeon instance (e.g. `.tele GundrakInstance`)
2. Aggro a mob, then move to a position where the mob cannot path to you (elevated ledge, out of water for aquatic mobs, across geometry)
3. Use Feign Death (Hunter spell 5384)
4. Verify you immediately drop out of combat (combat indicator gone, can eat/drink)
5. Cancel Feign Death near the mob - verify combat re-engages normally
6. Test in open world to verify no regression (should still work as before via `CombatStop`)

## Known Issues and TODO List:

- [ ] PvP suppression in dungeons is included for edge cases (cross-faction mods) - may need further testing with such modules
- [ ] Should be tested with dungeon bosses to ensure no interaction with boss encounter combat pulses