### PR TITLE
fix(Core/SmartAI): Fix Scarlet Monastery Cathedral encounter reset

### DIFF
--- a/data/sql/updates/pending_db_world/rev_fix_scarlet_monastery_evade.sql
+++ b/data/sql/updates/pending_db_world/rev_fix_scarlet_monastery_evade.sql
@@ -1,0 +1,30 @@
+-- Fix Scarlet Monastery Cathedral Mograine/Whitemane encounter resetting during scripted phase
+-- Disable evade during the scripted "fake death" / "Deep Sleep" / "resurrection" phase
+-- to prevent JustExitedCombat auto-evade from triggering SMART_EVENT_EVADE and setting FAIL
+
+-- Mograine: Disable evade when fake-dying (actionlist 397600)
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 397600 AND `source_type` = 9 AND `id` = 10;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(397600, 9, 10, 0, 0, 0, 100, 0, 0, 0, 0, 0, 117, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Scarlet Commander Mograine - Actionlist - Disable Evade');
+
+-- Mograine: Re-enable evade when reaching Whitemane after resurrection (On Reached Point 1 chain)
+-- Update id 24 to link to new id 29
+UPDATE `smart_scripts` SET `link` = 29 WHERE `entryorguid` = 3976 AND `source_type` = 0 AND `id` = 24;
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 3976 AND `source_type` = 0 AND `id` = 29;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(3976, 0, 29, 0, 61, 0, 100, 0, 0, 0, 0, 0, 117, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Scarlet Commander Mograine - On Reached Point 1 - Enable Evade');
+
+-- Whitemane: Disable evade when casting Deep Sleep (actionlist 397700)
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 397700 AND `source_type` = 9 AND `id` = 5;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(397700, 9, 5, 0, 0, 0, 100, 0, 0, 0, 0, 0, 117, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'High Inquisitor Whitemane - Actionlist - Disable Evade');
+
+-- Whitemane: Re-enable evade when re-engaging after resurrection (actionlist 397701)
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 397701 AND `source_type` = 9 AND `id` = 8;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(397701, 9, 8, 0, 0, 0, 100, 0, 0, 0, 0, 0, 117, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'High Inquisitor Whitemane - Actionlist - Enable Evade');

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -697,6 +697,20 @@ void SmartAI::MovementInform(uint32 MovementType, uint32 Data)
         MovepointReached(Data);
 }
 
+void SmartAI::JustExitedCombat()
+{
+    // When evade is suppressed or disabled, don't auto-evade on combat exit.
+    // This prevents scripted encounters (e.g. Mograine/Whitemane) from resetting
+    // when bosses temporarily stop fighting during scripted phases.
+    if (mSuppressEvade || mEvadeDisabled)
+    {
+        EngagementOver();
+        return;
+    }
+
+    CreatureAI::JustExitedCombat();
+}
+
 void SmartAI::EnterEvadeMode(EvadeReason /*why*/)
 {
     if (mSuppressEvade)

--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -85,6 +85,9 @@ public:
     // Called for reaction at enter to combat if not in combat yet (enemy can be nullptr)
     void JustEngagedWith(Unit* enemy) override;
 
+    // Called when creature exits combat (all combat refs gone)
+    void JustExitedCombat() override;
+
     // Called for reaction at stopping attack at no attackers or targets
     void EnterEvadeMode(EvadeReason why = EVADE_REASON_OTHER) override;
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.6 was used to investigate the issue and implement the fix.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25324

## Summary

After the threat system port (984baa92d), `CreatureAI::JustExitedCombat()` auto-evades when all combat references are dropped. SmartAI did not override this method, so there was no way for SAI scripts to prevent the auto-evade during scripted encounter phases (unlike `EnterEvadeMode()` which already respects `mSuppressEvade`/`mEvadeDisabled`).

During the Mograine/Whitemane encounter, when both bosses enter the scripted resurrection phase (REACT_PASSIVE + Deep Sleep on all players), if combat references are lost, `JustExitedCombat()` triggers `EnterEvadeMode()`, which fires `SMART_EVENT_EVADE`, setting the instance data to FAIL and despawning both bosses.

### Core Fix
- Override `JustExitedCombat()` in SmartAI to check `mSuppressEvade` and `mEvadeDisabled`
- When either flag is set, only call `EngagementOver()` without auto-evading
- Otherwise fall through to `CreatureAI::JustExitedCombat()` (no change for existing encounters)

### Database Fix
- Add `SMART_ACTION_DISABLE_EVADE(1)` to Mograine's fake-death actionlist (397600) and Whitemane's Deep Sleep actionlist (397700)
- Re-enable evade when bosses go REACT_AGGRESSIVE: Mograine on Reached Point 1, Whitemane in resurrection actionlist (397701)

This follows the same pattern as the Moroes Vanish fix (e144326f0) — protecting scripted phases from combat system resets.

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

The encounter behavior is well-documented on Wowhead and other classic WoW databases. The expected flow is: Mograine fake-dies → Whitemane casts Deep Sleep → resurrects Mograine → both resume fighting.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Scarlet Monastery Cathedral instance
2. Pull and fight Scarlet Commander Mograine until he reaches 1% HP and "dies"
3. High Inquisitor Whitemane emerges, fight her to 50% HP
4. Whitemane casts Deep Sleep on all players and begins the resurrection sequence
5. Verify that both bosses remain in the encounter and do NOT despawn/reset
6. After Deep Sleep wears off and Mograine is resurrected, verify both bosses resume fighting
7. Kill both bosses and verify the encounter completes normally

## Known Issues and TODO List:

- [ ] Verify no regression with other SmartAI encounters that use `mEvadeDisabled`
- [ ] Test with multiple party sizes (solo, duo, full group)

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.