### PR TITLE
fix(Core/Transports): Force transport passengers into legacy spawn group

### DIFF
--- a/src/server/game/Entities/Transport/Transport.cpp
+++ b/src/server/game/Entities/Transport/Transport.cpp
@@ -318,6 +318,9 @@ void MotionTransport::RemovePassenger(WorldObject* passenger, bool withAll)
 Creature* MotionTransport::CreateNPCPassenger(ObjectGuid::LowType guid, CreatureData const* data)
 {
     Map* map = GetMap();
+    if (map->GetCreatureRespawnTime(guid))
+        return nullptr;
+
     Creature* creature = new Creature();
 
     if (!creature->LoadCreatureFromDB(guid, map, false))
@@ -366,6 +369,9 @@ Creature* MotionTransport::CreateNPCPassenger(ObjectGuid::LowType guid, Creature
 GameObject* MotionTransport::CreateGOPassenger(ObjectGuid::LowType guid, GameObjectData const* data)
 {
     Map* map = GetMap();
+    if (map->GetGORespawnTime(guid))
+        return nullptr;
+
     GameObject* go = new GameObject();
     ASSERT(!sObjectMgr->IsGameObjectStaticTransport(data->id));
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -2422,9 +2422,14 @@ void ObjectMgr::LoadCreatures()
             data.spawntimesecs = 14 * DAY;
 
         // Skip spawnMask check for transport maps
-        if (!_transportMaps.count(data.mapid) && data.spawnMask & ~spawnMasks[data.mapid])
-            LOG_ERROR("sql.sql", "Table `creature` have creature (SpawnId: {}) that have wrong spawn mask {} including not supported difficulty modes for map (Id: {}).",
-                spawnId, data.spawnMask, data.mapid);
+        if (!_transportMaps.count(data.mapid))
+        {
+            if (data.spawnMask & ~spawnMasks[data.mapid])
+                LOG_ERROR("sql.sql", "Table `creature` have creature (SpawnId: {}) that have wrong spawn mask {} including not supported difficulty modes for map (Id: {}).",
+                    spawnId, data.spawnMask, data.mapid);
+        }
+        else
+            data.spawnGroupId = 1; // force compatibility group for transport spawns
 
         bool ok = true;
         for (uint32 diff = 0; diff < MAX_DIFFICULTY - 1 && ok; ++diff)
@@ -2955,8 +2960,13 @@ void ObjectMgr::LoadGameobjects()
 
         data.spawnMask      = fields[14].Get<uint8>();
 
-        if (!_transportMaps.count(data.mapid) && data.spawnMask & ~spawnMasks[data.mapid])
-            LOG_ERROR("sql.sql", "Table `gameobject` has gameobject (GUID: {} Entry: {}) that has wrong spawn mask {} including not supported difficulty modes for map (Id: {}), skip", guid, data.id, data.spawnMask, data.mapid);
+        if (!_transportMaps.count(data.mapid))
+        {
+            if (data.spawnMask & ~spawnMasks[data.mapid])
+                LOG_ERROR("sql.sql", "Table `gameobject` has gameobject (GUID: {} Entry: {}) that has wrong spawn mask {} including not supported difficulty modes for map (Id: {}), skip", guid, data.id, data.spawnMask, data.mapid);
+        }
+        else
+            data.spawnGroupId = 1; // force compatibility group for transport spawns
 
         data.phaseMask      = fields[15].Get<uint32>();
         int16 gameEvent     = fields[16].Get<int16>();
@@ -8771,11 +8781,12 @@ void ObjectMgr::LoadSpawnGroups()
     uint32 oldMSTime = getMSTime();
 
     // Reset prior state for hot-reload support
+    // Preserve the forced legacy group for spawns on transport maps (set in LoadCreatures/LoadGameobjects).
     _spawnGroupMapStore.clear();
     for (auto& [id, data] : _creatureDataStore)
-        data.spawnGroupId = 0;
+        data.spawnGroupId = _transportMaps.count(data.mapid) ? 1 : 0;
     for (auto& [id, data] : _gameObjectDataStore)
-        data.spawnGroupId = 0;
+        data.spawnGroupId = _transportMaps.count(data.mapid) ? 1 : 0;
 
     //                                               0        1          2
     QueryResult result = WorldDatabase.Query("SELECT groupId, spawnType, spawnId FROM spawn_group");

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -235,11 +235,11 @@ public:
                 data.posZ = chr->GetTransOffsetZ();
                 data.orientation = chr->GetTransOffsetO();
 
-                Creature* creature = trans->CreateNPCPassenger(guid, &data);
-
-                creature->SaveToDB(trans->GetGOInfo()->moTransport.mapID, 1 << map->GetSpawnMode(), chr->GetPhaseMaskForSpawn());
-
-                sObjectMgr->AddCreatureToGrid(guid, &data);
+                if (Creature* creature = trans->CreateNPCPassenger(guid, &data))
+                {
+                    creature->SaveToDB(trans->GetGOInfo()->moTransport.mapID, 1 << map->GetSpawnMode(), chr->GetPhaseMaskForSpawn());
+                    sObjectMgr->AddCreatureToGrid(guid, &data);
+                }
                 return true;
             }
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Transport passenger spawns (`creature.map` / `gameobject.map` == a MO_Transport's internal map) live in a transport-relative coordinate space but at runtime end up on the transport's current parent continent map. With the new-style respawn queue introduced in #25206, `Map::ProcessCreatureRespawn` checks `IsGridLoaded(data->posX, data->posY)` against those tiny transport-offset coordinates on the continent, which never loads a real player grid, so the respawn is re-queued forever and passengers stay dead until server restart.

Closes https://github.com/chromiecraft/chromiecraft/issues/9326

### Repro

- `.go creature <guid>` to any Sister Mercy (map 594) passenger, e.g. a Mutinous Sea Dog.
- Kill it.
- Observe: `acore_characters.creature_respawn` row written with `mapId = 571` (Northrend) and `guid = <spawn guid>`. The respawn timer expires but the creature never comes back. `ProcessRespawns` on Map 571 keeps re-queueing it because the grid at the transport-relative coords is never player-active on the continent.

### Key changes:

- Port TrinityCore [a5df77a9d6](https://github.com/TrinityCore/TrinityCore/commit/a5df77a9d6) by Shauren:
  - `MotionTransport::CreateNPCPassenger` / `CreateGOPassenger`: skip creation while a respawn time is pending, so the transport's own load cycle (unload on grid-deactivate → reload on grid-activate) becomes the respawn mechanism for passengers instead of `Map::ProcessRespawns`.
  - `ObjectMgr::LoadCreatures` / `LoadGameobjects`: creatures/gameobjects on transport maps are forced into spawn group 1 (Legacy/Compatibility), so they use in-place respawn and don't rely on the map respawn queue that assumes world coordinates.
  - `cs_npc.cpp` (`.npc add`): null-check the return value of `CreateNPCPassenger` since it can now return nullptr.

- **AzerothCore-specific fix** on top: `ObjectMgr::LoadSpawnGroups()` contains a hot-reload reset loop (added by #25206) that unconditionally zeros every `_creatureDataStore` / `_gameObjectDataStore` entry's `spawnGroupId`. That loop doesn't exist in TC (which uses pointer-based `SpawnGroupTemplateData*` with `GetLegacySpawnGroup()`), and it clobbers the transport-map assignment made by `LoadCreatures`/`LoadGameobjects` on every startup. The reset now preserves the legacy-group assignment for transport-map spawns so the invariant survives hot-reloads and the ordinary boot sequence.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code (Claude Opus 4.6) was used to assist with investigation, porting the TC commit, and the AC-specific hot-reload fix.

## Issues Addressed:

- Transport passenger respawn is broken after #25206. Concrete visible symptom: the Sister Mercy quest scene (map 594, "Mutiny on the Mercy" — Mutinous Sea Dog / Cursed Sea Dog / Captain Ellis) stays dead after being killed until the server restarts.

## SOURCE:

- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Cherry-picked from TrinityCore commit [a5df77a9d6f3e48f2c4e8a61d60e3b5f2f0c326e](https://github.com/TrinityCore/TrinityCore/commit/a5df77a9d6f3e48f2c4e8a61d60e3b5f2f0c326e) by Shauren (`shauren.trinity@gmail.com`). The commit preserves the original author via `--author`. The additional `LoadSpawnGroups` reset-loop change is AC-specific and not part of the TC commit (TC doesn't need it).

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

1. Before applying this PR, confirm the bug: `.go creature <sister_mercy_passenger_guid>`, kill, wait past the respawn timer, the creature does not come back. Confirm a row appears in `acore_characters.creature_respawn` with `mapId = 571` for a spawn whose `creature.map = 594`.
2. Apply this PR and rebuild the worldserver.
3. Wipe stale respawn rows (they're keyed on the wrong map, pre-fix): `DELETE FROM acore_characters.creature_respawn WHERE guid IN (SELECT guid FROM acore_world.creature WHERE map IN (SELECT data6 FROM acore_world.gameobject_template WHERE type = 15 AND data6 != 0));` — or just restart the worldserver to let the legacy-path clear them naturally.
4. Repeat the test. Kill a Sister Mercy passenger, wait for the respawn timer (`spawntimesecs`), creature should respawn in-place as a proper transport passenger with correct transport-offset positioning.
5. Regression-check ICC gunships (`Orgrim's Hammer` / `The Skybreaker`, entries 192241/192242 and 201580+), plus any other module spawning on MO_Transport internal maps, since all transport-map spawns now flip to the legacy spawn group.

## Known Issues and TODO List:

- [ ] Servers that already have `creature_respawn` rows with the wrong `mapId` from before this PR won't self-heal — those rows remain orphan until cleared manually or via restart. Not persistent data loss, just a one-time cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)