### PR TITLE
fix(Core/Druid): preserve shapeshift form across map changes

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -1895,7 +1895,10 @@ uint32 ObjectMgr::GetModelForShapeshift(ShapeshiftForm form, Player* player) con
     else
         customizationID = player->GetByteValue(PLAYER_BYTES, 0); // Use Skin Color
 
-    auto itr = _playerShapeshiftModel.find(std::make_tuple(form, player->getRace(), customizationID, player->getGender()));
+    // getGender() tracks the active display model; real gender lives in PLAYER_BYTES_3
+    uint8 gender = player->GetByteValue(PLAYER_BYTES_3, PLAYER_BYTES_3_OFFSET_GENDER);
+
+    auto itr = _playerShapeshiftModel.find(std::make_tuple(form, player->getRace(), customizationID, gender));
     if (itr != _playerShapeshiftModel.end())
         return itr->second; // Explicit combination
 
@@ -1903,7 +1906,7 @@ uint32 ObjectMgr::GetModelForShapeshift(ShapeshiftForm form, Player* player) con
     if (itr != _playerShapeshiftModel.end())
         return itr->second; // Combination applied to both genders
 
-    itr = _playerShapeshiftModel.find(std::make_tuple(form, player->getRace(), 255, player->getGender()));
+    itr = _playerShapeshiftModel.find(std::make_tuple(form, player->getRace(), 255, gender));
     if (itr != _playerShapeshiftModel.end())
         return itr->second; // Default gender-dependent model
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`ObjectMgr::GetModelForShapeshift` looked up the player's gender via `Unit::getGender()`, which reads `UNIT_FIELD_BYTES_0` byte 2. That byte is overwritten by `Unit::SetDisplayId` with `CreatureModelInfo::gender` every time the display model changes, and some shapeshift models (e.g. fallback cat `8571`) carry `gender = GENDER_NONE`. After entering a map the lookup therefore missed every `(form, race, custID, gender)` / `(form, race, 255, gender)` entry in `player_shapeshift_model`, returned 0, and `Unit::GetModelForForm` fell through to the DBC path — which returned `modelID_A` (the Night Elf cat 892) because `SpellShapeshiftForm.dbc` lists `modelID_H = 0` for FORM_CAT.

The persistent character gender lives in `PLAYER_BYTES_3` byte 0, which is what the player save path already uses for this exact reason (see the `// save gender from PLAYER_BYTES_3, UNIT_BYTES_0 changes with every transform effect` comments in `Player::SaveToDB`). Reading from there keeps the shapeshift lookup stable across `SetDisplayId` calls.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code (Claude Opus 4.7) with azerothMCP for code navigation and DB inspection.

## Issues Addressed:
- Closes #25528

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

TrinityCore 3.3.5 handles the same quirk by exposing `Player::GetNativeGender()` that reads `PLAYER_BYTES_3` and using it for druid form lookups (`Unit::GetModelForForm`). This PR applies the same principle to AzerothCore's `ObjectMgr::GetModelForShapeshift` without altering the surrounding API.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Reproduced before the fix with a female Tauren druid: cat form model flipped from `8571` (Tauren default) to `892` (Night Elf cat) after the first map change, then to `29411` (male Tauren cat) after the next, as `UNIT_FIELD_BYTES_0` gender byte drifted between `GENDER_NONE` and `GENDER_MALE`. With the fix the model stays consistent across enter/exit cycles.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Log in with a Horde (Tauren) druid. Female characters hit the bug fastest, but male is also affected if the skin color has no exact `player_shapeshift_model` row.
2. Cast Cat Form (or Bear Form).
3. Enter a dungeon (Dungeon Finder or a ported summon — anything that triggers a map change) and immediately step outside / port back.
4. Confirm the cat/bear model remains the Tauren version across every map change. Before the fix it flipped to the Night Elf version (and with repeated transitions to the wrong-gender Tauren model).

## Known Issues and TODO List:

- [ ] None.