### PR TITLE
feat(Core/Conf): Adjustable Glyph Slot Level Requirements

### DIFF
--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -2207,6 +2207,34 @@ Rate.MissChanceMultiplier.TargetPlayer = 7
 Rate.MissChanceMultiplier.OnlyAffectsPlayer = 0
 
 #
+#    GlyphLevelReq.Enable
+#
+#       Description: Enables configurable glyph slot level requirements.
+#       Default:     0 - Disabled, use stock WotLK/AzerothCore requirements.
+#                    1 - Enabled, use GlyphLevelReq.Slot*.Level values.
+#
+#       Description: Minimum character level required to unlock each glyph slot.
+#                    These are server-side slot indexes, 0 through 5. Client-side slot values are handled as 1 through 6.
+#       Default:     GlyphLevelReq.Slot0.Level = 15
+#                    GlyphLevelReq.Slot1.Level = 15
+#                    GlyphLevelReq.Slot2.Level = 50
+#                    GlyphLevelReq.Slot3.Level = 30
+#                    GlyphLevelReq.Slot4.Level = 70
+#                    GlyphLevelReq.Slot5.Level = 80
+#                    Note: This does NOT change stock Blizzard tooltip text like: "Unlocked at level 80".
+#                    The client-side UI handles the glyph slot text and the level at which the glyph tab becomes visible.
+#                    
+
+GlyphLevelReq.Enable = 0
+
+GlyphLevelReq.Slot0.Level = 15
+GlyphLevelReq.Slot1.Level = 15
+GlyphLevelReq.Slot2.Level = 50
+GlyphLevelReq.Slot3.Level = 30
+GlyphLevelReq.Slot4.Level = 70
+GlyphLevelReq.Slot5.Level = 80
+
+#
 #     LevelReq.Trade
 #        Description: Level requirement for characters to be able to initiate a trade.
 #        Default:     1

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13339,27 +13339,72 @@ uint32 Player::GetBarberShopCost(uint8 newhairstyle, uint8 newhaircolor, uint8 n
     return uint32(cost);
 }
 
+uint8 Player::GetDefaultGlyphSlotRequiredLevel(uint8 glyphSlot)
+{
+    switch (glyphSlot)
+    {
+        case 0:
+        case 1:
+            return 15;
+        case 2:
+            return 50;
+        case 3:
+            return 30;
+        case 4:
+            return 70;
+        case 5:
+            return 80;
+        default:
+            return 0;
+    }
+}
+
+uint8 Player::GetGlyphSlotRequiredLevel(uint8 glyphSlot)
+{
+    if (glyphSlot >= MAX_GLYPH_SLOT_INDEX)
+        return 0;
+
+    if (!sConfigMgr->GetOption<bool>("GlyphLevelReq.Enable", false))
+        return GetDefaultGlyphSlotRequiredLevel(glyphSlot);
+
+    std::string option = "GlyphLevelReq.Slot" + std::to_string(glyphSlot) + ".Level";
+
+    uint32 level = sConfigMgr->GetOption<uint32>(option, GetDefaultGlyphSlotRequiredLevel(glyphSlot));
+
+    // WotLK 3.3.5a max level.
+    if (level > 80)
+        level = 80;
+
+    return static_cast<uint8>(level);
+}
+
 void Player::InitGlyphsForLevel()
 {
+    // Initialize glyph slot IDs from GlyphSlot.dbc.
+    // This controls slot order and Major/Minor socket type.
     for (uint32 i = 0; i < sGlyphSlotStore.GetNumRows(); ++i)
         if (GlyphSlotEntry const* gs = sGlyphSlotStore.LookupEntry(i))
             if (gs->Order)
                 SetGlyphSlot(gs->Order - 1, gs->Id);
 
-    uint8 level = GetLevel();
     uint32 value = 0;
 
-    // 0x3F = 0x01 | 0x02 | 0x04 | 0x08 | 0x10 | 0x20 for 80 level
-    if (level >= 15)
-        value |= (0x01 | 0x02);
-    if (level >= 30)
-        value |= 0x08;
-    if (level >= 50)
-        value |= 0x04;
-    if (level >= 70)
-        value |= 0x10;
-    if (level >= 80)
-        value |= 0x20;
+    /*  Glyph Slot bitmask values
+        slot 0 -> 0x01
+        slot 1 -> 0x02
+        slot 2 -> 0x04
+        slot 3 -> 0x08
+        slot 4 -> 0x10
+        slot 5 -> 0x20
+    */
+
+    for (uint8 slot = 0; slot < MAX_GLYPH_SLOT_INDEX; ++slot)
+    {
+        uint8 minLevel = GetGlyphSlotRequiredLevel(slot);
+
+        if (!minLevel || GetLevel() >= minLevel)
+            value |= 1 << slot;
+    }
 
     SetUInt32Value(PLAYER_GLYPHS_ENABLED, value);
 }

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1770,6 +1770,8 @@ public:
     uint32 GetSpec(int8 spec = -1);
 
     void InitGlyphsForLevel();
+    static uint8 GetDefaultGlyphSlotRequiredLevel(uint8 glyphSlot);
+    static uint8 GetGlyphSlotRequiredLevel(uint8 glyphSlot);
     void SetGlyphSlot(uint8 slot, uint32 slottype) { SetUInt32Value(PLAYER_FIELD_GLYPH_SLOTS_1 + slot, slottype); }
     [[nodiscard]] uint32 GetGlyphSlot(uint8 slot) const { return GetUInt32Value(PLAYER_FIELD_GLYPH_SLOTS_1 + slot); }
     void SetGlyph(uint8 slot, uint32 glyph, bool save)


### PR DESCRIPTION
Adds worldserver config settings to allow adjustable glyph slot level requirements. 

The goal of this feature is to allow for greater control over what level player glyph slots are unlocked at. For example, this could fully unlock all Major and Minor glyph slots for players in specific brackets such as level 70, level 60, and below.

There is a caveat - to my knowledge the following glyph ui visual/text features are handled client-side: 
1. The tooltip text "Unlocked at level 80". 
2. Glyph Tab is set to unlock at level 15 

In terms of functionality, this does not negatively impact the feature. 
If I set my glyphs to unlock at levels 15, 15, 20, 25, 30, 35 then at level 35 I will unlock my final glyph slot. However, until my character reaches level 35, that final glyph slot will inaccurately state that level 80 is needed to unlock it. 
Here is a client addon to further test functionality. It can rename level reqs to the ones you set in your world config as well as making the glyph tab visible starting from level 1. You can modify these values inside GlyphLevelReqTooltip.lua 
[GlyphLevelReqTooltip](https://github.com/alca-00/WoW-3.3.5-Addon-GlyphLevelReqTooltip)

Please let me know if this is a worthwhile feature! Since the majority of glyphs are available much sooner than level 80, this type of feature would bring more customization to Wotlk servers that focus on lower level brackets and bring a greater possibility of customization to those characters. My knowledge of the acore codebase is not expert-level by any means, so let me know if there are better ways of implementing this.

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
- ChatGPT-5.5 assisted in planning, organizing and writing this PR.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Open worldserver.conf, find GlyphLevelReq.Enable = 0 and set to 1
2. Modify any or all GlyphLevelReq.Slot fields with your custom levels, test glyph slot availability on a GM character by using the .level command
3. To test glyph slot availability at level 1 the addon may be used to see your glyph tab prior to level 15.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

-
-

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
