### PR TITLE
fix(Scripts/Spells): Shadow Vault Decree engages Thane Ufrang

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1777417304651314500.sql
+++ b/data/sql/updates/pending_db_world/rev_1777417304651314500.sql
@@ -1,0 +1,20 @@
+--
+-- Quest 12943 "Shadow Vault Decree" - Thane Ufrang the Mighty (29919)
+--
+-- The CheckCast "Thane is nearby" check moves out of spell_q12943_shadow_vault_decree
+-- and into a CONDITION_NEAR_CREATURE on spell 31696. The script now also clears
+-- Thane's idle unit flags via ReplaceAllUnitFlags before calling AttackStart, so
+-- combat actually engages instead of the player getting stuck unable to attack.
+--
+-- The old SAI "Remove Unit Flags" action (id 6) chained off the 12s "Say Line 4"
+-- timer is removed - the C++ handles flag removal at cast time.
+--
+
+-- Cast-time precondition: Thane (alive) must be within 30y of the caster.
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 17 AND `SourceEntry` = 31696;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(17, 0, 31696, 0, 0, 29, 0, 29919, 30, 0, 0, 12, 0, '', 'Spell Shadow Vault Decree requires nearby Thane Ufrang the Mighty');
+
+-- Drop the now-redundant linked Remove-Unit-Flags action and its parent's link to it.
+UPDATE `smart_scripts` SET `link` = 0 WHERE `entryorguid` = 29919 AND `source_type` = 0 AND `id` = 5;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 29919 AND `source_type` = 0 AND `id` = 6;

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -386,6 +386,8 @@ class spell_q12943_shadow_vault_decree : public SpellScript
         Unit* caster = GetCaster();
         if (Creature* thane = caster->FindNearestCreature(NPC_THANE_UFRANG, 30.0f))
         {
+            if (thane->IsInCombat())
+                return;
             thane->ReplaceAllUnitFlags(UNIT_FLAG_NONE);
             thane->AI()->AttackStart(caster);
         }

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -381,27 +381,18 @@ class spell_q12943_shadow_vault_decree : public SpellScript
 {
     PrepareSpellScript(spell_q12943_shadow_vault_decree);
 
-    SpellCastResult CheckRequirement()
-    {
-        // if thane is present and not in combat - allow cast
-        Unit* caster = GetCaster();
-        if (Creature* thane = caster->FindNearestCreature(NPC_THANE_UFRANG, 30.0f))
-            if (!thane->IsInCombat())
-                return SPELL_CAST_OK;
-
-        return SPELL_FAILED_CASTER_AURASTATE;
-    }
-
     void HandleScriptEffect(SpellEffIndex /*effIndex*/)
     {
         Unit* caster = GetCaster();
         if (Creature* thane = caster->FindNearestCreature(NPC_THANE_UFRANG, 30.0f))
+        {
+            thane->ReplaceAllUnitFlags(UNIT_FLAG_NONE);
             thane->AI()->AttackStart(caster);
+        }
     }
 
     void Register() override
     {
-        OnCheckCast += SpellCheckCastFn(spell_q12943_shadow_vault_decree::CheckRequirement);
         OnEffectHitTarget += SpellEffectFn(spell_q12943_shadow_vault_decree::HandleScriptEffect, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
     }
 };


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

Thane Ufrang the Mighty (creature 29919) sits in his throne with `NON_ATTACKABLE | IMMUNE_TO_PC | IMMUNE_TO_NPC | SILENCED | PACIFIED` applied by his SAI on reset (action 18, mask `140034`). The existing data only stripped those flags 12 seconds into combat, off the *Say Line 4* timer linked from id 5 → id 6. Using the *Shadow Vault Decree* (spell 31696, item 41776) put the player in combat with an unselectable, immune Thane and left them stuck there until death.

This PR:

- Moves the "Thane is nearby" precondition out of `spell_q12943_shadow_vault_decree::CheckRequirement` into a `CONDITION_NEAR_CREATURE` row on spell 31696 (entry 29919, range 30, alive, error `SPELL_FAILED_BAD_TARGETS`).
- In the script effect, clears Thane's flags via `ReplaceAllUnitFlags(UNIT_FLAG_NONE)` before calling `AttackStart`. Thane's `creature_template.unit_flags` is `0`, so this puts the field back to template default; the SAI's On Reset re-applies the idle flags after evade.
- Drops the now-redundant linked `Remove-Unit-Flags` SAI row (id 6) and unlinks id 5.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.7 (Claude Code) was used for investigation and drafting.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9288

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Cross-referenced with TrinityCore's SAI for the same NPC, which uses a comparable `PACIFIED | NOT_SELECTABLE` mask and removes flags after the dialogue chain. https://www.wowhead.com/wotlk/quest=12943/shadow-vault-decree describes the expected interaction (read decree → Thane stands up and attacks).

## Tests Performed:
This PR has been:
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds clean locally; in-game behavior was reasoned about from the data/script flow but should be verified by a tester.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Pick up quest 12943 *Shadow Vault Decree* in Icecrown.
2. Travel to Thane Ufrang the Mighty.
3. Use the *Shadow Vault Decree* (item 41776) within 30 yards of him.
4. Verify he stands up, becomes attackable, and engages you in combat with his Brutal Strike / Rend / Powerful Smash rotation.
5. Try using the decree away from Thane — the cast should fail with "You can't do that right now" / bad-targets error rather than going through.
6. Kill Thane to complete the quest.

## Known Issues and TODO List:

- [ ] Lines 2/3/4 of Thane's combat dialogue still fire on `SMART_EVENT_UPDATE_IC` fixed timers rather than `SMART_EVENT_TEXT_OVER` chains — out of scope for this PR.