### PR TITLE
fix(DB/Spells): Ribbon of Sacrifice direct heal proc

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1777416298415433931.sql
+++ b/data/sql/updates/pending_db_world/rev_1777416298415433931.sql
@@ -1,0 +1,3 @@
+-- Ribbon of Sacrifice (28590) - Blessing of Life proc on direct heals
+DELETE FROM `spell_proc` WHERE `SpellId` = 38332;
+INSERT INTO `spell_proc` (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `DisableEffectsMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`) VALUES (38332, 0, 0, 0, 0, 0, 0x4000, 2, 2, 0, 0, 0, 0, 100, 0, 0);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Adds an explicit `spell_proc` entry for spell **38332 "Blessing of Life"** (the on-use proc on **Ribbon of Sacrifice**, item `28590`) so direct heals cast under its buff actually grant **Fecundity (38333)** to the heal target, stacking up to 5.

In Spell.dbc, spell 38332 is flagged `SpellFamilyName = SPELLFAMILY_PALADIN` and the `SPELL_AURA_PROC_TRIGGER_SPELL` effect carries `SpellClassMask = [1<<23, 0, 0]`. AC's auto-generated `spell_proc` entry copies both fields, so `CanSpellTriggerProcOnEvent` only fires the proc for paladin spells whose family flags include bit 23. No paladin direct heal has bit 23 (Holy Light = bit 31, Flash of Light = bit 30), and the trinket is BoP usable by all classes, so in practice **no class** triggered Fecundity. The mask appears to be a vestigial/incorrect DBC value.

| Field | Value | Meaning |
|---|---|---|
| `SpellFamilyName`/`SpellFamilyMask*` | 0 | no class restriction |
| `ProcFlags` | `0x4000` | `PROC_FLAG_DONE_SPELL_MAGIC_DMG_CLASS_POS` (direct positive magic spells) |
| `SpellTypeMask` | 2 | `PROC_SPELL_TYPE_HEAL` (excludes shields/buffs) |
| `SpellPhaseMask` | 2 | `PROC_SPELL_PHASE_HIT` |
| `Chance` | 100 | always |

HoTs (Renew, Rejuvenation, etc.) use `PROC_FLAG_DONE_PERIODIC` and so are correctly **not** procced.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Tool used: **Claude Code with azerothMCP**.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9415
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25639

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Wowhead spell tooltip for [Blessing of Life (38332)](https://www.wowhead.com/wotlk/spell=38332) and [Fecundity (38333)](https://www.wowhead.com/wotlk/spell=38333), and the [Ribbon of Sacrifice](https://www.wowhead.com/wotlk/item=28590) item description: *"For the next 15 sec, your direct heals grant Fecundity to your target… stacks up to 5 times."*

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. \`.additem 28590\` (Ribbon of Sacrifice). Equip and use the trinket — caster gains the Blessing of Life buff.
2. Cast a direct heal on self or an ally: Holy Light, Flash of Light, Greater Heal, Healing Touch, Healing Wave, Penance heal effect, etc. Confirm the target gains **Fecundity (38333)**, that it stacks up to 5, and that recasting refreshes the duration.
3. Verify HoTs (Renew, Rejuvenation, Lifebloom, Riptide) do **not** apply Fecundity.
4. Repeat steps 1–2 on a non-paladin caster (priest/druid/shaman/paladin) to confirm class-agnostic behavior.

## Known Issues and TODO List:

- [ ] None known.