### PR TITLE
feat(Core/Commands): add .pet rename command

### DIFF
--- a/data/sql/updates/pending_db_auth/rev_1779639149576950000.sql
+++ b/data/sql/updates/pending_db_auth/rev_1779639149576950000.sql
@@ -1,0 +1,8 @@
+-- RBAC permission for .pet rename (sec 3+, Admin role 196).
+DELETE FROM `rbac_permissions` WHERE `id` = 922;
+INSERT INTO `rbac_permissions` (`id`, `name`) VALUES
+(922, 'Command: pet rename');
+
+DELETE FROM `rbac_linked_permissions` WHERE `linkedId` = 922;
+INSERT INTO `rbac_linked_permissions` (`id`, `linkedId`) VALUES
+(196, 922);

--- a/data/sql/updates/pending_db_world/rev_1779639149576950000.sql
+++ b/data/sql/updates/pending_db_world/rev_1779639149576950000.sql
@@ -1,0 +1,23 @@
+-- acore_string entries for .pet rename command.
+DELETE FROM `acore_string` WHERE `entry` IN (35453, 35454);
+INSERT INTO `acore_string` (`entry`, `content_default`, `locale_koKR`, `locale_frFR`, `locale_deDE`, `locale_zhCN`, `locale_zhTW`, `locale_esES`, `locale_esMX`, `locale_ruRU`) VALUES
+(35453,
+ 'Invalid pet name: {}.',
+ '잘못된 펫 이름입니다: {}.',
+ 'Nom de familier invalide : {}.',
+ 'Ungültiger Begleitername: {}.',
+ '无效的宠物名称: {}。',
+ '無效的寵物名稱：{}。',
+ 'Nombre de mascota no válido: {}.',
+ 'Nombre de mascota no válido: {}.',
+ 'Недопустимое имя питомца: {}.'),
+(35454,
+ 'Renamed pet {0} ({1} -> {2}) for player {3} ({4}).',
+ '플레이어 {3} ({4})의 펫 {0}의 이름을 {1}에서 {2}(으)로 변경했습니다.',
+ 'Familier {0} renommé ({1} -> {2}) pour le joueur {3} ({4}).',
+ 'Begleiter {0} umbenannt ({1} -> {2}) für Spieler {3} ({4}).',
+ '已将玩家 {3} ({4}) 的宠物 {0} 重命名 ({1} -> {2})。',
+ '已將玩家 {3} ({4}) 的寵物 {0} 重新命名（{1} -> {2}）。',
+ 'Mascota {0} renombrada ({1} -> {2}) para el jugador {3} ({4}).',
+ 'Mascota {0} renombrada ({1} -> {2}) para el jugador {3} ({4}).',
+ 'Питомец {0} переименован ({1} -> {2}) у игрока {3} ({4}).');

--- a/data/sql/updates/pending_db_world/rev_1779639149576950000.sql
+++ b/data/sql/updates/pending_db_world/rev_1779639149576950000.sql
@@ -1,23 +1,5 @@
 -- acore_string entries for .pet rename command.
 DELETE FROM `acore_string` WHERE `entry` IN (35453, 35454);
 INSERT INTO `acore_string` (`entry`, `content_default`, `locale_koKR`, `locale_frFR`, `locale_deDE`, `locale_zhCN`, `locale_zhTW`, `locale_esES`, `locale_esMX`, `locale_ruRU`) VALUES
-(35453,
- 'Invalid pet name: {}.',
- '잘못된 펫 이름입니다: {}.',
- 'Nom de familier invalide : {}.',
- 'Ungültiger Begleitername: {}.',
- '无效的宠物名称: {}。',
- '無效的寵物名稱：{}。',
- 'Nombre de mascota no válido: {}.',
- 'Nombre de mascota no válido: {}.',
- 'Недопустимое имя питомца: {}.'),
-(35454,
- 'Renamed pet {0} ({1} -> {2}) for player {3} ({4}).',
- '플레이어 {3} ({4})의 펫 {0}의 이름을 {1}에서 {2}(으)로 변경했습니다.',
- 'Familier {0} renommé ({1} -> {2}) pour le joueur {3} ({4}).',
- 'Begleiter {0} umbenannt ({1} -> {2}) für Spieler {3} ({4}).',
- '已将玩家 {3} ({4}) 的宠物 {0} 重命名 ({1} -> {2})。',
- '已將玩家 {3} ({4}) 的寵物 {0} 重新命名（{1} -> {2}）。',
- 'Mascota {0} renombrada ({1} -> {2}) para el jugador {3} ({4}).',
- 'Mascota {0} renombrada ({1} -> {2}) para el jugador {3} ({4}).',
- 'Питомец {0} переименован ({1} -> {2}) у игрока {3} ({4}).');
+(35453, 'Invalid pet name: {}.', '잘못된 펫 이름입니다: {}.', 'Nom de familier invalide : {}.', 'Ungültiger Begleitername: {}.', '无效的宠物名称: {}。', '無效的寵物名稱：{}。', 'Nombre de mascota no válido: {}.', 'Nombre de mascota no válido: {}.', 'Недопустимое имя питомца: {}.'),
+(35454, 'Renamed pet {0} ({1} -> {2}) for player {3} ({4}).', '플레이어 {3} ({4})의 펫 {0}의 이름을 {1}에서 {2}(으)로 변경했습니다.', 'Familier {0} renommé ({1} -> {2}) pour le joueur {3} ({4}).', 'Begleiter {0} umbenannt ({1} -> {2}) für Spieler {3} ({4}).', '已将玩家 {3} ({4}) 的宠物 {0} 重命名 ({1} -> {2})。', '已將玩家 {3} ({4}) 的寵物 {0} 重新命名（{1} -> {2}）。', 'Mascota {0} renombrada ({1} -> {2}) para el jugador {3} ({4}).', 'Mascota {0} renombrada ({1} -> {2}) para el jugador {3} ({4}).', 'Питомец {0} переименован ({1} -> {2}) у игрока {3} ({4}).');

--- a/src/server/game/Accounts/RBAC.h
+++ b/src/server/game/Accounts/RBAC.h
@@ -683,6 +683,7 @@ enum RBACPermissions
     RBAC_PERM_COMMAND_RESPAWN_GAMEOBJECT_ENTRY               = 919,
     RBAC_PERM_COMMAND_DEBUG_INFO                             = 920,
     RBAC_PERM_COMMAND_DEBUG_COSMETIC                         = 921,
+    RBAC_PERM_COMMAND_PET_RENAME                             = 922,
     // custom permissions 1000+
     RBAC_PERM_MAX
 };

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -1508,6 +1508,10 @@ enum AcoreStrings
     LANG_RESPAWN_ENTRY_GAMEOBJECT_QUEUED     = 35452,
 
     // List respawns console support
-    LANG_LIST_RESPAWNS_NO_MAP           = 35447
+    LANG_LIST_RESPAWNS_NO_MAP           = 35447,
+
+    // Pet rename command
+    LANG_PET_RENAME_INVALID             = 35453,
+    LANG_PET_RENAME_SUCCESS             = 35454
 };
 #endif

--- a/src/server/scripts/Commands/cs_pet.cpp
+++ b/src/server/scripts/Commands/cs_pet.cpp
@@ -19,6 +19,8 @@
 #include "CommandScript.h"
 #include "DatabaseEnv.h"
 #include <algorithm>
+#include "GameTime.h"
+#include "Group.h"
 #include "Language.h"
 #include "Log.h"
 #include "ObjectMgr.h"
@@ -43,6 +45,7 @@ public:
             { "delete",  HandlePetDeleteCommand,  rbac::RBAC_PERM_COMMAND_PET_DELETE,  Console::Yes },
             { "learn",   HandlePetLearnCommand,   rbac::RBAC_PERM_COMMAND_PET_LEARN,   Console::No  },
             { "list",    HandlePetListCommand,    rbac::RBAC_PERM_COMMAND_PET_LIST,    Console::Yes },
+            { "rename",  HandlePetRenameCommand,  rbac::RBAC_PERM_COMMAND_PET_RENAME,  Console::Yes },
             { "unlearn", HandlePetUnlearnCommand, rbac::RBAC_PERM_COMMAND_PET_UNLEARN, Console::No  }
         };
 
@@ -224,6 +227,79 @@ public:
                                      creatureName, name, uint32(level), uint32(petType));
         } while (result->NextRow());
 
+        return true;
+    }
+
+    static bool HandlePetRenameCommand(ChatHandler* handler, PlayerIdentifier owner, uint32 petNumber, std::string newName)
+    {
+        if (ObjectMgr::CheckPetName(newName) != PET_NAME_SUCCESS)
+        {
+            handler->SendErrorMessage(LANG_PET_RENAME_INVALID, newName);
+            return false;
+        }
+
+        ObjectGuid ownerGuid = owner.GetGUID();
+
+        QueryResult result = CharacterDatabase.Query("SELECT name FROM character_pet WHERE id = {} AND owner = {}", petNumber, ownerGuid.GetCounter());
+
+        if (!result)
+        {
+            handler->SendErrorMessage(LANG_PET_DELETE_NOT_FOUND, petNumber, owner.GetName(), ownerGuid.GetCounter());
+            return false;
+        }
+
+        std::string oldName = result->Fetch()[0].Get<std::string>();
+
+        CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_CHAR_PET_NAME);
+        stmt->SetData(0, newName);
+        stmt->SetData(1, ownerGuid.GetCounter());
+        stmt->SetData(2, petNumber);
+        CharacterDatabase.Execute(stmt);
+
+        if (Player* online = owner.GetConnectedPlayer())
+        {
+            if (Pet* activePet = online->GetPet())
+            {
+                if (activePet->GetCharmInfo() && activePet->GetCharmInfo()->GetPetNumber() == petNumber)
+                {
+                    activePet->SetName(newName);
+                    // Bump the name timestamp so nearby clients re-query and drop their cached pet name.
+                    activePet->SetUInt32Value(UNIT_FIELD_PET_NAME_TIMESTAMP, uint32(GameTime::GetGameTime().count()));
+                    activePet->RemoveByteFlag(UNIT_FIELD_BYTES_2, 2, UNIT_CAN_BE_RENAMED);
+                    if (online->GetGroup())
+                        online->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_PET_NAME);
+                }
+            }
+
+            if (PetStable* stable = online->GetPetStable())
+            {
+                if (stable->CurrentPet && stable->CurrentPet->PetNumber == petNumber)
+                {
+                    stable->CurrentPet->Name = newName;
+                    stable->CurrentPet->WasRenamed = true;
+                }
+
+                for (Optional<PetStable::PetInfo>& stabled : stable->StabledPets)
+                {
+                    if (stabled && stabled->PetNumber == petNumber)
+                    {
+                        stabled->Name = newName;
+                        stabled->WasRenamed = true;
+                    }
+                }
+
+                for (PetStable::PetInfo& unslotted : stable->UnslottedPets)
+                {
+                    if (unslotted.PetNumber == petNumber)
+                    {
+                        unslotted.Name = newName;
+                        unslotted.WasRenamed = true;
+                    }
+                }
+            }
+        }
+
+        handler->PSendSysMessage(LANG_PET_RENAME_SUCCESS, petNumber, oldName, newName, owner.GetName(), ownerGuid.GetCounter());
         return true;
     }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Adds a console-capable `.pet rename <owner> <petNumber> <newname>` command (sec 3+, RBAC perm 922) that mirrors the targeting structure of `.pet delete`: it accepts a `PlayerIdentifier` and works whether the owner is online or offline.

- Validates the new name via `ObjectMgr::CheckPetName` (same path the in-game rename uses).
- Writes through the existing `CHAR_UPD_CHAR_PET_NAME` prepared statement, so the DB row is the source of truth for stabled / dismissed pets the next time they load.
- If the owner is online and the renamed pet is currently summoned, patches `Pet::m_name`, bumps `UNIT_FIELD_PET_NAME_TIMESTAMP` so nearby clients re-query and drop their cached name, clears `UNIT_CAN_BE_RENAMED`, and refreshes the group pet-name flag — no relog or resummon required.
- Updates the in-memory `PetStable` (current / stabled / unslotted) so the stable UI reflects the new name immediately.

SQL: adds RBAC permission 922 linked to admin role 196, plus two `acore_string` entries (35453 invalid name, 35454 success) with translations for all supported locales.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.7 (Claude Code) was used to assist with the implementation.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The in-memory update path mirrors `WorldSession::HandlePetRename` in `PetHandler.cpp`, which is the reference for what state must change for the rename to be visible to the client without a relog.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.pet list <ownerName>` to find the `petNumber` of an existing pet.
2. While the owner is **online with the pet summoned**: `.pet rename <ownerName> <petNumber> Newname` — confirm the pet's nameplate updates for the owner and for nearby players without anyone relogging, and that the rename persists across logout/login.
3. While the owner is **online with the pet stabled/dismissed**: rename, then resummon — confirm the new name shows up.
4. While the owner is **offline**: rename, then log them in — confirm the new name is loaded from the DB.
5. Invalid names (too short, too long, reserved, profane) should be rejected with `LANG_PET_RENAME_INVALID`.
6. Unknown `petNumber` for the given owner should be rejected with the not-found error.

## Known Issues and TODO List:

- [ ]
- [ ]