### PR TITLE
fix(Scripts/UP): fix "My Girl Loves to Skadi All the Time" achievement

### DIFF
--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
@@ -71,7 +71,6 @@ enum Actions
     ACTION_START_ENCOUNTER              = 1,
     ACTION_DRAKE_BREATH                 = 2,
     ACTION_PHASE2                       = 3,
-    ACTION_HARPOON_HIT                  = 4,
 };
 
 enum CombatPhase
@@ -171,8 +170,6 @@ public:
             _events.Reset();
             _summons.DespawnAll();
             _phase = PHASE_GROUND;
-            _harpoonHit = 0;
-            _loveSkadi = 0;
             _firstWaveSummoned = false;
             _encounterStarted = false;
 
@@ -266,8 +263,6 @@ public:
                     _events.ScheduleEvent(EVENT_SKADI_RESET_CHECK, 6s);
                     break;
                 case ACTION_DRAKE_BREATH:
-                    if (_loveSkadi == 1)
-                        ++_loveSkadi;
                     Talk(SAY_DRAKE_BREATH);
                     break;
                 case ACTION_PHASE2:
@@ -283,19 +278,7 @@ public:
                     _events.ScheduleEvent(EVENT_SKADI_SPEAR, 11s);
                     _events.ScheduleEvent(EVENT_SKADI_WHIRLWIND, 23s);
                     break;
-                case ACTION_HARPOON_HIT:
-                    ++_harpoonHit;
-                    if (_harpoonHit == 1)
-                        _loveSkadi = 1;
-                    break;
             }
-        }
-
-        uint32 GetData(uint32 id) const override
-        {
-            if (id == DATA_LOVE_TO_SKADI)
-                return _loveSkadi;
-            return 0;
         }
 
         void UpdateAI(uint32 diff) override
@@ -384,8 +367,6 @@ public:
         EventMap _events;
         SummonList _summons;
         CombatPhase _phase;
-        uint8 _harpoonHit;
-        uint8 _loveSkadi;
         bool _firstWaveSummoned;
         bool _encounterStarted;
     };
@@ -415,6 +396,7 @@ public:
             me->SetReactState(REACT_PASSIVE);
             me->SetSpeedRate(MOVE_RUN, 2.5f);
             _flyingToSide = false;
+            _passFreshStart = false;
         }
 
         void DoAction(int32 param) override
@@ -428,13 +410,6 @@ public:
                 me->SetAnimTier(AnimTier::Fly);
                 me->GetMotionMaster()->MovePath(PATH_INITIAL, FORCED_MOVEMENT_RUN);
             }
-        }
-
-        void SpellHit(Unit* /*caster*/, SpellInfo const* spellInfo) override
-        {
-            if (spellInfo->Id == SPELL_LAUNCH_HARPOON)
-                if (Creature* skadi = _instance->GetCreature(DATA_SKADI_THE_RUTHLESS))
-                    skadi->AI()->DoAction(ACTION_HARPOON_HIT);
         }
 
         void MovementInform(uint32 type, uint32 /*id*/) override
@@ -470,6 +445,7 @@ public:
                         FORCED_MOVEMENT_RUN);
                     break;
                 case EVENT_GRAUF_BREATH_START:
+                    _passFreshStart = me->IsFullHealth();
                     me->GetMotionMaster()->MovePath(
                         _lastSide == POINT_LEFT ? PATH_LEFT : PATH_RIGHT,
                         FORCED_MOVEMENT_RUN);
@@ -493,10 +469,11 @@ public:
             {
                 skadi->ExitVehicle();
                 skadi->AI()->DoAction(ACTION_PHASE2);
-
-                if (skadi->AI()->GetData(DATA_LOVE_TO_SKADI) == 1)
-                    _instance->SetData(DATA_SKADI_ACHIEVEMENT, true);
             }
+
+            if (_passFreshStart)
+                _instance->SetData(DATA_SKADI_ACHIEVEMENT, true);
+
             me->DespawnOrUnsummon(6s);
         }
 
@@ -506,6 +483,7 @@ public:
         SummonList _summons;
         uint8 _lastSide = POINT_LEFT;
         bool _flyingToSide = false;
+        bool _passFreshStart = false;
     };
 };
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

The previous implementation tracked harpoon hits via a cross-AI state machine (`ACTION_HARPOON_HIT` / `_loveSkadi`) to determine whether the achievement should fire. This approach had a logic flaw: harpoons fired during Grauf's 10-second breach rest period (between breath passes) would still hit Grauf and corrupt the state machine, causing the achievement to fail permanently even if players correctly fired all 3 harpoons in a single pass.

The fix replaces the entire state machine with a single boolean `_passFreshStart`, set via `me->IsFullHealth()` at the start of each breath pass. In `JustDied`, the achievement is granted if and only if Grauf was at full health when the killing pass began — accurately reflecting the "from 100% to dead in a single pass" requirement regardless of which pass kills him.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Sonnet 4.6 (Claude Code) was used to assist with investigation and implementation.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9471

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Achievement tooltip: *"Defeat Skadi the Ruthless in Utgarde Pinnacle on Heroic Difficulty after having killed Grauf from 100% to dead in a single pass."*

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Utgarde Pinnacle on Heroic difficulty.
2. Engage Skadi the Ruthless and allow Grauf to begin breath passes.
3. Fire all 3 harpoons during a **single** breath pass to kill Grauf in one pass — the achievement should be awarded.
4. Verify that the achievement does **not** fire if Grauf survives the first pass and a second pass begins before he is killed.

## Known Issues and TODO List:

- [ ]
- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.