### PR TITLE
fix(Core/Spells): Include absorbed damage in PROC_SPELL_TYPE_DAMAGE classification

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6768,7 +6768,7 @@ void Unit::ProcSkillsAndAuras(Unit* actor, Unit* victim, uint32 procAttacker, ui
         }
         else if (healInfo && healInfo->GetHeal())
             spellTypeMask = PROC_SPELL_TYPE_HEAL;
-        else if (damageInfo && damageInfo->GetDamage())
+        else if (damageInfo && (damageInfo->GetDamage() || damageInfo->GetAbsorb()))
             spellTypeMask = PROC_SPELL_TYPE_DAMAGE;
         else if (procSpellInfo)
             spellTypeMask = PROC_SPELL_TYPE_NO_DMG_HEAL;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code was used for research and drafting.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25116

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**
  - Based on TrinityCore's approach in `Spell.cpp` where `procSpellType` is determined before absorbs are applied (`spell->m_damage > 0` at line 2577), ensuring absorbed damage is classified as `PROC_SPELL_TYPE_DAMAGE`.

## Description

### Problem

In `Unit::ProcDamageAndSpellFor`, `spellTypeMask` is determined **after** absorbs:

```cpp
else if (damageInfo && damageInfo->GetDamage())
    spellTypeMask = PROC_SPELL_TYPE_DAMAGE;
```

When damage is fully absorbed, `GetDamage()` returns 0, so the type becomes `PROC_SPELL_TYPE_NO_DMG_HEAL`. This causes `spell_proc` entries with `SpellTypeMask = PROC_SPELL_TYPE_DAMAGE` to fail matching.

In TrinityCore, `procSpellType` is set in `Spell.cpp` based on `spell->m_damage > 0` **before** absorbs are applied, so absorbed hits are correctly classified as `DAMAGE`.

### Specific bug

ICC Kinetic Bomb has spell 72059 (Unstable) with `SPELL_AURA_PROC_TRIGGER_SPELL` → triggers 72087 (Kinetic Bomb Knockback). The `spell_proc` entry (identical in both AC and TC) has `SpellTypeMask = 1 (PROC_SPELL_TYPE_DAMAGE)`. Since the bomb's absorb aura (72054) absorbs 100% of damage, spell attacks result in `GetDamage() == 0`, the type becomes `NO_DMG_HEAL`, and the proc never fires. Melee auto-attacks bypass the `SpellTypeMask` check entirely (not in `SPELL_PROC_FLAG_MASK`), which is why melee still works.

### Fix

Also check `GetAbsorb()` when determining `spellTypeMask`:
```cpp
else if (damageInfo && (damageInfo->GetDamage() || damageInfo->GetAbsorb()))
    spellTypeMask = PROC_SPELL_TYPE_DAMAGE;
```

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go xyz 4660.49 2769.20 364.83 631` (Blood Prince Council in ICC)
2. Engage Prince Valanar, wait for Kinetic Bomb to spawn
3. Attack the Kinetic Bomb with **ranged spells** — it should bounce upward
4. Verify melee attacks still work as well
5. Test on 25-man

### Regression testing

Since this changes generic proc type classification, also verify:
- Absorb shields (e.g. Power Word: Shield) don't cause unintended procs
- Stealth is not broken by fully absorbed damage (separate mechanic via aura interrupt flags)
- General proc behavior remains correct for normal (non-absorbed) damage

## Known Issues and TODO List:

- [ ] Other proc trigger spells on creatures with full absorb auras may also benefit from this fix