### PR TITLE
fix(Core/Scripts): use DespawnOrUnsummon respawn parameter

### DIFF
--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/instance_trial_of_the_champion.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/instance_trial_of_the_champion.cpp
@@ -325,11 +325,9 @@ public:
                         }
                         if (Creature* c = instance->GetCreature(NPC_AnnouncerGUID))
                         {
-                            c->DespawnOrUnsummon();
                             c->SetHomePosition(748.309f, 619.488f, 411.172f, 4.71239f);
-                            c->SetPosition(748.309f, 619.488f, 411.172f, 4.71239f);
-                            c->SetRespawnTime(3);
                             c->SetNpcFlag(UNIT_NPC_FLAG_GOSSIP);
+                            c->DespawnOrUnsummon(0ms, 3s);
                         }
                         InstanceProgress = INSTANCE_PROGRESS_INITIAL;
                     }
@@ -338,10 +336,7 @@ public:
                     {
                         if (Creature* announcer = instance->GetCreature(NPC_AnnouncerGUID))
                         {
-                            announcer->DespawnOrUnsummon();
                             announcer->SetHomePosition(735.81f, 661.92f, 412.39f, 4.714f);
-                            announcer->SetPosition(735.81f, 661.92f, 412.39f, 4.714f);
-                            announcer->SetRespawnTime(3);
                             announcer->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
 
                             for( uint8 i = 0; i < 3; ++i )
@@ -374,6 +369,7 @@ public:
                                             break;
                                     }
                                 }
+                            announcer->DespawnOrUnsummon(0ms, 3s);
                         }
                     }
                     break;
@@ -396,11 +392,9 @@ public:
                         NPC_ArgentChampionGUID.Clear();
                         if (Creature* c = instance->GetCreature(NPC_AnnouncerGUID))
                         {
-                            c->DespawnOrUnsummon();
                             c->SetHomePosition(743.14f, 628.77f, 411.2f, 4.71239f);
-                            c->SetPosition(743.14f, 628.77f, 411.2f, 4.71239f);
-                            c->SetRespawnTime(3);
                             c->SetNpcFlag(UNIT_NPC_FLAG_GOSSIP);
+                            c->DespawnOrUnsummon(0ms, 3s);
                         }
                         NPC_MemoryEntry = 0;
                         InstanceProgress = INSTANCE_PROGRESS_CHAMPIONS_DEAD;
@@ -420,11 +414,9 @@ public:
                         NPC_BlackKnightGUID.Clear();
                         if (Creature* c = instance->GetCreature(NPC_AnnouncerGUID))
                         {
-                            c->DespawnOrUnsummon();
                             c->SetHomePosition(743.14f, 628.77f, 411.2f, 4.71239f);
-                            c->SetPosition(743.14f, 628.77f, 411.2f, 4.71239f);
-                            c->SetRespawnTime(3);
                             c->SetNpcFlag(UNIT_NPC_FLAG_GOSSIP);
+                            c->DespawnOrUnsummon(0ms, 3s);
                         }
                         InstanceProgress = INSTANCE_PROGRESS_ARGENT_CHALLENGE_DIED;
                     }

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/instance_trial_of_the_champion.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/instance_trial_of_the_champion.cpp
@@ -176,10 +176,7 @@ public:
                 case VEHICLE_ARGENT_WARHORSE:
                 case VEHICLE_ARGENT_BATTLEWORG:
                     if (InstanceProgress < INSTANCE_PROGRESS_CHAMPIONS_UNMOUNTED && m_auiEncounter[0] == NOT_STARTED)
-                    {
-                        creature->DespawnOrUnsummon(0ms, 3s);
                         VehicleList.push_back(creature->GetGUID());
-                    }
                     else
                         creature->DespawnOrUnsummon();
                     break;
@@ -300,6 +297,7 @@ public:
             switch (InstanceProgress)
             {
                 case INSTANCE_PROGRESS_INITIAL:
+                    break;
                 case INSTANCE_PROGRESS_GRAND_CHAMPIONS_REACHED_DEST:
                 case INSTANCE_PROGRESS_CHAMPION_GROUP_DIED_1:
                 case INSTANCE_PROGRESS_CHAMPION_GROUP_DIED_2:
@@ -308,9 +306,8 @@ public:
                     {
                         for (ObjectGuid const& guid : VehicleList)
                             if (Creature* veh = instance->GetCreature(guid))
-                            {
                                 veh->DespawnOrUnsummon(0ms, 3s);
-                            }
+                        VehicleList.clear();
                         for( uint8 i = 0; i < 3; ++i )
                         {
                             for( uint8 j = 0; j < 3; ++j )

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/instance_trial_of_the_champion.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/instance_trial_of_the_champion.cpp
@@ -177,8 +177,7 @@ public:
                 case VEHICLE_ARGENT_BATTLEWORG:
                     if (InstanceProgress < INSTANCE_PROGRESS_CHAMPIONS_UNMOUNTED && m_auiEncounter[0] == NOT_STARTED)
                     {
-                        creature->DespawnOrUnsummon();
-                        creature->SetRespawnTime(3);
+                        creature->DespawnOrUnsummon(0ms, 3s);
                         VehicleList.push_back(creature->GetGUID());
                     }
                     else
@@ -310,8 +309,7 @@ public:
                         for (ObjectGuid const& guid : VehicleList)
                             if (Creature* veh = instance->GetCreature(guid))
                             {
-                                veh->DespawnOrUnsummon();
-                                veh->SetRespawnTime(3);
+                                veh->DespawnOrUnsummon(0ms, 3s);
                             }
                         for( uint8 i = 0; i < 3; ++i )
                         {

--- a/src/server/scripts/Northrend/VioletHold/instance_violet_hold.cpp
+++ b/src/server/scripts/Northrend/VioletHold/instance_violet_hold.cpp
@@ -172,8 +172,7 @@ public:
                         if (Creature* sinclari = GetCreature(DATA_SINCLARI))
                         {
                             sinclari->AI()->Talk(SAY_SINCLARI_COMPLETE);
-                            sinclari->DespawnOrUnsummon();
-                            sinclari->SetRespawnTime(3);
+                            sinclari->DespawnOrUnsummon(0ms, 3s);
                         }
                     }
                     else if (state == FAIL || state == NOT_STARTED)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Replace `DespawnOrUnsummon()` + `SetRespawnTime(3)` with the two-parameter overload `DespawnOrUnsummon(0ms, 3s)` in Trial of the Champion and Violet Hold instance scripts.

After `DespawnOrUnsummon()` is called, the creature is flagged for removal, so a subsequent `SetRespawnTime()` call may not take effect reliably. The two-parameter overload passes the respawn time atomically before the despawn is processed.

**Affected scripts:**
- `instance_trial_of_the_champion.cpp` — vehicle spawn setup (line 180) and vehicle list cleanup on encounter revert (line 313)
- `instance_violet_hold.cpp` — Sinclari despawn after Cyanigosa completion (line 175)

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Opus 4.6 was used to identify occurrences and prepare the PR.

## Issues Addressed:
- Related to bc38cf2d275462193379deb6d028f66d148a8937 which fixed the same pattern in VH's `InstanceCleanup()`

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Code inspection of the `DespawnOrUnsummon` two-parameter overload confirms it sets respawn time before processing the despawn.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Trial of the Champion, start and wipe on the first encounter. Verify vehicles respawn correctly after reset.
2. Enter Violet Hold, complete the instance (kill Cyanigosa). Verify Sinclari respawns after the victory RP.

## Known Issues and TODO List:

- [ ] Needs in-game verification for both instances