### PR TITLE
fix(Scripts/MoltenCore): Fix Majordomo Executus gossip for Ragnaros summoning

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_majordomo_executus.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_majordomo_executus.cpp
@@ -509,12 +509,14 @@ struct boss_majordomo : public BossAI
 
     void sGossipHello(Player* player) override
     {
+        ClearGossipMenuFor(player);
         AddGossipItemFor(player, GOSSIP_ITEM_SUMMON_1, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF);
         SendGossipMenuFor(player, TEXT_ID_SUMMON_1, me->GetGUID());
     }
 
-    void sGossipSelect(Player* player, uint32 /*sender*/, uint32 action) override
+    void sGossipSelect(Player* player, uint32 /*menuId*/, uint32 gossipListId) override
     {
+        uint32 const action = player->PlayerTalkClass->GetGossipOptionAction(gossipListId);
         ClearGossipMenuFor(player);
         switch (action)
         {


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25304

The refactoring in 2c4b7c3cd converted `boss_majordomo` from `CreatureScript` to struct-based registration but broke the gossip handlers in two ways:

1. **`sGossipSelect` parameter mismatch**: The old `CreatureScript::OnGossipSelect` received `(sender, action)` where `action` was the value stored via `AddGossipItemFor`. The new `sGossipSelect` receives `(menuId, gossipListId)` where `gossipListId` is the option index (always 0). The switch on `GOSSIP_ACTION_INFO_DEF` (value 1) never matched, falling through to default which just closed the gossip menu.

2. **Duplicate gossip options in `sGossipHello`**: The old `OnGossipHello` returned `true` to prevent the default DB gossip handler from loading. `sGossipHello` is void and runs *after* the default handler, so DB gossip items were still present, causing duplicate options.

**Fix**: Retrieve the actual action value from `PlayerTalkClass->GetGossipOptionAction()` before switching, and clear the gossip menu at the start of `sGossipHello`.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Molten Core
2. Set all bosses 0-8 to DONE via `.instance setbossstate`
3. Leave and re-enter instance so Majordomo spawns at Ragnaros area (or `.npc add temp 12018` and set faction 1080 + gossip flag)
4. Talk to Majordomo — should show exactly one gossip option (not two)
5. Click through all 4 gossip dialogue steps
6. Verify the Ragnaros summoning RP sequence begins after the final click

## Known Issues and TODO List:

- [ ] N/A