### PR TITLE
fix(Scripts/TheEye): Fix Al'ar evading during Flame Quills

### DIFF
--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_alar.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_alar.cpp
@@ -168,7 +168,7 @@ struct boss_alar : public BossAI
     {
         if (why == EVADE_REASON_BOUNDARY)
             BossAI::EnterEvadeMode(why);
-        else if (me->GetThreatMgr().IsThreatListEmpty())
+        else if (me->GetThreatMgr().IsThreatListEmpty(true))
             BossAI::EnterEvadeMode(why);
     }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

The threat system port (984baa92d) changed `GetThreatList().empty()` to `IsThreatListEmpty()` in Al'ar's `EnterEvadeMode` override. The new method defaults to `includeOffline=false`, which only counts AVAILABLE threat references.

When Al'ar reaches the Flame Quills position (z=43) and stops moving, `CanAIAttack()` returns `false` for all players since they are out of melee range and the boss is stationary. The new threat system marks all threat references as OFFLINE. `IsThreatListEmpty()` then returns `true`, causing Al'ar to evade and reset the encounter.

This fix passes `includeOffline=true` to restore the original behavior: Al'ar only evades when no players exist on the threat list at all, regardless of their online/offline state.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [X] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code (Claude Opus 4.6) was used for investigation and fix authoring.

## Issues Addressed:

- Progress https://github.com/azerothcore/azerothcore-wotlk/issues/25406

## SOURCE:

- [X] The regression was traced to commit 984baa92d (threat system port), which changed `GetThreatList().empty()` to `IsThreatListEmpty()` without accounting for the different default parameter behavior (`includeOffline=false`).

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.