### PR TITLE
fix(Scripts/MoltenCore): Move Majordomo Executus gossip to database

### DIFF
--- a/data/sql/updates/pending_db_world/rev_majordomo_gossip_to_db.sql
+++ b/data/sql/updates/pending_db_world/rev_majordomo_gossip_to_db.sql
@@ -1,0 +1,9 @@
+-- Move Majordomo Executus Ragnaros summoning gossip chain to database
+-- Previously handled entirely in C++ script (sGossipHello/sGossipSelect)
+
+-- Add gossip_menu entries (MenuID -> TextID) for the gossip chain
+DELETE FROM `gossip_menu` WHERE `MenuID` IN (4093, 4108, 4109);
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES
+(4093, 4995),
+(4109, 5011),
+(4108, 5012);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_majordomo_executus.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_majordomo_executus.cpp
@@ -95,13 +95,7 @@ enum Events
 
 enum Misc
 {
-    TEXT_ID_SUMMON_1                        = 4995,
-    TEXT_ID_SUMMON_2                        = 5011,
-    TEXT_ID_SUMMON_3                        = 5012,
-
-    GOSSIP_ITEM_SUMMON_1                    = 4093,
-    GOSSIP_ITEM_SUMMON_2                    = 4109,
-    GOSSIP_ITEM_SUMMON_3                    = 4108,
+    MENU_ID_RAGNAROS_SUMMON                 = 4108,
 
     FACTION_MAJORDOMO_FRIENDLY              = 1080,
     SUMMON_GROUP_ADDS                       = 1,
@@ -507,48 +501,14 @@ struct boss_majordomo : public BossAI
         }
     }
 
-    void sGossipHello(Player* player) override
+    void sGossipSelect(Player* player, uint32 menuId, uint32 /*gossipListId*/) override
     {
-        ClearGossipMenuFor(player);
-        AddGossipItemFor(player, GOSSIP_ITEM_SUMMON_1, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF);
-        SendGossipMenuFor(player, TEXT_ID_SUMMON_1, me->GetGUID());
-    }
-
-    void sGossipSelect(Player* player, uint32 /*menuId*/, uint32 gossipListId) override
-    {
-        uint32 const action = player->PlayerTalkClass->GetGossipOptionAction(gossipListId);
-        ClearGossipMenuFor(player);
-        switch (action)
+        if (menuId == MENU_ID_RAGNAROS_SUMMON)
         {
-            case GOSSIP_ACTION_INFO_DEF:
-            {
-                AddGossipItemFor(player, GOSSIP_ITEM_SUMMON_2, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-                SendGossipMenuFor(player, TEXT_ID_SUMMON_2, me->GetGUID());
-                break;
-            }
-            case GOSSIP_ACTION_INFO_DEF+1:
-            {
-                AddGossipItemFor(player, GOSSIP_ITEM_SUMMON_2, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
-                SendGossipMenuFor(player, TEXT_ID_SUMMON_2, me->GetGUID());
-                break;
-            }
-            case GOSSIP_ACTION_INFO_DEF+2:
-            {
-                AddGossipItemFor(player, GOSSIP_ITEM_SUMMON_3, 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 3);
-                SendGossipMenuFor(player, TEXT_ID_SUMMON_3, me->GetGUID());
-                break;
-            }
-            case GOSSIP_ACTION_INFO_DEF+3:
-            {
-                CloseGossipMenuFor(player);
-                me->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
-                Talk(SAY_RAG_SUM_1, player);
-                DoAction(ACTION_START_RAGNAROS_INTRO);
-                break;
-            }
-            default:
-                CloseGossipMenuFor(player);
-                break;
+            CloseGossipMenuFor(player);
+            me->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
+            Talk(SAY_RAG_SUM_1, player);
+            DoAction(ACTION_START_RAGNAROS_INTRO);
         }
     }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code (Claude Opus 4.6)

## Description

Moves the Majordomo Executus Ragnaros-summoning gossip chain from hardcoded C++ (`sGossipHello`/`sGossipSelect`) to database-driven gossip using `gossip_menu` and `gossip_menu_option` tables.

**C++ changes:**
- Removed `sGossipHello` override entirely — the initial menu is now served by `creature_template.gossip_menu_id = 4093` and the DB gossip system
- Simplified `sGossipSelect` from ~40 lines to 8 — only intercepts the final click on menu 4108 to remove gossip flag, trigger `SAY_RAG_SUM_1`, and start the Ragnaros intro via `DoAction`
- Removed 6 unused enum values (`TEXT_ID_SUMMON_1/2/3`, `GOSSIP_ITEM_SUMMON_1/2/3`), replaced with single `MENU_ID_RAGNAROS_SUMMON`
- Also removed a duplicate gossip page that showed the same text/option twice consecutively

**SQL changes:**
- Added missing `gossip_menu` rows mapping MenuID to TextID: (4093, 4995), (4109, 5011), (4108, 5012)
- The `gossip_menu_option` entries and chain (4093 → 4109 → 4108) already existed in the DB but were unused

**Gossip chain:** 4093 ("Tell me more.") → 4109 ("What else do you have to say?") → 4108 ("You challenged us...") → script closes gossip and starts Ragnaros intro

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Defeat Majordomo Executus in Molten Core (kill all 8 adds)
2. After his defeat outro, find him near Ragnaros' lava pool
3. Interact with him — verify the 3-page gossip chain displays correctly with proper NPC text
4. Click through all options — verify Ragnaros summoning event starts after the final option
5. Verify gossip flag is removed after triggering the summon (cannot re-click)

## Known Issues and TODO List:

- [ ] None known

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.