### PR TITLE
fix(Scripts/BRD): Fix Doom'rel and Gloom'rel gossip not working

### DIFF
--- a/data/sql/updates/pending_db_world/fix_tomb_of_seven_gossip.sql
+++ b/data/sql/updates/pending_db_world/fix_tomb_of_seven_gossip.sql
@@ -1,0 +1,42 @@
+-- Doomrel (9039): Create "Continue..." menu and chain from initial gossip
+DELETE FROM `gossip_menu` WHERE `MenuID` = 1950;
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES (1950, 2605);
+
+DELETE FROM `gossip_menu_option` WHERE `MenuID` = 1950;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`, `BoxBroadcastTextID`, `VerifiedBuild`) VALUES
+(1950, 0, 0, 'Continue...', 5256, 1, 1, 0, 0, 0, 0, '', 0, 0);
+
+UPDATE `gossip_menu_option` SET `ActionMenuID` = 1950 WHERE `MenuID` = 1947 AND `OptionID` = 0;
+
+-- Gloomrel (9037): Create "Continue..." menus for smelt and chalice paths
+DELETE FROM `gossip_menu` WHERE `MenuID` IN (1952, 1953);
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES
+(1952, 2606),
+(1953, 2604);
+
+DELETE FROM `gossip_menu_option` WHERE `MenuID` IN (1952, 1953);
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`, `BoxBroadcastTextID`, `VerifiedBuild`) VALUES
+(1952, 0, 0, 'Continue...', 5256, 1, 1, 0, 0, 0, 0, '', 0, 0),
+(1953, 0, 0, 'Continue...', 5256, 1, 1, 0, 0, 0, 0, '', 0, 0);
+
+UPDATE `gossip_menu_option` SET `ActionMenuID` = 1952 WHERE `MenuID` = 1945 AND `OptionID` = 0;
+UPDATE `gossip_menu_option` SET `ActionMenuID` = 1953 WHERE `MenuID` = 1945 AND `OptionID` = 1;
+
+-- Gloomrel: Conditional gossip text when quest completed
+DELETE FROM `gossip_menu` WHERE `MenuID` = 1945 AND `TextID` = 2605;
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES (1945, 2605);
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 14 AND `SourceGroup` = 1945 AND `SourceEntry` = 2605;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 1945, 2605, 0, 0, 8, 0, 4083, 0, 0, 0, 0, 0, '', 'Gloomrel - text requires quest 4083 rewarded'),
+(14, 1945, 2605, 0, 0, 7, 0, 186, 230, 0, 0, 0, 0, '', 'Gloomrel - text requires Mining >= 230'),
+(14, 1945, 2605, 0, 0, 16, 0, 14891, 0, 0, 1, 0, 0, '', 'Gloomrel - text requires NOT having Smelt Dark Iron');
+
+-- Gloomrel: Conditions for gossip options
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` = 1945 AND `SourceEntry` IN (0, 1);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 1945, 0, 0, 0, 8, 0, 4083, 0, 0, 0, 0, 0, '', 'Gloomrel - option 0 requires quest 4083 rewarded'),
+(15, 1945, 0, 0, 0, 7, 0, 186, 230, 0, 0, 0, 0, '', 'Gloomrel - option 0 requires Mining >= 230'),
+(15, 1945, 0, 0, 0, 16, 0, 14891, 0, 0, 1, 0, 0, '', 'Gloomrel - option 0 requires NOT having Smelt Dark Iron'),
+(15, 1945, 1, 0, 0, 8, 0, 4083, 0, 0, 1, 0, 0, '', 'Gloomrel - option 1 requires quest 4083 NOT rewarded'),
+(15, 1945, 1, 0, 0, 7, 0, 186, 230, 0, 0, 0, 0, '', 'Gloomrel - option 1 requires Mining >= 230');

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
@@ -23,18 +23,7 @@
 
 enum Spells
 {
-    SPELL_SMELT_DARK_IRON                         = 14891,
     SPELL_LEARN_SMELT                             = 14894,
-};
-
-enum Quests
-{
-    QUEST_SPECTRAL_CHALICE                        = 4083
-};
-
-enum Misc
-{
-    DATA_SKILLPOINT_MIN                           = 230
 };
 
 enum Says
@@ -44,57 +33,32 @@ enum Says
 
 enum Gossip
 {
-    GOSSIP_TEXT_CONTINUE                          = 1828, // Continue...
-    GOSSIP_GROOMREL                               = 1945, // Option 1 : Before quest(4083) accepted, option 0 after quest(4083) accepted
-    GOSSIP_DOOMREL_START_COMBAT                   = 1947, // Your bondage is at an end, Doom'rel.  I challenge you!
-    SAY_DOOMREL_HELLO                             = 2601, // Our fate is the doom of all who face the Great Fire.
-    SAY_QUEST_ACCEPTED                            = 2604, // You wish to learn the old craft?  You wish to smelt dark iron?$B$BAppease me, $r.  Show me a sacrifice and I will consider it!
-    SAY_QUEST_COMPLETED                           = 2605, // Your will is strong, and your intent is clear.$B$BPerhaps you are worthy...
-    SAY_QUEST_COMPLETED_END                       = 2606, // You have shown me your desire, and have payed with precious stone.  I will teach you...
+    GOSSIP_GLOOMREL_CONTINUE_SMELT                = 1952,
+    GOSSIP_GLOOMREL_CONTINUE_CHALICE              = 1953,
+    GOSSIP_DOOMREL_CONTINUE                       = 1950,
 };
 
 struct boss_gloomrel : public ScriptedAI
 {
     boss_gloomrel(Creature* creature) : ScriptedAI(creature) { }
 
-    void sGossipSelect(Player* player, uint32 /*sender*/, uint32 action) override
+    void sGossipSelect(Player* player, uint32 menuId, uint32 gossipListId) override
     {
-        ClearGossipMenuFor(player);
-        switch (action)
+        if (gossipListId != 0)
+            return;
+
+        if (menuId == GOSSIP_GLOOMREL_CONTINUE_SMELT)
         {
-            case GOSSIP_ACTION_INFO_DEF+1:
-                AddGossipItemFor(player, GOSSIP_TEXT_CONTINUE, 1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 11);
-                SendGossipMenuFor(player, SAY_QUEST_COMPLETED_END, me->GetGUID());
-                break;
-            case GOSSIP_ACTION_INFO_DEF+11:
-                CloseGossipMenuFor(player);
-                player->CastSpell(player, SPELL_LEARN_SMELT, false);
-                break;
-            case GOSSIP_ACTION_INFO_DEF+2:
-                AddGossipItemFor(player, GOSSIP_TEXT_CONTINUE, 1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 22);
-                SendGossipMenuFor(player, SAY_QUEST_ACCEPTED, me->GetGUID());
-                break;
-            case GOSSIP_ACTION_INFO_DEF+22:
-                CloseGossipMenuFor(player);
-                if (InstanceScript* instance = me->GetInstanceScript())
-                    //are 5 minutes expected? go template may have data to despawn when used at quest
-                    instance->DoRespawnGameObject(instance->GetGuidData(DATA_GO_CHALICE), MINUTE * 5);
-                break;
+            CloseGossipMenuFor(player);
+            player->CastSpell(player, SPELL_LEARN_SMELT, false);
         }
-    }
-
-    void sGossipHello(Player* player) override
-    {
-        if (player->GetQuestRewardStatus(QUEST_SPECTRAL_CHALICE) == 1 && player->GetSkillValue(SKILL_MINING) >= DATA_SKILLPOINT_MIN && !player->HasSpell(SPELL_SMELT_DARK_IRON))
+        else if (menuId == GOSSIP_GLOOMREL_CONTINUE_CHALICE)
         {
-            AddGossipItemFor(player, GOSSIP_GROOMREL, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-            SendGossipMenuFor(player, SAY_QUEST_COMPLETED, me->GetGUID());
+            CloseGossipMenuFor(player);
+            if (InstanceScript* instance = me->GetInstanceScript())
+                //are 5 minutes expected? go template may have data to despawn when used at quest
+                instance->DoRespawnGameObject(instance->GetGuidData(DATA_GO_CHALICE), MINUTE * 5);
         }
-
-        if (player->GetQuestRewardStatus(QUEST_SPECTRAL_CHALICE) == 0 && player->GetSkillValue(SKILL_MINING) >= DATA_SKILLPOINT_MIN)
-            AddGossipItemFor(player, GOSSIP_GROOMREL, 1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
-
-        SendGossipMenuFor(player, player->GetGossipTextId(me), me->GetGUID());
     }
 };
 
@@ -126,30 +90,17 @@ struct boss_doomrel : public ScriptedAI
     EventMap _events;
     bool Voidwalkers;
 
-    void sGossipSelect(Player* player, uint32 /*sender*/, uint32 action) override
+    void sGossipSelect(Player* player, uint32 menuId, uint32 gossipListId) override
     {
-        ClearGossipMenuFor(player);
-        switch (action)
+        if (menuId == GOSSIP_DOOMREL_CONTINUE && gossipListId == 0)
         {
-            case GOSSIP_ACTION_INFO_DEF+1:
-                AddGossipItemFor(player, GOSSIP_TEXT_CONTINUE, 1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
-                SendGossipMenuFor(player, SAY_QUEST_COMPLETED, me->GetGUID());
-                break;
-            case GOSSIP_ACTION_INFO_DEF+2:
-                CloseGossipMenuFor(player);
-                me->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
-                // Start encounter
-                if (instance)
-                    instance->SetData(TYPE_TOMB_OF_SEVEN, IN_PROGRESS);
-                Talk(SAY_START_FIGHT);
-                break;
+            CloseGossipMenuFor(player);
+            me->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
+            // Start encounter
+            if (instance)
+                instance->SetData(TYPE_TOMB_OF_SEVEN, IN_PROGRESS);
+            Talk(SAY_START_FIGHT);
         }
-    }
-
-    void sGossipHello(Player* player) override
-    {
-        AddGossipItemFor(player, GOSSIP_DOOMREL_START_COMBAT, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-        SendGossipMenuFor(player, SAY_DOOMREL_HELLO, me->GetGUID());
     }
 
     void Reset() override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

The refactor to ScriptedAI structs (commit d5b55c1ba) broke both Doom'rel and Gloom'rel gossip in the Tomb of Seven:

- `sGossipSelect` received `menuId`/`gossipListId` from the packet but the code checked stored `GOSSIP_ACTION_INFO_DEF` values, so actions never matched and the encounter could not start
- `sGossipHello` duplicated gossip options already sent by the default handler, showing each option twice

This fix moves gossip chaining and conditions entirely to the DB:
- `ActionMenuID` handles intermediate "Continue..." page chaining
- `conditions` system handles Gloom'rel's conditional options (quest status, mining skill, spell known)
- C++ `sGossipSelect` only handles the final actions that require code (start encounter, teach Smelt Dark Iron, spawn Spectral Chalice)
- `sGossipHello` is removed entirely — the default handler + DB conditions cover everything

Net result: -72 lines of C++, replaced by clean DB-driven gossip.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Opus 4.6 was used.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25247

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Doom'rel:**
1. `.go c id 9039`
2. Talk to Doom'rel — should see one gossip option: "Your bondage is at an end, Doom'rel. I challenge you!"
3. Click the option — should see "Continue..." with lore text
4. Click Continue — gossip closes, encounter starts, Doom'rel speaks

**Gloom'rel (requires Mining >= 230):**
1. `.go c id 9037` and `.mod skill 186 300`
2. Without quest 4083 completed: should see "Gloom'rel, tell me your secrets!" → Continue → spawns Spectral Chalice
3. With quest 4083 completed (`.quest complete 4083`): should see "I have paid your price, Gloom'rel..." → Continue → teaches Smelt Dark Iron
4. After learning the spell: option should no longer appear

## Known Issues and TODO List:

- [ ] Gloom'rel's Spectral Chalice path needs testing with the actual quest flow

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.