### PR TITLE
fix(Core/Combat): On vehicle exit transfer combat state to player

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1778874528834789670.sql
+++ b/data/sql/updates/pending_db_world/rev_1778874528834789670.sql
@@ -1,0 +1,14 @@
+-- Increase range to 40 yards
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 28018) AND (`source_type` = 0) AND (`id` IN (2));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(28018, 0, 2, 0, 6, 0, 100, 512, 0, 0, 0, 0, 0, 0, 45, 1, 0, 0, 0, 0, 0, 19, 28006, 40, 0, 0, 0, 0, 0, 0, 'Thiassi the Lightning Bringer - On Death - remove unitflag from target');
+
+-- Reset -> JustSummoned
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 28006) AND (`source_type` = 0) AND (`id` IN (5));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(28006, 0, 5, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 50494, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Grand Necrolord Antiok - On Just Summoned - Cast \'Shroud of Lightning\'');
+
+-- Despawn on Evade
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 28006) AND (`source_type` = 0) AND (`id` IN (7));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(28006, 0, 7, 0, 7, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Grand Necrolord Antiok - On Evade - Despawn Instant');

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -14137,6 +14137,24 @@ void Unit::Kill(Unit* killer, Unit* victim, bool durabilityLoss, WeaponAttackTyp
         }
     }
 
+    if (victim->IsVehicle() && victim->GetCharmer() && victim->GetCharmer()->IsPlayer())
+    {
+        Player* rider = victim->GetCharmer()->ToPlayer();
+        if (rider && rider->IsAlive() && !victim->GetCombatManager().IsInEvadeMode())
+        {
+            rider->GetCombatManager().InheritCombatStatesFrom(victim);
+
+            for (auto const& [guid, threatRef] : victim->GetThreatMgr().GetThreatenedByMeList())
+            {
+                Unit* hostile = threatRef->GetOwner();
+                if (!hostile || !hostile->IsAlive())
+                    continue;
+
+                hostile->GetThreatMgr().AddThreat(rider, hostile->GetThreatMgr().GetThreat(victim, true), nullptr, true, true);
+            }
+        }
+    }
+
     if (!spiritOfRedemption)
     {
         LOG_DEBUG("entities.unit", "SET DeathState::JustDied");

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -507,7 +507,23 @@ void Vehicle::RemovePassenger(Unit* unit)
     seat->second.Passenger.Reset();
 
     if (_me->IsCreature() && unit->IsPlayer() && seat->second.SeatInfo->m_flags & VEHICLE_SEAT_FLAG_CAN_CONTROL)
+    {
+        if (!_me->GetCombatManager().IsInEvadeMode())
+        {
+            unit->GetCombatManager().InheritCombatStatesFrom(_me);
+
+            for (auto const& [guid, threatRef] : _me->GetThreatMgr().GetThreatenedByMeList())
+            {
+                Unit* hostile = threatRef->GetOwner();
+                if (!hostile || !hostile->IsAlive())
+                    continue;
+
+                hostile->GetThreatMgr().AddThreat(unit, hostile->GetThreatMgr().GetThreat(_me, true), nullptr, true, true);
+            }
+        }
+
         _me->RemoveCharmedBy(unit);
+    }
 
     if (_me->IsInWorld())
     {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Grand Necrolord Antiok is a vehicle accessory with a manual despawn set. SmartAI now despawns Grand Necrolord Antiok on evade.

An issue I noticed was that Antiok evades when the player exits the vehicle due to:
1. Player exists manually
2. Antiok kills the Vehicle

`InheritCombatStatesFrom` was added to fix these 2 scenario's. I'm sure that if a player exits, the creatures in combat with it shouldn't evade. I'm not so sure about the second scenario

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25824

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
3.
4.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
