### PR TITLE
fix(warrior): let Juggernaut stack with Recklessness crit

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -140,6 +140,11 @@ enum CharacterFlags
     CHARACTER_FLAG_UNK32                = 0x80000000
 };
 
+enum WarriorSpellMods
+{
+    SPELL_WARRIOR_JUGGERNAUT_CRIT_BONUS_BUFF = 65156
+};
+
 enum CharacterCustomizeFlags
 {
     CHAR_CUSTOMIZE_FLAG_NONE            = 0x00000000,
@@ -9793,8 +9798,10 @@ void Player::ApplySpellMod(uint32 spellId, SpellModOp op, T& basevalue, Spell* s
 
         if (mod->type == SPELLMOD_FLAT)
         {
-            // xinef: do not allow to consume more than one 100% crit increasing spell
-            if (mod->op == SPELLMOD_CRITICAL_CHANCE && totalflat >= 100)
+            // xinef: do not allow to consume more than one 100% crit increasing spell.
+            // Juggernaut's Mortal Strike/Slam bonus is additive with Recklessness and
+            // must still apply above 100% so resilience cannot push the hit below crit.
+            if (mod->op == SPELLMOD_CRITICAL_CHANCE && totalflat >= 100 && mod->spellId != SPELL_WARRIOR_JUGGERNAUT_CRIT_BONUS_BUFF)
                 return;
 
             int32 flatValue = mod->value;


### PR DESCRIPTION
## Changes
- Allows the Juggernaut crit bonus aura (`65156`) to still apply when another flat crit modifier has already brought the spell to 100% crit chance.
- Keeps the existing safeguard for other 100% crit modifiers unchanged.

## Why
Issue #20741 reports Mortal Strike/Slam can still land non-critical hits when Recklessness and Juggernaut are both active. The generic spellmod path currently skips any later flat crit modifier once `totalflat >= 100`, which means Recklessness can prevent Juggernaut's additional +25% from applying depending on modifier iteration order. That leaves the result vulnerable to crit-reduction effects such as resilience.

Juggernaut is a documented additive bonus for Mortal Strike/Slam and should stack with Recklessness above 100%, while both auras are consumed by the spell.

## Proof
Static verification of the affected path:
- Juggernaut crit buff is spell `65156` in `src/server/scripts/Spells/spell_warrior.cpp`.
- Spell modifiers store their owning spell id via `AuraEffect::CalculateSpellMod()` (`m_spellmod->spellId = GetId()`).
- `Player::ApplySpellMod()` was skipping all flat critical-chance modifiers once `totalflat >= 100`.
- This patch exempts only spell `65156`, so Juggernaut can contribute its +25% over Recklessness' +100%, while the global multiple-100%-crit guard remains in place.

I did not run a full AzerothCore server build in this environment.

Fixes #20741

BountyHub: https://www.bountyhub.dev/bounty/view/36759f3c-f8b3-4ff0-95cd-1efefa4cc7e5
