### PR TITLE
fix(DB/Conditions): Fix Gloom'rel condition type for Smelt Dark Iron check

### DIFF
--- a/data/sql/updates/pending_db_world/fix_gloomrel_condition_type.sql
+++ b/data/sql/updates/pending_db_world/fix_gloomrel_condition_type.sql
@@ -1,0 +1,2 @@
+UPDATE `conditions` SET `ConditionTypeOrReference` = 25 WHERE `SourceTypeOrReferenceId` = 14 AND `SourceGroup` = 1945 AND `SourceEntry` = 2605 AND `ConditionTypeOrReference` = 16 AND `ConditionValue1` = 14891 AND `NegativeCondition` = 1;
+UPDATE `conditions` SET `ConditionTypeOrReference` = 25 WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` = 1945 AND `SourceEntry` = 0 AND `ConditionTypeOrReference` = 16 AND `ConditionValue1` = 14891 AND `NegativeCondition` = 1;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Two conditions added in #25256 for Gloom'rel (NPC 9037) use `ConditionTypeOrReference = 16` (`CONDITION_RACE`) where they should use `25` (`CONDITION_SPELL`). The intent is to hide the "Learn to smelt Dark Iron" gossip option and text from players who already know the spell (ID 14891, Smelt Dark Iron). Instead, `CONDITION_RACE` performs a bitmask check (`getRaceMask() & 14891`), which accidentally hides the option from Human, Orc, Night Elf, Tauren, and Blood Elf players regardless of whether they know the spell — while always showing it to Dwarf, Undead, Gnome, Troll, and Draenei players regardless of whether they know it.

With `CONDITION_SPELL (25)`, the check correctly evaluates `player->HasSpell(14891)`, and `NegativeCondition = 1` makes it pass only when the player does not yet know the spell.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (claude-sonnet-4-6) was used to investigate and identify the bug.

## Issues Addressed:
- Related to #25256
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25763

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code inspection of `ConditionMgr.cpp`: `CONDITION_RACE (16)` evaluates `unit->getRaceMask() & ConditionValue1`; `CONDITION_SPELL (25)` evaluates `player->HasSpell(ConditionValue1)`. Using spell ID 14891 as a race bitmask produces incorrect race-dependent filtering.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Have a character of any race complete quest 4083 (The Spectral Chalice) with Mining >= 230.
2. Talk to Gloom'rel (NPC 9037) in Blackrock Depths, Tomb of the Seven.
3. Verify the "I have paid your price, Gloom'rel. Now, teach me your secrets!" option appears.
4. Select it and confirm the Dark Iron Smelting spell is learned.
5. Talk to Gloom'rel again and verify the option no longer appears (spell already known).

Before this fix, steps 3-4 fail for Human, Orc, Night Elf, Tauren, and Blood Elf characters.

## Known Issues and TODO List:

- [ ]
- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
