### PR TITLE
fix(DB/SAI): Deadliest Trap Ever Laid counter survives evade

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1779409400513743000.sql
+++ b/data/sql/updates/pending_db_world/rev_1779409400513743000.sql
@@ -1,0 +1,10 @@
+--
+-- Quest 'The Deadliest Trap Ever Laid' (11097/11101): kill counter survives evade
+--
+
+UPDATE `smart_scripts` SET `event_type` = 38, `event_param1` = 1, `event_param2` = 20, `comment` = 'Commander Hobb - On Data Set field=1 value=20 - Run Script (Complete Quest)' WHERE `entryorguid` = 23434 AND `source_type` = 0 AND `id` = 11;
+UPDATE `smart_scripts` SET `event_type` = 38, `event_param1` = 1, `event_param2` = 20, `comment` = 'Commander Arcus - On Data Set field=1 value=20 - Run Script (Complete Quest)' WHERE `entryorguid` = 23452 AND `source_type` = 0 AND `id` = 11;
+UPDATE `smart_scripts` SET `action_type` = 242, `action_param1` = 1, `action_param2` = 1, `action_param3` = 0, `comment` = 'Dragonmaw Skybreaker - On Just Died - Inc Data field=1 +1 on Commander Hobb' WHERE `entryorguid` = 23440 AND `source_type` = 0 AND `id` = 3;
+UPDATE `smart_scripts` SET `action_type` = 242, `action_param1` = 1, `action_param2` = 1, `action_param3` = 0, `comment` = 'Dragonmaw Skybreaker - On Just Died - Inc Data field=1 +1 on Commander Arcus' WHERE `entryorguid` = 23441 AND `source_type` = 0 AND `id` = 3;
+UPDATE `smart_scripts` SET `action_type` = 45, `action_param1` = 1, `action_param2` = 0, `action_param3` = 0, `comment` = 'Commander Hobb - Actionlist - Seed Data field=1 value=0' WHERE `entryorguid` = 2343400 AND `source_type` = 9 AND `id` = 1;
+UPDATE `smart_scripts` SET `action_type` = 45, `action_param1` = 1, `action_param2` = 0, `action_param3` = 0, `comment` = 'Commander Arcus - Actionlist - Seed Data field=1 value=0' WHERE `entryorguid` = 2345200 AND `source_type` = 9 AND `id` = 1;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

Migrates the kill tally on Commander Hobb (23434) and Commander Arcus (23452) for quests 11097 (Scryers) / 11101 (Aldor) from `SMART_ACTION_SET_COUNTER` (storage: `SmartScript::mCounterList`) to `SMART_ACTION_INC_DATA` (storage: `SmartAI::aiDataSet`).

### Why

The commander's counter was wiped by `SmartScript::OnReset` on every `EnterEvadeMode` / `JustReachedHome` cycle. Commander Hobb has `SMART_ACTION_CALL_FOR_HELP` on aggro, so any combat resolved by allies (or by the player landing AoE on his target) caused him to evade, walk home, and lose the accumulated kill count. Without the OnReset wipe issue, players could end up with 18 of the required 20 kills logged - and then the counter would zero - producing the 'never completes' / 'sometimes finishes after 60+ kills' symptom in the linked issue.

### What changed

| Row | Before | After |
|---|---|---|
| 23440 (Skybreaker S) `id=3` On Just Died | `action 63 SET_COUNTER(1, +1)` -> Hobb | `action 242 INC_DATA(field=1, +1)` -> Hobb |
| 23441 (Skybreaker A) `id=3` On Just Died | `action 63 SET_COUNTER(1, +1)` -> Arcus | `action 242 INC_DATA(field=1, +1)` -> Arcus |
| 23434 (Hobb) `id=11` | `event 77 COUNTER_SET (id=1, val=20)` | `event 38 DATA_SET (id=1, val=20)` |
| 23452 (Arcus) `id=11` | `event 77 COUNTER_SET (id=1, val=20)` | `event 38 DATA_SET (id=1, val=20)` |
| Hobb actionlist 2343400 `id=1` | `action 63 SET_COUNTER(1, 0, reset)` self | `action 45 SET_DATA(field=1, value=0)` self |
| Arcus actionlist 2345200 `id=1` | `action 63 SET_COUNTER(1, 0, reset)` self | `action 45 SET_DATA(field=1, value=0)` self |

Targets and event timings unchanged - the only behavioural change is which storage on the commander holds the tally.

### Dependency

Requires `SMART_ACTION_INC_DATA` from #25922. That PR must merge first or this one will hit an invalid action_type at SAI load time.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Used Claude (Opus 4.7) for root-cause analysis (mCounterList vs aiDataSet lifecycle) and for drafting the SAI substitutions.

## Issues Addressed:
- Closes [chromiecraft/chromiecraft#7391](https://github.com/chromiecraft/chromiecraft/issues/7391)

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Reproduction confirmed in-game with an engine debug trace: counter built up to 18 of 20 required kills on Commander Hobb, then `OnReset` (triggered by his evade-and-walk-home after his aggroed target died) wiped the counter to zero. Subsequent kills started over from 1, and players ended up well past the threshold without quest completion.

Threshold value (20) matches the existing AC data. Wowhead community notes / video reference: 30 kills, ~6 minute time limit ([wowhead quest 11097](https://www.wowhead.com/quest=11097/the-deadliest-trap-ever-laid)). This PR intentionally leaves the threshold at 20 to keep the scope of the fix narrow - chasing strict Blizz parity (30 kills + 6 min timeout, see [chromiecraft#7391 comments](https://github.com/chromiecraft/chromiecraft/issues/7391)) would be a separate follow-up.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

In-game: accepted quest 11097, pulled Dragonmaw Skybreakers, allowed Commander Hobb to engage and evade multiple times during the wave. Counter advanced correctly across evade cycles. On reaching 20 kills, the quest completed and Hobb's complete actionlist fired as expected. Verified the data wipe happens only on respawn (Hobb dying mid-event -> respawn -> aiDataSet cleared - the intended boundary).

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Accept quest 11097 (Scryers) from Commander Hobb at Sanctum of the Stars, or 11101 (Aldor) from Commander Arcus at Altar of Sha'tar. Requires the Netherwing Ledge infiltration chain (`PrevQuestID = 11095`, level 70+, positive Scryer/Aldor standing).
2. Engage the Dragonmaw Skybreakers as they spawn.
3. Allow the commander to enter combat and evade at least once during the wave (e.g., let allies finish his target, or take aggro yourself and pull mobs away).
4. Confirm the kill tally continues to advance after the commander evades and walks home - and that the quest completes at exactly 20 Dragonmaw Skybreaker kills.

## Known Issues and TODO List:

- [ ] Threshold remains at 20 kills (existing AC value). Wowhead community / video reference shows 30 kills with a 6-minute timeout. Tightening Blizz parity is a separate change.
- [ ] Other side concerns mentioned in the issue (mobs not dismounting on death, NPCs not healable) are not addressed by this PR.