### PR TITLE
fix(Scripts/OS): clear Twilight Torment on encounter end

### DIFF
--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
@@ -416,6 +416,9 @@ struct boss_sartharion : public BossAI
         for (uint32 i : dragons)
             if (Creature* boss = instance->GetCreature(i))
                 boss->DespawnOrUnsummon();
+
+        instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_TWILIGHT_TORMENT_VESPERON);
+        instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_TWILIGHT_TORMENT_SARTHARION);
     }
 
     void SetData(uint32 type, uint32 data) override
@@ -838,6 +841,8 @@ struct boss_sartharion_dragonAI : public BossAI
             {
                 Talk(SAY_VESPERON_DEATH);
                 instance->DoAction(ACTION_CLEAR_PORTAL);
+                instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_TWILIGHT_TORMENT_VESPERON);
+                instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_TWILIGHT_TORMENT_SARTHARION);
                 if (!isCalledBySartharion || instance->GetBossState(DATA_SARTHARION) != IN_PROGRESS)
                     instance->SetBossState(DATA_VESPERON, DONE);
                 break;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Twilight Torment (57935 / 58835) currently persists on players after the Obsidian Sanctum encounter ends in two scenarios:

1. **Vesperon killed mid-Sartharion fight** — `boss_sartharion_dragonAI::JustDied` only invokes `ClearInstance()` (which strips the auras) when `!isCalledBySartharion`. The `NPC_VESPERON` branch did nothing about the torment auras when called by Sartharion.
2. **3-drake kill (3D)** — Vesperon never dies; Sartharion's `JustDied` simply `DespawnOrUnsummon`s the surviving drakes, so neither dragon's `JustDied` runs and the torment is never removed.

This PR adds `instance->DoRemoveAurasDueToSpellOnPlayers` for both spell IDs in:
- `boss_sartharion_dragonAI::JustDied` — `NPC_VESPERON` case.
- `boss_sartharion::JustDied`.

Both paths now guarantee the debuff is cleared when the encounter ends, regardless of how Vesperon was handled.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (Opus 4.7) was used to assist in investigating the cause and drafting the change.

## Issues Addressed:
- Closes #25694

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Official 2008 video reference cited in the issue showing Twilight Torment dropping when Vesperon dies: https://www.youtube.com/watch?v=iJJ4hhL9DU0

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. `.tele obsid`, pull Sartharion with all 3 drakes alive.
2. Wait for Vesperon's Twilight Torment phase, then kill Vesperon while Sartharion is still up — confirm Twilight Torment drops on Vesperon's death.
3. Repeat the encounter and instead leave Vesperon alive; finish Sartharion with all 3 drakes still up — confirm Twilight Torment drops on Sartharion's death.
4. Engage Vesperon solo (without pulling Sartharion) — confirm existing solo cleanup path still removes the buff (regression check).

## Known Issues and TODO List:

- [ ]
- [ ]