### PR TITLE
fix(Core/Trade): fix crash from use-after-free in trade logging

### DIFF
--- a/src/server/game/Handlers/TradeHandler.cpp
+++ b/src/server/game/Handlers/TradeHandler.cpp
@@ -458,6 +458,16 @@ void WorldSession::HandleAcceptTradeOpcode(WorldPacket& /*recvPacket*/)
             return;
         }
 
+        // log traded items before moving (pointers become invalid after moveItems)
+        std::string myItemsStr, hisItemsStr;
+        for (uint8 i = 0; i < TRADE_SLOT_TRADED_COUNT; ++i)
+        {
+            if (myItems[i])
+                myItemsStr += Acore::StringFormat("{} (Entry:{}) x{}, ", myItems[i]->GetTemplate()->Name1, myItems[i]->GetEntry(), myItems[i]->GetCount());
+            if (hisItems[i])
+                hisItemsStr += Acore::StringFormat("{} (Entry:{}) x{}, ", hisItems[i]->GetTemplate()->Name1, hisItems[i]->GetEntry(), hisItems[i]->GetCount());
+        }
+
         // execute trade: 1. remove
         for (uint8 i = 0; i < TRADE_SLOT_TRADED_COUNT; ++i)
         {
@@ -495,23 +505,11 @@ void WorldSession::HandleAcceptTradeOpcode(WorldPacket& /*recvPacket*/)
         trader->ModifyMoney(my_trade->GetMoney());
 
         // log completed trade
-        {
-            std::string myItemsStr, hisItemsStr = "";
-
-            for (uint8 i = 0; i < TRADE_SLOT_TRADED_COUNT; ++i)
-            {
-                if (myItems[i])
-                    myItemsStr += Acore::StringFormat("{} (Entry:{}) x{}, ", myItems[i]->GetTemplate()->Name1, myItems[i]->GetEntry(), myItems[i]->GetCount());
-                if (hisItems[i])
-                    hisItemsStr += Acore::StringFormat("{} (Entry:{}) x{}, ", hisItems[i]->GetTemplate()->Name1, hisItems[i]->GetEntry(), hisItems[i]->GetCount());
-            }
-
-            LOG_INFO("entities.player.trade", "Trade: Account: {} (IP: {}), Player [{}] ({}) traded with Player [{}] ({}): gave {} copper, received {} copper, gave item(s) [{}], received item(s) [{}]",
-                GetAccountId(), GetRemoteAddress(), _player->GetName(), _player->GetGUID().GetCounter(),
-                trader->GetName(), trader->GetGUID().GetCounter(),
-                my_trade->GetMoney(), his_trade->GetMoney(),
-                myItemsStr, hisItemsStr);
-        }
+        LOG_INFO("entities.player.trade", "Trade: Account: {} (IP: {}), Player [{}] ({}) traded with Player [{}] ({}): gave {} copper, received {} copper, gave item(s) [{}], received item(s) [{}]",
+            GetAccountId(), GetRemoteAddress(), _player->GetName(), _player->GetGUID().GetCounter(),
+            trader->GetName(), trader->GetGUID().GetCounter(),
+            my_trade->GetMoney(), his_trade->GetMoney(),
+            myItemsStr, hisItemsStr);
 
         if (my_spell)
             my_spell->prepare(&my_targets);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (claude-opus-4-6) was used to analyze the crash log and implement the fix.

## Issues Addressed:

Server crashes with SIGSEGV in `HandleAcceptTradeOpcode` when trading stackable items that get merged during trade.

## Description

The trade logging code at `TradeHandler.cpp:506` accessed `myItems[]` and `hisItems[]` **after** the items had already been moved between players via `MoveItemFromInventory()` and `moveItems()`. When `MoveItemToInventory()` merges a traded item into an existing stack in the recipient's inventory, the original `Item` object is deleted. The logging code then dereferences the dangling pointer, causing a segfault in `Object::GetUInt32Value()`.

**Fix:** Move the item info capture (name, entry, count) to **before** the item transfer loop, while the pointers are still valid.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Crash log analysis — the backtrace shows `GetUInt32Value` called on freed memory from the trade logging block.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Have two players initiate a trade.
2. One player puts a stackable item in the trade window where the other player already has a partial stack of the same item in their inventory.
3. Both players accept the trade.
4. Verify the trade completes without crashing and the log message is printed correctly.

## Known Issues and TODO List:

- [ ] Needs in-game testing with stackable item trades to confirm fix.


🤖 Generated with [Claude Code](https://claude.com/claude-code)