### PR TITLE
fix(Core/Vehicles): Remove incorrect passenger->vehicle threat redirection

### DIFF
--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -206,6 +206,10 @@ void ThreatReference::HeapNotifyDecreased()
             if (tWho->GetSummonerGUID().IsPlayer())
                 return false;
 
+    // accessories are fully treated as components of the parent and cannot have threat
+    if (cWho->HasUnitTypeMask(UNIT_MASK_ACCESSORY))
+        return false;
+
     return true;
 }
 
@@ -394,15 +398,6 @@ void ThreatManager::AddThreat(Unit* target, float amount, SpellInfo const* spell
             return;
         if (!_owner->IsEngaged() && spell->HasAttribute(SPELL_ATTR3_SUPPRESS_TARGET_PROCS))
             return;
-    }
-
-    // while riding a vehicle, all threat goes to the vehicle, not the pilot
-    if (Unit* vehicle = target->GetVehicleBase())
-    {
-        AddThreat(vehicle, amount, spell, ignoreModifiers, ignoreRedirects);
-        if (target->HasUnitTypeMask(UNIT_MASK_ACCESSORY)) // accessories are fully treated as components of the parent and cannot have threat
-            return;
-        amount = 0.0f;
     }
 
     // if we cannot actually have a threat list, we instead just set combat state and avoid creating threat refs altogether

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -313,7 +313,10 @@ void Vehicle::InstallAccessory(uint32 entry, int8 seatId, bool minion, uint8 typ
     if (TempSummon* accessory = _me->SummonCreature(entry, *_me, TempSummonType(type), summonTime))
     {
         if (minion)
+        {
             accessory->AddUnitTypeMask(UNIT_MASK_ACCESSORY);
+            accessory->GetThreatMgr().Initialize(); // reinitialize CanHaveThreatList cached value
+        }
 
         if (!_me->HandleSpellClick(accessory, seatId))
         {
@@ -455,9 +458,9 @@ bool Vehicle::AddPassenger(Unit* unit, int8 seatId)
         init.SetTransportEnter();
         init.Launch();
 
-        // Transfer threat from passenger to vehicle
+        // Put the vehicle in combat with anything that was threatening the passenger; the threat itself stays on the passenger
         for (auto const& [guid, threatRef] : unit->GetThreatMgr().GetThreatenedByMeList())
-            threatRef->GetOwner()->GetThreatMgr().AddThreat(_me, threatRef->GetThreat(), nullptr, true, true);
+            threatRef->GetOwner()->GetThreatMgr().AddThreat(_me, 0.0f, nullptr, true, true);
 
         if (_me->IsCreature())
         {


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`ThreatManager::AddThreat` used to auto-redirect all incoming threat from a vehicle passenger to the vehicle itself: accessories returned early, other passengers had their threat zeroed, and the vehicle accumulated threat by proxy. This was incorrect — vehicles only need to be in combat alongside their passengers, they shouldn't pull threat off of them.

- `CanHaveThreatList` now returns `false` for `UNIT_MASK_ACCESSORY`, so accessories simply can't have a threat list at all (no redirect needed).
- `Vehicle::InstallAccessory` reinitializes the threat manager after applying `UNIT_MASK_ACCESSORY` so the cached `_ownerCanHaveThreatList` reflects the new state.
- `Vehicle::AddPassenger` still puts the vehicle in combat with the passenger's threateners, but with 0 threat instead of transferring the passenger's actual threat over.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Tools used: **Claude Code with AzerothMCP** (used to identify a suitable test vehicle and explain the existing redirect behavior; the change itself is a direct cherry-pick from TrinityCore).

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Cherry-picked from TrinityCore commit `a2d9179` by Shauren (credited via `Co-authored-by` trailer).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.aura 55629` on yourself (Wintergrasp Lieutenant rank — bypasses the `npc_wg_siege_machine` per-second kick-out check).
2. `.npc add 28312` to spawn a Wintergrasp Siege Engine. Right-click to mount the driver seat; the Siege Turret accessory (`28319`) installs at seat 7.
3. Have a hostile NPC attack you while you're driving the engine. Confirm threat lands on **your** threat list, not the engine's; the engine should enter combat alongside you with 0 threat instead of taking the threat over.
4. Have something attack the Siege Turret directly and confirm it never builds its own threat list (it's now treated as a pure component of the parent — `CanHaveThreatList` returns false for accessories).

## Known Issues and TODO List:

- [ ]
- [ ]

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.