### PR TITLE
fix(DB/Spells): Talisman of Troll Divinity direct heal proc

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1777984830390464692.sql
+++ b/data/sql/updates/pending_db_world/rev_1777984830390464692.sql
@@ -1,0 +1,4 @@
+-- Talisman of Troll Divinity (37734) - Touched by a Troll proc on direct heals
+DELETE FROM `spell_proc` WHERE `SpellId` = 60517;
+INSERT INTO `spell_proc` (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `DisableEffectsMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`) VALUES
+(60517, 0, 0, 0, 0, 0, 0x4000, 2, 2, 0, 0, 0, 0, 100, 0, 0);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Adds a `spell_proc` override for spell `60517` (Talisman of Troll Divinity, item `37734`) so the trinket's "Touched by a Troll" stacking buff (`60518`) triggers on direct heals from any healer class.

The DBC effect for `60517` carries `SpellFamilyName=10 (Paladin)` with `SpellClassMask=[0x800000, 0, 0]`, restricting the proc to a specific Paladin spell. This mirrors the Ribbon of Sacrifice / Blessing of Life issue (spell `38332`) addressed in #25644 - same DBC pattern, same fix shape.

The override clears the family/mask gating, keeps `ProcFlags=0x4000` (PROC_FLAG_DONE_SPELL_MAGIC_DMG_CLASS_POS), and sets `SpellTypeMask=2` (heal) / `SpellPhaseMask=2` (hit) at 100% chance.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with AzerothMCP.

## Issues Addressed:
- Closes #25710
- Closes https://github.com/chromiecraft/chromiecraft/issues/9444 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

- https://www.wowhead.com/wotlk/item=37734/talisman-of-troll-divinity#comments
- Same DBC pattern as #25644 (Ribbon of Sacrifice / Blessing of Life)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Create or use a healer of any class (Priest, Druid, Shaman, Paladin).
2. `.additem 37734` (Talisman of Troll Divinity) and equip it.
3. `.go creature id 1756` (target dummy) or use any friendly target.
4. Activate the trinket, then cast a direct heal (e.g. Flash Heal, Healing Wave, Holy Light, Healing Touch) on a friendly target.
5. Confirm "Touched by a Troll" (spell `60518`) is applied to the target and stacks up to 5 times while the trinket buff is active.

## Known Issues and TODO List:

- [ ]
- [ ]