### PR TITLE
fix(DB/Spell): restore warrior proc family masks

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1778894246000000000.sql
+++ b/data/sql/updates/pending_db_world/rev_1778894246000000000.sql
@@ -1,0 +1,4 @@
+--
+-- Restore Warrior family masks from the legacy spell_proc_event entries after the spell_proc migration.
+-- Includes Hamstring (0x0002), Rend (0x0020), and Sunder Armor (0x4000).
+UPDATE `spell_proc` SET `SpellFamilyName` = 4, `SpellFamilyMask0` = 0xAA604466, `SpellFamilyMask1` = 0x00400105, `SpellFamilyMask2` = 0 WHERE `SpellId` IN (-12281, -29723);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Codex was used to inspect the current `spell_proc` rows, compare them with the legacy `spell_proc_event` update, prepare the SQL update, and run local checks. I reviewed the mask values before submission.

## Issues Addressed:
- Closes #20250

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

The linked issue identifies Hamstring, Rend, and Sunder Armor as melee weapon abilities that should proc Sword Specialization/Sudden Death. The old `spell_proc_event` fix added those bits (`0x4022`), but the active `spell_proc` rows currently have empty family masks after the proc-table migration.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Local checks:
- `PYTHONIOENCODING=utf-8 python apps/codestyle/codestyle-sql.py data/sql/updates/pending_db_world/rev_1778894246000000000.sql`
- `git diff --check`

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a Warrior with Sword Specialization and a sword equipped.
2. Use Hamstring, Rend, and Sunder Armor against a target dummy or high-health target.
3. Confirm these abilities can trigger Sword Specialization extra attacks.
4. With Sudden Death talented, confirm Sunder Armor and Rend can also trigger Sudden Death as described in the issue.

## Known Issues and TODO List:

- [x] Needs in-game confirmation on a live test realm.