### PR TITLE
fix(DB/Quest): On Ruby Wings - prevent Antiok idle despawn pre-engage

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1778350030492406400.sql
+++ b/data/sql/updates/pending_db_world/rev_1778350030492406400.sql
@@ -1,0 +1,6 @@
+-- Restore TEMPSUMMON_MANUAL_DESPAWN (8) with no timer for Thiassi -> Antiok
+-- accessory. With timer 0 this is rewritten to TEMPSUMMON_DEAD_DESPAWN at
+-- runtime, so Antiok only despawns when he dies and no longer ticks down
+-- while seated on Thiassi pre-engage.
+UPDATE `vehicle_template_accessory` SET `summontype` = 8, `summontimer` = 0
+    WHERE `entry` = 28018 AND `accessory_entry` = 28006;


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

Follow-up to #25683. That PR fixed the original *On Ruby Wings* (12498) bug where Grand Necrolord Antiok (28006) despawned the moment Thiassi the Lightning Bringer (28018) died, by removing the `On Evade -> Force Despawn` SmartAI rule on Antiok. That part was correct and should stay.

The same PR also changed `vehicle_template_accessory` for entry 28018 from `summontype=8 (TEMPSUMMON_MANUAL_DESPAWN), summontimer=0` to `summontype=1 (TEMPSUMMON_TIMED_OR_DEAD_DESPAWN), summontimer=30000`. The PR description claimed the timer "ticks only while alive **and** out of combat, so it won't despawn Antiok mid-encounter." That is true *during* combat, but the description missed the obvious case: Antiok is alive and out of combat **while just sitting on Thiassi after spawn, before any player engages**. The 30s timer ticks down and despawns him.

See [TemporarySummon.cpp:177-192](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Entities/Creature/TemporarySummon.cpp#L177-L192):

```cpp
case TEMPSUMMON_TIMED_OR_DEAD_DESPAWN:
{
    if (!IsInCombat() && IsAlive())   // true at idle spawn
    {
        if (m_timer <= diff) { UnSummon(); return; }
        else m_timer -= diff;
    }
    ...
}
```

This PR restores the row to `summontype=8, summontimer=0`. With timer 0, [TempSummon::InitStats](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Entities/Creature/TemporarySummon.cpp#L212-L213) rewrites the type to `TEMPSUMMON_DEAD_DESPAWN`, so Antiok only despawns when he or his vehicle host actually dies. This matches the long-standing pre-#25683 behavior. The smart_scripts row deletion from #25683 (the actual fix for the original bug) is not touched.

### Why not match TrinityCore directly?

TrinityCore's `vehicle_template_accessory` row in TDB shows the same `summontype=1, summontimer=30000`, and Trinity's `TempSummon::Update` for type 1 has byte-identical logic. The Trinity 2014 commit that introduced `summontype=1` for this entry only ran `UPDATE … set summontype=1` and did not specify `summontimer` — the 30000 likely came in later via TDB schema/default migration. The OOC tick race exists on Trinity too; it just rarely surfaces because in normal play the player engages Thiassi well within 30s of his respawn. Players who arrive at the spawn location early, or who linger before engaging, can hit it on either core.

### Pending issues / out of scope

- **Vehicle accessory orphan cleanup is not solved by any single `summontype`.** With the manual/dead despawn used here, an Antiok stranded alive after Thiassi's death (e.g. all players leave before killing him) will evade home and persist; on the next Thiassi respawn 300s later, `Vehicle::InstallAccessory` will summon a new Antiok because the seat is empty, leaving a duplicate. Any timer-based type (1, 2, 4, 10) on the other hand ticks while seated and reproduces this PR's regression.
- **Proper fix is core-level**: pause the despawn timer for accessory passengers while they are seated (`!GetVehicle()` check on the relevant cases in `TempSummon::Update`). That would make `summontype=1, summontimer=30000` behave as the original PR author intended (timer only after dismount), cleaning up orphans without despawning seated accessories. Worth a separate Core PR.
- **Remaining RP-timing / Flesh-Harvest-target issues for this encounter** are still tracked in #24664 and remain out of scope.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request.

Investigation, root-cause analysis, and SQL drafted with the help of Claude (Anthropic, Opus 4.7), including cross-referencing TrinityCore's `tc_world` snapshot and `TemporarySummon.cpp` to confirm both cores share the same data and update logic.

## Issues Addressed:

- Follow-up to #25683 (regression introduced by the `vehicle_template_accessory` change in that PR)

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Reasoning is grounded in reading both AzerothCore and TrinityCore 3.3.5 source for `TempSummon::Update`, `Vehicle::InstallAccessory`, and `ObjectMgr::LoadVehicleTemplateAccessories`, plus comparing the live `vehicle_template_accessory` rows in `acore_world` and `tc_world`.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Be level 71+ with quest 12498 *On Ruby Wings* in the log.
2. Stand near Thiassi's spawn point (Dragonblight, ~52, 30) without engaging — wait at least 60 seconds after he appears.
3. Confirm Grand Necrolord Antiok stays mounted on Thiassi indefinitely (no idle 30s despawn).
4. Use the `Ruby Beacon of the Dragon Queen` (item 38302) to summon a `Wyrmrest Vanquisher`, fly in, kill Thiassi.
5. Confirm Antiok is ejected, plays his RP, becomes attackable, and the encounter completes as fixed in #25683.

## Known Issues and TODO List:

- [ ] Vehicle accessory orphan cleanup after Thiassi respawn while a stranded Antiok is alive — see "Pending issues" above; needs a core-level `!GetVehicle()` guard in `TempSummon::Update`.
- [ ] Remaining RP-timing / Flesh-Harvest-target issues are tracked in #24664.