### PR TITLE
fix(Core/Trade): fix use-after-free in GM trade log on stack merge

### DIFF
--- a/src/server/game/Handlers/TradeHandler.cpp
+++ b/src/server/game/Handlers/TradeHandler.cpp
@@ -459,14 +459,35 @@ void WorldSession::HandleAcceptTradeOpcode(WorldPacket& /*recvPacket*/)
             return;
         }
 
-        // log traded items before moving (pointers become invalid after moveItems)
+        // cache traded item info before moving (pointers become invalid after moveItems if items merge into existing stacks)
+        struct TradedItemInfo
+        {
+            bool present = false;
+            std::string name;
+            uint32 entry = 0;
+            uint32 count = 0;
+        };
+        TradedItemInfo myItemsInfo[TRADE_SLOT_TRADED_COUNT];
+        TradedItemInfo hisItemsInfo[TRADE_SLOT_TRADED_COUNT];
         std::string myItemsStr, hisItemsStr;
         for (uint8 i = 0; i < TRADE_SLOT_TRADED_COUNT; ++i)
         {
             if (myItems[i])
-                myItemsStr += Acore::StringFormat("{} (Entry:{}) x{}, ", myItems[i]->GetTemplate()->Name1, myItems[i]->GetEntry(), myItems[i]->GetCount());
+            {
+                myItemsInfo[i].present = true;
+                myItemsInfo[i].name = myItems[i]->GetTemplate()->Name1;
+                myItemsInfo[i].entry = myItems[i]->GetEntry();
+                myItemsInfo[i].count = myItems[i]->GetCount();
+                myItemsStr += Acore::StringFormat("{} (Entry:{}) x{}, ", myItemsInfo[i].name, myItemsInfo[i].entry, myItemsInfo[i].count);
+            }
             if (hisItems[i])
-                hisItemsStr += Acore::StringFormat("{} (Entry:{}) x{}, ", hisItems[i]->GetTemplate()->Name1, hisItems[i]->GetEntry(), hisItems[i]->GetCount());
+            {
+                hisItemsInfo[i].present = true;
+                hisItemsInfo[i].name = hisItems[i]->GetTemplate()->Name1;
+                hisItemsInfo[i].entry = hisItems[i]->GetEntry();
+                hisItemsInfo[i].count = hisItems[i]->GetCount();
+                hisItemsStr += Acore::StringFormat("{} (Entry:{}) x{}, ", hisItemsInfo[i].name, hisItemsInfo[i].entry, hisItemsInfo[i].count);
+            }
         }
 
         // execute trade: 1. remove
@@ -509,10 +530,10 @@ void WorldSession::HandleAcceptTradeOpcode(WorldPacket& /*recvPacket*/)
         {
             for (uint8 i = 0; i < TRADE_SLOT_TRADED_COUNT; ++i)
             {
-                if (myItems[i])
+                if (myItemsInfo[i].present)
                     LOG_GM(GetAccountId(), "GM {} (Account: {}) traded item: {} (Entry: {} Count: {}) to {}",
                         _player->GetName(), GetAccountId(),
-                        myItems[i]->GetTemplate()->Name1, myItems[i]->GetEntry(), myItems[i]->GetCount(),
+                        myItemsInfo[i].name, myItemsInfo[i].entry, myItemsInfo[i].count,
                         trader->GetName());
             }
             if (my_trade->GetMoney() > 0)
@@ -523,10 +544,10 @@ void WorldSession::HandleAcceptTradeOpcode(WorldPacket& /*recvPacket*/)
         {
             for (uint8 i = 0; i < TRADE_SLOT_TRADED_COUNT; ++i)
             {
-                if (hisItems[i])
+                if (hisItemsInfo[i].present)
                     LOG_GM(trader->GetSession()->GetAccountId(), "GM {} (Account: {}) traded item: {} (Entry: {} Count: {}) to {}",
                         trader->GetName(), trader->GetSession()->GetAccountId(),
-                        hisItems[i]->GetTemplate()->Name1, hisItems[i]->GetEntry(), hisItems[i]->GetCount(),
+                        hisItemsInfo[i].name, hisItemsInfo[i].entry, hisItemsInfo[i].count,
                         _player->GetName());
             }
             if (his_trade->GetMoney() > 0)


### PR DESCRIPTION
## Changes Proposed:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

The GM trade logging block in `WorldSession::HandleAcceptTradeOpcode` (added by the RBAC PR #24641) dereferences `myItems[i]` / `hisItems[i]` *after* `moveItems()` runs. When a traded item merges into an existing stack on the recipient side, `Player::MoveItemToInventory` destroys the source `Item`, leaving those pointers dangling. Any account with `rbac::RBAC_PERM_LOG_GM_TRADE` (granted by Moderator role 194 and inherited by Administrator) hits a use-after-free, which manifests as a crash in some setups and as the trade window hanging in others.

This is the same class of bug that #25452 already fixed for the trade-completion log line. This PR extends the existing pre-`moveItems()` cache loop to also capture each traded item's name, entry, and count into a small `TradedItemInfo` struct, and the GM logging blocks now read from that struct instead of from `myItems[i]` / `hisItems[i]`.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Tool used: Claude Code with AzerothMCP.

## Issues Addressed:
- Closes #25716

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Reproduction steps and root-cause confirmation provided in #25716 by @TheSCREWEDSoftware (revoking RBAC perm 11 makes the crash disappear, which exactly matches this code path).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Verified locally with two Administrator-level accounts (both inherit `RBAC_PERM_LOG_GM_TRADE`, so both sides hit the patched logging path). Trade of a 2-stack of Frostweave Cloth (33470) into an existing 18-stack on the recipient now completes cleanly: recipient ends with a single 20-stack, sender's stack is gone, and the GM trade log emits with the correct pre-merge `Count: 2` value. No crash; server uptime preserved.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Two accounts where at least one has `RBAC_PERM_LOG_GM_TRADE` (granted by Moderator role 194 / inherited by Administrator).
2. `.additem <gm_char> 33470 2` and `.additem <other_char> 33470 18` (or any stackable item the recipient already partially holds).
3. Open a trade from the GM character to the other, drop the 2-stack into a trade slot, both Accept.
4. Pre-fix: server crashes (or trade window hangs). Post-fix: trade completes, recipient has a merged 20-stack, GM trade log line is emitted with the correct pre-merge count.

## Known Issues and TODO List:
- [ ]