### PR TITLE
fix(Scripts/Sartharion): randomize Flame Tsunami wave direction

### DIFF
--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
@@ -136,7 +136,7 @@ enum Misc
     // Movement points
     POINT_LANDING                               = 1,
 
-    // Lava directions. Its used to identify to which side lava was moving by last time
+    // Lava directions
     LAVA_LEFT_SIDE                              = 0,
     LAVA_RIGHT_SIDE                             = 1,
 
@@ -307,7 +307,6 @@ struct boss_sartharion : public BossAI
 {
     explicit boss_sartharion(Creature* creature) : BossAI(creature, DATA_SARTHARION),
         dragonsCount(0),
-        lastLavaSide(LAVA_RIGHT_SIDE),
         usedBerserk(false),
         below11PctReached(false)
     {
@@ -628,8 +627,8 @@ private:
         extraEvents.ScheduleEvent(EVENT_SARTHARION_START_LAVA, 3600ms);
         extraEvents.ScheduleEvent(EVENT_SARTHARION_FINISH_LAVA, 11s);
 
-        // Send wave from left
-        if (lastLavaSide == LAVA_RIGHT_SIDE)
+        // Randomly choose which side the wave comes from
+        if (urand(LAVA_LEFT_SIDE, LAVA_RIGHT_SIDE) == LAVA_LEFT_SIDE)
         {
             for (uint8 i = 0; i < MAX_LEFT_LAVA_TSUNAMIS; ++i)
             {
@@ -638,10 +637,7 @@ private:
                 if (((i - 1) % 3 == 0) && tsunami) // If center of wave
                     tsunami->CastSpell(tsunami, SPELL_FLAME_TSUNAMI_VISUAL, true);
             }
-
-            lastLavaSide = LAVA_LEFT_SIDE;
         }
-        // from right
         else
         {
             for (uint8 i = 0; i < MAX_RIGHT_LAVA_TSUNAMIS; ++i)
@@ -651,8 +647,6 @@ private:
                 if (((i - 1) % 3 == 0) && tsunami) // If center of wave
                     tsunami->CastSpell(tsunami, SPELL_FLAME_TSUNAMI_VISUAL, true);
             }
-
-            lastLavaSide = LAVA_RIGHT_SIDE;
         }
     }
 
@@ -683,7 +677,6 @@ private:
     EventMap extraEvents;
     std::list<uint32> volcanoBlows;
     uint8 dragonsCount;
-    uint8 lastLavaSide; // 0 = left, 1 = right
     bool usedBerserk;
     bool below11PctReached;
 };


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Flame Tsunami waves in the Sartharion encounter were hardscripted to always alternate left→right→left→right. On retail, the side the wave spawns from is random.

This replaces the deterministic alternation (`lastLavaSide` state) with a random roll (`urand`) each wave, so waves can now come from either side unpredictably.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code (Claude Opus 4.6) was used.

## Issues Addressed:

- Closes https://github.com/chromiecraft/chromiecraft/issues/9220

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Source: https://www.wowhead.com/wotlk/guide/raids/obsidian-sanctum/sartharion-strategy
> "Flame Tsunami... These can spawn on the left and move right, or spawn on the right and move left."

Video reference: https://youtu.be/jE-eGGBm51s?si=2y0cVCXv3twt30ri&t=119

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Obsidian Sanctum and engage Sartharion
2. Observe multiple Flame Tsunami waves
3. Verify waves spawn from both left and right sides randomly, rather than strictly alternating

## Known Issues and TODO List:

- [ ] Gap/pattern randomization is not addressed in this PR — the left and right wave patterns still use fixed Y-offsets. This could be a separate enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)