### PR TITLE
fix(Core/SmartAI): Keep combat pose on aggro

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -911,7 +911,7 @@ void SmartAI::AttackStart(Unit* who)
         return;
     }
 
-    if (who && me->Attack(who, me->IsWithinMeleeRange(who)))
+    if (who && me->Attack(who, mCanAutoAttack))
     {
         if (!me->HasUnitState(UNIT_STATE_NO_COMBAT_MOVEMENT))
         {


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`SmartAI::AttackStart` passed `meleeAttack = me->IsWithinMeleeRange(who)` to `Unit::Attack`. Because SmartAI creatures almost always engage from outside melee range (detection range is the usual aggro trigger), this path skipped `AddUnitState(UNIT_STATE_MELEE_ATTACKING)` and never sent `SMSG_ATTACKSTART`. Autoswings on arrival landed damage via `AttackerStateUpdate` (which does not depend on that flag), but the client never saw the combat stance, so melee SmartAI NPCs ran around their target in their idle pose while hitting for full damage.

The charmed/possessed branch a few lines above already uses `mCanAutoAttack` correctly. This one-line change aligns the non-possessed path with it.

ranged/caster SmartAI NPCs

`mCanAutoAttack` is already the authoritative "does this creature melee?" flag — `SmartAI::UpdateAI` gates `DoMeleeAttackIfReady()` on it (SmartAI.cpp:595). Using it as the `meleeAttack` argument to `Unit::Attack` just aligns the pose with the behavior that field already governs.

Audited all 242 `smart_scripts` rows using `SMART_ACTION_AUTO_ATTACK` (`action_type = 20`):
- 16 rows fire `AUTO_ATTACK 0` on `SMART_EVENT_SPAWN` — runs during `AIM_Initialize`, well before any aggro, so `AttackStart` correctly sees `mCanAutoAttack = false` and skips the pose. These are improved (no more flicker when pulled into melee range).
- 108 rows fire `AUTO_ATTACK 0` via `SMART_EVENT_LINK` mid-combat, 100 rows fire `AUTO_ATTACK 1` via `LINK` to re-enable. `AttackStart` is only called on engage, so mid-combat toggles are unaffected.
- 0 rows fire `AUTO_ATTACK 0` on `SMART_EVENT_AGGRO` — no ordering race against `AttackStart`.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Tools used: **Claude Code with AzerothMCP**.

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Reference: TrinityCore commit `7fff83d67526efff63867d41b9e036a19a9287b3` ("Core/Movement: waypoint movement", PR #20121) introduced `mCanAutoAttack` here. Original author `ccrs` credited via `Co-Authored-By:` on the commit.

**Deliberately not ported from that TC commit:** the adjacent motion-master changes (`GetMotionMaster()->Clear`, `PauseMovement`, `SetRun`) — AC's `SmartAI::AttackStart` has a locally diverged motion path (gated on `UNIT_STATE_NO_COMBAT_MOVEMENT`, uses `_attackDistance`) and changing it is out of scope for this fix.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Reproduced on Heb'Drakkar Headhunter (creature 28600, SmartAI). With debug logs on `Unit::Attack` the broken path shows `Attack start ... meleeAttack=false` on engage; after the fix `meleeAttack=true` and the client renders the melee combat stance immediately. Damage, evade, and combat-stop paths are unchanged (all independent of `UNIT_STATE_MELEE_ATTACKING`).

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go creature id 28600` (Heb'Drakkar Headhunter, or any melee SmartAI mob — e.g. 671 Bloodscalp Headhunter, 2641 Vilebranch Headhunter).
2. Pull the creature from outside melee range.
3. Observe: before this PR, the creature chases and swings in idle (weapon-sheathed) stance; after this PR, it enters combat stance (weapon drawn) as soon as it aggros.
4. Regression-spot-check a caster SmartAI NPC that uses `SMART_ACTION_AUTO_ATTACK 0` on spawn — confirm it stays out of melee stance when pulled.

## Known Issues and TODO List:

- [ ]
- [ ]