### PR TITLE
fix(Core/Battlefield): Restrict Within Our Grasp to attackers

### DIFF
--- a/src/server/game/Battlefield/BattlefieldMgr.cpp
+++ b/src/server/game/Battlefield/BattlefieldMgr.cpp
@@ -112,6 +112,13 @@ Battlefield* BattlefieldMgr::GetBattlefieldByBattleId(uint32 battleId)
     return nullptr;
 }
 
+bool BattlefieldMgr::IsWintergraspAttackerVictory()
+{
+    if (Battlefield* bf = GetBattlefieldByBattleId(BATTLEFIELD_BATTLEID_WG))
+        return static_cast<BattlefieldWG*>(bf)->IsLastBattleAttackerVictory();
+    return false;
+}
+
 void BattlefieldMgr::Update(uint32 diff)
 {
     _updateTimer += diff;

--- a/src/server/game/Battlefield/BattlefieldMgr.h
+++ b/src/server/game/Battlefield/BattlefieldMgr.h
@@ -47,6 +47,9 @@ public:
     Battlefield* GetBattlefieldToZoneId(uint32 zoneId);
     Battlefield* GetBattlefieldByBattleId(uint32 battleId);
 
+    // True iff the most recent Wintergrasp battle ended with the keep captured.
+    [[nodiscard]] bool IsWintergraspAttackerVictory();
+
     ZoneScript* GetZoneScript(uint32 zoneId);
 
     void AddZone(uint32 zoneId, Battlefield* handle);

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -348,6 +348,9 @@ void BattlefieldWG::CapturePointTaken(uint32 areaId)
 
 void BattlefieldWG::OnBattleEnd(bool endByTimer)
 {
+    // Must be set before SPELL_VICTORY_REWARD so the 1755 criterion can gate on it.
+    LastBattleAttackerVictory = !endByTimer;
+
     // Remove relic
     if (GameObject* go = GetRelic())
         go->RemoveFromWorld();

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -403,6 +403,9 @@ public:
 
     uint32 GetData(uint32 data) const override;
 
+    // True iff the most recent battle ended with the keep captured (attacker win).
+    [[nodiscard]] bool IsLastBattleAttackerVictory() const { return LastBattleAttackerVictory; }
+
     bool IsKeepNpc(uint32 entry)
     {
         switch (entry)
@@ -451,6 +454,8 @@ protected:
     int32 TenacityStack;
 
     ObjectGuid TitansRelic;
+
+    bool LastBattleAttackerVictory{false};
 };
 
 uint8 const WG_MAX_OBJ = 32;

--- a/src/server/scripts/Northrend/zone_wintergrasp.cpp
+++ b/src/server/scripts/Northrend/zone_wintergrasp.cpp
@@ -1160,6 +1160,10 @@ public:
         if (!wintergrasp)
             return false;
 
+        // Attacker-only achievement -- defenders winning fast must not qualify.
+        if (!sBattlefieldMgr->IsWintergraspAttackerVictory())
+            return false;
+
         return wintergrasp->GetTimer() >= (20 * MINUTE * IN_MILLISECONDS);
     }
 };


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Wintergrasp achievement 1755 *Within Our Grasp* ("Attack Wintergrasp and succeed in 10 minutes or less.") was being awarded to **defenders** that won the battle in under 10 minutes — reproducible by `.bf start 1` followed by `.bf stop 1`, or by configuring `Wintergrasp.BattleTime` below 10 minutes.

### Why

`achievement_wg_within_our_grasp::OnCheck` in `src/server/scripts/Northrend/zone_wintergrasp.cpp` only checked `wintergrasp->GetTimer() >= 20 * MINUTE * IN_MILLISECONDS` — i.e. that the war ended in under 10 minutes — but did not check which team actually won. `SPELL_VICTORY_REWARD` (56902) is cast on the winners in both the attacker-capture path (`endByTimer == false`) and the defender-timeout path (`endByTimer == true`), so the `BE_SPELL_TARGET` criterion fired for defenders too.

### What changed

| File | Change |
|---|---|
| `BattlefieldWG.h` | Add `LastBattleAttackerVictory` member + `IsLastBattleAttackerVictory()` getter. |
| `BattlefieldWG.cpp` | Set `LastBattleAttackerVictory = !endByTimer` at the top of `OnBattleEnd`, before any victory spells are cast. |
| `BattlefieldMgr.h` / `.cpp` | Add `BattlefieldMgr::IsWintergraspAttackerVictory()` so script code does not have to downcast `Battlefield*` to `BattlefieldWG*`. |
| `zone_wintergrasp.cpp` | `achievement_wg_within_our_grasp::OnCheck` now also requires `sBattlefieldMgr->IsWintergraspAttackerVictory()` before the existing timer check. |

No DBC / SQL changes. The criterion gate is now: keep was captured (attacker win) **and** war ended with ≥20 minutes still on the clock (under 10 minutes elapsed).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Used Claude (Opus 4.7) for code investigation and drafting the patch.

## Issues Addressed:
- Closes #24967

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Achievement description per Wowhead [achievement=1755](https://www.wowhead.com/achievement=1755/within-our-grasp): "Attack Wintergrasp and succeed in 10 minutes or less." — attacker-only by design.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

In-game:
- `.bf start 1` → `.bf stop 1` within seconds on a character of the defending team: no longer earns the achievement (previously did).
- Titan relic clicked within 10 minutes by an attacker character: still earns the achievement.
- Defender win at the full natural timer (>10 min): unchanged (does not earn, as before).

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Log a character on the *defending* WG team. `.bf start 1`, then `.bf stop 1` within 10 minutes. Confirm the character does **not** receive *Within Our Grasp*.
2. Log a character on the *attacking* WG team. `.bf start 1`, then click the titan relic within 10 minutes (or `.bf switch 1`). Confirm the character **does** receive *Within Our Grasp*.
3. Let a full battle run out (>10 min) with defenders holding the keep. Confirm no one receives the achievement.

## Known Issues and TODO List:

- [ ] None.