### PR TITLE
fix(Core/Vehicles): Prevent accessory double-install and respawn orphans

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1113,9 +1113,6 @@ bool Creature::AIM_Initialize(CreatureAI* ai)
     IsAIEnabled = true;
     i_AI->InitializeAI();
 
-    // Xinef: Initialize vehicle if it is not summoned!
-    if (GetVehicleKit() && m_spawnId)
-        GetVehicleKit()->Reset();
     return true;
 }
 
@@ -2052,6 +2049,10 @@ void Creature::Respawn(bool force)
 
             if (getDeathState() == DeathState::Dead)
             {
+                // TempSummons (no m_spawnId) shouldn't be resurrected here; TempSummon::Update UnSummons them on the next tick once deathState is Dead.
+                if (!m_spawnId && !force)
+                    return;
+
                 if (m_spawnId)
                 {
                     GetMap()->RemoveCreatureRespawnTime(m_spawnId);

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -88,11 +88,16 @@ void Vehicle::Install()
 
 void Vehicle::InstallAllAccessories(bool evading)
 {
-    // Clear stale control-vehicle auras only on first install; a re-Reset
-    // would otherwise eject the just-seated accessory and fire a spurious
-    // SMART_EVENT_PASSENGER_REMOVED on the vehicle's SAI.
+    // Clear stale control-vehicle auras only on the first non-evade reset;
+    // a re-Reset would otherwise eject a just-seated passenger and, for
+    // accessories, fire a spurious SMART_EVENT_PASSENGER_REMOVED.
     if (GetBase()->IsPlayer() || (!evading && !_accessoriesInstalled))
         RemoveAllPassengers();
+
+    // Mark the initial reset as done even if this vehicle has no accessory
+    // list, so subsequent Resets don't eject passengers on vehicles without
+    // accessories (e.g. WG demolisher/catapult).
+    _accessoriesInstalled = true;
 
     VehicleAccessoryList const* accessories = sObjectMgr->GetVehicleAccessoryList(this);
     if (!accessories)
@@ -101,8 +106,6 @@ void Vehicle::InstallAllAccessories(bool evading)
     for (VehicleAccessoryList::const_iterator itr = accessories->begin(); itr != accessories->end(); ++itr)
         if (!evading || itr->IsMinion)  // only install minions on evade mode
             InstallAccessory(itr->AccessoryEntry, itr->SeatId, itr->IsMinion, itr->SummonedType, itr->SummonTime);
-
-    _accessoriesInstalled = true;
 }
 
 void Vehicle::Uninstall()

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -29,7 +29,8 @@
 #include <algorithm>
 
 Vehicle::Vehicle(Unit* unit, VehicleEntry const* vehInfo, uint32 creatureEntry) :
-    _me(unit), _vehicleInfo(vehInfo), _usableSeatNum(0), _creatureEntry(creatureEntry), _status(STATUS_NONE)
+    _me(unit), _vehicleInfo(vehInfo), _usableSeatNum(0), _creatureEntry(creatureEntry), _status(STATUS_NONE),
+    _accessoriesInstalled(false)
 {
     for (uint32 i = 0; i < MAX_VEHICLE_SEATS; ++i)
     {
@@ -87,8 +88,11 @@ void Vehicle::Install()
 
 void Vehicle::InstallAllAccessories(bool evading)
 {
-    if (GetBase()->IsPlayer() || !evading)
-        RemoveAllPassengers();   // We might have aura's saved in the DB with now invalid casters - remove
+    // Clear stale control-vehicle auras only on first install; a re-Reset
+    // would otherwise eject the just-seated accessory and fire a spurious
+    // SMART_EVENT_PASSENGER_REMOVED on the vehicle's SAI.
+    if (GetBase()->IsPlayer() || (!evading && !_accessoriesInstalled))
+        RemoveAllPassengers();
 
     VehicleAccessoryList const* accessories = sObjectMgr->GetVehicleAccessoryList(this);
     if (!accessories)
@@ -97,6 +101,8 @@ void Vehicle::InstallAllAccessories(bool evading)
     for (VehicleAccessoryList::const_iterator itr = accessories->begin(); itr != accessories->end(); ++itr)
         if (!evading || itr->IsMinion)  // only install minions on evade mode
             InstallAccessory(itr->AccessoryEntry, itr->SeatId, itr->IsMinion, itr->SummonedType, itr->SummonTime);
+
+    _accessoriesInstalled = true;
 }
 
 void Vehicle::Uninstall()
@@ -111,6 +117,7 @@ void Vehicle::Uninstall()
     _status = STATUS_UNINSTALLING;
     LOG_DEBUG("vehicles", "Vehicle::Uninstall {}", _me->GetGUID().ToString());
     RemoveAllPassengers();
+    _accessoriesInstalled = false;
 
     if (_me && _me->IsCreature())
     {

--- a/src/server/game/Entities/Vehicle/Vehicle.h
+++ b/src/server/game/Entities/Vehicle/Vehicle.h
@@ -96,6 +96,7 @@ private:
     uint32 _usableSeatNum;         // Number of seats that match VehicleSeatEntry::UsableByPlayer, used for proper display flags
     uint32 _creatureEntry;         // Can be different than me->GetBase()->GetEntry() in case of players
     Status _status;
+    bool _accessoriesInstalled;
 };
 
 class VehicleDespawnEvent : public BasicEvent

--- a/src/server/game/Grids/GridObjectLoader.cpp
+++ b/src/server/game/Grids/GridObjectLoader.cpp
@@ -24,6 +24,7 @@
 #include "GridNotifiers.h"
 #include "ObjectMgr.h"
 #include "Transport.h"
+#include "Vehicle.h"
 
 template <class T>
 void GridObjectLoader::AddObjectHelper(Map* map, T* obj)
@@ -52,6 +53,10 @@ void GridObjectLoader::LoadCreatures(CellGuidSet const& guid_set, Map* map)
         }
 
         AddObjectHelper<Creature>(map, obj);
+
+        // Grid load bypasses Map::AddToMap, so seat accessories here.
+        if (Vehicle* vehicle = obj->GetVehicleKit())
+            vehicle->Reset();
 
         if (!obj->IsMoveInLineOfSightDisabled() && obj->GetDefaultMovementType() == IDLE_MOTION_TYPE && !obj->isNeedNotify(NOTIFY_VISIBILITY_CHANGED | NOTIFY_AI_RELOCATION))
         {

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -346,8 +346,7 @@ bool Map::AddToMap(T* obj, bool checkTransport)
     //also, trigger needs to cast spell, if not update, cannot see visual
     obj->UpdateObjectVisibility(true);
 
-    // Xinef: little hack for vehicles, accessories have to be added after visibility update so they wont fall off the vehicle, moved from Creature::AIM_Initialize
-    // Initialize vehicle, this is done only for summoned npcs, DB creatures are handled by grid loaders
+    // Post-visibility so accessories seat after the vehicle's create packet reaches clients.
     if (obj->IsCreature())
         if (Vehicle* vehicle = obj->ToCreature()->GetVehicleKit())
             vehicle->Reset();


### PR DESCRIPTION
## Changes Proposed:
Collapses the vehicle accessory install path so `Vehicle::Reset()` no longer fires twice during a single spawn. The second Reset previously called `RemoveAllPassengers()`, ejecting the just-seated accessory and firing a spurious `SMART_EVENT_PASSENGER_REMOVED` on the base vehicle. Any SAI reacting to that event (e.g. `Onslaught Warhorse`/`Onslaught Knight` at New Hearthglen) entered its dismounted state at spawn, producing orphaned accessories that accumulated on every respawn.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### Context

Two paths were calling `Vehicle::Reset()` during a single spawn:

1. `Creature::AIM_Initialize` — pre-visibility, guarded on `m_spawnId` (DB creatures only).
2. `Map::AddToMap` — post-visibility, unconditional.

The second Reset ran `InstallAllAccessories` → `RemoveAllPassengers`, which ejected the accessory seated by the first Reset, then re-summoned a fresh one. The eject fired a spurious `SMART_EVENT_PASSENGER_REMOVED`. Warhorse SAI reacts to that event by entering its dismounted state (faction 35, pacified, 30s despawn), which then leaves a friendly/pacified vehicle with an orphaned accessory and despawns the Warhorse — but the accessory is `minion=0` in `vehicle_template_accessory`, so it survives and wanders. The `.respawn all` GM tool compounded this by resurrecting dead accessory `TempSummon` corpses as orphans.

### Fix

- Drop the pre-visibility Reset in `Creature::AIM_Initialize`. Accessories now seat only post-visibility, matching Xinef's original comment intent ("accessories have to be added after visibility update so they won't fall off the vehicle").
- Add `_accessoriesInstalled` flag on `Vehicle`. On subsequent non-evade Resets (e.g. compat-mode Update-tick Reset), `RemoveAllPassengers` is skipped; `InstallAccessory` is already idempotent for same-entry seats, so the re-Reset becomes a no-op instead of ejecting and re-summoning. Flag is set **before** the no-accessories early return so it also protects vehicles without accessory entries (WG demolisher / catapult) from re-eviction on subsequent Resets.
- Seat accessories from `GridObjectLoader::LoadCreatures` since grid load bypasses `Map::AddToMap` and would otherwise leave grid-loaded vehicles (Onslaught Warhorses on server startup) without their accessories.
- In `Creature::Respawn`, skip the resurrection branch for `TempSummon` corpses (no `m_spawnId`, not forced). `TempSummon::Update` UnSummons them naturally on the next tick once `deathState` reaches `Dead`. Script-driven `Respawn(true)` still proceeds.

### Why this avoids PR #25486's crash

PR #25486 (which was reverted in #25491) tried to solve the same double-install by deferring Reset to the next `Creature::Update` tick. That opened a window where scripts could `SummonCreature(vehicle)` and immediately seat a real passenger (e.g. Professor Putricide mutated monstrosity with `VEHICLE_SPELL_RIDE_HARDCODED`); the deferred Reset then called `RemoveAllPassengers` and ejected that real passenger.

This fix keeps the post-visibility Reset **synchronous** inside `Map::AddToMap`, so accessories are seated before control returns to any summoning script — no deferred window for real passengers to be ejected.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP was used for investigation, reproduction analysis, TrinityCore comparison, and drafting the patch. All changes were reviewed and tested by the author.

## Issues Addressed:
- Closes #25475

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Behaviour compared against TrinityCore: TC's `AIM_Initialize` runs `Reset()` unconditionally pre-visibility and relies on an Update-tick Reset only in compat mode; TC has no post-visibility Reset. AzerothCore's visibility/summon order differs from TC (Xinef's original comment in `Map::AddToMap` documented this). This fix keeps AC's post-visibility model and makes it single-install, rather than adopting TC's pre-visibility model wholesale.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Vehicle creation paths audited to ensure `Reset()` still fires exactly once per spawn:
- `LoadCreatureFromDB(addToMap=true)` → `Map::AddToMap` (ObjectMgr, PoolMgr, GameEventMgr, respawn)
- `GridObjectLoader::LoadCreatures` (server startup / grid activation) — handled explicitly
- `MotionTransport::CreateNPCPassenger` → `Map::AddToMap` (ICC gunship cannons)
- `Map::SummonCreature` → `Map::AddToMap` (scripted summons, Flame Leviathan, Putricide)
- `Battleground::AddCreature` → `Map::AddToMap` (SotA demolishers, IoC siege)
- `Battlefield::SpawnCreature` → `Map::AddToMap` (Wintergrasp)

Given this change affects every vehicle in the game, further regression testing on other vehicle content is strongly recommended, especially:
- Ulduar (Flame Leviathan and its accessories, Siege Engine / Chopper / Demolisher quest vehicles)
- Icecrown Citadel (Gunship cannons, Professor Putricide mutated monstrosity)
- Mount-with-accessory quests across zones
- Strand of the Ancients / Isle of Conquest / Wintergrasp vehicles

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

### Onslaught Warhorse/Knight (primary repro — `#25475`)

1. `.gm on`
2. `.go xyz 2540 -475 1 571`  (New Hearthglen, Dragonblight)
3. Verify every Warhorse spawn has **exactly one** Knight seated and both are hostile (red nameplates) on a fresh server start.
4. Kill the Warhorse. The Knight exits, stays alive, attacks you (MoP-correct).
5. Kill the Knight. The Warhorse goes into dismounted state (faction 35, pacified) and despawns after 30s.
6. Run `.respawn all` a few times. Verify no orphaned Knights accumulate — each new Warhorse spawn has exactly one seated Knight.

### Wintergrasp vehicles (regression for `_accessoriesInstalled` flag position)

Vehicles without entries in `vehicle_template_accessory` (WG demolisher/catapult) would previously hit the no-accessories early return before the flag was set, causing the driver to be ejected by the compat-mode Update-tick Reset. Test:

1. `.cast 55629`  (grants `SPELL_LIEUTENANT` — bypasses the WG script rank check)
2. `.npc tempadd 27881`  (Catapult, no accessories)
3. `.npc tempadd 28094`  (Demolisher, no accessories)
4. `.npc tempadd 28312`  (Siege Engine, has Turret accessory 28319)
5. Right-click each to mount. Verify you stay seated; the siege engine's turret seat is also occupied by its NPC accessory.

### Summoned-vehicle regression (the crash case from #25486 revert)

1. Pull Professor Putricide in ICC to phase 3. The player that drinks the mutated plague should be transformed into the mutated monstrosity vehicle and retain the ability to cast abilities without being immediately ejected.
2. Alternative quick check: any quest that summons a vehicle and immediately seats the player (Argent Tournament jousting mounts, etc.).

### Grid-load regression (server-start vehicles)

1. Restart worldserver.
2. Before triggering any respawns, approach a grid-loaded vehicle with accessories (Onslaught Warhorse spawnId 102719 is easiest). Accessory should be seated on first sight.

## Known Issues and TODO List:

- [ ]
- [ ]