### PR TITLE
fix(Core/Scripts): Fix Valithria Dreamwalker encounter and default JustExitedCombat

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -309,12 +309,8 @@ void CreatureAI::EngagementOver()
 
 void CreatureAI::JustExitedCombat()
 {
-    EngagementOver();
-
-    // If creature is alive, in world, and not already evading, trigger evade to return home
-    // Check IsInWorld to avoid evade during server shutdown/cleanup
-    if (me->IsAlive() && me->IsInWorld() && !me->IsInEvadeMode())
-        EnterEvadeMode(EVADE_REASON_NO_HOSTILES);
+    // Creatures evade through UpdateVictim() detecting out-of-combat state.
+    // Scripts that need custom combat-exit behavior should override this.
 }
 
 /*void CreatureAI::AttackedBy(Unit* attacker)

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
@@ -341,18 +341,12 @@ public:
                 _done = true;
                 Talk(SAY_VALITHRIA_SUCCESS);
                 _instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);
-                _instance->DoRemoveAurasDueToSpellOnPlayers(70766);
                 me->RemoveAurasDueToSpell(SPELL_CORRUPTION_VALITHRIA);
                 me->CastSpell(me, SPELL_ACHIEVEMENT_CHECK, true);
                 me->CastSpell((Unit*)nullptr, SPELL_DREAMWALKERS_RAGE, false);
-                _events.Reset();
                 _events.ScheduleEvent(EVENT_DREAM_SLIP, 3500ms);
-                _instance->SetBossState(DATA_VALITHRIA_DREAMWALKER, DONE);
-
-                if (Creature* trigger = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_VALITHRIA_TRIGGER)))
-                    trigger->AI()->EnterEvadeMode();
                 if (Creature* lichKing = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_VALITHRIA_LICH_KING)))
-                    lichKing->AI()->Reset();
+                    lichKing->AI()->EnterEvadeMode();
             }
             else if (!_over75PercentTalkDone && me->HealthAbovePctHealed(75, heal))
             {
@@ -361,11 +355,8 @@ public:
             }
             else if (_instance->GetBossState(DATA_VALITHRIA_DREAMWALKER) == NOT_STARTED)
             {
-                if (Creature* trigger = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_VALITHRIA_TRIGGER)))
-                {
-                    trigger->AI()->DoAction(ACTION_ENTER_COMBAT);
-                    _instance->SetBossState(DATA_VALITHRIA_DREAMWALKER, IN_PROGRESS);
-                }
+                if (Creature* archmage = me->FindNearestCreature(NPC_RISEN_ARCHMAGE, 30.0f))
+                    DoZoneInCombat(archmage); // archmage chain will put trigger in combat
             }
         }
 
@@ -388,7 +379,7 @@ public:
                         Talk(SAY_VALITHRIA_DEATH);
                         _instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);
                         if (Creature* trigger = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_VALITHRIA_TRIGGER)))
-                            trigger->AI()->EnterEvadeMode();
+                            trigger->AI()->DoAction(ACTION_DEATH);
                     }
                 }
             }
@@ -404,6 +395,8 @@ public:
                 me->SetDisplayId(11686);
                 me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
                 me->DespawnOrUnsummon(4s);
+                if (Creature* trigger = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_VALITHRIA_TRIGGER)))
+                    Unit::Kill(me, trigger);
                 if (Creature* lichKing = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_VALITHRIA_LICH_KING)))
                     lichKing->CastSpell(lichKing, SPELL_SPAWN_CHEST, false);
                 _instance->SetData(DATA_WEEKLY_QUEST_ID, 0); // show hidden npc if necessary
@@ -434,13 +427,8 @@ public:
         void UpdateAI(uint32 diff) override
         {
             // does not enter combat
-            if (_instance->GetBossState(DATA_VALITHRIA_DREAMWALKER) == NOT_STARTED)
-            {
-                uint32 startingHealth = me->GetMaxHealth() * 0.5f;
-                if (me->GetHealth() != startingHealth) // healing when boss cannot be engaged (lower spire not finished, cheating) doesn't start the fight, prevent winning this way
-                    me->SetHealth(startingHealth);
+            if (_instance->GetBossState(DATA_VALITHRIA_DREAMWALKER) != IN_PROGRESS)
                 return;
-            }
 
             _events.Update(diff);
 
@@ -544,11 +532,6 @@ public:
 
         void MoveInLineOfSight(Unit* /*who*/) override {}
 
-        bool CanAIAttack(Unit const* target) const override
-        {
-            return target->IsPlayer();
-        }
-
         void JustExitedCombat() override
         {
             EngagementOver();
@@ -556,6 +539,8 @@ public:
             me->setActive(false);
 
             if (!me->IsAlive())
+                return;
+            if (instance->GetBossState(DATA_VALITHRIA_DREAMWALKER) == DONE)
                 return;
             DoAction(ACTION_DEATH);
         }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code with azerothMCP were used to research TrinityCore reference implementations, diagnose root causes, and implement fixes.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25298

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**
  - TrinityCore's `boss_valithria_dreamwalker.cpp` used as reference for the encounter flow.

## Description

### Core: `CreatureAI::JustExitedCombat` no-op (matching TrinityCore)

The threat system port (#24715) added `EngagementOver()` + `EnterEvadeMode()` to the default `CreatureAI::JustExitedCombat`. This is redundant — creatures already evade through `UpdateVictim()` detecting out-of-combat state (line 368-371 in CreatureAI.cpp). The blanket override caused passive creatures like Valithria Dreamwalker to reset when NPCs attacking them (Suppressors) died, since they never call `UpdateVictim()` but still exit combat.

In TrinityCore, `UnitAI::JustExitedCombat` is a no-op. Scripts that need custom combat-exit behavior (like `npc_green_dragon_combat_trigger`) explicitly override it.

### Valithria script fixes (ported from TrinityCore)

Multiple divergences from TC caused the encounter to break after the threat system port:

1. **HealReceived success path**: AC called `trigger->EnterEvadeMode()` + `SetBossState(DONE)` which cascaded to the trigger's `JustExitedCombat` → `ACTION_DEATH` → `SetBossState(NOT_STARTED)`, resetting everything. TC only evades the Lich King and lets `SpellHit(DREAM_SLIP)` handle completion.

2. **SpellHit(DREAM_SLIP)**: AC didn't kill the trigger. TC calls `Unit::Kill(me, trigger)` which prevents `JustExitedCombat` from triggering wipe logic (the `!me->IsAlive()` check returns early).

3. **HealReceived encounter start**: AC called `trigger->DoAction(ACTION_ENTER_COMBAT)` but the trigger's `DoAction` only handles `ACTION_DEATH` — silently ignored. TC uses `DoZoneInCombat(archmage)` which chains through the archmage's `JustEnteredCombat` to properly put the trigger in combat.

4. **DamageTaken death path**: AC called `trigger->EnterEvadeMode()`. TC calls `trigger->DoAction(ACTION_DEATH)`.

5. **Trigger CanAIAttack**: AC restricted to players only, causing the trigger to reject non-player threat refs. TC doesn't have this restriction.

6. **UpdateAI health guard**: AC checked `== NOT_STARTED` (reset health to 50%). TC checks `!= IN_PROGRESS` (simply returns).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Valithria Dreamwalker:**
1. Enter ICC, start the Valithria encounter
2. Heal Valithria to full HP
3. Verify: explosion kills adds, Dream Slip casts, chest spawns, encounter completes
4. Verify she does NOT reset to spawn position after being healed

**Regression testing (core change):**
The `JustExitedCombat` core change affects all creatures. However:
- Creatures that call `UpdateVictim()` (standard mobs, bosses) are unaffected — they evade through that path
- Only 9 scripts override `JustExitedCombat` across the entire codebase — all have their own `EngagementOver()` calls
- The `_isEngaged` flag is properly cleared through `_EnterEvadeMode()` → `EngagementOver()` in the evade path

## Known Issues and TODO List:

- [ ] Verify other encounters with passive/friendly NPCs that get attacked by hostile NPCs still work correctly