### PR TITLE
fix(Scripts/AQ40): prevent Master's Eye respawn crash in OnCreatureCreate

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/instance_temple_of_ahnqiraj.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/instance_temple_of_ahnqiraj.cpp
@@ -81,7 +81,7 @@ public:
                         creature->Respawn();
                     break;
                 case NPC_MASTERS_EYE:
-                    if (GetBossState(DATA_TWIN_EMPERORS) != DONE)
+                    if (GetBossState(DATA_TWIN_EMPERORS) != DONE && !creature->IsAlive())
                         creature->Respawn(true);
                     break;
                 case NPC_CTHUN:


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Opus 4.6 was used to analyze crash dumps and investigate the root cause.

## Description

In `OnCreatureCreate`, The Master's Eye (entry 15963, spawnId 88072) calls `Respawn(true)` when Twin Emperors are not yet defeated. However, the creature is already alive at this point — `OnCreatureCreate` fires after `AddToWorld()` during the normal spawn/respawn flow.

Calling `Respawn(true)` on an already-alive creature:
1. Sets death state to `JustDied` (Creature.cpp:2021)
2. `RemoveCorpse` bails out because state is `JustDied`, not `Corpse` (Creature.cpp:420-421)
3. The respawn logic block is skipped because state is not `Dead` (Creature.cpp:2053)
4. Falls through to `UpdateObjectVisibility(false)` (Creature.cpp:2117) with `visibilityDistanceType = 3` (huge radius)
5. Back in `AddToMap`, a second `UpdateObjectVisibility(true)` fires (Map.cpp:347)
6. On the next update tick, the creature processes `JustDied` → `Corpse` → `Dead` → respawn cycle repeats

This causes a 30+ second freeze in `VisibleChangesNotifier::Visit` during map updates, triggering the FreezeDetector abort. Two separate crash dumps confirmed this — both showing map worker threads stuck in grid visibility notification for this creature during AQ40 instance updates.

The fix adds an `!creature->IsAlive()` guard, consistent with how every other `OnCreatureCreate` handler in the codebase guards `Respawn(true)` calls (e.g., Karazhan's NPC_BARNES, Blood Furnace's prisoners).

## Issues Addressed:

- Closes 

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Two GDB crash dumps from a live ChromieCraft server were analyzed, both showing the same freeze pattern in AQ40 instance map updates.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Temple of Ahn'Qiraj (AQ40) without killing Twin Emperors
2. Verify The Master's Eye (NPC 15963) spawns correctly near the Twin Emperors area
3. Approach the Twin Emperors area trigger to confirm the emote/despawn sequence still works
4. Reset the instance and re-enter to confirm the creature respawns properly
5. Monitor server logs for any freeze detector warnings during AQ40 instance updates

## Known Issues and TODO List:

- [ ] Needs in-game verification that the Twin Emperors intro RP sequence still functions correctly after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)