### PR TITLE
fix(Core/Battlefield): Restrict WG relic-room kick to wartime

### DIFF
--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -911,8 +911,8 @@ void BattlefieldWG::OnPlayerEnterZone(Player* player)
     // Send worldstate to player
     SendInitWorldStatesTo(player);
 
-    // xinef: Attacker, if hidden in relic room kick him out
-    if (player->GetTeamId() == GetAttackerTeam())
+    // xinef: Attacker, if hidden in relic room kick him out (only during wartime)
+    if (IsWarTime() && player->GetTeamId() == GetAttackerTeam())
         if (player->GetPositionX() > 5400.0f && player->GetPositionX() < 5490.0f && player->GetPositionY() > 2803.0f && player->GetPositionY() < 2878.0f)
             KickPlayerFromBattlefield(player->GetGUID());
 }

--- a/src/server/game/Battlegrounds/Zones/BattlegroundAV.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundAV.cpp
@@ -1586,7 +1586,7 @@ uint8 BattlegroundAV::GetAttackString(BG_AV_Nodes node, TeamId teamId)
         if (teamId == TEAM_ALLIANCE)
             strId = AV_TEXT_A_HERALD_ICEBLOOD_TOWER_ATTACK;
         else
-            strId = AV_TEXT_H_HERALD_ICEBLOOD_TOWER_ATTACK;                
+            strId = AV_TEXT_H_HERALD_ICEBLOOD_TOWER_ATTACK;
         break;
     case BG_AV_NODES_ICEBLOOD_GRAVE:
         if (teamId == TEAM_ALLIANCE)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`BattlefieldWG::OnPlayerEnterZone` unconditionally teleports attacking-team players out of the relic-room rectangle on zone entry, evicting them from the keep even during peacetime. This patch wraps that kick in `IsWarTime()` so the anti-camping rule only enforces while a war is active. Outside of wartime, both factions can freely walk through the keep.

The companion war-start kick at `BattlefieldWG.cpp:269-281` is unchanged — that one correctly fires only when the battle begins.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (Anthropic) assisted with diagnosis and patch authoring.

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. With Wintergrasp **not in wartime**, log in on a character whose faction is the current attacker team and enter Wintergrasp Fortress (zone 4197) inside the rectangle X 5400–5490, Y 2803–2878 (e.g. `.go xyz 5448 2872 418 571`). The player should remain in place (before this patch they would be teleported out).
2. Wait for / force a war to start (`.bf start 1`). Repeat the same entry on the attacker team — the player should still be kicked out by `KickPlayerFromBattlefield`, matching the original behavior.
3. Repeat steps 1 and 2 on a defender-team character — behavior should be unchanged at all times.
4. Confirm the existing war-start eviction (`BattlefieldWG.cpp:269-281`) still teleports anyone inside the relic-room box when the battle begins.

## Known Issues and TODO List:

- [ ]
- [ ]