### PR TITLE
fix(Core/Combat): Immediately reselect victim after taunt aura update

### DIFF
--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -544,6 +544,7 @@ void ThreatManager::TauntUpdate()
     // immediately reselect victim so taunt takes effect without waiting
     // for the next THREAT_UPDATE_INTERVAL (1 s) timer tick
     UpdateVictim();
+    _updateTimer = THREAT_UPDATE_INTERVAL;
 }
 
 void ThreatManager::SetTauntStateForTesting(

--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -540,6 +540,10 @@ void ThreatManager::TauntUpdate()
 
     // taunt aura update also re-evaluates all suppressed states (retail behavior)
     EvaluateSuppressed(true);
+
+    // immediately reselect victim so taunt takes effect without waiting
+    // for the next THREAT_UPDATE_INTERVAL (1 s) timer tick
+    UpdateVictim();
 }
 
 void ThreatManager::SetTauntStateForTesting(

--- a/src/server/game/Combat/ThreatManager.h
+++ b/src/server/game/Combat/ThreatManager.h
@@ -182,6 +182,8 @@ public:
     // Test-only: directly set taunt state on a threat ref
     // Uses uint32 to avoid incomplete-type issue with ThreatReference
     void SetTauntStateForTesting(Unit* target, uint32 state);
+    // Immediately reselect victim (bypasses 1-second Update timer)
+    void UpdateVictimForTesting() { UpdateVictim(); }
 
     ///== REDIRECT SYSTEM ==
     void RegisterRedirectThreat(uint32 spellId, ObjectGuid const& victim, uint32 pct);

--- a/src/test/server/game/Combat/ThreatManagerTest.cpp
+++ b/src/test/server/game/Combat/ThreatManagerTest.cpp
@@ -2313,4 +2313,247 @@ TEST_F(ThreatManagerIntegrationTest,
     delete creatureC;
 }
 
+// ============================================================================
+// TauntUpdate immediate victim reselection tests
+// Verify that TauntUpdate() calls UpdateVictim() immediately (no 1-second
+// delay), and that rapid/repeated calls do not cause recursion or crashes.
+//
+// Note: TauntUpdate() reads real auras via GetAuraEffectsByType(), which are
+// not present in unit tests.  Tests that need taunt state to persist use
+// SetTauntStateForTesting() + UpdateVictim() to exercise the same code path
+// (ReselectVictim → ProcessAIUpdates) that TauntUpdate now invokes.
+// TauntUpdate()-specific tests verify no-crash / no-recursion behaviour.
+// ============================================================================
+
+TEST_F(ThreatManagerIntegrationTest,
+       UpdateVictim_ImmediateReselectAfterTauntState)
+{
+    TestCreature* creatureC = new TestCreature();
+    creatureC->SetupForCombatTest(_map, 3, 12347);
+    creatureC->SetFaction(90002);
+
+    // B has low threat, C has high threat
+    _creatureA->TestGetThreatMgr().AddThreat(_creatureB, 100.0f);
+    _creatureA->TestGetThreatMgr().AddThreat(creatureC, 500.0f);
+    _creatureA->TestGetThreatMgr().Update(
+        ThreatManager::THREAT_UPDATE_INTERVAL);
+    EXPECT_EQ(
+        _creatureA->TestGetThreatMgr().GetCurrentVictim(),
+        creatureC);
+
+    // Set taunt on B, then call UpdateVictim directly (the call that
+    // TauntUpdate now makes internally) — WITHOUT waiting for the
+    // 1-second Update() timer
+    _creatureA->TestGetThreatMgr().SetTauntStateForTesting(
+        _creatureB, ThreatReference::TAUNT_STATE_TAUNT);
+    _creatureA->TestGetThreatMgr().UpdateVictimForTesting();
+
+    // Victim should switch immediately to B (taunted)
+    EXPECT_EQ(
+        _creatureA->TestGetThreatMgr().GetCurrentVictim(),
+        _creatureB);
+
+    creatureC->CleanupCombatState();
+    delete creatureC;
+}
+
+TEST_F(ThreatManagerIntegrationTest,
+       UpdateVictim_Idempotent_MultipleCalls)
+{
+    TestCreature* creatureC = new TestCreature();
+    creatureC->SetupForCombatTest(_map, 3, 12347);
+    creatureC->SetFaction(90002);
+
+    _creatureA->TestGetThreatMgr().AddThreat(_creatureB, 100.0f);
+    _creatureA->TestGetThreatMgr().AddThreat(creatureC, 500.0f);
+    _creatureA->TestGetThreatMgr().Update(
+        ThreatManager::THREAT_UPDATE_INTERVAL);
+
+    _creatureA->TestGetThreatMgr().SetTauntStateForTesting(
+        _creatureB, ThreatReference::TAUNT_STATE_TAUNT);
+
+    // Call UpdateVictim many times in a row — must be idempotent
+    for (int i = 0; i < 50; ++i)
+        _creatureA->TestGetThreatMgr().UpdateVictimForTesting();
+
+    EXPECT_EQ(
+        _creatureA->TestGetThreatMgr().GetCurrentVictim(),
+        _creatureB);
+
+    creatureC->CleanupCombatState();
+    delete creatureC;
+}
+
+TEST_F(ThreatManagerIntegrationTest,
+       UpdateVictim_RapidTauntToggle_NoCrash)
+{
+    TestCreature* creatureC = new TestCreature();
+    creatureC->SetupForCombatTest(_map, 3, 12347);
+    creatureC->SetFaction(90002);
+
+    _creatureA->TestGetThreatMgr().AddThreat(_creatureB, 100.0f);
+    _creatureA->TestGetThreatMgr().AddThreat(creatureC, 500.0f);
+    _creatureA->TestGetThreatMgr().Update(
+        ThreatManager::THREAT_UPDATE_INTERVAL);
+
+    // Rapidly toggle taunt state with immediate UpdateVictim each time
+    for (int i = 0; i < 50; ++i)
+    {
+        _creatureA->TestGetThreatMgr().SetTauntStateForTesting(
+            _creatureB, ThreatReference::TAUNT_STATE_TAUNT);
+        _creatureA->TestGetThreatMgr().UpdateVictimForTesting();
+        EXPECT_EQ(
+            _creatureA->TestGetThreatMgr().GetCurrentVictim(),
+            _creatureB);
+
+        _creatureA->TestGetThreatMgr().SetTauntStateForTesting(
+            _creatureB, ThreatReference::TAUNT_STATE_NONE);
+        _creatureA->TestGetThreatMgr().UpdateVictimForTesting();
+        EXPECT_EQ(
+            _creatureA->TestGetThreatMgr().GetCurrentVictim(),
+            creatureC);
+    }
+
+    creatureC->CleanupCombatState();
+    delete creatureC;
+}
+
+TEST_F(ThreatManagerIntegrationTest,
+       UpdateVictim_WithConcurrentThreatChanges_NoCrash)
+{
+    TestCreature* creatureC = new TestCreature();
+    creatureC->SetupForCombatTest(_map, 3, 12347);
+    creatureC->SetFaction(90002);
+
+    _creatureA->TestGetThreatMgr().AddThreat(_creatureB, 100.0f);
+    _creatureA->TestGetThreatMgr().AddThreat(creatureC, 500.0f);
+    _creatureA->TestGetThreatMgr().Update(
+        ThreatManager::THREAT_UPDATE_INTERVAL);
+
+    // Simulate taunt landing while threat is also being modified
+    // (e.g. damage events arriving in the same server tick)
+    _creatureA->TestGetThreatMgr().SetTauntStateForTesting(
+        _creatureB, ThreatReference::TAUNT_STATE_TAUNT);
+    _creatureA->TestGetThreatMgr().AddThreat(creatureC, 200.0f);
+    _creatureA->TestGetThreatMgr().UpdateVictimForTesting();
+
+    // B should be victim because taunt overrides threat
+    EXPECT_EQ(
+        _creatureA->TestGetThreatMgr().GetCurrentVictim(),
+        _creatureB);
+
+    creatureC->CleanupCombatState();
+    delete creatureC;
+}
+
+TEST_F(ThreatManagerIntegrationTest,
+       UpdateVictim_MultipleTaunters_HighestStateWins)
+{
+    TestCreature* creatureC = new TestCreature();
+    creatureC->SetupForCombatTest(_map, 3, 12347);
+    creatureC->SetFaction(90002);
+
+    TestCreature* creatureD = new TestCreature();
+    creatureD->SetupForCombatTest(_map, 4, 12348);
+    creatureD->SetFaction(90002);
+
+    _creatureA->TestGetThreatMgr().AddThreat(_creatureB, 100.0f);
+    _creatureA->TestGetThreatMgr().AddThreat(creatureC, 200.0f);
+    _creatureA->TestGetThreatMgr().AddThreat(creatureD, 300.0f);
+    _creatureA->TestGetThreatMgr().Update(
+        ThreatManager::THREAT_UPDATE_INTERVAL);
+    EXPECT_EQ(
+        _creatureA->TestGetThreatMgr().GetCurrentVictim(),
+        creatureD);
+
+    // Two taunters: B (state=TAUNT) and C (state=TAUNT+1, i.e. "last taunt")
+    _creatureA->TestGetThreatMgr().SetTauntStateForTesting(
+        _creatureB, ThreatReference::TAUNT_STATE_TAUNT);
+    _creatureA->TestGetThreatMgr().SetTauntStateForTesting(
+        creatureC, static_cast<ThreatReference::TauntState>(
+            ThreatReference::TAUNT_STATE_TAUNT + 1));
+    _creatureA->TestGetThreatMgr().UpdateVictimForTesting();
+
+    // C has the higher taunt state — should be victim immediately
+    EXPECT_EQ(
+        _creatureA->TestGetThreatMgr().GetCurrentVictim(),
+        creatureC);
+
+    creatureC->CleanupCombatState();
+    creatureD->CleanupCombatState();
+    delete creatureC;
+    delete creatureD;
+}
+
+TEST_F(ThreatManagerIntegrationTest,
+       UpdateVictim_FixateStillTakesPrecedence)
+{
+    TestCreature* creatureC = new TestCreature();
+    creatureC->SetupForCombatTest(_map, 3, 12347);
+    creatureC->SetFaction(90002);
+
+    _creatureA->TestGetThreatMgr().AddThreat(_creatureB, 100.0f);
+    _creatureA->TestGetThreatMgr().AddThreat(creatureC, 200.0f);
+
+    // Fixate on C
+    _creatureA->TestGetThreatMgr().FixateTarget(creatureC);
+    _creatureA->TestGetThreatMgr().Update(
+        ThreatManager::THREAT_UPDATE_INTERVAL);
+    EXPECT_EQ(
+        _creatureA->TestGetThreatMgr().GetCurrentVictim(),
+        creatureC);
+
+    // Taunt from B + immediate UpdateVictim — fixate should still win
+    _creatureA->TestGetThreatMgr().SetTauntStateForTesting(
+        _creatureB, ThreatReference::TAUNT_STATE_TAUNT);
+    _creatureA->TestGetThreatMgr().UpdateVictimForTesting();
+
+    EXPECT_EQ(
+        _creatureA->TestGetThreatMgr().GetCurrentVictim(),
+        creatureC);
+    EXPECT_EQ(
+        _creatureA->TestGetThreatMgr().GetFixateTarget(),
+        creatureC);
+
+    creatureC->CleanupCombatState();
+    delete creatureC;
+}
+
+TEST_F(ThreatManagerIntegrationTest,
+       TauntUpdate_EmptyThreatList_NoCrash)
+{
+    // TauntUpdate on a creature with no threats should not crash
+    // even though UpdateVictim is now called internally
+    _creatureA->TestGetThreatMgr().TauntUpdate();
+    EXPECT_EQ(
+        _creatureA->TestGetThreatMgr().GetCurrentVictim(),
+        nullptr);
+}
+
+TEST_F(ThreatManagerIntegrationTest,
+       TauntUpdate_RapidCalls_NoCrash)
+{
+    TestCreature* creatureC = new TestCreature();
+    creatureC->SetupForCombatTest(_map, 3, 12347);
+    creatureC->SetFaction(90002);
+
+    _creatureA->TestGetThreatMgr().AddThreat(_creatureB, 100.0f);
+    _creatureA->TestGetThreatMgr().AddThreat(creatureC, 500.0f);
+    _creatureA->TestGetThreatMgr().Update(
+        ThreatManager::THREAT_UPDATE_INTERVAL);
+
+    // Rapidly call TauntUpdate (no real auras — clears taunt state each
+    // time and calls UpdateVictim). Must not crash or recurse.
+    for (int i = 0; i < 50; ++i)
+        _creatureA->TestGetThreatMgr().TauntUpdate();
+
+    // C remains victim (highest threat, no taunt active)
+    EXPECT_EQ(
+        _creatureA->TestGetThreatMgr().GetCurrentVictim(),
+        creatureC);
+
+    creatureC->CleanupCombatState();
+    delete creatureC;
+}
+
 } // namespace


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->

`TauntUpdate()` re-sorted the threat heap when a taunt aura was applied/removed, but did not call `UpdateVictim()`, leaving `_currentVictimRef` stale until the next `THREAT_UPDATE_INTERVAL` (1-second) timer tick. Combined with the 400ms movement recheck in `ChaseMovementGenerator`, this caused taunts to feel delayed by up to ~1.4 seconds.

The fix adds an `UpdateVictim()` call at the end of `TauntUpdate()` so victim reselection happens immediately when a taunt aura is applied or removed.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code** with **azerothMCP** were used for codebase investigation, implementation, and test authoring.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Player reports of taunt feeling delayed by 1-2 seconds, especially noticeable when taunting mobs already running toward another player (e.g. Azjol-Nerub last boss elite adds).

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**


## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

8 new unit tests added covering:
- Immediate victim reselection after taunt state change
- Idempotency (50x repeated `UpdateVictim` calls)
- Rapid taunt on/off toggling (50 cycles with assertions each iteration)
- Concurrent threat modifications during taunt
- Multiple simultaneous taunters (highest state wins)
- Fixate still takes precedence over taunt
- `TauntUpdate()` on empty threat list (no crash)
- Rapid `TauntUpdate()` calls (no recursion)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter a dungeon with a tank and DPS
2. Have the DPS pull a mob or wait for adds to spawn (e.g. Azjol-Nerub last boss)
3. Taunt the mob while it is running toward the DPS
4. The mob should immediately turn and run toward the tank — no 1-2 second delay

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [x] The redundant `UpdateVictim()` call from the 1-second timer after a taunt is harmless but could be optimized by resetting `_updateTimer`

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.