### PR TITLE
fix(Scripts/Wintergrasp): Use TeamId for vehicle teleporter

### DIFF
--- a/src/server/scripts/Northrend/zone_wintergrasp.cpp
+++ b/src/server/scripts/Northrend/zone_wintergrasp.cpp
@@ -28,7 +28,6 @@
 #include "ObjectMgr.h"
 #include "Player.h"
 #include "PoolMgr.h"
-#include "RaceMgr.h"
 #include "ScriptedCreature.h"
 #include "ScriptedGossip.h"
 #include "SpellScript.h"
@@ -860,8 +859,12 @@ public:
 
         bool IsFriendly(Unit* passenger)
         {
-            return ((me->GetUInt32Value(GAMEOBJECT_FACTION) == WintergraspFaction[TEAM_HORDE] && passenger->getRaceMask() & sRaceMgr->GetHordeRaceMask()) ||
-                    (me->GetUInt32Value(GAMEOBJECT_FACTION) == WintergraspFaction[TEAM_ALLIANCE] && passenger->getRaceMask() & sRaceMgr->GetAllianceRaceMask()));
+            Player* player = passenger->ToPlayer();
+            if (!player)
+                return false;
+
+            TeamId goTeam = me->GetUInt32Value(GAMEOBJECT_FACTION) == WintergraspFaction[TEAM_HORDE] ? TEAM_HORDE : TEAM_ALLIANCE;
+            return player->GetTeamId() == goTeam;
         }
 
         Creature* IsValidVehicle(Creature* cVeh)


### PR DESCRIPTION
## Changes Proposed:
The Wintergrasp vehicle teleporter (GO 192951, ``go_wg_vehicle_teleporter``) decided whether a vehicle's passenger was friendly to the teleporter pad by comparing the passenger's race mask against ``sRaceMgr->GetHordeRaceMask()`` / ``GetAllianceRaceMask()``. This is brittle:

- Custom races added by modules are not necessarily reflected in those masks, so legitimate defender-team passengers fall through and are denied the teleport.
- Under crossfaction setups where the passenger's race is faked, the race mask reflects the faked race rather than the player's actual team.

Switch to ``Player::GetTeamId()``, which already accounts for both cases (race-mask masks are derived from the same race data, but ``GetTeamId()`` is the canonical "what team is this player on right now" check used throughout the rest of the battlefield code). The unused ``RaceMgr.h`` include is dropped.

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude Opus 4.7 (Claude Code).**

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

1. Start a Wintergrasp battle.
2. As a defender-team player, build and mount a siege vehicle (catapult, demolisher, or siege engine) at a workshop.
3. Drive onto one of the two vehicle teleporter pads inside the fortress (``(5314.5, 2703.7, 408.5)`` or ``(5316.2, 2977.0, 408.5)``).
4. Verify the vehicle is teleported as expected.
5. Repeat as an attacker-team player and verify the pad does **not** teleport you (faction mismatch).
6. If you run a custom-race module or a crossfaction setup, repeat steps 2-5 with affected races/faked players to verify the fix.

## Known Issues and TODO List:

- [ ]
- [ ]