### PR TITLE
feat(Core/Scripting): Add OnBattlefieldWarEnd script hook

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -364,6 +364,7 @@ void Battlefield::EndBattle(bool endByTimer)
         DoPlaySoundToAll(BF_HORDE_WINS);
 
     OnBattleEnd(endByTimer);
+    sScriptMgr->OnBattlefieldWarEnd(this, endByTimer);
 
     // Reset battlefield timer
     Timer = NoWarBattleTime;

--- a/src/server/game/Scripting/ScriptDefines/BattlefieldScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/BattlefieldScript.cpp
@@ -44,6 +44,11 @@ void ScriptMgr::OnBattlefieldBeforeInvitePlayerToWar(Battlefield* bf, Player* pl
     CALL_ENABLED_HOOKS(BattlefieldScript, BATTLEFIELDHOOK_BEFORE_INVITE_PLAYER_TO_WAR, script->OnBattlefieldBeforeInvitePlayerToWar(bf, player));
 }
 
+void ScriptMgr::OnBattlefieldWarEnd(Battlefield* bf, bool endByTimer)
+{
+    CALL_ENABLED_HOOKS(BattlefieldScript, BATTLEFIELDHOOK_ON_WAR_END, script->OnBattlefieldWarEnd(bf, endByTimer));
+}
+
 BattlefieldScript::BattlefieldScript(char const* name, std::vector<uint16> enabledHooks) :
     ScriptObject(name, BATTLEFIELDHOOK_END)
 {

--- a/src/server/game/Scripting/ScriptDefines/BattlefieldScript.h
+++ b/src/server/game/Scripting/ScriptDefines/BattlefieldScript.h
@@ -28,6 +28,7 @@ enum BattlefieldHook
     BATTLEFIELDHOOK_ON_PLAYER_JOIN_WAR,            // 2 - fires after player is added to the active war
     BATTLEFIELDHOOK_ON_PLAYER_LEAVE_WAR,           // 3 - fires after player is removed from the active war
     BATTLEFIELDHOOK_BEFORE_INVITE_PLAYER_TO_WAR,   // 4 - fires in InvitePlayerToWar before InvitedPlayers insert
+    BATTLEFIELDHOOK_ON_WAR_END,                    // 5 - fires in EndBattle after OnBattleEnd(), before timer reset
     BATTLEFIELDHOOK_END
 };
 
@@ -87,6 +88,17 @@ public:
      * @param player The player being invited to war
      */
     virtual void OnBattlefieldBeforeInvitePlayerToWar(Battlefield* /*bf*/, Player* /*player*/) { }
+
+    /**
+     * @brief Called in EndBattle() after OnBattleEnd() completes, before the timer is reset.
+     * All core PlayersInWar/InvitedPlayers structures have already been cleared.
+     * Modules that maintain their own per-war player tracking should use this hook
+     * to perform end-of-war cleanup (e.g. restoring cross-faction disguises).
+     *
+     * @param bf         The Battlefield instance
+     * @param endByTimer True if the war ended by the countdown timer expiring
+     */
+    virtual void OnBattlefieldWarEnd(Battlefield* /*bf*/, bool /*endByTimer*/) { }
 };
 
 #endif // SCRIPT_OBJECT_BATTLEFIELD_SCRIPT_H_

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -587,6 +587,7 @@ public: /* BattlefieldScript */
     void OnBattlefieldPlayerJoinWar(Battlefield* bf, Player* player);
     void OnBattlefieldPlayerLeaveWar(Battlefield* bf, Player* player);
     void OnBattlefieldBeforeInvitePlayerToWar(Battlefield* bf, Player* player);
+    void OnBattlefieldWarEnd(Battlefield* bf, bool endByTimer);
 
 public: /* BGScript */
     void OnBattlegroundStart(Battleground* bg);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Adds `BATTLEFIELDHOOK_ON_WAR_END` to `BattlefieldScript` and a corresponding `ScriptMgr::OnBattlefieldWarEnd(Battlefield* bf, bool endByTimer)` invoker. The hook is called from `Battlefield::EndBattle()` after `OnBattleEnd()` completes, before the timer is reset.

**Why this hook is needed:**

When a war ends, `Battlefield::EndBattle()` calls the virtual `OnBattleEnd()` which clears `PlayersInWar` in bulk — no per-player `OnBattlefieldPlayerLeaveWar` hook fires. Players who remain in the zone after war ends never trigger `OnBattlefieldPlayerLeaveZone` either. Modules that maintain their own per-war player tracking (e.g. for cross-faction assignment) have no existing event at which to perform cleanup for this case.

**Changes:**
- `BattlefieldScript.h` — add `BATTLEFIELDHOOK_ON_WAR_END` enum value + `OnBattlefieldWarEnd(Battlefield*, bool endByTimer)` virtual method with doc comment
- `BattlefieldScript.cpp` — add `ScriptMgr::OnBattlefieldWarEnd` invoker via `CALL_ENABLED_HOOKS`
- `ScriptMgr.h` — add `OnBattlefieldWarEnd` declaration under `/* BattlefieldScript */`
- `Battlefield.cpp` — call `sScriptMgr->OnBattlefieldWarEnd(this, endByTimer)` in `EndBattle()` after `OnBattleEnd()`

The hook fires for all battlefield war-end paths: timer expiry, relic interaction, `.bf stop`, and `.bf switch`.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Claude Sonnet 4.6** (Claude Code) was used to investigate the missing hook, design the fix, and author the changes.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Apply this PR and [mod-cfbg's companion fix](https://github.com/azerothcore/mod-cfbg/pulls) (adds `OnBattlefieldWarEnd` usage to restore cross-faction disguises)
2. Enter Wintergrasp with characters from both factions; accept the war invitation so some are cross-faction assigned
3. End the war (timer, relic capture, or `.bf stop`)
4. Confirm players still in the WG zone immediately revert to their real faction — no relog required

## Known Issues and TODO List:

- [ ]