### PR TITLE
fix(DB/Conditions): Subjugated Iskalder despawns mid-quest 13133

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1779630778037161600.sql
+++ b/data/sql/updates/pending_db_world/rev_1779630778037161600.sql
@@ -1,13 +1,4 @@
 --
--- Fix quest 13133 "Find the Ancient Hero": Subjugated Iskalder (30886)
--- despawns when the player drags him onto the lower floors of the Halls of
--- the Ancestors. The OOC despawn rule (smart_scripts id=3) whitelists
--- AreaIds {4498, 4526} but the surrounding/lower area is 4496 (Jotunheim),
--- so any time the creature reports area 4496 the despawn fires.
--- Adding 4496 to the whitelist keeps the original "scoped to quest area"
--- intent while covering the full legitimate path:
---   4526 (Njorndar Village) -> 4496 (Jotunheim / Halls lower) -> 4498 (Halls upper)
---
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 22) AND (`SourceGroup` = 4) AND (`SourceEntry` = 30886);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (22, 4, 30886, 0, 0, 23, 1, 4526, 0, 0, 1, 0, 0, '', 'Despawn Subjugated Iskalder when outside quest areas'),

--- a/data/sql/updates/pending_db_world/rev_1779630778037161600.sql
+++ b/data/sql/updates/pending_db_world/rev_1779630778037161600.sql
@@ -1,0 +1,15 @@
+--
+-- Fix quest 13133 "Find the Ancient Hero": Subjugated Iskalder (30886)
+-- despawns when the player drags him onto the lower floors of the Halls of
+-- the Ancestors. The OOC despawn rule (smart_scripts id=3) whitelists
+-- AreaIds {4498, 4526} but the surrounding/lower area is 4496 (Jotunheim),
+-- so any time the creature reports area 4496 the despawn fires.
+-- Adding 4496 to the whitelist keeps the original "scoped to quest area"
+-- intent while covering the full legitimate path:
+--   4526 (Njorndar Village) -> 4496 (Jotunheim / Halls lower) -> 4498 (Halls upper)
+--
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 22) AND (`SourceGroup` = 4) AND (`SourceEntry` = 30886);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(22, 4, 30886, 0, 0, 23, 1, 4526, 0, 0, 1, 0, 0, '', 'Despawn Subjugated Iskalder when outside quest areas'),
+(22, 4, 30886, 0, 0, 23, 1, 4498, 0, 0, 1, 0, 0, '', 'Despawn Subjugated Iskalder when outside quest areas'),
+(22, 4, 30886, 0, 0, 23, 1, 4496, 0, 0, 1, 0, 0, '', 'Despawn Subjugated Iskalder when outside quest areas');


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Quest **13133 — Find the Ancient Hero** (The Bone Witch, Njorndar Village, Icecrown) has Subjugated Iskalder (creature `30886`) follow the player after they use *The Bone Witch's Amulet*. Today he despawns 5–10 seconds after subjugation whenever the player drags him onto the **lower floors / exterior** of the Halls of the Ancestors, so the quest is only completable if Iskalder is found on the upper interior floor.

### Root cause

The OOC despawn rule (`smart_scripts` `id=3`, action `41 FORCE_DESPAWN`) is gated by a `conditions` whitelist of `AreaId` values:

```
(22, 4, 30886, 0, 0, 23, 1, 4498, 0, 0, 1, ...)   -- NOT in area 4498 (Halls upper)
(22, 4, 30886, 0, 0, 23, 1, 4526, 0, 0, 1, ...)   -- NOT in area 4526 (Njorndar Village)
```

Both rows share `ElseGroup=0` and are negated, so the despawn-action runs when the creature is **not** in either area. The lower floors and the building's surrounds, however, report area **4496 (Jotunheim)** — which was missing from the whitelist. Result: as soon as the player leaves the upper interior, the negated AND chain evaluates to true and the 5-second OOC tick despawns Iskalder.

### Fix

Add `4496` to the whitelist so the full legitimate path is covered:

`4526 (Njorndar Village) -> 4496 (Jotunheim / Halls lower) -> 4498 (Halls upper interior)`

Walking Iskalder elsewhere in Icecrown (e.g. open wilderness area `210`, area `4517`) still triggers the intended despawn within ~5 s, so the original safeguard against trolling the NPC across the zone is preserved.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Tools used: Claude Code (Opus 4.7).** The author understood the SmartAI/condition flow, validated the area IDs in-game via a temporary diagnostic log, and authored the final fix.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs
- [ ] Video evidence, knowledge databases or other public sources
- [ ] Cherry-pick from another project

The missing area was identified by instrumenting `SmartScript::ProcessTimedAction` with a temporary `LOG_ERROR("sql.sql", ...)` print of `me->GetAreaId()` / `me->GetZoneId()` for `entryOrGuid == 30886 && event_id == 3`, then walking the quest path. Sample trace (debug code reverted before commit):

```
[Iskalder DEBUG] zone=210 area=4498 condsMet=false -> safe          (Halls upper)
[Iskalder DEBUG] zone=210 area=4498 condsMet=false -> safe
[Iskalder DEBUG] zone=210 area=4496 condsMet=true  -> DESPAWN WILL FIRE  (Halls lower / Jotunheim)
```

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members.
- [ ] This pull request requires further testing and may have edge cases to be tested.

In-game verification on a local AzerothCore worldserver:
1. Pick up quest 13133 from The Bone Witch in Njorndar Village.
2. Enter the Halls of the Ancestors, wake Slumbering Mjordin until Iskalder spawns, use the amulet.
3. **Before fix:** Subjugated Iskalder despawns within ~5 s as soon as the player crosses into area `4496` (confirmed via debug logging).
4. **After fix:** Iskalder follows the full path through `4496 -> 4526` back to The Bone Witch; quest credit (spell `25729 Find the Ancient Hero: Kill Credit`) fires correctly on follow-completion.
5. Walking Iskalder out into open Icecrown (e.g. area `4517` or `210`) still despawns him within ~5 s as intended.

## How to Test the Changes:

1. Apply the SQL and restart the worldserver (or `.reload conditions`).
2. Accept quest 13133 from The Bone Witch (Njorndar Village, Icecrown).
3. Enter the Halls of the Ancestors and progress to a Mjordin on the **lower** floor; subjugate Iskalder there.
4. Walk him back to The Bone Witch — he should not despawn anywhere along the path.
5. Re-test by deliberately walking him out into open Icecrown (away from Njorndar/Halls) — confirm the OOC despawn still fires after ~5 s.

## Known Issues and TODO List:

- [ ] None.