### PR TITLE
fix(Core/Scripts): Fix Aeranas reset loop during quest Avruu's Orb

### DIFF
--- a/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
+++ b/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
@@ -83,6 +83,9 @@ public:
 
         void Reset() override
         {
+            if (_defeated)
+                return;
+
             faction_Timer = 8000;
             envelopingWinds_Timer = 9000;
             shock_Timer = 5000;
@@ -91,6 +94,15 @@ public:
             me->SetFaction(FACTION_FRIENDLY);
 
             Talk(SAY_SUMMON);
+        }
+
+        void JustReachedHome() override
+        {
+            if (_defeated)
+            {
+                Talk(SAY_FREE);
+                me->SetNpcFlag(UNIT_NPC_FLAG_QUESTGIVER);
+            }
         }
 
         void UpdateAI(uint32 diff) override
@@ -110,12 +122,11 @@ public:
 
             if (HealthBelowPct(30))
             {
-                me->SetFaction(FACTION_FRIENDLY);
-                me->SetNpcFlag(UNIT_NPC_FLAG_QUESTGIVER);
+                _defeated = true;
                 me->RemoveAllAuras();
-                me->GetThreatMgr().ClearAllThreat();
+                me->SetFaction(FACTION_FRIENDLY);
                 me->CombatStop(true);
-                Talk(SAY_FREE);
+                me->GetThreatMgr().ClearAllThreat();
                 return;
             }
 
@@ -140,6 +151,7 @@ public:
         uint32 faction_Timer;
         uint32 envelopingWinds_Timer;
         uint32 shock_Timer;
+        bool _defeated = false;
     };
 
     CreatureAI* GetAI(Creature* creature) const override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP were used.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25282

## Description

After the threat system port (#24715), `CombatStop()` in the Aeranas script triggers an evade which calls `Reset()`, restarting the hostile cycle indefinitely. The creature spawns friendly, turns hostile after 8s, gets beaten to 30%, stops combat, evades, resets, and repeats — making the quest impossible to complete.

Fix adds a `_defeated` flag to prevent `Reset()` from restarting the cycle, and moves the questgiver flag and "free" dialogue to `JustReachedHome()` so they are applied after the creature finishes walking back to its spawn point.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.quest add 9418`
2. `.go c 59418` to the Haal'eshi Altar
3. Use the nearby gameobject to summon Aeranas
4. Aeranas spawns friendly, turns hostile after ~8s
5. Beat him below 30% HP
6. Should stop fighting, walk home, then say "free" text and become a questgiver
7. Turn in the quest

## Known Issues and TODO List:

- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.