### PR TITLE
fix(Core/Spells): Fix Bone Shield double charge consumption

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1776010695888104892.sql
+++ b/data/sql/updates/pending_db_world/rev_1776010695888104892.sql
@@ -1,0 +1,2 @@
+-- Remove Bone Shield spell script (double charge consumption bug)
+DELETE FROM `spell_script_names` WHERE `spell_id` = 49222 AND `ScriptName` = 'spell_dk_bone_shield';

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -3003,7 +3003,6 @@ void AddSC_deathknight_spell_scripts()
     RegisterSpellScript(spell_dk_improved_blood_presence_triggered);
     RegisterSpellScript(spell_dk_wandering_plague_aura);
     RegisterSpellScript(spell_dk_rune_of_the_fallen_crusader);
-
     RegisterSpellScript(spell_dk_hungering_cold);
     RegisterSpellScript(spell_dk_blood_caked_blade);
     RegisterSpellScript(spell_dk_dancing_rune_weapon);

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -580,34 +580,6 @@ class spell_dk_rune_of_the_fallen_crusader : public SpellScript
     }
 };
 
-// 49222 - Bone Shield
-class spell_dk_bone_shield : public AuraScript
-{
-    PrepareAuraScript(spell_dk_bone_shield);
-
-    uint32 lastChargeUsedTime = 0;
-
-    void HandleProc(ProcEventInfo& eventInfo)
-    {
-        PreventDefaultAction();
-        uint32 currentTime = getMSTime();
-        // Checks for 2 seconds between uses of bone shield charges
-        if ((currentTime - lastChargeUsedTime) < 2000)
-            return;
-
-        if (!eventInfo.GetSpellInfo() || !eventInfo.GetSpellInfo()->IsTargetingArea())
-        {
-            DropCharge();
-            lastChargeUsedTime = currentTime;
-        }
-    }
-
-    void Register() override
-    {
-        OnProc += AuraProcFn(spell_dk_bone_shield::HandleProc);
-    }
-};
-
 // 51209 - Hungering Cold
 class spell_dk_hungering_cold : public AuraScript
 {
@@ -3031,7 +3003,7 @@ void AddSC_deathknight_spell_scripts()
     RegisterSpellScript(spell_dk_improved_blood_presence_triggered);
     RegisterSpellScript(spell_dk_wandering_plague_aura);
     RegisterSpellScript(spell_dk_rune_of_the_fallen_crusader);
-    RegisterSpellScript(spell_dk_bone_shield);
+
     RegisterSpellScript(spell_dk_hungering_cold);
     RegisterSpellScript(spell_dk_blood_caked_blade);
     RegisterSpellScript(spell_dk_dancing_rune_weapon);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9244

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

The `spell_proc` table already has the correct configuration for Bone Shield (49222):
- `Cooldown: 2000` (2-second ICD between charge consumption)
- `SpellTypeMask: PROC_SPELL_TYPE_DAMAGE` (only damage consumes charges)

The `spell_dk_bone_shield` script was redundant and caused double charge consumption. `PrepareProcToTrigger` already drops a charge before the script's `OnProc` handler runs, then the script's `DropCharge()` dropped a second one. With 3 charges, Bone Shield lasted only 2 damaging hits instead of 3.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a Death Knight, `.learn all my class`, `.cheat cooldown`
2. `.cast 49222` (Bone Shield — 3 charges)
3. Aggro a pack of mobs so you take rapid melee hits
4. **Before fix**: charges drop 2 at a time, Bone Shield lasts only 2 hits
5. **After fix**: charges drop 1 at a time with ~2s gaps, Bone Shield lasts all 3 hits