### PR TITLE
fix(Core/Combat): Restrict NullCreatureAI combat disallow to triggers only

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1774759571712435204.sql
+++ b/data/sql/updates/pending_db_world/rev_1774759571712435204.sql
@@ -1,0 +1,2 @@
+-- Fix Ashtongue Channeler saved health (was incorrectly 1)
+UPDATE `creature` SET `curhealth` = 87973 WHERE `id1` = 23421;

--- a/src/server/game/AI/CoreAI/PassiveAI.cpp
+++ b/src/server/game/AI/CoreAI/PassiveAI.cpp
@@ -23,8 +23,9 @@ PossessedAI::PossessedAI(Creature* c) : CreatureAI(c) { me->SetReactState(REACT_
 NullCreatureAI::NullCreatureAI(Creature* c) : CreatureAI(c)
 {
     me->SetReactState(REACT_PASSIVE);
-    // TODO: Remove once WorldObject casting is ported (triggers won't create combat refs from spell casts)
-    me->SetIsCombatDisallowed(true);
+    // TODO: Remove once WorldObject spell casting is ported (triggers won't create combat refs from spell casts)
+    if (me->IsTrigger())
+        me->SetIsCombatDisallowed(true);
 }
 
 int32 NullCreatureAI::Permissible(Creature const* creature)

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -314,11 +314,7 @@ public:
 
 struct npc_training_dummy : NullCreatureAI
 {
-    npc_training_dummy(Creature* creature) : NullCreatureAI(creature)
-    {
-        // TODO: Remove once WorldObject casting is ported
-        me->SetIsCombatDisallowed(false);
-    }
+    npc_training_dummy(Creature* creature) : NullCreatureAI(creature) { }
 
     void JustEnteredCombat(Unit* who) override
     {
@@ -363,8 +359,6 @@ struct npc_target_dummy : NullCreatureAI
 {
     npc_target_dummy(Creature* creature) : NullCreatureAI(creature)
     {
-        // TODO: Remove once WorldObject casting is ported
-        me->SetIsCombatDisallowed(false);
         _deathTimer = 15s;
     }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP were used.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25281

## Description

`NullCreatureAI` previously called `SetIsCombatDisallowed(true)` for **all** creatures using that AI. This was added to fix Naxx Toxic Tunnel triggers creating unresolvable combat refs, but it had the side effect of preventing all NullCreatureAI creatures from entering combat — meaning their health regen never stopped, even while players were attacking them.

Affected creatures include:
- **Shield Orb (25502)** — Kil'jaeden encounter, aura-driven shadow bolt caster
- **Ashtongue Channeler (23421)** — Shade of Akama encounter, channels on the Shade
- **Ashtongue Sorcerer (23215)** — Shade of Akama encounter, paths toward the Shade

The fix restricts `SetIsCombatDisallowed(true)` to only `IsTrigger()` creatures, which correctly targets the invisible trigger NPCs that cause the combat ref issue without affecting encounter creatures. Training dummy workarounds are also removed since they are no longer needed.

Additionally fixes `curhealth=1` for Ashtongue Channelers in the `creature` table.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). Compared against TrinityCore's NullCreatureAI implementation which does not set IsCombatDisallowed.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Kil'jaeden Shield Orb:**
1. `.go c 55066` to KJ area, start the encounter
2. Wait for Shield Orbs to spawn, hit one without killing it
3. Stop attacking — health should not regenerate

**Shade of Akama Channelers:**
1. `.go c 148235`, talk to Akama to start encounter
2. Hit a channeler without killing it, stop attacking
3. Health should not regenerate

**Shade of Akama Sorcerers:**
1. Same encounter, wait for sorcerers to spawn from the left side
2. Hit a sorcerer, stop — health should not regenerate

**Naxx Toxic Tunnel (regression test):**
1. `.go c 127631` in Naxx
2. Walk through toxic gas, take damage
3. Walk away — should drop combat after a few seconds

**Training Dummies (regression test):**
1. Attack any training dummy
2. Verify combat works normally and you can leave combat

## Known Issues and TODO List:

- [ ] The `IsTrigger()` check is a workaround — should be removed once WorldObject spell casting is ported

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.