### PR TITLE
fix(Core/Vehicle): Exit vehicle on reconnect to prevent stuck state

### DIFF
--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -1130,6 +1130,13 @@ void WorldSession::HandlePlayerLoginToCharInWorld(Player* pCurrChar)
     ChatHandler chH = ChatHandler(this);
     m_playerLoading = true;
 
+    // Exit vehicle on reconnect - the client has fully reset so
+    // the player can no longer control the vehicle. Without this
+    // the player is stuck: server-side still seated, but the
+    // client has no vehicle UI or movement control.
+    if (pCurrChar->GetVehicle())
+        pCurrChar->ExitVehicle();
+
     pCurrChar->SendDungeonDifficulty(false);
 
     WorldPacket data(SMSG_LOGIN_VERIFY_WORLD, 20);


### PR DESCRIPTION
## Summary
- When `CONFIG_ENABLE_LOGIN_AFTER_DC` is enabled, the player object stays in-world during a disconnect. On reconnect, `HandlePlayerLoginToCharInWorld` transfers the player to the new session but never exits the vehicle. The client has fully reset and has no vehicle UI, leaving the player stuck: unable to move or exit.
- Adds a vehicle exit check at the start of `HandlePlayerLoginToCharInWorld` so the player is cleanly removed from the vehicle before the reconnect login packets are sent.

## How to reproduce
1. Enter a vehicle (e.g. demolisher in Strand of the Ancients)
2. Disconnect from the game
3. Log back in while `CONFIG_ENABLE_LOGIN_AFTER_DC` is enabled
4. Player appears stuck: has Ride Vehicle aura but cannot move or exit

## Root cause
- `LogoutPlayer()` is never called on the old session during reconnect — the player object is simply transferred
- `ExitVehicle()` (which normally runs via `RemoveFromWorld()`) is therefore never called
- The vehicle retains the `SPELL_AURA_CONTROL_VEHICLE` aura with the player as caster
- The client has no vehicle state, so the player is stuck with no movement or exit controls

## Changes
- `CharacterHandler.cpp`: Call `ExitVehicle()` at the start of `HandlePlayerLoginToCharInWorld` if the player is in a vehicle

## Test plan
- [ ] Enter a vehicle in a battleground (e.g. demolisher in SotA)
- [ ] Disconnect while in the vehicle
- [ ] Reconnect — player should be placed near the vehicle, free to move
- [ ] Verify normal vehicle enter/exit still works after the change
- [ ] Verify normal login (non-reconnect) is unaffected

Closes https://github.com/chromiecraft/chromiecraft/issues/9254

🤖 Generated with [Claude Code](https://claude.com/claude-code)