### PR TITLE
fix(Scripts/VioletHold): fix NPCs not respawning in Violet Hold

### DIFF
--- a/src/server/scripts/Northrend/VioletHold/instance_violet_hold.cpp
+++ b/src/server/scripts/Northrend/VioletHold/instance_violet_hold.cpp
@@ -84,7 +84,6 @@ public:
             _cleaned = false;
             _encounterStatus = NOT_STARTED;
             _events.Reset();
-            _events.RescheduleEvent(EVENT_CHECK_PLAYERS, 0ms);
             _gateHealth = 100;
             _waveCount = 0;
             _portalLocation = 0;
@@ -212,6 +211,7 @@ public:
                             sinclari->AI()->Talk(SAY_SINCLARI_LEAVING);
                         }
                         _events.RescheduleEvent(EVENT_GUARDS_FALL_BACK, 4s);
+                        _events.RescheduleEvent(EVENT_CHECK_PLAYERS, 5s);
                     }
                     break;
                 case DATA_PORTAL_DEFEATED:
@@ -376,8 +376,8 @@ public:
                 case EVENT_START_ENCOUNTER:
                     if (Creature* sinclari = GetCreature(DATA_SINCLARI))
                     {
-                        sinclari->SetNpcFlag(UNIT_NPC_FLAG_GOSSIP);
                         sinclari->AI()->Talk(SAY_SINCLARI_DOOR_LOCK);
+                        sinclari->DespawnOrUnsummon(5s);
                     }
                     if (Creature* doorSeal = GetCreature(DATA_DOOR_SEAL))
                         doorSeal->RemoveAllAuras();
@@ -448,19 +448,17 @@ public:
 
         void OnPlayerEnter(Player* plr) override
         {
-            if (DoNeedCleanup(plr->IsAlive()))
-                InstanceCleanup();
-
             if (_encounterStatus == IN_PROGRESS)
             {
+                if (DoNeedCleanup(plr->IsAlive()))
+                    InstanceCleanup();
+
                 plr->SendUpdateWorldState(WORLD_STATE_VIOLET_HOLD_SHOW, 1);
                 plr->SendUpdateWorldState(WORLD_STATE_VIOLET_HOLD_PRISON_STATE, (uint32)_gateHealth);
                 plr->SendUpdateWorldState(WORLD_STATE_VIOLET_HOLD_WAVE_COUNT, (uint32)_waveCount);
             }
             else
                 plr->SendUpdateWorldState(WORLD_STATE_VIOLET_HOLD_SHOW, 0);
-
-            _events.RescheduleEvent(EVENT_CHECK_PLAYERS, 5s);
         }
 
         bool DoNeedCleanup(bool enter)
@@ -488,18 +486,19 @@ public:
             if (Creature* sinclari = GetCreature(DATA_SINCLARI))
             {
                 sinclari->SetNpcFlag(UNIT_NPC_FLAG_GOSSIP);
-                sinclari->DespawnOrUnsummon();
-                sinclari->SetRespawnTime(3);
+                sinclari->DespawnOrUnsummon(0ms, 3s);
             }
 
-            for (ObjectGuid const& guid : _guardGuid)
+            for (ObjectGuid& guid : _guardGuid)
+            {
                 if (Creature* guard = instance->GetCreature(guid))
                 {
-                    guard->DespawnOrUnsummon();
-                    guard->SetRespawnTime(3);
                     guard->SetVisible(GetBossState(DATA_CYANIGOSA) != DONE);
                     guard->SetReactState(REACT_AGGRESSIVE);
+                    guard->DespawnOrUnsummon(0ms, 3s);
                 }
+                guid.Clear();
+            }
 
             if (Creature* portal = GetCreature(DATA_TELEPORTATION_PORTAL))
                 portal->DespawnOrUnsummon();
@@ -530,26 +529,27 @@ public:
                 {
                     if (Creature* boss = GetCreature(id))
                     {
-                        boss->DespawnOrUnsummon();
-                        boss->SetRespawnTime(3);
                         boss->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                         boss->SetImmuneToNPC(true);
+                        boss->DespawnOrUnsummon(0ms, 3s);
                     }
                 }
+
                 if (Creature* guard1 = instance->GetCreature(_erekemGuardGuid[0]))
                 {
-                    guard1->DespawnOrUnsummon();
-                    guard1->SetRespawnTime(3);
                     guard1->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                     guard1->SetImmuneToNPC(true);
+                    guard1->DespawnOrUnsummon(0ms, 3s);
                 }
+                _erekemGuardGuid[0].Clear();
                 if (Creature* guard2 = instance->GetCreature(_erekemGuardGuid[1]))
                 {
-                    guard2->DespawnOrUnsummon();
-                    guard2->SetRespawnTime(3);
                     guard2->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                     guard2->SetImmuneToNPC(true);
+                    guard2->DespawnOrUnsummon(0ms, 3s);
                 }
+                _erekemGuardGuid[1].Clear();
+
                 if (Creature* cyanigosa = GetCreature(DATA_CYANIGOSA))
                     cyanigosa->DespawnOrUnsummon();
             }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Opus 4.6 was used to assist with identifying the root cause and implementing fixes.

## Issues Addressed:
- Violet Hold instance has no bosses, guards, or Sinclari visible when entering.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Violet Hold instance with `.gm off`
2. Verify Sinclari, guards, bosses, and Erekem guards are all visible on entry
3. Talk to Sinclari to start the encounter
4. Verify guards walk back and become invisible
5. Verify Sinclari moves outside and despawns after her yell
6. Verify portal waves spawn and bosses are released correctly
7. Wipe or reset the instance and verify all NPCs respawn correctly for a fresh encounter attempt

## Known Issues and TODO List:

- [ ] Verify that multi-player scenarios (player leaving/re-entering mid-encounter) handle cleanup correctly
- [ ] Verify the Defenseless achievement criteria still works after encounter reset changes

## Root Cause

`InstanceCleanup()` called `DespawnOrUnsummon()` followed by `SetRespawnTime(3)`. However, `ForcedDespawn()` computes `m_respawnTime` inside `setDeathState()` using the DB `m_respawnDelay` (14400s for bosses, 3600s for guards) **before** `SetRespawnTime(3)` could override it. The creatures would not respawn for hours.

The fix uses `DespawnOrUnsummon(0ms, 3s)` which passes the forced respawn timer directly into `ForcedDespawn`, overriding `m_respawnDelay` before `setDeathState` computes the respawn time.

Additional fixes:
- Guard GUID arrays are cleared after despawn so respawned creatures re-register correctly via `OnCreatureCreate`
- Cleanup checks only run after the encounter starts, preventing unnecessary despawn/respawn cycles on instance entry
- Sinclari despawns after delivering her line when the encounter door locks

🤖 Generated with [Claude Code](https://claude.com/claude-code)