### PR TITLE
fix(Core/Movement): restore JustExitedCombat evade to fix waypoint resume

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -309,8 +309,12 @@ void CreatureAI::EngagementOver()
 
 void CreatureAI::JustExitedCombat()
 {
-    // Creatures evade through UpdateVictim() detecting out-of-combat state.
-    // Scripts that need custom combat-exit behavior should override this.
+    EngagementOver();
+
+    // If creature is alive, in world, and not already evading, trigger evade to return home
+    // Check IsInWorld to avoid evade during server shutdown/cleanup
+    if (me->IsAlive() && me->IsInWorld() && !me->IsInEvadeMode())
+        EnterEvadeMode(EVADE_REASON_NO_HOSTILES);
 }
 
 /*void CreatureAI::AttackedBy(Unit* attacker)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Opus 4.6 was used to diagnose the regression and prepare the fix.

## Issues Addressed:
- Creatures fail to resume waypoint movement after evade — they stutter in place instead of cleanly returning home.
- Regression introduced in 037588ed0 (#25315), which emptied `CreatureAI::JustExitedCombat()`.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

This restores the code that was removed in 037588ed0. The original logic was correct — `JustExitedCombat()` must call `EngagementOver()` to clear the `_isEngaged` flag and then `EnterEvadeMode()` to trigger `MoveTargetedHome()`. Without this, `_isEngaged` remains stale after `CombatManager` purges combat refs, causing `UpdateVictim()` to still enter the engaged path. `SelectVictim()` eventually triggers evade from within the threat resolution path, but by then the AI's own `UpdateAI` is already issuing conflicting movement commands, resulting in stuttering.

The Valithria trigger script (`boss_valithria_dreamwalker.cpp`) already overrides `JustExitedCombat()` with its own logic, so it is unaffected by this restore.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Find any creature with waypoint movement (e.g. patrolling NPCs in Elwynn Forest or Stormwind guards).
2. Engage the creature in combat, then leave its chase/evade range.
3. Observe that the creature cleanly returns to its spawn point and resumes its waypoint path without stuttering.
4. Test the Valithria Dreamwalker encounter in ICC to verify no regression from #25315.

## Known Issues and TODO List:

- [ ] Verify Valithria Dreamwalker encounter still functions correctly after this change.
- [ ] Regression test other creatures that override `JustExitedCombat()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)