### PR TITLE
fix(Scripts/World): Null check Precious in npc_simone RespawnPet

### DIFF
--- a/src/server/scripts/World/npc_stave_of_ancients.cpp
+++ b/src/server/scripts/World/npc_stave_of_ancients.cpp
@@ -574,12 +574,16 @@ public:
 
         void RespawnPet()
         {
+            Creature* precious = Precious();
+            if (!precious)
+                return;
+
             Position current = me->GetNearPosition(-5.0f, 0.0f);
-            Precious()->RemoveCorpse(false, false);
-            Precious()->SetPosition(current);
-            Precious()->SetHomePosition(current);
-            Precious()->setDeathState(DeathState::JustRespawned);
-            Precious()->UpdateObjectVisibility(true);
+            precious->RemoveCorpse(false, false);
+            precious->SetPosition(current);
+            precious->SetHomePosition(current);
+            precious->setDeathState(DeathState::JustRespawned);
+            precious->UpdateObjectVisibility(true);
         }
 
         void HandlePetRespawn()


### PR DESCRIPTION
## Changes Proposed:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Fixes a `SIGSEGV` in `npc_simone::npc_simoneAI::RespawnPet()` (`src/server/scripts/World/npc_stave_of_ancients.cpp:579`).

`RespawnPet()` repeatedly invoked `Precious()` (an accessor lookup that can return `nullptr`) and dereferenced the result without a null check. If the pet creature was no longer accessible at the time the `SIMONE_EVENT_CHECK_PET_STATE` event fired (e.g. after `RemoveCorpse()` side effects or grid unload), the next `Precious()` call returned null and `Creature::SetPosition` was invoked on `this == 0x0`.

The fix caches the `Precious()` result once, returns early if null, and operates on the local pointer for the remaining calls. Same defensive pattern as the recent HellfirePeninsula null-check fixes (22749aa20, 1831e2a5a).

### Crash backtrace (excerpt)
```
#0 Creature::SetPosition (this=0x0, ...) at Creature.cpp:3275
#1 Creature::SetPosition (this=0x0, pos=...) at Creature.h:345
#2 npc_simone::npc_simoneAI::RespawnPet (this=...) at npc_stave_of_ancients.cpp:579
#3 npc_simone::npc_simoneAI::UpdateAI (...) at npc_stave_of_ancients.cpp:714
```

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.6 (Claude Code) assisted with the analysis of the crash backtrace and authoring of the patch.

## Issues Addressed:
- Closes 

## SOURCE:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Crash report from a production worldserver (gdb backtrace included above).

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

1. Engage Simone the Seductress (Stave of the Ancients quest NPC) and her pet Precious.
2. Force conditions where Precious would be removed/unavailable while Simone's `SIMONE_EVENT_CHECK_PET_STATE` event keeps firing (kill Precious then despawn / grid unload edge cases).
3. Confirm worldserver no longer crashes; Simone simply skips the respawn attempt when Precious is unreachable and re-attempts on the next 1s tick.

## Known Issues and TODO List:

- [ ] None known.