### PR TITLE
fix(Core/Spells): Stop JoL/JoW from procing caster's heal trinkets

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -562,11 +562,15 @@ void SpellMgr::LoadSpellInfoCorrections()
         20184,  // Judgement of Justice
         20185,  // Judgement of Light
         20186,  // Judgement of Wisdom
+        20267,  // Judgement of Light (triggered heal on attacker)
+        20268,  // Judgement of Wisdom (triggered mana on attacker)
         68055   // Judgements of the Just
         }, [](SpellInfo* spellInfo)
     {
         // hack for seal of light and few spells, judgement consists of few single casts and each of them can proc
         // some spell, base one has disabled proc flag but those dont have this flag
+        // 20267/20268 are passive proc effects from the judgement debuff; they must not cause the paladin's
+        // on-heal/on-cast procs (e.g. Soul Preserver, which has CAN_PROC_FROM_PROCS) to fire
         spellInfo->AttributesEx3 |= SPELL_ATTR3_SUPPRESS_CASTER_PROCS;
     });
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Judgement of Light's passive heal-on-attacker (spell 20267) and Judgement of Wisdom's passive mana-on-attacker (spell 20268) are cast as triggered spells with the paladin as `originalCaster`. Because the original caster is the paladin, the cast runs through `Unit::ProcSkillsAndAuras` on the paladin's side, exposing the paladin's auras to a proc opportunity per attacker hit.

Triggered spells are normally filtered out of proc handling, but auras flagged `SPELL_ATTR3_CAN_PROC_FROM_PROCS` bypass that guard. Soul Preserver (60510) is one such aura — its `AttributesEx3` includes `0x04000000`. Result: every time *any* attacker (including teammates) gets healed/manaed by the judgement debuff, the paladin's Soul Preserver (and similar `CAN_PROC_FROM_PROCS` heal/cast trinkets) ticks.

The fix adds `SPELL_ATTR3_SUPPRESS_CASTER_PROCS` to 20267 and 20268, which gates `canEffectTrigger` in `Spell::DoAllEffectOnTarget` and skips proc handling for these passive carrier casts entirely. This matches the existing treatment of the judgement debuff auras (20184/20185/20186/68055) in the same correction block in `SpellInfoCorrections.cpp`.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Soul Preserver and similar healer trinkets are widely documented to proc only on actively cast heal spells, not on passive proc effects like Judgement of Light. The existing correction for 20184/20185/20186/68055 in this same block uses the same mechanism for the parent judgement casts.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. As a paladin: `.additem 37111` (Soul Preserver trinket) and equip it.
2. Cast Seal of Light, then Judgement on a target dummy (or any combat target).
3. Auto-attack the target — or, better, have a second player attack the target — until you see Judgement of Light's heal floaters on the attacker.
4. Watch the paladin's buff bar.
   - **Before fix:** "Healing Trance" (60513) appears repeatedly as JoL ticks heals on attackers.
   - **After fix:** "Healing Trance" does not appear from this scenario.
5. Sanity check the trinket still procs from real heals: `.cheat cooldown` + `.cheat power`, then spam Flash of Light / Holy Light — "Healing Trance" should still proc occasionally (~2% chance per heal).
6. Verify Judgement of Light still heals attackers normally and Judgement of Wisdom still restores mana — only the *paladin's* on-cast/on-heal procs from these passive effects are suppressed.

## Known Issues and TODO List:

- [ ] None known.