### PR TITLE
fix(DB/SAI): Fix Your Inner Turmoil not attackable in The Cleansing quest

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1776042031257473530.sql
+++ b/data/sql/updates/pending_db_world/rev_1776042031257473530.sql
@@ -1,0 +1,2 @@
+-- Remove UNIT_FLAG_IMMUNE_TO_PC (256) instead of UNIT_FLAG_IMMUNE_TO_NPC (512)
+UPDATE `smart_scripts` SET `action_param1`=256 WHERE `entryorguid`=2795900 AND `source_type`=9 AND `id`=9;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9284

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.quest add 11317`
2. `.go xyz 3035.8 -5092.26 722.618 571`
3. Use the Frostblade Shrine, wait for Cleansing Soul buff to expire
4. Wait for Your Inner Turmoil RP to finish (~13s)
5. Verify you can attack and kill Your Inner Turmoil
6. Verify quest objective completes
7. Repeat with Alliance quest: `.quest add 11322`

## Known Issues and TODO List:

- None