### PR TITLE
fix(DB/Locale): correct zhCN text for creature 19175

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1778027634294559600.sql
+++ b/data/sql/updates/pending_db_world/rev_1778027634294559600.sql
@@ -1,0 +1,11 @@
+--
+-- Fix wrong Chinese (zhCN) translation for creature_text 19175, GroupID 6, ID 6.
+-- The English text is "For the Alliance!" but the current zhCN translation
+-- shows "为了部落！" (For the Horde!). Replacing it with "为了联盟！" so the
+-- localized text matches the English one.
+-- Closes issue #13501.
+--
+
+DELETE FROM `creature_text_locale` WHERE `CreatureID`=19175 AND `GroupID`=6 AND `ID`=6 AND `Locale`='zhCN';
+INSERT INTO `creature_text_locale` (`CreatureID`, `GroupID`, `ID`, `Locale`, `Text`) VALUES
+(19175, 6, 6, 'zhCN', '为了联盟！');


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [X] Database (SAI, creatures, etc).

The Chinese (zhCN) translation for `creature_text` 19175 / GroupID 6 / ID 6 is wrong. The English text is `For the Alliance!` but the current zhCN row says `为了部落！` (which means `For the Horde!`). I'm replacing it with `为了联盟！` (`For the Alliance!`) so the translation actually matches the English line.

It's a one row data update in `creature_text_locale`, no logic changes.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [X] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (Anthropic) was used to help draft the SQL file and the PR description. The fix itself is a one line text swap (one Chinese phrase replaced by another), so I can confirm and justify the change against the English source.

## Issues Addressed:

- Closes #13501

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

The English text is `For the Alliance!`. `为了联盟！` is the standard zhCN translation for it, just like `为了部落！` is the standard one for `For the Horde!` (used elsewhere in the same table). So the existing zhCN row is using the Horde phrasing for an Alliance line, which is the bug.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.

I don't run a zhCN client myself, so I haven't checked it visually in game. The change just rewrites one row keyed by (CreatureID, GroupID, ID, Locale), so the only thing that changes is which string a zhCN client sees when this creature_text fires.

## How to Test the Changes:

1. Apply the SQL update on a server with zhCN locale data.
2. Trigger `creature_text` 19175 GroupID 6 ID 6 in game with a zhCN client.
3. The text should now be `为了联盟！` instead of `为了部落！`.