### PR TITLE
fix(Scripts/HoL): Restart Bjarngrim escort after JustRespawned

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_bjarngrim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_bjarngrim.cpp
@@ -129,6 +129,13 @@ struct boss_bjarngrim : public npc_escortAI
         AddWaypoint(7, 1262.0f, -26.9f, 33.5f, 0);
     }
 
+    void JustRespawned() override
+    {
+        npc_escortAI::JustRespawned();
+        me->SetWalk(true);
+        Start(true, ObjectGuid::Empty, nullptr, false, true);
+    }
+
     void Reset() override
     {
         events.Reset();


### PR DESCRIPTION
## Changes Proposed:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

General Bjarngrim stands still on his center platform and never patrols between the three stance platforms (Battle / Berserker / Defensive).

Root cause: #25482 set `TriggerJustRespawned = true` in the `Creature` constructor so `JustRespawned` now fires on initial spawn for non-summons. `boss_bjarngrim` sets up its escort synchronously in the AI constructor (`InitializeWaypoints()` + `Start()`), so `STATE_ESCORT_ESCORTING` is set — then the first `Update` tick calls `AI()->JustRespawned()`, and `npc_escortAI::JustRespawned()` does `RemoveEscortState(STATE_ESCORT_ESCORTING | ...)`, killing the patrol before it can serve a single waypoint.

Fix: override `JustRespawned()` to re-arm the escort after the base clears it.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with AzerothMCP.

## Issues Addressed:
- Closes

## SOURCE:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Regression bisected to #25482 (`fix(Core/Creature): Fire JustRespawned for non-compat spawns`). Behavior prior to that PR is the expected live behavior (Bjarngrim patrols between the three stance platforms).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds clean with clang, `SCRIPTS=static`, `MODULES=static`, `RelWithDebInfo`. Verified in-game on Halls of Lightning 5-man: Bjarngrim walks the full stance-platform patrol, changes stance at each platform, and picks up `Temporary Electrical Charge` as expected.

Other escort-AI scripts that invoke `Start()` from the AI constructor could be affected by the same `JustRespawned`-on-initial-spawn regression and have not been audited here — reviewers may want to spot-check.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.tele hallsoflightning`
2. `.go creature id 28586` — General Bjarngrim.
3. Stand back and watch for ~30s. He should walk between the three stance platforms, pausing ~10s at each, and change stance + equipment on arrival. Without this fix he remains idle at the spawn platform.

## Known Issues and TODO List:

- [ ]
- [ ]