### PR TITLE
fix(Core/Movement): resume waypoint movement after casting interruption

### DIFF
--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -363,6 +363,7 @@ bool WaypointMovementGenerator<Creature>::DoUpdate(Creature* creature, uint32 di
         creature->StopMoving();
         _lastSplineId = 0;
         _smoothSplineLaunched = false;
+        _hasBeenStalled = true;
     }
 
     // Set home position to current position.


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

The smooth waypoint movement port (#25106) rewrote `WaypointMovementGenerator::DoUpdate` but introduced a bug in the interruption handling. The old code used `Stop(1000)` which set a timer that would naturally re-trigger `StartMove` after 1 second. The new code stops the spline and sets `_lastSplineId = 0` but does not set `_hasBeenStalled = true`, so the three resume conditions (`_waypointReached`, `_recalculateSpeed`, `_hasBeenStalled`) are all false and `StartMove` is never called again.

This affects any waypoint creature that casts non-triggered spells, gets rooted, or gets stunned during patrol. The same bug exists in the upstream Cata Preservation Project source this was ported from.

The fix adds `_hasBeenStalled = true` to the interruption block, which is already used for the same purpose in `DoReset`, `Pause`, and `Resume`.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Tools used:** Claude Code, AzerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9214

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

The old `DoUpdate` used `Stop(1000)` as a resume mechanism. The rewrite removed it without adding an equivalent. `_hasBeenStalled` is already the designated resume flag used in `DoReset`, `Pause`, and `Resume` for the same purpose.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.tele naxxramas` and navigate to the Construct Quarter
2. `.go creature id 127781` to teleport to Grobbulus
3. Observe Grobbulus patrolling up/down the ramp along his 30-waypoint path
4. Wait for him to reach the upper area near waypoint 21 (~3174, -3306) where he casts Bombard Slime (28280)
5. Verify he resumes patrolling after the cast completes (without this fix he permanently freezes)
6. Test other waypoint creatures that cast spells during patrol to verify no regressions

## Known Issues and TODO List:
