### PR TITLE
fix(Core/Quests): Fix quest mob tooltips not displaying correctly

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -11121,7 +11121,7 @@ void ObjectMgr::LoadCreatureQuestItems()
         } while (result->NextRow());
     }
 
-    // Derive additional quest item hints from loot tables so creature_questitem gaps don't silently break tooltips.
+    // Pass 1: items that only drop when a quest is active (QuestRequired=1)
     QueryResult lootResult = WorldDatabase.Query(
         "SELECT ct.entry, clt.Item "
         "FROM creature_loot_template clt "
@@ -11154,7 +11154,49 @@ void ObjectMgr::LoadCreatureQuestItems()
         } while (lootResult->NextRow());
     }
 
-    LOG_INFO("server.loading", ">> Loaded {} Creature Quest Items ({} derived from loot templates) in {} ms", count + autoCount, autoCount, GetMSTimeDiffToNow(oldMSTime));
+    // Pass 2: regular loot items that are required by a quest (ReqItemId in quest_template)
+    QueryResult questItemResult = WorldDatabase.Query(
+        "SELECT ct.entry, clt.Item "
+        "FROM creature_loot_template clt "
+        "INNER JOIN creature_template ct ON ct.lootid = clt.Entry "
+        "INNER JOIN ( "
+        "    SELECT RequiredItemId1 AS ItemId FROM quest_template WHERE RequiredItemId1 > 0 "
+        "    UNION SELECT RequiredItemId2 FROM quest_template WHERE RequiredItemId2 > 0 "
+        "    UNION SELECT RequiredItemId3 FROM quest_template WHERE RequiredItemId3 > 0 "
+        "    UNION SELECT RequiredItemId4 FROM quest_template WHERE RequiredItemId4 > 0 "
+        "    UNION SELECT RequiredItemId5 FROM quest_template WHERE RequiredItemId5 > 0 "
+        "    UNION SELECT RequiredItemId6 FROM quest_template WHERE RequiredItemId6 > 0 "
+        ") AS qi ON clt.Item = qi.ItemId "
+        "WHERE clt.Reference = 0 "
+        "ORDER BY ct.entry ASC, clt.Item ASC");
+
+    uint32 autoQuestCount = 0;
+    if (questItemResult)
+    {
+        do
+        {
+            Field* fields = questItemResult->Fetch();
+            uint32 entry = fields[0].Get<uint32>();
+            uint32 item  = fields[1].Get<uint32>();
+
+            if (!GetItemTemplate(item))
+                continue;
+
+            CreatureQuestItemList& questItems = _creatureQuestItemStore[entry];
+
+            if (std::find(questItems.begin(), questItems.end(), item) != questItems.end())
+                continue;
+
+            if (questItems.size() >= MAX_CREATURE_QUEST_ITEMS)
+                continue;
+
+            questItems.push_back(item);
+            ++autoQuestCount;
+        } while (questItemResult->NextRow());
+    }
+
+    LOG_INFO("server.loading", ">> Loaded {} Creature Quest Items ({} from loot templates, {} from quest requirements) in {} ms",
+        count + autoCount + autoQuestCount, autoCount, autoQuestCount, GetMSTimeDiffToNow(oldMSTime));
     LOG_INFO("server.loading", " ");
 }
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -11069,8 +11069,7 @@ void ObjectMgr::LoadGameObjectQuestItems()
             continue;
         };
 
-        ItemEntry const* dbcData = sItemStore.LookupEntry(item);
-        if (!dbcData)
+        if (!GetItemTemplate(item))
         {
             LOG_ERROR("sql.sql", "Table `gameobject_questitem` has nonexistent item (ID: {}) in gameobject (entry: {}, idx: {}), skipped", item, entry, idx);
             continue;
@@ -11092,41 +11091,70 @@ void ObjectMgr::LoadCreatureQuestItems()
     //                                               0              1        2
     QueryResult result = WorldDatabase.Query("SELECT CreatureEntry, ItemId, Idx FROM creature_questitem ORDER BY Idx ASC");
 
-    if (!result)
+    uint32 count = 0;
+    if (result)
     {
-        LOG_WARN("server.loading", ">> Loaded 0 creature quest items. DB table `creature_questitem` is empty.");
-        return;
+        do
+        {
+            Field* fields = result->Fetch();
+
+            uint32 entry = fields[0].Get<uint32>();
+            uint32 item = fields[1].Get<uint32>();
+            uint32 idx = fields[2].Get<uint32>();
+
+            CreatureTemplate const* creatureInfo = GetCreatureTemplate(entry);
+            if (!creatureInfo)
+            {
+                LOG_ERROR("sql.sql", "Table `creature_questitem` has data for nonexistent creature (entry: {}, idx: {}), skipped", entry, idx);
+                continue;
+            }
+
+            if (!GetItemTemplate(item))
+            {
+                LOG_ERROR("sql.sql", "Table `creature_questitem` has nonexistent item (ID: {}) in creature (entry: {}, idx: {}), skipped", item, entry, idx);
+                continue;
+            }
+
+            _creatureQuestItemStore[entry].push_back(item);
+
+            ++count;
+        } while (result->NextRow());
     }
 
-    uint32 count = 0;
-    do
+    // Derive additional quest item hints from loot tables so creature_questitem gaps don't silently break tooltips.
+    QueryResult lootResult = WorldDatabase.Query(
+        "SELECT ct.entry, clt.Item "
+        "FROM creature_loot_template clt "
+        "INNER JOIN creature_template ct ON ct.lootid = clt.Entry "
+        "WHERE clt.QuestRequired = 1 AND clt.Reference = 0 "
+        "ORDER BY ct.entry ASC, clt.Item ASC");
+
+    uint32 autoCount = 0;
+    if (lootResult)
     {
-        Field* fields = result->Fetch();
-
-        uint32 entry = fields[0].Get<uint32>();
-        uint32 item = fields[1].Get<uint32>();
-        uint32 idx = fields[2].Get<uint32>();
-
-        CreatureTemplate const* creatureInfo = GetCreatureTemplate(entry);
-        if (!creatureInfo)
+        do
         {
-            LOG_ERROR("sql.sql", "Table `creature_questitem` has data for nonexistent creature (entry: {}, idx: {}), skipped", entry, idx);
-            continue;
-        };
+            Field* fields = lootResult->Fetch();
+            uint32 entry = fields[0].Get<uint32>();
+            uint32 item  = fields[1].Get<uint32>();
 
-        ItemEntry const* dbcData = sItemStore.LookupEntry(item);
-        if (!dbcData)
-        {
-            LOG_ERROR("sql.sql", "Table `creature_questitem` has nonexistent item (ID: {}) in creature (entry: {}, idx: {}), skipped", item, entry, idx);
-            continue;
-        };
+            if (!GetItemTemplate(item))
+                continue;
 
-        _creatureQuestItemStore[entry].push_back(item);
+            CreatureQuestItemList& questItems = _creatureQuestItemStore[entry];
 
-        ++count;
-    } while (result->NextRow());
+            if (std::find(questItems.begin(), questItems.end(), item) != questItems.end())
+                continue;
 
-    LOG_INFO("server.loading", ">> Loaded {} Creature Quest Items in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+            if (questItems.size() >= MAX_CREATURE_QUEST_ITEMS)
+                continue;
+
+            questItems.push_back(item);
+            ++autoCount;
+        } while (lootResult->NextRow());
+    }
+
+    LOG_INFO("server.loading", ">> Loaded {} Creature Quest Items ({} derived from loot templates) in {} ms", count + autoCount, autoCount, GetMSTimeDiffToNow(oldMSTime));
     LOG_INFO("server.loading", " ");
 }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [X] Claude used throughout the investigation and implementation of this fix.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #25759

## SOURCE:
<!-- If you can, include a source that can strengthen your claim --> For Shoveltusk Soup Again?: https://www.wowhead.com/wotlk/quest=11155/shoveltusk-soup-again
https://www.youtube.com/watch?v=qjKc8MVwmIw

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.) 
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed --> No errors, checked the worldserver logs for any issues as well. Everything behaves as expected. In that being said, this changes how the system works and potentially affects hundreds of quests. I do not have the resources to test them all. 
https://streamable.com/mn37fb
https://streamable.com/bftlqh
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. quest add 12216
2. .go c i 27131
3. mouseover the quest creature, observe the tooltip 

## Notes:
Two bugs fixed in ObjectMgr - LoadCreatureQuestItems() and LoadGameObjectQuestItems().
1. Wrong validator for quest-class items
Both functions were using sItemStore.LookupEntry() which checks Item.dbc. Some quest class items aren't in the DBC — they live in item_template — so valid quest items were getting silently dropped and never sent to the client in SMSG_CREATURE_QUERY_RESPONSE. Fixed by switching to GetItemTemplate(), which validates against the database instead.

2. Gaps in creature_questitem
The table is manually updated and is out of sync with creature_loot_template. Lots of creatures have QuestRequired=1 loot entries that were never added to creature_questitem, so the client gets empty tooltip slots even with fix 1 in place.
Due to resource constrains, having to update DB on hundreds of quests, LoadCreatureQuestItems() now fills missing entries directly from creature_loot_template at startup. 
It runs after the table loads so manual entries take priority, checks against existing entries, and respects the MAX_CREATURE_QUEST_ITEMS cap (6 slots, packet format limit). A potential fix for feature content as well but I will leave to the reviewer to make the decision if this is more appropriate than checking and updating DB individually for all the quests with this issue.