### PR TITLE
fix(Scripts/Magtheridon): update scheduler before UpdateVictim check

### DIFF
--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
@@ -242,10 +242,11 @@ struct boss_magtheridon : public BossAI
 
     void UpdateAI(uint32 diff) override
     {
+        scheduler.Update(diff);
+
         if (!UpdateVictim())
             return;
 
-        scheduler.Update(diff);
         _interruptScheduler.Update(diff);
 
         if (_currentPhase != 1 && !_castingQuake)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Opus 4.6 was used for analysis and code assistance.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25375

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Magtheridon's Lair
2. Kill all 5 Hellfire Channelers without directly engaging Magtheridon
3. Observe that Magtheridon properly releases: becomes selectable/attackable, enters combat, and closes instance doors

## Known Issues and TODO List:

- [ ] Channelers registered as minions will respawn if `SetBossState(IN_PROGRESS)` is called after any channeler has died — this is a separate issue from the scheduler fix and needs further investigation.

## Description

Moves `scheduler.Update(diff)` before the `UpdateVictim()` gate in Magtheridon's `UpdateAI`. 

When all 5 Hellfire Channelers are killed, `DoAction` schedules `ScheduleCombatEvents()` (which removes `UNIT_FLAG_NOT_SELECTABLE`, `ImmuneToPC`, and `REACT_PASSIVE`) on the TaskScheduler with a 3-second delay. However, `UpdateVictim()` returns false because Magtheridon has no valid targets while immune/passive/not selectable, causing `UpdateAI` to bail out before the scheduler ever ticks. This creates a deadlock where the function that would make Magtheridon targetable can never execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)