### PR TITLE
fix(DB/SAI): Move Magister Aledis behavior to SmartAI.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1776948696.sql
+++ b/data/sql/updates/pending_db_world/rev_1776948696.sql
@@ -16,12 +16,13 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (20159, 0, 6, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 2015900, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Gossip Option 0 Selected - Run Script'),
 (20159, 0, 7, 8, 2, 1, 100, 0, 0, 20, 0, 0, 0, 0, 22, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Between 0-20% Health - Set Event Phase 2 (Phase 1)'),
 (20159, 0, 8, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 2015901, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Between 0-20% Health - Run Script (Phase 1)'),
-(20159, 0, 9, 0, 7, 1, 100, 0, 0, 0, 0, 0, 0, 0, 41, 5000, 30, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Evade - Despawn In 5000 ms (Phase 1)'),
-(20159, 0, 10, 0, 0, 0, 100, 0, 0, 0, 5000, 8000, 0, 0, 11, 20823, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - In Combat - Cast \'Fireball\''),
-(20159, 0, 11, 0, 106, 0, 100, 0, 5000, 10000, 12000, 18000, 0, 10, 11, 11831, 64, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Hostile in Range - Cast \'Frost Nova\'');
+(20159, 0, 9, 10, 7, 1, 100, 0, 0, 0, 0, 0, 0, 0, 22, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Evade - Set Event Phase 0 (Phase 1)'),
+(20159, 0, 10, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 2015902, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Evade - Run Script (Phase 1)'),
+(20159, 0, 11, 0, 0, 0, 100, 0, 0, 0, 5000, 8000, 0, 0, 11, 20823, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - In Combat - Cast \'Fireball\''),
+(20159, 0, 12, 0, 106, 0, 100, 0, 5000, 10000, 12000, 18000, 0, 10, 11, 11831, 64, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Hostile in Range - Cast \'Frost Nova\'');
 
 -- Set Action Lists.
-DELETE FROM `smart_scripts` WHERE (`source_type` = 9) AND (`entryorguid` IN (2015900, 2015901));
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9) AND (`entryorguid` IN (2015900, 2015901, 2015902));
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (2015900, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 42, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Set Invincibility Hp 1%'),
 (2015900, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 206, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Dismount'),
@@ -34,4 +35,9 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (2015901, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 2, 1604, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Set Faction 1604'),
 (2015901, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Add Npc Flags Questgiver'),
 (2015901, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Say Line 1'),
-(2015901, 9, 5, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 60000, 30, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Despawn In 60000 ms');
+(2015901, 9, 5, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 60000, 30, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Despawn In 60000 ms'),
+(2015902, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Add Npc Flags Gossip'),
+(2015902, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 18, 256, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Set Flags Immune To Players'),
+(2015902, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Reset Invincibility Hp'),
+(2015902, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 2, 1604, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Set Faction 1604'),
+(2015902, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 43, 0, 18696, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Mount To Model 18696');

--- a/data/sql/updates/pending_db_world/rev_1776948696.sql
+++ b/data/sql/updates/pending_db_world/rev_1776948696.sql
@@ -1,0 +1,37 @@
+
+-- Remove Mount from Creature Addon (it is setted using SAI).
+UPDATE `creature_addon` SET `mount` = 0 WHERE (`guid` IN (86873));
+
+-- Set General SAI.
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `ScriptName` = '' WHERE `entry` = 20159;
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 20159);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(20159, 0, 0, 1, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Respawn - Remove Npc Flags Questgiver'),
+(20159, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 18, 256, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Respawn - Set Flags Immune To Players'),
+(20159, 0, 2, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 43, 0, 18696, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Respawn - Mount To Model 18696'),
+(20159, 0, 3, 4, 62, 0, 100, 0, 8081, 0, 0, 0, 0, 0, 64, 23, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Gossip Option 0 Selected - Store Targetlist'),
+(20159, 0, 4, 5, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 83, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Gossip Option 0 Selected - Remove Npc Flags Gossip'),
+(20159, 0, 5, 6, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 22, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Gossip Option 0 Selected - Set Event Phase 1'),
+(20159, 0, 6, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 2015900, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Gossip Option 0 Selected - Run Script'),
+(20159, 0, 7, 8, 2, 1, 100, 0, 0, 20, 0, 0, 0, 0, 22, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Between 0-20% Health - Set Event Phase 2 (Phase 1)'),
+(20159, 0, 8, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 2015901, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Between 0-20% Health - Run Script (Phase 1)'),
+(20159, 0, 9, 0, 7, 1, 100, 0, 0, 0, 0, 0, 0, 0, 41, 5000, 30, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Evade - Despawn In 5000 ms (Phase 1)'),
+(20159, 0, 10, 0, 0, 0, 100, 0, 0, 0, 5000, 8000, 0, 0, 11, 20823, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - In Combat - Cast \'Fireball\''),
+(20159, 0, 11, 0, 106, 0, 100, 0, 5000, 10000, 12000, 18000, 0, 10, 11, 11831, 64, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - On Hostile in Range - Cast \'Frost Nova\'');
+
+-- Set Action Lists.
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9) AND (`entryorguid` IN (2015900, 2015901));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2015900, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 42, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Set Invincibility Hp 1%'),
+(2015900, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 206, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Dismount'),
+(2015900, 9, 2, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Say Line 0'),
+(2015900, 9, 3, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 19, 256, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Remove Flags Immune To Players'),
+(2015900, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 2, 14, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Set Faction 14'),
+(2015900, 9, 5, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 12, 23, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Start Attacking'),
+(2015901, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 224, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Stop Attack'),
+(2015901, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 18, 256, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Set Flags Immune To Players'),
+(2015901, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 2, 1604, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Set Faction 1604'),
+(2015901, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 82, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Add Npc Flags Questgiver'),
+(2015901, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Say Line 1'),
+(2015901, 9, 5, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 60000, 30, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Magister Aledis - Actionlist - Despawn In 60000 ms');

--- a/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
+++ b/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
@@ -457,113 +457,6 @@ public:
     }
 };
 
-enum Aledis
-{
-    SAY_CHALLENGE = 0,
-    SAY_DEFEATED = 1,
-    EVENT_TALK = 1,
-    EVENT_ATTACK = 2,
-    EVENT_EVADE = 3,
-    EVENT_FIREBALL = 4,
-    EVENT_FROSTNOVA = 5,
-    SPELL_FIREBALL = 20823,
-    SPELL_FROSTNOVA = 11831,
-};
-
-struct npc_magister_aledis : public ScriptedAI
-{
-    npc_magister_aledis(Creature* creature) : ScriptedAI(creature) { }
-
-    void StartFight(Player* player)
-    {
-        me->Dismount();
-        me->SetFacingToObject(player);
-        me->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
-        _playerGUID = player->GetGUID();
-        _events.ScheduleEvent(EVENT_TALK, 2s);
-    }
-
-    void Reset() override
-    {
-        me->RestoreFaction();
-        me->RemoveNpcFlag(UNIT_NPC_FLAG_QUESTGIVER);
-        me->SetNpcFlag(UNIT_NPC_FLAG_GOSSIP);
-        me->SetImmuneToPC(true);
-    }
-
-    void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*damageType*/, SpellSchoolMask /*spellInfo = nullptr*/) override
-    {
-        if (damage > me->GetHealth() || me->HealthBelowPctDamaged(20, damage))
-        {
-            damage = 0;
-
-            _events.Reset();
-            me->RestoreFaction();
-            me->RemoveAllAuras();
-            me->GetThreatMgr().ClearAllThreat();
-            me->CombatStop(true);
-            me->SetNpcFlag(UNIT_NPC_FLAG_QUESTGIVER);
-            me->SetImmuneToPC(true);
-            Talk(SAY_DEFEATED);
-
-            _events.ScheduleEvent(EVENT_EVADE, 1min);
-        }
-    }
-
-    void UpdateAI(uint32 diff) override
-    {
-        _events.Update(diff);
-
-        while (uint32 eventId = _events.ExecuteEvent())
-        {
-            switch (eventId)
-            {
-                case EVENT_TALK:
-                    Talk(SAY_CHALLENGE);
-                    _events.ScheduleEvent(EVENT_ATTACK, 2s);
-                    break;
-                case EVENT_ATTACK:
-                    me->SetImmuneToPC(false);
-                    me->SetFaction(FACTION_MONSTER);
-                    if (Player* player = ObjectAccessor::GetPlayer(*me, _playerGUID))
-                    {
-                        AttackStart(player);
-                    }
-                    _events.ScheduleEvent(EVENT_FIREBALL, 1ms);
-                    _events.ScheduleEvent(EVENT_FROSTNOVA, 5s);
-                    break;
-                case EVENT_FIREBALL:
-                    DoCast(SPELL_FIREBALL);
-                    _events.ScheduleEvent(EVENT_FIREBALL, 10s);
-                    break;
-                case EVENT_FROSTNOVA:
-                    DoCastAOE(SPELL_FROSTNOVA);
-                    _events.ScheduleEvent(EVENT_FROSTNOVA, 20s);
-                    break;
-                case EVENT_EVADE:
-                    EnterEvadeMode();
-                    break;
-            }
-        }
-
-        if (UpdateVictim())
-        {
-            DoMeleeAttackIfReady();
-        }
-    }
-
-    void sGossipSelect(Player* player, uint32 /*sender*/, uint32 /*action*/) override
-    {
-        CloseGossipMenuFor(player);
-        me->StopMoving();
-        StartFight(player);
-    }
-
-private:
-    EventMap _events;
-    ObjectGuid _playerGUID;
-};
-
 enum Beacon
 {
     NPC_STONESCHYE_WHELP        = 16927,
@@ -645,6 +538,5 @@ void AddSC_hellfire_peninsula()
     new npc_fel_guard_hound();
     new go_beacon();
 
-    RegisterCreatureAI(npc_magister_aledis);
     RegisterGameObjectAI(go_magtheridons_head);
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25541

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
