### PR TITLE
fix(Core/Spells): Apply healing done % to Swiftmend

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1532,7 +1532,11 @@ void Spell::EffectHeal(SpellEffIndex effIndex)
 
             int32 tickheal = targetAura->GetAmount();
             if (Unit* auraCaster = targetAura->GetCaster())
+            {
+                // MOD_HEALING_DONE_PERCENT is applied per-tick, not baked into GetAmount.
+                tickheal = int32(float(tickheal) * auraCaster->GetTotalAuraMultiplier(SPELL_AURA_MOD_HEALING_DONE_PERCENT));
                 tickheal = unitTarget->SpellHealingBonusTaken(auraCaster, targetAura->GetSpellInfo(), tickheal, DOT);
+            }
 
             //int32 tickheal = targetAura->GetSpellInfo()->EffectBasePoints[idx] + 1;
             //It is said that talent bonus should not be included


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Swiftmend (`18562`) computes its instant heal from the consumed Rejuvenation/Regrowth's stored per-tick amount (`AuraEffect::GetAmount()`). That stored amount is calculated via `SpellPctHealingModsDone(..., includeHealingDonePct=false)` (`SpellAuraEffects.cpp:590`), which deliberately excludes `SPELL_AURA_MOD_HEALING_DONE_PERCENT`. The aura is reapplied fresh on every periodic tick (`SpellAuraEffects.cpp:6637`), so live HoT ticks scale correctly with caster-side healing-done auras like Master Shapeshifter (`48422`, the in-`FORM_TREE` `+4%` aura).

Swiftmend never reapplied that multiplier, so its heal was missing the same bonus its source HoT was already getting per tick. Fix: apply `auraCaster->GetTotalAuraMultiplier(SPELL_AURA_MOD_HEALING_DONE_PERCENT)` to `tickheal` before multiplying by tickcount, matching the periodic-tick path.

Verified in-game with debug logging: rank 2 Master Shapeshifter (`pctMod=1.04`) now scales Swiftmend output proportionally to the Rejuvenation tick value (`516 vs 497`, `≈+3.8%` after the fixed `SpellHealingBonusTaken` term — clean `4%` on the multiplied portion). Tree of Life Aura (`MOD_HEALING_PCT`, target-side) and Gift of Nature (`SPELLMOD_DOT`, baked into the tick at apply-time) were already working and continue to.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with AzerothMCP.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9450

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Cross-checked against TrinityCore behavior: TC bakes `MOD_HEALING_DONE_PERCENT` into the stored periodic amount via `Aura::SaveCasterInfo` → `SpellHealingPctDone` (`Unit.cpp:7495`), so its Swiftmend path inherits the bonus implicitly. AzerothCore snapshots HoT pct mods without `MOD_HEALING_DONE_PERCENT` and reapplies on tick; this fix mirrors that behavior in the Swiftmend path.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Level 80 Restoration Druid with **Swiftmend** and **Tree of Life** (`33891`) learned, and **Master Shapeshifter** rank 1 or 2 (`48411`/`48412`).
2. `/cast Tree of Life`. Confirm aura `48422` is present (`.aura list`). If learning the talent while already shifted, re-toggle form so `HandleAuraModShapeshift` re-runs the `FORM_TREE` branch and casts `48422`.
3. Cast **Rejuvenation** on a friendly target, then **Swiftmend**. Note the heal value.
4. `.unaura 48422` (or drop talent / leave form). Reapply Rejuvenation, cast Swiftmend. Note the heal value.
5. The Swiftmend heal in step 3 should be ~`(1 + rank * 2%)` higher than step 4, matching the ratio observed on individual Rejuvenation ticks. Repeat with Regrowth (6 ticks) for a second data point.

## Known Issues and TODO List:

- [ ] Talent application while already in `FORM_TREE` does not retroactively cast `48422` (form-switch handler only fires on transition). Out of scope for this PR; symmetric across cat/bear/moonkin too.
- [ ]