### PR TITLE
fix(DB/Spell): Distract should not break stealth or invisibility

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1776009858572502474.sql
+++ b/data/sql/updates/pending_db_world/rev_1776009858572502474.sql
@@ -1,0 +1,2 @@
+-- Add SPELL_ATTR0_CU_DONT_BREAK_STEALTH (0x40) to Distract (1725)
+UPDATE `spell_custom_attr` SET `attributes` = `attributes` | 0x40 WHERE `spell_id` = 1725;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/24750

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The DBC tooltip for Distract (spell 1725) explicitly states: **"Does not break stealth."**

TrinityCore applies the same fix via their `spell_custom_attr` DB table (value 64 = `SPELL_ATTR0_CU_DONT_BREAK_STEALTH`).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create two characters: Alliance Rogue, Horde Mage. Both `.level 69`, `.learn all my class`.
2. Both `.tele plaguelands`, `/pvp` on both, `.cheat cooldown` and `.cheat power` on both.
3. **Test stealth**: Rogue uses Stealth → Mage uses Distract on Rogue → Rogue should remain stealthed.
4. **Test invisibility**: Mage casts Invisibility → Rogue uses Distract on Mage → Mage should remain invisible/continue fading.

## Known Issues and TODO List:

- [ ] If invisibility fading phase (spell 66) has `AURA_INTERRUPT_FLAG_HITBYSPELL` in DBC, that path is not covered by this fix (matches TrinityCore behavior — they don't gate it either).