### PR TITLE
fix(Core/Scripts): Clear IMMUNE_TO_PC before engaging after threat system port

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1774549776059314574.sql
+++ b/data/sql/updates/pending_db_world/rev_1774549776059314574.sql
@@ -1,7 +1,0 @@
--- Remove IMMUNE_TO_PC from creatures whose scripts never clear it (breaks threat engagement after threat system port)
--- Gortok Palehoof encounter (Utgarde Pinnacle): boss + 4 beasts, normal + heroic
-UPDATE `creature_template` SET `unit_flags` = `unit_flags` & ~0x100 WHERE `entry` IN (26683, 26684, 26685, 26686, 26687, 30770, 30772, 30774, 30790, 30803);
--- Razorscale (Ulduar): normal + heroic
-UPDATE `creature_template` SET `unit_flags` = `unit_flags` & ~0x100 WHERE `entry` IN (33186, 33724);
--- Scourgelord Tyrannus (Pit of Saron): normal + heroic
-UPDATE `creature_template` SET `unit_flags` = `unit_flags` & ~0x100 WHERE `entry` IN (36658, 36938);

--- a/data/sql/updates/pending_db_world/rev_1774549776059314574.sql
+++ b/data/sql/updates/pending_db_world/rev_1774549776059314574.sql
@@ -1,0 +1,7 @@
+-- Remove IMMUNE_TO_PC from creatures whose scripts never clear it (breaks threat engagement after threat system port)
+-- Gortok Palehoof encounter (Utgarde Pinnacle): boss + 4 beasts, normal + heroic
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` & ~0x100 WHERE `entry` IN (26683, 26684, 26685, 26686, 26687, 30770, 30772, 30774, 30790, 30803);
+-- Razorscale (Ulduar): normal + heroic
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` & ~0x100 WHERE `entry` IN (33186, 33724);
+-- Scourgelord Tyrannus (Pit of Saron): normal + heroic
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` & ~0x100 WHERE `entry` IN (36658, 36938);

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_scourgelord_tyrannus.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_scourgelord_tyrannus.cpp
@@ -116,6 +116,7 @@ public:
                 // start real fight
                 me->RemoveAllAuras();
                 me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+                me->SetImmuneToPC(false);
                 DoZoneInCombat();
                 me->CastSpell(me, 43979, true);
                 Talk(SAY_AGGRO);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -181,6 +181,7 @@ struct boss_razorscale : public BossAI
 
     void JustEngagedWith(Unit* who) override
     {
+        me->SetImmuneToPC(false);
         BossAI::JustEngagedWith(who);
         events.ScheduleEvent(EVENT_COMMANDER_SAY_AGGRO, 5s);
         events.ScheduleEvent(EVENT_EE_SAY_MOVE_OUT, 10s);

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_palehoof.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_palehoof.cpp
@@ -191,6 +191,7 @@ public:
                     cr->SetDisableGravity(true);
                     cr->GetMotionMaster()->MovePoint(0, 275.4f, -453, 110); // ROOM CENTER
                     events.RescheduleEvent(EVENT_UNFREEZE_MONSTER, 10s);
+                    me->SetImmuneToPC(false);
                     me->SetInCombatWithZone();
                     me->SetControlled(true, UNIT_STATE_STUNNED);
                 }
@@ -373,6 +374,7 @@ public:
             {
                 me->RemoveAurasDueToSpell(SPELL_FREEZE);
                 me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+                me->SetImmuneToPC(false);
                 me->SetInCombatWithZone();
 
                 events.ScheduleEvent(EVENT_JORMUNGAR_ACID_SPIT, 3s);
@@ -499,6 +501,7 @@ public:
             {
                 me->RemoveAurasDueToSpell(SPELL_FREEZE);
                 me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+                me->SetImmuneToPC(false);
                 me->SetInCombatWithZone();
 
                 events.ScheduleEvent(EVENT_RHINO_STOMP, 3s);
@@ -609,6 +612,7 @@ public:
             {
                 me->RemoveAurasDueToSpell(SPELL_FREEZE);
                 me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+                me->SetImmuneToPC(false);
                 me->SetInCombatWithZone();
 
                 events.ScheduleEvent(EVENT_FURBOLG_CHAIN, 3s);
@@ -717,6 +721,7 @@ public:
             {
                 me->RemoveAurasDueToSpell(SPELL_FREEZE);
                 me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+                me->SetImmuneToPC(false);
                 me->SetInCombatWithZone();
 
                 events.ScheduleEvent(EVENT_WORGEN_MORTAL, 3s);


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - **Claude Code** (claude-opus-4-6) with **AzerothMCP** for database research and verification.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9211
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25259

## Description:

After the TrinityCore heap-based threat system port (#24715) and the subsequent removal of the auto-immunity-clearing code in `Creature::AtEngage` (#25121), creatures that have `UNIT_FLAG_IMMUNE_TO_PC` (0x100) in their `creature_template.unit_flags` but never explicitly clear it in their C++ script are now broken.

**Root cause:** `ThreatReference::FlagsAllowFighting()` returns `false` when a player-controlled unit targets a creature with `IMMUNE_TO_PC`, causing all threat references to be set to `OFFLINE`. This makes `UpdateVictim()` return `nullptr`, so all event processing in `UpdateAI()` is skipped.

Previously, `Creature::AtEngage()` had a safety net that auto-cleared `IMMUNE_TO_PC` when entering combat. This was removed in #25121 (Malygos fix) because it was too broad.

**Fix:** Add `SetImmuneToPC(false)` in the C++ scripts before `SetInCombatWithZone()`/`DoZoneInCombat()` calls, preserving the sniffed `creature_template` flags.

**Affected encounters:**
- **Utgarde Pinnacle — Gortok Palehoof** (boss + 4 beasts): The orb floats to center but never activates beasts because events never fire.
- **Ulduar — Razorscale**: Boss enters combat but all phase transitions stall.
- **Pit of Saron — Scourgelord Tyrannus**: Script removes `NON_ATTACKABLE` before `DoZoneInCombat()` but never clears `IMMUNE_TO_PC`.

All other bosses with `IMMUNE_TO_PC` in their template were verified to already clear it in their scripts (via `SetImmuneToPC(false)`, `SetImmuneToAll(false)`, or `RemoveUnitFlag`).

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Source code analysis of `ThreatManager.cpp` (`FlagsAllowFighting`, `ShouldBeOffline`, `ReselectVictim`) confirming the interaction between `IMMUNE_TO_PC` and the new threat reference system.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Utgarde Pinnacle (Gortok Palehoof):**
1. `.tele utgarde`
2. Navigate to the second boss area
3. Activate the Stasis Generator pedestal
4. Verify the red orb channels at a beast, unfreezing it
5. Kill the beast(s), verify Palehoof activates and fights

**Ulduar (Razorscale):**
1. `.tele ulduar`
2. Navigate to Razorscale's area
3. Talk to Expedition Commander to start the encounter
4. Verify Razorscale's phase transitions work (adds spawn, harpoons ground her, ground phase combat)

**Pit of Saron (Scourgelord Tyrannus):**
1. `.tele pos`
2. Navigate to the final boss area
3. Engage Tyrannus after the intro RP
4. Verify he becomes attackable and fights normally

## Known Issues and TODO List:

- [ ] Regression test other encounters in the same dungeons to ensure no side effects

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.