### PR TITLE
fix(Core/AI): Prevent uint32 underflow in ScriptedEscortAI

### DIFF
--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
@@ -549,8 +549,6 @@ void npc_escortAI::GenerateWaypointArray(Movement::PointsArray* points)
     if (WaypointList.empty())
         return;
 
-    uint32 startingWaypointId = CurrentWP->id;
-
     // Flying unit, just fill array
     if (me->m_movementInfo.HasMovementFlag((MovementFlags)(MOVEMENTFLAG_CAN_FLY | MOVEMENTFLAG_DISABLE_GRAVITY)))
     {
@@ -562,12 +560,13 @@ void npc_escortAI::GenerateWaypointArray(Movement::PointsArray* points)
     }
     else
     {
+        uint32 remainingWaypoints = std::distance(CurrentWP, WaypointList.end());
         for (float size = 1.0f; size; size *= 0.5f)
         {
             std::vector<G3D::Vector3> pVector;
             // xinef: first point in vector is unit real position
             pVector.push_back(G3D::Vector3(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ()));
-            uint32 length = (WaypointList.size() - startingWaypointId) * size;
+            uint32 length = remainingWaypoints * size;
 
             uint32 cnt = 0;
             for (std::list<Escort_Waypoint>::const_iterator itr = CurrentWP; itr != WaypointList.end() && cnt <= length; ++itr, ++cnt)


### PR DESCRIPTION
fix(Core/AI): Prevent uint32 underflow in ScriptedEscortAI

## Description

This PR fixes a critical and long-standing `uint32` integer underflow bug in `ScriptedEscortAI::GenerateWaypointArray`. 

Currently, the code incorrectly assumes that `CurrentWP->id` (which comes from the database `pointid` column) is a small zero-based index. When the database `pointid` is a large number (e.g., `2878703`), subtracting it from `WaypointList.size()` causes an integer underflow, resulting in a massively distorted `length` (around 4.2 billion).

Since the recent smooth waypoint movement update (PR #25106), the underlying `MoveSplineInitArgs::Validate()` has become much stricter. When it receives a movement request with an array size of 4.2 billion, or calculates invalid velocities due to it, it outright blocks the movement request and throws an error. This leaves the Escort NPC permanently stuck and continuously twitching/stuttering in place after exiting combat.

**This completely resolves the issues where escort NPCs (like Crok in ICC or Legoso) get permanently stuck after combat.**

Fixes #25317 
Fixes #25325

## How to Test
1. Engage in an escort quest with an NPC that uses `ScriptedEscortAI` and has large `pointid`s in the DB (e.g., ICC Crok escort, or any mentioned in the issues above).
2. Wait for the NPC to enter combat.
3. Finish the combat.
4. Observe that the NPC gracefully returns to the path and continues the escort without stuttering or getting stuck in place.

## Changes
Replaced the flawed `id` subtraction with `std::distance` to accurately calculate the remaining number of waypoints in the memory list.