### PR TITLE
fix(Scripts/Kalimdor): prevent starting Caravan escort when in progress

### DIFF
--- a/src/server/scripts/Kalimdor/zone_desolace.cpp
+++ b/src/server/scripts/Kalimdor/zone_desolace.cpp
@@ -395,9 +395,12 @@ public:
                         active->RemoveNpcFlag(UNIT_NPC_FLAG_QUESTGIVER);
                     break;
                 case EVENT_RESTART_ESCORT:
-                    CheckCaravan();
-                    SetDespawnAtEnd(false);
-                    Start(true, ObjectGuid::Empty, 0, false, false, true);
+                    if (!IsEscorted())
+                    {
+                        CheckCaravan();
+                        SetDespawnAtEnd(false);
+                        Start(true, ObjectGuid::Empty, 0, false, false, true);
+                    }
                     break;
             }
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify which model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## SOURCE:

The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Go to Desolace zone and find the Gizelton Caravan (NPC entry: 11625)
2. Observe the server console - you will see repeated warnings:
   EscortAI (script: npc_cork_gizelton, creature entry: 11625) attempts to Start while already escorting
3. After this fix, the warning should no longer appear
4. The caravan should continue to function normally

## Problem & Root Cause

### Console Error
`
EscortAI (script: npc_cork_gizelton, creature entry: 11625) attempts to Start while already escorting
`

This warning is logged by 
pc_escortAI::Start() when it detects that STATE_ESCORT_ESCORTING is already set.

### Root Cause
The 
pc_cork_gizeltonAI script schedules EVENT_RESTART_ESCORT when the caravan reaches waypoint 282. This event handler directly calls Start() without checking if the escort is already in progress.

The Gizelton caravan runs on a **cyclic route** - when the caravan completes one loop and returns to waypoint 282, the next EVENT_RESTART_ESCORT fires while the previous escort may still be active. Since Start() detects that STATE_ESCORT_ESCORTING is already set, it logs the warning and refuses to restart.

### Solution
Added an IsEscorted() check in the EVENT_RESTART_ESCORT handler. If the escort is already running, we skip the Start() call entirely, preventing the warning from being triggered.

## Known Issues and TODO List:

- [ ]
- [ ]