### PR TITLE
fix(DB/Creature): Fix Reanimated Exarch unit_flags after spawn

### DIFF
--- a/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
+++ b/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
@@ -1,0 +1,2 @@
+
+UPDATE `creature_template` SET `unit_flags` = 512 WHERE (`entry` = 22452);

--- a/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
+++ b/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
@@ -1,2 +1,4 @@
 
-UPDATE `creature_template` SET `unit_flags` = 512 WHERE (`entry` = 22452);
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 22452) AND (`source_type` = 0) AND (`id` IN (2));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(22452, 0, 2, 3, 60, 0, 100, 769, 5500, 5500, 0, 0, 0, 0, 19, 768, 1, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 4.72, 'Reanimated Exarch - On Update - Remove Unit Flags');

--- a/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
+++ b/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
@@ -1,4 +1,4 @@
 
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 22452) AND (`source_type` = 0) AND (`id` IN (2));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(22452, 0, 2, 3, 60, 0, 100, 769, 5500, 5500, 0, 0, 0, 0, 19, 768, 1, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 4.72, 'Reanimated Exarch - On Update - Remove Unit Flags');
+(22452, 0, 2, 3, 60, 0, 100, 769, 5500, 5500, 0, 0, 0, 0, 19, 768, 1, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - On Update - Remove Unit Flags');

--- a/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
+++ b/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
@@ -9,5 +9,5 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 22452;
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 22452);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(22452, 0, 0, 0, 54, 0, 100, 0, 500, 500, 0, 0, 0, 0, 80, 2245200, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - On Update - Run Script'),
+(22452, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 2245200, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - On Just Summoned - Run Script'),
 (22452, 0, 1, 0, 0, 0, 100, 1, 2000, 4000, 0, 0, 0, 0, 11, 8258, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - In Combat - Cast \'Devotion Aura\' (No Repeat)');

--- a/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
+++ b/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
@@ -2,7 +2,7 @@
 DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 2245200);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (2245200, 9, 0, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 0, 1, 0, 3500, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - Actionlist - Say Line 0'),
-(2245200, 9, 1, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 4.72, 'Reanimated Exarch - Actionlist - Set Orientation 4.72'),
+(2245200, 9, 1, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 21, 20, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - Actionlist - Set Orientation Closest Player'),
 (2245200, 9, 2, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - Actionlist - Remove Flags Immune To Players & Immune To NPC\'s'),
 (2245200, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 21, 20, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - Actionlist - Start Attacking');
 

--- a/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
+++ b/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
@@ -9,5 +9,5 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 22452;
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 22452);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(22452, 0, 0, 0, 60, 0, 100, 0, 500, 500, 0, 0, 0, 0, 80, 2245200, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - On Update - Run Script'),
+(22452, 0, 0, 0, 54, 0, 100, 0, 500, 500, 0, 0, 0, 0, 80, 2245200, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - On Update - Run Script'),
 (22452, 0, 1, 0, 0, 0, 100, 1, 2000, 4000, 0, 0, 0, 0, 11, 8258, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - In Combat - Cast \'Devotion Aura\' (No Repeat)');

--- a/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
+++ b/data/sql/updates/pending_db_world/npc_22452_quest_10915.sql
@@ -1,4 +1,13 @@
 
-DELETE FROM `smart_scripts` WHERE (`entryorguid` = 22452) AND (`source_type` = 0) AND (`id` IN (2));
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 2245200);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(22452, 0, 2, 3, 60, 0, 100, 769, 5500, 5500, 0, 0, 0, 0, 19, 768, 1, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - On Update - Remove Unit Flags');
+(2245200, 9, 0, 0, 0, 0, 100, 0, 500, 500, 0, 0, 0, 0, 1, 0, 3500, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - Actionlist - Say Line 0'),
+(2245200, 9, 1, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 4.72, 'Reanimated Exarch - Actionlist - Set Orientation 4.72'),
+(2245200, 9, 2, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 19, 768, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - Actionlist - Remove Flags Immune To Players & Immune To NPC\'s'),
+(2245200, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 21, 20, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - Actionlist - Start Attacking');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 22452;
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 22452);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(22452, 0, 0, 0, 60, 0, 100, 0, 500, 500, 0, 0, 0, 0, 80, 2245200, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - On Update - Run Script'),
+(22452, 0, 1, 0, 0, 0, 100, 1, 2000, 4000, 0, 0, 0, 0, 11, 8258, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Reanimated Exarch - In Combat - Cast \'Devotion Aura\' (No Repeat)');


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
- Closes #25451

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
1. `.quest add 10915`
2. Attack Reanimated Exarch (id:22452)

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
