### PR TITLE
fix(Core/Battlefield): reject expired war invites

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -292,7 +292,14 @@ void Battlefield::KickPlayerFromBattlefield(ObjectGuid guid)
     if (Player* player = ObjectAccessor::FindPlayer(guid))
         if (player->GetZoneId() == GetZoneId() && !player->IsGameMaster()
             && !PlayersInWar[player->GetTeamId()].count(guid))
+        {
             player->TeleportTo(KickPosition);
+            // Eagerly drop zone tracking: the teleport's zone change does not
+            // propagate until the next Player::Update, so callers iterating
+            // Players[team] in the same tick would otherwise still see them.
+            for (uint8 i = 0; i < PVP_TEAMS_COUNT; ++i)
+                Players[i].erase(guid);
+        }
 }
 
 void Battlefield::StartBattle()
@@ -318,11 +325,25 @@ void Battlefield::StartBattle()
 
     _scheduler.Schedule(1s, BATTLEFIELD_TIMER_GROUP_WAR, [this](TaskContext context)
     {
-        time_t now = GameTime::GetGameTime().count();
+        time_t const now = GameTime::GetGameTime().count();
+
+        // Send eject so the 3.3.5 client closes its popup (it does not on its
+        // own when the timer hits zero), then drop the entry and teleport.
         for (uint8 team = 0; team < PVP_TEAMS_COUNT; ++team)
-            for (PlayerTimerMap::value_type const& pair : InvitedPlayers[team])
-                if (pair.second <= now)
-                    KickPlayerFromBattlefield(pair.first);
+        {
+            std::vector<ObjectGuid> expired;
+            for (auto const& [guid, expireAt] : InvitedPlayers[team])
+                if (expireAt <= now)
+                    expired.push_back(guid);
+
+            for (ObjectGuid const& guid : expired)
+            {
+                if (Player* player = ObjectAccessor::FindPlayer(guid))
+                    player->GetSession()->SendBfLeaveMessage(BattleId, BF_LEAVE_REASON_EXITED);
+                InvitedPlayers[team].erase(guid);
+                KickPlayerFromBattlefield(guid);
+            }
+        }
 
         InvitePlayersInZoneToWar();
         for (uint8 team = 0; team < PVP_TEAMS_COUNT; ++team)
@@ -415,13 +436,21 @@ void Battlefield::PlayerAcceptInviteToWar(Player* player)
     if (!IsWarTime())
         return;
 
+    // Reject unknown / expired invites; the kick task only sweeps every 5s.
+    TeamId const invitedTeam = player->GetTeamId();
+    auto itr = InvitedPlayers[invitedTeam].find(player->GetGUID());
+    if (itr == InvitedPlayers[invitedTeam].end()
+        || itr->second <= GameTime::GetGameTime().count())
+        return;
+
     sScriptMgr->OnBattlefieldPlayerJoinWar(this, player);
 
     if (AddOrSetPlayerToCorrectBfGroup(player))
     {
         player->GetSession()->SendBfEntered(BattleId);
         PlayersInWar[player->GetTeamId()].insert(player->GetGUID());
-        InvitedPlayers[player->GetTeamId()].erase(player->GetGUID());
+        // Use pre-hook team: JoinWar may have just reassigned GetTeamId().
+        InvitedPlayers[invitedTeam].erase(player->GetGUID());
 
         if (player->isAFK())
             player->ToggleAFK();


### PR DESCRIPTION
## Changes Proposed:

Three related fixes in `Battlefield`:

1. **`PlayerAcceptInviteToWar` now validates the invite.** Previously it only checked `IsWarTime()`, so a player could click an expired popup (the 3.3.5 client does not auto-dismiss `SMSG_BATTLEFIELD_MGR_ENTRY_INVITE` when its countdown reaches zero) and still be joined to the war. Adds a membership + timestamp guard.

2. **Expiry sweep in `StartBattle` now sends `SendBfLeaveMessage(BF_LEAVE_REASON_EXITED)`** before erasing the entry and teleporting. Without the explicit eject, the popup stayed on screen indefinitely after the timer hit zero.

3. **`KickPlayerFromBattlefield` clears `Players[i]` eagerly.** The teleport's zone change does not propagate until the next `Player::Update`, so the very next line in the scheduler — `InvitePlayersInZoneToWar()` — would re-invite the player it had just kicked.

Bonus: the accept-side erase now uses the team the invite was written under, not the post-hook team. This stops script hooks that reassign `GetTeamId()` (e.g. cross-faction Wintergrasp modules) from leaking the entry into `InvitedPlayers` until the player leaves the zone.

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Tool used:** Claude Code with Claude Opus 4.7 (1M context). The model assisted with code review, comparison against CMaNGOS's equivalent (`HandleWarInviteResponse`), and iterative debugging of an initial regression where the eager erase caused same-tick re-invites. Final logic was reviewed and tested by the author.

## Issues Addressed:
- Closes 

## SOURCE:

Compared with CMaNGOS's `Battlefield::HandleWarInviteResponse` ([source](https://github.com/cmangos/mangos-wotlk/blob/master/src/game/Battlefield/Battlefield.cpp)) which validates membership and erases entries on expiry. This PR adds the timestamp guard on top so the brief 0-5s window between expiry and the next sweep tick cannot admit a stale accept.

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.) — cross-referenced TrinityCore 3.3.5 (same bug) and CMaNGOS wotlk (validates invite via membership; expiry-erase + leave message pattern adopted here).
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Wintergrasp during an active war and accept the join popup → joins normally.
2. Enter Wintergrasp during an active war and ignore the popup for the full 20s → popup should now auto-close (previously stuck at `1 Second`), and an accept click after expiry should be rejected.
3. Click decline on the popup → kicked out, not re-invited the same tick.
4. As a GM, ignore the popup → popup closes, GM remains in zone, gets re-invited on the next sweep (~5s).
5. With a cross-faction Wintergrasp module loaded (e.g. mod-cfbg with `CFBG.Battlefield.Enable`): get invited under one team, get reassigned on accept → no stale entry remains in `InvitedPlayers` for the original team.

## Known Issues and TODO List:

- [ ] None known.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.