### PR TITLE
chore(deps/boost): Fix CMP0167 deprecation warning

### DIFF
--- a/deps/boost/CMakeLists.txt
+++ b/deps/boost/CMakeLists.txt
@@ -56,7 +56,7 @@ target_link_libraries(boost
 
 target_include_directories(boost
   INTERFACE
-    $<TARGET_PROPERTY:Boost::boost,INTERFACE_INCLUDE_DIRECTORIES>)
+    ${Boost_INCLUDE_DIRS})
 
 target_compile_definitions(boost
   INTERFACE

--- a/deps/boost/CMakeLists.txt
+++ b/deps/boost/CMakeLists.txt
@@ -31,6 +31,11 @@ else()
   set(BOOST_REQUIRED_VERSION 1.74)
 endif()
 
+# Suppress deprecation of FindBoost module (CMake >= 3.30 uses Boost's own config).
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
+
 # Boost.System is header-only since 1.69; do not require it explicitly.
 find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED COMPONENTS filesystem program_options iostreams regex)
 
@@ -44,11 +49,14 @@ add_library(boost INTERFACE)
 
 target_link_libraries(boost
   INTERFACE
-    ${Boost_LIBRARIES})
+    Boost::filesystem
+    Boost::program_options
+    Boost::iostreams
+    Boost::regex)
 
 target_include_directories(boost
   INTERFACE
-    ${Boost_INCLUDE_DIRS})
+    $<TARGET_PROPERTY:Boost::headers,INTERFACE_INCLUDE_DIRECTORIES>)
 
 target_compile_definitions(boost
   INTERFACE

--- a/deps/boost/CMakeLists.txt
+++ b/deps/boost/CMakeLists.txt
@@ -56,7 +56,7 @@ target_link_libraries(boost
 
 target_include_directories(boost
   INTERFACE
-    $<TARGET_PROPERTY:Boost::headers,INTERFACE_INCLUDE_DIRECTORIES>)
+    $<TARGET_PROPERTY:Boost::boost,INTERFACE_INCLUDE_DIRECTORIES>)
 
 target_compile_definitions(boost
   INTERFACE


### PR DESCRIPTION
…orted targets



<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
Enable policy CMP0167 to avoid FindBoost deprecation warnings on CMake >= 3.30. 

* closes https://github.com/azerothcore/azerothcore-wotlk/issues/25462
### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. Claude Sonnet

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
