### PR TITLE
fix(Core/Spells): Slow Fall procs helpful trinkets

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6788,7 +6788,14 @@ void Unit::ProcSkillsAndAuras(Unit* actor, Unit* victim, uint32 procAttacker, ui
         else if (damageInfo && (damageInfo->GetDamage() || damageInfo->GetAbsorb()))
             spellTypeMask = PROC_SPELL_TYPE_DAMAGE;
         else if (procSpellInfo)
-            spellTypeMask = PROC_SPELL_TYPE_NO_DMG_HEAL;
+        {
+            // Patch 3.3.0: Slow Fall activates helpful-spell trinkets.
+            // https://www.bluetracker.gg/wow/topic/eu-en/11824414100-33-patch-notes/
+            if (procSpellInfo->Id == 130)
+                spellTypeMask = PROC_SPELL_TYPE_HEAL;
+            else
+                spellTypeMask = PROC_SPELL_TYPE_NO_DMG_HEAL;
+        }
 
         actor->TriggerAurasProcOnEvent(nullptr, nullptr, victim, procAttacker, procVictim, spellTypeMask, procPhase, procExtra, const_cast<Spell*>(procSpell), damageInfo, healInfo);
     }


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Patch 3.3.0 explicitly enabled **Slow Fall** to activate trinkets that can trigger from casting a helpful spell. The AC proc system classifies any spell with no damage and no heal as `PROC_SPELL_TYPE_NO_DMG_HEAL`, which after the tightening in #25630 (`SpellTypeMask = DAMAGE | HEAL` on chance-on-helpful-spell trinkets) stops matching those trinkets. Slow Fall (spell 130) should still match — it's the one helpful self-cast retail explicitly opted into the helpful-spell proc category in 3.3.0.

The fix is localised to `Unit::ProcSkillsAndAuras` where `spellTypeMask` is computed: when a spell with no damage/heal would otherwise be reported as `NO_DMG_HEAL`, special-case spell 130 and report `HEAL` instead. The trinket filter then accepts it (`0x2 & 0x3 == 0x2`).

Scope:
- Only affects spell 130 (Mage Slow Fall). Every other helpful self-cast (Conjure Refreshment, Create Healthstone, drink/food, Levitate, etc.) still reports `NO_DMG_HEAL` and stays blocked.
- Only the HIT-phase classification changes. CAST-phase events already get `MASK_ALL` upstream and were never blocked for Slow Fall by the prior PR.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Tooling: **Claude Code with azerothMCP**.

## Issues Addressed:

- Follow-up to #25630 (chromiecraft/chromiecraft#9399 known issues).

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Patch 3.3.0 notes (Dec 8 2009): *"Slow Fall: This spell can now activate trinkets that can trigger from casting a helpful spell."*
- https://www.bluetracker.gg/wow/topic/eu-en/11824414100-33-patch-notes/
- https://wowpedia.fandom.com/wiki/Patch_3.3.0

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

1. Apply #25630 first (this PR depends on the SpellTypeMask tightening to demonstrate the fix is needed).
2. As a Mage with Dying Curse (40255), Embrace of the Spider (39229), or any other chance-on-helpful-spell trinket equipped, cast Slow Fall (`/cast Slow Fall` or `.cast 130`) on yourself or a raid member ~10 times.
3. **Without this PR (after #25630):** the proc never fires — Slow Fall is rejected as `NO_DMG_HEAL`.
4. **With this PR:** the trinket buff (e.g. *Curse of Mending*) lands within a few casts, matching retail 3.3.0 behavior.
5. Sanity: cast Conjure Refreshment (`.cast 58660`) — the trinket should still NOT fire (only spell 130 is special-cased).

## Known Issues and TODO List:

- [ ]