### PR TITLE
fix(Core/RBAC): use filter perm to gate .whispers command

### DIFF
--- a/data/sql/updates/pending_db_auth/rev_63913873569817690000.sql
+++ b/data/sql/updates/pending_db_auth/rev_63913873569817690000.sql
@@ -1,0 +1,2 @@
+DELETE FROM `rbac_linked_permissions` WHERE `id` = 198 AND `linkedId` = 471;
+DELETE FROM `rbac_permissions` WHERE `id` = 471;

--- a/src/server/game/Accounts/RBAC.h
+++ b/src/server/game/Accounts/RBAC.h
@@ -300,7 +300,6 @@ enum RBACPermissions
     RBAC_PERM_COMMAND_GMNOTIFY                               = 468,
     RBAC_PERM_COMMAND_NAMEANNOUNCE                           = 469,
     RBAC_PERM_COMMAND_NOTIFY                                 = 470,
-    RBAC_PERM_COMMAND_WHISPERS                               = 471,
     RBAC_PERM_COMMAND_GROUP                                  = 472,
     RBAC_PERM_COMMAND_GROUP_LEADER                           = 473,
     RBAC_PERM_COMMAND_GROUP_DISBAND                          = 474,

--- a/src/server/scripts/Commands/cs_message.cpp
+++ b/src/server/scripts/Commands/cs_message.cpp
@@ -45,7 +45,7 @@ public:
             { "gmannounce",     HandleGMAnnounceCommand,     rbac::RBAC_PERM_COMMAND_GMANNOUNCE,     Console::Yes },
             { "notify",         HandleNotifyCommand,         rbac::RBAC_PERM_COMMAND_NOTIFY,         Console::Yes },
             { "gmnotify",       HandleGMNotifyCommand,       rbac::RBAC_PERM_COMMAND_GMNOTIFY,       Console::Yes },
-            { "whispers",       HandleWhispersCommand,       rbac::RBAC_PERM_COMMAND_WHISPERS,       Console::No },
+            { "whispers",       HandleWhispersCommand,       rbac::RBAC_PERM_CAN_FILTER_WHISPERS,    Console::No },
         };
         return commandTable;
     }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

`RBAC_PERM_COMMAND_WHISPERS` (471) gated access to the `.whispers` command, but `RBAC_PERM_CAN_FILTER_WHISPERS` (36) is what the system actually checks in two separate places to enforce the filter:

- [`ChatHandler.cpp`](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Handlers/ChatHandler.cpp) — blocks incoming whispers only when the receiver has perm 36 **and** has whispers off.
- [`Player.cpp`](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Entities/Player/Player.cpp) — force-calls `SetAcceptWhispers(true)` on login for any account that lacks perm 36, resetting `.whispers off` on every relog.

Because 471 and 36 were never linked, an account with the command permission but without the filter permission could toggle `.whispers off` in memory, but whispers were never actually blocked and the flag was reset on the next login. The command was structurally inert without perm 36 — neither can function without the other.

The fix replaces the command's RBAC gate with `RBAC_PERM_CAN_FILTER_WHISPERS` directly, so a single permission controls both access to the command and enforcement of the filter.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Sonnet 4.6 (Claude Code) was used to assist with investigation and implementation.

## Issues Addressed:
- N/A

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Log in with a GM account (security level ≥ 1).
2. Run `.whispers off`.
3. Have another account attempt to whisper the GM character.
4. Confirm the whisper is blocked and the sender receives a player-not-found notice.
5. Relog the GM character and confirm `.whispers` remains off (not reset to on).

## Known Issues and TODO List:

- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.