### PR TITLE
fix(DB/Quest): On Ruby Wings - prevent Antiok despawn when Thiassi dies

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1777681720427119100.sql
+++ b/data/sql/updates/pending_db_world/rev_1777681720427119100.sql
@@ -1,0 +1,4 @@
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 28006 AND `id` = 7);
+
+UPDATE `vehicle_template_accessory` SET `summontype` = 1, `summontimer` = 30000
+    WHERE `entry` = 28018 AND `accessory_entry` = 28006;


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

Quest 12498 *On Ruby Wings*: when the player kills Thiassi the Lightning Bringer (28018), Grand Necrolord Antiok (28006) is supposed to play out his RP and become attackable. Today he despawns immediately instead.

Root cause: Antiok's SmartAI has an `On Evade -> Force Despawn` rule. When Thiassi dies, his vehicle is uninstalled and Antiok is ejected as a passenger; the resulting AI state churn briefly enters evade and the rule force-despawns him before the timed action list can run.

This PR:
1. **Drops the `On Evade -> Force Despawn` rule** on Antiok (`smart_scripts` row `entryorguid=28006, id=7`). TrinityCore does not have this rule and avoids the bug.
2. **Updates `vehicle_template_accessory`** for the Thiassi -> Antiok pair from `summontype=8 (TEMPSUMMON_MANUAL_DESPAWN), summontimer=0` to `summontype=1 (TEMPSUMMON_TIMED_OR_DEAD_DESPAWN), summontimer=30000`, mirroring the value used by TrinityCore. The timer only ticks while alive **and** out of combat ([TemporarySummon.cpp:177](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Entities/Creature/TemporarySummon.cpp#L177)), so it won't despawn Antiok mid-encounter; it only cleans up a stuck accessory after a clean reset.

The unrelated RP timing / Flesh Harvest target issues tracked in #24664 are intentionally **not** addressed here.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Investigation and SQL drafted with the help of Claude (Anthropic, Opus 4.7).

## Issues Addressed:

- Closes #25637

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Cherry-picked from TrinityCore commit [`e7310186`](https://github.com/TrinityCore/TrinityCore/commit/e73101862bc1c081b69853b6d3aee070be16667b) (`DB/Quest: On Ruby Wings`), originally by @Killyana based on work by @Nevadas, committed by @Dr-J. Commit `--author` is set to Dr-J (the git author of record on the upstream commit).

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Be level 71+ with quest 12498 *On Ruby Wings* in the log.
2. Use the `Ruby Beacon of the Dragon Queen` (item 38302) outside the Wicked Coil to summon a `Wyrmrest Vanquisher`.
3. Fly to Thiassi the Lightning Bringer (Dragonblight, ~52, 30) and kill him while mounted on the dragon.
4. Confirm: Grand Necrolord Antiok stays in the world after Thiassi dies (instead of despawning), plays his RP, and becomes attackable.

## Known Issues and TODO List:

- [ ] The remaining RP-timing / Flesh-Harvest-target issues for this encounter are tracked separately in #24664 and are out of scope here.
- [ ]