### PR TITLE
fix(Core/Battlegrounds): keep BG spirit guides Alive

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1711,7 +1711,6 @@ bool Battleground::AddSpiritGuide(uint32 type, float x, float y, float z, float 
 
     if (Creature* creature = AddCreature(entry, type, x, y, z, o))
     {
-        creature->setDeathState(DeathState::Dead);
         creature->SetGuidValue(UNIT_FIELD_CHANNEL_OBJECT, creature->GetGUID());
         // aura
         /// @todo: Fix display here


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### Problem

After #25206 ported the TrinityCore dynamic spawn system, BG spirit healers/guides stopped appearing at graveyards. Players die, release, and find no spirit healer — corpses turn to bones immediately and the mass resurrect never fires. Reported at chromiecraft/chromiecraft#9341, reproduced across WSG and other BGs, unrelated to cross-faction.

### Root Cause

`Battleground::AddSpiritGuide` has historically called `creature->setDeathState(DeathState::Dead)` on the freshly-created guide. With `m_respawnTime == 0`, `Creature::Update` enters `case DeathState::Dead` every tick and calls `Respawn()`.

Under the old compatibility-only respawn path, `Respawn()` early-returned for creatures with no `m_spawnId`, so the guide stayed put. After #25206, `Creature::Respawn()` gained a non-compat branch that calls `AddObjectToRemoveList()` when the creature is not alive and has no `m_spawnId` — so BG spirit guides (created via `new Creature()` with no spawnId) get destroyed on the first tick as soon as anything places them in non-compat mode.

### Fix

Align with [TrinityCore 3.3.5 `Battleground::AddSpiritGuide`](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Battlegrounds/Battleground.cpp#L1574): drop the `setDeathState(DeathState::Dead)` call. TC keeps the guide in `Alive` state and relies on the creature template (entries 13116/13117) for the ghost visual — only the channel object GUID, channel spell id, and cast speed are set by code. This removes the `DeathState::Dead` → `Respawn()` loop entirely, so neither compat nor non-compat respawn paths can touch the guide.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools were used in preparing this pull request. **Claude Code (Claude Opus 4.7)** was used to investigate the regression against the chromiecraft report, diff the AC path against TrinityCore 3.3.5, and draft the fix.

## Issues Addressed:

- Closes https://github.com/chromiecraft/chromiecraft/issues/9341

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). TrinityCore 3.3.5 has never called `setDeathState(Dead)` on BG spirit guides — this PR aligns AC with that behavior.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Queue and enter any BG (WSG is the reported one).
2. Die and release spirit.
3. Verify a spirit healer is present at the graveyard with the channel-spell visual and hovering appearance.
4. Wait for the 30-second mass resurrect cycle and confirm players get resurrected.
5. Regression: confirm spirit guides in all BGs (WSG, AB, EotS, AV, SA, IoC) still appear correctly and are not targetable/attackable by the opposing faction — the visual/flag state must come from the creature template (entries 13116 Alliance / 13117 Horde).

## Known Issues and TODO List:

- [ ] If any deployment shows the guide as "alive-looking" (non-ghost model, attackable), it points to missing template flags on entries 13116/13117 that the old forced-Dead state was masking — that would be a DB follow-up rather than a revert.