### PR TITLE
fix(DB/Auras): Taunka Soldiers, Greatmother Icemist and Roanauk Icemist are now invisible until their related quests are completed.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1777666032.sql
+++ b/data/sql/updates/pending_db_world/rev_1777666032.sql
@@ -1,0 +1,27 @@
+
+-- Set Quest Pre-requisite From the Depths of Azjol-Nerub for Strength of Icemist.
+UPDATE `quest_template_addon` SET `PrevQuestID` = 12036 WHERE (`ID` = 12063);
+
+-- Delete wrong guid (Taunka Soldier)
+DELETE FROM `creature` WHERE (`id1` = 26437) AND (`guid` IN (102363));
+DELETE FROM `creature_addon` WHERE (`guid` IN (102363));
+
+-- Set Reward Spells
+UPDATE `quest_template` SET `RewardSpell` = 46997 WHERE `ID` = 11978;
+UPDATE `quest_template` SET `RewardSpell` = 47418 WHERE `ID` = 12069;
+
+DELETE FROM `spell_area` WHERE (`spell` IN (46997, 47418));
+INSERT INTO `spell_area` (`spell`, `area`, `quest_start`, `quest_end`, `aura_spell`, `racemask`, `gender`, `autocast`, `quest_start_status`, `quest_end_status`) VALUES
+(46997, 4165, 11978, 0, 0, 0, 2, 1, 64, 0),
+(47418, 4165, 12069, 0, 0, 0, 2, 1, 64, 0);
+
+-- Set Auras (Taunka Soldiers & Greatmother Icemist)
+UPDATE `creature_addon` SET `auras` = '46996' WHERE (`guid` IN (102326, 102327, 102328, 102329, 102330, 102331, 102332, 102333, 102337, 102338, 102340, 102341, 98402));
+
+-- Set Unit Flags for Roanauk Icemist (Sniffed)
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` |768 WHERE (`entry` = 26810);
+
+-- Set Auras (Roanauk Icemist)
+DELETE FROM `creature_template_addon` WHERE (`entry` = 26810);
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(26810, 0, 0, 0, 0, 0, 0, '47417');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes Reported on Discord

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [X] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
