### PR TITLE
fix(DB/Proc): restore warrior proc masks

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1779252761841110000.sql
+++ b/data/sql/updates/pending_db_world/rev_1779252761841110000.sql
@@ -1,0 +1,3 @@
+-- Restore Warrior Sword Specialization/Sudden Death masks after spell_proc migration
+UPDATE `spell_proc` SET `SpellFamilyName`=4, `SpellFamilyMask0`=0xAA604466, `SpellFamilyMask1`=0x00400105, `SpellFamilyMask2`=0x00000000, `SpellTypeMask`=0, `SpellPhaseMask`=2 WHERE `SpellId`=-12281;
+UPDATE `spell_proc` SET `SpellFamilyName`=4, `SpellFamilyMask0`=0xAA604466, `SpellFamilyMask1`=0x00400105, `SpellFamilyMask2`=0x00000000, `SpellTypeMask`=0, `SpellPhaseMask`=2|4 WHERE `SpellId`=-29723;


### PR DESCRIPTION
## Changes Proposed

This PR restores the Warrior proc family masks that were present in `spell_proc_event` before the current `spell_proc` migration path.

- Updates Sword Specialization (`-12281`) to use Warrior family masks `0xAA604466 / 0x00400105`.
- Updates Sudden Death (`-29723`) to use the same Warrior family masks.
- Clears `SpellTypeMask` for both rows so non-damage melee abilities such as Sunder Armor can trigger the proc checks.
- Restores Sudden Death to listen on hit and finish phases, matching the existing Execute finish-phase aura script.

## Issues Addressed

- Follow-up for #20250

## BountyHub

- Claim: https://www.bountyhub.dev/bounty/view/c66fe2c7-3ae4-480d-a081-f81cdb674954
- PayPal: https://paypal.me/tanchaowen

## Tests Performed

- `PYTHONIOENCODING=utf-8 python3 apps/codestyle/codestyle-sql.py data/sql/updates/pending_db_world/rev_1779252761841110000.sql`
- `git diff --check`
- Static target check confirming the pending SQL updates both `SpellId` values, sets the restored masks, clears `SpellTypeMask`, and keeps Sudden Death on `SpellPhaseMask=2|4`.

## How to Test the Changes

1. Create a Warrior with Sword Specialization and a sword equipped.
2. Use Hamstring, Rend, and Sunder Armor against a high-health target or training dummy.
3. Confirm these abilities can trigger Sword Specialization extra attacks.
4. With Sudden Death talented, confirm Sunder Armor and Rend can also trigger Sudden Death.

## Known Issues

- Not tested in-game locally.
