### PR TITLE
feat(Core/SmartAI): add SMART_ACTION_INC_DATA (242)

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -1369,6 +1369,7 @@ void SmartGameObjectAI::UpdateAI(uint32 diff)
 void SmartGameObjectAI::InitializeAI()
 {
     GetScript()->OnInitialize(me);
+    aiDataSet.clear();
 
     // Xinef: do not call respawn event if go is not spawned
     if (me->isSpawned())
@@ -1437,7 +1438,17 @@ void SmartGameObjectAI::SetData(uint32 id, uint32 value, WorldObject* invoker)
             gob = invoker->ToGameObject();
     }
 
+    aiDataSet[id] = value;
     GetScript()->ProcessEventsFor(SMART_EVENT_DATA_SET, unit, id, value, false, nullptr, gob);
+}
+
+uint32 SmartGameObjectAI::GetData(uint32 id) const
+{
+    std::unordered_map<uint32, uint32>::const_iterator itr = aiDataSet.find(id);
+    if (itr != aiDataSet.end())
+        return itr->second;
+
+    return 0;
 }
 
 void SmartGameObjectAI::SetScript9(SmartScriptHolder& e, uint32 entry, WorldObject* invoker)

--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -304,6 +304,7 @@ public:
     void Destroyed(Player* player, uint32 eventId) override;
     void SetData(uint32 id, uint32 value) override { SetData(id, value, nullptr); }
     void SetData(uint32 id, uint32 value, WorldObject* invoker);
+    uint32 GetData(uint32 id) const override;
     void SetScript9(SmartScriptHolder& e, uint32 entry, WorldObject* invoker);
     void OnGameEvent(bool start, uint16 eventId) override;
     void OnStateChanged(uint32 state, Unit* unit) override;
@@ -324,6 +325,7 @@ public:
 
 protected:
     SmartScript mScript;
+    std::unordered_map<uint32, uint32> aiDataSet;
 };
 
 /// Registers scripts required by the SAI scripting system

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1463,6 +1463,35 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
             break;
         }
+        case SMART_ACTION_INC_DATA:
+        {
+            WorldObject* invoker = me ? static_cast<WorldObject*>(me) : static_cast<WorldObject*>(go);
+
+            for (WorldObject* target : targets)
+            {
+                if (Creature* cTarget = target->ToCreature())
+                {
+                    if (SmartAI* smartAI = CAST_AI(SmartAI, cTarget->AI()))
+                    {
+                        uint32 const newValue = smartAI->GetData(e.action.setData.field) + e.action.setData.data;
+                        smartAI->SetData(e.action.setData.field, newValue, invoker);
+                    }
+                    else
+                        LOG_ERROR("sql.sql", "SmartScript: Action target for SMART_ACTION_INC_DATA is not using SmartAI, skipping");
+                }
+                else if (GameObject* oTarget = target->ToGameObject())
+                {
+                    if (SmartGameObjectAI* smartGOAI = CAST_AI(SmartGameObjectAI, oTarget->AI()))
+                    {
+                        uint32 const newValue = smartGOAI->GetData(e.action.setData.field) + e.action.setData.data;
+                        smartGOAI->SetData(e.action.setData.field, newValue, invoker);
+                    }
+                    else
+                        LOG_ERROR("sql.sql", "SmartScript: Action target for SMART_ACTION_INC_DATA is not using SmartGameObjectAI, skipping");
+                }
+            }
+            break;
+        }
         case SMART_ACTION_MOVE_FORWARD:
         {
             if (!me)

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -759,6 +759,7 @@ bool SmartAIMgr::CheckUnusedActionParams(SmartScriptHolder const& e)
             case SMART_ACTION_MOUNT_TO_ENTRY_OR_MODEL: return sizeof(SmartAction::morphOrMount);
             case SMART_ACTION_SET_INGAME_PHASE_MASK: return sizeof(SmartAction::ingamePhaseMask);
             case SMART_ACTION_SET_DATA: return sizeof(SmartAction::setData);
+            case SMART_ACTION_INC_DATA: return sizeof(SmartAction::setData);
             case SMART_ACTION_MOVE_FORWARD: return sizeof(SmartAction::moveRandom);
             case SMART_ACTION_ATTACK_STOP: return NO_PARAMS;
             case SMART_ACTION_SET_VISIBILITY: return sizeof(SmartAction::visibility);
@@ -1975,6 +1976,7 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         case SMART_ACTION_THREAT_SINGLE_PCT:
         case SMART_ACTION_SET_INST_DATA64:
         case SMART_ACTION_SET_DATA:
+        case SMART_ACTION_INC_DATA:
         case SMART_ACTION_MOVE_FORWARD:
         case SMART_ACTION_ESCORT_PAUSE:
         case SMART_ACTION_SET_FLY:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -726,8 +726,9 @@ enum SMART_ACTION
     SMART_ACTION_SET_ANIM_TIER                      = 239,    // animtier
     SMART_ACTION_SET_GOSSIP_MENU                    = 240,    // gossipMenuId
     SMART_ACTION_SUMMON_GAMEOBJECT_GROUP            = 241,    // group
+    SMART_ACTION_INC_DATA                           = 242,    // field, increment (uses aiDataSet, wipe-safe across evade)
 
-    SMART_ACTION_AC_END                             = 242,    // placeholder
+    SMART_ACTION_AC_END                             = 243,    // placeholder
 };
 
 enum class SmartActionSummonCreatureFlags

--- a/src/test/server/game/Globals/GameObjectSummonGroupTest.cpp
+++ b/src/test/server/game/Globals/GameObjectSummonGroupTest.cpp
@@ -110,7 +110,8 @@ TEST_F(GameObjectSummonGroupTest, DifferentGroupsAreIndependent)
 TEST_F(GameObjectSummonGroupTest, SmartActionEnumValue)
 {
     EXPECT_EQ(SMART_ACTION_SUMMON_GAMEOBJECT_GROUP, 241);
-    EXPECT_EQ(SMART_ACTION_AC_END, 242);
+    EXPECT_EQ(SMART_ACTION_INC_DATA, 242);
+    EXPECT_EQ(SMART_ACTION_AC_END, 243);
 }
 
 TEST_F(GameObjectSummonGroupTest, SmartActionUnionSize)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Adds a new SAI action `SMART_ACTION_INC_DATA = 242` that increments the target's `aiDataSet[field]` by a configured delta and then fires `SMART_EVENT_DATA_SET` so existing watchers can react. Parameters reuse the existing `SmartAction::setData` struct (`field`, `increment`). Supports both `Creature` and `GameObject` targets symmetrically.

### Why it is needed

The existing `SMART_ACTION_SET_COUNTER` (action 63) stores values in `SmartScript::mCounterList`. That map is unconditionally wiped to zero inside `SmartScript::OnReset()` ([SmartScript.cpp:133](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/AI/SmartScripts/SmartScript.cpp#L133)), and `OnReset` runs on every `EnterEvadeMode` and `JustReachedHome` call. The result is that any combat-capable creature using `SET_COUNTER` to tally something across combat cycles loses its progress every time it disengages and walks home.

`SmartAI::aiDataSet` (the storage used by `SET_DATA`) is wiped only on `JustRespawned` and `InitializeAI`, so it is the correct place for state that needs to survive evade. The missing primitive was an in-place increment - `SET_DATA` only writes absolute values and the source creature has no way to read the target's current value to compute `current+1` from SAI alone.

`SMART_ACTION_INC_DATA` fills that gap.

### Side fix included for parity

Previously `SmartGameObjectAI::SetData` was fire-and-forget - it called `ProcessEventsFor(SMART_EVENT_DATA_SET)` without persisting anything (no `aiDataSet` on the GameObject side). To make `INC_DATA` work uniformly on both creature and gameobject targets, this PR adds `aiDataSet` storage and a `GetData` override to `SmartGameObjectAI`, and cleared on `InitializeAI`. As a small side effect, `SET_DATA` on a gameobject now persists too - watchers of `SMART_EVENT_DATA_SET` will see the same firing as before, plus the value is now retrievable.

Existing `SET_DATA` and `SET_COUNTER` semantics are otherwise unchanged.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Used Claude (Opus 4.7) for analysis of the `OnReset`/counter interaction and drafting the action handler.

## Issues Addressed:
Enables a clean fix for [chromiecraft/chromiecraft#7391](https://github.com/chromiecraft/chromiecraft/issues/7391) ("The Deadliest Trap Ever Laid does not finish consistently"). The accompanying SAI data PR (#25923) uses this action.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Root cause analysis is engine-internal (see code references above). Behaviour was confirmed in-game with a debug trace on `SmartScript::OnReset` and `SmartScript::StoreCounter` for the affected quest creatures: Commander Hobb's counter consistently hit 18 of the required 20 kills and was then wiped to 0 when he reached home after an aggro/evade cycle.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Built and ran on a local AC server. Verified that `SMART_ACTION_INC_DATA` correctly increments the target's `aiDataSet[field]` (creature path) and fires `SMART_EVENT_DATA_SET` so the existing data watchers respond. The GameObject path mirrors the creature path - same arithmetic and event fire - and is covered by the same code shape; in-game regression test focused on the creature case used by the linked quest fix.

No regression observed in unrelated SAI behaviour (existing `SET_DATA` and `SET_COUNTER` paths untouched aside from `SET_DATA` on GO now also persisting, which is additive).

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Build core.
2. Author SAI that uses `action_type = 242` with `target_type` pointing at a SmartAI creature (or SmartGameObjectAI gameobject); set `action_param1 = field`, `action_param2 = increment`.
3. Confirm the target's `aiDataSet[field]` advances by the configured delta each time the action fires.
4. Confirm `SMART_EVENT_DATA_SET(field, expectedValue)` watchers on the target fire when the data reaches the expected value.
5. Regression: confirm existing `SET_DATA` and `SET_COUNTER` calls are unchanged in behaviour (the only added behaviour is `SET_DATA` on a GameObject now also persists, which is additive).

## Known Issues and TODO List:

- [ ] None known.