### PR TITLE
fix(DB/Creature): credit Draconis Gastritis on proto-drake event

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1778893712000000000.sql
+++ b/data/sql/updates/pending_db_world/rev_1778893712000000000.sql
@@ -1,0 +1,6 @@
+--
+UPDATE `smart_scripts` SET `link` = 2 WHERE (`entryorguid` = 23689 AND `source_type` = 0 AND `id` = 1);
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 23689 AND `source_type` = 0 AND `id` = 2);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(23689, 0, 2, 4, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 33, 24170, 0, 0, 0, 0, 0, 18, 35, 0, 0, 0, 0, 0, 0, 0, 'Proto-Drake - On Follow Complete - Quest Credit \'Draconis Gastritis Bunny\'');


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Codex was used to inspect the existing SmartAI, prepare the SQL update, and run local checks. I reviewed the linked-action credit path before submission.

## Issues Addressed:
- Closes #13842

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

The linked issue describes the proto-drake reaching the plagued meat but failing to complete the quest. This keeps the existing bunny death credit path and adds direct credit to nearby observing players at the proto-drake follow-complete event.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Local checks:
- `PYTHONIOENCODING=utf-8 python apps/codestyle/codestyle-sql.py data/sql/updates/pending_db_world/rev_1778893712000000000.sql`
- `git diff --check`

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Accept quest `Draconis Gastritis` (11280).
2. Use Tillinghast's Plagued Meat near the proto-drakes.
3. Stay near the meat and wait for the proto-drake to reach it.
4. Confirm the quest objective is credited when the proto-drake reaches/eats the meat.

## Known Issues and TODO List:

- [x] Needs in-game confirmation on a live test realm.