### PR TITLE
fix(Core/Player): Recheck shapeshift bonus auras on spec swap

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -15417,6 +15417,15 @@ void Player::ActivateSpec(uint8 spec)
             ++iter;
     }
 
+    // Recheck shapeshift bonus auras: drop and re-apply form-tied passives
+    // so buffs from talents missing in the new spec (e.g. Master Shapeshifter) go away
+    Unit::AuraEffectList const& shapeshiftAuras = GetAuraEffectsByType(SPELL_AURA_MOD_SHAPESHIFT);
+    for (AuraEffect* aurEff : shapeshiftAuras)
+    {
+        aurEff->HandleShapeshiftBoosts(this, false);
+        aurEff->HandleShapeshiftBoosts(this, true);
+    }
+
     sScriptMgr->OnPlayerAfterSpecSlotChanged(this, GetActiveSpec());
 }
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Form-tied passives applied while shapeshifted (e.g. Master Shapeshifter cat/bear/moonkin/tree buffs, Survival of the Fittest, Nurturing Instinct, glyph form passives) were not reconciled against the new spec's talents on a dual-spec swap. If the talent that granted the buff was not learned in the new spec, the buff persisted on the player while still in form.

The fix re-runs the existing `HandleShapeshiftBoosts(false)` / `HandleShapeshiftBoosts(true)` pair at the end of `Player::ActivateSpec` for every active `SPELL_AURA_MOD_SHAPESHIFT` aura. The `false` pass strips form-tied passives; the `true` pass rebuilds them based on the now-active spec's spells/talents, so anything not granted by the new spec is correctly omitted.

Cherry-picked behavior from TrinityCore (commit `16c14593dc860f5c61b1c2f1ca9301d63580ea74` by ariel-, "Core/Player: recheck shapeshift bonus auras when switching spec.") — credited via `Co-Authored-By`.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Tooling used: Claude Code (Opus 4.7) with AzerothMCP.

## Issues Addressed:
- Closes #25758
- Closes https://github.com/chromiecraft/chromiecraft/issues/9474

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Druid with dual-spec, allocate 2/2 in Master Shapeshifter on the primary spec, leave the secondary spec empty (or without Master Shapeshifter).
2. Shift into Cat Form (or Bear/Moonkin/Tree). Confirm the +4% form buff is present (visible on the character sheet).
3. Switch to the secondary spec while still in form.
4. Verify the Master Shapeshifter buff is gone.
5. Repeat for Bear/Dire Bear, Moonkin, and Tree of Life.

## Known Issues and TODO List:

- [ ]
- [ ]