### PR TITLE
chore(gitignore): optimize Claude ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,9 +54,11 @@ CMakeLists.txt.user
 *.LOCAL.*
 
 #
-# AI tools
+# Claude
 #
-.claude
+.claude/worktrees
+.claude/settings.local.json
+.claude/plans/**
 
 #
 # IDE & other software


### PR DESCRIPTION
Reasoning: we don't want to ignore the whole `.claude` folder as normally there are things people do want to share across the same project (e.g., skills, project settings, rules, etc.).

However we still want to ignore:
- `worktrees` so devs can [Run parallel sessions with worktrees](https://code.claude.com/docs/en/common-workflows#run-parallel-sessions-with-worktrees)
- `plans` so devs can generate plans and other documents locally applying [RAP](https://medium.com/@borzifrancesco/the-refine-plan-act-pattern-for-agentic-ai-coding-59ee013e4427) or similar patterns without accidentally including them on their PRs (whether if and how we want to share them, can be a discussion for later)
- `settings.local.json` as this is for user-specific settings