### PR TITLE
fix(Scripts/Gundrak): fix Drakkari Colossus unkillable at low HP

### DIFF
--- a/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
@@ -282,7 +282,6 @@ public:
 
         void Reset() override
         {
-            SetInvincibility(true);
             me->CastSpell(me, SPELL_ELEMENTAL_SPAWN_EFFECT, false);
         }
 

--- a/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
@@ -56,9 +56,7 @@ enum Misc
 
     EVENT_COLOSSUS_MIGHTY_BLOW          = 1,
     EVENT_COLOSSUS_MORTAL_STRIKE        = 2,
-    EVENT_COLOSSUS_HEALTH_1             = 3,
-    EVENT_COLOSSUS_HEALTH_2             = 4,
-    EVENT_COLOSSUS_START_FIGHT          = 5,
+    EVENT_COLOSSUS_START_FIGHT          = 3,
 
     EVENT_ELEMENTAL_HEALTH              = 10,
     EVENT_ELEMENTAL_SURGE               = 11,
@@ -108,6 +106,8 @@ public:
         {
         }
 
+        bool _secondEmerge;
+
         void MoveInLineOfSight(Unit*  /*who*/) override
         {
         }
@@ -139,6 +139,7 @@ public:
             }
 
             SetInvincibility(true);
+            _secondEmerge = false;
         }
 
         void JustReachedHome() override
@@ -152,8 +153,21 @@ public:
             events.ScheduleEvent(EVENT_COLOSSUS_START_FIGHT, 1s);
             events.ScheduleEvent(EVENT_COLOSSUS_MIGHTY_BLOW, 10s);
             events.ScheduleEvent(EVENT_COLOSSUS_MORTAL_STRIKE, 7s);
-            events.ScheduleEvent(EVENT_COLOSSUS_HEALTH_1, 1s);
-            events.ScheduleEvent(EVENT_COLOSSUS_HEALTH_2, 1s);
+
+            ScheduleHealthCheckEvent(51, [&] {
+                me->CastSpell(me, SPELL_EMERGE, false);
+                me->CastSpell(me, SPELL_EMERGE_SUMMON, true);
+                me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+                me->GetMotionMaster()->Clear();
+            });
+
+            ScheduleHealthCheckEvent(2, [&] {
+                _secondEmerge = true;
+                me->CastSpell(me, SPELL_EMERGE, false);
+                me->CastSpell(me, SPELL_EMERGE_SUMMON, true);
+                me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+                me->GetMotionMaster()->Clear();
+            });
         }
 
         void JustSummoned(Creature* summon) override
@@ -163,7 +177,7 @@ public:
                 summon->SetRegeneratingHealth(false);
                 summon->SetReactState(REACT_PASSIVE);
                 summon->m_Events.AddEventAtOffset(new RestoreFight(summon), 3s);
-                if (!events.HasTimeUntilEvent(EVENT_COLOSSUS_HEALTH_2))
+                if (_secondEmerge)
                 {
                     summon->SetHealth(summon->GetMaxHealth() / 2);
                     summon->LowerPlayerDamageReq(summon->GetMaxHealth() / 2);
@@ -178,10 +192,7 @@ public:
         {
             summons.Despawn(summon);
             if (summon->GetEntry() == NPC_DRAKKARI_ELEMENTAL)
-            {
-                SetInvincibility(false);
                 me->KillSelf();
-            }
         }
 
         void SummonedCreatureDespawn(Creature* summon) override
@@ -189,7 +200,6 @@ public:
             summons.Despawn(summon);
             if (summon->GetEntry() == NPC_DRAKKARI_ELEMENTAL)
             {
-                SetInvincibility(false);
                 me->SetHealth(me->GetMaxHealth() / 2);
                 me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
                 me->RemoveAurasDueToSpell(SPELL_FREEZE_ANIM);
@@ -220,28 +230,6 @@ public:
                 case EVENT_COLOSSUS_MORTAL_STRIKE:
                     DoCastVictim(SPELL_MORTAL_STRIKE);
                     events.ScheduleEvent(EVENT_COLOSSUS_MORTAL_STRIKE, 7s);
-                    break;
-                case EVENT_COLOSSUS_HEALTH_1:
-                    if (me->HealthBelowPct(51))
-                    {
-                        me->CastSpell(me, SPELL_EMERGE, false);
-                        me->CastSpell(me, SPELL_EMERGE_SUMMON, true);
-                        me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
-                        me->GetMotionMaster()->Clear();
-                        break;
-                    }
-                    events.ScheduleEvent(EVENT_COLOSSUS_HEALTH_1, 1s);
-                    break;
-                case EVENT_COLOSSUS_HEALTH_2:
-                    if (me->HealthBelowPct(2))
-                    {
-                        me->CastSpell(me, SPELL_EMERGE, false);
-                        me->CastSpell(me, SPELL_EMERGE_SUMMON, true);
-                        me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
-                        me->GetMotionMaster()->Clear();
-                        break;
-                    }
-                    events.ScheduleEvent(EVENT_COLOSSUS_HEALTH_2, 1s);
                     break;
             }
 
@@ -274,10 +262,7 @@ public:
         void DoAction(int32 param) override
         {
             if (param == ACTION_INFORM)
-            {
                 events.CancelEvent(EVENT_ELEMENTAL_HEALTH);
-                SetInvincibility(false);
-            }
         }
 
         void Reset() override

--- a/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
@@ -137,6 +137,8 @@ public:
                 me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                 me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
             }
+
+            SetInvincibility(true);
         }
 
         void JustReachedHome() override
@@ -176,7 +178,10 @@ public:
         {
             summons.Despawn(summon);
             if (summon->GetEntry() == NPC_DRAKKARI_ELEMENTAL)
+            {
+                SetInvincibility(false);
                 me->KillSelf();
+            }
         }
 
         void SummonedCreatureDespawn(Creature* summon) override
@@ -184,18 +189,13 @@ public:
             summons.Despawn(summon);
             if (summon->GetEntry() == NPC_DRAKKARI_ELEMENTAL)
             {
+                SetInvincibility(false);
                 me->SetHealth(me->GetMaxHealth() / 2);
                 me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
                 me->RemoveAurasDueToSpell(SPELL_FREEZE_ANIM);
                 if (me->GetVictim())
                     me->GetMotionMaster()->MoveChase(me->GetVictim());
             }
-        }
-
-        void DamageTaken(Unit*  /*attacker*/, uint32& damage, DamageEffectType, SpellSchoolMask) override
-        {
-            if (damage >= me->GetHealth())
-                damage = 0;
         }
 
         void UpdateAI(uint32 diff) override
@@ -274,11 +274,15 @@ public:
         void DoAction(int32 param) override
         {
             if (param == ACTION_INFORM)
+            {
                 events.CancelEvent(EVENT_ELEMENTAL_HEALTH);
+                SetInvincibility(false);
+            }
         }
 
         void Reset() override
         {
+            SetInvincibility(true);
             me->CastSpell(me, SPELL_ELEMENTAL_SPAWN_EFFECT, false);
         }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code (Claude Opus 4.6) was used to investigate the issue and prepare this PR.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25380

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Gundrak and engage Drakkari Colossus
2. Kill the Living Mojos to activate the boss
3. Damage the Colossus below 50% HP (first elemental phase)
4. After the elemental merges back, damage the Colossus to below 2% HP
5. Verify the second elemental spawns promptly when the boss reaches 1 HP (no long delay)
6. Kill the second elemental and verify the Colossus dies

## Root Cause

The Colossus had a custom `DamageTaken` override that set `damage = 0` when the incoming hit would be lethal (`damage >= me->GetHealth()`). Unlike the framework's `SetInvincibility` (which clamps damage to `health - 1`, allowing the boss to reach 1 HP), this approach **completely negates** all lethal damage. 

This means if the boss is at, say, 3% HP and every incoming hit exceeds that amount, all damage is zeroed and the boss's HP never decreases. The `EVENT_COLOSSUS_HEALTH_2` check (`HealthBelowPct(2)`) never passes because the boss is stuck above 2%. Players experience the boss appearing unkillable at low HP for extended periods until a sufficiently small hit (DoT tick, pet attack) lands non-lethally.

## Fix

Replace the custom `DamageTaken` override with `SetInvincibility(true)` on both the Colossus and the Drakkari Elemental. The built-in `ScriptedAI::DamageTaken` handler clamps lethal damage to `health - 1`, ensuring the boss always drops to 1 HP immediately. `KillSelf()` (called when the second elemental dies) bypasses `DamageTaken` entirely via `Unit::Kill`, so invincibility does not prevent the boss from dying at the correct time.

## Known Issues and TODO List:

- [ ] N/A

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.