### PR TITLE
fix(Scripts/Karazhan): fix Moroes guests not respawning on evade

### DIFF
--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_moroes.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_moroes.cpp
@@ -77,18 +77,6 @@ struct boss_moroes : public BossAI
         _activeGuests = 0;
     }
 
-    void InitializeAI() override
-    {
-        BossAI::InitializeAI();
-        InitializeGuests();
-    }
-
-    void JustReachedHome() override
-    {
-        BossAI::JustReachedHome();
-        InitializeGuests();
-    }
-
     void InitializeGuests()
     {
         if (!me->IsAlive())
@@ -96,16 +84,18 @@ struct boss_moroes : public BossAI
 
         if (_activeGuests == 0)
         {
-            _activeGuests |= 0x3F;
+            _activeGuests = 0x3F;
             uint8 rand1 = RAND(0x01, 0x02, 0x04);
             uint8 rand2 = RAND(0x08, 0x10, 0x20);
             _activeGuests &= ~(rand1 | rand2);
         }
-        for (uint8 i = 0; i < MAX_GUEST_COUNT; ++i)
+
+        uint8 positionIndex = 0;
+        for (uint8 i = 0; i < MAX_GUEST_COUNT && positionIndex < ACTIVE_GUEST_COUNT; ++i)
         {
             if ((1 << i) & _activeGuests)
             {
-                me->SummonCreature(GuestEntries[i], GuestsPosition[summons.size()], TEMPSUMMON_MANUAL_DESPAWN);
+                me->SummonCreature(GuestEntries[i], GuestsPosition[positionIndex++], TEMPSUMMON_MANUAL_DESPAWN);
             }
         }
 
@@ -129,6 +119,8 @@ struct boss_moroes : public BossAI
         DoCastSelf(SPELL_DUAL_WIELD, true);
         _recentlySpoken = false;
         _vanished = false;
+
+        InitializeGuests();
 
         ScheduleHealthCheckEvent(30, [&] {
             DoCastSelf(SPELL_FRENZY, true);
@@ -203,6 +195,9 @@ struct boss_moroes : public BossAI
             }
         }
 
+        if (guestList.empty())
+            return nullptr;
+
         return Acore::Containers::SelectRandomContainerElement(guestList);
     }
 
@@ -211,12 +206,12 @@ struct boss_moroes : public BossAI
         bool guestsInRoom = true;
         summons.DoForAllSummons([&guestsInRoom](WorldObject* summon)
         {
-            if ((summon->ToCreature()->GetPositionX()) < -11028.f || (summon->ToCreature()->GetPositionY()) < -1955.f) //boundaries of the two doors
+            Creature* creature = summon->ToCreature();
+            if (creature->IsAlive() &&
+                ((creature->GetPositionX() < -11028.f) || (creature->GetPositionY() < -1955.f))) // boundaries of the two doors
             {
                 guestsInRoom = false;
-                return false;
             }
-            return true;
         });
 
         return guestsInRoom;
@@ -229,10 +224,6 @@ struct boss_moroes : public BossAI
         if (!CheckGuestsInRoom())
         {
             EnterEvadeMode();
-            summons.DoForAllSummons([](WorldObject* summon)
-            {
-                summon->ToCreature()->DespawnOnEvade(5s);
-            });
             return;
         }
 


### PR DESCRIPTION
## Changes Proposed:
- [x] Scripts (bosses, spell scripts, creature scripts).

### Description

Moroes's guests (combat adds) would not respawn after a wipe/evade due to a fragile position-index calculation and unneeded dead code interfering with the reset path. This PR rewrites the add management logic to be correct and self-contained.

**Root cause — `GuestsPosition[summons.size()]` as spawn index:**
`InitializeGuests()` used the live summons list size as an index into `GuestsPosition[]` (4 entries). If the list was non-empty for any reason at call time, guests would be placed at wrong or out-of-bounds positions and silently fail to appear.

**Other issues fixed:**
- `DespawnOnEvade(5s)` block in `UpdateAI` was dead code — `EnterEvadeMode()` calls `Reset()` → `_Reset()` → `DespawnAll()` synchronously, emptying the summons list before `DoForAllSummons` ran
- `CheckGuestsInRoom()` checked dead guest corpses, which could trigger a false evade if a corpse happened to be near the room boundary; added `IsAlive()` guard
- `DoForAllSummons` lambda used `return false`/`return true` for early exit, but the signature is `void(WorldObject*)` — the values were silently discarded
- `GetRandomGuest()` called `SelectRandomContainerElement` on a potentially empty list (undefined behaviour); added empty-list guard
- `InitializeGuests()` is now called from `Reset()` so both initial spawn and post-evade respawn share a single code path

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Claude (Anthropic)** was used to assist with investigation and implementation of the fix.

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Moroes's guests are a core mechanic of the encounter — they should persist across evades within the same instance.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

Verified:
- Guests spawn correctly on first instance entry
- Guests respawn at table positions after Moroes evades
- Guest selection (4 of 6) remains consistent across evades within the same instance reset
- Kiting a guest out of the room correctly triggers Moroes to evade
- Dead guest corpses no longer trigger a false evade

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

1. Enter a fresh Karazhan instance and verify 4 guests are seated at Moroes's table
2. Pull Moroes — confirm all 4 guests engage
3. Wipe (or reset via GM command) — confirm Moroes evades and guests respawn at the table
4. Repeat step 2–3 multiple times, confirming the same 4 guests appear each time
5. Kite a living guest through one of the two door boundaries — confirm Moroes evades and guests respawn

## Known Issues and TODO List:

- [ ]

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.