### PR TITLE
fix(Core/Spells): Fix Flexweave Underlay script targeting wrong spell

### DIFF
--- a/data/sql/updates/pending_db_world/fix_flexweave_underlay_script.sql
+++ b/data/sql/updates/pending_db_world/fix_flexweave_underlay_script.sql
@@ -1,0 +1,3 @@
+-- Move Flexweave Underlay script from enchant application spell (55002) to parachute use-spell (55001)
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (55001, 55002) AND `ScriptName` = 'spell_item_flexweave_underlay';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (55001, 'spell_item_flexweave_underlay');

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -3564,7 +3564,7 @@ class spell_item_rocket_boots : public SpellScript
     }
 };
 
-// 55002 - Flexweave Underlay
+// 55001 - Flexweave Underlay (Parachute)
 class spell_item_flexweave_underlay : public SpellScript
 {
     PrepareSpellScript(spell_item_flexweave_underlay);
@@ -3573,7 +3573,7 @@ class spell_item_flexweave_underlay : public SpellScript
     {
         if (GetCaster()->IsFlying() || GetCaster()->IsFalling())
             return SPELL_CAST_OK;
-        return SPELL_FAILED_NOT_FLYING;
+        return SPELL_FAILED_CANT_DO_THAT_RIGHT_NOW;
     }
 
     void Register() override


### PR DESCRIPTION
## Summary
- Moves the `spell_item_flexweave_underlay` CheckCast from spell **55002** (enchant application) to spell **55001** (parachute use-spell). The script was preventing players from applying the enchant to their cloak entirely.
- Fixes the error code from `SPELL_FAILED_NOT_FLYING` (client displays "You are flying") to `SPELL_FAILED_CANT_DO_THAT_RIGHT_NOW` ("You can't do that right now") for when parachute is used on the ground.

## How to test
1. `.mod skill 202 450` — set Engineering skill
2. `.additem 41111` — Flexweave Underlay
3. `.additem 34241` — a cloak to enchant
4. Use Flexweave Underlay on the cloak — **should succeed** (was blocked before)
5. Fly up and dismount, use the cloak tinker — **parachute should deploy**
6. Stand on the ground, use the cloak tinker — **should fail** with "You can't do that right now"

## Changes
| Commit | Summary |
|---|---|
| fix(Core/Spells) | Move script from 55002→55001, fix error code |

🤖 Generated with [Claude Code](https://claude.com/claude-code)