### PR TITLE
fix(Scripts/RFD): make Belnistrasz's Brazier persist after his despawn

### DIFF
--- a/src/server/scripts/Kalimdor/RazorfenDowns/razorfen_downs.cpp
+++ b/src/server/scripts/Kalimdor/RazorfenDowns/razorfen_downs.cpp
@@ -204,7 +204,9 @@ public:
                     case EVENT_COMPLETE:
                         {
                             DoCast(me, SPELL_IDOM_ROOM_CAMERA_SHAKE);
-                            me->SummonGameObject(GO_BELNISTRASZS_BRAZIER, 2577.196f, 947.0781f, 53.16757f, 2.356195f, 0, 0, 0.9238796f, 0.3826832f, 3600);
+                            // Summon via the map so the brazier is not tied to Belnistrasz's
+                            // m_gameObj list and survives his despawn below.
+                            me->GetMap()->SummonGameObject(GO_BELNISTRASZS_BRAZIER, 2577.196f, 947.0781f, 53.16757f, 2.356195f, 0, 0, 0.9238796f, 0.3826832f, 3600);
                             std::list<WorldObject*> ClusterList;
                             Acore::AllWorldObjectsInRange objects(me, 50.0f);
                             Acore::WorldObjectListSearcher<Acore::AllWorldObjectsInRange> searcher(me, ClusterList, objects);
@@ -223,7 +225,7 @@ public:
                                 }
                             }
                             instance->SetData(GO_BELNISTRASZS_BRAZIER, DONE);
-                            me->DespawnOrUnsummon();
+                            me->DespawnOrUnsummon(5s);
                             break;
                         }
                     case EVENT_FIREBALL:


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Quest 3525 *Extinguishing the Idol* in Razorfen Downs could not be turned in because Belnistrasz's Brazier (the questender GO, entry `152097`) was destroyed in the same tick it spawned.

In `npc_belnistrasz`'s `EVENT_COMPLETE`:

```cpp
me->SummonGameObject(GO_BELNISTRASZS_BRAZIER, ...);
...
me->DespawnOrUnsummon();
```

`WorldObject::SummonGameObject` defaults to `GO_SUMMON_TIMED_OR_CORPSE_DESPAWN`, so for creatures it calls `ToUnit()->AddGameObject(go)` and the brazier is appended to Belnistrasz's `m_gameObj` list. Belnistrasz is a DB-spawned creature, so `DespawnOrUnsummon(0ms)` removes him from the world the same tick, and `Unit::RemoveFromWorld` -> `RemoveAllGameObjects` calls `Delete()` on every entry of `m_gameObj` — including the freshly-summoned brazier. The GO never reaches any client snapshot.

This bug has been latent since the script was written in 2016 (`f6eefedcd5`).

### Fix
- Spawn the brazier via `me->GetMap()->SummonGameObject(...)` instead of `me->SummonGameObject(...)`. `Map::SummonGameObject` does not add the GO to any unit's `m_gameObj`, so the brazier's lifetime is decoupled from Belnistrasz. The 1-hour respawn time is preserved.
- Delay his despawn by `5s` (matching the death path on line 128) so `SAY_EVENT_END` is not cut off.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (Opus 4.7) was used to investigate the report, trace the lifecycle of the summoned GO through `Object.cpp` / `Unit.cpp`, and draft the patch. The fix was reviewed and authored by me.

## Issues Addressed:
- Reported on the ChromieCraft Discord (4/30/2026): players running the quest twice could not find the brazier to turn in.

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)

On retail-behavior servers the brazier appears under the idol after the channel completes and remains usable until the instance resets. The current AzerothCore behavior diverges from this because of the `m_gameObj` cleanup described above.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Code-level reasoning has been verified end-to-end against `WorldObject::SummonGameObject`, `Map::SummonGameObject`, `Unit::AddGameObject`, and `Unit::RemoveFromWorld` / `RemoveAllGameObjects`. In-game test pending.

## How to Test the Changes:

1. Enter Razorfen Downs at an appropriate level and pick up *Extinguishing the Idol* (3525) from Belnistrasz at the entrance.
2. Escort him to the idol room and protect him through the full channel (~6 minutes / 4 waves).
3. After his completion line and the camera shake, confirm that *Belnistrasz's Brazier* (GO `152097`) is present in front of the idol.
4. Interact with the brazier to turn the quest in and receive the reward.
5. Verify Belnistrasz remains visible for ~5 seconds after his final line before despawning.

## Known Issues and TODO List:

- [ ] None known.