### PR TITLE
fix(Scripts/Quest): Drake Hunt drake flies away on subdue

### DIFF
--- a/src/server/scripts/Northrend/zone_borean_tundra.cpp
+++ b/src/server/scripts/Northrend/zone_borean_tundra.cpp
@@ -23,6 +23,7 @@
 #include "ScriptedEscortAI.h"
 #include "ScriptedFollowerAI.h"
 #include "ScriptedGossip.h"
+#include "SmartAI.h"
 #include "SpellAuras.h"
 #include "SpellInfo.h"
 #include "SpellScript.h"
@@ -55,6 +56,8 @@ class spell_q11919_q11940_drake_hunt_aura : public AuraScript
 
         Creature* owner = GetOwner()->ToCreature();
         owner->RemoveAllAurasExceptType(SPELL_AURA_DUMMY);
+        if (SmartAI* ai = CAST_AI(SmartAI, owner->AI()))
+            ai->SetEvadeDisabled(true);
         owner->CombatStop(true);
         owner->GetThreatMgr().ClearAllThreat();
         owner->GetMotionMaster()->Clear(false);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Fixes the Drake Hunt quest chain in Coldarra, Borean Tundra (quests 11919 *Drake Hunt* and 11940 *Pawn Captured*). When the Nexus Drake Hatchling (NPC 26127) was successfully subdued, the drake would fly away to its spawn point instead of following the player back to Raelorasz, preventing quest completion.

### Root Cause
`spell_q11919_q11940_drake_hunt_aura::HandleEffectRemove` calls `CombatStop(true)` followed by `MoveFollow(GetCaster(), ...)` on the drake. The Nexus Drake Hatchling uses SmartAI (see `smart_scripts` for entry 26127). On the next AI tick after combat exit, `SmartAI::JustExitedCombat` / `EnterEvadeMode` invokes `MoveTargetedHome()`, which overrides the `MoveFollow` and sends the drake back to its flight-path spawn point.

### Fix
Call `SmartAI::SetEvadeDisabled(true)` on the subdued drake before `CombatStop`, the same flag exposed by SAI action `SMART_ACTION_DISABLE_EVADE`. With evade disabled, `EnterEvadeMode` short-circuits and `MoveFollow` survives, so the drake follows the player to Raelorasz as intended. The drake is despawned 180s later, so the disabled flag has no lasting effect.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Investigation and patch drafting assisted by Claude (Anthropic, claude-sonnet-4.7) via Claude Code. The author reviewed and validated the change.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Wowhead comments on quests [11919](https://www.wowhead.com/wotlk/quest=11919) and [11940](https://www.wowhead.com/wotlk/quest=11940) describe the intended behaviour: subdued drake follows the player back to Raelorasz.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Built on Windows with MSVC, RelWithDebInfo. No new warnings.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Pick up *Drake Hunt* (11919) from Raelorasz at Transitus Shield, Coldarra.
2. Use the harpoon to attach to a Nexus Drake Hatchling and ride out the subdue minigame until the aura expires.
3. **Before the fix:** drake becomes non-hostile then immediately flies away to its spawn point.  
   **After the fix:** drake becomes friendly and follows the player.
4. Fly back to Raelorasz; the drake should arrive and trigger quest credit.

## Known Issues and TODO List:

- [ ] None known.