### PR TITLE
fix(Core/Vehicles): defer accessory init to avoid double install

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -713,6 +713,13 @@ void Creature::Update(uint32 diff)
             m_vehicleKit->Reset();
     }
 
+    if (_triggerVehicleKitInit)
+    {
+        _triggerVehicleKitInit = false;
+        if (m_vehicleKit)
+            m_vehicleKit->Reset();
+    }
+
     switch (m_deathState)
     {
         case DeathState::JustRespawned:
@@ -1113,9 +1120,10 @@ bool Creature::AIM_Initialize(CreatureAI* ai)
     IsAIEnabled = true;
     i_AI->InitializeAI();
 
-    // Xinef: Initialize vehicle if it is not summoned!
-    if (GetVehicleKit() && m_spawnId)
-        GetVehicleKit()->Reset();
+    // Defer vehicle kit init to the next Creature::Update tick so accessories
+    // install after visibility sync.
+    if (GetVehicleKit())
+        _triggerVehicleKitInit = true;
     return true;
 }
 

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -536,6 +536,9 @@ private:
     // Formation variable
     CreatureGroup* m_formation;
     bool TriggerJustRespawned;
+    // Deferred vehicle init: set in AIM_Initialize, consumed on the next
+    // Creature::Update tick so accessories install after visibility sync.
+    bool _triggerVehicleKitInit = false;
 
     // Shared timer between mobs who assist another.
     // Damaging one extends leash range on all of them.

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -346,11 +346,6 @@ bool Map::AddToMap(T* obj, bool checkTransport)
     //also, trigger needs to cast spell, if not update, cannot see visual
     obj->UpdateObjectVisibility(true);
 
-    // Xinef: little hack for vehicles, accessories have to be added after visibility update so they wont fall off the vehicle, moved from Creature::AIM_Initialize
-    // Initialize vehicle, this is done only for summoned npcs, DB creatures are handled by grid loaders
-    if (obj->IsCreature())
-        if (Vehicle* vehicle = obj->ToCreature()->GetVehicleKit())
-            vehicle->Reset();
     return true;
 }
 


### PR DESCRIPTION
## Changes Proposed:
Vehicle accessories are being installed twice on every spawn. This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### Context

Two code paths were calling `Vehicle::Reset()` during a single spawn:

1. `Creature::AIM_Initialize` called `GetVehicleKit()->Reset()` pre-visibility, guarded on `m_spawnId` (so DB creatures only).
2. `Map::AddToMap` called `vehicle->Reset()` again post-visibility, unconditionally (covering both DB and summoned creatures).

The second `Reset()` ran `InstallAllAccessories` -> `RemoveAllPassengers`, which ejected the accessory seated by the first `Reset()`, then re-summoned a fresh one. The eject fired a spurious `SMART_EVENT_PASSENGER_REMOVED` on the base vehicle. Any creature whose SAI reacts to that event (e.g. `Onslaught Warhorse` / `Onslaught Knight`) entered its dismounted state at spawn, leaving a pacified "friendly" vehicle and an orphaned accessory behind.

### Fix

Collapse both paths into a single deferred init:
- `AIM_Initialize` now sets a `TriggerVehicleKitInit` flag instead of calling `Reset()` directly.
- `Creature::Update` consumes the flag on the next tick, mirroring the existing `TriggerJustRespawned` pattern.
- The post-visibility block in `Map::AddToMap` is removed.

This runs post-visibility for both grid-loaded (DB) and `AddToMap`-loaded (summoned) vehicles, matching what the original Map.cpp comment intended. Respawn resets (`TriggerJustRespawned` -> `m_vehicleKit->Reset()`) and evade resets (`CreatureAI::EnterEvadeMode` -> `Reset(true)`) are untouched.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.6 was used for investigation, reproduction analysis, and drafting the patch. All changes were reviewed and tested by the author.

## Issues Addressed:
- Closes #25475 (partial — fixes the double-install root cause; any remaining symptoms caused by downstream effects of the spurious `PASSENGER_REMOVED` should also be resolved)

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Confirmed via targeted debug logging (now removed) that prior to this patch every Onslaught Warhorse spawn produced:
- `Reset()` x2
- `InstallAllAccessories()` x2
- `InstallAccessory(27206)` x2 (two Knight summons, first immediately orphaned)
- `RemovePassenger` of the first Knight while still alive at full HP
- `SMART_ACTION_CALL_TIMED_ACTIONLIST 2721300` (make-friendly / despawn)

After this patch, a single `Reset()` runs per spawn with the expected single accessory install, no spurious passenger removal, and the Warhorse stays hostile as intended.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Tested on the specific Onslaught Warhorse / Onslaught Knight pair at Dragonblight (New Hearthglen). Given this change affects every vehicle creature in the game, regression testing on other vehicle content is strongly recommended, especially:
- Ulduar (Flame Leviathan and its accessories, Siege Engine / Chopper / Demolisher quest vehicles)
- Icecrown Citadel (Gunship cannons)
- Mount-with-accessory quests across zones

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.gm on`
2. `.go xyz 2540 -475 1 571`
3. Kill the Onslaught Warhorse (spawnId 102719). Verify it respawns with a visually-mounted Onslaught Knight, both hostile (red nameplates).
4. Kill the Onslaught Knight, leave the rider/mount interaction to play out. Verify the horse enters its dismounted state only after the rider dies, and despawns normally after 30 seconds.
5. Run `.respawn all` several times in the area and confirm no excess Knights accumulate.
6. Regression: test a summoned vehicle (e.g. Flame Leviathan) to confirm accessories still install correctly with the deferred init path.

## Known Issues and TODO List:

- [ ] `Onslaught Knight` / `Onslaught Warhorse` retail behaviour (horse despawns on rider death, rider despawns on leash after dismount) is a separate SAI/DB concern not addressed here.
- [ ] Wider vehicle regression testing across all content tiers.