### PR TITLE
fix(Scripts/VioletHold): Fix Ethereal Sphere speed in Xevozz encounter

### DIFF
--- a/src/server/scripts/Northrend/VioletHold/boss_xevozz.cpp
+++ b/src/server/scripts/Northrend/VioletHold/boss_xevozz.cpp
@@ -157,8 +157,7 @@ public:
         {
             if (pSummoned)
             {
-                pSummoned->GetMotionMaster()->MoveFollow(me, 0.0f, 0.0f);
-                pSummoned->RemoveUnitMovementFlag(MOVEMENTFLAG_WALKING);
+                pSummoned->GetMotionMaster()->MoveFollow(me, 0.0f, 0.0f, MOTION_SLOT_ACTIVE, true, false);
                 spheres.Summon(pSummoned);
                 if (pInstance)
                     pInstance->SetGuidData(DATA_ADD_TRASH_MOB, pSummoned->GetGUID());


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code was used for research and drafting.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25242

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Description

After #25085 (`fix(Core/Movement): followers match their target's motion speed`), `MoveFollow` defaults to `inheritSpeed=true`. This causes creature-to-creature follows to inherit the target's speed. The Ethereal Spheres summoned by Xevozz now inherit his run speed (1.71429) instead of using their own slow `speed_run` from `creature_template` (0.42857), making them ~4x faster than intended and impossible to kite.

The fix passes `inheritSpeed=false` to `MoveFollow` so spheres use their own `creature_template` speed.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.tele violet hold`
2. Start the instance and get Xevozz as a boss (or force via script edit)
3. Engage Xevozz, wait ~10s for Ethereal Sphere summon
4. Kite Xevozz away — spheres should move much slower than player run speed
5. Test on heroic — two spheres should spawn, both slow

## Known Issues and TODO List:

- [ ] Other encounters using `MoveFollow` for deliberately slow creatures may need the same `inheritSpeed=false` fix after #25085