### PR TITLE
fix(Core/Spells): resolve pet to owner in SummonGuardian

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5943,6 +5943,9 @@ void Spell::SummonGuardian(uint32 i, uint32 entry, SummonPropertiesEntry const* 
 
     if (caster->IsTotem())
         caster = caster->ToTotem()->GetOwner();
+    else if (caster->IsPet())
+        if (Unit* owner = caster->GetOwner())
+            caster = owner;
 
     // in another case summon new
     uint8 summonLevel = caster->GetLevel();


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

When a pet casts a spell with `SPELL_EFFECT_SUMMON` (e.g. via `SMART_ACTION_CROSS_CAST` when the pet gets the killing blow on a creature), the summoned guardian's owner is incorrectly set to the pet instead of the player. This causes a server crash via assertion failure `!IsPet()` in `Unit::UpdatePetCombatState` because the combat system walks the owner chain and calls `UpdatePetCombatState` on the pet.

The fix resolves pet casters to their player owner in `Spell::SummonGuardian`, matching the existing pattern already in place for totems.

### AI-assisted Pull Requests

- [x] AI tools were used in preparing this pull request: Claude Code (Anthropic) with AzerothMCP

## SOURCE:
The changes have been validated through:
- [x] Crash log analysis (GDB backtrace from production server)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue

## Known Issues and TODO List: