### PR TITLE
fix(DB/SAI): Remove Baneflight defender summons

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1777414508507884400.sql
+++ b/data/sql/updates/pending_db_world/rev_1777414508507884400.sql
@@ -1,0 +1,2 @@
+DELETE FROM `smart_scripts` WHERE `entryorguid`=28615 AND `source_type`=0 AND `id` IN (0,1);
+UPDATE `creature_template` SET `AIName`='' WHERE `entry`=28615;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

Baneflight (`28615`) is a multi-faction flight master at Ebon Watch. His SmartAI unconditionally summons **both** an Enraged Gryphon (`9526`, Alliance faction 11) and an Enraged Wyvern (`9297`, Horde faction 85) on aggro. Because the defenders belong to opposing factions, they immediately fight each other to the death. The bug is most visibly triggered by nearby hostile NPCs that AoE-aggro the flight master, e.g. Icetouched Earthrager (`29436`) — its `Avalanche` cast pulls Baneflight into combat and spawns the two defenders, which then kill each other.

This PR removes the two SmartAI rows for Baneflight and clears his `AIName`. After this change, Baneflight no longer summons any defender. Per the MoP reference video linked in the issue, retail does not summon defenders on NPC aggro.

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Investigation and SQL drafted with assistance from Claude (Opus 4.7) via Claude Code.

## Issues Addressed:
- Closes #24663

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

MoP reference clip showing no defender summon on NPC aggro: https://www.youtube.com/watch?v=NTPyYviGsI0 (linked in the issue).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Apply the migration.
2. In GM mode, `.go c i 28615` to teleport to Baneflight.
3. `.npc add temp 29436` to spawn an Icetouched Earthrager near him.
4. Observe: Earthrager casts `Avalanche`, pulls Baneflight into combat — no Enraged Gryphon or Enraged Wyvern is summoned, and no faction-vs-faction defender fight occurs.
5. Verify Baneflight still functions normally as a flight master for both Alliance and Horde players.

## Known Issues and TODO List:

- [ ] The same buggy SmartAI pattern exists on other multi-faction Northrend flight masters (Danica Saint `28618`, Gurric `28623`, Maaka `28624`, Aludane Whitecloud `28674`, …). They are intentionally left out of this PR's scope; a follow-up can apply the same treatment if desired.
- [ ] A separate sub-note in the issue mentions Baneflight not properly returning to his home position after combat — that is unrelated to the defender summons and is not addressed here.