### PR TITLE
fix(Core/Creature): Skip JustRespawned for temp summons

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -707,10 +707,15 @@ void Creature::Update(uint32 diff)
 {
     if (IsAIEnabled && TriggerJustRespawned && getDeathState() != DeathState::Dead)
     {
-        if (_respawnCompatibilityMode && m_vehicleKit)
-            m_vehicleKit->Reset();
         TriggerJustRespawned = false;
-        AI()->JustRespawned();
+
+        // Skip for temp summons: InitializeAI already reset them, and JustRespawned would clobber state set synchronously during SUMMON.
+        if (!IsSummon())
+        {
+            if (_respawnCompatibilityMode && m_vehicleKit)
+                m_vehicleKit->Reset();
+            AI()->JustRespawned();
+        }
     }
 
     switch (m_deathState)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Since faeec8274, `TriggerJustRespawned = true` in the `Creature` constructor causes `AI()->JustRespawned()` to fire on the first `Update()` tick for every freshly-constructed creature. For temp summons this is a regression: vehicle summons run `SUMMON_CATEGORY_VEHICLE` → ride-vehicle → `PassengerBoarded` → `StartPath` *synchronously* during SUMMON, setting `SMART_ESCORT_ESCORTING` before the first tick. `JustRespawned` then wipes `mEscortState` one tick later, so `MovementInform` short-circuits and no waypoint-reached actions fire — no kill credit, no despawn.

Skip `JustRespawned` for `IsSummon()` creatures; real respawns (compat + non-compat destroy-and-reconstruct) are `IsSummon() == false` and still fire it as faeec8274 intended.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP.

## Issues Addressed:

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25531

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

Quest 12983 "The Last of Her Kind":
1. `.tele stormpeaks`
2. `.quest add 12905; .quest complete 12905; .aura 55012` (disguise)
3. `.quest add 12983`
4. `.go creature id 29563`; right-click the bear
5. Bear should auto-path 51 waypoints to Brunnhildar, tick credit at WP 50, despawn/dismount at WP 51

Regression: Onslaught Warhorses (#25475, closed by faeec8274) — kill, `.respawn all`, confirm SAI `SMART_EVENT_RESPAWN` still resets state. They are `IsSummon() == false` so unchanged.