### PR TITLE
fix(warrior): allow Juggernaut crit bonus with Recklessness

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -9793,15 +9793,15 @@ void Player::ApplySpellMod(uint32 spellId, SpellModOp op, T& basevalue, Spell* s
 
         if (mod->type == SPELLMOD_FLAT)
         {
-            // xinef: do not allow to consume more than one 100% crit increasing spell
-            if (mod->op == SPELLMOD_CRITICAL_CHANCE && totalflat >= 100)
-                return;
-
             int32 flatValue = mod->value;
 
             // SPELL_MOD_THREAT - divide by 100 (in packets we send threat * 100)
             if (mod->op == SPELLMOD_THREAT)
                 flatValue /= 100;
+
+            // xinef: do not allow to consume more than one 100% crit increasing spell
+            if (mod->op == SPELLMOD_CRITICAL_CHANCE && totalflat >= 100 && flatValue >= 100)
+                return;
 
             totalflat += flatValue;
         }


### PR DESCRIPTION
## Changes
- allow flat critical chance bonuses below 100% to keep stacking after a 100% crit modifier has already been applied
- preserve the existing guard that prevents consuming more than one 100% crit-increasing modifier

## Why
Recklessness contributes a 100% crit modifier, and Juggernaut contributes an additional crit bonus for the next Mortal Strike/Slam after Charge. The previous guard skipped every later flat crit modifier once the accumulated flat value reached 100, which meant Juggernaut could be ignored when Recklessness was already active. Keeping smaller follow-up crit bonuses lets the combined chance survive later victim-side reductions such as resilience/defense adjustments.

Fixes #20741

## Tests
- `git diff --check`
- `python ./apps/codestyle/codestyle-cpp.py`

## Notes
- I also attempted local CMake configure with `cmake -S . -B build\codex-check -DTOOLS=0 -DSCRIPTS=static -DSERVERS=0 -DWITH_WARNINGS=0`; it stopped before compilation because local Boost 1.78+ headers/libraries are not installed.