### PR TITLE
fix(Scripts/Northrend): KTZ Void Blast can now fail Immortal criteria

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1777468016237312188.sql
+++ b/data/sql/updates/pending_db_world/rev_1777468016237312188.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` = 27812 AND `ScriptName` = 'spell_kelthuzad_void_blast';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(27812, 'spell_kelthuzad_void_blast');

--- a/src/server/scripts/Northrend/Naxxramas/boss_kelthuzad.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_kelthuzad.cpp
@@ -680,10 +680,34 @@ class spell_kelthuzad_detonate_mana_aura : public AuraScript
     }
 };
 
+class spell_kelthuzad_void_blast : public SpellScript
+{
+    PrepareSpellScript(spell_kelthuzad_void_blast);
+
+    void HandleAfterHit()
+    {
+        Player* player = GetHitPlayer();
+        if (!player)
+            return;
+
+        if (player->IsAlive())
+            return;
+
+        if (InstanceScript* instance = player->GetInstanceScript())
+            instance->StorePersistentData(PERSISTENT_DATA_IMMORTAL_FAIL, 1);
+    }
+
+    void Register() override
+    {
+        AfterHit += SpellHitFn(spell_kelthuzad_void_blast::HandleAfterHit);
+    }
+};
+
 void AddSC_boss_kelthuzad()
 {
     new boss_kelthuzad();
     new boss_kelthuzad_minion();
     RegisterSpellScript(spell_kelthuzad_frost_blast);
     RegisterSpellScript(spell_kelthuzad_detonate_mana_aura);
+    RegisterSpellScript(spell_kelthuzad_void_blast);
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Shadow Fissure 16129 is summoned by spell 27810. NPC has a generic script `trigger_periodic`

Spell 27810 is only used by Shadow Fissure. Both 10m and 25m use the same spell


### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25405

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Go to KTZ `.tele kelth`
`.cast back 27810` 

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
