### PR TITLE
fix(Core/Movement): Pass waypoint point ID to MovementInform

### DIFF
--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -172,21 +172,21 @@ void WaypointMovementGenerator<Creature>::ProcessWaypointArrival(Creature* creat
     // Inform AI
     if (CreatureAI* AI = creature->AI())
     {
-        AI->MovementInform(WAYPOINT_MOTION_TYPE, i_currentNode);
+        AI->MovementInform(WAYPOINT_MOTION_TYPE, waypoint.Id);
         AI->WaypointReached(waypoint.Id, i_path->Id);
     }
 
     if (Unit* owner = creature->GetCharmerOrOwner())
     {
         if (UnitAI* AI = owner->GetAI())
-            AI->SummonMovementInform(creature, WAYPOINT_MOTION_TYPE, i_currentNode);
+            AI->SummonMovementInform(creature, WAYPOINT_MOTION_TYPE, waypoint.Id);
     }
     else
     {
         if (TempSummon* tempSummon = creature->ToTempSummon())
             if (Unit* owner2 = tempSummon->GetSummonerUnit())
                 if (UnitAI* AI = owner2->GetAI())
-                    AI->SummonMovementInform(creature, WAYPOINT_MOTION_TYPE, i_currentNode);
+                    AI->SummonMovementInform(creature, WAYPOINT_MOTION_TYPE, waypoint.Id);
     }
 
     // All hooks called and infos updated. Time to increment the waypoint node id
@@ -391,7 +391,7 @@ bool WaypointMovementGenerator<Creature>::DoUpdate(Creature* creature, uint32 di
 
             if (CreatureAI* AI = creature->AI())
             {
-                AI->MovementInform(WAYPOINT_MOTION_TYPE, i_currentNode);
+                AI->MovementInform(WAYPOINT_MOTION_TYPE, passedWp.Id);
                 AI->WaypointReached(passedWp.Id, i_path->Id);
             }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

#25106 changed waypoint storage from `std::map<uint32, WaypointData>` (keyed by DB `point` number) to `std::vector<WaypointNode>` (0-based index). However, `MovementInform(WAYPOINT_MOTION_TYPE, ...)` and `SummonMovementInform(...)` still passed `i_currentNode` — now a 0-based vector index instead of the waypoint's DB point ID.

This broke every C++ script that checks the point ID in `MovementInform` with `WAYPOINT_MOTION_TYPE`. Affected scripts include:
- **Koltira Deathweaver** (Bloody Breakout) — mount, despawn, equipment timing all wrong
- **Ebonroc** (BWL) — checks `id != 13`
- **Rend Blackhand** (UBRS)
- **Zul'Aman** Harrison Jones — checks `id == 3`, `id == 9`
- **Illidan** (Black Temple)
- **Ghostlands** NPCs
- And others (~20+ scripts)

The fix passes `waypoint.Id` (the DB point number) instead of `i_currentNode` (the vector index), in both `ProcessWaypointArrival` and the smooth-spline passage loop in `DoUpdate`.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP was used to trace the regression, identify affected scripts, and prepare the fix.

## Issues Addressed:
- Progress https://github.com/chromiecraft/chromiecraft/issues/9207

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Code tracing confirmed `i_currentNode` changed from map-key (1-based point ID) to vector index (0-based) in #25106. Debug logging on a live server confirmed `waypoint.Id` returns the correct DB point numbers (1, 2, 3, 4 for path 289120; 1, 2 for path 289130).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Koltira Deathweaver (Bloody Breakout):**
1. `.go xyz 1642.35 -6037.85 127.58 609`
2. `.quest add 12727`
3. Talk to Koltira to start the event via gossip
4. Verify waves spawn and Valroth attacks
5. Kill Valroth — Koltira should mount when exiting the building (point 1), then despawn at the end (point 2)

**Regression — spot-check other scripts:**
- Ebonroc (BWL): `.go c id 14601` — verify waypoint-based landing
- Zul'Aman Harrison Jones: `.go c id 23358` — verify gong sequence
- Rend Blackhand (UBRS): verify waypoint event triggers

## Known Issues and TODO List:

- [ ] `creature_equip_template` is missing for entry 28912 (Koltira) — equipment won't show after transform. This is a pre-existing DB issue, not a regression from #25106.