### PR TITLE
fix(Core/Combat): Training dummy stuck combat after pet recall

### DIFF
--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -329,6 +329,12 @@ struct npc_training_dummy : NullCreatureAI
             return;
 
         _combatTimer[attacker->GetGUID()] = 5s;
+
+        // Pet attacks engage the owner via propagation without firing
+        // JustEnteredCombat here, so track the owner's timer too.
+        if (Unit* owner = attacker->GetCharmerOrOwner())
+            if (me->GetCombatManager().IsInCombatWith(owner))
+                _combatTimer[owner->GetGUID()] = 5s;
     }
 
     void UpdateAI(uint32 diff) override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Fix a stuck-combat state on training dummies when a player stops attacking while their pet continues, then recalls the pet — the player remains in combat indefinitely.

**Root cause:** `npc_training_dummy` tracks per-attacker timers in `_combatTimer`, populated from `JustEnteredCombat` and `DamageTaken`. When the player stops attacking, their timer expires and the dummy ends the player↔dummy `CombatReference`. The pet's next auto-attack calls `Unit::AtTargetAttacked`, whose owner-side propagation (added in #25166) re-engages the pet's owner with the dummy — creating a brand-new `CombatReference`. But because the dummy was still engaged with the pet, `CombatManager::UpdateOwnerCombatState` returns false on the dummy side and `JustEnteredCombat` never fires for the new ref. The player's `_combatTimer` entry is never repopulated, the ref lives on, and recalling the pet leaves the player permanently in combat.

**Fix:** in `DamageTaken`, when the attacker has an owner and that owner is already in combat with the dummy, refresh the owner's `_combatTimer` entry. While the pet is swinging, the owner's timer stays alive; once the pet is recalled, both timers drain and the refs close within ~5s.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Code with azerothMCP

## Issues Addressed:
- Closes chromiecraft/chromiecraft#9360
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25561

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Repro (confirms original bug):**
1. `.go creature id 30527` (Training Dummy) — or any training dummy: 31146 Heroic, 32541 Initiate's, 32667 Master's, etc.
2. Log in as a class with a pet (Hunter, Warlock, DK with Master of Ghouls).
3. Pet on Defensive/Aggressive, send pet to attack the dummy.
4. Attack the dummy yourself for a few swings.
5. Stop attacking — leave the pet hitting.
6. Wait 10+ seconds.
7. Recall/dismiss the pet.
8. Before fix: combat swords stay on indefinitely (cannot mount, eat, drink).
   After fix: combat drops within ~5s of the pet leaving.

**Regression — recall pet first (was already working):**
1. Pet + you both attacking the dummy.
2. Recall pet first, then stop attacking.
3. Combat drops ~5s later.

**Regression — solo player:**
1. No pet. Attack dummy, stop.
2. Combat drops ~5s later.

**Regression — pet keeps owner in combat while fighting (retail behavior restored in #25166):**
1. Send pet at dummy, do NOT attack yourself.
2. While pet is swinging, try to mount / eat / drink — should be blocked.
3. Combat swords visible on your character.

**Edge cases:**
1. Warlock Corruption DoT + pet attacking — after pet recall, DoT alone does not refresh the 5s timer (DOT guard unchanged).
2. DK Army of the Dead + Ghoul — multiple controlled units, dismiss/expire in any order, combat drops cleanly.
3. Mage Water Elemental, Shaman Fire Elemental Totem — same script path via `GetCharmerOrOwner()`.

## Known Issues and TODO List:

- [ ] None known.