### PR TITLE
fix(Core/AI): keep charmed creature victim set by charmer

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -358,6 +358,10 @@ bool CreatureAI::UpdateVictim()
         return false;
     }
 
+    // Charmed creatures: the charmer controls target selection, don't interfere
+    if (me->IsCharmed())
+        return me->GetVictim() != nullptr;
+
     if (!me->HasReactState(REACT_PASSIVE))
     {
         if (Unit* victim = me->SelectVictim())


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`CharmInfo`'s constructor forces `REACT_PASSIVE` on the charmed creature. When a charmed creature (still running SmartAI/CreatureAI) is commanded to attack via the pet bar, `CreatureAI::UpdateVictim` hits the passive-in-combat branch every tick and calls `me->AttackStop()`, wiping the victim. The chase generator then sees `HasLostTarget` and pauses immediately, producing the "takes one step then stops" behavior reported in #25544 (Servant of Drakuru on quest 12686 *Zero Tolerance*).

TC avoids this by swapping the charmed creature's AI to `PetAI` entirely, so `CreatureAI::UpdateVictim` never runs. AzerothCore intentionally keeps `SmartAI` running during charm because a few creatures depend on `SMART_EVENT_CHARMED` (including this quest — the SAI transforms the Servant into a Hand of Drakuru and runs a 180s duration timer). Porting TC's AI-swap approach would break those SAIs.

The fix is a surgical guard in `CreatureAI::UpdateVictim`: if the creature is charmed, leave the victim alone and let the charmer's command + `MoveChase` drive behavior. This matches the effective behavior of TC's PetAI path without breaking `SMART_EVENT_CHARMED`.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code (Opus 4.7) with azerothMCP was used to investigate the issue and locate the root cause.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9330
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25544

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Referenced TC behavior (`Unit::UpdateCharmAI` swapping to `PetAI`) to understand the expected semantics, but the fix itself is AC-specific.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Verified locally: before the fix the MC'd Servant stepped once and stopped; after the fix it chases Darmuk and auto-attacks as expected.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.gm on; .quest add 12686; .additem 38699; .additem 39206`
2. Teleport to a Servant of Drakuru (e.g. `.go xyz 6127.9 -2244.61 238.568 571`)
3. Equip the Ensorcelled Choker, use the Scepter of Empowerment on a Servant
4. Target Darmuk (28793), click Attack on the MC bar — the servant should run up and auto-attack

## Known Issues and TODO List:

- [ ]
- [ ]