### PR TITLE
fix(DB/Commands): Help text for 7 missing commands

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1779026647185880331.sql
+++ b/data/sql/updates/pending_db_world/rev_1779026647185880331.sql
@@ -1,6 +1,4 @@
-DELETE FROM `command` WHERE `name` IN
-('debug combat','debug threatinfo','pdump copy','pet delete','pet list','rbac list','reload rbac');
-
+DELETE FROM `command` WHERE `name` IN ('debug combat','debug threatinfo','pdump copy','pet delete','pet list','rbac list','reload rbac');
 INSERT INTO `command` (`name`,`security`,`help`) VALUES
 ('debug combat',3,'Syntax: .debug combat\nLists PvP and PvE combat references of the selected unit (or self).'),
 ('debug threatinfo',3,'Syntax: .debug threatinfo\nDisplays various debug information about the target''s threat state, modifiers, redirects and similar.'),

--- a/data/sql/updates/pending_db_world/rev_1779026647185880331.sql
+++ b/data/sql/updates/pending_db_world/rev_1779026647185880331.sql
@@ -1,0 +1,11 @@
+DELETE FROM `command` WHERE `name` IN
+('debug combat','debug threatinfo','pdump copy','pet delete','pet list','rbac list','reload rbac');
+
+INSERT INTO `command` (`name`,`security`,`help`) VALUES
+('debug combat',3,'Syntax: .debug combat\nLists PvP and PvE combat references of the selected unit (or self).'),
+('debug threatinfo',3,'Syntax: .debug threatinfo\nDisplays various debug information about the target''s threat state, modifiers, redirects and similar.'),
+('pdump copy',3,'Syntax: .pdump copy $playerNameOrGUID $account [$newname] [$newguid]\nCopy character with name/guid $playerNameOrGUID into character list of $account with $newname, with first free or $newguid guid.'),
+('pet delete',3,'Syntax: .pet delete $playerNameOrGUID #petNumber\nDeletes the pet with the given pet number belonging to the specified player.'),
+('pet list',1,'Syntax: .pet list $playerNameOrGUID\nLists all pets owned by the specified player (id, entry, level, slot, name, type).'),
+('rbac list',3,'Syntax: .rbac list [#id]\nView list of all permissions. If #id is given will show only info for that permission.'),
+('reload rbac',3,'Syntax: .reload rbac\nReload rbac system.');


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Adds `command` rows for 7 commands that have no DB entry, silencing the `Table \`command\` is missing help text for command '...'` warnings: `debug combat`, `debug threatinfo`, `pdump copy`, `pet delete`, `pet list`, `rbac list`, `reload rbac`.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Apply the pending world DB update, restart or `.reload command`.
2. Confirm no `Table \`command\` is missing help text...` warnings for these 7 commands.
3. Run `.help <each command>` and verify the help text renders.

## Known Issues and TODO List:
- [ ]
- [ ]