### PR TITLE
fix(Scripts/UtgardePinnacle): Fix Skadi Poisoned Spear not applying DOT in Heroic

### DIFF
--- a/data/sql/updates/pending_db_world/fix_skadi_poisoned_spear_heroic.sql
+++ b/data/sql/updates/pending_db_world/fix_skadi_poisoned_spear_heroic.sql
@@ -1,0 +1,5 @@
+-- Fix Skadi Poisoned Spear not applying periodic DOT in Heroic mode.
+-- Spell 59331 is the heroic variant of 50255 (mapped via spelldifficulty_dbc),
+-- but the spell script was only registered for the normal version.
+DELETE FROM `spell_script_names` WHERE `spell_id` = 59331 AND `ScriptName` = 'spell_skadi_poisoned_spear';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (59331, 'spell_skadi_poisoned_spear');

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
@@ -533,7 +533,7 @@ class spell_skadi_launch_harpoon : public SpellScript
     }
 };
 
-// 50255 - Poisoned Spear
+// 50255, 59331 - Poisoned Spear
 class spell_skadi_poisoned_spear : public SpellScript
 {
     PrepareSpellScript(spell_skadi_poisoned_spear);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Opus 4.6** was used for investigation and fix authoring.

## Issues Addressed:

Skadi's Poisoned Spear does not apply its periodic DOT in Heroic Utgarde Pinnacle.

**Root cause:** The `spell_skadi_poisoned_spear` script was only registered in `spell_script_names` for the normal spell ID (50255). In Heroic mode, the core remaps the spell to 59331 via `spelldifficulty_dbc`, but since no script was registered for 59331, the `HandleScript` hook never fired and the periodic DOT (59334) was never applied. The spear dealt its initial hit but no DOT.

**Fix:**
- Added `spell_script_names` entry for Heroic variant 59331 → `spell_skadi_poisoned_spear`
- Updated C++ comment to document both difficulty variants (`// 50255, 59331`), matching TrinityCore convention

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

TrinityCore registers `spell_skadi_poisoned_spear` for both 50255 and 59331 in their `spell_script_names` table. Their `boss_skadi.cpp` documents this with the comment `// 50255, 59331 - Poisoned Spear`.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Heroic Utgarde Pinnacle and engage Skadi the Ruthless
2. Reach ground phase (Phase 2) by killing Grauf with harpoons
3. Wait for Skadi to cast Poisoned Spear on a random player
4. Verify that the target receives the periodic Nature damage DOT (spell 59334) in addition to the initial hit damage

## Known Issues and TODO List:

- [ ] Normal mode should also be verified to ensure no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)