### PR TITLE
fix(Core/Spells): Fix quest 11893 credit handler resolving totem owner

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5390,10 +5390,10 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                             {
                                 if (target->isDead() && GetBase() && target->IsCreature() && target->GetEntry() == 24601)
                                 {
-                                    auto caster2 = GetBase()->GetCaster();
-                                    if (caster2 && caster2->IsPlayer())
+                                    if (Unit* caster2 = GetBase()->GetCaster())
                                     {
-                                        caster2->ToPlayer()->KilledMonsterCredit(25987);
+                                        if (Player* player = caster2->GetCharmerOrOwnerPlayerOrPlayerItself())
+                                            player->KilledMonsterCredit(25987);
                                     }
                                 }
                                 return;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP

### Description

The quest credit handler for "The Power of the Elements" (11893) in `SpellAuraEffects.cpp` called `GetBase()->GetCaster()->IsPlayer()`, but the caster of aura 46374 is the Windsoul Totem creature (25987), not the player. Changed to `GetCharmerOrOwnerPlayerOrPlayerItself()` to resolve the totem's owner for kill credit.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9219

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.quest add 11893`
2. `.go xyz 4020.82 4606.51 -2.42 571` (near Steam Ragers, Borean Tundra)
3. Use Windsoul Totem item (35281) to plant the totem
4. Kill a Steam Rager within 30yd of the totem — quest credit should increment ("Energy collected")

## Known Issues and TODO List:

- [ ]