### PR TITLE
fix(Core/Movement): Fix use-after-free in WaypointMovementGenerator

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -879,10 +879,10 @@ void MotionMaster::MoveDistract(uint32 timer)
 
 void MotionMaster::Mutate(MovementGenerator* m, MovementSlot slot)
 {
+    bool const delayed = (_cleanFlag & MMCF_UPDATE);
+
     while (MovementGenerator* curr = Impl[slot])
     {
-        bool delayed = (_top == slot && (_cleanFlag & MMCF_UPDATE));
-
         // clear slot AND decrease top immediately to avoid crashes when referencing null top in DirectDelete
         Impl[slot] = nullptr;
         while (!empty() && !top())

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -157,27 +157,31 @@ void WaypointMovementGenerator<Creature>::ProcessWaypointArrival(Creature* creat
         creature->GetMap()->ScriptsStart(sWaypointScripts, waypoint.EventId, creature, nullptr);
     }
 
-    creature->UpdateWaypointID(waypoint.Id);
-    creature->UpdateCurrentWaypointInfo(waypoint.Id, i_path->Id);
+    // scripts can invalidate current path, store what we need
+    uint32 const waypointId = waypoint.Id;
+    uint32 const pathId = i_path->Id;
+
+    creature->UpdateWaypointID(waypointId);
+    creature->UpdateCurrentWaypointInfo(waypointId, pathId);
 
     // Inform AI
     if (CreatureAI* AI = creature->AI())
     {
-        AI->MovementInform(WAYPOINT_MOTION_TYPE, waypoint.Id);
-        AI->WaypointReached(waypoint.Id, i_path->Id);
+        AI->MovementInform(WAYPOINT_MOTION_TYPE, waypointId);
+        AI->WaypointReached(waypointId, pathId);
     }
 
     if (Unit* owner = creature->GetCharmerOrOwner())
     {
         if (UnitAI* AI = owner->GetAI())
-            AI->SummonMovementInform(creature, WAYPOINT_MOTION_TYPE, waypoint.Id);
+            AI->SummonMovementInform(creature, WAYPOINT_MOTION_TYPE, waypointId);
     }
     else
     {
         if (TempSummon* tempSummon = creature->ToTempSummon())
             if (Unit* owner2 = tempSummon->GetSummonerUnit())
                 if (UnitAI* AI = owner2->GetAI())
-                    AI->SummonMovementInform(creature, WAYPOINT_MOTION_TYPE, waypoint.Id);
+                    AI->SummonMovementInform(creature, WAYPOINT_MOTION_TYPE, waypointId);
     }
 
     // Path end notifications fire after WaypointReached so that m_path_id
@@ -187,11 +191,11 @@ void WaypointMovementGenerator<Creature>::ProcessWaypointArrival(Creature* creat
         creature->UpdateCurrentWaypointInfo(0, 0);
 
         if (CreatureAI* AI = creature->AI())
-            AI->PathEndReached(i_path->Id);
+            AI->PathEndReached(pathId);
 
         // Re-fetch AI — PathEndReached may have despawned the creature or swapped its AI
         if (CreatureAI* AI = creature->AI())
-            AI->WaypointPathEnded(waypoint.Id, i_path->Id);
+            AI->WaypointPathEnded(waypointId, pathId);
     }
 
     // All hooks called and infos updated. Time to increment the waypoint node id
@@ -385,8 +389,15 @@ bool WaypointMovementGenerator<Creature>::DoUpdate(Creature* creature, uint32 di
             WaypointNode const& passedWp = i_path->Nodes.at(i_currentNode);
 
             UpdateHomePosition(creature, passedWp);
-            creature->UpdateWaypointID(passedWp.Id);
-            creature->UpdateCurrentWaypointInfo(passedWp.Id, i_path->Id);
+
+            // Save data before AI callbacks — they can invalidate the reference
+            uint32 const wpId = passedWp.Id;
+            uint32 const wpPathId = i_path->Id;
+            uint32 const wpDelay = passedWp.Delay;
+            std::optional<float> const wpOrientation = passedWp.Orientation;
+
+            creature->UpdateWaypointID(wpId);
+            creature->UpdateCurrentWaypointInfo(wpId, wpPathId);
 
             if (passedWp.EventId && urand(0, 99) < passedWp.EventChance)
             {
@@ -396,23 +407,24 @@ bool WaypointMovementGenerator<Creature>::DoUpdate(Creature* creature, uint32 di
 
             if (CreatureAI* AI = creature->AI())
             {
-                AI->MovementInform(WAYPOINT_MOTION_TYPE, passedWp.Id);
-                AI->WaypointReached(passedWp.Id, i_path->Id);
+                AI->MovementInform(WAYPOINT_MOTION_TYPE, wpId);
+                AI->WaypointReached(wpId, wpPathId);
             }
 
             // Advance node
-            i_currentNode = (i_currentNode + 1) % i_path->Nodes.size();
+            if (i_path && !i_path->Nodes.empty())
+                i_currentNode = (i_currentNode + 1) % i_path->Nodes.size();
 
             // If this waypoint has a delay, stop the spline and pause
-            if (passedWp.Delay > 0)
+            if (wpDelay > 0)
             {
                 creature->StopMoving();
                 creature->ClearUnitState(UNIT_STATE_ROAMING_MOVE);
-                _waypointDelay = passedWp.Delay;
+                _waypointDelay = wpDelay;
                 _waypointReached = true;
                 _smoothSplineLaunched = false;
-                if (passedWp.Orientation.has_value())
-                    creature->SetFacingTo(*passedWp.Orientation);
+                if (wpOrientation.has_value())
+                    creature->SetFacingTo(*wpOrientation);
 
                 return true;
             }
@@ -423,15 +435,17 @@ bool WaypointMovementGenerator<Creature>::DoUpdate(Creature* creature, uint32 di
             if (!_repeating)
             {
                 // Path ended
+                uint32 const endWpId = i_path->Nodes.at(i_currentNode).Id;
+                uint32 const endPathId = i_path->Id;
                 _done = true;
                 _smoothSplineLaunched = false;
                 creature->UpdateCurrentWaypointInfo(0, 0);
                 if (CreatureAI* AI = creature->AI())
-                    AI->PathEndReached(i_path->Id);
+                    AI->PathEndReached(endPathId);
 
                 // Re-fetch AI — PathEndReached may have despawned the creature or swapped its AI
                 if (CreatureAI* AI = creature->AI())
-                    AI->WaypointPathEnded(i_path->Nodes.at(i_currentNode).Id, i_path->Id);
+                    AI->WaypointPathEnded(endWpId, endPathId);
             }
             else
             {


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

AI callbacks in `WaypointMovementGenerator::ProcessWaypointArrival` can trigger movement generator replacement via `MotionMaster::Mutate`. Under certain conditions, this results in `DirectDelete` of the currently-executing generator, causing use-after-free when the function continues accessing member variables.

**Fix:**
1. Cache needed values into local variables before AI callbacks.
2. After each callback, verify the generator is still valid before accessing member variables.

The local-caching approach is based on TrinityCore commit `8d43d2b` by Shauren. The validity checks are AC-specific due to differences in `MotionMaster::Mutate` behavior.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP was used to trace the crash, identify the root cause, and prepare the fix.

## SOURCE:
The changes have been validated through:
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Partially based on TrinityCore commit `8d43d2bafc2e2c42e51c82d0526f2c9c0fd79f53` by Shauren.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

Verified with AddressSanitizer — no heap-use-after-free errors after fix.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Build with AddressSanitizer
2. Exercise creatures that use non-repeating waypoint paths with AI callbacks that modify movement on path end
3. Verify no ASAN errors

## Known Issues and TODO List:

- [ ] `MotionMaster::Mutate` could be hardened to use `DelayedDelete` more broadly, which would prevent this class of bug globally.