### PR TITLE
fix(Scripts/Karazhan): Midnight no longer evades during Attumen fight

### DIFF
--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_midnight.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_midnight.cpp
@@ -82,11 +82,6 @@ struct boss_attumen : public BossAI
         Initialize();
     }
 
-    bool CanMeleeHit()
-    {
-        return me->GetVictim() && (me->GetVictim()->GetPositionZ() < 53.0f || me->GetVictim()->GetDistance(me->GetHomePosition()) < 50.0f);
-    }
-
     void EnterEvadeMode(EvadeReason why) override
     {
         if (Creature* midnight = instance->GetCreature(DATA_MIDNIGHT))
@@ -215,18 +210,10 @@ struct boss_attumen : public BossAI
 
     void UpdateAI(uint32 diff) override
     {
-        if (_phase != PHASE_NONE)
-        {
-            if (!UpdateVictim())
-            {
-                return;
-            }
-        }
-        if (!CanMeleeHit())
-        {
-            BossAI::EnterEvadeMode(EvadeReason::EVADE_REASON_BOUNDARY);
-        }
-        scheduler.Update(diff, std::bind(&BossAI::DoMeleeAttackIfReady, this));
+        if (_phase != PHASE_NONE && !UpdateVictim())
+            return;
+
+        scheduler.Update(diff, [this] { DoMeleeAttackIfReady(); });
     }
 
     void SpellHit(Unit* /*caster*/, SpellInfo const* spellInfo) override

--- a/src/server/scripts/EasternKingdoms/Karazhan/instance_karazhan.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/instance_karazhan.cpp
@@ -15,6 +15,7 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "AreaBoundary.h"
 #include "Creature.h"
 #include "GameObject.h"
 #include "InstanceMapScript.h"
@@ -65,6 +66,12 @@ DoorData const doorData[] =
     { 0,                        0,              DOOR_TYPE_ROOM  }
 };
 
+BossBoundaryData const boundaries =
+{
+    { DATA_ATTUMEN,     new CircleBoundary(Position(-11126.3f, -1929.11f), 50.0f) },
+    { DATA_ATTUMEN,     new ZRangeBoundary(49.0f, 55.0f) },
+};
+
 class instance_karazhan : public InstanceMapScript
 {
 public:
@@ -81,6 +88,7 @@ public:
         {
             SetHeaders(DataHeader);
             SetBossNumber(EncounterCount);
+            LoadBossBoundaries(boundaries);
             LoadObjectData(creatureData, gameObjectData);
             LoadDoorData(doorData);
 


### PR DESCRIPTION

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

CanMeleeHit() returns false when Midnight is low hp and summoning Attumen, which then triggers an EVADE_REASON_BOUNDARY. 

This now uses a boss boundary instead.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
