### PR TITLE
fix(Core/Combat): safe StopAttackFaction and restore escort evade

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -309,12 +309,9 @@ void CreatureAI::EngagementOver()
 
 void CreatureAI::JustExitedCombat()
 {
-    EngagementOver();
-
-    // If creature is alive, in world, and not already evading, trigger evade to return home
-    // Check IsInWorld to avoid evade during server shutdown/cleanup
-    if (me->IsAlive() && me->IsInWorld() && !me->IsInEvadeMode())
-        EnterEvadeMode(EVADE_REASON_NO_HOSTILES);
+    // No-op: synchronous EnterEvadeMode cascades via MemberEvaded and frees
+    // refs held by upstream iterators (StopAttackFaction crash). EngagementOver
+    // here also resets scripted fights on brief combat gaps (Valithria).
 }
 
 /*void CreatureAI::AttackedBy(Unit* attacker)

--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
@@ -189,6 +189,15 @@ void npc_escortAI::ReturnToLastPoint()
     me->GetMotionMaster()->MovePoint(POINT_LAST_POINT, x, y, z, FORCED_MOVEMENT_RUN);
 }
 
+void npc_escortAI::JustExitedCombat()
+{
+    // Evade synchronously so UpdateAI does not push a waypoint spline before
+    // SelectVictim's evade fallback fires; stacked motion intents twitch.
+    EngagementOver();
+    if (me->IsAlive() && me->IsInWorld() && !me->IsInEvadeMode())
+        EnterEvadeMode(EVADE_REASON_NO_HOSTILES);
+}
+
 void npc_escortAI::EnterEvadeMode(EvadeReason /*why*/)
 {
     me->GetThreatMgr().ClearAllThreat();

--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.h
@@ -70,6 +70,8 @@ public:
 
     void EnterEvadeMode(EvadeReason /*why*/ = EVADE_REASON_OTHER) override;
 
+    void JustExitedCombat() override;
+
     void UpdateAI(uint32 diff) override;                   //the "internal" update, calls UpdateEscortAI()
     virtual void UpdateEscortAI(uint32 diff);     //used when it's needed to add code in update (abilities, scripted events, etc)
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -16105,13 +16105,19 @@ void Unit::StopAttackFaction(uint32 faction_id)
             ++itr;
     }
 
-    // End combat and threat references with creatures in this faction
-    std::vector<CombatReference*> refsToEnd;
+    // Collect GUIDs, not pointers: EndCombat can cascade through AI callbacks
+    // (formation MemberEvaded -> CombatStop) and free other refs in the list.
+    std::vector<ObjectGuid> guidsToEnd;
     for (auto const& pair : m_combatManager.GetPvECombatRefs())
         if (pair.second->GetOther(this)->GetFactionTemplateEntry()->faction == faction_id)
-            refsToEnd.push_back(pair.second);
-    for (CombatReference* ref : refsToEnd)
-        ref->EndCombat();
+            guidsToEnd.push_back(pair.first);
+    for (ObjectGuid const& guid : guidsToEnd)
+    {
+        auto const& refs = m_combatManager.GetPvECombatRefs();
+        auto it = refs.find(guid);
+        if (it != refs.end())
+            it->second->EndCombat();
+    }
 
     for (ControlSet::const_iterator itr = m_Controlled.begin(); itr != m_Controlled.end(); ++itr)
         (*itr)->StopAttackFaction(faction_id);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Two related fixes:

**1. `Unit::StopAttackFaction` — stop holding `CombatReference*` across EndCombat**

The function pre-collected `CombatReference*` pointers into a local vector, then iterated and called `EndCombat()` on each. `EndCombat()` can cascade through AI callbacks (`JustExitedCombat` → `EnterEvadeMode` → `CreatureGroup::MemberEvaded` → other members' `CombatStop`) and free other refs still held by the list, leaving dangling pointers.

Repro context: quest **12983 "The Last of Her Kind"** — player rides creature 29563 (Injured Icemaw Matriarch) into area 4422 (Hibernal Cavern). Spell **55012 "Lok'lira's Bargain"** auto-casts and applies a force-reaction aura that calls `StopAttackFaction(1121)` on the player, which recurses into the vehicle. The vehicle accumulates PvE combat refs with faction-1121 creatures; when the force-reaction fires, cascading evade can free a ref mid-iteration. A production GDB backtrace captured a hard crash in `ThreatManager::ClearThreat` with `target = 0x5f4f4e5f4e4f5341` (freed memory pattern). In practice the crash is rare — it needs a formation-attached attacker (`GROUP_AI_FLAG_EVADE_TOGETHER`) plus specific timing — but ASAN reliably flags the dangling-pointer read.

Fix: collect stable `ObjectGuid` keys and re-lookup the map each iteration — cascade-freed refs are skipped safely.

**2. `CreatureAI::JustExitedCombat` — keep no-op; `npc_escortAI` — override with synchronous evade**

Earlier commits ping-ponged on this function. This PR takes the nuanced middle path:
- **`CreatureAI::JustExitedCombat` stays no-op**. Calling `EnterEvadeMode` here reproduces the same cascade as above. Calling `EngagementOver` clears `_isEngaged` on transient combat-ref drops and resets scripted encounters that depend on staying engaged between add waves (e.g. Valithria Dreamwalker's `npc_green_dragon_combat_trigger`).
- **`npc_escortAI` overrides to evade synchronously**. Escort NPCs' `UpdateAI` pushes a waypoint `MoveSplinePath` *before* `SelectVictim`'s lazy evade fallback fires. The stacked motion intents (waypoint spline + `ReturnToLastPoint` `MovePoint`) collide and the creature twitches in place for 1–3s before walking home. Synchronous evade here is safe — escort NPCs are not in `CreatureGroup` formations. Fixes Crok Scourgebane and all escort-quest NPCs (Gilthares, Rin'ji, Wizzlecrank, Magwin, Maxx A. Million, etc.).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Opus 4.7 was used to analyze the crash dump, identify the cascade, and draft the fix.

## Issues Addressed:
- Rare server crash in `ThreatManager::ClearThreat` triggered by force-reaction aura cascade (reported via GDB log from quest 12983 path, ChromieCraft).
- Post-combat "twitching in place" on escort NPCs (Crok Scourgebane, all `npc_escortAI`-derived quest escorts).

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25411
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25487

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

GDB backtrace from production captured the crash at `StopAttackFaction` → `EndCombat` → `ClearThreat` on poisoned memory with the `refsToEnd` vector mid-iteration. Cascade source traced to `CreatureAI::EnterEvadeMode` → `formation->MemberEvaded` → sibling `CombatStop`.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

**1. `StopAttackFaction` cascade safety (ASAN recommended — crash is rare without it):**
```
# Build with AddressSanitizer:
#   cmake .. -DCMAKE_CXX_FLAGS='-fsanitize=address -fno-omit-frame-pointer'
#
.tele stormpeaks
.quest add 12905 ; .quest complete 12905     # grants Hyldsmeet disguise precursor
.quest add 12983
.go creature id 29563                         # Injured Icemaw Matriarch (vehicle)
# ride the Matriarch; pull 6–8 faction-1121 Vrykul onto it
# drive into area 4422 (Hibernal Cavern)
# spell 55012 auto-casts -> force-reaction -> StopAttackFaction(1121)
# BEFORE: ASAN flags heap-use-after-free in ThreatManager::ClearThreat
#         (hard crash possible when attackers share a formation)
# AFTER:  clean exit, mobs go neutral, no ASAN report
```

**2. Escort twitch repro (should evade cleanly):**
```
.go creature id 3465                          # Gilthares Firebough, Ratchet
.quest add 891
# gossip to start escort; pirates aggro along path
# .die or leash out of range during combat
# BEFORE: twitches in place ~2s before ReturnToLastPoint
# AFTER:  immediate ReturnToLastPoint, clean waypoint resume
```

**3. Crok gauntlet (should evade cleanly mid-path):**
```
# ICC Frostwing Halls
.go creature id 37129                         # Crok Scourgebane
# trigger gauntlet, wipe mid-path on a Vrykul pack
# BEFORE: twitch before evade
# AFTER:  clean ReturnToLastPoint, gauntlet resumes on next pull
```

**4. Valithria Dreamwalker (must still reset on wipe, not twitch or evade):**
```
# ICC Valithria chamber
# engage fight, wipe raid
# expect: trigger fires ACTION_DEATH -> boss state NOT_STARTED -> 5s despawn
# regression check: fight should NOT reset mid-combat between add waves
#                   (this is why CreatureAI::JustExitedCombat stays no-op)
```

**5. Plain SmartAI patrol control (e.g. Devilsaur 6498) — should behave as before, no regression.**

## Known Issues and TODO List:

- [ ] SmartAI patrols/escorts with active paths (OOX-09/HL robot, some quest escort SAI) may still twitch. Evaluated as a potential follow-up — left out of this PR to keep scope narrow.
- [ ] `npc_argent_captainAI` (Crok's Captains: Arnath/Brandon/Grondel/Rupert) uses plain `ScriptedAI`. If they twitch in testing, a per-script override may be warranted.