### PR TITLE
fix(Scripts/ICC): Ball of Flames Proc stack drop on hit

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1776309913700597434.sql
+++ b/data/sql/updates/pending_db_world/rev_1776309913700597434.sql
@@ -1,0 +1,10 @@
+--
+-- Ball of Flames Proc (ICC Prince Valanar):
+-- ensure the spell script is registered so the new AuraScript
+-- decrements a stack each time the ball hits a player.
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (71756, 72782, 72783, 72784) AND `ScriptName`='spell_taldaram_ball_of_inferno_flame';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(71756, 'spell_taldaram_ball_of_inferno_flame'),
+(72782, 'spell_taldaram_ball_of_inferno_flame'),
+(72783, 'spell_taldaram_ball_of_inferno_flame'),
+(72784, 'spell_taldaram_ball_of_inferno_flame');

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
@@ -1543,6 +1543,21 @@ class spell_taldaram_ball_of_inferno_flame : public SpellScript
     }
 };
 
+class spell_taldaram_ball_of_inferno_flame_aura : public AuraScript
+{
+    PrepareAuraScript(spell_taldaram_ball_of_inferno_flame_aura);
+
+    void HandleStackDrop(ProcEventInfo& /*eventInfo*/)
+    {
+        ModStackAmount(-1);
+    }
+
+    void Register() override
+    {
+        OnProc += AuraProcFn(spell_taldaram_ball_of_inferno_flame_aura::HandleStackDrop);
+    }
+};
+
 class spell_valanar_kinetic_bomb : public SpellScript
 {
     PrepareSpellScript(spell_valanar_kinetic_bomb);
@@ -1704,7 +1719,7 @@ void AddSC_boss_blood_prince_council()
     RegisterSpellScript(spell_blood_council_shadow_prison_damage);
     RegisterSpellScript(spell_taldaram_glittering_sparks);
     RegisterSpellScript(spell_taldaram_summon_flame_ball);
-    RegisterSpellScript(spell_taldaram_ball_of_inferno_flame);
+    RegisterSpellAndAuraScriptPair(spell_taldaram_ball_of_inferno_flame, spell_taldaram_ball_of_inferno_flame_aura);
     RegisterSpellAndAuraScriptPair(spell_valanar_kinetic_bomb, spell_valanar_kinetic_bomb_aura);
     RegisterSpellScript(spell_valanar_kinetic_bomb_absorb_aura);
     RegisterSpellScript(spell_valanar_kinetic_bomb_knockback);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

On Prince Valanar (ICC Blood Prince Council), `Conjure Empowered Flame` (72040) summons a ball of flame that chases a targeted player. The ball was meant to shrink and deal reduced damage each time it passed through another player. Since the QAston proc refactor (#24233), this mechanic no longer works — the ball keeps full size and full damage regardless of interceptors.

Root cause: the refactor removed a hardcoded case in `Unit::HandleProcTriggerSpell` that called `RemoveAuraFromStack(71756)` on proc. The new proc system fires the proc event for aura 71756 correctly, but nothing consumes a stack, so `MOD_SCALE` and `MOD_DAMAGE_DONE` amounts stay pinned at 20 stacks.

Fix: port the `AuraScript::OnProc` handler from TrinityCore that calls `ModStackAmount(-1)`, pair it with the existing `SpellScript` via `RegisterSpellAndAuraScriptPair`, and include an idempotent `spell_script_names` migration for the four proc-variant spells (71756 / 72782 / 72783 / 72784).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP.

## Issues Addressed:
- Closes #25470

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

AuraScript ported from TrinityCore (`spell_taldaram_ball_of_inferno_flame_aura`, introduced by ariel- in commit 2ff855054f5). Co-authored in the commit.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Two players `.go xyz 4660.49 2769.20 364.83 631` (Blood Prince Council).
2. Position one player between the ball's spawn point and its targeted player.
3. Engage Valanar, wait for Taldaram to cast `Conjure Empowered Flame` (72040).
4. Confirm the ball visibly shrinks on each interceptor passed and hits the target for reduced damage; with no interceptors it arrives at full size / full damage.
5. Repeat on 25N / 10H / 25H to cover 72782 / 72783 / 72784.

## Known Issues and TODO List:

- [ ]