### PR TITLE
fix(DB/Spell): Reckoning extra attack on miss/dodge/parry

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1778947663933117644.sql
+++ b/data/sql/updates/pending_db_world/rev_1778947663933117644.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_proc` WHERE `SpellId` = 20178;
+INSERT INTO `spell_proc` (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `DisableEffectsMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`) VALUES
+(20178, 0, 0, 0, 0, 0, 0x4, 0, 0, 0x2477, 0, 0, 0, 100, 0, 4);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Paladin's Reckoning talent only generated the extra attack on damaging swings. The buff aura (spell 20178) has no `spell_proc` row, so `SpellMgr::CanSpellTriggerProcOnEvent` falls back to the default HitMask (`NORMAL | CRITICAL | ABSORB`) and drops miss/dodge/parry/block/full block.

Add a `spell_proc` entry for 20178 with `ProcFlags = PROC_FLAG_DONE_MELEE_AUTO_ATTACK`, `Charges = 4`, `Chance = 100`, and `HitMask = 0x2477` (NORMAL | CRITICAL | MISS | DODGE | PARRY | BLOCK | ABSORB | FULL_BLOCK).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP.

## Issues Addressed:
- Closes #25833

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Verified live by adding a temporary `LOG_INFO` in `HandleProcTriggerSpellAuraProc` filtered to spell 20178. Apply DB row, `.aura 20178`, attack a higher-level humanoid as a low-level char: log lines printed for `hitMask` values `0x1` (normal), `0x2` (crit), `0x20` (parry), `0x41` (normal + partial block). Without the row, miss/dodge/parry produced no log line.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Paladin with Reckoning talent specced (or use `.aura 20178` for 4 stacks, 8s).
2. Attack a target that produces non-damaging swings: a much higher-level humanoid for misses, face the target for parries, attack from the side/behind for dodges.
3. Confirm each swing — hit, crit, miss, dodge, parry, full block, absorb — generates the extra Reckoning swing and consumes 1 charge.

## Known Issues and TODO List:
- [ ]
- [ ]