### PR TITLE
fix(Core/Player): preserve extra_flags when GM-state restore gate skips

### DIFF
--- a/src/server/game/Entities/Player/PlayerStorage.cpp
+++ b/src/server/game/Entities/Player/PlayerStorage.cpp
@@ -5400,6 +5400,11 @@ bool Player::LoadFromDB(ObjectGuid playerGuid, CharacterDatabaseQueryHolder cons
 
     uint32 extraflags = fields[36].Get<uint16>();
 
+    // Mirror before the gate below so saved bits survive when the gate
+    // skips effect application; otherwise the next SaveToDB writes 0
+    // over them.
+    m_ExtraFlags = extraflags;
+
     _LoadPetStable(fields[37].Get<uint8>(), holder.GetPreparedResult(PLAYER_LOGIN_QUERY_LOAD_PET_SLOTS));
 
     m_atLoginFlags = fields[38].Get<uint16>();


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Mirror the DB `extra_flags` field into `m_ExtraFlags` before the perm-39-gated restore block in `Player::LoadFromDB`. Previously, when the gate skipped (e.g. when the RBAC role chain failed to expand `RBAC_PERM_RESTORE_SAVED_GM_STATE` to a given account for any reason), `m_ExtraFlags` stayed at its `Player` constructor-init `0`, and the next `SaveToDB` wrote `0` over the saved bits, permanently losing the saved GM-invisible/chat/whispers/login state in `characters.extra_flags`.

The mirror only changes what is held in memory; the perm gate still controls whether the runtime effects (`SetGMVisible`, `SetGameMaster`, etc.) re-apply on load. The saved bits now round-trip safely regardless of the gate's outcome.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP.

## Issues Addressed:
- Progress #25793

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. As a GM-tier account with `GM.Visible = 2` (default), run `.gm vis off` in-game.
2. Log out cleanly.
3. Log back in. The GM should remain invisible to other players, with the visual aura applied. Before this PR, the bit could be silently lost on the next save if the RBAC perm-39 expansion failed for the account, and the saved state would never re-stick.
4. Optional DB check: `SELECT extra_flags FROM characters WHERE name = '<toon>';` should be `16` (0x10) before and after the relog.

For an account currently in the broken state (DB already has `extra_flags = 0` because of a prior failed load), the GM needs to run `.gm vis off` once after this lands; subsequent relogs will then preserve the bit.

The same code path also gates `.gm chat`, `.whispers`, and `.gm on` save-state restoration, so the fix covers those flags identically.

## Known Issues and TODO List:

- [ ] None.