### PR TITLE
fix(DB/Loot): Add Emblem of Triumph drop to minidrakes in Obsidian Sanctum.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1776033024.sql
+++ b/data/sql/updates/pending_db_world/rev_1776033024.sql
@@ -5,8 +5,8 @@ UPDATE `creature_template` SET `lootid` = 31520 WHERE (`entry` = 31520);
 
 DELETE FROM `creature_loot_template` WHERE (`Entry` IN (30451, 31520)) AND (`Item` IN (47241));
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(30451, 47241, 0, 100, 0, 1, 0, 1, 1, ''),
-(31520, 47241, 0, 100, 0, 1, 0, 1, 1, '');
+(30451, 47241, 0, 100, 0, 1, 0, 1, 1, 'Emblem of Triumph'),
+(31520, 47241, 0, 100, 0, 1, 0, 1, 1, 'Emblem of Triumph');
 
 -- Vesperon
 UPDATE `creature_template` SET `lootid` = 30449 WHERE (`entry` = 30449);
@@ -14,8 +14,8 @@ UPDATE `creature_template` SET `lootid` = 31535 WHERE (`entry` = 31535);
 
 DELETE FROM `creature_loot_template` WHERE (`Entry` IN (30449, 31535)) AND (`Item` IN (47241));
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(30449, 47241, 0, 100, 0, 1, 0, 1, 1, ''),
-(31535, 47241, 0, 100, 0, 1, 0, 1, 1, '');
+(30449, 47241, 0, 100, 0, 1, 0, 1, 1, 'Emblem of Triumph'),
+(31535, 47241, 0, 100, 0, 1, 0, 1, 1, 'Emblem of Triumph');
 
 -- Tenebron
 UPDATE `creature_template` SET `lootid` = 30452 WHERE (`entry` = 30452);
@@ -23,5 +23,8 @@ UPDATE `creature_template` SET `lootid` = 31534 WHERE (`entry` = 31534);
 
 DELETE FROM `creature_loot_template` WHERE (`Entry` IN (30452, 31534)) AND (`Item` IN (47241));
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(30452, 47241, 0, 100, 0, 1, 0, 1, 1, ''),
-(31534, 47241, 0, 100, 0, 1, 0, 1, 1, '');
+(30452, 47241, 0, 100, 0, 1, 0, 1, 1, 'Emblem of Triumph'),
+(31534, 47241, 0, 100, 0, 1, 0, 1, 1, 'Emblem of Triumph');
+
+-- Reduce Emblem of Triump (Sartharion 10M).
+UPDATE `creature_loot_template` SET `MinCount` = 1, `MaxCount` = 1 WHERE (`Entry` = 28860) AND (`Item` IN (47241));

--- a/data/sql/updates/pending_db_world/rev_1776033024.sql
+++ b/data/sql/updates/pending_db_world/rev_1776033024.sql
@@ -1,0 +1,27 @@
+
+-- Shadron
+UPDATE `creature_template` SET `lootid` = 30451 WHERE (`entry` = 30451);
+UPDATE `creature_template` SET `lootid` = 31520 WHERE (`entry` = 31520);
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` IN (30451, 31520)) AND (`Item` IN (47241));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(30451, 47241, 0, 100, 0, 1, 0, 1, 1, ''),
+(31520, 47241, 0, 100, 0, 1, 0, 1, 1, '');
+
+-- Vesperon
+UPDATE `creature_template` SET `lootid` = 30449 WHERE (`entry` = 30449);
+UPDATE `creature_template` SET `lootid` = 31535 WHERE (`entry` = 31535);
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` IN (30449, 31535)) AND (`Item` IN (47241));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(30449, 47241, 0, 100, 0, 1, 0, 1, 1, ''),
+(31535, 47241, 0, 100, 0, 1, 0, 1, 1, '');
+
+-- Tenebron
+UPDATE `creature_template` SET `lootid` = 30452 WHERE (`entry` = 30452);
+UPDATE `creature_template` SET `lootid` = 31534 WHERE (`entry` = 31534);
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` IN (30452, 31534)) AND (`Item` IN (47241));
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(30452, 47241, 0, 100, 0, 1, 0, 1, 1, ''),
+(31534, 47241, 0, 100, 0, 1, 0, 1, 1, '');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Related To https://github.com/chromiecraft/chromiecraft/issues/9278 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
