### PR TITLE
fix(Scripts/Spells): Corpse Tongue Coin proc target and HP check

### DIFF
--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -221,8 +221,10 @@ enum CommendationOfKaelthas
 
 enum CorpseTongueCoin
 {
-    SPELL_CORPSE_TONGUE_COIN        = 71633,
-    SPELL_CORPSE_TONGUE_COIN_HERO   = 71634
+    SPELL_CORPSE_TONGUE_COIN_PROC       = 71634,
+    SPELL_CORPSE_TONGUE_COIN_PROC_HERO  = 71640,
+    SPELL_THICK_SKIN                    = 71633,
+    SPELL_THICK_SKIN_HERO               = 71639
 };
 
 enum CrystalSpireOfKarabor
@@ -5726,46 +5728,58 @@ class spell_item_commendation_of_kaelthas : public AuraScript
     }
 };
 
-// 71632 - Corpse Tongue Coin
+// 71634 - Corpse Tongue Coin
 class spell_item_corpse_tongue_coin : public AuraScript
 {
     PrepareAuraScript(spell_item_corpse_tongue_coin);
 
     bool Validate(SpellInfo const* /*spellInfo*/) override
     {
-        return ValidateSpellInfo({ SPELL_CORPSE_TONGUE_COIN });
+        return ValidateSpellInfo({ SPELL_THICK_SKIN });
     }
 
-    void HandleProc(ProcEventInfo& eventInfo)
+    bool CheckProc(ProcEventInfo& /*eventInfo*/)
+    {
+        return GetTarget()->HealthBelowPct(35);
+    }
+
+    void HandleProc(ProcEventInfo& /*eventInfo*/)
     {
         PreventDefaultAction();
-        eventInfo.GetActor()->CastSpell((Unit*)nullptr, SPELL_CORPSE_TONGUE_COIN, true, nullptr, GetEffect(EFFECT_0));
+        GetTarget()->CastSpell(GetTarget(), SPELL_THICK_SKIN, true, nullptr, GetEffect(EFFECT_0));
     }
 
     void Register() override
     {
+        DoCheckProc += AuraCheckProcFn(spell_item_corpse_tongue_coin::CheckProc);
         OnProc += AuraProcFn(spell_item_corpse_tongue_coin::HandleProc);
     }
 };
 
-// 71639 - Corpse Tongue Coin (Heroic)
+// 71640 - Corpse Tongue Coin (Heroic)
 class spell_item_corpse_tongue_coin_heroic : public AuraScript
 {
     PrepareAuraScript(spell_item_corpse_tongue_coin_heroic);
 
     bool Validate(SpellInfo const* /*spellInfo*/) override
     {
-        return ValidateSpellInfo({ SPELL_CORPSE_TONGUE_COIN_HERO });
+        return ValidateSpellInfo({ SPELL_THICK_SKIN_HERO });
     }
 
-    void HandleProc(ProcEventInfo& eventInfo)
+    bool CheckProc(ProcEventInfo& /*eventInfo*/)
+    {
+        return GetTarget()->HealthBelowPct(35);
+    }
+
+    void HandleProc(ProcEventInfo& /*eventInfo*/)
     {
         PreventDefaultAction();
-        eventInfo.GetActor()->CastSpell((Unit*)nullptr, SPELL_CORPSE_TONGUE_COIN_HERO, true, nullptr, GetEffect(EFFECT_0));
+        GetTarget()->CastSpell(GetTarget(), SPELL_THICK_SKIN_HERO, true, nullptr, GetEffect(EFFECT_0));
     }
 
     void Register() override
     {
+        DoCheckProc += AuraCheckProcFn(spell_item_corpse_tongue_coin_heroic::CheckProc);
         OnProc += AuraProcFn(spell_item_corpse_tongue_coin_heroic::HandleProc);
     }
 };


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

The `spell_item_corpse_tongue_coin` and `spell_item_corpse_tongue_coin_heroic` AuraScripts were registered on the wrong spell IDs (71632, which does not exist in Spell.dbc, and 71639, which is the heroic Thick Skin buff — not its proc aura). Because the scripts never attached to the real proc auras (71634 / 71640), the generic proc path handled the trinket:

- no `< 35% HP` condition was enforced, so the buff procced at any HP
- the caster of the triggered spell fell through to the attacker, so Thick Skin was applied to the **enemy** instead of the wearer

This PR:
- renames the enum to distinguish proc auras (71634 / 71640) from the Thick Skin buffs (71633 / 71639)
- re-targets both scripts to the real proc auras
- adds a `CheckProc` that returns `GetTarget()->HealthBelowPct(35)`
- casts the Thick Skin buff on `GetTarget()` (the wearer) via `PreventDefaultAction()` + `CastSpell`

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with AzerothMCP.

## Issues Addressed:
- Closes #25388

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Spell.dbc + tooltip: `Melee attacks which reduce you below 35% health cause you to gain 71633s1 armor for 71633d. Cannot occur more than once every 30 sec.`
https://www.wowhead.com/wotlk/item=50352/corpse-tongue-coin

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

**Normal (item 50352, proc aura 71634, buff 71633):**
1. `.additem 50352` and equip the trinket.
2. Take melee damage while above 35% HP → no proc.
3. Drop below 35% HP and take one more melee hit → wearer gains Thick Skin (71633); enemy has no new buff.
4. Take another hit within 30s → no re-proc (ICD).
5. After 30s, another sub-35% hit → procs again.

**Heroic (item 50349, proc aura 71640, buff 71639):**
1. `.additem 50349` and equip.
2. Repeat steps 2–5; buff should be 71639 on self only.

## Known Issues and TODO List:

- [ ]
- [ ]