### PR TITLE
fix(Scripts/CoS): prevent Arthas from spamming Exorcism

### DIFF
--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
@@ -1190,7 +1190,7 @@ public:
                     if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                         me->CastSpell(target, SPELL_ARTHAS_EXORCISM, false);
 
-                    combatEvents.Repeat(7300ms);
+                    combatEvents.Repeat(7s, 14s);
                     break;
                 case EVENT_COMBAT_HEALTH_CHECK:
                     if (HealthBelowPct(40))
@@ -1247,8 +1247,8 @@ void npc_arthas::npc_arthasAI::JustEngagedWith(Unit* /*who*/)
     DoCast(me, SPELL_ARTHAS_AURA);
 
     // Fight
-    combatEvents.ScheduleEvent(EVENT_COMBAT_EXORCISM, 2s);
-    combatEvents.ScheduleEvent(EVENT_COMBAT_HEALTH_CHECK, 2s);
+    combatEvents.RescheduleEvent(EVENT_COMBAT_EXORCISM, 7s, 14s);
+    combatEvents.RescheduleEvent(EVENT_COMBAT_HEALTH_CHECK, 2s);
 }
 
 void npc_arthas::npc_arthasAI::ReorderInstance(uint32 data)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`JustEngagedWith` in the Arthas NPC script was using `ScheduleEvent` for `EVENT_COMBAT_EXORCISM`, which uses `emplace` on a multimap — it stacks duplicate entries. Because `JustEngagedWith` fires once per enemy Arthas enters combat with, pulling a full wave would schedule 5–10 independent Exorcism events, all firing in rapid succession. Additionally, the initial delay was 2s and the repeat interval was a fixed 7300ms, both more aggressive than the reference implementation.

Fixes:
- `ScheduleEvent` → `RescheduleEvent` in `JustEngagedWith` to prevent event stacking across multi-enemy pulls
- Initial delay changed from `2s` to `7s–14s` random, matching TrinityCore reference
- Repeat interval changed from fixed `7300ms` to `7s–14s` random, matching TrinityCore reference

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Sonnet 4.6 (Claude Code) was used to assist with root cause analysis and identifying the fix. The TrinityCore reference script was reviewed and verified manually.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9493

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore reference: `npc_arthas.cpp` uses `urandms(7, 14)` (7–14 seconds) for both initial delay and repeat interval, and uses a single manual cooldown variable that cannot stack.

Video evidence of the bug: https://github.com/chromiecraft/chromiecraft/issues/9493

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Enter Culling of Stratholme with Arthas as escort.
2. Pull a wave of enemies so Arthas enters combat with multiple targets simultaneously.
3. Observe that Arthas no longer spams Exorcism in rapid succession and instead casts it at 7–14 second intervals.

## Known Issues and TODO List:

- [ ]
- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.