### PR TITLE
fix(DB/SAI): fix Phantasmal Water repeated casts never firing

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1775396325178598900.sql
+++ b/data/sql/updates/pending_db_world/rev_1775396325178598900.sql
@@ -1,0 +1,1 @@
+UPDATE `smart_scripts` SET `event_phase_mask` = 0 WHERE `entryorguid` = 27653 AND `id` IN (2, 3);


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Phantasmal Water (27653) in The Oculus would cast Water Bolt Volley once on aggro and then stand idle for the rest of the encounter.

The `SMART_EVENT_AREA_RANGE` events (SAI rows 2 and 3) had `event_phase_mask = 1`, requiring SmartAI phase 1 to fire. However, no SAI action ever sets the creature's SmartAI phase — it stays at the default of 0. `SmartScript::IsInPhase()` returns `false` when `mEventPhase == 0`, so the repeated cast events were permanently skipped.

The fix sets `event_phase_mask` to `0` (all phases) so the events fire normally. The `SMARTCAST_COMBAT_MOVE` flag (64) already present on these rows handles the ranged caster behavior (stand at range, chase on OOM/out of range).

TrinityCore's implementation uses 15 SAI rows with linked events that increment the phase after aggro, making the phase gate work. AzerothCore's simplified 4-row version dropped the linked phase-increment events but kept the phase mask requirement, breaking the repeated casts.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (claude-opus-4-6) was used during analysis and fix preparation.

## Issues Addressed:

N/A

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

TrinityCore's SAI for this creature was used as reference. Their implementation uses linked events to set SmartAI phase 1 after aggro, confirming the phase gate was intentional but the phase-setting mechanism was lost during AzerothCore's SAI simplification.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter The Oculus (normal or heroic).
2. Engage Mage-Lord Urom on the first platform (elementals group).
3. Observe the Phantasmal Water — it should repeatedly cast Water Bolt Volley every ~3.4-4.8 seconds, not just once on aggro.
4. Verify the creature stands at range and does not just melee chase.

## Known Issues and TODO List:

- [ ] The heroic version (creature 30913) has no SAI of its own and no `AIName` set — it may have separate issues, but that is outside the scope of this fix.