### PR TITLE
feat(Core): add OnPlayerQuestAccept hook to PlayerScript

### DIFF
--- a/src/server/game/Entities/Player/PlayerQuest.cpp
+++ b/src/server/game/Entities/Player/PlayerQuest.cpp
@@ -422,6 +422,7 @@ bool Player::CanRewardQuest(Quest const* quest, bool msg)
 void Player::AddQuestAndCheckCompletion(Quest const* quest, Object* questGiver)
 {
     AddQuest(quest, questGiver);
+    sScriptMgr->OnPlayerQuestAccept(this, quest);
 
     if (CanCompleteQuest(quest->GetQuestId()))
         CompleteQuest(quest->GetQuestId());

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -852,6 +852,11 @@ void ScriptMgr::OnPlayerQuestAbandon(Player* player, uint32 questId)
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_QUEST_ABANDON, script->OnPlayerQuestAbandon(player, questId));
 }
 
+void ScriptMgr::OnPlayerQuestAccept(Player* player, Quest const* quest)
+{
+    CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_PLAYER_QUEST_ACCEPT, script->OnPlayerQuestAccept(player, quest));
+}
+
 // Player anti cheat
 void ScriptMgr::AnticheatSetCanFlybyServer(Player* player, bool apply)
 {

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.h
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.h
@@ -190,6 +190,7 @@ enum PlayerHook
     PLAYERHOOK_ON_PLAYER_ENTER_COMBAT,
     PLAYERHOOK_ON_PLAYER_LEAVE_COMBAT,
     PLAYERHOOK_ON_QUEST_ABANDON,
+    PLAYERHOOK_ON_PLAYER_QUEST_ACCEPT,
     PLAYERHOOK_ON_GET_QUEST_RATE,
     PLAYERHOOK_ON_CAN_PLAYER_FLY_IN_ZONE,
     PLAYERHOOK_ANTICHEAT_SET_CAN_FLY_BY_SERVER,
@@ -729,6 +730,14 @@ public:
      * @param questId Contains information about the quest id
      */
     virtual void OnPlayerQuestAbandon(Player* /*player*/, uint32 /*questId*/) { }
+
+    /**
+     * @brief This hook called after a player accepts a quest, regardless of quest giver type
+     *
+     * @param player Contains information about the Player
+     * @param quest Contains information about the Quest
+     */
+    virtual void OnPlayerQuestAccept(Player* /*player*/, Quest const* /*quest*/) { }
 
     /**
      * @brief This hook called before other CanFlyChecks are applied

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -454,6 +454,7 @@ public: /* PlayerScript */
     void OnPlayerEnterCombat(Player* player, Unit* enemy);
     void OnPlayerLeaveCombat(Player* player);
     void OnPlayerQuestAbandon(Player* player, uint32 questId);
+    void OnPlayerQuestAccept(Player* player, Quest const* quest);
     bool OnPlayerCanSendErrorAlreadyLooted(Player* player);
     void OnPlayerAfterCreatureLoot(Player* player);
     void OnPlayerAfterCreatureLootMoney(Player* player);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

This PR adds an `OnPlayerQuestAccept(Player*, Quest const*)` hook to `PlayerScript`, fired once in `Player::AddQuestAndCheckCompletion` immediately after `AddQuest` — covering all quest giver types (creature, game object, item) with a single player-centric callback.

-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

> Claude Sonnet 4.6 (claude.ai/code) was used to assist with code generation. The implementation was reviewed and validated by the author.

## Issues Addressed:

- Closes

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

1. Build the core with this PR applied.
2. Create a module that overrides `PlayerScript::OnPlayerQuestAccept`.
3. Accept a quest from a creature, a game object, and an item-start quest.
4. Verify the hook fires exactly once per accept for all three giver types.
5. Confirm existing `AllCreatureScript::CanCreatureQuestAccept`, `AllGameObjectScript::CanGameObjectQuestAccept`, and `AllItemScript::CanItemQuestAccept` hooks continue to fire normally (no regression).

## Known Issues and TODO List:

- [ ]

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.