### PR TITLE
fix(Scripts/ObsidianSanctum): Despawn drakes on Sartharion death

### DIFF
--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
@@ -411,6 +411,11 @@ struct boss_sartharion : public BossAI
     {
         _JustDied();
         Talk(SAY_SARTHARION_DEATH);
+
+        // Despawn remaining drakes
+        for (uint32 i : dragons)
+            if (Creature* boss = instance->GetCreature(i))
+                boss->DespawnOrUnsummon();
     }
 
     void SetData(uint32 type, uint32 data) override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Drakes called during the Sartharion encounter (Tenebron, Shadron, Vesperon) kept running their AI after Sartharion died — still in combat, still casting Shadow Breath/Fissure, still opening portals and spawning adds. This happened because `boss_sartharion::JustDied()` only called `_JustDied()`, which despawns creatures tracked in the boss `summons` list; the drakes are pre-spawned instance bosses accessed via `instance->GetGuidData(...)`, so they are not in that list.

The fix mirrors the existing cleanup in `EnterEvadeMode` — iterate the `dragons` array and call `DespawnOrUnsummon()` on any drake still present.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.6 (via Claude Code) was used to analyze the script and draft the fix. All changes were reviewed and understood by the author.

## Issues Addressed:
- Closes #

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

In retail, when Sartharion dies in a drake-up attempt, any remaining drakes become inactive and are cleaned up along with the encounter. `EnterEvadeMode` already performs this cleanup; `JustDied` was the missing counterpart.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

1. Enter Obsidian Sanctum with at least one drake still alive (e.g. 1D/2D/3D attempt).
2. Engage Sartharion so that the drake(s) get called and land.
3. Kill Sartharion while one or more drakes are still alive.
4. Verify that the remaining drakes despawn cleanly instead of continuing to fight, cast abilities, or spawn adds.

## Known Issues and TODO List:

- [ ]
- [ ]