### PR TITLE
fix(Core/Network): guard against null m_Socket in WorldSession::Update idle check

### DIFF
--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -364,7 +364,7 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
     ///- Before we process anything:
     /// If necessary, kick the player because the client didn't send anything for too long
     /// (or they've been idling in character select)
-    if (IsConnectionIdle() && !HasPermission(rbac::RBAC_PERM_IGNORE_IDLE_CONNECTION))
+    if (m_Socket && IsConnectionIdle() && !HasPermission(rbac::RBAC_PERM_IGNORE_IDLE_CONNECTION))
         m_Socket->CloseSocket();
 
     if (updater.ProcessUnsafe())


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Adds a one-token null guard at `WorldSession::Update` so the idle-connection check no longer dereferences a null `m_Socket`:

```diff
-    if (IsConnectionIdle() && !HasPermission(rbac::RBAC_PERM_IGNORE_IDLE_CONNECTION))
+    if (m_Socket && IsConnectionIdle() && !HasPermission(rbac::RBAC_PERM_IGNORE_IDLE_CONNECTION))
         m_Socket->CloseSocket();
```

### Crash this fixes

`SIGSEGV` on a `MapUpdater` worker thread:

```
#0  std::atomic<SocketState>::compare_exchange_strong (this=0xe8, ...)
#2  Socket<WorldSocket>::CloseSocket (this=0x0)        <-- null this
#3  WorldSession::Update (this=0x15536b913000, ...)    at WorldSession.cpp:368
#4  Map::Update                                         at Map.cpp:444
#5  MapUpdateRequest::call
#6  MapUpdater::WorkerThread
```

The `WorldSession` is alive (`_player` is valid), but `m_Socket` was already nulled — and line 368 is the only `m_Socket` access in this file that lacks the guard every other site uses (lines 289, 385, 569, 579, 587, 598, 707).

### Why it happens (and why TrinityCore doesn't see it)

This is an **AzerothCore-specific** race introduced by the lingering-session / reconnect-tolerance feature added by **pussywizard**: [`WorldSession::HandleSocketClosed()`](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Server/WorldSession.cpp#L596) (the function still carries the `// pussywizard:` marker at its only caller in [`WorldSessionMgr.cpp:117`](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Server/WorldSessionMgr.cpp#L117)).

That function nulls `m_Socket` while the `Player` is still in the world, then moves the session into `_offlineSessions` for the reconnect grace period. `Player::m_session` still points at this session, so `Map::Update` continues to walk it — and on the next tick where the idle timer has expired, line 368 dereferences the now-null socket.

Upstream TrinityCore (3.3.5 and master) carries the same unguarded line, but it never crashes there because TC has no `HandleSocketClosed` / offline-grace path: in TC, `m_Socket` is only nulled inside `Update()` itself, *after* the idle check has already passed. The invariant "if `Update` is running, `m_Socket` is non-null on this thread" holds in TC and is broken in AC. Hence the fix has to live in AC.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Crash analysis and patch produced with assistance from Claude (Anthropic, model `claude-opus-4-7`).

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Crash captured on a live ChromieCraft worldserver (gdb backtrace above). The unguarded line is the lone outlier in `WorldSession.cpp` — every other `m_Socket` access in the same file already null-checks.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on Linux x86_64, GCC 11, RelWithDebInfo. Without the patch the repro below crashes the worldserver within seconds; with the patch the session is left to be reaped by the normal offline-grace cleanup.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

To shrink the repro window, temporarily lower the idle timers in `worldserver.conf`:

```
SocketTimeOutTime       = 15000   # 15 s (default 900000)
SocketTimeOutTimeActive = 5000    # 5  s (default 60000)
```

Then:

1. Log in a non-privileged account (no `RBAC_PERM_IGNORE_IDLE_CONNECTION`) and zone into the world.
2. Kill the connection abruptly — *not* a clean logout. Easiest: on the server box, `iptables -A OUTPUT -p tcp --sport 8085 -j DROP`. Alternatively `taskkill /F /IM Wow.exe` on the client, or pull the network cable.
3. Without this PR: within ~5 s the Map worker for that player's map crashes with the SIGSEGV above.
4. With this PR: no crash; the session is moved to `_offlineSessions` by `HandleSocketClosed()` and reaped by the normal offline-grace timer.

Restore the default timeouts after verifying.

## Known Issues and TODO List:

- [ ] None known. The guard is a strict superset of safety: identical behavior when `m_Socket` is non-null; safely no-ops the close call (which would be a no-op anyway, since there is no socket to close) when it is null.