### PR TITLE
fix(Core/Chat): fix crash when using GetModuleString() from console

### DIFF
--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -895,6 +895,11 @@ std::string CliHandler::GetAcoreString(uint32 entry) const
     return sObjectMgr->GetAcoreStringForDBCLocale(entry);
 }
 
+std::string const* CliHandler::GetModuleString(std::string module, uint32 id) const
+{
+    return sObjectMgr->GetModuleString(module, id, LocaleConstant(sObjectMgr->GetDBCLocaleIndex()));
+}
+
 void CliHandler::SendSysMessage(std::string_view str, bool /*escapeCharacters*/)
 {
     m_print(m_callbackArg, str);

--- a/src/server/game/Chat/Chat.h
+++ b/src/server/game/Chat/Chat.h
@@ -156,7 +156,7 @@ public:
         return Acore::StringFormat(GetAcoreString(entry), std::forward<Args>(args)...);
     }
 
-    std::string const* GetModuleString(std::string module, uint32 id) const;
+    virtual std::string const* GetModuleString(std::string module, uint32 id) const;
 
     template<typename... Args>
     void PSendModuleSysMessage(std::string module, uint32 id, Args&&... args)
@@ -260,6 +260,7 @@ public:
 
     // overwrite functions
     std::string GetAcoreString(uint32 entry) const override;
+    std::string const* GetModuleString(std::string module, uint32 id) const override;
     void SendSysMessage(std::string_view, bool escapeCharacters) override;
     bool ParseCommands(std::string_view str) override;
     std::string GetNameLink() const override;


### PR DESCRIPTION
## Changes Proposed:
- [x] Core (units, players, creatures, game systems).

`CliHandler::GetModuleString` was missing, causing `PSendModuleSysMessage` to crash with a null pointer dereference whenever any chat command called it from the worldserver console (CLI).

**Root cause:** `ChatHandler::GetModuleString` called `m_session->GetModuleString()` unconditionally. `CliHandler` has no session (`m_session` is `nullptr`), but its `HasSession()` override returns `true` to allow console output — masking the null pointer until the dereference.

**Fix:** Mirrors the existing `GetAcoreString` pattern exactly:
- `GetModuleString` is made `virtual` in `ChatHandler`
- `CliHandler::GetModuleString` is added as an override, resolving the string directly via `sObjectMgr` using the DBC locale index — no session needed

This is consistent with how `CliHandler::GetAcoreString` already bypasses the session:

```cpp
// Existing pattern (GetAcoreString):
std::string CliHandler::GetAcoreString(uint32 entry) const
{
    return sObjectMgr->GetAcoreStringForDBCLocale(entry);
}

// New (GetModuleString, same pattern):
std::string const* CliHandler::GetModuleString(std::string module, uint32 id) const
{
    return sObjectMgr->GetModuleString(module, id, LocaleConstant(sObjectMgr->GetDBCLocaleIndex()));
}
```

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Sonnet 4.6 (Claude Code) was used to diagnose the crash and draft the fix.

## Issues Addressed:
- Closes N/A — discovered while developing a module that uses `PSendModuleSysMessage` from a command handler.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Code analysis: `CliHandler::HasSession()` returns `true` unconditionally (so `SendNotification`/`PSendSysMessage` reach the console), but `m_session` is `nullptr`. `PSendModuleSysMessage` calls `GetModuleString` only when `HasSession()` is true — hitting the null dereference. Stack frame `World::ProcessCliCommands()` confirms the crash path.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Verified that commands using `PSendModuleSysMessage` no longer crash when executed from the worldserver console.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Load any module that registers a command handler using `PSendModuleSysMessage` (e.g. any module with `Console::Yes` commands).
2. From the worldserver console, run one of those commands.
3. Before this fix: segfault / server crash. After: command responds correctly.

## Known Issues and TODO List:

- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.