### PR TITLE
feat(Core/Battlefield): Skip GMs from war invites

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -235,6 +235,9 @@ void Battlefield::InvitePlayerToWar(Player* player)
     if (!player)
         return;
 
+    if (player->IsGameMaster())
+        return;
+
     /// @todo : needed ?
     if (player->IsInFlight())
         return;


### PR DESCRIPTION
## Changes Proposed:
Skip Game Masters when sending Wintergrasp war invites. A GM entering the battlefield zone during war will no longer receive the invite popup. They can still observe the zone, monitor players, and use admin commands as normal. If a GM actually wants to participate, ``.gm off`` makes them eligible again.

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude Opus 4.7 (Claude Code).**

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

1. Start a battle in Wintergrasp.
2. Log in as a GM character (``.gm on``) and enter the Wintergrasp zone.
3. Verify that no war invite popup is shown.
4. Run ``.gm off`` and re-enter (or wait for the next periodic re-invite from ``InvitePlayersInZoneToWar``). The invite should now appear.

## Known Issues and TODO List:

- [ ]
- [ ]