### PR TITLE
fix(Core/Spells): Fix proc spell type classification for cast and finish

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1775946528519437800.sql
+++ b/data/sql/updates/pending_db_world/rev_1775946528519437800.sql
@@ -3,4 +3,3 @@ DELETE FROM `spell_proc` WHERE `SpellId` IN (60485, 60519);
 INSERT INTO `spell_proc` (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `DisableEffectsMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`) VALUES
 (60485, 0, 0, 0, 0, 0, 81920, 3, 4, 0, 0, 0, 0, 0, 0, 0),
 (60519, 0, 0, 0, 0, 0, 82944, 3, 2, 0, 0, 0, 0, 0, 50000, 0);
-

--- a/data/sql/updates/pending_db_world/rev_1775946528519437800.sql
+++ b/data/sql/updates/pending_db_world/rev_1775946528519437800.sql
@@ -1,0 +1,6 @@
+-- Fix spell_proc: Add missing proc entry for spell 60485 and fix SpellTypeMask for spell 60519
+DELETE FROM `spell_proc` WHERE `SpellId` IN (60485, 60519);
+INSERT INTO `spell_proc` (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `DisableEffectsMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`) VALUES
+(60485, 0, 0, 0, 0, 0, 81920, 3, 4, 0, 0, 0, 0, 0, 0, 0),
+(60519, 0, 0, 0, 0, 0, 82944, 3, 2, 0, 0, 0, 0, 0, 50000, 0);
+

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6792,14 +6792,28 @@ void Unit::ProcSkillsAndAuras(Unit* actor, Unit* victim, uint32 procAttacker, ui
             // procs that check for damage/heal type based on spell info (like Backlash)
             // At FINISH phase, damageInfo may be null but spell did do damage - use MASK_ALL
             // to match TrinityCore behavior (see TC Spell.cpp PROC_SPELL_PHASE_FINISH call)
-            spellTypeMask = PROC_SPELL_TYPE_MASK_ALL;
+            bool reliable = false;
+
+            if (procSpellInfo)
+                spellTypeMask = procSpellInfo->GetStaticProcSpellTypeMask(reliable);
+
+            if (!reliable)
+                spellTypeMask = PROC_SPELL_TYPE_MASK_ALL;
         }
         else if (healInfo && healInfo->GetHeal())
             spellTypeMask = PROC_SPELL_TYPE_HEAL;
         else if (damageInfo && (damageInfo->GetDamage() || damageInfo->GetAbsorb()))
             spellTypeMask = PROC_SPELL_TYPE_DAMAGE;
         else if (procSpellInfo)
-            spellTypeMask = PROC_SPELL_TYPE_NO_DMG_HEAL;
+        {
+            bool reliable = false;
+            uint32 staticSpellTypeMask = procSpellInfo->GetStaticProcSpellTypeMask(reliable);
+
+            if (reliable && (staticSpellTypeMask & (PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_HEAL)))
+                spellTypeMask = staticSpellTypeMask & (PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_HEAL);
+            else
+                spellTypeMask = PROC_SPELL_TYPE_NO_DMG_HEAL;
+        }
 
         actor->TriggerAurasProcOnEvent(nullptr, nullptr, victim, procAttacker, procVictim, spellTypeMask, procPhase, procExtra, const_cast<Spell*>(procSpell), damageInfo, healInfo);
     }

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -869,6 +869,7 @@ SpellInfo::SpellInfo(SpellEntry const* spellEntry)
     _isSpellValid = true;
     _isCritCapable = false;
     _requireCooldownInfo = false;
+    LoadStaticProcSpellTypeMask();
     JumpDistance = 0.0f;
 }
 
@@ -1317,9 +1318,140 @@ bool SpellInfo::IsAutoRepeatRangedSpell() const
     return AttributesEx2 & SPELL_ATTR2_AUTO_REPEAT;
 }
 
+uint32 SpellInfo::_CalculateStaticProcSpellTypeMask(bool& reliable) const
+{
+    if (HasAttribute(SPELL_ATTR0_IS_TRADESKILL))
+    {
+        reliable = true;
+        return PROC_SPELL_TYPE_NO_DMG_HEAL;
+    }
+
+    uint32 mask = 0;
+    bool sawKnownEffect = false;
+    bool sawAmbiguousEffect = false;
+
+    for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
+    {
+        SpellEffectInfo const& effectInfo = Effects[effectIndex];
+        if (!effectInfo.IsEffect())
+            continue;
+
+        bool effectReliable = true;
+        uint32 effectMask = PROC_SPELL_TYPE_NO_DMG_HEAL;
+
+        switch (effectInfo.Effect)
+        {
+            case SPELL_EFFECT_SCHOOL_DAMAGE:
+            case SPELL_EFFECT_ENVIRONMENTAL_DAMAGE:
+            case SPELL_EFFECT_WEAPON_DAMAGE:
+            case SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL:
+            case SPELL_EFFECT_NORMALIZED_WEAPON_DMG:
+            case SPELL_EFFECT_WEAPON_PERCENT_DAMAGE:
+            case SPELL_EFFECT_POWER_BURN:
+                effectMask = PROC_SPELL_TYPE_DAMAGE;
+                break;
+            case SPELL_EFFECT_HEALTH_LEECH:
+                effectMask = PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_HEAL;
+                break;
+            case SPELL_EFFECT_HEAL:
+            case SPELL_EFFECT_HEAL_MAX_HEALTH:
+            case SPELL_EFFECT_HEAL_PCT:
+            case SPELL_EFFECT_HEAL_MECHANICAL:
+                effectMask = PROC_SPELL_TYPE_HEAL;
+                break;
+            case SPELL_EFFECT_APPLY_AURA:
+            case SPELL_EFFECT_APPLY_AREA_AURA_PARTY:
+            case SPELL_EFFECT_APPLY_AREA_AURA_RAID:
+            case SPELL_EFFECT_APPLY_AREA_AURA_FRIEND:
+            case SPELL_EFFECT_APPLY_AREA_AURA_ENEMY:
+            case SPELL_EFFECT_APPLY_AREA_AURA_PET:
+            case SPELL_EFFECT_APPLY_AREA_AURA_OWNER:
+            case SPELL_EFFECT_PERSISTENT_AREA_AURA:
+                switch (effectInfo.ApplyAuraName)
+                {
+                    case SPELL_AURA_PERIODIC_DAMAGE:
+                    case SPELL_AURA_PERIODIC_DAMAGE_PERCENT:
+                        effectMask = PROC_SPELL_TYPE_DAMAGE;
+                        break;
+                    case SPELL_AURA_PERIODIC_HEAL:
+                    case SPELL_AURA_OBS_MOD_HEALTH:
+                        effectMask = PROC_SPELL_TYPE_HEAL;
+                        break;
+                    case SPELL_AURA_PERIODIC_LEECH:
+                    case SPELL_AURA_PERIODIC_HEALTH_FUNNEL:
+                        effectMask = PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_HEAL;
+                        break;
+                    case SPELL_AURA_PERIODIC_MANA_LEECH:
+                        effectMask = PROC_SPELL_TYPE_DAMAGE;
+                        break;
+                    case SPELL_AURA_PROC_TRIGGER_SPELL:
+                    case SPELL_AURA_PROC_TRIGGER_DAMAGE:
+                    case SPELL_AURA_PERIODIC_TRIGGER_SPELL:
+                    case SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE:
+                    case SPELL_AURA_PERIODIC_DUMMY:
+                    case SPELL_AURA_DUMMY:
+                        effectReliable = false;
+                        effectMask = PROC_SPELL_TYPE_NONE;
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case SPELL_EFFECT_DUMMY:
+            case SPELL_EFFECT_SCRIPT_EFFECT:
+            case SPELL_EFFECT_TRIGGER_SPELL:
+            case SPELL_EFFECT_TRIGGER_SPELL_WITH_VALUE:
+            case SPELL_EFFECT_TRIGGER_MISSILE:
+            case SPELL_EFFECT_TRIGGER_MISSILE_SPELL_WITH_VALUE:
+                effectReliable = false;
+                effectMask = PROC_SPELL_TYPE_NONE;
+                break;
+            default:
+                break;
+        }
+
+        if (!effectReliable)
+        {
+            sawAmbiguousEffect = true;
+            continue;
+        }
+
+        sawKnownEffect = true;
+
+        if (effectMask & (PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_HEAL))
+            mask |= effectMask &(PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_HEAL);
+    }
+
+    if (mask)
+    {
+        reliable = true;
+        return mask;
+    }
+
+    if (sawKnownEffect && !sawAmbiguousEffect)
+    {
+        reliable = true;
+        return PROC_SPELL_TYPE_NO_DMG_HEAL;
+    }
+
+    reliable = false;
+    return PROC_SPELL_TYPE_NONE;
+}
+
 bool SpellInfo::HasInitialAggro() const
 {
-    return !(HasAttribute(SPELL_ATTR1_NO_THREAT) || HasAttribute(SPELL_ATTR3_SUPPRESS_TARGET_PROCS));
+    return !(HasAttribute(SPELL_ATTR1_NO_THREAT) ||HasAttribute(SPELL_ATTR3_SUPPRESS_TARGET_PROCS));
+}
+
+uint32 SpellInfo::GetStaticProcSpellTypeMask(bool& reliable) const
+{
+    reliable = _isStaticProcSpellTypeMaskReliable;
+    return _staticProcSpellTypeMask;
+}
+
+void SpellInfo::LoadStaticProcSpellTypeMask()
+{
+    _staticProcSpellTypeMask = _CalculateStaticProcSpellTypeMask(_isStaticProcSpellTypeMaskReliable);
 }
 
 bool SpellInfo::IsAffected(uint32 familyName, flag96 const& familyFlags) const

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1440,7 +1440,7 @@ uint32 SpellInfo::_CalculateStaticProcSpellTypeMask(bool& reliable) const
 
 bool SpellInfo::HasInitialAggro() const
 {
-    return !(HasAttribute(SPELL_ATTR1_NO_THREAT) ||HasAttribute(SPELL_ATTR3_SUPPRESS_TARGET_PROCS));
+    return !(HasAttribute(SPELL_ATTR1_NO_THREAT) || HasAttribute(SPELL_ATTR3_SUPPRESS_TARGET_PROCS));
 }
 
 uint32 SpellInfo::GetStaticProcSpellTypeMask(bool& reliable) const

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -425,7 +425,12 @@ public:
     bool _isSpellValid;
     bool _isCritCapable;
     bool _requireCooldownInfo;
+    uint32 _staticProcSpellTypeMask;
+    bool _isStaticProcSpellTypeMaskReliable;
     float JumpDistance;
+
+    void LoadStaticProcSpellTypeMask();
+    uint32 _CalculateStaticProcSpellTypeMask(bool& reliable) const;
 
     SpellInfo(SpellEntry const* spellEntry);
     ~SpellInfo();
@@ -492,6 +497,7 @@ public:
     bool IsRangedWeaponSpell() const;
     bool IsAutoRepeatRangedSpell() const;
     bool HasInitialAggro() const;
+    uint32 GetStaticProcSpellTypeMask(bool& reliable) const;
 
     [[nodiscard]] bool IsAffected(uint32 familyName, flag96 const& familyFlags) const;
 

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3722,6 +3722,7 @@ void SpellMgr::LoadSpellInfoCustomAttributes()
         }
 
         sScriptMgr->OnLoadSpellCustomAttr(spellInfo);
+        spellInfo->LoadStaticProcSpellTypeMask();
     }
 
     // Xinef: addition for binary spells, ommit spells triggering other spells


### PR DESCRIPTION
Cache static proc spell type masks on SpellInfo and refresh them during spell loading so spells can be classified as damage, heal, or no-damage-heal from static data when reliable.

Use the cached classification for PROC_SPELL_PHASE_CAST and PROC_SPELL_PHASE_FINISH, while keeping PROC_SPELL_TYPE_MASK_ALL as a fallback for ambiguous dummy and trigger-based spells. Apply the same logic to zero-result outcomes so absorb and immune cases keep the correct damage or heal spell type.

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [X] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25371

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [X] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1..additem 34657
2.Take damage from an enemy — proc should NOT trigger
3.Use an enchant scroll — proc should NOT trigger
4.Apply a buff to yourself — proc should NOT trigger
5.Perform a Life skill (gathering, fishing, etc.) — proc should NOT trigger
6.Perform a Professional craft — proc should NOT trigger

1..additem 40432
2.Use a DOT (Damage over Time) skill — verify each tick does NOT trigger the proc
3.Use a HOT (Heal over Time) skill — verify each tick does NOT trigger the proc

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
