### PR TITLE
fix(Scripts/MagtheridonsLair): prevent Hellfire Channelers from respawning during boss fight

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1778152540751174200.sql
+++ b/data/sql/updates/pending_db_world/rev_1778152540751174200.sql
@@ -8,13 +8,13 @@
 --
 DELETE FROM `creature_formations` WHERE `leaderGUID`=90978;
 INSERT INTO `creature_formations`
-    (`leaderGUID`,`memberGUID`,`dist`,`angle`,`groupAI`,`point_1`,`point_2`)
+(`leaderGUID`,`memberGUID`,`dist`,`angle`,`groupAI`,`point_1`,`point_2`)
 VALUES
-    (90978, 90978, 0, 0, 8, 0, 0),
-    (90978, 90979, 0, 0, 8, 0, 0),
-    (90978, 90980, 0, 0, 8, 0, 0),
-    (90978, 90981, 0, 0, 8, 0, 0),
-    (90978, 90982, 0, 0, 8, 0, 0);
+(90978, 90978, 0, 0, 8, 0, 0),
+(90978, 90979, 0, 0, 8, 0, 0),
+(90978, 90980, 0, 0, 8, 0, 0),
+(90978, 90981, 0, 0, 8, 0, 0),
+(90978, 90982, 0, 0, 8, 0, 0);
 
 --
 -- On evade:
@@ -29,13 +29,13 @@ VALUES
 --
 DELETE FROM `smart_scripts` WHERE `entryorguid`=17256 AND `source_type`=0 AND `id` IN (9, 10);
 INSERT INTO `smart_scripts`
-    (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,
-     `event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,
-     `action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,
-     `target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,
-     `target_x`,`target_y`,`target_z`,`target_o`,`comment`)
+(`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,
+ `event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,
+ `action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,
+ `target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,
+ `target_x`,`target_y`,`target_z`,`target_o`,`comment`)
 VALUES
-    (17256, 0, 9,  0, 7, 0, 100, 0, 0, 0, 0, 0, 0, 34, 10,    0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-     'Hellfire Channeler - On Evade - Set Instance Data 10 to 0'),
-    (17256, 0, 10, 0, 7, 0, 100, 0, 0, 0, 0, 0, 0, 28, 30531, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-     'Hellfire Channeler - On Evade - Remove Soul Transfer Aura');
+(17256, 0, 9,  0, 7, 0, 100, 0, 0, 0, 0, 0, 0, 34, 10,    0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+ 'Hellfire Channeler - On Evade - Set Instance Data 10 to 0'),
+(17256, 0, 10, 0, 7, 0, 100, 0, 0, 0, 0, 0, 0, 28, 30531, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+'Hellfire Channeler - On Evade - Remove Aura \'Soul Transfer\'');

--- a/data/sql/updates/pending_db_world/rev_1778152540751174200.sql
+++ b/data/sql/updates/pending_db_world/rev_1778152540751174200.sql
@@ -1,26 +1,34 @@
 --
--- Magtheridon's Lair: group the 5 Hellfire Channelers in a formation with
--- RESPAWN_ON_EVADE (groupAI flag 0x008). When any surviving Channeler
--- evades (e.g. raid wipes during phase 1), the dead members of the group
--- respawn automatically. This replaces the previous reliance on the
--- minion system, which caused dead Channelers to be resurrected when
+-- Magtheridon's Lair: group the 5 Hellfire Channelers in a single formation.
+-- groupAI = 11 (0x00B) combines:
+--   0x001 MEMBER_ASSIST_LEADER - members aggro when the leader is engaged
+--   0x002 LEADER_ASSIST_MEMBER - leader aggros when any member is engaged
+--                                (fans out to the other members via 0x001)
+--   0x008 RESPAWN_ON_EVADE     - dead members respawn when a surviving member evades
+-- EVADE_TOGETHER (0x004) is intentionally NOT set: in CreatureGroup::MemberEvaded
+-- the EVADE_TOGETHER branch short-circuits on dead members and skips the
+-- respawn path, so a partial wipe (e.g. 3/5 killed) would leave the corpses
+-- on the ground. Without that flag, each surviving Channeler evades on its
+-- own when its target list empties, and each evade triggers RESPAWN_ON_EVADE
+-- to bring the dead members back. This replaces the previous reliance on
+-- the minion system, which caused dead Channelers to be resurrected when
 -- Magtheridon's combat state oscillated between IN_COMBAT and NONE.
 --
 DELETE FROM `creature_formations` WHERE `leaderGUID`=90978;
 INSERT INTO `creature_formations`
 (`leaderGUID`,`memberGUID`,`dist`,`angle`,`groupAI`,`point_1`,`point_2`)
 VALUES
-(90978, 90978, 0, 0, 8, 0, 0),
-(90978, 90979, 0, 0, 8, 0, 0),
-(90978, 90980, 0, 0, 8, 0, 0),
-(90978, 90981, 0, 0, 8, 0, 0),
-(90978, 90982, 0, 0, 8, 0, 0);
+(90978, 90978, 0, 0, 11, 0, 0),
+(90978, 90979, 0, 0, 11, 0, 0),
+(90978, 90980, 0, 0, 11, 0, 0),
+(90978, 90981, 0, 0, 11, 0, 0),
+(90978, 90982, 0, 0, 11, 0, 0);
 
 --
 -- On evade:
 --  * id=9 notifies the instance script so it can force-reset Magtheridon
 --    (otherwise his _channelersKilled counter would stay stale across
---    pulls — Magtheridon is held in combat by SetInCombatWithZone() and
+--    pulls; Magtheridon is held in combat by SetInCombatWithZone() and
 --    his own EnterEvadeMode does not always fire).
 --  * id=10 strips the Soul Transfer (30531) auras stacked on the surviving
 --    Channelers from each ally that died during the previous pull.

--- a/data/sql/updates/pending_db_world/rev_1778152540751174200.sql
+++ b/data/sql/updates/pending_db_world/rev_1778152540751174200.sql
@@ -1,0 +1,41 @@
+--
+-- Magtheridon's Lair: group the 5 Hellfire Channelers in a formation with
+-- RESPAWN_ON_EVADE (groupAI flag 0x008). When any surviving Channeler
+-- evades (e.g. raid wipes during phase 1), the dead members of the group
+-- respawn automatically. This replaces the previous reliance on the
+-- minion system, which caused dead Channelers to be resurrected when
+-- Magtheridon's combat state oscillated between IN_COMBAT and NONE.
+--
+DELETE FROM `creature_formations` WHERE `leaderGUID`=90978;
+INSERT INTO `creature_formations`
+    (`leaderGUID`,`memberGUID`,`dist`,`angle`,`groupAI`,`point_1`,`point_2`)
+VALUES
+    (90978, 90978, 0, 0, 8, 0, 0),
+    (90978, 90979, 0, 0, 8, 0, 0),
+    (90978, 90980, 0, 0, 8, 0, 0),
+    (90978, 90981, 0, 0, 8, 0, 0),
+    (90978, 90982, 0, 0, 8, 0, 0);
+
+--
+-- On evade:
+--  * id=9 notifies the instance script so it can force-reset Magtheridon
+--    (otherwise his _channelersKilled counter would stay stale across
+--    pulls — Magtheridon is held in combat by SetInCombatWithZone() and
+--    his own EnterEvadeMode does not always fire).
+--  * id=10 strips the Soul Transfer (30531) auras stacked on the surviving
+--    Channelers from each ally that died during the previous pull.
+--    Without this, on a partial wipe (e.g. 3/5 killed) the survivors
+--    return to spawn with permanent damage/health buffs.
+--
+DELETE FROM `smart_scripts` WHERE `entryorguid`=17256 AND `source_type`=0 AND `id` IN (9, 10);
+INSERT INTO `smart_scripts`
+    (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,
+     `event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,
+     `action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,
+     `target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,
+     `target_x`,`target_y`,`target_z`,`target_o`,`comment`)
+VALUES
+    (17256, 0, 9,  0, 7, 0, 100, 0, 0, 0, 0, 0, 0, 34, 10,    0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+     'Hellfire Channeler - On Evade - Set Instance Data 10 to 0'),
+    (17256, 0, 10, 0, 7, 0, 100, 0, 0, 0, 0, 0, 0, 28, 30531, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+     'Hellfire Channeler - On Evade - Remove Soul Transfer Aura');

--- a/data/sql/updates/pending_db_world/rev_1778152540751174200.sql
+++ b/data/sql/updates/pending_db_world/rev_1778152540751174200.sql
@@ -1,49 +1,13 @@
---
--- Magtheridon's Lair: group the 5 Hellfire Channelers in a single formation.
--- groupAI = 11 (0x00B) combines:
---   0x001 MEMBER_ASSIST_LEADER - members aggro when the leader is engaged
---   0x002 LEADER_ASSIST_MEMBER - leader aggros when any member is engaged
---                                (fans out to the other members via 0x001)
---   0x008 RESPAWN_ON_EVADE     - dead members respawn when a surviving member evades
--- EVADE_TOGETHER (0x004) is intentionally NOT set: in CreatureGroup::MemberEvaded
--- the EVADE_TOGETHER branch short-circuits on dead members and skips the
--- respawn path, so a partial wipe (e.g. 3/5 killed) would leave the corpses
--- on the ground. Without that flag, each surviving Channeler evades on its
--- own when its target list empties, and each evade triggers RESPAWN_ON_EVADE
--- to bring the dead members back. This replaces the previous reliance on
--- the minion system, which caused dead Channelers to be resurrected when
--- Magtheridon's combat state oscillated between IN_COMBAT and NONE.
---
+-- Hellfire Channelers formation: groupAI = 3 (MEMBER_ASSIST_LEADER | LEADER_ASSIST_MEMBER), pack-aggro only. Wipe handling lives in the instance script's hard reset.
 DELETE FROM `creature_formations` WHERE `leaderGUID`=90978;
 INSERT INTO `creature_formations`
 (`leaderGUID`,`memberGUID`,`dist`,`angle`,`groupAI`,`point_1`,`point_2`)
 VALUES
-(90978, 90978, 0, 0, 11, 0, 0),
-(90978, 90979, 0, 0, 11, 0, 0),
-(90978, 90980, 0, 0, 11, 0, 0),
-(90978, 90981, 0, 0, 11, 0, 0),
-(90978, 90982, 0, 0, 11, 0, 0);
+(90978, 90978, 0, 0, 3, 0, 0),
+(90978, 90979, 0, 0, 3, 0, 0),
+(90978, 90980, 0, 0, 3, 0, 0),
+(90978, 90981, 0, 0, 3, 0, 0),
+(90978, 90982, 0, 0, 3, 0, 0);
 
---
--- On evade:
---  * id=9 notifies the instance script so it can force-reset Magtheridon
---    (otherwise his _channelersKilled counter would stay stale across
---    pulls; Magtheridon is held in combat by SetInCombatWithZone() and
---    his own EnterEvadeMode does not always fire).
---  * id=10 strips the Soul Transfer (30531) auras stacked on the surviving
---    Channelers from each ally that died during the previous pull.
---    Without this, on a partial wipe (e.g. 3/5 killed) the survivors
---    return to spawn with permanent damage/health buffs.
---
-DELETE FROM `smart_scripts` WHERE `entryorguid`=17256 AND `source_type`=0 AND `id` IN (9, 10);
-INSERT INTO `smart_scripts`
-(`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,
- `event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,
- `action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,
- `target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,
- `target_x`,`target_y`,`target_z`,`target_o`,`comment`)
-VALUES
-(17256, 0, 9,  0, 7, 0, 100, 0, 0, 0, 0, 0, 0, 34, 10,    0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
- 'Hellfire Channeler - On Evade - Set Instance Data 10 to 0'),
-(17256, 0, 10, 0, 7, 0, 100, 0, 0, 0, 0, 0, 0, 28, 30531, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-'Hellfire Channeler - On Evade - Remove Aura \'Soul Transfer\'');
+-- Hellfire Channeler SAI: drop id=6. Death tracking moved to the instance script (OnUnitDeath).
+DELETE FROM `smart_scripts` WHERE `entryorguid`=17256 AND `source_type`=0 AND `id`=6;

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
@@ -70,12 +70,6 @@ enum Groups
     GROUP_EARLY_RELEASE_CHECK   = 0
 };
 
-enum Actions
-{
-    ACTION_INCREASE_HELLFIRE_CHANNELER_DEATH_COUNT  = 1,
-    ACTION_BANISH_SELF = 2
-};
-
 struct boss_magtheridon : public BossAI
 {
     boss_magtheridon(Creature* creature) : BossAI(creature, DATA_MAGTHERIDON)
@@ -84,7 +78,6 @@ struct boss_magtheridon : public BossAI
     void Reset() override
     {
         BossAI::Reset();
-        _channelersKilled = 0;
         _currentPhase = 0;
         _castingQuake = false;
         _recentlySpoken = false;
@@ -194,21 +187,19 @@ struct boss_magtheridon : public BossAI
 
     void DoAction(int32 action) override
     {
-        if (action == ACTION_INCREASE_HELLFIRE_CHANNELER_DEATH_COUNT)
+        if (action == ACTION_RELEASE_MAGTHERIDON)
         {
-            _channelersKilled++;
+            if (_magReleased)
+                return;
 
-            if (_channelersKilled >= 5 && !_magReleased)
+            Talk(SAY_EMOTE_FREE);
+            Talk(SAY_FREE);
+            scheduler.CancelGroup(GROUP_EARLY_RELEASE_CHECK); //cancel regular countdown
+            _magReleased = true;
+            scheduler.Schedule(3s, [this](TaskContext)
             {
-                Talk(SAY_EMOTE_FREE);
-                Talk(SAY_FREE);
-                scheduler.CancelGroup(GROUP_EARLY_RELEASE_CHECK); //cancel regular countdown
-                _magReleased = true;
-                scheduler.Schedule(3s, [this](TaskContext)
-                {
-                    ScheduleCombatEvents();
-                });
-            }
+                ScheduleCombatEvents();
+            });
         }
         else if (action == ACTION_BANISH_SELF)
         {
@@ -256,7 +247,6 @@ private:
     bool _recentlySpoken;
     bool _magReleased;
     uint8 _currentPhase;
-    uint8 _channelersKilled;
     TaskScheduler _interruptScheduler;
 };
 

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
@@ -222,10 +222,6 @@ struct boss_magtheridon : public BossAI
         BossAI::JustEngagedWith(who);
         Talk(SAY_EMOTE_BEGIN);
 
-        instance->DoForAllMinions(DATA_MAGTHERIDON, [&](Creature* creature) {
-            creature->SetInCombatWithZone();
-        });
-
         scheduler.Schedule(60s, GROUP_EARLY_RELEASE_CHECK, [this](TaskContext /*context*/)
         {
             Talk(SAY_EMOTE_NEARLY);

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/instance_magtheridons_lair.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/instance_magtheridons_lair.cpp
@@ -178,8 +178,15 @@ public:
                     if (data == 1)
                     {
                         if (GetBossState(DATA_MAGTHERIDON) != IN_PROGRESS)
+                        {
+                            // Magtheridon is ImmuneToPC during phase 1, so
+                            // SetInCombatWithZone() alone does not always reach
+                            // JustEngagedWith. Force the encounter start so the
+                            // door closes the moment a Channeler is engaged.
+                            SetBossState(DATA_MAGTHERIDON, IN_PROGRESS);
                             if (Creature* magtheridon = instance->GetCreature(_magtheridonGUID))
                                 magtheridon->SetInCombatWithZone();
+                        }
                     }
                     else
                     {

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/instance_magtheridons_lair.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/instance_magtheridons_lair.cpp
@@ -53,6 +53,26 @@ public:
             _columnSet.clear();
         }
 
+        bool IsAnyChannelerAlive()
+        {
+            return std::ranges::any_of(_channelersSet, [&](ObjectGuid const& guid)
+            {
+                if (Creature* channeler = instance->GetCreature(guid))
+                    return channeler->IsAlive();
+                return false;
+            });
+        }
+
+        bool IsAnyChannelerAliveAndInCombat()
+        {
+            return std::ranges::any_of(_channelersSet, [&](ObjectGuid const& guid)
+            {
+                if (Creature* channeler = instance->GetCreature(guid))
+                    return channeler->IsAlive() && channeler->IsInCombat();
+                return false;
+            });
+        }
+
         void OnCreatureCreate(Creature* creature) override
         {
             switch (creature->GetEntry())
@@ -139,29 +159,12 @@ public:
                     if (state == NOT_STARTED)
                         SetData(DATA_COLLAPSE, GO_READY);
 
-                    // The Channeler formation uses RESPAWN_ON_EVADE, which only
-                    // fires when a *living* member evades. If the raid wipes
-                    // after every Channeler is already dead (phase 2/3 wipe, or
-                    // a wipe during the 3s window before Magtheridon is freed),
-                    // no member is alive to trigger the formation respawn, and
-                    // the encounter would be left unrecoverable. Respawn the
-                    // pack manually in that case.
-                    if (state == NOT_STARTED || state == FAIL)
-                    {
-                        bool anyChannelerAlive = false;
+                    // Channeler formation respawns only when a living member evades.
+                    // If all Channelers are dead on wipe, respawn them manually.
+                    if ((state == NOT_STARTED || state == FAIL) && !IsAnyChannelerAlive())
                         for (ObjectGuid const& guid : _channelersSet)
                             if (Creature* channeler = instance->GetCreature(guid))
-                                if (channeler->IsAlive())
-                                {
-                                    anyChannelerAlive = true;
-                                    break;
-                                }
-
-                        if (!anyChannelerAlive)
-                            for (ObjectGuid const& guid : _channelersSet)
-                                if (Creature* channeler = instance->GetCreature(guid))
-                                    channeler->Respawn(true);
-                    }
+                                channeler->Respawn(true);
                 }
             }
             return true;
@@ -172,8 +175,6 @@ public:
             switch (type)
             {
                 case DATA_CHANNELER_COMBAT:
-                    // data == 1: a Channeler entered combat
-                    // data == 0: a Channeler evaded (sent from SmartAI on evade)
                     if (data == 1)
                     {
                         if (GetBossState(DATA_MAGTHERIDON) != IN_PROGRESS)
@@ -182,35 +183,15 @@ public:
                     }
                     else
                     {
-                        // The formation handles respawning dead Channelers
-                        // when a living one evades, but Magtheridon himself
-                        // is held in combat by SetInCombatWithZone and his
-                        // own EnterEvadeMode does not always fire — leaving
-                        // his _channelersKilled counter stale, which would
-                        // release him prematurely on the next pull. Once
-                        // every Channeler has finished evading (and Mag is
-                        // still in his pre-release passive state), force a
-                        // full encounter reset.
+                        // If Mag's evade doesn't update the Channeler counter
+                        // and no Channelers are alive or in combat, reset the
+                        // encounter to avoid a stale state.
                         if (Creature* magtheridon = instance->GetCreature(_magtheridonGUID))
-                        {
-                            if (!magtheridon->IsEngaged() && magtheridon->IsImmuneToPC())
+                            if (!magtheridon->IsEngaged() && magtheridon->IsImmuneToPC() && !IsAnyChannelerAliveAndInCombat())
                             {
-                                bool anyChannelerStillFighting = false;
-                                for (ObjectGuid const& guid : _channelersSet)
-                                    if (Creature* channeler = instance->GetCreature(guid))
-                                        if (channeler->IsAlive() && channeler->IsInCombat())
-                                        {
-                                            anyChannelerStillFighting = true;
-                                            break;
-                                        }
-
-                                if (!anyChannelerStillFighting)
-                                {
-                                    SetBossState(DATA_MAGTHERIDON, NOT_STARTED);
-                                    magtheridon->AI()->Reset();
-                                }
+                                SetBossState(DATA_MAGTHERIDON, NOT_STARTED);
+                                magtheridon->AI()->Reset();
                             }
-                        }
                     }
                     break;
                 case DATA_ACTIVATE_CUBES:
@@ -222,6 +203,8 @@ public:
                     for (ObjectGuid const& guid : _columnSet)
                         if (GameObject* column = instance->GetGameObject(guid))
                             column->SetGoState(GOState(data));
+                    break;
+                default:
                     break;
             }
         }

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/instance_magtheridons_lair.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/instance_magtheridons_lair.cpp
@@ -30,12 +30,6 @@ DoorData const doorData[] =
     { 0,                        0,                          DOOR_TYPE_ROOM } // END
 };
 
-MinionData const minionData[] =
-{
-    { NPC_HELLFIRE_CHANNELER,   DATA_MAGTHERIDON },
-    { 0, 0 } // END
-};
-
 class instance_magtheridons_lair : public InstanceMapScript
 {
 public:
@@ -48,12 +42,12 @@ public:
             SetHeaders(DataHeader);
             SetBossNumber(MAX_ENCOUNTER);
             LoadDoorData(doorData);
-            LoadMinionData(minionData);
             LoadBossBoundaries(boundaries);
         }
 
         void Initialize() override
         {
+            _channelersSet.clear();
             _wardersSet.clear();
             _cubesSet.clear();
             _columnSet.clear();
@@ -67,20 +61,10 @@ public:
                     _magtheridonGUID = creature->GetGUID();
                     break;
                 case NPC_HELLFIRE_CHANNELER:
-                    AddMinion(creature);
+                    _channelersSet.insert(creature->GetGUID());
                     break;
                 case NPC_HELLFIRE_WARDER:
                     _wardersSet.insert(creature->GetGUID());
-                    break;
-            }
-        }
-
-        void OnCreatureRemove(Creature* creature) override
-        {
-            switch (creature->GetEntry())
-            {
-                case NPC_HELLFIRE_CHANNELER:
-                    RemoveMinion(creature);
                     break;
             }
         }
@@ -154,6 +138,30 @@ public:
 
                     if (state == NOT_STARTED)
                         SetData(DATA_COLLAPSE, GO_READY);
+
+                    // The Channeler formation uses RESPAWN_ON_EVADE, which only
+                    // fires when a *living* member evades. If the raid wipes
+                    // after every Channeler is already dead (phase 2/3 wipe, or
+                    // a wipe during the 3s window before Magtheridon is freed),
+                    // no member is alive to trigger the formation respawn, and
+                    // the encounter would be left unrecoverable. Respawn the
+                    // pack manually in that case.
+                    if (state == NOT_STARTED || state == FAIL)
+                    {
+                        bool anyChannelerAlive = false;
+                        for (ObjectGuid const& guid : _channelersSet)
+                            if (Creature* channeler = instance->GetCreature(guid))
+                                if (channeler->IsAlive())
+                                {
+                                    anyChannelerAlive = true;
+                                    break;
+                                }
+
+                        if (!anyChannelerAlive)
+                            for (ObjectGuid const& guid : _channelersSet)
+                                if (Creature* channeler = instance->GetCreature(guid))
+                                    channeler->Respawn(true);
+                    }
                 }
             }
             return true;
@@ -164,9 +172,46 @@ public:
             switch (type)
             {
                 case DATA_CHANNELER_COMBAT:
-                    if (GetBossState(DATA_MAGTHERIDON) != IN_PROGRESS)
+                    // data == 1: a Channeler entered combat
+                    // data == 0: a Channeler evaded (sent from SmartAI on evade)
+                    if (data == 1)
+                    {
+                        if (GetBossState(DATA_MAGTHERIDON) != IN_PROGRESS)
+                            if (Creature* magtheridon = instance->GetCreature(_magtheridonGUID))
+                                magtheridon->SetInCombatWithZone();
+                    }
+                    else
+                    {
+                        // The formation handles respawning dead Channelers
+                        // when a living one evades, but Magtheridon himself
+                        // is held in combat by SetInCombatWithZone and his
+                        // own EnterEvadeMode does not always fire — leaving
+                        // his _channelersKilled counter stale, which would
+                        // release him prematurely on the next pull. Once
+                        // every Channeler has finished evading (and Mag is
+                        // still in his pre-release passive state), force a
+                        // full encounter reset.
                         if (Creature* magtheridon = instance->GetCreature(_magtheridonGUID))
-                            magtheridon->SetInCombatWithZone();
+                        {
+                            if (!magtheridon->IsEngaged() && magtheridon->IsImmuneToPC())
+                            {
+                                bool anyChannelerStillFighting = false;
+                                for (ObjectGuid const& guid : _channelersSet)
+                                    if (Creature* channeler = instance->GetCreature(guid))
+                                        if (channeler->IsAlive() && channeler->IsInCombat())
+                                        {
+                                            anyChannelerStillFighting = true;
+                                            break;
+                                        }
+
+                                if (!anyChannelerStillFighting)
+                                {
+                                    SetBossState(DATA_MAGTHERIDON, NOT_STARTED);
+                                    magtheridon->AI()->Reset();
+                                }
+                            }
+                        }
+                    }
                     break;
                 case DATA_ACTIVATE_CUBES:
                     for (ObjectGuid const& guid : _cubesSet)
@@ -183,6 +228,7 @@ public:
 
     private:
         ObjectGuid _magtheridonGUID;
+        GuidSet _channelersSet;
         GuidSet _wardersSet;
         GuidSet _cubesSet;
         GuidSet _columnSet;

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/instance_magtheridons_lair.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/instance_magtheridons_lair.cpp
@@ -15,6 +15,7 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "CreatureAI.h"
 #include "InstanceMapScript.h"
 #include "InstanceScript.h"
 #include "magtheridons_lair.h"
@@ -49,6 +50,7 @@ public:
         {
             _channelersSet.clear();
             _wardersSet.clear();
+            _burningAbyssalsSet.clear();
             _cubesSet.clear();
             _columnSet.clear();
         }
@@ -59,16 +61,6 @@ public:
             {
                 if (Creature* channeler = instance->GetCreature(guid))
                     return channeler->IsAlive();
-                return false;
-            });
-        }
-
-        bool IsAnyChannelerAliveAndInCombat()
-        {
-            return std::ranges::any_of(_channelersSet, [&](ObjectGuid const& guid)
-            {
-                if (Creature* channeler = instance->GetCreature(guid))
-                    return channeler->IsAlive() && channeler->IsInCombat();
                 return false;
             });
         }
@@ -86,7 +78,37 @@ public:
                 case NPC_HELLFIRE_WARDER:
                     _wardersSet.insert(creature->GetGUID());
                     break;
+                case NPC_BURNING_ABYSSAL:
+                    _burningAbyssalsSet.insert(creature->GetGUID());
+                    break;
             }
+        }
+
+        void OnCreatureRemove(Creature* creature) override
+        {
+            if (creature->GetEntry() == NPC_BURNING_ABYSSAL)
+                _burningAbyssalsSet.erase(creature->GetGUID());
+        }
+
+        void OnUnitDeath(Unit* unit) override
+        {
+            Creature* creature = unit ? unit->ToCreature() : nullptr;
+            if (!creature || creature->GetEntry() != NPC_HELLFIRE_CHANNELER)
+                return;
+
+            // IN_PROGRESS guard: stays inert during the hard-reset Respawn(true) cycle.
+            if (GetBossState(DATA_MAGTHERIDON) != IN_PROGRESS || IsAnyChannelerAlive())
+                return;
+
+            if (Creature* magtheridon = instance->GetCreature(_magtheridonGUID))
+                magtheridon->AI()->DoAction(ACTION_RELEASE_MAGTHERIDON);
+        }
+
+        void OnCreatureEvade(Creature* creature) override
+        {
+            // Phase-1 wipe signal: Mag is ImmuneToPC so BossAI evade does not fire; a Channeler evade is the trigger.
+            if (creature->GetEntry() == NPC_HELLFIRE_CHANNELER && GetBossState(DATA_MAGTHERIDON) == IN_PROGRESS)
+                SetBossState(DATA_MAGTHERIDON, NOT_STARTED);
         }
 
         void OnGameObjectCreate(GameObject* go) override
@@ -159,12 +181,17 @@ public:
                     if (state == NOT_STARTED)
                         SetData(DATA_COLLAPSE, GO_READY);
 
-                    // Channeler formation respawns only when a living member evades.
-                    // If all Channelers are dead on wipe, respawn them manually.
-                    if ((state == NOT_STARTED || state == FAIL) && !IsAnyChannelerAlive())
+                    // Hard reset: vanish Channelers and their lingering Burning Abyssal summons.
+                    if (state == NOT_STARTED || state == FAIL)
+                    {
                         for (ObjectGuid const& guid : _channelersSet)
                             if (Creature* channeler = instance->GetCreature(guid))
                                 channeler->Respawn(true);
+
+                        for (ObjectGuid const& guid : _burningAbyssalsSet)
+                            if (Creature* abyssal = instance->GetCreature(guid))
+                                abyssal->DespawnOrUnsummon();
+                    }
                 }
             }
             return true;
@@ -175,30 +202,12 @@ public:
             switch (type)
             {
                 case DATA_CHANNELER_COMBAT:
-                    if (data == 1)
+                    // Force the encounter start: Mag is ImmuneToPC so SetInCombatWithZone alone may miss JustEngagedWith.
+                    if (GetBossState(DATA_MAGTHERIDON) != IN_PROGRESS)
                     {
-                        if (GetBossState(DATA_MAGTHERIDON) != IN_PROGRESS)
-                        {
-                            // Magtheridon is ImmuneToPC during phase 1, so
-                            // SetInCombatWithZone() alone does not always reach
-                            // JustEngagedWith. Force the encounter start so the
-                            // door closes the moment a Channeler is engaged.
-                            SetBossState(DATA_MAGTHERIDON, IN_PROGRESS);
-                            if (Creature* magtheridon = instance->GetCreature(_magtheridonGUID))
-                                magtheridon->SetInCombatWithZone();
-                        }
-                    }
-                    else
-                    {
-                        // If Mag's evade doesn't update the Channeler counter
-                        // and no Channelers are alive or in combat, reset the
-                        // encounter to avoid a stale state.
+                        SetBossState(DATA_MAGTHERIDON, IN_PROGRESS);
                         if (Creature* magtheridon = instance->GetCreature(_magtheridonGUID))
-                            if (!magtheridon->IsEngaged() && magtheridon->IsImmuneToPC() && !IsAnyChannelerAliveAndInCombat())
-                            {
-                                SetBossState(DATA_MAGTHERIDON, NOT_STARTED);
-                                magtheridon->AI()->Reset();
-                            }
+                            magtheridon->SetInCombatWithZone();
                     }
                     break;
                 case DATA_ACTIVATE_CUBES:
@@ -220,6 +229,7 @@ public:
         ObjectGuid _magtheridonGUID;
         GuidSet _channelersSet;
         GuidSet _wardersSet;
+        GuidSet _burningAbyssalsSet;
         GuidSet _cubesSet;
         GuidSet _columnSet;
     };

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/magtheridons_lair.h
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/magtheridons_lair.h
@@ -39,7 +39,14 @@ enum NpcIds
     NPC_HELLFIRE_CHANNELER          = 17256,
     NPC_HELLFIRE_WARDER             = 18829,
     NPC_HELLFIRE_RAID_TRIGGER       = 17376,
-    NPC_TARGET_TRIGGER              = 17474
+    NPC_TARGET_TRIGGER              = 17474,
+    NPC_BURNING_ABYSSAL             = 17454
+};
+
+enum MagtheridonActions
+{
+    ACTION_RELEASE_MAGTHERIDON      = 1,
+    ACTION_BANISH_SELF              = 2
 };
 
 enum GoIds


### PR DESCRIPTION
## Changes Proposed:

This PR fixes a bug in **Magtheridon's Lair** where killing the 5 Hellfire Channelers in phase 1 caused them to respawn and rejoin the boss fight as soon as Magtheridon himself engaged the raid.

**Root cause:** `SetBossState(DATA_MAGTHERIDON, IN_PROGRESS)` was triggered late in the encounter (when Magtheridon engaged), at which point `InstanceScript::UpdateMinionState()` iterated over the registered minions (the Channelers) and called `Respawn()` on every dead one. The boss script never excluded that path.

**Fix:** transition the encounter to `IN_PROGRESS` as soon as the first Channeler enters combat. By the time Magtheridon's own `JustEngagedWith` runs, the state is already `IN_PROGRESS` and `UpdateMinionState` becomes a no-op for the dead Channelers.

**Side benefit (intentional):** room doors close and boss mods (DBM, etc.) are notified the moment a Channeler is engaged, rather than waiting for Magtheridon to attack a player. This matches the way the encounter behaves on retail.

**Phase-1 wipe handling:** since Magtheridon stays passive (immune to PC) until the last Channeler dies, his `BossAI` never triggers `_EnterEvadeMode`. The instance script now resets the encounter to `NOT_STARTED` when all Channelers have evaded; otherwise, after a phase-1 wipe, the room doors would stay locked. A new SmartAI hook on `SMART_EVENT_EVADE` for entry 17256 sends `DATA_CHANNELER_COMBAT` with `data=0` to trigger the reset.

This PR proposes changes to:
- [x] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request.

I used Claude (Anthropic) to help analyze the AzerothCore source, identify the root cause, and draft the patch. I tested all scenarios in-game on a current master build (which already includes #25379) and I understand the changes I'm submitting.

## Issues Addressed:

Related to #25375 (closed on 2026-04-05 by #25379). #25379 fixed the scheduler-vs-`UpdateVictim` deadlock in `boss_magtheridon.cpp` so Magtheridon now becomes engageable properly, but it did not touch the Channeler-respawn flow described above — that flow is what this PR addresses.

No open issue currently tracks the respawn bug. I'm happy to open one if a maintainer prefers having a dedicated issue reference.

## SOURCE:

- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Knowledge databases or other public sources

On retail/Classic, killing the Hellfire Channelers permanently removes them for the duration of the encounter — they never respawn during phase 2/3. Confirmed via Wowhead, player guides and video evidence.

## Tests Performed:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members.
- [ ] This pull request requires further testing and may have edge cases to be tested.

I tested on a current master build (commit `295e45b0a`, which includes #25379).

## How to Test the Changes:

- [x] This pull request requires further testing.

### Test scenarios

1. **Normal kill** — Enter Magtheridon's Lair, attack one of the Hellfire Channelers. **Expect:** doors close immediately, encounter is `IN_PROGRESS`. Kill all 5 Channelers; wait for Magtheridon to be released; defeat him. **Expect:** no Channeler ever respawns during phase 2/3.

2. **Phase-1 wipe** — Engage the Channelers, then wipe the raid. **Expect:** surviving Channelers evade and reset; once the last one is back home, the encounter resets to `NOT_STARTED`, doors open, and the raid can re-enter.

3. **Phase-1 leave** — Engage a Channeler, then have everyone leave the room (Feign Death / vanish / out of range). **Expect:** same as wipe — encounter resets when Channelers evade.

4. **Phase 2/3 wipe** — Kill all Channelers, engage Magtheridon, wipe. **Expect:** standard `BossAI::_EnterEvadeMode` reset; doors open. (Verifies the new code path doesn't interfere with the existing one.)

5. **Victory** — Defeat Magtheridon. **Expect:** doors open, encounter state `DONE`.

## Known Issues and TODO List:

- None known. The fix is contained to the Magtheridon's Lair instance script and SmartAI for entry 17256.
