### PR TITLE
fix(Core/Scripts): Fix Ragnaros combat evade after Wrath of Ragnaros knockback

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_ragnaros.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_ragnaros.cpp
@@ -117,7 +117,6 @@ struct boss_ragnaros : public BossAI
     boss_ragnaros(Creature* creature) : BossAI(creature, DATA_RAGNAROS),
         _isIntroDone(false),
         _hasYelledMagmaBurst(false),
-        _processingMagmaBurst(false),
         _hasSubmergedOnce(false),
         _isKnockbackEmoteAllowed(true)
     {
@@ -140,7 +139,6 @@ struct boss_ragnaros : public BossAI
         }
 
         _hasYelledMagmaBurst = false;
-        _processingMagmaBurst = false;
         _hasSubmergedOnce = false;
         _isKnockbackEmoteAllowed = true;
         me->SetUInt32Value(UNIT_NPC_EMOTESTATE, 0);
@@ -218,29 +216,6 @@ struct boss_ragnaros : public BossAI
             DoStartNoMovement(target);
     }
 
-    void EnterEvadeMode(EvadeReason why) override
-    {
-        if (!me->GetThreatMgr().IsThreatListEmpty())
-        {
-            if (!_processingMagmaBurst)
-            {
-                // Boss try to evade, but still got some targets on threat list - it means that none of these targets are in melee range - cast magma blast
-                _processingMagmaBurst = true;
-                events.ScheduleEvent(EVENT_MAGMA_BLAST, 4s, PHASE_EMERGED, PHASE_EMERGED);
-            }
-        }
-        else
-        {
-            BossAI::EnterEvadeMode(why);
-        }
-    }
-
-    bool CanAIAttack(Unit const* victim) const override
-    {
-        // Used for Magma Blast handling to force EnterEvadeMode if there are no melee targets
-        return me->IsWithinMeleeRange(victim);
-    }
-
     void UpdateAI(uint32 diff) override
     {
         if (!extraEvents.Empty())
@@ -307,10 +282,7 @@ struct boss_ragnaros : public BossAI
         }
 
         if (!UpdateVictim())
-        {
-            if (!_processingMagmaBurst)
-                return;
-        }
+            return;
 
         events.Update(diff);
 
@@ -350,8 +322,6 @@ struct boss_ragnaros : public BossAI
                 }
                 case EVENT_MAGMA_BLAST:
                 {
-                    _processingMagmaBurst = false;
-
                     if (!IsVictimWithinMeleeRange())
                     {
                         DoCastRandomTarget(SPELL_MAGMA_BLAST);
@@ -362,7 +332,7 @@ struct boss_ragnaros : public BossAI
                             _hasYelledMagmaBurst = true;
                         }
                     }
-
+                    events.Repeat(4s);
                     break;
                 }
                 case EVENT_MIGHT_OF_RAGNAROS:
@@ -419,7 +389,6 @@ private:
     EventMap extraEvents;
     bool _isIntroDone;
     bool _hasYelledMagmaBurst;
-    bool _processingMagmaBurst;
     bool _hasSubmergedOnce;
     bool _isKnockbackEmoteAllowed;  // Prevents possible text overlap
 
@@ -452,6 +421,7 @@ private:
         events.RescheduleEvent(EVENT_WRATH_OF_RAGNAROS, 30s, PHASE_EMERGED, PHASE_EMERGED);
         events.RescheduleEvent(EVENT_HAND_OF_RAGNAROS, 25s, PHASE_EMERGED, PHASE_EMERGED);
         events.RescheduleEvent(EVENT_LAVA_BURST, 10s, PHASE_EMERGED, PHASE_EMERGED);
+        events.RescheduleEvent(EVENT_MAGMA_BLAST, 4s, PHASE_EMERGED, PHASE_EMERGED);
         events.RescheduleEvent(EVENT_SUBMERGE, 180s, PHASE_EMERGED, PHASE_EMERGED);
         events.RescheduleEvent(EVENT_MIGHT_OF_RAGNAROS, 11s, PHASE_EMERGED, PHASE_EMERGED);
     }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with AzerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9225
- Closes https://github.com/chromiecraft/chromiecraft/issues/9226

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**
  - Adapted from TrinityCore's Ragnaros script (offl's rewrite in TrinityCore#31549)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go xyz 838.31 -831.47 -232.19 409`
2. `.instance setbossstate 8 3`
3. `.npc add temp 12018`
4. `.npc set faction 1080`
5. `.npc set flag 1`
6. Talk to Majordomo to trigger Ragnaros summon
7. Engage Ragnaros in melee
8. Wait for **Wrath of Ragnaros** (spell 20566) to knockback all players out of melee range
9. **Before fix**: Ragnaros evades and resets the encounter
10. **After fix**: Ragnaros stays in combat and casts **Magma Blast** (spell 20565) on random targets until players re-enter melee range

## Known Issues and TODO List:

- [ ] Verify submerge/emerge cycle still functions correctly after the timer changes
- [ ] Verify Magma Blast does not fire when a player is in melee range

## Description

The old Ragnaros script used `CanAIAttack` to restrict valid targets to melee range, then intercepted `EnterEvadeMode` to cast Magma Blast when no melee targets existed. This design became incompatible with the new threat system port, which uses `CanAIAttack` to determine threat entry online/offline status. When all players were knocked back:

1. `CanAIAttack` returned false for everyone → all threat entries marked offline
2. `IsThreatListEmpty()` (default: excludes offline) returned true → Ragnaros fully evaded
3. Even with a fix to include offline entries, `SelectTarget`/`DoCastRandomTarget` skipped offline entries → Magma Blast couldn't find targets

The fix adapts TrinityCore's approach: Magma Blast is now a regular repeating event (4s) that checks `IsWithinMeleeRange` before casting. `CanAIAttack` and the custom `EnterEvadeMode` are removed entirely, so the threat system operates normally.