### PR TITLE
fix(Scripts/Eye): Kael'thas advisors fail to engage and aggro before being called

### DIFF
--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -229,9 +229,6 @@ struct boss_kaelthas : public BossAI
             {
                 advisor->Respawn(true);
                 advisor->StopMovingOnCurrentPos();
-                advisor->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
-                advisor->SetReactState(REACT_PASSIVE);
-                summons.Summon(advisor);
             }
         }
     }
@@ -550,7 +547,7 @@ struct boss_kaelthas : public BossAI
     void IntroduceNewAdvisor(KTYells talkIntroduction, KTActions kaelAction)
     {
         std::chrono::milliseconds attackStartTimer = 0ms;
-        EyeNPCs advisorNPCId = NPC_THALADRED;
+        uint32 dataIdx = DATA_THALADRED;
         scheduler.Schedule(2s, [this, talkIntroduction](TaskContext)
         {
             Talk(talkIntroduction);
@@ -560,26 +557,26 @@ struct boss_kaelthas : public BossAI
         {
             case ACTION_START_THALADRED:
                 attackStartTimer = 7s;
-                advisorNPCId = NPC_THALADRED;
+                dataIdx = DATA_THALADRED;
                 break;
             case ACTION_START_SANGUINAR:
                 attackStartTimer = 14500ms;
-                advisorNPCId = NPC_LORD_SANGUINAR;
+                dataIdx = DATA_LORD_SANGUINAR;
                 break;
             case ACTION_START_CAPERNIAN:
                 attackStartTimer = 9s;
-                advisorNPCId = NPC_CAPERNIAN;
+                dataIdx = DATA_CAPERNIAN;
                 break;
             case ACTION_START_TELONICUS:
                 attackStartTimer = 10400ms;
-                advisorNPCId = NPC_TELONICUS;
+                dataIdx = DATA_TELONICUS;
                 break;
             default:
                 break;
         }
-        scheduler.Schedule(attackStartTimer, [this, advisorNPCId](TaskContext)
+        scheduler.Schedule(attackStartTimer, [this, dataIdx](TaskContext)
         {
-            if (Creature* advisor = summons.GetCreatureWithEntry(advisorNPCId))
+            if (Creature* advisor = instance->GetCreature(dataIdx))
             {
                 advisor->SetReactState(REACT_AGGRESSIVE);
                 advisor->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
@@ -735,6 +732,13 @@ struct advisor_baseAI : public ScriptedAI
         _feigning = false;
         me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
         scheduler.CancelAll();
+    }
+
+    void JustRespawned() override
+    {
+        ScriptedAI::JustRespawned();
+        me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+        me->SetReactState(REACT_PASSIVE);
     }
 
     void JustEngagedWith(Unit* /*who*/) override { ScheduleEvents(); }

--- a/src/server/scripts/Outland/TempestKeep/Eye/instance_the_eye.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/instance_the_eye.cpp
@@ -67,41 +67,9 @@ public:
             LoadBossBoundaries(boundaries);
         }
 
-        ObjectGuid ThaladredTheDarkenerGUID;
-        ObjectGuid LordSanguinarGUID;
-        ObjectGuid GrandAstromancerCapernianGUID;
-        ObjectGuid MasterEngineerTelonicusGUID;
-        ObjectGuid AlarGUID;
-        ObjectGuid KaelthasGUID;
         ObjectGuid BridgeWindowGUID;
         ObjectGuid KaelStateRightGUID;
         ObjectGuid KaelStateLeftGUID;
-
-        void OnCreatureCreate(Creature* creature) override
-        {
-            switch (creature->GetEntry())
-            {
-                case NPC_ALAR:
-                    AlarGUID = creature->GetGUID();
-                    break;
-                case NPC_KAELTHAS:
-                    KaelthasGUID = creature->GetGUID();
-                    break;
-                case NPC_THALADRED:
-                    ThaladredTheDarkenerGUID = creature->GetGUID();
-                    break;
-                case NPC_TELONICUS:
-                    MasterEngineerTelonicusGUID = creature->GetGUID();
-                    break;
-                case NPC_CAPERNIAN:
-                    GrandAstromancerCapernianGUID = creature->GetGUID();
-                    break;
-                case NPC_LORD_SANGUINAR:
-                    LordSanguinarGUID = creature->GetGUID();
-                    break;
-            }
-            InstanceScript::OnCreatureCreate(creature);
-        }
 
         void OnGameObjectCreate(GameObject* gobject) override
         {
@@ -130,10 +98,6 @@ public:
                     return KaelStateRightGUID;
                 case GO_KAEL_STATUE_LEFT:
                     return KaelStateLeftGUID;
-                case NPC_ALAR:
-                    return AlarGUID;
-                case NPC_KAELTHAS:
-                    return KaelthasGUID;
             }
 
             return ObjectGuid::Empty;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Fixes two related bugs with Kael'thas' advisors (Thaladred, Sanguinar, Capernian, Telonicus):

1. **Advisors fail to engage when called.** `boss_kaelthas::PrepareAdvisors` called `advisor->Respawn(true)` followed by `summons.Summon(advisor)`. `Respawn(true)` destroys the live `Creature` and the respawn cycle creates a new instance with a new GUID, so the GUID cached in `summons` becomes stale immediately. At engage time, `summons.GetCreatureWithEntry(entry)` resolves to `nullptr` and the advisor never engages. Switched the lookup to `instance->GetCreature(DATA_*)`, which uses the `LoadObjectData` mapping that's refreshed via `InstanceScript::OnCreatureCreate` on respawn.
2. **Advisors aggro on approach before Kael calls them.** `PrepareAdvisors` set `UNIT_FLAG_NON_ATTACKABLE` and `REACT_PASSIVE` on the dying advisor (after `Respawn(true)` marked it JustDied). The new creature came up with `InitializeReactState`'s default `REACT_AGGRESSIVE` and no immunity flag. Moved the flag setup into `advisor_baseAI::JustRespawned`, which fires after `InitializeReactState` — so the state sticks on the live creature. Evade-triggered `Reset` doesn't touch flags, so advisors never get stuck non-attackable mid-encounter.

Also cleaned up unused scaffolding in `instance_the_eye.cpp`: removed six dead `ObjectGuid` fields (four advisors, Alar, Kaelthas) and the custom `OnCreatureCreate` switch. `LoadObjectData(creatureData)` already registers these and provides `instance->GetCreature(DATA_*)` for free — the hand-rolled fields were never read anywhere.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.7 (via Claude Code) was used to diagnose the stale-GUID behaviour and draft the fix. All changes reviewed and tested by the author.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25510

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Root cause identified by instrumenting `PrepareAdvisors` / `IntroduceNewAdvisor` and tracing GUIDs across respawns — the original Thaladred spawn (Low:222) was replaced by a new instance (Low:224) after `Respawn(true)`, while the summons list still held the old GUID.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter The Eye and approach Kael'thas' room without engaging — advisors should remain passive and non-attackable.
2. Trigger Kael's intro and wait through phase 1. Each advisor should engage in turn (Thaladred → Sanguinar → Capernian → Telonicus) when called.
3. Wipe during phase 1 and re-engage — confirm advisors reset to passive/non-attackable and the sequence restarts cleanly.

## Known Issues and TODO List:

- [ ]
- [ ]