### PR TITLE
fix(DB/Creature): Fix Fel Crystal not targetable on Heroic Selin Fireheart

### DIFF
--- a/data/sql/updates/pending_db_world/rev_3400765412202039638.sql
+++ b/data/sql/updates/pending_db_world/rev_3400765412202039638.sql
@@ -1,0 +1,3 @@
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` &~ 0x00040000 WHERE `entry` = 24722;
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` &~ (0x00000100|0x00000200) WHERE `entry` = 25552;
+UPDATE `creature_template_addon` SET `auras` = '25900' WHERE `entry` IN (24722, 25552);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code (Claude Opus 4) was used to investigate the issue and prepare the SQL fix.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25414

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

3.4.2 sniff (build 50664) from [issue comment](https://github.com/azerothcore/azerothcore-wotlk/issues/25414#issuecomment-4230562020) shows Fel Crystal with:
- `unit_flags`: 33816576 (`0x02040000` = `NOT_SELECTABLE` + `STUNNED`)
- Aura 25900 (Stun Self) applied, which is the source of the `STUNNED` flag

### Root Cause

The Heroic Fel Crystal (`creature_template` entry 25552) had `unit_flags = 33555200` (`0x02000300`), which includes `UNIT_FLAG_IMMUNE_TO_PC` and `UNIT_FLAG_IMMUNE_TO_NPC`. The boss script in `MovementInform()` only removes `UNIT_FLAG_NOT_SELECTABLE` when Selin reaches a crystal. In normal mode this was sufficient, but in heroic mode the remaining immunity flags prevented players from targeting/attacking the crystal.

### Fix

- Remove `UNIT_FLAG_IMMUNE_TO_PC` (`0x100`) and `UNIT_FLAG_IMMUNE_TO_NPC` (`0x200`) from Heroic Fel Crystal (25552)
- Remove `UNIT_FLAG_STUNNED` (`0x40000`) from Normal Fel Crystal (24722) — this flag is applied at runtime by aura 25900
- Add aura 25900 to `creature_template_addon` for both entries (24722, 25552) per sniff

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Magister's Terrace on Heroic difficulty
2. Engage Selin Fireheart
3. Wait for Selin to run out of mana and move to a Fel Crystal
4. Verify the crystal becomes targetable and attackable
5. Also verify normal mode still works correctly

## Known Issues and TODO List:

- [ ] The sniff also shows 4 stacks of spell 44374 (Fel Crystal Cosmetic) on the crystal — this may warrant further investigation but is cosmetic only

🤖 Generated with [Claude Code](https://claude.com/claude-code)