### PR TITLE
fix(Scripts/ObsidianSanctum): Prevent Feign Death pull

### DIFF
--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "CreatureScript.h"
+#include "GridNotifiers.h"
 #include "ScriptedCreature.h"
 #include "SpellAuras.h"
 #include "SpellScript.h"
@@ -338,6 +339,8 @@ struct boss_sartharion : public BossAI
             if (Creature* boss = instance->GetCreature(i) )
                 boss->DespawnOnEvade();
         }
+
+        me->DespawnOnEvade(30s);
     }
 
     void DoAction(int32 param) override
@@ -405,7 +408,31 @@ struct boss_sartharion : public BossAI
             instance->DoAction(ACTION_START_PATROL);
         }
 
-        me->CallForHelp(500.0f);
+        // Pull arena trash into combat with the raid. SetInCombatWithZone
+        // bypasses CanAssistTo, so Feign Death / untargetable pulls can't skip trash.
+        std::list<Creature*> arenaTrash;
+        Acore::AllFriendlyCreaturesInGrid check(me);
+        Acore::CreatureListSearcher<Acore::AllFriendlyCreaturesInGrid> searcher(me, arenaTrash, check);
+        Cell::VisitObjects(me, searcher, 500.0f);
+        for (Creature* trash : arenaTrash)
+        {
+            if (trash == me || trash->IsInCombat() || !trash->IsAlive())
+                continue;
+            if (trash->GetEntry() == NPC_SARTHARION)
+                continue;
+            if (trash->IsCritter() || trash->IsTrigger())
+                continue;
+            // Drakes (Tenebron/Shadron/Vesperon) carry NOT_SELECTABLE until
+            // Sartharion's scripted call-in engages them — skip here so they
+            // follow the staggered script, not the trash pull.
+            if (trash->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE))
+                continue;
+            if (trash->IsImmuneToPC() || trash->IsImmuneToNPC())
+                continue;
+            if (!trash->HasReactState(REACT_AGGRESSIVE))
+                continue;
+            trash->SetInCombatWithZone();
+        }
     }
 
     void JustDied(Unit* /*killer*/) override

--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
@@ -339,8 +339,6 @@ struct boss_sartharion : public BossAI
             if (Creature* boss = instance->GetCreature(i) )
                 boss->DespawnOnEvade();
         }
-
-        me->DespawnOnEvade(30s);
     }
 
     void DoAction(int32 param) override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

In Obsidian Sanctum, a hunter could pull Sartharion with Feign Death and Misdirect the boss to the tank while surrounding arena trash never entered combat, allowing the trash tier to be skipped entirely.

Root cause: `boss_sartharion::JustEngagedWith` used `CallForHelp(500.0f)`. `CallForHelp` resolves a target from the caller's threat manager and then asks nearby creatures (via `CanAssistTo`) whether to join the fight. Feign Death removes the puller from Sartharion's threat list, so `CallForHelp` finds no target and bails out — no trash is engaged.

Fix:
- Replace `CallForHelp` with a grid search around Sartharion that forces every eligible arena creature into combat via `SetInCombatWithZone()`. This pathway does not depend on the caller's threat list or `CanAssistTo`, so it is immune to Feign Death / Misdirection manipulation.
- Preserve the staggered drake call-in — Tenebron/Shadron/Vesperon carry `UNIT_FLAG_NOT_SELECTABLE` until Sartharion's scripted events engage them, and the filter excludes flagged, immune, non-aggressive, critter, and trigger creatures. Only regular arena trash is pulled.
- Add `me->DespawnOnEvade(30s)` to `EnterEvadeMode` so any legitimate reset (wipe, leash, MD-gone-wrong) cleanly despawns and respawns Sartharion instead of leaving him in a half-broken engaged state.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Tool used: Claude Code (Anthropic) with azerothMCP for codebase exploration and script analysis.

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

1. Enter Obsidian Sanctum (map 615) with a small group including a hunter.
2. With a hunter at max range, use Feign Death, Misdirect onto tank, then shoot Sartharion. Expected: arena trash is pulled into combat with the raid; drakes remain dormant and follow the scripted call-in sequence (Tenebron 20s, Shadron 60s, Vesperon 120s).
3. Pull Sartharion normally (tank walks in). Expected: identical behavior to previous builds — drakes still handled by staggered events, trash engages, portals and patrols unchanged.
4. Force an evade (wipe or everyone runs out of leash range). Expected: Sartharion and the three drakes despawn; Sartharion respawns at his spawn point ~30s later with starting triggers re-summoned.
5. Kill Sartharion normally. Expected: no regression — loot drops, encounter marks DONE.
6. Pull a drake individually on patrol without engaging Sartharion. Expected: unchanged behavior; Sartharion is not in combat so the new despawn-on-evade path does not trigger for him.

## Known Issues and TODO List:

- [ ]
- [ ]