### PR TITLE
fix(DB/Wintergrasp): Phase Whispering Wind during battle

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1779666411474117300.sql
+++ b/data/sql/updates/pending_db_world/rev_1779666411474117300.sql
@@ -1,0 +1,7 @@
+-- Hide Whispering Wind (30848) during Wintergrasp battle.
+-- Aura 52107 phases the creature out while war is active; the other five
+-- small WG elementals (30842, 30845, 30846, 30847, 30849) already have it
+-- in creature_template_addon — 30848 was missed.
+DELETE FROM `creature_template_addon` WHERE `entry` = 30848;
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(30848, 0, 0, 0, 1, 0, 0, '52107');


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

Creature **30848 (Whispering Wind)** is one of the six small Wintergrasp farming elementals but was missing from `creature_template_addon`. The other five — `30842` Wandering Shadow, `30845` Living Lasher, `30846` Glacial Spirit, `30847` Raging Flame, `30849` Chilled Earth Elemental — all carry aura `52107` (`spell_wintergrasp_hide_small_elementals_aura`, defined in `src/server/scripts/Northrend/zone_wintergrasp.cpp`), which phases them out of phasemask 1 while `Battlefield::IsWarTime()` is true. Whispering Wind was simply skipped between `30847` and `30849` in the addon block at `data/sql/base/db_world/creature_template_addon.sql:9564-9568`, so it stayed visible (and lootable / aggressive) during active battles while its siblings disappeared.

This PR adds the matching `creature_template_addon` row for `30848` so it behaves like the rest of the set.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Investigation and SQL drafted with Claude (Opus 4.7). Author reviewed the script logic and DB row format before committing.

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

The six elementals are documented as a coherent set on Wowhead (each drops one Crystallized reagent — Shadow / Life / Water / Fire / Air / Earth). Reproduced in-game: during an active Wintergrasp battle, Whispering Wind spawns remained visible to phasemask-1 players while the other five vanished as expected.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
1. Start a Wintergrasp battle (or wait for one).
2. As a non-GM character in phasemask 1, fly over the southern half of Wintergrasp where Whispering Wind spawns.
3. **Before patch:** Whispering Wind elementals remain visible / attackable during the battle, while the other five elemental types are correctly phased out.
4. **After patch:** within one aura tick (~10s of the battle starting), Whispering Wind should disappear along with its siblings, and reappear once the battle ends.

## Known Issues and TODO List:
- [ ] None.