### PR TITLE
fix(Core/RBAC): guard against null RBACData in .rbac account commands

### DIFF
--- a/src/server/scripts/Commands/cs_rbac.cpp
+++ b/src/server/scripts/Commands/cs_rbac.cpp
@@ -74,8 +74,10 @@ public:
 
     static RBACCommandData GetRBACData(uint32 accountId, std::string const& accountName)
     {
+        // session->GetRBACData() can be null after World::ReloadRBAC()
         if (WorldSession* session = sWorldSessionMgr->FindSession(accountId))
-            return { session->GetRBACData(), false };
+            if (rbac::RBACData* sessionRbac = session->GetRBACData())
+                return { sessionRbac, false };
 
         rbac::RBACData* rbac = new rbac::RBACData(accountId, accountName, realm.Id.Realm, AccountMgr::GetSecurity(accountId, realm.Id.Realm));
         rbac->LoadFromDB();


### PR DESCRIPTION
## Changes Proposed:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

`cs_rbac.cpp::GetRBACData()` returns `session->GetRBACData()` without a null check, but `World::ReloadRBAC()` (triggered by `.reload rbac`) deliberately leaves every online session's `_RBACData` set to `nullptr` and relies on the next `WorldSession::HasPermission()` call to reload it lazily. If any of the four `.rbac account list / grant / deny / revoke` subcommands fire at a still-online target during the gap between reload and the next permission check on that session, the handler dereferences a null pointer and crashes the worldserver.

Reproduction is timing-sensitive on a busy server because `WorldSession::Update()` calls `HasPermission(RBAC_PERM_IGNORE_IDLE_CONNECTION)` on every idle-connection check, which silently refills `_RBACData` long before most operators would type a follow-up command. A user-supplied crash dump captured the state cleanly:

```
Local RBACCommandData data
    rbac::RBACData* rbac = NULL          // null at crash
    bool needDelete = 0x0                // came via session branch, not the `new + LoadFromDB` branch
```

`needDelete == false` mathematically excludes the fallback DB-load branch, so the only path consistent with the dump is the session-found branch returning a null `RBACData*`.

The fix mirrors the lazy-load fallback that `WorldSession::HasPermission` already applies one frame deeper: skip the session branch when its `RBACData` is null and fall through to the existing `new + LoadFromDB` path used for offline accounts. One change covers all four `.rbac account` subcommands.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Tool used: Claude Code with AzerothMCP.

## Issues Addressed:
- Closes

User-supplied WheatyExceptionReport stack trace and local-variable dump captured the null `data.rbac` at `cs_rbac.cpp:210` inside `HandleRBACPermListCommand`.

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Diagnosis grounded in an actual crash dump from a Windows worldserver build (registers, call stack, and local variables of `HandleRBACPermListCommand`'s frame all consistent with `session->GetRBACData()` returning null on a live, found session immediately after `World::ReloadRBAC()`).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

`.reload rbac` followed by `.rbac account list <online_account>` continues to return the expected granted/denied/inherited listing on the patched build. The fallback `new + LoadFromDB` branch is unchanged and still covers offline accounts. Reliable crash repro is timing-sensitive (see notes above), so the change is positioned as a defensive fix matching the existing `HasPermission` lazy-load pattern rather than a hot fix.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing.

1. Have at least one online account.
2. Run `.reload rbac` from console/SOAP.
3. Within the same world tick (before any `HasPermission`-triggering activity on the target session), run `.rbac account list <online_account>`.
4. On master: chance of null-deref crash. On this branch: command returns the permission listing normally.

## Known Issues and TODO List:
- [ ]