### PR TITLE
fix(Scripts/EoE): restore hover disk flight for players

### DIFF
--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -1011,6 +1011,7 @@ struct npc_hover_disk : public VehicleAI
                 who->ApplySpellImmune(0, IMMUNITY_ID, SPELL_SURGE_OF_POWER_DMG, true);
                 me->SetSpeed(MOVE_RUN, 1.5f);
                 me->SetSpeed(MOVE_FLIGHT, 1.5f);
+                me->SetCanFly(true);
                 me->SetDisableGravity(true);
             }
             else if (who->GetEntry() == NPC_NEXUS_LORD)


### PR DESCRIPTION
## Changes Proposed:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Regression from #25442. That PR refactored `npc_hover_disk::PassengerBoarded` in `boss_malygos.cpp` into three per-passenger branches (player / Nexus Lord / Scion). The previous code set `me->SetCanFly(true)` unconditionally at the end of the apply branch; the refactor moved the call into each branch individually but omitted it from the player branch, which only received `SetDisableGravity(true)`.

Without `CAN_FLY` on the vehicle, the client rejects upward flight input, so players could board the Hover Disk in Malygos Phase 2 but could not fly up to engage the Scions of Eternity and Nexus Lords. The other two branches already set `SetCanFly(true)`, so Nexus Lord / Scion-driven disks were unaffected — this restores the player branch to match.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with AzerothMCP.

## Issues Addressed:
- Closes #25474
- Closes chromiecraft/chromiecraft#9298

## SOURCE:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Reference: https://www.wowhead.com/wotlk/npc=30248/hover-disk — the Hover Disk is a flying vehicle intended to allow players to engage Malygos P2 adds in the air. Bug introduced by git-blame of #25442.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Be level 80, `.cheat god`, `.additem 44581`, `.tele eyeofeternity`.
2. Engage Malygos and push him to Phase 2 with `.damage 56 pct`.
3. Kill one of the adds riding a Hover Disk (NPC 30248) so the disk becomes rider-less.
4. Right-click the empty Hover Disk to mount it.
5. Press spacebar / forward-up — the disk should now ascend and allow you to fly around the arena to engage the remaining Scions / Nexus Lords.
6. Dismount — disk should land smoothly back onto the platform (unchanged behavior).
7. Regression: confirm AI-driven Hover Disks (carrying Nexus Lords / Scions) still fly and patrol the arena normally.

## Known Issues and TODO List:

- [ ] Secondary concern raised in the issue about Nexus Lords stacking / charging is not addressed here — it appears to be a separate behavior and out of scope for this regression fix.