### PR TITLE
fix(Core/Unit): Skip evade aura removal for player-owned creatures

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5697,6 +5697,9 @@ void Unit::RemoveAllAurasExceptType(AuraType type)
 // Xinef: We should not remove passive auras on evade, if npc has player owner (scripted one cast auras)
 void Unit::RemoveEvadeAuras()
 {
+    if (IsCharmedOwnedByPlayerOrPlayer())
+        return;
+
     for (AuraApplicationMap::iterator iter = m_appliedAuras.begin(); iter != m_appliedAuras.end();)
     {
         Aura const* aura = iter->second->GetBase();


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

After the threat system port (#24715), player-charmed vehicles like the Oculus drakes now enter evade mode when their combat target dies. During evade, `RemoveEvadeAuras()` strips critical auras — including the Flight aura (59553) and Soar trigger (50325) — causing the drake to drop mid-air and players to fall through the floor.

The fix adds an early return in `RemoveEvadeAuras()` for player-owned/charmed creatures, matching TrinityCore's `RemoveAurasOnEvade()` behavior which skips aura removal entirely via `IsCharmedOwnedByPlayerOrPlayer()`.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with AzerothMCP

## Issues Addressed:
- Oculus drakes dropping players through the floor after killing Ley-Guardian Eregos

## SOURCE:
The changes have been validated through:
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**
  - TrinityCore `Unit::RemoveAurasOnEvade()` — early return for `IsCharmedOwnedByPlayerOrPlayer()`

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter The Oculus (instance 578)
2. Clear through to Ley-Guardian Eregos (final boss)
3. Mount a drake and engage Eregos
4. Kill Eregos — verify the drake stays airborne and you retain control
5. Dismount normally — verify you land on the platform correctly

## Known Issues and TODO List:

- [ ] Other player-charmed vehicles that enter evade should also benefit from this fix — regression testing recommended