### PR TITLE
fix(DB/Quest): Reward bag contains 0 gems

### DIFF
--- a/data/sql/updates/pending_db_world/123451252.sql
+++ b/data/sql/updates/pending_db_world/123451252.sql
@@ -1,0 +1,8 @@
+DELETE FROM `item_loot_template` WHERE (`Entry` = 41888) AND (`Item` IN (41450, 41452, 41466, 41468, 41492, 41497));
+INSERT INTO `item_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(41888, 41450, 0, 16.9, 0, 1, 1, 1, 1, 'Small Velvet Bag - Perfect Balanced Shadow Crystal'),
+(41888, 41452, 0, 16.9, 0, 1, 1, 1, 1, 'Small Velvet Bag - Perfect Glowing Shadow Crystal'),
+(41888, 41466, 0, 17.7, 0, 1, 1, 1, 1, 'Small Velvet Bag - Perfect Forceful Dark Jade'),
+(41888, 41468, 0, 16.3, 0, 1, 1, 1, 1, 'Small Velvet Bag - Perfect Jagged Dark Jade'),
+(41888, 41492, 0, 13, 0, 1, 1, 1, 1, 'Small Velvet Bag - Perfect Inscribed Huge Citrine'),
+(41888, 41497, 0, 19.3, 0, 1, 1, 1, 1, 'Small Velvet Bag - Perfect Reckless Huge Citrine');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Problem: Player can get from 0 to 5 gems in random.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes: #25845

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Website: https://www.wowhead.com/wotlk/item=41888/small-velvet-bag#comments:id=891666:reply=133868

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .quest add 13004
2. .quest com 13004
3. .quest rew 13004
4. Get 1 unusual gem


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
