### PR TITLE
fix(Scripts/HoR): keep leader intro events across double Reset

### DIFF
--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
@@ -215,12 +215,10 @@ public:
             instance = me->GetInstanceScript();
             if (!instance)
                 me->IsAIEnabled = false;
-            first = (instance && !instance->GetPersistentData(PERSISTENT_DATA_INTRO));
         }
 
         InstanceScript* instance;
         EventMap events;
-        bool first;
         bool shortver;
 
         void Reset() override
@@ -228,9 +226,8 @@ public:
             shortver = false;
             events.Reset();
             me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
-            if (first)
+            if (instance && !instance->GetPersistentData(PERSISTENT_DATA_INTRO))
             {
-                first = false;
                 events.ScheduleEvent(EVENT_PRE_INTRO_1, 10s);
                 events.ScheduleEvent(EVENT_PRE_INTRO_2, 11s);
                 events.ScheduleEvent(EVENT_EMOTE_LEADER_1, 16s);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`npc_hor_leader` (Lady Sylvanas / Lady Jaina at the HoR entrance) spawns invisible and is made visible later by `EVENT_PRE_INTRO_1` (10s after spawn). The scheduling lived inside `Reset()` and was gated by a one-shot `bool first` flag set in the AI constructor.

After [#25482](https://github.com/azerothcore/azerothcore-wotlk/pull/25482) (Apr 17), the `Creature` ctor defaults `TriggerJustRespawned = true` and `Creature::Update` fires `AI()->JustRespawned()` on the first tick after spawn for non-compat creatures. `CreatureAI::JustRespawned()` calls `Reset()`, so `Reset()` now runs **twice** on a fresh spawn:

1. `AddToWorld → AIM_Initialize → InitializeAI → Reset()` — `first` true, events scheduled, `first ← false`.
2. **Next tick:** `Update() → JustRespawned() → Reset()` — `events.Reset()` wipes the queue, `first` is false, nothing rescheduled.

Result: `EVENT_PRE_INTRO_1` never fires, `SetVisible(true)` is never called, and the dungeon cannot be started on either faction or difficulty.

The fix drops the one-shot `first` flag and gates scheduling on `PERSISTENT_DATA_INTRO`. Both Reset calls re-arm the same intro events; the EventMap timer restarts from the latest Reset, so the player-visible delay is unchanged. Once the intro completes and `PERSISTENT_DATA_INTRO` is stored, the gate falls through and no events are scheduled, matching the previous behavior.

`npc_hor_leader_second` doesn't pre-schedule anything in `Reset()` (its events come from `DoAction` during the LK escape), so it's unaffected by the same pattern and not touched here.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code (Opus 4.7) assisted with bisecting the regression and drafting the patch under author review.

## Issues Addressed:
- Closes #25558
- Closes #25687

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Pure regression fix — restores the pre-#25482 behavior.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Enter Halls of Reflection (Normal or Heroic) on a fresh instance, both Alliance and Horde.
2. Verify Lady Jaina (Alliance) / Lady Sylvanas (Horde) appears at the entrance after ~10s and starts the intro RP, then offers gossip after ~19s.
3. Start the intro via gossip and confirm the full intro plays through to the wave event.
4. Verify the skip-intro gossip option still works when its quest prerequisite is met.
5. Reload the instance after the intro is complete and confirm the leader does not respawn at the entrance (gate falls through correctly).

## Known Issues and TODO List:

- [ ] None known. The same `first`-in-ctor pattern may exist in other scripts not touched here; flagged for follow-up if encountered.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.