### PR TITLE
fix(DB/Creature): remove stale Naxxanar teleporter quest condition

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1778893317000000000.sql
+++ b/data/sql/updates/pending_db_world/rev_1778893317000000000.sql
@@ -1,0 +1,2 @@
+--
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` = 9417 AND `SourceEntry` = 0 AND `SourceId` = 0 AND `ElseGroup` = 0 AND `ConditionTypeOrReference` = 9 AND `ConditionValue1` = 12019;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Codex was used to inspect the issue, prepare the SQL update, and run local checks. I reviewed the resulting one-line DB change before submission.

## Issues Addressed:
- Closes #21317

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

The linked issue includes video evidence for the expected top-of-Naxxanar teleporter behavior. The stale condition required quest 12019 to be in progress, but players complete that quest immediately before needing the top teleporter.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Local checks:
- `PYTHONIOENCODING=utf-8 python apps/codestyle/codestyle-sql.py data/sql/updates/pending_db_world/rev_1778893317000000000.sql`
- `git diff --check`

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Complete or progress through `Last Rites` until reaching the top of Naxxanar.
2. Use the top teleporter after the quest is no longer in progress.
3. Confirm the teleporter offers the gossip option and sends the player back down.

## Known Issues and TODO List:

- [x] Needs in-game confirmation on a live test realm.