### PR TITLE
fix(Core/Spells): No SP bonus for DmgClass NONE without spell_bonus_data

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8845,6 +8845,12 @@ uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, uin
             }
         }
     }
+    else
+    {
+        // No bonus damage for SPELL_DAMAGE_CLASS_NONE class spells by default
+        if (spellProto->DmgClass == SPELL_DAMAGE_CLASS_NONE)
+            return uint32(std::max((float(pdamage) + DoneTotal) * DoneTotalMod, 0.0f));
+    }
 
     // Default calculation
     if (coeff && DoneAdvertisedBenefit)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Port of TrinityCore's guard in `Unit::SpellDamageBonusDone`: spells with `DmgClass = SPELL_DAMAGE_CLASS_NONE` that lack a `spell_bonus_data` entry now skip the default spell-power coefficient path.

Fixes Obsidian Sanctum **Twilight Shift (57874)** ticks picking up the player's spell power inside the portal (mages ~3.5k/tick vs ~1.2k for melee). After the fix, every class takes the intended ~1017–1181 per tick. Same latent issue affects ~1,800 other generic / boss / environmental damage spells; zero player-class spells are affected.

### Follow-up audit — no regressions expected

Cross-referenced the 1,838 affected spells against `item_template` / `spell_proc` / `spellitemenchantment_dbc`. Only 9 player-usable items fall in scope: Saronite Bomb (41119), The Decapitator (28767), Shard of the Fallen Star (21891), Sul'thraze the Lasher (9372), Circle of Flame (11808), Barovian Family Sword (14541), Demonic Rune (12662), Dark Rune (20520), Skull of Impending Doom (4984). Every one of these is flat-damage by design (engineering bomb, classic/TBC weapon/trinket procs pre-dating spell power as a stat, self-damage consumables) — none should have been scaling with SP to begin with, so no `spell_bonus_data` rows needed.

### AI-assisted Pull Requests

- [x] AI tools were used in preparing this pull request.

**Tools used:** Claude Code with azerothMCP.

## Issues Addressed:
- Closes

## SOURCE:
- [x] Live research
- [x] Cherry-pick — port of the guard in TrinityCore's `Unit::SpellDamageBonusDone` (co-authors credited in commit).

## Tests Performed:
- [x] Tested in-game by the author.
- [x] Further testing welcome (broad change).

## How to Test the Changes:

1. `.tele obsidiansanctum`, engage Vesperon (30452), enter the Twilight Portal.
2. Verify Twilight Shift (57874) ticks ~1017–1181 shadow per second for every class (mage, warlock, DK, warrior should match). Pre-fix, casters tick 3–4k.
3. Regression: target-dummy parse core rotations (Fireball, Shadow Bolt, Mind Flay, Lightning Bolt, Moonfire, Steady Shot, Death Coil, etc.) — unchanged (none are DmgClass=NONE).
4. Spot-check other NONE-class mechanics: ICC Marrowgar Coldflame, Ulduar Tympanic Tantrum, TOC Anub'arak Penetrating Cold — damage flat across classes.