### PR TITLE
fix(DB/SAI): fix The Cleansing quest Your Inner Turmoil immune to players

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1775999236170441600.sql
+++ b/data/sql/updates/pending_db_world/rev_1775999236170441600.sql
@@ -1,4 +1,4 @@
 --
-DELETE FROM `smart_scripts` WHERE `entryorguid` = 2795900 AND `id` = 9;
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 2795900) AND (`source_type` = 9) AND (`id` = 9);
 INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`event_param6`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
 (2795900,9,9,0,0,0,100,0,0,0,0,0,0,0,19,256,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Your Inner Turmoil - Actionlist - Remove Flags Immune To Players');

--- a/data/sql/updates/pending_db_world/rev_1775999236170441600.sql
+++ b/data/sql/updates/pending_db_world/rev_1775999236170441600.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 2795900 AND `id` = 9;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`event_param6`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(2795900,9,9,0,0,0,100,0,0,0,0,0,0,0,19,256,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Your Inner Turmoil - Actionlist - Remove Flags Immune To Players');


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Opus 4.6 was used to investigate the issue and prepare the fix.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25420

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

The SmartAI actionlist for "Your Inner Turmoil" (entry 27959, actionlist 2795900, step 9) was removing `UNIT_FLAG_IMMUNE_TO_NPC` (512) instead of `UNIT_FLAG_IMMUNE_TO_PC` (256).

The creature_template for NPC 27959 has `unit_flags = 256` (`UNIT_FLAG_IMMUNE_TO_PC`), so the script was removing a flag the creature didn't even have, leaving the player-immunity flag intact. This made the creature unattackable during "The Cleansing" quest (11317/11322).

Fix: Change the removed flag in the actionlist from 512 to 256.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Be Horde, level 70
2. `.quest add 11286` then `.quest complete 11286` then `.quest reward 11286`
3. `.go c i 24186` and take "The Cleansing" quest
4. `.go gameobject 150378` and click the Frostblade Shrine
5. Wait for the RP to finish — "Your Inner Turmoil" should spawn and be attackable
6. Kill "Your Inner Turmoil" to complete the quest

## Known Issues and TODO List:

- [ ] The issue also mentions the Frostblade Shrine orientation being wrong — this is not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)