### PR TITLE
fix(Core/Quest): award kill credit when pet proxies as reward source

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -12750,7 +12750,9 @@ void Player::RewardPlayerAndGroupAtEvent(uint32 creature_id, WorldObject* pRewar
     if (!pRewardSource)
         return;
 
-    ObjectGuid creature_guid = (pRewardSource->IsCreature()) ? pRewardSource->GetGUID() : ObjectGuid::Empty;
+    ObjectGuid creature_guid;
+    if (pRewardSource->IsCreature() && pRewardSource->GetEntry() == creature_id)
+        creature_guid = pRewardSource->GetGUID();
 
     // prepare data for near group iteration
     if (Group* group = GetGroup())


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

SmartAI patterns of the form *\"on JustDied → cast X on ACTION_INVOKER\"* are common for quests that award a virtual kill credit (e.g. the SAI for the *Weakness to Lightning* bots casts spell 46443 on the killer). When a pet lands the killing blow, the action invoker is the pet, so the `SPELL_EFFECT_KILL_CREDIT` (effect 134) spell lands on the pet.

`Spell::EffectKillCredit` correctly resolves the owner via `GetCharmerOrOwnerPlayerOrPlayerItself()` and calls `player->RewardPlayerAndGroupAtEvent(creatureEntry, unitTarget)`. However `RewardPlayerAndGroupAtEvent` unconditionally forwards the reward source's GUID to `Player::KilledMonsterCredit`, which then looks the creature up and **overwrites `real_entry` with the pet's entry**. The intended kill-credit entry (e.g. 26082) never matches any quest objective and the credit is silently dropped.

Only forward the GUID when the reward source is in fact the credited creature; otherwise leave it empty so the supplied credit entry is used directly. Solo/group flow and existing callers passing the actual credited creature are unaffected.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code (Opus 4.7) with azerothMCP was used to investigate the issue and locate the root cause.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9327

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Verified locally with quest *Weakness to Lightning* (11896): before the fix, pet killing blows did not advance the objective; after the fix, pet kills and player kills both grant credit as expected.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.gm on; .quest add 11896; .additem 35352`
2. Teleport near a Scavenge-bot 004-A8 (25752), e.g. `.go xyz 4007.9 4839.1 -12.9948 571`
3. On a pet class, use *Sage's Lightning Rod* on the robot, then let the pet land the killing blow
4. Quest log should show \"Robots weakened and destroyed\" count advance; repeat and also confirm self-kills still advance

## Known Issues and TODO List:

- [ ]
- [ ]