### PR TITLE
fix(Core/Commands): Show combat refs in .debug hostile output

### DIFF
--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -1042,6 +1042,22 @@ public:
         }
 
         handler->SendSysMessage("End of threatened by me list.");
+
+        // Also show combat refs that may not appear in the threat list
+        // (e.g. creatures without threat lists like triggers/environmental hazards)
+        handler->PSendSysMessage("Combat refs (InCombat: {} | HasCombat: {})", target->IsInCombat(), target->GetCombatManager().HasCombat());
+        for (auto const& ref : target->GetCombatManager().GetPvECombatRefs())
+        {
+            Unit* unit = ref.second->GetOther(target);
+            handler->PSendSysMessage("   [PvE] {} ({}) Entry: {}", unit->GetName(), unit->GetGUID().ToString(),
+                unit->IsCreature() ? unit->ToCreature()->GetEntry() : 0);
+        }
+        for (auto const& ref : target->GetCombatManager().GetPvPCombatRefs())
+        {
+            Unit* unit = ref.second->GetOther(target);
+            handler->PSendSysMessage("   [PvP] {} ({})", unit->GetName(), unit->GetGUID().ToString());
+        }
+
         return true;
     }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with AzerothMCP

## Issues Addressed:
The `.debug hostile` command only showed threat list entries (`ThreatenedByMeList`), which misses combat references from creatures that don't maintain a threat list (triggers, environmental hazards like BRD Ironhand Guardians). Players stuck in combat with these invisible creatures would see "nothing in hostile list" despite being held in combat.

Now the command also displays all CombatManager PvE and PvP refs, making it possible to identify the source of stuck-in-combat issues.

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
1. Enter a dungeon with environmental damage creatures (e.g. BRD Lyceum with Ironhand Guardians)
2. Aggro creatures that don't have threat lists (triggers, environmental hazards)
3. Run `.debug hostile` - verify that combat refs now appear in output even when the threat list is empty
4. Compare with `.debug combat` output to verify consistency

## Known Issues and TODO List:
- [ ] None