### PR TITLE
fix(Core/Spells): Don't generate threat from happiness energize

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8381,8 +8381,10 @@ void Unit::EnergizeBySpell(Unit* victim, uint32 spellID, uint32 damage, Powers p
 {
     victim->ModifyPower(powerType, damage, false);
 
-    if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellID))
-        victim->GetThreatMgr().ForwardThreatForAssistingMe(this, float(damage) / 2.0f, spellInfo, true);
+    // Happiness is internal hunter pet state, not combat assistance — energizing it must not generate threat
+    if (powerType != POWER_HAPPINESS)
+        if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellID))
+            victim->GetThreatMgr().ForwardThreatForAssistingMe(this, float(damage) / 2.0f, spellInfo, true);
 
     SendEnergizeSpellLog(victim, spellID, damage, powerType);
 }


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

`Unit::EnergizeBySpell` unconditionally forwards assist threat for every energize call. When the energized power is `POWER_HAPPINESS` (a hunter-pet-only resource), the path that reaches it routinely has the pet itself as both the spell caster and the energize target, which makes the pet appear as its own assist-threat source.

The visible trigger is the **Glyph of Mend Pet (57870)**, which procs every Mend Pet tick and has the pet self-cast spell **57894** (`SPELL_EFFECT_ENERGIZE_PCT`, `TARGET_UNIT_CASTER`, 1% of max happiness). Because the pet is the spell caster, `EnergizeBySpell`'s `this` is the pet, and `ForwardThreatForAssistingMe` then attributes ~5,250 assist-threat to the pet itself on every creature the pet is in combat with — every 3 seconds, AoE-style across all engaged mobs, without the pet attacking. For a single Mend Pet cast (5 ticks) on a pet engaged with 1 mob, that's roughly 26,000 spurious threat on the pet; with multiple mobs it scales linearly per mob.

This change skips the assist-threat forward when `powerType == POWER_HAPPINESS`. Same path covers `Feed Pet` and any other happiness-energize source.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with AzerothMCP.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9441

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

The behavior change here is derived from in-game observation of the bug rather than from sniffs or external sources. Reviewers familiar with retail-era happiness/energize behavior, or with relevant sniff data, are encouraged to weigh in on whether the right scope is `powerType == POWER_HAPPINESS` (this PR), `this == victim` (self-cast energize), or `SPELL_ATTR1_NO_THREAT` on the specific spell.

## Tests Performed:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on a level-80 hunter with a hunter pet (Boar), Mend Pet rank 10 (48990) and Glyph of Mend Pet (item 43350) equipped, against an Expert's Training Dummy (entry 32666). Verified via `LOG_INFO("server", ...)` instrumentation:

**Before fix** — every glyph proc:
```
ForwardThreatForAssistingMe owner=Boar(Pet) assistant=Boar(Pet) spell=57894 baseAmount=10500
```
The pet itself appeared as the assist-threat source.

**After fix** — every glyph proc:
```
EnergizeBySpell: skipped threat for HAPPINESS energize spell=57894 ... damage=21000
```
No `ForwardThreatForAssistingMe` line for spell 57894. Mend Pet's own healing threat (spell 48990) continues to be correctly attributed to the hunter — that path is untouched.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Roll a hunter, learn Mend Pet, equip Glyph of Mend Pet (`.additem 43350` then slot it in the major glyph slot).
2. Send the pet to attack a training dummy (or any mob the pet will hold for several seconds).
3. From a second character (or via threat addon), observe pet threat on the dummy while casting Mend Pet.
4. **Before this fix:** pet threat balloons by ~26,000 per Mend Pet cast (5 ticks × ~5,250).
5. **After this fix:** pet threat is unaffected by Mend Pet; only the hunter accrues healing threat (~525/tick to the hunter, as expected from healing-assist threat).

## Known Issues and TODO List:

- [ ] None.