### PR TITLE
fix(Core/Battlegrounds): respawn SotA demolishers after death

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
@@ -1118,7 +1118,7 @@ void BattlegroundSA::UpdateDemolisherSpawns()
                                                  BG_SA_NpcSpawnlocs[i][2], BG_SA_NpcSpawnlocs[i][3]);
 
                             Demolisher->SetVisible(true);
-                            Demolisher->Respawn();
+                            Demolisher->Respawn(true);
                             DemoliserRespawnList.erase(i);
                         }
                     }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Strand of the Ancients demolishers stopped respawning after being killed. Regression caused by #25499, which added an early return in `Creature::Respawn(bool force)` for creatures without an `m_spawnId` to prevent `TempSummon` orphans from being resurrected:

```cpp
// TempSummons (no m_spawnId) shouldn't be resurrected here; TempSummon::Update
// UnSummons them on the next tick once deathState is Dead.
if (!m_spawnId && !force)
    return;
```

The assumption that *no spawnId ⇒ TempSummon* does not hold for creatures added via `Battleground::AddCreature`, which constructs them with `new Creature()` + `Creature::Create(... spawnId=0 ...)`. SotA demolishers fall into this category and were being silently skipped in `UpdateDemolisherSpawns`.

This PR forces the respawn call, matching how IoC already handles its catapults, glaive throwers, siege engines and demolishers (all using `Respawn(true)`). Cannons (`BG_SA_GUN_1..10`) are intentionally not respawned — same as TrinityCore.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.7 was used to investigate the regression and identify the root cause.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9358

## SOURCE:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Pre-#25499 behaviour and TrinityCore's `Creature::Respawn` both handle this case without the early return. TrinityCore's `BattlegroundSA::UpdateDemolisherSpawns` uses the same 30s timer and a plain `Respawn()` (their `Creature::Respawn` has no no-spawnId guard).

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Queue into Strand of the Ancients.
2. Kill an attacker demolisher.
3. Wait 30 seconds — demolisher should respawn at its original location.

## Known Issues and TODO List:

- [ ]
- [ ]