### PR TITLE
fix(DB/SAI): migrate 'Deadliest Trap' quest to manual-spawn groups

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1776906471063424160.sql
+++ b/data/sql/updates/pending_db_world/rev_1776906471063424160.sql
@@ -1,0 +1,56 @@
+--
+-- Fix quest "The Deadliest Trap Ever Laid" (11097 Scryer / 11101 Aldor):
+-- the AC-specific SCRIPTED_SPAWN (state=0 on AI_INIT -> despawn self)
+-- pattern loops forever under the ported dynamic spawn system because
+-- each respawn creates a new creature whose AI_INIT fires the despawn
+-- again. Migrate to MANUAL_SPAWN spawn groups and SPAWN_SPAWNGROUP /
+-- DESPAWN_SPAWNGROUP, which is what the spawn system port was built for.
+--
+
+-- Four manual-spawn groups: two per quest (defenders, skybreakers)
+DELETE FROM `spawn_group_template` WHERE `groupId` IN (100, 101, 102, 103);
+INSERT INTO `spawn_group_template` (`groupId`, `groupName`, `groupFlags`) VALUES
+(100, 'Sanctum of the Stars - Defenders',   0x04),
+(101, 'Sanctum of the Stars - Skybreakers', 0x04),
+(102, 'Altar of Sha''tar - Defenders',      0x04),
+(103, 'Altar of Sha''tar - Skybreakers',    0x04);
+
+-- Assign existing creature spawns to their groups
+DELETE FROM `spawn_group` WHERE `groupId` = 100;
+INSERT INTO `spawn_group` (`groupId`, `spawnType`, `spawnId`) SELECT 100, 0, `guid` FROM `creature` WHERE `id1` = 23435;
+DELETE FROM `spawn_group` WHERE `groupId` = 101;
+INSERT INTO `spawn_group` (`groupId`, `spawnType`, `spawnId`) SELECT 101, 0, `guid` FROM `creature` WHERE `id1` = 23440;
+DELETE FROM `spawn_group` WHERE `groupId` = 102;
+INSERT INTO `spawn_group` (`groupId`, `spawnType`, `spawnId`) SELECT 102, 0, `guid` FROM `creature` WHERE `id1` = 23453;
+DELETE FROM `spawn_group` WHERE `groupId` = 103;
+INSERT INTO `spawn_group` (`groupId`, `spawnType`, `spawnId`) SELECT 103, 0, `guid` FROM `creature` WHERE `id1` = 23441;
+
+-- Skybreakers respawn mid-event (wave mechanic)
+UPDATE `creature` SET `spawntimesecs` = 5 WHERE `id1` IN (23440, 23441);
+
+-- Drop the creatures' AI_INIT self-despawn events (dormancy now handled by MANUAL_SPAWN)
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `event_type` = 37 AND `action_type` = 226 AND `entryorguid` IN (23435, 23440, 23441, 23453);
+
+-- Commander Hobb: On Just Died cleanup -> DESPAWN_SPAWNGROUP
+UPDATE `smart_scripts` SET `action_type` = 132, `action_param1` = 100, `action_param2` = 0, `action_param3` = 0, `target_type` = 1, `target_param1` = 0, `target_param3` = 0, `comment` = 'Commander Hobb - On Just Died - Despawn Defenders Group'   WHERE `entryorguid` = 23434 AND `source_type` = 0 AND `id` = 7;
+UPDATE `smart_scripts` SET `action_type` = 132, `action_param1` = 101, `action_param2` = 0, `action_param3` = 0, `target_type` = 1, `target_param1` = 0, `target_param3` = 0, `comment` = 'Commander Hobb - On Just Died - Despawn Skybreakers Group' WHERE `entryorguid` = 23434 AND `source_type` = 0 AND `id` = 8;
+
+-- Commander Arcus (Aldor): same cleanup
+UPDATE `smart_scripts` SET `action_type` = 132, `action_param1` = 102, `action_param2` = 0, `action_param3` = 0, `target_type` = 1, `target_param1` = 0, `target_param3` = 0, `comment` = 'Commander Arcus - On Just Died - Despawn Defenders Group'   WHERE `entryorguid` = 23452 AND `source_type` = 0 AND `id` = 7;
+UPDATE `smart_scripts` SET `action_type` = 132, `action_param1` = 103, `action_param2` = 0, `action_param3` = 0, `target_type` = 1, `target_param1` = 0, `target_param3` = 0, `comment` = 'Commander Arcus - On Just Died - Despawn Skybreakers Group' WHERE `entryorguid` = 23452 AND `source_type` = 0 AND `id` = 8;
+
+-- Hobb start actionlist: SPAWN_SPAWNGROUP
+UPDATE `smart_scripts` SET `action_type` = 131, `action_param1` = 100, `action_param2` = 0, `action_param3` = 0, `action_param4` = 0, `action_param5` = 0, `target_type` = 1, `target_param1` = 0, `target_param3` = 0, `comment` = 'Commander Hobb - Actionlist - Spawn Sanctum Defenders Group'   WHERE `entryorguid` = 2343400 AND `source_type` = 9 AND `id` = 3;
+UPDATE `smart_scripts` SET `action_type` = 131, `action_param1` = 101, `action_param2` = 0, `action_param3` = 0, `action_param4` = 0, `action_param5` = 0, `target_type` = 1, `target_param1` = 0, `target_param3` = 0, `comment` = 'Commander Hobb - Actionlist - Spawn Dragonmaw Skybreakers Group' WHERE `entryorguid` = 2343400 AND `source_type` = 9 AND `id` = 10;
+
+-- Hobb complete actionlist: DESPAWN_SPAWNGROUP
+UPDATE `smart_scripts` SET `action_type` = 132, `action_param1` = 100, `action_param2` = 0, `action_param3` = 0, `target_type` = 1, `target_param1` = 0, `target_param3` = 0, `comment` = 'Commander Hobb - Actionlist - Despawn Defenders Group'   WHERE `entryorguid` = 2343402 AND `source_type` = 9 AND `id` = 0;
+UPDATE `smart_scripts` SET `action_type` = 132, `action_param1` = 101, `action_param2` = 0, `action_param3` = 0, `target_type` = 1, `target_param1` = 0, `target_param3` = 0, `comment` = 'Commander Hobb - Actionlist - Despawn Skybreakers Group' WHERE `entryorguid` = 2343402 AND `source_type` = 9 AND `id` = 1;
+
+-- Arcus start actionlist
+UPDATE `smart_scripts` SET `action_type` = 131, `action_param1` = 102, `action_param2` = 0, `action_param3` = 0, `action_param4` = 0, `action_param5` = 0, `target_type` = 1, `target_param1` = 0, `target_param3` = 0, `comment` = 'Commander Arcus - Actionlist - Spawn Altar Defenders Group'     WHERE `entryorguid` = 2345200 AND `source_type` = 9 AND `id` = 5;
+UPDATE `smart_scripts` SET `action_type` = 131, `action_param1` = 103, `action_param2` = 0, `action_param3` = 0, `action_param4` = 0, `action_param5` = 0, `target_type` = 1, `target_param1` = 0, `target_param3` = 0, `comment` = 'Commander Arcus - Actionlist - Spawn Dragonmaw Skybreakers Group' WHERE `entryorguid` = 2345200 AND `source_type` = 9 AND `id` = 9;
+
+-- Arcus complete actionlist
+UPDATE `smart_scripts` SET `action_type` = 132, `action_param1` = 102, `action_param2` = 0, `action_param3` = 0, `target_type` = 1, `target_param1` = 0, `target_param3` = 0, `comment` = 'Commander Arcus - Actionlist - Despawn Defenders Group'   WHERE `entryorguid` = 2345202 AND `source_type` = 9 AND `id` = 0;
+UPDATE `smart_scripts` SET `action_type` = 132, `action_param1` = 103, `action_param2` = 0, `action_param3` = 0, `target_type` = 1, `target_param1` = 0, `target_param3` = 0, `comment` = 'Commander Arcus - Actionlist - Despawn Skybreakers Group' WHERE `entryorguid` = 2345202 AND `source_type` = 9 AND `id` = 1;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -2054,6 +2054,8 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         case SMART_ACTION_WORLD_SCRIPT:
         case SMART_ACTION_SET_GOSSIP_MENU:
         case SMART_ACTION_SUMMON_GAMEOBJECT_GROUP:
+        case SMART_ACTION_SPAWN_SPAWNGROUP:
+        case SMART_ACTION_DESPAWN_SPAWNGROUP:
             break;
         default:
             LOG_ERROR("sql.sql", "SmartAIMgr: Not handled action_type({}), event_type({}), Entry {} SourceType {} Event {}, skipped.", e.GetActionType(), e.GetEventType(), e.entryOrGuid, e.GetScriptType(), e.event_id);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### Problem

Quest *The Deadliest Trap Ever Laid* (11097 Scryer / 11101 Aldor, Shadowmoon Valley dailies) — accepting the quest triggers Hobb/Arcus to walk down the stairs and speak, but the wave of Dragonmaw Skybreakers never spawns, leaving the quest uncompletable.

Root cause is a mismatch between two systems:

1. AC's legacy `SMART_ACTION_SCRIPTED_SPAWN` (action 226) was built around compat-mode respawn. The Sanctum defender/skybreaker SAIs use *on AI_INIT → state=0 (despawn self)* to stay dormant at server start.
2. PR #25206 ported TC's dynamic spawn system. Under dynamic respawn, a despawned creature is removed via `AddObjectToRemoveList()` and `ProcessRespawns()` creates a fresh creature with a new GUID. Its AI_INIT fires the self-despawn again — infinite respawn/despawn loop, and the `SCRIPTED_SPAWN state=2` \"enable respawning\" action never sticks.

While debugging, a second latent bug surfaced: `SmartAIMgr`'s validator whitelist was missing `SMART_ACTION_SPAWN_SPAWNGROUP` / `SMART_ACTION_DESPAWN_SPAWNGROUP` (added by the port but never listed alongside the other handled actions), so any SAI row using them was silently dropped at load time.

### Fix

**Core** (1 hunk in `SmartScriptMgr.cpp`): add actions 131 and 132 to the handled-actions whitelist, matching TC's `SmartScriptMgr.cpp:2049-2050`.

**DB** (new pending SQL migration): migrate the four creature entries to MANUAL_SPAWN spawn groups and swap Hobb/Arcus SAI from `SCRIPTED_SPAWN` to `SPAWN_SPAWNGROUP` / `DESPAWN_SPAWNGROUP`. Dormancy is now driven by the group flag rather than a self-despawn trick, so the new dynamic respawn path is happy. The per-creature `On AI_INIT` self-despawn events are removed. Skybreakers get `spawntimesecs = 5` for the wave-respawn mechanic; defenders stay at 0 (one-shot).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code (Opus 4.7) with azerothMCP was used to investigate the issue and locate the root cause.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9356

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The SmartAIMgr whitelist entry mirrors TrinityCore's `SmartScriptMgr.cpp:2049-2050` (credit: `r00ty-tc`, added as co-author on the commit).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Verified locally: before the fix, no waves ever spawned. After the fix, accepting the quest causes defenders to spawn in on schedule and skybreaker waves to respawn every 5s during the event. Hobb's death-cleanup despawns both groups cleanly.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Complete prereqs (`.quest add/complete/reward 11095` for a quick test) and talk to Commander Hobb at Sanctum of the Stars.
2. Accept *The Deadliest Trap Ever Laid*.
3. Hobb should walk down the stairs; defenders should spawn in on cue; Dragonmaw Skybreakers waves should appear shortly after.
4. Kill 20+ skybreakers → quest completes; the two spawn groups should despawn.
5. Let Hobb die instead → quest fails; spawn groups also despawn.

## Known Issues and TODO List:

- [ ] Aldor side (quest 11101 / Commander Arcus) is migrated identically but was not independently tested — expected to behave the same since it uses the same SAI pattern.
- [ ]