### PR TITLE
fix(Scripts/Karazhan): Clear Moroes immunity flag on reset

### DIFF
--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_moroes.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_moroes.cpp
@@ -119,6 +119,7 @@ struct boss_moroes : public BossAI
         DoCastSelf(SPELL_DUAL_WIELD, true);
         _recentlySpoken = false;
         _vanished = false;
+        me->SetImmuneToAll(false);
 
         InitializeGuests();
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Fixes a state-leak bug in `boss_moroes`: Moroes can be permanently untargetable after a wipe.

### Root cause
Moroes' Vanish sets `UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC` via `SetImmuneToAll(true, true)` and schedules a follow-up task 5-7s later to clear it:

https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/scripts/EasternKingdoms/Karazhan/boss_moroes.cpp#L139-L151

If the boss evades during that 5-7s window (player wipe, leash break, etc.), `BossAI::_Reset()` calls `scheduler.CancelAll()` before the cleanup task fires. The immunity flags then persist across the reset because:

- They are unit flags, not auras, so `RemoveEvadeAuras()` (invoked by `_EnterEvadeMode`) does not touch them.
- `Reset()` clears `_vanished` but never clears the flags.

On the next pull, only the guests respond; Moroes is visible but untargetable until the worldserver restarts.

### Fix
Explicitly clear the flags in `Reset()`:

```cpp
me->SetImmuneToAll(false);
```

One line. Defensive — no effect on a clean reset (flags already false).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.7 (Claude Code) assisted with diagnosis and patch authoring. The cause and fix were verified against `BossAI::_Reset()`, `CreatureAI::_EnterEvadeMode`, `Unit::RemoveEvadeAuras`, and `Unit::SetImmuneToPC/NPC` in the current tree.

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Bug reproduced on a private 3.3.5 (AzerothCore) server during a duo Moroes attempt: a wipe during Vanish left Moroes permanently untargetable until worldserver restart. For reference, TrinityCore (3.3.5) and CMaNGOS-TBC do not use any immunity flag during Vanish — they rely on the Vanish aura's stealth alone — so they don't have this bug surface. This PR keeps AzerothCore's existing design (immunity + teleport-behind-target) and only adds the missing cleanup.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

The bug itself was reproduced in-game on AzerothCore prior to the fix. The fix has not yet been verified in-game post-rebuild; verification welcome.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Engage Moroes in Karazhan.
2. Wait for him to cast Vanish (~30s into the fight). During the 5-7s window where he is invisible and untargetable, wipe the group (or cause a leash by pulling a guest out of the door boundary).
3. Without restarting worldserver, reset the encounter and re-engage.
4. **Before this PR:** Moroes stands in place untargetable; only the guests pull.
5. **After this PR:** Moroes is fully targetable and engages normally.

## Known Issues and TODO List:

- [ ] A more thorough fix would tie the Vanish state cleanup to the SPELL_VANISH aura's removal (via an `AfterEffectRemove` on `spell_moroes_vanish`), matching CMaNGOS' design. That avoids the need for any defensive cleanup in `Reset()` because any aura-removal path (natural expiry, evade, dispel, death) auto-cleans. Out of scope for this minimal fix.
- [ ]