### PR TITLE
fix(Scripts/HoR): drop player combat with Arthas on chase end

### DIFF
--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/instance_halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/instance_halls_of_reflection.cpp
@@ -382,7 +382,11 @@ public:
                     if (Creature* leader = GetCreature(NPC_SYLVANAS_PART2))
                         leader->setActive(false);
                     if (Creature* lichKing = GetCreature(NPC_LICH_KING_BOSS))
+                    {
+                        lichKing->GetThreatMgr().ClearAllThreat();
+                        lichKing->CombatStop(true);
                         lichKing->setActive(false);
+                    }
                     _isLichKingFightActive = false;
                     _outroStep = 1;
                     _outroTimer = 0;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

When the Lich King escape in Halls of Reflection concludes (`DATA_LICH_KING = DONE`), any player who attacked Arthas during the chase remained stuck in combat through the ~18 second gunship outro, because `CombatStop` was only called at outro step 5 (`instance_halls_of_reflection.cpp:1022`). Players couldn't mount, drink, or interact with the leader's gossip until the very end of the cinematic.

The fix mirrors the existing cleanup pattern from the `ACTION_STOP_LK_FIGHT` (FAIL) branch: clear threat and call `CombatStop(true)` on Arthas immediately when `SetBossState(DATA_LICH_KING, DONE)` fires. Combat refs drop the same tick Arthas yells *"Nowhere to run!"*. The outro animation reuses the same Arthas creature for `SPELL_HARVEST_SOUL`, emote states, and the gunship cannon-fire reaction, so despawning (the TrinityCore approach) isn't viable here.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore handles the same problem by despawning chase Arthas on `DATA_THE_LICH_KING_ESCAPE = DONE` in their `instance_halls_of_reflection.cpp`, which implicitly clears combat refs. AC keeps the creature alive for outro animations, so we clear combat explicitly instead. Original TC authors (MitchesD, joschiwald — commit `8e7cf15`) credited as Co-Authored-By.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Halls of Reflection (map 668) on a level 80 character, complete (or skip via GM) Falric, Marwyn, and the Frostsworn General.
2. Walk into the Shadow Throne areatrigger to fire the LK intro cinematic, then gossip Sylvanas/Jaina to start the chase.
3. Attack Arthas during the chase (damage is clamped to HP - 1).
4. Stay near the leader so all 4 ice walls are broken.
5. When Arthas yells *"Nowhere to run!"*, observe the in-combat icon. Before this PR: it stays lit for ~18 seconds. After this PR: it drops immediately.

Regressions:
- Clean escape (don't touch Arthas) — outro plays identically.
- Failed escape (let leader die) — `ACTION_STOP_LK_FIGHT` path resets Arthas correctly.

## Known Issues and TODO List:

- [ ]
- [ ]