### PR TITLE
fix(Core/Maps): fix pooled creature/GO respawn in instanced maps

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2717,12 +2717,18 @@ void Map::ProcessRespawns()
 
 void Map::ProcessCreatureRespawn(ObjectGuid::LowType spawnId)
 {
-    // Pool members are handled entirely by PoolMgr
-    if (uint32 poolId = sPoolMgr->IsPartOfAPool<Creature>(spawnId))
+    // Pool members in non-instanced maps are handled entirely by PoolMgr.
+    // In instanced maps the pool system operates globally and Spawn1Object is
+    // a no-op for instanceable maps, so fall through to the normal per-instance
+    // respawn logic instead.
+    if (!Instanceable())
     {
-        sPoolMgr->UpdatePool<Creature>(poolId, spawnId);
-        RemoveCreatureRespawnTime(spawnId);
-        return;
+        if (uint32 poolId = sPoolMgr->IsPartOfAPool<Creature>(spawnId))
+        {
+            sPoolMgr->UpdatePool<Creature>(poolId, spawnId);
+            RemoveCreatureRespawnTime(spawnId);
+            return;
+        }
     }
 
     CreatureData const* data = sObjectMgr->GetCreatureData(spawnId);
@@ -2778,12 +2784,16 @@ void Map::ProcessCreatureRespawn(ObjectGuid::LowType spawnId)
 
 void Map::ProcessGameObjectRespawn(ObjectGuid::LowType spawnId)
 {
-    // Pool members are handled entirely by PoolMgr
-    if (uint32 poolId = sPoolMgr->IsPartOfAPool<GameObject>(spawnId))
+    // Same rationale as ProcessCreatureRespawn: pool management via PoolMgr is
+    // only meaningful for non-instanced maps where Spawn1Object actually spawns.
+    if (!Instanceable())
     {
-        sPoolMgr->UpdatePool<GameObject>(poolId, spawnId);
-        RemoveGORespawnTime(spawnId);
-        return;
+        if (uint32 poolId = sPoolMgr->IsPartOfAPool<GameObject>(spawnId))
+        {
+            sPoolMgr->UpdatePool<GameObject>(poolId, spawnId);
+            RemoveGORespawnTime(spawnId);
+            return;
+        }
     }
 
     GameObjectData const* data = sObjectMgr->GetGameObjectData(spawnId);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Pooled creatures and game objects inside instanced maps (dungeons, raids) were silently lost after being killed — they were removed from the world but never recreated when their respawn timer expired.

`ProcessCreatureRespawn` / `ProcessGameObjectRespawn` intercept pool members with an early return that routes through `UpdatePool` → `Spawn1Object`. `Spawn1Object` has a `!map->Instanceable()` guard (necessary because it uses `CreateBaseMap()`, which returns the template map rather than the specific instance), making the entire call a no-op for instance maps. The creature was already removed from the world (non-compat, spawn group 0 = dynamic mode) with no fallback to recreate it.

The fix: guard the pool-manager early return with `if (!Instanceable())`. For instanced maps, execution falls through to the standard per-instance `LoadCreatureFromDB` / `LoadGameObjectFromDB` respawn path. The same fix is applied symmetrically in both functions.

**TrinityCore comparison:** TC avoids this entirely by using a per-map `SpawnedPoolData` struct (holding a `Map*`), so `Spawn1Object` always targets the correct instance with no `Instanceable()` guard needed. AC uses a global pool state — hence the guard was necessary but broke instance respawns.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Claude Sonnet 4.6** (Anthropic) was used to assist with investigation and authoring this fix.

## Issues Addressed:
- Closes #25745

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Code analysis: traced the full respawn flow from `setDeathState(JustDied)` → `RemoveCorpse` → `_respawnQueue` → `ProcessCreatureRespawn` → `UpdatePool` → `Spawn1Object` and confirmed the `!map->Instanceable()` guard is the point of failure. Cross-referenced with TrinityCore's `PoolMgr.cpp` which uses per-map `SpawnedPoolData` and has no such guard.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Enter Blackrock Depths
2. Kill a Shadowforge Flame Keeper (NPC 9956, pool 1550 — guids 47302, 47303, 91119, 91120)
3. Wait 5 minutes (their `spawntimesecs = 300`)
4. Confirm the NPC respawns at its spawn position

## Known Issues and TODO List:

- [ ] Long-term: port TrinityCore's per-map `SpawnedPoolData` so pool rotation works correctly inside instances (each instance independently tracks which pool members are active). The current fix bypasses pool rotation for instanced maps — all pool members can respawn independently, which is correct for instanced content but loses the randomised rotation that pools provide on shared world maps.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.