### PR TITLE
fix(DB/Creature): Add Baron Longshore missing spawnpoints and pool.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1779058242.sql
+++ b/data/sql/updates/pending_db_world/rev_1779058242.sql
@@ -1,0 +1,27 @@
+
+-- Update 15066 spawntime (it must be instant), add two new spawn points and set random in radius.
+DELETE FROM `creature` WHERE (`id1` = 3467); 
+INSERT INTO `creature` (`guid`, `id1`, `id2`, `id3`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
+(15066, 3467, 0, 0, 1, 0, 0, 1, 1, 1, -1571.79, -3884.28, 16.2173, 3.83286, 1, 5, 0, 356, 0, 1, 0, 0, 0, '67511', 0, 0, NULL),
+(15215, 3467, 0, 0, 1, 0, 0, 1, 1, 1, -1748.25, -3721.78, 16.2173, 14.1181, 1, 5, 0, 356, 0, 1, 0, 0, 0, '67511', 0, 0, NULL),
+(15217, 3467, 0, 0, 1, 0, 0, 1, 1, 1, -1706.97, -3818.9, 13.1778, 4.88414, 1, 5, 0, 356, 0, 1, 0, 0, 0, '67511', 0, 0, NULL);
+
+-- Delete Baron Longshore Creature Addon
+DELETE FROM `creature_addon` WHERE (`guid` IN (15066));
+
+-- Set Baron Longshore template addon.
+DELETE FROM `creature_template_addon` WHERE (`entry` = 3467);
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(3467, 0, 0, 0, 1, 0, 0, '');
+
+-- Set Baron Longshore Pool Template
+DELETE FROM `pool_template` WHERE (`entry` IN (144));
+INSERT INTO `pool_template` (`entry`, `max_limit`, `description`) VALUES 
+(144, 1, 'Baron Longshore');
+
+-- Link Baron Longshore Spawn Points to Pool Entry.
+DELETE FROM `pool_creature` WHERE (`guid` IN (15066, 15215, 15217));
+INSERT INTO `pool_creature` (`guid`, `pool_entry`, `chance`, `description`) VALUES 
+(15066, 144, 0, 'Baron Longshore 1'),
+(15215, 144, 0, 'Baron Longshore 2'),
+(15217, 144, 0, 'Baron Longshore 3');

--- a/data/sql/updates/pending_db_world/rev_1779058242.sql
+++ b/data/sql/updates/pending_db_world/rev_1779058242.sql
@@ -1,6 +1,6 @@
 
 -- Update 15066 spawntime (it must be instant), add two new spawn points and set random in radius.
-DELETE FROM `creature` WHERE (`id1` = 3467); 
+DELETE FROM `creature` WHERE (`id1` = 3467);
 INSERT INTO `creature` (`guid`, `id1`, `id2`, `id3`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`, `CreateObject`, `Comment`) VALUES
 (15066, 3467, 0, 0, 1, 0, 0, 1, 1, 1, -1571.79, -3884.28, 16.2173, 3.83286, 1, 5, 0, 356, 0, 1, 0, 0, 0, '67511', 0, 0, NULL),
 (15215, 3467, 0, 0, 1, 0, 0, 1, 1, 1, -1748.25, -3721.78, 16.2173, 14.1181, 1, 5, 0, 356, 0, 1, 0, 0, 0, '67511', 0, 0, NULL),
@@ -16,12 +16,12 @@ INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `b
 
 -- Set Baron Longshore Pool Template
 DELETE FROM `pool_template` WHERE (`entry` IN (144));
-INSERT INTO `pool_template` (`entry`, `max_limit`, `description`) VALUES 
+INSERT INTO `pool_template` (`entry`, `max_limit`, `description`) VALUES
 (144, 1, 'Baron Longshore');
 
 -- Link Baron Longshore Spawn Points to Pool Entry.
 DELETE FROM `pool_creature` WHERE (`guid` IN (15066, 15215, 15217));
-INSERT INTO `pool_creature` (`guid`, `pool_entry`, `chance`, `description`) VALUES 
+INSERT INTO `pool_creature` (`guid`, `pool_entry`, `chance`, `description`) VALUES
 (15066, 144, 0, 'Baron Longshore 1'),
 (15215, 144, 0, 'Baron Longshore 2'),
 (15217, 144, 0, 'Baron Longshore 3');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/13585

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [X] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
