### PR TITLE
fix(Scripts/Arcatraz): prevent Harbinger Skyriss encounter reset

### DIFF
--- a/src/server/scripts/Outland/TempestKeep/arcatraz/arcatraz.cpp
+++ b/src/server/scripts/Outland/TempestKeep/arcatraz/arcatraz.cpp
@@ -385,11 +385,11 @@ public:
 
         void DamageTaken(Unit* attacker, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
-            if (attacker && attacker->GetCharmerOrOwnerOrOwnGUID().IsPlayer() && damage > 0 && !me->isActiveObject())
+            if (attacker && attacker->GetCharmerOrOwnerOrOwnGUID().IsPlayer() && damage > 0 && instance->GetBossState(DATA_WARDEN_MELLICHAR) != IN_PROGRESS)
             {
                 me->setActive(true);
                 me->InterruptNonMeleeSpells(false);
-                me->SetImmuneToAll(true);
+                me->SetImmuneToAll(true, true);
                 events.ScheduleEvent(EVENT_WARDEN_INTRO1, 1500ms);
                 events.ScheduleEvent(EVENT_WARDEN_CHECK_PLAYERS, 1s);
                 instance->SetBossState(DATA_WARDEN_MELLICHAR, IN_PROGRESS);


### PR DESCRIPTION
## Changes Proposed:
- [x] Scripts (bosses, spell scripts, creature scripts).

Warden Mellichar's `DamageTaken` used `!me->isActiveObject()` as the guard for starting the encounter. After the encounter began and the shield opened, Mellichar was still attackable; stray/AoE damage from the Skyriss fight reaching Mellichar could put him back into combat flow and ultimately cause the encounter to reset, despawning Harbinger Skyriss.

Fix: guard the encounter start on the boss state (`DATA_WARDEN_MELLICHAR != IN_PROGRESS`) so subsequent hits during the fight are ignored and cannot re-trigger or reset the event. Uses existing state — no new variables.

### AI-assisted Pull Requests
- [x] AI tools were used in preparing this pull request. Tool: Claude Code (Opus 4.6).

## Issues Addressed:
- Closes azerothcore/azerothcore-wotlk#25381

## SOURCE:
- [x] Video evidence, knowledge databases or other public sources (issue report + code analysis).

## Tests Performed:
- [ ] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Enter Arcatraz and progress to the Harbinger Skyriss encounter.
2. Attack Warden Mellichar to begin the event; allow intro to proceed and Skyriss to spawn.
3. During the Skyriss fight, ensure stray damage / AoE near Mellichar no longer resets the encounter.

## Known Issues and TODO List:
- [ ]