### PR TITLE
fix(Core/Creature): Fire JustRespawned for non-compat spawns

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1776306475076268412.sql
+++ b/data/sql/updates/pending_db_world/rev_1776306475076268412.sql
@@ -1,0 +1,5 @@
+-- Onslaught Knight (27206): Add On Evade -> Despawn
+-- Prevents ejected riders from piling up when warhorses respawn
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 27206) AND (`source_type` = 0) AND (`id` IN (2));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(27206, 0, 2, 0, 7, 0, 100, 512, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Onslaught Knight - On Evade - Despawn Instant');

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -284,7 +284,7 @@ Creature::Creature(): Unit(), MovableMapObject(), m_groupLootTimer(0), lootingGr
     m_CombatDistance = 0.0f;
 
     ResetLootMode(); // restore default loot mode
-    TriggerJustRespawned = false;
+    TriggerJustRespawned = true;
     _focusSpell = nullptr;
 
     m_respawnedTime = time_t(0);
@@ -705,12 +705,12 @@ bool Creature::UpdateEntry(uint32 Entry, const CreatureData* data, bool changele
 
 void Creature::Update(uint32 diff)
 {
-    if (IsAIEnabled && TriggerJustRespawned)
+    if (IsAIEnabled && TriggerJustRespawned && getDeathState() != DeathState::Dead)
     {
+        if (_respawnCompatibilityMode && m_vehicleKit)
+            m_vehicleKit->Reset();
         TriggerJustRespawned = false;
         AI()->JustRespawned();
-        if (m_vehicleKit)
-            m_vehicleKit->Reset();
     }
 
     switch (m_deathState)


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

### Problem

In non-compatibility mode (the default after #25206), creatures are fully removed on death and recreated by `Map::ProcessRespawns()`. The existing `TriggerJustRespawned` flag was initialized to `false` in the `Creature` constructor and only ever set to `true` inside the compat-mode branch of `Creature::Respawn()` — so `AI()->JustRespawned()` never fired for freshly-spawned creatures in the new dynamic spawn system.

Because `SmartAI::JustRespawned()` is what drives:
- `ProcessEventsFor(SMART_EVENT_RESPAWN)` (phase setup, flag clears, etc.)
- `RestoreFaction()` when the current faction differs from the template

…every SAI that relies on On Respawn was silently broken for non-compat creatures. This is what causes the Onslaught Warhorse stacking / friendly-respawn behavior in #25475: the warhorse's `On Passenger Removed` SAI sets faction 35 + pacified, and the fresh respawn never restores it because On Respawn never fires.

### Fix

Port the behavior from TrinityCore's `m_triggerJustAppeared`:
- Initialize `TriggerJustRespawned = true` in the `Creature` constructor so the hook fires for both initial spawns and non-compat respawns.
- Guard the vehicle kit reset in `Creature::Update()` with `_respawnCompatibilityMode` — non-compat creatures already get `Vehicle::Reset()` via `Map::AddToMap()`, so this avoids a double-reset of accessories.
- Skip the hook when the creature is in `DeathState::Dead`, matching TC.

### DB side (Onslaught Knight)

The knight (27206) is a vehicle accessory with `summontype = 8` (MANUAL_DESPAWN), so ejected riders never clean up on their own — every warhorse respawn installs a fresh accessory on top. Added an `On Evade -> Despawn` SAI event so leashed/reset riders despawn, matching the retail behavior described in the issue.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools were used in preparing this pull request. **Claude Code (Claude Opus 4.6)** with the **azerothMCP** server was used to investigate the regression, cross-reference against TrinityCore's dynamic spawn implementation, and draft the fix.

## Issues Addressed:

- Closes #25475
- Closes https://github.com/chromiecraft/chromiecraft/issues/9295

## SOURCE:

- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The Core change mirrors TrinityCore commit [`184c45cfe0`](https://github.com/TrinityCore/TrinityCore/commit/184c45cfe0fbe4f3e4fb701f0f99994df98bdc8a) by Treeston, which introduced the same fix for TC's dynamic spawn system ("Properly invoke JustAppeared for new (re-)spawns - fixes #20111"). Credited via `Co-Authored-By` on the Core commit.

## Tests Performed:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.gm on`
2. `.go xyz 2540 -475 1 571` (New Hearthglen, Dragonblight)
3. Kill an Onslaught Warhorse (entry 27213), let the rider die or evade
4. `.respawn all`, repeat — the warhorse should come back hostile (faction 16), and ejected knights should despawn on evade instead of piling up
5. Regression check: verify SAI On Respawn events still fire once for normal (non-vehicle) creatures after respawn — e.g. any creature with SAI id=0 event_type=11 (boss reset phase, faction restore, etc.) should continue to behave as before

## Known Issues and TODO List:

- [ ] Behavioral note: the On Respawn hook now also fires on **initial** creature load (matching TC). This was previously only fired after death. Any existing SAI that relied on On Respawn specifically not firing on first load may behave differently — `SmartAI::JustRespawned()` is idempotent for fresh template state, so the expected impact is limited to scripts that intentionally skip first-load reset logic.