### PR TITLE
fix(DB/Proc): block on-demand trinket procs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1777336731781479719.sql
+++ b/data/sql/updates/pending_db_world/rev_1777336731781479719.sql
@@ -1,17 +1,3 @@
---
--- Tighten chance-on-spell trinket procs (chromiecraft #9399) so they can no
--- longer be triggered on demand from utility self-casts (Conjure Refreshment
--- table click, Create Healthstone via Soulwell, drink/food, Lightwell, etc.).
--- Setting SpellTypeMask = 3 (PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_HEAL)
--- restricts the proc to actual damaging or healing spell hits and rejects
--- PROC_SPELL_TYPE_NO_DMG_HEAL (=4) events that the proc system fires for
--- self-cast utility spells.
---
--- Each of the auras below has tooltip wording that matches the chromiecraft
--- wowhead filter ("Your spells have a chance to..." / "Each time you cast a
--- spell..."). All currently let PROC_SPELL_TYPE_NO_DMG_HEAL events through
--- on AC (SpellTypeMask = 0 (any) or 7 (any)).
---
 --   60493  Dying Curse                    item 40255 (213) "Your spells have a chance..."
 --   60490  Embrace of the Spider          item 39229 (200) "Your spells have a chance..."
 --   64742  Pandora's Plea                 item 45490 (226) "Your spells have a chance..."
@@ -23,5 +9,4 @@
 --   60519  Spark of Life                  item 37657 (200) "Each time you cast a damaging or healing spell..." (was 7 -> 3, matches TC)
 --   67698  Solace of the Defeated/Fallen  items 47041, 47271 (245)
 --   67752  Solace of the Defeated/Fallen  items 47059, 47432 (258)
---
 UPDATE `spell_proc` SET `SpellTypeMask` = 3 WHERE `SpellId` IN (60493, 60490, 64742, 60524, 49622, 64738, 65002, 64999, 60519, 67698, 67752);

--- a/data/sql/updates/pending_db_world/rev_1777336731781479719.sql
+++ b/data/sql/updates/pending_db_world/rev_1777336731781479719.sql
@@ -1,0 +1,27 @@
+--
+-- Tighten chance-on-spell trinket procs (chromiecraft #9399) so they can no
+-- longer be triggered on demand from utility self-casts (Conjure Refreshment
+-- table click, Create Healthstone via Soulwell, drink/food, Lightwell, etc.).
+-- Setting SpellTypeMask = 3 (PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_HEAL)
+-- restricts the proc to actual damaging or healing spell hits and rejects
+-- PROC_SPELL_TYPE_NO_DMG_HEAL (=4) events that the proc system fires for
+-- self-cast utility spells.
+--
+-- Each of the auras below has tooltip wording that matches the chromiecraft
+-- wowhead filter ("Your spells have a chance to..." / "Each time you cast a
+-- spell..."). All currently let PROC_SPELL_TYPE_NO_DMG_HEAL events through
+-- on AC (SpellTypeMask = 0 (any) or 7 (any)).
+--
+--   60493  Dying Curse                    item 40255 (213) "Your spells have a chance..."
+--   60490  Embrace of the Spider          item 39229 (200) "Your spells have a chance..."
+--   64742  Pandora's Plea                 item 45490 (226) "Your spells have a chance..."
+--   60524  Majestic Dragon Figurine       item 40430 (200) "Each time you cast a spell..."
+--   49622  Je'Tze's Bell                  item 37835 (200) "Each time you cast a spell..."
+--   64738  Show of Faith                  item 45535 (239) "Each time you cast a spell..."
+--   65002  Sif's Remembrance              item 45929 (226) "Each time you cast a spell..."
+--   64999  Meteoric Inspiration           item 46051 (226) "Each spell cast within 20 seconds..."
+--   60519  Spark of Life                  item 37657 (200) "Each time you cast a damaging or healing spell..." (was 7 -> 3, matches TC)
+--   67698  Solace of the Defeated/Fallen  items 47041, 47271 (245)
+--   67752  Solace of the Defeated/Fallen  items 47059, 47432 (258)
+--
+UPDATE `spell_proc` SET `SpellTypeMask` = 3 WHERE `SpellId` IN (60493, 60490, 64742, 60524, 49622, 64738, 65002, 64999, 60519, 67698, 67752);

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -1481,7 +1481,8 @@ public:
                 return true;
             }
 
-            player->CastSpell(player, stoneSpell, false);
+            // Cast as the warlock owner so the clicker's trinkets can't proc.
+            owner->CastSpell(player, stoneSpell, true);
 
             // Item has to actually be created to remove a charge on the well.
             if (player->HasItemCount(stoneId))


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25371
- Closes chromiecraft/chromiecraft#9399

### 1. `fix(DB/Proc)` — tighten `SpellTypeMask` on chance-on-spell trinket auras

Ten chance-on-spell trinket proc auras currently have `SpellTypeMask = 0` (any), which lets the engine fire them on `PROC_SPELL_TYPE_NO_DMG_HEAL` events emitted for self-cast utility spells:

- Conjure Refreshment Table click (spells 43988 / 58660)
- Create Healthstone via Soulwell (spells 34130/34149/34150 / 58890/58896/58898)
- Drink / Food / Conjured refreshments (spells 430 / 433 / etc.)
- Lightwell click (spell 60123)

Setting `SpellTypeMask = 3` (`PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_HEAL`) makes the proc filter reject NO_DMG_HEAL events while leaving normal damage and healing spell procs untouched (`SpellMgr::CanSpellTriggerProcOnEvent`: `0x4 & 0x3 == 0` rejects, `0x1 & 0x3 == 0x1` and `0x2 & 0x3 == 0x2` pass).

| SpellId | Aura | Items | iLvl | Tooltip |
|---|---|---|---|---|
| 60493 | Dying Curse | 40255 | 213 | "Your spells have a chance..." |
| 60490 | Embrace of the Spider | 39229 | 200 | "Your spells have a chance..." |
| 64742 | Pandora's Plea | 45490 | 226 | "Your spells have a chance..." |
| 60524 | Majestic Dragon Figurine | 40430 | 200 | "Each time you cast a spell..." |
| 49622 | Bonus Mana Regen (Je'Tze's Bell) | 37835 | 200 | "Each time you cast a spell..." |
| 64738 | Show of Faith | 45535 | 239 | "Each time you cast a spell..." |
| 65002 | Bonus Mana Regen (Sif's Remembrance) | 45929 | 226 | "Each time you cast a spell..." |
| 64999 | Meteoric Inspiration (Meteorite Crystal) | 46051 | 226 | "Each spell cast within 20 seconds..." |
| 67698 | Solace of the Defeated/Fallen (245) | 47041, 47271 | 245 | "Each time you cast a spell..." |
| 67752 | Solace of the Defeated/Fallen (258) | 47059, 47432 | 258 | "Each time you cast a spell..." |

**Excluded with rationale:**
- Soul of the Dead (60537) — already requires a critical hit (`HitMask = 2`); Conjure Refreshment cannot crit.
- The General's Heart (64764) — defensive proc with `ProcFlags = 0x2a8` (TAKEN melee/ranged only); cannot fire from a self-cast magic spell.

### 2. `fix(Scripts/GO)` — Soulwell casts as the warlock owner

`go_soulwell` was making the clicker the caster of the create-healthstone spell, so every raid member who took a stone fired their own chance-on-spell trinket procs. Switched to `owner->CastSpell(player, stoneSpell, true)` — the warlock is the caster, the clicker is only the target. Mirrors TrinityCore's `go_soulwell` implementation.

This is complementary to (1): even if a future trinket regression re-widens `SpellTypeMask`, the clicker still won't be the spell's caster.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Tooling: **Claude Code with azerothMCP**. Used for proc-system code tracing across AC and TrinityCore, DBC/spell_proc cross-referencing, and runtime instrumentation of TC's proc filter to confirm which gate rejects the cast (`SpellTypeMask` mismatch).

## Issues Addressed:

- Closes chromiecraft/chromiecraft#9399

## SOURCE:

The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. As GM with Dying Curse (`.additem 40255`) equipped, cast Conjure Refreshment directly: `.cast 58660` (or `.cast 43988` for the older table). Repeat 10–15 times. **Before:** the proc aura ("Curse of Mending", spell 60494) lands within a handful of casts. **After:** the proc never fires from these casts.
2. Repeat with a real damaging spell (e.g. Frostbolt at a target dummy) — the proc should still fire normally, confirming regular proc paths are unaffected.
3. As a warlock summon a Soulwell with another character in the same raid. Have the other character (Dying Curse equipped) take a healthstone. **Before:** taking the stone triggers the clicker's trinket. **After:** the warlock is the spell's caster; the clicker is only the target and no DONE-side proc fires on them.

## Known Issues and TODO List:

- [x] **Slow Fall (3.3.0 retail change)**: Patch 3.3.0 explicitly enabled Slow Fall (spell 1706) to activate trinkets that can trigger from casting a helpful spell. Slow Fall is `DmgClass = NONE`, helpful self-cast — i.e. it would now fail the new `SpellTypeMask = 3` filter introduced here. To match retail, Slow Fall should be granted a special trigger or per-spell override that re-enables it to fire helpful-spell proc trinkets. Tracking as a follow-up PR.
- [ ] Refreshment Table (`gameobject_template` entries 186812, 193061) `GAMEOBJECT_TYPE_SPELLCASTER` path still casts as the clicker; `SpellTypeMask = 3` blocks the in-scope trinkets but a per-GO script (matching the Soulwell pattern) would be a stronger fix for any future trinket additions. Out of scope here.