### PR TITLE
fix(Core/Scripts): fix Razorscale encounter not starting

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -170,6 +170,7 @@ struct boss_razorscale : public BossAI
         CommanderGUID.Clear();
         bGroundPhase = false;
         flyTimes = 0;
+        me->SetImmuneToPC(true);
         me->SetAnimTier(AnimTier::Fly);
     }
 
@@ -610,6 +611,7 @@ public:
 
                 if (razorscale->AI())
                 {
+                    razorscale->SetImmuneToPC(false);
                     razorscale->AI()->AttackStart(player);
                     razorscale->GetMotionMaster()->MoveIdle();
                     razorscale->GetMotionMaster()->MovePoint(POINT_RAZORSCALE_INIT, CORDS_AIR.GetPositionX(), CORDS_AIR.GetPositionY(), CORDS_AIR.GetPositionZ(), FORCED_MOVEMENT_NONE, 0.f, 0.f, false, false, MOTION_SLOT_ACTIVE, AnimTier::Fly);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Opus 4.6 (Claude Code) was used to investigate and fix this issue.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9282

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Ulduar and go to the Razorscale arena
2. Speak to the Expedition Commander and select the gossip option to start the fight
3. Verify that Razorscale enters combat and begins the encounter (fireballs, mole machines, etc.)
4. Wipe and verify the encounter resets properly and can be restarted via gossip

## Known Issues and TODO List:

- [ ] None

## Root Cause

After the TrinityCore heap-based threat system port (#24715), `ThreatReference::ShouldBeOffline()` calls `FlagsAllowFighting()` which returns `false` when a player-controlled unit is on the threat list of a creature with `UNIT_FLAG_IMMUNE_TO_PC`.

Razorscale has `UNIT_FLAG_IMMUNE_TO_PC` (0x100) in its creature template (`unit_flags = 33536`). When the gossip handler calls `razorscale->AI()->AttackStart(player)`, the new threat reference is created with initial state `OFFLINE`. Since `ShouldBeOffline()` returns `true` (due to `IMMUNE_TO_PC`) and the reference is already `OFFLINE`, `UpdateOffline()` is a no-op — `JustStartedThreateningMe` is never called, `EngagementStart` never fires, and `JustEngagedWith` is never reached.

The previous fix (#25263) placed `SetImmuneToPC(false)` inside `JustEngagedWith`, but that function is never called because the `IMMUNE_TO_PC` flag prevents threat engagement in the first place — a chicken-and-egg problem.

### Fix

- Clear `IMMUNE_TO_PC` **before** `AttackStart` in the gossip handler so the threat reference stays `ONLINE`
- Restore the flag in `Reset()` for wipe scenarios (since `LoadCreaturesAddon` does not restore `unit_flags`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)