### PR TITLE
fix(Core/SmartAI): Suppress evade during SMART_ACTION_COMBAT_STOP

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -44,6 +44,7 @@ SmartAI::SmartAI(Creature* c) : CreatureAI(c)
     mCanRepeatPath = false;
 
     mEvadeDisabled = false;
+    mSuppressEvade = false;
 
     mCanAutoAttack = true;
 
@@ -698,6 +699,9 @@ void SmartAI::MovementInform(uint32 MovementType, uint32 Data)
 
 void SmartAI::EnterEvadeMode(EvadeReason /*why*/)
 {
+    if (mSuppressEvade)
+        return;
+
     if (mEvadeDisabled)
     {
         GetScript()->ProcessEventsFor(SMART_EVENT_EVADE);

--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -181,6 +181,7 @@ public:
     void SetSwim(bool swim = true);
 
     void SetEvadeDisabled(bool disable = true);
+    void SetSuppressEvade(bool suppress) { mSuppressEvade = suppress; }
 
     void SetInvincibilityHpLevel(uint32 level) { mInvincibilityHpLevel = level; }
 
@@ -249,6 +250,7 @@ private:
     uint32 GetWPCount() { return mWayPoints ? mWayPoints->Nodes.size() : 0; }
     bool mCanRepeatPath;
     bool mEvadeDisabled;
+    bool mSuppressEvade;
     bool mCanAutoAttack;
     bool mForcedPaused;
     uint32 mInvincibilityHpLevel;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1039,7 +1039,16 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             if (!me)
                 break;
 
+            // Suppress evade during script-initiated combat stop so
+            // JustExitedCombat does not trigger EnterEvadeMode.
+            if (SmartAI* sai = CAST_AI(SmartAI, me->AI()))
+                sai->SetSuppressEvade(true);
+
             me->CombatStop(true);
+
+            if (SmartAI* sai = CAST_AI(SmartAI, me->AI()))
+                sai->SetSuppressEvade(false);
+
             break;
         }
         case SMART_ACTION_CALL_GROUPEVENTHAPPENS:


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

`SMART_ACTION_COMBAT_STOP` (action_type 27) calls `CombatStop(true)`, which triggers `JustExitedCombat` → `EnterEvadeMode`. This causes any SmartAI creature that uses this action to unintentionally evade — firing evade handlers (despawn, fail quest, reset faction, walk home) and breaking the script's intended flow.

The fix adds a `mSuppressEvade` flag to `SmartAI` that completely blocks `EnterEvadeMode` while `SMART_ACTION_COMBAT_STOP` is executing. This is stronger than `mEvadeDisabled`, which still processes `SMART_EVENT_EVADE` handlers.

**Affected creatures** (27 uses across ~20 creatures/actionlists):
- Mogor (Ring of Blood) — fake death + resurrect broken
- Phoenix (Kael'thas) — stops at low HP for egg mechanic
- Argent Crusade NPCs (Korfax, Eligor, Tyrosus, etc.) — training fight surrenders
- Death Knight Initiate — DK starter zone duels
- Wastewalker Slave/Worker — freed from cages
- Dark Portal NPCs — timed event combat stops
- Private Hendel, Tapoke Jahn — quest scripted surrenders

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP was used to investigate the issue, trace the evade chain through the codebase, and prepare the fix.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25246
- Closes https://github.com/chromiecraft/chromiecraft/issues/9204
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25292

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Code tracing confirmed `CombatStop(true)` → `EndAllPvECombat()` → `CombatReference::EndCombat()` → `JustExitedCombat()` → `EnterEvadeMode()`. Debug logging on a live server confirmed the full evade chain fires for Mogor entry 18069.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Regression testing recommended for other creatures using `SMART_ACTION_COMBAT_STOP` listed above.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go c id 18069` to teleport to Mogor's area (Ring of Blood, Nagrand)
2. Complete the Ring of Blood quest chain up to quest 9977 "The Final Challenge"
3. Accept quest 9977 from Gurgthock — Mogor spawns and engages
4. Fight Mogor until he feign-deaths at ~1% HP
5. Wait for resurrection — Mogor should get up, yell, and attack the player aggressively
6. Verify Mogor is hostile and attackable (not following like a pet)
7. Kill Mogor — quest should complete successfully

## Known Issues and TODO List:

- [ ] Other creatures using SMART_ACTION_COMBAT_STOP should be regression tested (see list above)