### PR TITLE
fix(Core/Battlefield): respawn Wintergrasp NPCs after death

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -187,6 +187,17 @@ bool Battlefield::Update(uint32 diff)
                 objectiveChanged = true;
     }
 
+    // Creatures spawned via SpawnCreature have m_spawnId == 0 and are not
+    // TempSummons, so the unforced Respawn() call from Creature::Update is
+    // skipped by the no-spawnId guard added in #25499. Force the respawn
+    // here once the timer elapses.
+    time_t now = GameTime::GetGameTime().count();
+    for (ObjectGuid const& guid : SpawnedCreatures)
+        if (Creature* creature = GetCreature(guid))
+            if (creature->isDead() && creature->GetRespawnTime()
+                && creature->GetRespawnTime() <= now)
+                creature->Respawn(true);
+
     return objectiveChanged;
 }
 
@@ -777,6 +788,8 @@ Creature* Battlefield::SpawnCreature(uint32 entry, float x, float y, float z, fl
 
     map->AddToMap(creature);
     creature->setActive(true);
+
+    SpawnedCreatures.insert(creature->GetGUID());
 
     return creature;
 }

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -421,6 +421,8 @@ protected:
 
     GuidUnorderedSet Groups[PVP_TEAMS_COUNT];               // Contains different raid groups
 
+    GuidUnorderedSet SpawnedCreatures;                      // Creatures spawned via SpawnCreature (no spawnId, not TempSummon)
+
     std::vector<uint64> Data64;
     std::vector<uint32> Data32;
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Wintergrasp NPCs (e.g. Warsong Champion `30739`, Valiance Expedition Champion `30740`, keep guards, tower cannons) stop respawning after being killed. Same root cause as the SotA demolisher regression (#25551): #25499 added a guard in `Creature::Respawn(bool force)` that early-returns for creatures without an `m_spawnId`, on the assumption they must be `TempSummon`s.

`Battlefield::SpawnCreature` (used by every WG NPC) constructs creatures with `new Creature()` + `Creature::Create(... spawnId=0 ...)` — they have no spawnId but are not TempSummons. When killed, `Creature::Update` fires `Respawn()` unforced once the timer elapses, hits the early return, and never revives them.

Polling the existing WG creature lists (`KeepCreature`, `OutsideCreature`, `CanonList`) in `BattlefieldWG::Update` and force-respawning dead entries past their timer keeps the fix scoped to WG and leaves the original guard in place for actual TempSummon orphans.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.7 was used to investigate the regression and produce the fix.

## Issues Addressed:
- Related to #25551 (SotA demolishers; same root cause)

## SOURCE:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Pre-#25499 behaviour. TrinityCore's `Creature::Respawn` has no equivalent no-spawnId early return.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Enter Wintergrasp during a battle.
2. Kill a keep guard (e.g. Warsong Champion `30739` or Valiance Expedition Champion `30740`) or a tower cannon.
3. Wait for the creature's normal respawn delay — it should reappear at its spawn location.

## Known Issues and TODO List:

- [ ] Tower-internal creatures (`m_CreatureBottomList`, `m_CreatureTopList`, `m_TowerCannonBottomList`, `m_TurretTopList`) are not polled here. Their lifecycle is tied to tower destruction, so applying the same workaround there warrants separate review.
- [ ]