### PR TITLE
fix(Scripts/ObsidianSanctum): Drakes no longer bind during Sartharion fight

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1776388548411391900.sql
+++ b/data/sql/updates/pending_db_world/rev_1776388548411391900.sql
@@ -1,2 +1,3 @@
 --
-UPDATE `creature_template` SET `flags_extra` = `flags_extra` & ~0x1 WHERE `entry` IN (30449, 30451, 30452);
+UPDATE `creature_template` SET `flags_extra` = `flags_extra` & ~0x1
+    WHERE `entry` IN (30449, 30451, 30452, 31520, 31534, 31535);

--- a/data/sql/updates/pending_db_world/rev_1776388548411391900.sql
+++ b/data/sql/updates/pending_db_world/rev_1776388548411391900.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `flags_extra` = `flags_extra` & ~0x1 WHERE `entry` IN (30449, 30451, 30452);

--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
@@ -845,7 +845,10 @@ struct boss_sartharion_dragonAI : public BossAI
         }
 
         if (!isCalledBySartharion)
+        {
             ClearInstance();
+            me->GetMap()->ToInstanceMap()->PermBindAllPlayers();
+        }
         else
         {
             if (Creature* sartharion = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_SARTHARION)))


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Killing a drake while the Sartharion encounter is in progress no longer locks players to the raid ID. Standalone drake kills still bind, matching retail.

The drakes (Tenebron, Shadron, Vesperon) carried `CREATURE_FLAG_EXTRA_INSTANCE_BIND` (`0x1`) on `creature_template.flags_extra`. The core's death handler in `Unit::Kill` checks this flag unconditionally and calls `InstanceMap::PermBindAllPlayers()` regardless of any guards in the script's `JustDied`. The script-level encounter-state suppression (already in place via `isCalledBySartharion`) had no effect on this path.

Fix:
- Strip `0x1` from `flags_extra` for the three drakes (28860 Sartharion is unchanged and continues to bind players via the core flag path).
- In `boss_sartharion_dragonAI::JustDied`, explicitly call `me->GetMap()->ToInstanceMap()->PermBindAllPlayers()` only on the standalone-kill branch (`!isCalledBySartharion`), preserving the lock for the standalone drake encounters listed in `instance_encounters`.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (Opus 4) was used to assist in tracing the binding path and drafting the patch.

## Issues Addressed:
- Closes #25489

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Video evidence linked in the issue:
- WotLK Retail: https://youtu.be/fAY_56xoTgc?t=468 (7:52 — "you are now saved to this instance" only after killing Sartharion).
- WotLK Classic: https://youtu.be/TOQt6aKNBgc?t=342 (5:47 — same).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.cheat god` and `.go c id 28860`.
2. Engage Sartharion. Wait for Tenebron to be called into the fight, then kill Tenebron while Sartharion is still alive. Verify there is **no** "you are now saved to this instance" message and the player is **not** bound.
3. Kill Sartharion. Verify the bind message appears and the player is bound to the raid ID.
4. On a fresh character/instance, solo-pull a drake before engaging Sartharion. Verify the bind message appears (standalone drake encounter still binds).

## Known Issues and TODO List:

- [ ]
- [ ]