### PR TITLE
fix(DB/SAI): make Sigrid Iceborn attackable in Battle at Valhalas

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1776809863778409500.sql
+++ b/data/sql/updates/pending_db_world/rev_1776809863778409500.sql
@@ -1,5 +1,7 @@
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 31242 AND `id` = 3;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 31271 AND `id` = 2;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 31277 AND `id` = 6;
 INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`event_param6`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
 (31242, 0, 3, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Sigrid Iceborn - On Just Summoned - Remove Flags Immune To PC/NPC'),
-(31271, 0, 2, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Carnage - On Just Summoned - Remove Flags Immune To PC/NPC');
+(31271, 0, 2, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Carnage - On Just Summoned - Remove Flags Immune To PC/NPC'),
+(31277, 0, 6, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Thane Banahogg - On Just Summoned - Remove Flags Immune To PC/NPC');

--- a/data/sql/updates/pending_db_world/rev_1776809863778409500.sql
+++ b/data/sql/updates/pending_db_world/rev_1776809863778409500.sql
@@ -1,7 +1,9 @@
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 31242 AND `id` = 3;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 31271 AND `id` = 2;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 31277 AND `id` = 6;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 14688 AND `id` = 23;
 INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`event_param6`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
-(31242, 0, 3, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Sigrid Iceborn - On Just Summoned - Remove Flags Immune To PC/NPC'),
-(31271, 0, 2, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Carnage - On Just Summoned - Remove Flags Immune To PC/NPC'),
-(31277, 0, 6, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Thane Banahogg - On Just Summoned - Remove Flags Immune To PC/NPC');
+(31242, 0, 3, 0, 54, 0, 100, 0,     0,     0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Sigrid Iceborn - On Just Summoned - Remove Flags Immune To PC/NPC'),
+(31271, 0, 2, 0, 54, 0, 100, 0,     0,     0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Carnage - On Just Summoned - Remove Flags Immune To PC/NPC'),
+(31277, 0, 6, 0, 54, 0, 100, 0,     0,     0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Thane Banahogg - On Just Summoned - Remove Flags Immune To PC/NPC'),
+(14688, 0,23, 0,  1, 0, 100, 0, 14000, 14000, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Prince Sandoval - Out of Combat 14s - Remove Flags Immune To PC/NPC');

--- a/data/sql/updates/pending_db_world/rev_1776809863778409500.sql
+++ b/data/sql/updates/pending_db_world/rev_1776809863778409500.sql
@@ -1,3 +1,5 @@
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 31242 AND `id` = 3;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 31271 AND `id` = 2;
 INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`event_param6`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
-(31242, 0, 3, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Sigrid Iceborn - On Just Summoned - Remove Flags Immune To PC/NPC');
+(31242, 0, 3, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Sigrid Iceborn - On Just Summoned - Remove Flags Immune To PC/NPC'),
+(31271, 0, 2, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Carnage - On Just Summoned - Remove Flags Immune To PC/NPC');

--- a/data/sql/updates/pending_db_world/rev_1776809863778409500.sql
+++ b/data/sql/updates/pending_db_world/rev_1776809863778409500.sql
@@ -1,0 +1,3 @@
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 31242 AND `id` = 3;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`event_param6`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(31242, 0, 3, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Sigrid Iceborn - On Just Summoned - Remove Flags Immune To PC/NPC');


### PR DESCRIPTION
## Changes Proposed:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Adds a `SMART_EVENT_JUST_SUMMONED` → `SMART_ACTION_REMOVE_UNIT_FLAG` row to Sigrid Iceborn (31242) that clears `UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC` (768).

Her `creature_template.unit_flags = 33600` includes these two immunity flags. She is summoned from `npc_battle_at_valhalas` in `zone_icecrown.cpp` for quest 13216 and her AI immediately calls `AttackStart(player)` — so she engages the player but cannot be attacked back because the template immunity flags are never cleared. Clearing them on summon restores the intended fight.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (Opus 4.7) was used to investigate the issue and draft the SAI row.

## Issues Addressed:
- Closes #25521

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Sigrid Iceborn is expected to be attackable upon arrival in the arena per her Wowhead/aowow entry referenced in the linked issue.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Progress the Battle at Valhalas quest chain up to quest 13216 ("The Return of Sigrid Iceborn").
2. Accept the quest from Geirrvif.
3. Verify Sigrid Iceborn is attackable when she arrives in the arena and the fight can be completed.

## Known Issues and TODO List:

- [ ] Carnage (31271) and Thane Banahogg (31277) share the same `unit_flags` (33600) and are likely affected by the same bug; to be confirmed and fixed separately if reproduced.
- [ ]