### PR TITLE
feat(Core/Battlefield): Add OnBattlefieldPlayerKill script hook

### DIFF
--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -21,6 +21,7 @@
 
 #include "AreaDefines.h"
 #include "BattlefieldWG.h"
+#include "ScriptMgr.h"
 #include "Chat.h"
 #include "GameTime.h"
 #include "MapMgr.h"
@@ -722,16 +723,21 @@ void BattlefieldWG::HandleKill(Player* killer, Unit* victim)
     // xinef: tower cannons also grant rank
     if (victim->IsPlayer() || IsKeepNpc(victim->GetEntry()) || victim->GetEntry() == NPC_WINTERGRASP_TOWER_CANNON)
     {
-        if (victim->IsPlayer() && victim->HasAura(SPELL_LIEUTENANT))
+        if (Player* victimPlayer = victim->ToPlayer())
         {
-            // Quest - Wintergrasp - PvP Kill - Horde/Alliance
-            for (ObjectGuid const& playerGuid : PlayersInWar[killerTeam])
+            sScriptMgr->OnBattlefieldPlayerKill(this, killer, victimPlayer);
+
+            if (victimPlayer->HasAura(SPELL_LIEUTENANT))
             {
-                if (Player* player = ObjectAccessor::FindPlayer(playerGuid))
+                // Quest - Wintergrasp - PvP Kill - Horde/Alliance
+                for (ObjectGuid const& playerGuid : PlayersInWar[killerTeam])
                 {
-                    if (player->GetDistance2d(killer) < 40)
+                    if (Player* player = ObjectAccessor::FindPlayer(playerGuid))
                     {
-                        player->KilledMonsterCredit(killerTeam == TEAM_HORDE ? NPC_QUEST_PVP_KILL_ALLIANCE : NPC_QUEST_PVP_KILL_HORDE);
+                        if (player->GetDistance2d(killer) < 40)
+                        {
+                            player->KilledMonsterCredit(killerTeam == TEAM_HORDE ? NPC_QUEST_PVP_KILL_ALLIANCE : NPC_QUEST_PVP_KILL_HORDE);
+                        }
                     }
                 }
             }

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -735,9 +735,7 @@ void BattlefieldWG::HandleKill(Player* killer, Unit* victim)
                     if (Player* player = ObjectAccessor::FindPlayer(playerGuid))
                     {
                         if (player->GetDistance2d(killer) < 40)
-                        {
                             player->KilledMonsterCredit(killerTeam == TEAM_HORDE ? NPC_QUEST_PVP_KILL_ALLIANCE : NPC_QUEST_PVP_KILL_HORDE);
-                        }
                     }
                 }
             }

--- a/src/server/game/Scripting/ScriptDefines/BattlefieldScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/BattlefieldScript.cpp
@@ -49,6 +49,11 @@ void ScriptMgr::OnBattlefieldWarEnd(Battlefield* bf, bool endByTimer)
     CALL_ENABLED_HOOKS(BattlefieldScript, BATTLEFIELDHOOK_ON_WAR_END, script->OnBattlefieldWarEnd(bf, endByTimer));
 }
 
+void ScriptMgr::OnBattlefieldPlayerKill(Battlefield* bf, Player* killer, Player* victim)
+{
+    CALL_ENABLED_HOOKS(BattlefieldScript, BATTLEFIELDHOOK_ON_PLAYER_KILL, script->OnBattlefieldPlayerKill(bf, killer, victim));
+}
+
 BattlefieldScript::BattlefieldScript(char const* name, std::vector<uint16> enabledHooks) :
     ScriptObject(name, BATTLEFIELDHOOK_END)
 {

--- a/src/server/game/Scripting/ScriptDefines/BattlefieldScript.h
+++ b/src/server/game/Scripting/ScriptDefines/BattlefieldScript.h
@@ -35,7 +35,6 @@ enum BattlefieldHook
 
 class Battlefield;
 class Player;
-class Unit;
 
 class BattlefieldScript : public ScriptObject
 {

--- a/src/server/game/Scripting/ScriptDefines/BattlefieldScript.h
+++ b/src/server/game/Scripting/ScriptDefines/BattlefieldScript.h
@@ -29,11 +29,13 @@ enum BattlefieldHook
     BATTLEFIELDHOOK_ON_PLAYER_LEAVE_WAR,           // 3 - fires after player is removed from the active war
     BATTLEFIELDHOOK_BEFORE_INVITE_PLAYER_TO_WAR,   // 4 - fires in InvitePlayerToWar before InvitedPlayers insert
     BATTLEFIELDHOOK_ON_WAR_END,                    // 5 - fires in EndBattle after OnBattleEnd(), before timer reset
+    BATTLEFIELDHOOK_ON_PLAYER_KILL,                // 6 - fires in HandleKill for every player-kills-player event
     BATTLEFIELDHOOK_END
 };
 
 class Battlefield;
 class Player;
+class Unit;
 
 class BattlefieldScript : public ScriptObject
 {
@@ -99,6 +101,17 @@ public:
      * @param endByTimer True if the war ended by the countdown timer expiring
      */
     virtual void OnBattlefieldWarEnd(Battlefield* /*bf*/, bool /*endByTimer*/) { }
+
+    /**
+     * @brief Called inside BattlefieldWG::HandleKill for every player-kills-player event,
+     * regardless of the victim's WG rank. Fired before the core's own lieutenant-gated
+     * quest-credit loop so modules may grant credit for non-lieutenant kills.
+     *
+     * @param bf     The Battlefield instance
+     * @param killer The player who landed the killing blow
+     * @param victim The player who was killed
+     */
+    virtual void OnBattlefieldPlayerKill(Battlefield* /*bf*/, Player* /*killer*/, Player* /*victim*/) { }
 };
 
 #endif // SCRIPT_OBJECT_BATTLEFIELD_SCRIPT_H_

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -588,6 +588,7 @@ public: /* BattlefieldScript */
     void OnBattlefieldPlayerLeaveWar(Battlefield* bf, Player* player);
     void OnBattlefieldBeforeInvitePlayerToWar(Battlefield* bf, Player* player);
     void OnBattlefieldWarEnd(Battlefield* bf, bool endByTimer);
+    void OnBattlefieldPlayerKill(Battlefield* bf, Player* killer, Player* victim);
 
 public: /* BGScript */
     void OnBattlegroundStart(Battleground* bg);


### PR DESCRIPTION
## Changes Proposed:

Adds a new `OnBattlefieldPlayerKill(Battlefield*, Player* killer, Player* victim)` hook to `BattlefieldScript`, dispatched from `BattlefieldWG::HandleKill` for every player-kills-player event regardless of the victim's WG rank.

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### Motivation

The existing quest-credit path in `BattlefieldWG::HandleKill` is gated behind `victim->HasAura(SPELL_LIEUTENANT)`, meaning only players who have accumulated 10+ kills in the current WG session can yield quest credit. Modules that need credit on every kill (e.g. crossfaction WG) had no hook to intercept this. The new hook fires before the lieutenant-gated loop, providing modules a clean override point.

### Implementation notes

- `BATTLEFIELDHOOK_ON_PLAYER_KILL` (index 6) added to `BattlefieldHook` enum.
- `ScriptMgr::OnBattlefieldPlayerKill` dispatched via `CALL_ENABLED_HOOKS`.
- The two redundant consecutive `victim->IsPlayer()` checks in `HandleKill` are collapsed into a single `if (Player* victimPlayer = victim->ToPlayer())` block, with the new hook and the existing lieutenant branch both living inside it.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Sonnet 4.6 was used to implement this change.

## Issues Addressed:

- Closes N/A (dependency for mod-cfbg fix)

## SOURCE:

The changes have been validated through:
- [ ] Live research
- [ ] Sniffs
- [ ] Video evidence, knowledge databases or other public sources
- [ ] Cherry-pick

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing.

1. Apply the companion mod-cfbg PR that implements `OnBattlefieldPlayerKill`.
2. Enter Wintergrasp during an active war.
3. Kill an opposing player who does **not** have `SPELL_LIEUTENANT` (i.e. fewer than 10 WG kills this session).
4. Verify the mod-cfbg hook fires and grants quest credit.
5. Kill an opposing player who **does** have `SPELL_LIEUTENANT` and verify credit is granted exactly once (no double-credit).

## Known Issues and TODO List:

- [ ] Hook is currently only fired from `BattlefieldWG::HandleKill`; other Battlefield types would need to call it separately if they implement `HandleKill`.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).