### PR TITLE
fix(DB/SAI): Whisper Gulch gems despawn too fast

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1777173822227629900.sql
+++ b/data/sql/updates/pending_db_world/rev_1777173822227629900.sql
@@ -1,0 +1,4 @@
+DELETE FROM `smart_scripts`
+WHERE `entryorguid` IN (2397400, 2397401, 2397402, 2397403)
+  AND `source_type` = 9
+  AND `id` = 1;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

During *Danger! Explosives!* the Whisper Gulch ore/gem nodes (`186404`, `186466`, `186467`, `186468`) despawn within ~4 seconds of being broken, well before players can mine them all.

Whisper Gulch Ore Bunny (`23974`) is the SmartAI host that the explosive's spell hits. On hit it runs one of four timed actionlists (`2397400`-`2397403`); each one summons a gem GO with `despawnTime=120` and then force-despawns the bunny 4s later via `SMART_ACTION_FORCE_DESPAWN`.

`SMART_ACTION_SUMMON_GO` in AzerothCore calls `WorldObject::SummonGameObject` with the default `GO_SUMMON_TIMED_OR_CORPSE_DESPAWN`, which attaches the GO to the summoner via `Unit::AddGameObject`. When the bunny is force-despawned, `Creature::ForcedDespawn` -> `setDeathState(JustDied)` -> `RemoveCorpse(true)` -> `RemoveFromWorld` -> `Unit::RemoveAllGameObjects` deletes the gem with the bunny - the 120s timer never gets to apply.

Dropping the bunny's self-despawn lets the gem live out its full lifetime (it's deleted on loot via `GO_JUST_DEACTIVATED` + `GetSpellId()==1`). The bunny is a static-spawned invisible trigger (`flags_extra=128`, `unit_flags=0x02000B00`, faction 35), so leaving it standing has no visual or gameplay cost. The actionlist queue self-drains on the next world tick after `id=0` runs, so subsequent spell hits still re-arm the script.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Investigation and SQL drafted with Claude (Opus 4.7).

## Issues Addressed:
- Closes chromiecraft/chromiecraft#9380

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Reference video showing intended ~minute-scale node lifetime: https://www.youtube.com/watch?v=75nC089Ws5w

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Pick up *Danger! Explosives!* in Howling Fjord and travel to Whisper Gulch.
2. Throw an explosive at a rock to spawn a gem/ore node.
3. Confirm the node remains long enough to be mined (no longer despawns at ~4s).
4. Sanity-check that nothing in the area looks visibly off (the bunny is invisible/unselectable, so there should be no visible change in the world apart from the gem persisting).

## Known Issues and TODO List:

- [ ]
- [ ]