### PR TITLE
fix(Scripts/RazorfenDowns): prevent Belnistrasz evade during channeling

### DIFF
--- a/src/server/scripts/Kalimdor/RazorfenDowns/razorfen_downs.cpp
+++ b/src/server/scripts/Kalimdor/RazorfenDowns/razorfen_downs.cpp
@@ -100,6 +100,16 @@ public:
             }
         }
 
+        void JustExitedCombat() override
+        {
+            if (channeling)
+            {
+                EngagementOver();
+                return;
+            }
+            CreatureAI::JustExitedCombat();
+        }
+
         void JustEngagedWith(Unit* who) override
         {
             if (channeling)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - **Claude Opus 4.6** was used to investigate the root cause and draft the fix.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25401

## Description

The TrinityCore threat system port (#24715) introduced `CreatureAI::JustExitedCombat()`, which automatically calls `EnterEvadeMode` when a creature exits combat. This causes Belnistrasz to evade during the "Extinguishing the Idol" channeling event (quest 3525) when players kill a wave of spawned mobs:

1. Mobs spawn and attack Belnistrasz (faction 250 is hostile to mob faction 152)
2. Players kill all mobs in a wave
3. `JustExitedCombat()` fires → `EnterEvadeMode()`
4. `RemoveEvadeAuras()` **breaks the channeled spell** (`SPELL_IDOL_SHUTDOWN_VISUAL`)
5. `MoveTargetedHome()` causes the creature to move/reposition
6. The quest becomes impossible to complete

Before the threat system port, evade was only triggered via `UpdateVictim()` which the Belnistrasz script never calls during channeling, so the channel was never interrupted.

**Fix**: Override `JustExitedCombat()` in `npc_belnistrasz` to call only `EngagementOver()` (clearing engagement state) while channeling, suppressing `EnterEvadeMode`. During the escort walk phase (`channeling = false`), normal evade behavior is preserved so waypoint movement resumes correctly after combat.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - [Wowhead quest reference](https://www.wowhead.com/wotlk/quest=3525/extinguishing-the-idol)
  - [Video reference](https://www.youtube.com/watch?v=w1FWROsT69g)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Razorfen Downs and reach Belnistrasz (entry 8516) in The Murder Pens.
2. Accept quest "Extinguishing the Idol" and follow Belnistrasz to the idol.
3. Defend Belnistrasz during the channeling phase — kill each wave of spawned mobs.
4. Verify the channeling visual persists through all waves (no evade/reset).
5. After the 5-minute countdown, verify the brazier spawns and the quest completes.
6. Additionally test: engage Belnistrasz in combat during the **walk** (before channeling starts) and verify he still evades and resumes pathing normally.

## Known Issues and TODO List:

- [ ] Other escort-style scripts using channeled spells with `FACTION_ESCORTEE_*` may have the same `JustExitedCombat` regression from the threat system port.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.