### PR TITLE
fix(DB/Proc): restore Warrior Sword Specialization masks

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1778336815572155146.sql
+++ b/data/sql/updates/pending_db_world/rev_1778336815572155146.sql
@@ -1,0 +1,3 @@
+-- Restore Warrior Sword Specialization/Sudden Death proc masks after spell_proc migration
+UPDATE `spell_proc` SET `SpellFamilyName`=4, `SpellFamilyMask0`=0xAA604466, `SpellFamilyMask1`=0x00400105, `SpellFamilyMask2`=0x00000000, `SpellTypeMask`=0, `SpellPhaseMask`=2 WHERE `SpellId`=-12281;
+UPDATE `spell_proc` SET `SpellFamilyName`=4, `SpellFamilyMask0`=0xAA604466, `SpellFamilyMask1`=0x00400105, `SpellFamilyMask2`=0x00000000, `SpellTypeMask`=0, `SpellPhaseMask`=2|4 WHERE `SpellId`=-29723;


### PR DESCRIPTION
## Changes Proposed:
- Restore the Warrior `spell_proc` family masks that were previously fixed in `spell_proc_event` for Sword Specialization/Sudden Death.
- Clear the damage-only `SpellTypeMask` on these procs so no-damage warrior abilities such as Sunder Armor can trigger them.
- Restore Sudden Death to listen on hit and finish phases, keeping the existing aura script filter for Execute finish events.

## Issues Addressed:
- Fixes #20250

## Tests Performed:
- `python3 ./apps/codestyle/codestyle-sql.py`