### PR TITLE
fix(Core/Battlefield): pre-clear stale tracking on enter

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -76,6 +76,18 @@ Battlefield::~Battlefield()
 
 void Battlefield::HandlePlayerEnterZone(Player* player, uint32 /*zone*/)
 {
+    // Clear any stale entries from a prior visit that did not unwind cleanly.
+    // Runs before the script hook so scripts see a clean state if they read any
+    // of these containers.
+    for (uint8 i = 0; i < PVP_TEAMS_COUNT; ++i)
+    {
+        PlayersInWar[i].erase(player->GetGUID());
+        InvitedPlayers[i].erase(player->GetGUID());
+        PlayersInQueue[i].erase(player->GetGUID());
+        PlayersWillBeKick[i].erase(player->GetGUID());
+        Players[i].erase(player->GetGUID());
+    }
+
     // Allow scripts to adjust the player's effective team or appearance before
     // any team-based battlefield containers (such as player lists or queues) are updated.
     sScriptMgr->OnBattlefieldPlayerEnterZone(this, player);


### PR DESCRIPTION
## Changes Proposed:
At the top of ``Battlefield::HandlePlayerEnterZone``, sweep the entering player's GUID from every per-player tracking container on both teams (``PlayersInWar``, ``InvitedPlayers``, ``PlayersInQueue``, ``PlayersWillBeKick``, ``Players``).

This is a defensive cleanup against stale entries from a prior visit that did not unwind cleanly. It runs **before** ``OnBattlefieldPlayerEnterZone`` fires so script hooks (e.g. crossfaction team adjustment) see a clean state if they read from these containers. Mirrors the existing cleanup loop already done at the bottom of ``HandlePlayerLeaveZone``.

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude Opus 4.7 (Claude Code).**

## Issues Addressed:
- Closes https://github.com/azerothcore/mod-cfbg/issues/143

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

1. Enter and leave a battlefield zone (Wintergrasp) normally — behaviour should be unchanged (the sweep removes entries that should not exist).
2. With a crossfaction module that flips team in ``OnBattlefieldPlayerEnterZone``: confirm the hook still sees clean state and that the entering player isn't double-counted on either side.

## Known Issues and TODO List:

- [ ]
- [ ]