### PR TITLE
fix(Scripts/EyeOfEternity): fix hover disk hitbox desync when boarding mid-jump

### DIFF
--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -1011,25 +1011,27 @@ struct npc_hover_disk : public VehicleAI
                 who->ApplySpellImmune(0, IMMUNITY_ID, SPELL_SURGE_OF_POWER_DMG, true);
                 me->SetSpeed(MOVE_RUN, 1.5f);
                 me->SetSpeed(MOVE_FLIGHT, 1.5f);
+                me->SetDisableGravity(true);
             }
             else if (who->GetEntry() == NPC_NEXUS_LORD)
             {
+                who->CastSpell(who, SPELL_TELEPORT_VISUAL);
                 me->SetSpeed(MOVE_RUN, 1.5f);
                 me->SetSpeed(MOVE_FLIGHT, 1.5f);
+                me->SetCanFly(true);
             }
             else
             {
+                who->CastSpell(who, SPELL_TELEPORT_VISUAL);
                 me->SetSpeed(MOVE_RUN, 0.6f);
                 me->SetSpeed(MOVE_FLIGHT, 0.6f);
+                me->SetCanFly(true);
             }
-
-            who->SetFacingTo(me->GetOrientation());
-            me->SetCanFly(true);
         }
         else
         {
-            me->GetMotionMaster()->MoveIdle();
-            me->DisableSpline();
+            me->StopMoving();
+            me->SetDisableGravity(false);
             me->SetCanFly(false);
             me->GetMotionMaster()->MoveLand(0, me->GetPositionX(), me->GetPositionY(), 267.24f, 10.0f);
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Cherry-picks hover disk `PassengerBoarded` logic from TrinityCore to fix a hitbox desync that occurs when players board a Scion Disc while jumping during Malygos Phase 2.

### Root Cause

The `who->SetFacingTo(me->GetOrientation())` call in `npc_hover_disk::PassengerBoarded` launched a new movement spline that **overwrote** the transport-enter spline set by `Vehicle::AddPassenger`. The replacement spline used the player's stale pre-boarding world coordinates (their mid-air jump position) as the destination in transport space, causing the player's server-side hitbox to remain at the jump origin instead of the vehicle seat.

### Fix

- **Remove `SetFacingTo` call** — the transport-enter spline from `AddPassenger` already handles seat positioning and facing correctly.
- **Use `SetDisableGravity(true)` for player boarding** instead of `SetCanFly(true)` (matches TC).
- **Use `StopMoving()` on passenger exit** instead of `MoveIdle()` + `DisableSpline()` (cleaner, matches TC).
- **Add `SPELL_TELEPORT_VISUAL` cast on NPC boarding** for visual feedback (matches TC).
- **Retain `ApplySpellImmune`** for `SPELL_SURGE_OF_POWER_DMG` (56548) — this unlimited-range AoE has no DB conditions preventing it from hitting players on vehicles; the immunity is necessary. The existing conditions only reference NPC 30234 (TC's melee hover disk entry, unused in AC).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Opus 4.6 (Claude Code) was used for root cause analysis, TrinityCore comparison, and code adaptation.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25238

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**
  - TrinityCore `boss_malygos.cpp` — original authors: Manuel (`manue.l@live.com.ar`), Trista (`aconstantgoal@abv.bg`)

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Have two level 80 characters, `.cheat god`, `.additem 44581`
2. `.tele eyeofeternity`, use The Focusing Iris
3. Select Malygos, `.damage 56 pct` to reach Phase 2
4. Kill a scion on a disc, **jump toward the disc and click it mid-air**
5. Verify you can attack nearby scions from the disc — hitbox should match visual position

## Known Issues and TODO List:

- [ ] Verify that the `SetDisableGravity(true)` change doesn't affect player-controlled disc flight feel
- [ ] Regression test: confirm NPC hover discs (nexus lords, scions) still orbit correctly with `SetCanFly(true)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)