### PR TITLE
fix(Core/SotA): stuck-in-combat after damaging cannons/demolishers

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
@@ -703,13 +703,21 @@ void BattlegroundSA::OverrideGunFaction()
     for (uint8 i = BG_SA_GUN_1; i <= BG_SA_GUN_10; i++)
     {
         if (Creature* gun = GetBGCreature(i))
+        {
             gun->SetFaction(BG_SA_Factions[Attackers ? TEAM_ALLIANCE : TEAM_HORDE]);
+            // NullCreatureAI never evades and PvE combat refs have no timer,
+            // so attackers would stay in combat until death after damaging it.
+            gun->SetIsCombatDisallowed(true);
+        }
     }
 
     for (uint8 i = BG_SA_DEMOLISHER_1; i <= BG_SA_DEMOLISHER_4; i++)
     {
         if (Creature* dem = GetBGCreature(i))
+        {
             dem->SetFaction(BG_SA_Factions[Attackers]);
+            dem->SetIsCombatDisallowed(true);
+        }
     }
 }
 
@@ -968,7 +976,10 @@ void BattlegroundSA::CaptureGraveyard(BG_SA_Graveyards i, Player* Source)
                             BG_SA_NpcSpawnlocs[j][2], BG_SA_NpcSpawnlocs[j][3], 600);
 
                 if (Creature* dem = GetBGCreature(j))
+                {
                     dem->SetFaction(BG_SA_Factions[Attackers]);
+                    dem->SetIsCombatDisallowed(true);
+                }
             }
 
             UpdateWorldState(WORLD_STATE_BATTLEGROUND_SA_LEFT_GY_ALLIANCE, (GraveyardStatus[i] == TEAM_ALLIANCE ? 1 : 0));
@@ -999,7 +1010,10 @@ void BattlegroundSA::CaptureGraveyard(BG_SA_Graveyards i, Player* Source)
                             BG_SA_NpcSpawnlocs[j][2], BG_SA_NpcSpawnlocs[j][3], 600);
 
                 if (Creature* dem = GetBGCreature(j))
+                {
                     dem->SetFaction(BG_SA_Factions[Attackers]);
+                    dem->SetIsCombatDisallowed(true);
+                }
             }
 
             UpdateWorldState(WORLD_STATE_BATTLEGROUND_SA_RIGHT_GY_ALLIANCE, (GraveyardStatus[i] == TEAM_ALLIANCE ? 1 : 0));


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Antipersonnel Cannon (27894) and Battleground Demolisher (28781) both run `NullCreatureAI` with empty `EnterEvadeMode`/`UpdateAI` and no threat list. PvE `CombatReference`s have no timer, so once a player damages one of these vehicles the resulting ref is never cleared and the player stays in combat until death — and after the BG ends, the lingering state blocks queuing the next BG with "you can't do that while in combat".

The existing `NullCreatureAI` workaround in `PassiveAI.cpp` only flips `IsCombatDisallowed` when `IsTrigger()` is true. These entries are `flags_extra = 2` (no `0x80`/TRIGGER bit), so they slip past it.

Fix marks the SotA vehicles combat-disallowed at spawn time:
- `OverrideGunFaction()` (called from `ResetObjs` at BG start and every round transition) handles the 10 cannons + 4 beach demolishers.
- `CaptureGraveyard` handles the 4 graveyard-captured demolishers (slots 5–8) inline next to their existing `SetFaction` call.

`IsCombatDisallowed` survives `Creature::Respawn` for BG-spawned creatures (`m_spawnId == 0` skips the `UpdateEntry` re-init branch), so it persists across demolisher respawns and round-2 `ResetObjs`. Damage, killing-blow credit, gate damage and passenger PvP combat with their targets are unaffected — only the stuck creature-side combat ref is prevented (`IsCombatDisallowed` is read in exactly one place, `CombatManager::CanBeginCombat`).

`creature_template` is left untouched.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with AzerothMCP.

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

https://www.youtube.com/watch?v=R2aaeOgGPLg — shows no combat with the cannons/demolishers even with players inside, which matches the behavior this PR restores.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Setup: two GM characters, one Alliance and one Horde. '.debug bg' . Cannon nearest the defender side: `.go xyz 1436.43 110.05 41.41 607`. Beach demolisher: `.go xyz 1611.6 -117.27 8.72 607`.

1. **Cannon, foot attack (the bug).** Defender, on foot. One auto-attack on a cannon, then step ~20 yards back. Expected: no combat icon at any point; `/mount` works immediately.
2. **Demolisher, foot attack.** Same on a beach demolisher (attacker side). Expected: no stuck combat.
3. **Cannon as passenger (regression).** Defender spell-clicks a cannon and fires it at the Horde GM. Expected: defender enters PvP combat with the Horde GM only; clears ~5s after stopping (normal PvP timer). No phantom combat after dismount.
4. **Demolisher → gate (regression).** Attacker mounts the beach demolisher, drives to a gate, fires. Expected: gate takes damage and progresses through `damageState1/2`/destroyed as before.
5. **End-of-BG.** Damage a cannon during the round, let the BG end naturally. Expected: queue any other BG immediately — not blocked by "you can't do that while in combat".

## Known Issues and TODO List:

- [ ]
- [ ]