### PR TITLE
fix(Core/Battlefield): fire OnBattlefieldPlayerLeaveZone before HasPlayer guard

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -129,10 +129,13 @@ void Battlefield::HandlePlayerLeaveZone(Player* player, uint32 /*zone*/)
     for (BfCapturePoint* cp : CapturePoints)
         cp->HandlePlayerLeave(player);
 
-    InvitedPlayers[player->GetTeamId()].erase(player->GetGUID());
-    PlayersInQueue[player->GetTeamId()].erase(player->GetGUID());
-    PlayersWillBeKick[player->GetTeamId()].erase(player->GetGUID());
-    Players[player->GetTeamId()].erase(player->GetGUID());
+    for (uint8 i = 0; i < PVP_TEAMS_COUNT; ++i)
+    {
+        InvitedPlayers[i].erase(player->GetGUID());
+        PlayersInQueue[i].erase(player->GetGUID());
+        PlayersWillBeKick[i].erase(player->GetGUID());
+        Players[i].erase(player->GetGUID());
+    }
     SendRemoveWorldStates(player);
     RemovePlayerFromResurrectQueue(player->GetGUID());
     OnPlayerLeaveZone(player);
@@ -375,7 +378,10 @@ void Battlefield::DoPlaySoundToAll(uint32 soundId)
 
 bool Battlefield::HasPlayer(Player* player) const
 {
-    return Players[player->GetTeamId()].find(player->GetGUID()) != Players[player->GetTeamId()].end();
+    for (uint8 i = 0; i < PVP_TEAMS_COUNT; ++i)
+        if (Players[i].count(player->GetGUID()))
+            return true;
+    return false;
 }
 
 // Called in WorldSession::HandleBfQueueInviteResponse

--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -136,10 +136,6 @@ void Battlefield::HandlePlayerLeaveZone(Player* player, uint32 /*zone*/)
     SendRemoveWorldStates(player);
     RemovePlayerFromResurrectQueue(player->GetGUID());
     OnPlayerLeaveZone(player);
-    // Scripts must restore player->GetTeamId() here (e.g. ClearFakePlayer).
-    // All Battlefield data-structure cleanup above has already completed using
-    // the assigned team, so it is safe to restore the real team now.
-    sScriptMgr->OnBattlefieldPlayerLeaveZone(this, player);
 }
 
 bool Battlefield::Update(uint32 diff)

--- a/src/server/game/Battlefield/BattlefieldMgr.cpp
+++ b/src/server/game/Battlefield/BattlefieldMgr.cpp
@@ -17,6 +17,7 @@
 
 #include "BattlefieldMgr.h"
 #include "Player.h"
+#include "ScriptMgr.h"
 #include "Zones/BattlefieldWG.h"
 
 BattlefieldMgr::BattlefieldMgr() : _updateTimer(0)
@@ -82,6 +83,8 @@ void BattlefieldMgr::HandlePlayerLeaveZone(Player* player, uint32 zoneId)
     auto itr = _battlefieldMap.find(zoneId);
     if (itr == _battlefieldMap.end())
         return;
+
+    sScriptMgr->OnBattlefieldPlayerLeaveZone(itr->second, player);
 
     // teleport: remove once in removefromworld, once in updatezone
     if (!itr->second->HasPlayer(player))

--- a/src/server/game/Battlefield/BattlefieldMgr.cpp
+++ b/src/server/game/Battlefield/BattlefieldMgr.cpp
@@ -84,11 +84,10 @@ void BattlefieldMgr::HandlePlayerLeaveZone(Player* player, uint32 zoneId)
     if (itr == _battlefieldMap.end())
         return;
 
-    sScriptMgr->OnBattlefieldPlayerLeaveZone(itr->second, player);
-
     // teleport: remove once in removefromworld, once in updatezone
     if (!itr->second->HasPlayer(player))
         return;
+    sScriptMgr->OnBattlefieldPlayerLeaveZone(itr->second, player);
     itr->second->HandlePlayerLeaveZone(player, zoneId);
     LOG_DEBUG("bg.battlefield", "Player {} left outdoorpvp id {}", player->GetGUID().ToString(), itr->second->GetTypeId());
 }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### Description

`OnBattlefieldPlayerLeaveZone` was called at the end of `Battlefield::HandlePlayerLeaveZone`, which is only reached when `BattlefieldMgr::HandlePlayerLeaveZone` passes its `HasPlayer()` check.

`HasPlayer()` checks `Players[player->GetTeamId()]`, but a script may legitimately change the player's effective team mid-session (e.g. a cross-faction module that calls `player->setTeamId()` to assign an enemy-faction team for Wintergrasp). When `GetTeamId()` no longer matches the bucket the player was inserted into at zone entry, `HasPlayer()` returns `false` and the entire leave-zone path — including the script hook — is silently skipped.

**Fix:**
- Move `sScriptMgr->OnBattlefieldPlayerLeaveZone` to `BattlefieldMgr::HandlePlayerLeaveZone`, after the `HasPlayer` guard, so the dedup protection against double-calls during teleport is preserved.
- Fix `HasPlayer` to check all team buckets so cross-faction players are not silently skipped.
- Erase from all team buckets on leave so stale entries do not cause a second call to slip through `HasPlayer` on logout.

### How to test

With a module that hooks `OnBattlefieldPlayerLeaveZone` and changes `player->GetTeamId()` during `OnBattlefieldPlayerJoinWar` (e.g. mod-cfbg): enter Wintergrasp, accept the war on a cross-faction assignment, then leave. The hook should now fire reliably without double-firing for normal players.

---
*This PR was created with AI assistance (Claude Sonnet 4.6).*