### PR TITLE
refactor(Core/Scripts): move Outland gossip handlers to database

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1774580000_gossip_outland.sql
+++ b/data/sql/updates/pending_db_world/rev_1774580000_gossip_outland.sql
@@ -1,0 +1,118 @@
+-- Move Outland gossip handlers from C++ to database
+-- NPCs: Shattrath Flask Vendors (23484, 23483), Zephyr (25967), Drake Dealer Hurlunk (23489)
+
+-- =====================================================
+-- 1. npc_shattrathflaskvendors - Aldor vendor (23484), menu 8751
+-- Show vendor option only if Exalted with Aldor (932), Sha'tar (935), Cenarion Expedition (942)
+-- Text 11085 = qualified, Text 11083 = rejection (default)
+-- =====================================================
+
+-- Condition on gossip_menu: show text 11085 if Exalted with all 3 factions
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=14 AND `SourceGroup`=8751 AND `SourceEntry`=11085;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 8751, 11085, 0, 0, 5, 0, 932, 128, 0, 0, 0, 0, '', 'Haldor the Compulsive - Show text 11085 if Exalted with Aldor'),
+(14, 8751, 11085, 0, 0, 5, 0, 935, 128, 0, 0, 0, 0, '', 'Haldor the Compulsive - Show text 11085 if Exalted with Sha''tar'),
+(14, 8751, 11085, 0, 0, 5, 0, 942, 128, 0, 0, 0, 0, '', 'Haldor the Compulsive - Show text 11085 if Exalted with Cenarion Expedition');
+
+-- Condition on gossip_menu_option: show vendor option only if Exalted with all 3 factions
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=8751 AND `SourceEntry`=0;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 8751, 0, 0, 0, 5, 0, 932, 128, 0, 0, 0, 0, '', 'Haldor the Compulsive - Show vendor option if Exalted with Aldor'),
+(15, 8751, 0, 0, 0, 5, 0, 935, 128, 0, 0, 0, 0, '', 'Haldor the Compulsive - Show vendor option if Exalted with Sha''tar'),
+(15, 8751, 0, 0, 0, 5, 0, 942, 128, 0, 0, 0, 0, '', 'Haldor the Compulsive - Show vendor option if Exalted with Cenarion Expedition');
+
+-- Remove ScriptName
+UPDATE `creature_template` SET `ScriptName`='' WHERE `entry`=23484;
+
+-- =====================================================
+-- 2. npc_shattrathflaskvendors - Scryers vendor (23483), menu 8752
+-- Show vendor option only if Exalted with Scryers (934), Sha'tar (935), Cenarion Expedition (942)
+-- Text 11085 = qualified, Text 11084 = rejection (default)
+-- =====================================================
+
+-- Add qualified text 11085 to menu 8752 (only rejection text 11084 exists)
+DELETE FROM `gossip_menu` WHERE `MenuID`=8752 AND `TextID`=11085;
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES
+(8752, 11085);
+
+-- Condition on gossip_menu: show text 11085 if Exalted with all 3 factions
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=14 AND `SourceGroup`=8752 AND `SourceEntry`=11085;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(14, 8752, 11085, 0, 0, 5, 0, 934, 128, 0, 0, 0, 0, '', 'Arcanist Xorith - Show text 11085 if Exalted with Scryers'),
+(14, 8752, 11085, 0, 0, 5, 0, 935, 128, 0, 0, 0, 0, '', 'Arcanist Xorith - Show text 11085 if Exalted with Sha''tar'),
+(14, 8752, 11085, 0, 0, 5, 0, 942, 128, 0, 0, 0, 0, '', 'Arcanist Xorith - Show text 11085 if Exalted with Cenarion Expedition');
+
+-- Condition on gossip_menu_option: show vendor option only if Exalted with all 3 factions
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=8752 AND `SourceEntry`=0;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 8752, 0, 0, 0, 5, 0, 934, 128, 0, 0, 0, 0, '', 'Arcanist Xorith - Show vendor option if Exalted with Scryers'),
+(15, 8752, 0, 0, 0, 5, 0, 935, 128, 0, 0, 0, 0, '', 'Arcanist Xorith - Show vendor option if Exalted with Sha''tar'),
+(15, 8752, 0, 0, 0, 5, 0, 942, 128, 0, 0, 0, 0, '', 'Arcanist Xorith - Show vendor option if Exalted with Cenarion Expedition');
+
+-- Remove ScriptName
+UPDATE `creature_template` SET `ScriptName`='' WHERE `entry`=23483;
+
+-- =====================================================
+-- 3. npc_zephyr (25967), menu 9205
+-- Show teleport option if Revered+ with Keepers of Time (989)
+-- On select: player casts spell 37778 (Teleport: Caverns of Time)
+-- =====================================================
+
+-- Condition on gossip_menu_option: show option if Revered or Exalted with Keepers of Time
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=9205 AND `SourceEntry`=0;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 9205, 0, 0, 0, 5, 0, 989, 192, 0, 0, 0, 0, '', 'Zephyr - Show teleport option if Revered+ with Keepers of Time');
+
+-- SAI: on gossip select (menu 9205, option 0) -> invoker self-casts spell 37778
+DELETE FROM `smart_scripts` WHERE `entryorguid`=25967 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(25967, 0, 0, 0, 62, 0, 100, 512, 9205, 0, 0, 0, 0, 0, 134, 37778, 2, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Zephyr - On Gossip Select - Invoker Cast Teleport Caverns of Time');
+
+-- Update creature_template: set SmartAI, remove ScriptName
+UPDATE `creature_template` SET `ScriptName`='', `AIName`='SmartAI' WHERE `entry`=25967;
+
+-- =====================================================
+-- 4. npc_drake_dealer_hurlunk (23489), menu 8754
+-- Show vendor option only if Exalted with Netherwing (1015)
+-- =====================================================
+
+-- Condition on gossip_menu_option: show vendor option if Exalted with Netherwing
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=8754 AND `SourceEntry`=0;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 8754, 0, 0, 0, 5, 0, 1015, 128, 0, 0, 0, 0, '', 'Drake Dealer Hurlunk - Show vendor option if Exalted with Netherwing');
+
+-- Remove ScriptName
+UPDATE `creature_template` SET `ScriptName`='' WHERE `entry`=23489;
+
+-- =====================================================
+-- 5. npcs_flanis_swiftwing_and_kagrosh
+-- Flanis Swiftwing (21727), menu 8356 - give item 30658 if quest 10583 incomplete
+-- Kagrosh (21725), menu 8371 - give item 30659 if quest 10601 incomplete
+-- =====================================================
+
+-- Condition on menu 8356 option 0: quest 10583 incomplete AND player doesn't have item 30658
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=8356 AND `SourceEntry`=0;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 8356, 0, 0, 0, 47, 0, 10583, 8, 0, 0, 0, 0, '', 'Flanis Swiftwing - Show option if quest 10583 is in progress'),
+(15, 8356, 0, 0, 0, 2, 0, 30658, 1, 0, 1, 0, 0, '', 'Flanis Swiftwing - Show option if player does not have item 30658');
+
+-- Condition on menu 8371 option 0: quest 10601 incomplete AND player doesn't have item 30659
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=8371 AND `SourceEntry`=0;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 8371, 0, 0, 0, 47, 0, 10601, 8, 0, 0, 0, 0, '', 'Kagrosh - Show option if quest 10601 is in progress'),
+(15, 8371, 0, 0, 0, 2, 0, 30659, 1, 0, 1, 0, 0, '', 'Kagrosh - Show option if player does not have item 30659');
+
+-- SAI for Flanis (21727): on gossip select -> close gossip + add item 30658
+DELETE FROM `smart_scripts` WHERE `entryorguid`=21727 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(21727, 0, 0, 1, 62, 0, 100, 512, 8356, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Flanis Swiftwing - On Gossip Select - Close Gossip'),
+(21727, 0, 1, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 56, 30658, 1, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Flanis Swiftwing - Linked - Add Item 30658');
+
+-- SAI for Kagrosh (21725): on gossip select -> close gossip + add item 30659
+DELETE FROM `smart_scripts` WHERE `entryorguid`=21725 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(21725, 0, 0, 1, 62, 0, 100, 512, 8371, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Kagrosh - On Gossip Select - Close Gossip'),
+(21725, 0, 1, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 56, 30659, 1, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Kagrosh - Linked - Add Item 30659');
+
+-- Update creature_template: set SmartAI, remove ScriptName
+UPDATE `creature_template` SET `ScriptName`='', `AIName`='SmartAI' WHERE `entry` IN (21725, 21727);

--- a/src/server/scripts/Outland/zone_shadowmoon_valley.cpp
+++ b/src/server/scripts/Outland/zone_shadowmoon_valley.cpp
@@ -20,7 +20,6 @@
 #include "Group.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
-#include "ScriptedGossip.h"
 #include "SpellScript.h"
 #include "SpellScriptLoader.h"
 
@@ -655,98 +654,6 @@ public:
     private:
         float x, y, z;
     };
-};
-
-/*######
-## npc_drake_dealer_hurlunk
-######*/
-
-class npc_drake_dealer_hurlunk : public CreatureScript
-{
-public:
-    npc_drake_dealer_hurlunk() : CreatureScript("npc_drake_dealer_hurlunk") { }
-
-    bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action) override
-    {
-        ClearGossipMenuFor(player);
-        if (action == GOSSIP_ACTION_TRADE)
-            player->GetSession()->SendListInventory(creature->GetGUID());
-
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        if (creature->IsVendor() && player->GetReputationRank(1015) == REP_EXALTED)
-            AddGossipItemFor(player, GOSSIP_ICON_VENDOR, GOSSIP_TEXT_BROWSE_GOODS, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_TRADE);
-
-        SendGossipMenuFor(player, player->GetGossipTextId(creature), creature->GetGUID());
-
-        return true;
-    }
-};
-
-/*######
-## npc_flanis_swiftwing_and_kagrosh
-######*/
-
-enum Flanis : uint32
-{
-    QUEST_THE_FATE_OF_FLANIS    = 10583,
-    ITEM_FLAUNISS_PACK          = 30658,
-    GOSSIP_MENU_FLANIS          = 8356,
-};
-
-enum Kagrosh : uint32
-{
-    QUEST_THE_FATE_OF_KAGROSH   = 10601,
-    ITEM_KAGROSHS_PACK          = 30659,
-    GOSSIP_MENU_KAGROSH         = 8371,
-};
-
-class npcs_flanis_swiftwing_and_kagrosh : public CreatureScript
-{
-public:
-    npcs_flanis_swiftwing_and_kagrosh() : CreatureScript("npcs_flanis_swiftwing_and_kagrosh") { }
-
-    bool OnGossipSelect(Player* player, Creature* /*creature*/, uint32 /*sender*/, uint32 action) override
-    {
-        ClearGossipMenuFor(player);
-        if (action == GOSSIP_ACTION_INFO_DEF + 1)
-        {
-            ItemPosCountVec dest;
-            uint8 msg = player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, ITEM_FLAUNISS_PACK, 1, nullptr);
-            if (msg == EQUIP_ERR_OK)
-            {
-                player->StoreNewItem(dest, ITEM_FLAUNISS_PACK, true);
-            }
-        }
-        if (action == GOSSIP_ACTION_INFO_DEF + 2)
-        {
-            ItemPosCountVec dest;
-            uint8 msg = player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, ITEM_KAGROSHS_PACK, 1, nullptr);
-            if (msg == EQUIP_ERR_OK)
-            {
-                player->StoreNewItem(dest, ITEM_KAGROSHS_PACK, true);
-            }
-        }
-
-        CloseGossipMenuFor(player);
-
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        if (player->GetQuestStatus(QUEST_THE_FATE_OF_FLANIS) == QUEST_STATUS_INCOMPLETE && !player->HasItemCount(ITEM_FLAUNISS_PACK, 1, true))
-            AddGossipItemFor(player, GOSSIP_MENU_FLANIS, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-        if (player->GetQuestStatus(QUEST_THE_FATE_OF_KAGROSH) == QUEST_STATUS_INCOMPLETE && !player->HasItemCount(ITEM_KAGROSHS_PACK, 1, true))
-            AddGossipItemFor(player, GOSSIP_MENU_KAGROSH, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
-
-        SendGossipMenuFor(player, player->GetGossipTextId(creature), creature->GetGUID());
-
-        return true;
-    }
 };
 
 /*####
@@ -2219,8 +2126,6 @@ void AddSC_shadowmoon_valley()
     new npc_mature_netherwing_drake();
     RegisterCreatureAI(npc_enslaved_netherwing_drake);
     new npc_dragonmaw_peon();
-    new npc_drake_dealer_hurlunk();
-    new npcs_flanis_swiftwing_and_kagrosh();
     new npc_karynaku();
     new npc_lord_illidan_stormrage();
     new go_crystal_prison();

--- a/src/server/scripts/Outland/zone_shattrath_city.cpp
+++ b/src/server/scripts/Outland/zone_shattrath_city.cpp
@@ -20,101 +20,6 @@
 #include "Player.h"
 #include "ScriptedCreature.h"
 #include "ScriptedEscortAI.h"
-#include "ScriptedGossip.h"
-
-/*
-##################################################
-Shattrath City Flask Vendors provides flasks to people exalted with 3 fActions:
-Haldor the Compulsive
-Arcanist Xorith
-Both sell special flasks for use in Outlands 25man raids only,
-purchasable for one Mark of Illidari each
-Purchase requires exalted reputation with Scryers/Aldor, Cenarion Expedition and The Sha'tar
-##################################################
-*/
-
-class npc_shattrathflaskvendors : public CreatureScript
-{
-public:
-    npc_shattrathflaskvendors() : CreatureScript("npc_shattrathflaskvendors") { }
-
-    bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action) override
-    {
-        ClearGossipMenuFor(player);
-        if (action == GOSSIP_ACTION_TRADE)
-            player->GetSession()->SendListInventory(creature->GetGUID());
-
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        if (creature->GetEntry() == 23484)
-        {
-            // Aldor vendor
-            if (creature->IsVendor() && (player->GetReputationRank(932) == REP_EXALTED) && (player->GetReputationRank(935) == REP_EXALTED) && (player->GetReputationRank(942) == REP_EXALTED))
-            {
-                AddGossipItemFor(player, GOSSIP_ICON_VENDOR, GOSSIP_TEXT_BROWSE_GOODS, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_TRADE);
-                SendGossipMenuFor(player, 11085, creature->GetGUID());
-            }
-            else
-            {
-                SendGossipMenuFor(player, 11083, creature->GetGUID());
-            }
-        }
-
-        if (creature->GetEntry() == 23483)
-        {
-            // Scryers vendor
-            if (creature->IsVendor() && (player->GetReputationRank(934) == REP_EXALTED) && (player->GetReputationRank(935) == REP_EXALTED) && (player->GetReputationRank(942) == REP_EXALTED))
-            {
-                AddGossipItemFor(player, GOSSIP_ICON_VENDOR, GOSSIP_TEXT_BROWSE_GOODS, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_TRADE);
-                SendGossipMenuFor(player, 11085, creature->GetGUID());
-            }
-            else
-            {
-                SendGossipMenuFor(player, 11084, creature->GetGUID());
-            }
-        }
-
-        return true;
-    }
-};
-
-/*######
-# npc_zephyr
-######*/
-
-enum Zephyr : int32
-{
-    GOSSIP_MENU_ZEPHYR              = 9205,
-    SPELL_TELEPORT_CAVERNS_OF_TIME  = 37778,
-};
-
-class npc_zephyr : public CreatureScript
-{
-public:
-    npc_zephyr() : CreatureScript("npc_zephyr") { }
-
-    bool OnGossipSelect(Player* player, Creature* /*creature*/, uint32 /*sender*/, uint32 action) override
-    {
-        ClearGossipMenuFor(player);
-        if (action == GOSSIP_ACTION_INFO_DEF + 1)
-            player->CastSpell(player, SPELL_TELEPORT_CAVERNS_OF_TIME, false);
-
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        if (player->GetReputationRank(989) >= REP_REVERED)
-            AddGossipItemFor(player, GOSSIP_MENU_ZEPHYR, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-
-        SendGossipMenuFor(player, player->GetGossipTextId(creature), creature->GetGUID());
-
-        return true;
-    }
-};
 
 /*######
 # npc_kservant
@@ -415,8 +320,6 @@ struct npc_shattrath_daily_quest : public NullCreatureAI
 
 void AddSC_shattrath_city()
 {
-    new npc_shattrathflaskvendors();
-    new npc_zephyr();
     new npc_kservant();
     RegisterCreatureAI(npc_shattrath_daily_quest);
 }


### PR DESCRIPTION
## Changes Proposed

Move simple gossip handlers from C++ scripts to database conditions + SmartAI for 5 Outland NPCs:

- **Haldor the Compulsive** (23484) & **Arcanist Xorith** (23483) — Shattrath flask vendors: reputation-gated vendor (Exalted with 3 factions)
- **Zephyr** (25967) — Reputation-gated teleport to Caverns of Time (Revered+ Keepers of Time)
- **Drake Dealer Hurlunk** (23489) — Reputation-gated vendor (Exalted with Netherwing)
- **Flanis Swiftwing** (21727) & **Kagrosh** (21725) — Quest-gated item delivery

## How Has This Been Tested?

Requires in-game testing:
- [ ] Flask vendors show vendor option only when exalted with all 3 required factions, rejection text otherwise
- [ ] Zephyr shows teleport option only when Revered+ with Keepers of Time, casts teleport spell on select
- [ ] Drake Dealer Hurlunk shows vendor option only when Exalted with Netherwing
- [ ] Flanis gives pack only when quest 10583 is incomplete and player doesn't have item
- [ ] Kagrosh gives pack only when quest 10601 is incomplete and player doesn't have item

## Issues Addressed

Continuation of #25207 — moving hardcoded gossip handlers to database handling.

## AI Usage Disclosure

Generated with [Claude Code](https://claude.ai/code) (Claude Opus 4.6)