### PR TITLE
fix(Scripts/Karazhan): Fix Moroes resetting during Vanish

### DIFF
--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_moroes.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_moroes.cpp
@@ -149,7 +149,7 @@ struct boss_moroes : public BossAI
             _vanished = true;
             Talk(SAY_SPECIAL);
             DoCastSelf(SPELL_VANISH);
-            me->SetImmuneToAll(true);
+            me->SetImmuneToAll(true, true);
             scheduler.Schedule(5s, 7s, [this](TaskContext)
             {
                 me->SetImmuneToAll(false);


### PR DESCRIPTION
## Changes Proposed
- Pass `keepCombat = true` to `SetImmuneToAll()` when Moroes enters Vanish phase, preventing the boss from evading due to lost threat while immune.

## Issues Addressed
Moroes resets when he goes into Vanish. Setting immune without `keepCombat` causes him to drop out of combat, triggering an evade.

## Tests Performed
<!-- Describe any tests you have performed -->

## How to Test the Changes
1. Engage Moroes in Karazhan
2. Wait for Vanish phase (~30s into fight)
3. Verify he does not reset/evade and resumes attacking after Vanish ends

## Known Issues and TODO
- [ ] None

## AI-Assisted Development Disclosure
Generated with the assistance of Claude (Anthropic)