### PR TITLE
fix(DB/SAI): BRD Hurley Blackbreath group stuck immune to PCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1777506833363521200.sql
+++ b/data/sql/updates/pending_db_world/rev_1777506833363521200.sql
@@ -1,0 +1,38 @@
+--
+-- BRD: Hurley Blackbreath (9537) and Blackbreath Cronies (per-spawn
+-- overrides -71997/-71998/-71999) start with UNIT_FLAG_UNK_6 |
+-- UNIT_FLAG_IMMUNE_TO_PC (320) and only clear it via "OnReachedWP 3".
+-- The encounter propagates aggro: any mob entering combat fires
+-- OnAggro -> SetData 1=2 on every member, which triggers OnDataSet 1=2
+-- -> Attack on the rest. If a peer is still walking its WP path when
+-- this happens, its movement is interrupted, WP 3 is never reached,
+-- and the immunity flag is never cleared -> the mob stays in combat
+-- but cannot be damaged or targeted.
+--
+-- Failsafe: any combat-entry path also clears flag 320 on the unit.
+-- Two new rows per entity: one on OnAggro, one on OnDataSet 1=2.
+--
+
+-- Hurley Blackbreath
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0) AND (`entryorguid` = 9537) AND (`id` IN (19, 20));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(9537, 0, 19, 0,  4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 320, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Hurley Blackbreath - On Aggro - Remove Unit Flags Immune To PC (failsafe if pulled before reaching WP 3)'),
+(9537, 0, 20, 0, 38, 0, 100, 0, 1, 2, 0, 0, 0, 0, 19, 320, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Hurley Blackbreath - On Data Set 1=2 - Remove Unit Flags Immune To PC (failsafe if pulled before reaching WP 3)');
+
+-- Blackbreath Crony spawn 71997
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0) AND (`entryorguid` = -71997) AND (`id` IN (14, 15));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(-71997, 0, 14, 0,  4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 320, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Blackbreath Crony - On Aggro - Remove Unit Flags Immune To PC (failsafe)'),
+(-71997, 0, 15, 0, 38, 0, 100, 0, 1, 2, 0, 0, 0, 0, 19, 320, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Blackbreath Crony - On Data Set 1=2 - Remove Unit Flags Immune To PC (failsafe)');
+
+-- Blackbreath Crony spawn 71998
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0) AND (`entryorguid` = -71998) AND (`id` IN (14, 15));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(-71998, 0, 14, 0,  4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 320, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Blackbreath Crony - On Aggro - Remove Unit Flags Immune To PC (failsafe)'),
+(-71998, 0, 15, 0, 38, 0, 100, 0, 1, 2, 0, 0, 0, 0, 19, 320, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Blackbreath Crony - On Data Set 1=2 - Remove Unit Flags Immune To PC (failsafe)');
+
+-- Blackbreath Crony spawn 71999
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0) AND (`entryorguid` = -71999) AND (`id` IN (14, 15));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(-71999, 0, 14, 0,  4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 19, 320, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Blackbreath Crony - On Aggro - Remove Unit Flags Immune To PC (failsafe)'),
+(-71999, 0, 15, 0, 38, 0, 100, 0, 1, 2, 0, 0, 0, 0, 19, 320, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Blackbreath Crony - On Data Set 1=2 - Remove Unit Flags Immune To PC (failsafe)');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

Fix the encounter at the Grim Guzzler in Blackrock Depths where Hurley Blackbreath and/or one or more of his Cronies remain in combat but cannot be attacked.

Hurley (entry 9537) and each Blackbreath Crony spawn (per-GUID overrides for spawns 71997 / 71998 / 71999) start with `UNIT_FLAG_UNK_6 | UNIT_FLAG_IMMUNE_TO_PC` (decimal 320). The existing SAI only clears these flags via `Linked from OnReachedWP 3`, after the cinematic waypoint walk completes.

The encounter also propagates aggro: every member's `OnAggro` (rows 10–12 on the cronies, rows 16–17 on Hurley) calls `SetData 1=2` on every member of the group, which fires their `OnDataSet 1=2 → Attack closest player` (row 13 / row 18). Because the cronies' WP paths are uneven, one mob can finish first and be pulled by players while the rest are still walking. The propagation then yanks the still-walking mobs into combat, interrupting their movement. WP 3 is never reached, the immunity flag never gets cleared, and those mobs remain in the encounter as un-targetable, un-damageable, but combat-locking units.

This PR adds a failsafe to both combat-entry paths on all four entities. Whenever a unit enters combat (`OnAggro`) or is signaled to attack via the propagation cascade (`OnDataSet 1=2`), it now also runs `Remove Unit Flag 320` on itself, regardless of whether its waypoint walk finished. The existing WP 3 path still runs in the clean case (double-removal is a no-op).

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (Anthropic, Opus 4.7) was used to investigate the issue, identify the root cause, and draft the SQL patch. The change has been reviewed and is understood by the author.

## Issues Addressed:

- Closes https://github.com/chromiecraft/chromiecraft/issues/9424

## SOURCE:

The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Wowhead comments on Hurley Blackbreath (entry 9537) confirm Hurley and his cronies should engage as a single attackable group as soon as the Dark Iron Ale kegs are broken: https://www.wowhead.com/wotlk/npc=9537/hurley-blackbreath#comments

## Tests Performed:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Enter Blackrock Depths and clear to the Grim Guzzler back room.
2. Break the Dark Iron Ale kegs to spawn Hurley Blackbreath and his Blackbreath Cronies.
3. Pull a single mob in the group as soon as it becomes attackable (for example with a hunter pet or AoE) while the rest are still walking their waypoint path.
4. Confirm that every member of the group becomes attackable and damageable once they enter combat — none should remain stuck in combat as IMMUNE_TO_PC.
5. As a regression check, also do a clean pull where the whole group finishes its waypoint walk normally; the encounter should still play out as before.

## Known Issues and TODO List:

- [ ]
- [ ]