### PR TITLE
docs(Core/Maps): Clarify map update threads

### DIFF
--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -1379,6 +1379,8 @@ MapUpdateInterval = 10
 #
 #    MapUpdate.Threads
 #        Description: Number of threads to update maps.
+#                     This schedules separate map update jobs in parallel; it does
+#                     not partition a single non-instanced continent map update.
 #        Default:     1
 
 MapUpdate.Threads = 1


### PR DESCRIPTION
## Changes Proposed

This PR clarifies the `MapUpdate.Threads` description in `worldserver.conf.dist`.

The setting schedules separate map update jobs in parallel, but it does not partition a single non-instanced continent map update. This is relevant to the map partitioning discussion because the current config name can otherwise be mistaken for solving the continent bottleneck described in #22571.

This PR promotes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).
- [x] Documentation / configuration comments.

### AI-assisted Pull Requests

- [x] AI tools were used partially in preparing this pull request. Model used: OpenAI GPT-5 Codex.

## Issues Addressed

Related to #22571.

## Tests Performed

- [x] `git diff --check HEAD~1..HEAD`

No runtime test was run because this is a comment-only configuration documentation change.