### PR TITLE
fix(Scripts/Items): HP-gated proc for low-HP tank trinkets

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1776289351038929863.sql
+++ b/data/sql/updates/pending_db_world/rev_1776289351038929863.sql
@@ -1,0 +1,8 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (45057, 52420, 71634, 71640, 75475, 75481) OR `ScriptName` IN ('spell_item_commendation_of_kaelthas', 'spell_item_corpse_tongue_coin', 'spell_item_corpse_tongue_coin_heroic', 'spell_item_petrified_twilight_scale', 'spell_item_petrified_twilight_scale_heroic', 'spell_item_soul_harvesters_charm');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(45057, 'spell_item_proc_below_pct_damaged'),
+(52420, 'spell_item_proc_below_pct_damaged'),
+(71634, 'spell_item_proc_below_pct_damaged'),
+(71640, 'spell_item_proc_below_pct_damaged'),
+(75475, 'spell_item_proc_below_pct_damaged'),
+(75481, 'spell_item_proc_below_pct_damaged');

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -214,25 +214,9 @@ enum UnstablePower
     SPELL_UNSTABLE_POWER_AURA = 24659
 };
 
-enum CommendationOfKaelthas
-{
-    SPELL_COMMENDATION_OF_KAELTHAS = 45480
-};
-
-enum CorpseTongueCoin
-{
-    SPELL_CORPSE_TONGUE_COIN        = 71633,
-    SPELL_CORPSE_TONGUE_COIN_HERO   = 71634
-};
-
 enum CrystalSpireOfKarabor
 {
     SPELL_CRYSTAL_SPIRE_OF_KARABOR_MANA = 35476
-};
-
-enum SoulHarvestersCharm
-{
-    SPELL_SOUL_HARVESTERS_CHARM     = 60513
 };
 
 enum SunwellExaltedNeck
@@ -258,12 +242,6 @@ enum TinyAbominationInAJar
 enum TotemOfFlowingWater
 {
     SPELL_TOTEM_OF_FLOWING_WATER_MANA = 28857
-};
-
-enum PetrifiedTwilightScale
-{
-    SPELL_PETRIFIED_TWILIGHT_SCALE_HC = 75480,
-    SPELL_PETRIFIED_TWILIGHT_SCALE    = 75477
 };
 
 enum ShardOfTheScale
@@ -5706,67 +5684,30 @@ class spell_item_unstable_power : public AuraScript
     }
 };
 
-// 45478 - Commendation of Kael'thas
-class spell_item_commendation_of_kaelthas : public AuraScript
+// 45057 - Evasive Maneuvers (Commendation of Kael'thas)
+// 52420 - Deflection (Soul Harvester's Charm)
+// 71634 - Item - Icecrown 25 Normal Tank Trinket 1 (Corpse Tongue Coin)
+// 71640 - Item - Icecrown 25 Heroic Tank Trinket 1 (Corpse Tongue Coin (Heroic))
+// 75475 - Item - Chamber of Aspects 25 Tank Trinket (Petrified Twilight Scale)
+// 75481 - Item - Chamber of Aspects 25 Heroic Tank Trinket (Petrified Twilight Scale (Heroic))
+// Trinkets that proc only when a melee hit drops you below EFFECT_0 % HP.
+class spell_item_proc_below_pct_damaged : public AuraScript
 {
-    PrepareAuraScript(spell_item_commendation_of_kaelthas);
+    PrepareAuraScript(spell_item_proc_below_pct_damaged);
 
     bool CheckProc(ProcEventInfo& eventInfo)
     {
-        if (HealInfo* healInfo = eventInfo.GetHealInfo())
-            if (Unit* target = healInfo->GetTarget())
-                if (target->GetHealth() + healInfo->GetEffectiveHeal() >= target->GetMaxHealth())
-                    return true;
-        return false;
+        DamageInfo* damageInfo = eventInfo.GetDamageInfo();
+        if (!damageInfo || !damageInfo->GetDamage())
+            return false;
+
+        int32 pct = GetSpellInfo()->Effects[EFFECT_0].CalcValue();
+        return eventInfo.GetActionTarget()->HealthBelowPctDamaged(pct, damageInfo->GetDamage());
     }
 
     void Register() override
     {
-        DoCheckProc += AuraCheckProcFn(spell_item_commendation_of_kaelthas::CheckProc);
-    }
-};
-
-// 71632 - Corpse Tongue Coin
-class spell_item_corpse_tongue_coin : public AuraScript
-{
-    PrepareAuraScript(spell_item_corpse_tongue_coin);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_CORPSE_TONGUE_COIN });
-    }
-
-    void HandleProc(ProcEventInfo& eventInfo)
-    {
-        PreventDefaultAction();
-        eventInfo.GetActor()->CastSpell((Unit*)nullptr, SPELL_CORPSE_TONGUE_COIN, true, nullptr, GetEffect(EFFECT_0));
-    }
-
-    void Register() override
-    {
-        OnProc += AuraProcFn(spell_item_corpse_tongue_coin::HandleProc);
-    }
-};
-
-// 71639 - Corpse Tongue Coin (Heroic)
-class spell_item_corpse_tongue_coin_heroic : public AuraScript
-{
-    PrepareAuraScript(spell_item_corpse_tongue_coin_heroic);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_CORPSE_TONGUE_COIN_HERO });
-    }
-
-    void HandleProc(ProcEventInfo& eventInfo)
-    {
-        PreventDefaultAction();
-        eventInfo.GetActor()->CastSpell((Unit*)nullptr, SPELL_CORPSE_TONGUE_COIN_HERO, true, nullptr, GetEffect(EFFECT_0));
-    }
-
-    void Register() override
-    {
-        OnProc += AuraProcFn(spell_item_corpse_tongue_coin_heroic::HandleProc);
+        DoCheckProc += AuraCheckProcFn(spell_item_proc_below_pct_damaged::CheckProc);
     }
 };
 
@@ -5785,28 +5726,6 @@ class spell_item_crystal_spire_of_karabor : public AuraScript
     void Register() override
     {
         DoCheckProc += AuraCheckProcFn(spell_item_crystal_spire_of_karabor::CheckProc);
-    }
-};
-
-// 60512 - Soul Harvester's Charm
-class spell_item_soul_harvesters_charm : public AuraScript
-{
-    PrepareAuraScript(spell_item_soul_harvesters_charm);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_SOUL_HARVESTERS_CHARM });
-    }
-
-    void HandleProc(ProcEventInfo& eventInfo)
-    {
-        PreventDefaultAction();
-        eventInfo.GetActor()->CastSpell((Unit*)nullptr, SPELL_SOUL_HARVESTERS_CHARM, true, nullptr, GetEffect(EFFECT_0));
-    }
-
-    void Register() override
-    {
-        OnProc += AuraProcFn(spell_item_soul_harvesters_charm::HandleProc);
     }
 };
 
@@ -6022,50 +5941,6 @@ class spell_item_totem_of_flowing_water : public AuraScript
     void Register() override
     {
         OnEffectProc += AuraEffectProcFn(spell_item_totem_of_flowing_water::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
-    }
-};
-
-// 75466 - Petrified Twilight Scale
-class spell_item_petrified_twilight_scale : public AuraScript
-{
-    PrepareAuraScript(spell_item_petrified_twilight_scale);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_PETRIFIED_TWILIGHT_SCALE });
-    }
-
-    void HandleProc(ProcEventInfo& eventInfo)
-    {
-        PreventDefaultAction();
-        eventInfo.GetActionTarget()->CastSpell((Unit*)nullptr, SPELL_PETRIFIED_TWILIGHT_SCALE, true, nullptr, GetEffect(EFFECT_0));
-    }
-
-    void Register() override
-    {
-        OnProc += AuraProcFn(spell_item_petrified_twilight_scale::HandleProc);
-    }
-};
-
-// 75473 - Petrified Twilight Scale (Heroic)
-class spell_item_petrified_twilight_scale_heroic : public AuraScript
-{
-    PrepareAuraScript(spell_item_petrified_twilight_scale_heroic);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_PETRIFIED_TWILIGHT_SCALE_HC });
-    }
-
-    void HandleProc(ProcEventInfo& eventInfo)
-    {
-        PreventDefaultAction();
-        eventInfo.GetActionTarget()->CastSpell((Unit*)nullptr, SPELL_PETRIFIED_TWILIGHT_SCALE_HC, true, nullptr, GetEffect(EFFECT_0));
-    }
-
-    void Register() override
-    {
-        OnProc += AuraProcFn(spell_item_petrified_twilight_scale_heroic::HandleProc);
     }
 };
 
@@ -6355,11 +6230,8 @@ void AddSC_item_spell_scripts()
     RegisterSpellScript(spell_item_pet_healing);
     RegisterSpellScript(spell_item_restless_strength);
     RegisterSpellScript(spell_item_unstable_power);
-    RegisterSpellScript(spell_item_commendation_of_kaelthas);
-    RegisterSpellScript(spell_item_corpse_tongue_coin);
-    RegisterSpellScript(spell_item_corpse_tongue_coin_heroic);
+    RegisterSpellScript(spell_item_proc_below_pct_damaged);
     RegisterSpellScript(spell_item_crystal_spire_of_karabor);
-    RegisterSpellScript(spell_item_soul_harvesters_charm);
     RegisterSpellScript(spell_item_sunwell_exalted_caster_neck);
     RegisterSpellScript(spell_item_sunwell_exalted_healer_neck);
     RegisterSpellScript(spell_item_sunwell_exalted_melee_neck);
@@ -6368,8 +6240,6 @@ void AddSC_item_spell_scripts()
     RegisterSpellScript(spell_item_tiny_abomination_in_a_jar);
     RegisterSpellScript(spell_item_tiny_abomination_in_a_jar_hero);
     RegisterSpellScript(spell_item_totem_of_flowing_water);
-    RegisterSpellScript(spell_item_petrified_twilight_scale);
-    RegisterSpellScript(spell_item_petrified_twilight_scale_heroic);
     RegisterSpellScript(spell_item_purified_shard_of_the_scale);
     RegisterSpellScript(spell_item_shiny_shard_of_the_scale);
     RegisterSpellScript(spell_item_living_root_of_the_wildheart);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

Five "Melee attacks which reduce you below 35% health..." tank trinkets were either no-ops or wired to the wrong mechanic, and a sixth (Soul Harvester's Charm) had no script at all and procced on every melee hit:

| Spell | Item | Issue (before) |
|---|---|---|
| 45057 | Commendation of Kael'thas (34473) | Handler checked overheal-to-full, but spell 45057 procs on melee damage taken — trinket never fired |
| 52420 | Soul Harvester's Charm (38674) | No script (prior handler was wrongly attached to spell 60512, the druid-specific Soul Preserver proc, and crashed on null target) |
| 71634 | Corpse Tongue Coin (50352) | Handler just `PreventDefaultAction()`'d and re-cast the trigger spell with no HP gate |
| 71640 | Corpse Tongue Coin (Heroic) (50349) | Same as above |
| 75475 | Petrified Twilight Scale (54571) | Same as above |
| 75481 | Petrified Twilight Scale (Heroic) (54591) | Same as above |

All six DBC entries share the same shape: `ProcFlags = 0x28` (taken melee auto / taken melee spell), `EFFECT_0 BasePoints = 34` ("below 35% health"), 30s ICD (45s for the Petrified Twilight Scales) and a `TriggerSpell` that applies the buff.

Replace the five per-item handlers with a single `spell_item_proc_below_pct_damaged` `AuraScript` whose `CheckProc` gates on `HealthBelowPctDamaged(EFFECT_0_value, damage)`, then repoint all six spells to it via `spell_script_names`.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Tooling used: Claude Code with the [azerothMCP](https://github.com/azerothcore) MCP server (DBC/spell_proc/spell_script_names lookups, cross-DB verification against `tc_world`).

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The shared `CheckProc` pattern (and the registration list of all six spells) is ported from TrinityCore's `spell_gen_proc_below_pct_damaged`, originally introduced by **ariel-** in TC commit `2ff855054f` ("Core/Scripts: Convert spells to new proc system", 2016-09-25) and refactored by **Shauren** in `7a5a010d41` (2020-08-20). Both are credited as `Co-authored-by` on the commit.

Wowhead text on each spell confirms the "below 35% health" + 30s/45s ICD behavior.

## Tests Performed:
- [x] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds clean. In-game verification on a live tank is requested.

## How to Test the Changes:
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

For each trinket below: equip on a plate tank, take melee hits at >35% HP and confirm **no proc**; then drop below 35% HP from a melee hit and confirm the buff applies. Repeat to verify the 30s / 45s internal cooldown.

```
.additem 34473   # Commendation of Kael'thas      (45057 -> 45058 dodge,  30s)
.additem 38674   # Soul Harvester's Charm         (52420 -> 52419 parry,  30s)
.additem 50352   # Corpse Tongue Coin             (71634 -> 71633 armor,  30s)
.additem 50349   # Corpse Tongue Coin (Heroic)    (71640 -> 71639 armor,  30s)
.additem 54571   # Petrified Twilight Scale       (75475 -> 75477 dodge,  45s)
.additem 54591   # Petrified Twilight Scale (H)   (75481 -> 75480 dodge,  45s)
```

Regression: confirm no other items/spells previously bound to the deleted handler classes are still expected (verified — `spell_script_names` only contained the five rows now repointed).

## Known Issues and TODO List:

- [ ] None known