### PR TITLE
fix(Scripts/Naxxramas): Patchwerk's Hateful Strike target selection

### DIFF
--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2310,6 +2310,32 @@ namespace Acore
     private:
         bool const _ascending;
     };
+
+    // Binary predicate for sorting Units based on current value of health
+    class HealthOrderPred
+    {
+    public:
+        HealthOrderPred(bool ascending = true) : _ascending(ascending) { }
+
+        bool operator()(WorldObject const* objA, WorldObject const* objB) const
+        {
+            Unit const* a = objA->ToUnit();
+            Unit const* b = objB->ToUnit();
+            float rA = a ? float(a->GetHealth()) : 0.0f;
+            float rB = b ? float(b->GetHealth()) : 0.0f;
+            return _ascending ? rA < rB : rA > rB;
+        }
+
+        bool operator() (Unit const* a, Unit const* b) const
+        {
+            float rA = a ? float(a->GetHealth()) : 0.0f;
+            float rB = b ? float(b->GetHealth()) : 0.0f;
+            return _ascending ? rA < rB : rA > rB;
+        }
+
+    private:
+        bool const _ascending;
+    };
 }
 
 class RedirectSpellEvent : public BasicEvent

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2321,15 +2321,15 @@ namespace Acore
         {
             Unit const* a = objA->ToUnit();
             Unit const* b = objB->ToUnit();
-            float rA = a ? float(a->GetHealth()) : 0.0f;
-            float rB = b ? float(b->GetHealth()) : 0.0f;
+            uint32 rA = a ? a->GetHealth() : 0;
+            uint32 rB = b ? b->GetHealth() : 0;
             return _ascending ? rA < rB : rA > rB;
         }
 
         bool operator() (Unit const* a, Unit const* b) const
         {
-            float rA = a ? float(a->GetHealth()) : 0.0f;
-            float rB = b ? float(b->GetHealth()) : 0.0f;
+            uint32 rA = a ? a->GetHealth() : 0;
+            uint32 rB = b ? b->GetHealth() : 0;
             return _ascending ? rA < rB : rA > rB;
         }
 

--- a/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
@@ -115,7 +115,7 @@ public:
                     {
                         // Scan melee targets (melee range), choose target according to mechanics:
                         // - If only 1 melee target exists, hit the tank (current victim).
-                        // - Otherwise select the top RAID_MODE(2,3) threat targets (excluding current victim)
+                        // - Otherwise select the top RAID_MODE(1,2) threat targets (excluding current victim)
                         //   among melee targets and hit the one with the highest HP.
                         // - The target hit gains 500 flat threat.
 

--- a/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
@@ -113,49 +113,37 @@ public:
             {
                 case EVENT_HATEFUL_STRIKE:
                     {
-                        // Cast Hateful strike on the player with the highest amount of HP within melee distance, and second threat amount
-                        std::list<Unit*> meleeRangeTargets;
-                        Unit* finalTarget = nullptr;
-                        uint8 counter = 0;
-                        auto threatList = me->GetThreatMgr().GetSortedThreatList();
-                        for (auto i = threatList.begin(); i != threatList.end(); ++i, ++counter)
+                        // Scan melee targets (melee range), choose target according to mechanics:
+                        // - If only 1 melee target exists, hit the tank (current victim).
+                        // - Otherwise select the top RAID_MODE(2,3) threat targets (excluding current victim)
+                        //   among melee targets and hit the one with the highest HP.
+                        // - The target hit gains 500 flat threat.
+
+                        Unit* victim = me->GetVictim();
+                        if (!victim)
                         {
-                            // Gather all units with melee range
-                            Unit* target = (*i)->GetVictim();
-                            if (me->IsWithinMeleeRange(target))
-                            {
-                                meleeRangeTargets.push_back(target);
-                            }
-                            // and add threat to most hated
-                            if (counter < RAID_MODE(2, 3))
-                            {
-                                me->AddThreat(target, 500.0f);
-                            }
+                            events.RescheduleEvent(EVENT_HATEFUL_STRIKE, 1s);
+                            break;
                         }
-                        counter = 0;
-                        std::list<Unit*, std::allocator<Unit*>>::iterator itr;
-                        for (itr = meleeRangeTargets.begin(); itr != meleeRangeTargets.end(); ++itr, ++counter)
+
+                        Unit* hatefulTarget = victim; // default to current victim if no other target is available
+
+                        std::list<Unit*> meleeTargetsExcludingTank;
+                        constexpr float HATEFUL_STRIKE_RANGE = 5.0f;
+                        SelectTargetList(meleeTargetsExcludingTank, RAID_MODE(2, 3), SelectTargetMethod::MaxThreat, 0, [&](Unit const* target)
                         {
-                            // if there is only one target available
-                            if (meleeRangeTargets.size() == 1)
-                            {
-                                finalTarget = (*itr);
-                            }
-                            else if (counter > 0) // skip first target
-                            {
-                                if (!finalTarget || (*itr)->GetHealth() > finalTarget->GetHealth())
-                                {
-                                    finalTarget = (*itr);
-                                }
-                                // third loop
-                                if (counter >= 2)
-                                    break;
-                            }
-                        }
-                        if (finalTarget)
+                            return target && target->IsPlayer() && target != victim && me->IsWithinCombatRange(target, HATEFUL_STRIKE_RANGE);
+                        });
+
+                        if (!meleeTargetsExcludingTank.empty())
                         {
-                            me->CastSpell(finalTarget, SPELL_HATEFUL_STRIKE, false);
+                            meleeTargetsExcludingTank.sort(Acore::HealthOrderPred(false));
+                            hatefulTarget = meleeTargetsExcludingTank.front();
                         }
+
+                        me->CastSpell(hatefulTarget, SPELL_HATEFUL_STRIKE, false);
+                        me->AddThreat(hatefulTarget, 500.0f);
+
                         events.Repeat(1s);
                         break;
                     }

--- a/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
@@ -128,17 +128,17 @@ public:
 
                         Unit* hatefulTarget = victim; // default to current victim if no other target is available
 
-                        std::list<Unit*> meleeTargetsExcludingTank;
+                        std::list<Unit*> meleeTargets;
                         constexpr float HATEFUL_STRIKE_RANGE = 5.0f;
-                        SelectTargetList(meleeTargetsExcludingTank, RAID_MODE(1, 2), SelectTargetMethod::MaxThreat, 0, [&](Unit const* target)
+                        SelectTargetList(meleeTargets, RAID_MODE(1, 2), SelectTargetMethod::MaxThreat, 0, [&](Unit const* target)
                         {
                             return target && target->IsPlayer() && target != victim && me->IsWithinCombatRange(target, HATEFUL_STRIKE_RANGE);
                         });
 
-                        if (!meleeTargetsExcludingTank.empty())
+                        if (!meleeTargets.empty())
                         {
-                            meleeTargetsExcludingTank.sort(Acore::HealthOrderPred(false));
-                            hatefulTarget = meleeTargetsExcludingTank.front();
+                            meleeTargets.sort(Acore::HealthOrderPred(false));
+                            hatefulTarget = meleeTargets.front();
                         }
 
                         me->CastSpell(hatefulTarget, SPELL_HATEFUL_STRIKE, false);

--- a/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
@@ -130,7 +130,7 @@ public:
 
                         std::list<Unit*> meleeTargetsExcludingTank;
                         constexpr float HATEFUL_STRIKE_RANGE = 5.0f;
-                        SelectTargetList(meleeTargetsExcludingTank, RAID_MODE(2, 3), SelectTargetMethod::MaxThreat, 0, [&](Unit const* target)
+                        SelectTargetList(meleeTargetsExcludingTank, RAID_MODE(1, 2), SelectTargetMethod::MaxThreat, 0, [&](Unit const* target)
                         {
                             return target && target->IsPlayer() && target != victim && me->IsWithinCombatRange(target, HATEFUL_STRIKE_RANGE);
                         });


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Fix issues where Patchwerk can sometimes target the MT when he shouldn't.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/chromiecraft/chromiecraft/issues/9291

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
