### PR TITLE
fix(Core/Creature): Null-check idle motion slot in CanCreatureAttack

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2718,7 +2718,8 @@ bool Creature::CanCreatureAttack(Unit const* victim, bool skipDistCheck) const
 
     float x, y, z;
     x = y = z = 0.0f;
-    if (GetMotionMaster()->GetMotionSlot(MOTION_SLOT_IDLE)->GetResetPosition(x, y, z))
+    MovementGenerator* idleSlot = GetMotionMaster()->GetMotionSlot(MOTION_SLOT_IDLE);
+    if (idleSlot && idleSlot->GetResetPosition(x, y, z))
         return IsInDist2d(x, y, dist);
     else
         return IsInDist2d(&m_homePosition, dist);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Fix a SIGSEGV in `Creature::CanCreatureAttack` triggered during the threat-update path when a creature has no idle movement generator pushed.

`MotionMaster::GetMotionSlot()` returns `Impl[slot]` directly, with no null check. The slot is initialized to `nullptr` in the constructor and is only populated when an idle generator is pushed. The leash-distance branch added in #22245 dereferenced the result unconditionally:

```cpp
if (GetMotionMaster()->GetMotionSlot(MOTION_SLOT_IDLE)->GetResetPosition(x, y, z))
    return IsInDist2d(x, y, dist);
else
    return IsInDist2d(&m_homePosition, dist);
```

When the idle slot is empty, this segfaults. The fix null-checks the slot and falls through to the existing `m_homePosition` branch — which is exactly what the original PR intended for "creatures with no movement".

### Crash backtrace

```
Thread 18 "worldserver" received signal SIGSEGV, Segmentation fault.
#0  Creature::CanCreatureAttack at Creature.cpp:2721
#1  ThreatReference::ShouldBeOffline at ThreatManager.cpp:116
#2  ThreatManager::GetCurrentVictim at ThreatManager.cpp:246
#3  Creature::SelectVictim at Unit.cpp:11486
#4  CreatureAI::UpdateVictim at CreatureAI.cpp:367
#5  SmartAI::UpdateAI at SmartAI.cpp:573
#6  Creature::Update at Creature.cpp:884
#7  Map::UpdateNonPlayerObjects at Map.cpp:570
```

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Diagnosis and patch produced with assistance from Claude (Opus 4.7) via Claude Code. The author understands and stands behind the change.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Root cause derived from a production GDB backtrace and direct reading of `MotionMaster::GetMotionSlot` ([MotionMaster.h](src/server/game/Movement/MotionMaster.h)).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

The change is a defensive null check on a path that was previously crashing, so functional behavior is unchanged for creatures that have an idle generator. Compile-only verification by the author.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

1. Build worldserver with the patch applied.
2. Exercise threat updates against creatures that may not have an idle movement generator (e.g. SmartAI mobs immediately after spawn / after motion clear).
3. Confirm no crashes in `Creature::CanCreatureAttack` along the `ThreatManager::GetCurrentVictim` path.
4. Verify leash behavior is unchanged for normal mobs with an idle generator.

## Known Issues and TODO List:

- [ ] None known.