### PR TITLE
fix(Scripts/Quest): Don't Kill the Fat One submission flow

### DIFF
--- a/src/server/scripts/Outland/zone_terokkar_forest.cpp
+++ b/src/server/scripts/Outland/zone_terokkar_forest.cpp
@@ -231,7 +231,9 @@ enum UnkorTheRuthless
     FACTION_HOSTILE                 = 45,
     QUEST_DONTKILLTHEFATONE         = 9889,
 
-    SPELL_PULVERIZE                 = 2676
+    SPELL_PULVERIZE                 = 2676,
+
+    SUBMIT_DURATION                 = 120000
 };
 
 class npc_unkor_the_ruthless : public CreatureScript
@@ -248,22 +250,28 @@ public:
     {
         npc_unkor_the_ruthlessAI(Creature* creature) : ScriptedAI(creature) { }
 
-        bool CanDoQuest;
-        uint32 UnkorUnfriendly_Timer;
-        uint32 Pulverize_Timer;
+        bool Submitted;
+        uint32 UnfriendlyTimer;
+        uint32 PulverizeTimer;
 
         void Reset() override
         {
-            CanDoQuest = false;
-            UnkorUnfriendly_Timer = 0;
-            Pulverize_Timer = 3000;
+            Submitted = false;
+            UnfriendlyTimer = 0;
+            PulverizeTimer = 3000;
             me->SetStandState(UNIT_STAND_STATE_STAND);
             me->SetFaction(FACTION_HOSTILE);
         }
 
         void JustEngagedWith(Unit* /*who*/) override { }
 
-        void DoNice()
+        bool HasQuestActive(Player* player) const
+        {
+            QuestStatus status = player->GetQuestStatus(QUEST_DONTKILLTHEFATONE);
+            return status == QUEST_STATUS_INCOMPLETE || status == QUEST_STATUS_COMPLETE;
+        }
+
+        void Submit()
         {
             Talk(SAY_SUBMIT);
             me->SetFaction(FACTION_FRIENDLY);
@@ -271,7 +279,8 @@ public:
             me->RemoveAllAuras();
             me->GetThreatMgr().ClearAllThreat();
             me->CombatStop(true);
-            UnkorUnfriendly_Timer = 60000;
+            Submitted = true;
+            UnfriendlyTimer = SUBMIT_DURATION;
         }
 
         void DamageTaken(Unit* done_by, uint32& damage, DamageEffectType, SpellSchoolMask) override
@@ -280,61 +289,47 @@ public:
                 return;
 
             Player* player = done_by->ToPlayer();
-            if (player && me->HealthBelowPctDamaged(30, damage))
-            {
-                if (Group* group = player->GetGroup())
-                {
-                    for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
-                    {
-                        Player* groupie = itr->GetSource();
-                        if (groupie && groupie->IsInMap(player) &&
-                                groupie->GetQuestStatus(QUEST_DONTKILLTHEFATONE) == QUEST_STATUS_INCOMPLETE &&
-                                groupie->GetReqKillOrCastCurrentCount(QUEST_DONTKILLTHEFATONE, 18260) == 10)
-                        {
-                            groupie->AreaExploredOrEventHappens(QUEST_DONTKILLTHEFATONE);
-                            if (!CanDoQuest)
-                                CanDoQuest = true;
-                        }
-                    }
-                }
-                else if (player->GetQuestStatus(QUEST_DONTKILLTHEFATONE) == QUEST_STATUS_INCOMPLETE &&
-                         player->GetReqKillOrCastCurrentCount(QUEST_DONTKILLTHEFATONE, 18260) == 10)
-                {
-                    player->AreaExploredOrEventHappens(QUEST_DONTKILLTHEFATONE);
-                    CanDoQuest = true;
-                }
-            }
+            if (!player)
+                if (Unit* owner = done_by->GetOwner())
+                    player = owner->ToPlayer();
+            if (!player || !HasQuestActive(player))
+                return;
+
+            // Cap damage from quest holders so DoTs/pets/burst can't kill him.
+            if (damage >= me->GetHealth())
+                damage = me->GetHealth() - 1;
+
+            if (!me->HealthBelowPctDamaged(30, damage))
+                return;
+
+            player->GroupEventHappens(QUEST_DONTKILLTHEFATONE, me);
+
+            if (!Submitted)
+                Submit();
         }
 
         void UpdateAI(uint32 diff) override
         {
-            if (CanDoQuest)
+            if (Submitted)
             {
-                if (!UnkorUnfriendly_Timer)
+                if (UnfriendlyTimer <= diff)
                 {
-                    //DoCast(me, SPELL_QUID9889);        //not using spell for now
-                    DoNice();
+                    EnterEvadeMode();
+                    return;
                 }
-                else
-                {
-                    if (UnkorUnfriendly_Timer <= diff)
-                    {
-                        EnterEvadeMode();
-                        return;
-                    }
-                    else UnkorUnfriendly_Timer -= diff;
-                }
+                UnfriendlyTimer -= diff;
+                return;
             }
 
             if (!UpdateVictim())
                 return;
 
-            if (Pulverize_Timer <= diff)
+            if (PulverizeTimer <= diff)
             {
                 DoCast(me, SPELL_PULVERIZE);
-                Pulverize_Timer = 9000;
+                PulverizeTimer = 9000;
             }
-            else Pulverize_Timer -= diff;
+            else PulverizeTimer -= diff;
 
             DoMeleeAttackIfReady();
         }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Reworks `npc_unkor_the_ruthless` (creature 18262) for quest [9889 - Don't Kill the Fat One](https://www.wowhead.com/wotlk/quest=9889/dont-kill-the-fat-one). Four bugs in the existing AI:

| Bug | Symptom | Fix |
| --- | --- | --- |
| A | Burst damage / DoTs / pets can kill Unkor before he submits, breaking the quest chain. | `DamageTaken` clamps incoming damage to `HP-1` whenever the attacker is a quest holder. Pet/totem damage is resolved through the owner. Non-quest players are unaffected, so he can still die in normal open-world combat. |
| B | After Unkor submits, the quest flips to `QUEST_STATUS_COMPLETE`. If the player misses the 60s friendly window, `EnterEvadeMode` makes him hostile again, and on re-engage `DamageTaken` short-circuits because the old guard required `QUEST_STATUS_INCOMPLETE`. Result: the player can never talk to him again, locking out the entire chain. | New `HasQuestActive()` accepts both `INCOMPLETE` and `COMPLETE`, so a player who missed the window can drop him low again to talk. |
| C | Submission was gated on having already killed 10 Boulderfist Invaders, contradicting the [Wowhead/blizzlike report](https://www.wowhead.com/wotlk/quest=9889/dont-kill-the-fat-one#comments:id=26543:reply=3310) that he should submit on low HP regardless and only the *event credit* requires the 10 kills. | `Submit()` now fires for any quest holder. `GroupEventHappens(QUEST, me)` credits the area-event for the attacker (and party members at reward distance); the quest auto-completes whenever the player's invader kill count reaches 10 — whether the 10th kill happened before or after the submit. |
| D | The 60s friendly window was too tight: players reading the followup quest text often missed it (see chromiecraft#5073 comments). | `SUBMIT_DURATION` bumped to 120s. |

Also replaces the manual group iteration with `Player::GroupEventHappens`, which adds the proper `IsAtGroupRewardDistance` and `!GetCorpse()` checks.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.7 (Claude Code).

## Issues Addressed:
- Closes azerothcore/azerothcore-wotlk#15271
- Closes chromiecraft/chromiecraft#5073

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Wowhead comment by Farmbuyer (Premium User) on 2007/03/03, patch 2.0.8 — quoted in the linked issues. Also notes that the original Blizz implementation had the same DoT/pet kill bug that this PR closes.

TrinityCore 3.3.5 [zone_terokkar_forest.cpp](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Outland/zone_terokkar_forest.cpp) carries the same flawed logic, so it is not a useful reference.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Compile-only verification by the author. The change relies on existing primitives (`Player::GroupEventHappens`, `AreaExploredOrEventHappens`, `HealthBelowPctDamaged`) that are exercised across the codebase, but the full quest flow should be confirmed in-game.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

Suggested matrix:

1. `.quest add 9889`, `.go c 65547` — kill the 10 Boulderfist Invaders, then beat Unkor; he should submit, you can talk and accept *Success!*. Baseline.
2. Same as 1, but **wait > 60s** before talking. Old behavior: locked out. New: Unkor evades, becomes hostile; engage him again — he submits a second time and you can turn in.
3. **Beat Unkor before killing the 10**: he should submit and stay friendly. While he sits, kill the 10 invaders — the 10th kill should auto-complete the quest. Don't beat him again.
4. Burst test (warlock with DoTs / hunter pet): bring Unkor below 30% with damage that would otherwise overshoot — he should clamp at 1 HP, never die while a quest holder is the attacker.
5. Group test: 5-man party, all on the quest at varying invader-kill counts; one player drops Unkor below 30%. Members at reward distance should each get the event credit and have their quest complete as their kill counts reach 10.
6. Non-quest player (or a player who has already finished the chain) attacks him: damage flows normally, he can still die. The cap only applies while the attacker is on the quest.

## Known Issues and TODO List:
- [ ] None.