### PR TITLE
fix(Core/Spells): Fix Lady Vashj Phase 2 Generators

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -597,7 +597,7 @@ void Aura::UpdateTargetMap(Unit* caster, bool apply)
             if ((itr->second & (1 << effIndex)) && itr->first->IsImmunedToSpellEffect(GetSpellInfo(), effIndex, GetCaster()))
                 itr->second &= ~(1 << effIndex);
         }
-        if (!itr->second || itr->first->IsImmunedToSpell(GetSpellInfo()) || !CanBeAppliedOn(itr->first))
+        if (!itr->second || itr->first->IsImmunedToSpell(GetSpellInfo(), itr->second, GetCaster()) || !CanBeAppliedOn(itr->first))
             addUnit = false;
 
         if (addUnit && !itr->first->IsHighestExclusiveAura(this, true))


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

This PR fixes a Lady Vashj phase 2 regression where only one of the four shield generators would apply Magic Barrier on the boss. The fix is just one line but regardless was beyond my own capability to diagnose so this investigation was AI-driven and focused on recent commits prior to the 4/15 issue report I submitted. With the fix being a single line, I thought it would not be too much for maintainers to validate.

The root cause was in aura target registration. No specific commit was identified as being the singular cause for the regression, though the AI thought the strongest candidate was https://github.com/azerothcore/azerothcore-wotlk/commit/a90570a2dee7ae3c5333f22a1f8217cead5769fe. During Aura::UpdateTargetMap, the spell immunity check was performed without the active effect mask or caster context. After the first friendly Magic Barrier applied school immunity, later friendly barrier auras could be rejected during target registration even though they should have been allowed.

This change passes the current effect mask and caster into the immunity check so friendly-caster school-immunity exceptions are preserved during aura target registration. 

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

AI tools used: GitHub Copilot, model GPT-5.4.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25481

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Before the fix, only one generator beam applied and maintained Magic Barrier on Lady Vashj during phase 2. After the fix, all four generators successfully applied their barrier effects and phase 2 progressed correctly, with the Tainted Core being used on each generator and each use removing one copy of the aura from Vashj and dealing 5% damage.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

## Known Issues and TODO List:

I had the AI examine some potential paths for regression that may stem from this change. The takeaway was that the risk exists but is low and that a more comprehensive guard against theoretical risk would not be simple and thus I've proposed just this single-line PR for the immediate issue.

- [x] This change is in generic aura target registration code, so additional regression testing of other UpdateTargetMap-based aura applications is still desirable.
- [x] Theoretical risk remains for other aura-registration paths that depend on creature-specific spell-level immunity handling or broad spell immunity categories such as spell ID, allow-list, dispel, or spell-level mechanic immunity.