### PR TITLE
feat(Core/Battlefield): aura-driven resurrect queue 

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -634,34 +634,22 @@ GraveyardStruct const* Battlefield::GetClosestGraveyard(Player* player)
     return nullptr;
 }
 
-void Battlefield::AddPlayerToResurrectQueue(ObjectGuid npcGuid, ObjectGuid playerGuid)
+void Battlefield::AddPlayerToResurrectQueue(ObjectGuid /*npcGuid*/, ObjectGuid playerGuid)
 {
-    for (BfGraveyard* gy : GraveyardList)
-    {
-        if (!gy)
-            continue;
+    Player* player = ObjectAccessor::FindPlayer(playerGuid);
+    if (!player)
+        return;
 
-        if (gy->HasNpc(npcGuid))
-        {
-            gy->AddPlayer(playerGuid);
-            break;
-        }
-    }
+    player->CastSpell(player, SPELL_WAITING_FOR_RESURRECT, true);
 }
 
 void Battlefield::RemovePlayerFromResurrectQueue(ObjectGuid playerGuid)
 {
-    for (BfGraveyard* gy : GraveyardList)
-    {
-        if (!gy)
-            continue;
+    Player* player = ObjectAccessor::FindPlayer(playerGuid);
+    if (!player)
+        return;
 
-        if (gy->HasPlayer(playerGuid))
-        {
-            gy->RemovePlayer(playerGuid);
-            break;
-        }
-    }
+    player->RemoveAurasDueToSpell(SPELL_WAITING_FOR_RESURRECT);
 }
 
 void Battlefield::SendAreaSpiritHealerQueryOpcode(Player* player, ObjectGuid const& guid)
@@ -707,80 +695,9 @@ float BfGraveyard::GetDistance(Player* player)
     return player->GetDistance2d(safeLoc->x, safeLoc->y);
 }
 
-void BfGraveyard::AddPlayer(ObjectGuid playerGuid)
-{
-    if (!ResurrectQueue.count(playerGuid))
-    {
-        ResurrectQueue.insert(playerGuid);
-
-        if (Player* player = ObjectAccessor::FindPlayer(playerGuid))
-            player->CastSpell(player, SPELL_WAITING_FOR_RESURRECT, true);
-    }
-}
-
-void BfGraveyard::RemovePlayer(ObjectGuid playerGuid)
-{
-    ResurrectQueue.erase(ResurrectQueue.find(playerGuid));
-
-    if (Player* player = ObjectAccessor::FindPlayer(playerGuid))
-        player->RemoveAurasDueToSpell(SPELL_WAITING_FOR_RESURRECT);
-}
-
-void BfGraveyard::Resurrect()
-{
-    if (ResurrectQueue.empty())
-        return;
-
-    for (ObjectGuid const& guid : ResurrectQueue)
-    {
-        // Get player object from his guid
-        Player* player = ObjectAccessor::FindPlayer(guid);
-        if (!player)
-            continue;
-
-        // Check if the player is in world and on the good graveyard
-        if (player->IsInWorld())
-            if (Unit* spirit = ObjectAccessor::GetCreature(*player, SpiritGuide[ControlTeam]))
-                spirit->CastSpell(spirit, SPELL_SPIRIT_HEAL, true);
-
-        // Resurrect player
-        player->CastSpell(player, SPELL_RESURRECTION_VISUAL, true);
-        player->ResurrectPlayer(1.0f);
-        player->CastSpell(player, 6962, true);
-        player->CastSpell(player, SPELL_SPIRIT_HEAL_MANA, true);
-
-        player->SpawnCorpseBones(false);
-    }
-
-    ResurrectQueue.clear();
-}
-
-// For changing graveyard control
 void BfGraveyard::GiveControlTo(TeamId team)
 {
     ControlTeam = team;
-    // Teleport to other graveyard, players which were on this graveyard
-    RelocateDeadPlayers();
-}
-
-void BfGraveyard::RelocateDeadPlayers()
-{
-    GraveyardStruct const* closestGrave = nullptr;
-    for (ObjectGuid const& guid : ResurrectQueue)
-    {
-        Player* player = ObjectAccessor::FindPlayer(guid);
-        if (!player)
-            continue;
-
-        if (closestGrave)
-            player->TeleportTo(player->GetMapId(), closestGrave->x, closestGrave->y, closestGrave->z, player->GetOrientation());
-        else
-        {
-            closestGrave = Bf->GetClosestGraveyard(player);
-            if (closestGrave)
-                player->TeleportTo(player->GetMapId(), closestGrave->x, closestGrave->y, closestGrave->z, player->GetOrientation());
-        }
-    }
 }
 
 Creature* Battlefield::SpawnCreature(uint32 entry, Position pos, TeamId teamId)

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -169,18 +169,6 @@ public:
     // Set spirit service for the graveyard
     void SetSpirit(Creature* spirit, TeamId team);
 
-    // Add a player to the graveyard
-    void AddPlayer(ObjectGuid playerGuid);
-
-    // Remove a player from the graveyard
-    void RemovePlayer(ObjectGuid playerGuid);
-
-    // Resurrect players
-    void Resurrect();
-
-    // Move players waiting to that graveyard on the nearest one
-    void RelocateDeadPlayers();
-
     // Check if this graveyard has a spirit guide
     bool HasNpc(ObjectGuid guid)
     {
@@ -190,8 +178,7 @@ public:
         return (SpiritGuide[0] == guid || SpiritGuide[1] == guid);
     }
 
-    // Check if a player is in this graveyard's resurrect queue
-    bool HasPlayer(ObjectGuid guid) const { return ResurrectQueue.find(guid) != ResurrectQueue.end(); }
+    ObjectGuid GetSpiritGuide(TeamId team) const { return SpiritGuide[team]; }
 
     // Get the graveyard's ID.
     uint32 GetGraveyardId() const { return GraveyardId; }
@@ -200,7 +187,6 @@ protected:
     TeamId ControlTeam;
     uint32 GraveyardId;
     ObjectGuid SpiritGuide[2];
-    GuidUnorderedSet ResurrectQueue;
     Battlefield* Bf;
 };
 

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -193,9 +193,39 @@ bool BattlefieldWG::SetupBattlefield()
     _scheduler.Schedule(Milliseconds(RESURRECTION_INTERVAL),
         BATTLEFIELD_TIMER_GROUP_RESURRECT, [this](TaskContext context)
     {
-        for (BfGraveyard* gy : GraveyardList)
-            if (gy)
-                gy->Resurrect();
+        ForEachPlayerInZone([this](Player* player)
+        {
+            if (!player->HasAura(SPELL_WAITING_FOR_RESURRECT))
+                return;
+
+            TeamId team = player->GetTeamId();
+            Unit* closestSpirit = nullptr;
+            float closestDist = -1.0f;
+            for (BfGraveyard* gy : GraveyardList)
+            {
+                if (!gy)
+                    continue;
+                Unit* spirit = ObjectAccessor::GetCreature(*player, gy->GetSpiritGuide(team));
+                if (!spirit)
+                    continue;
+                float dist = player->GetDistance(spirit);
+                if (closestDist < 0.0f || dist < closestDist)
+                {
+                    closestDist = dist;
+                    closestSpirit = spirit;
+                }
+            }
+
+            if (closestSpirit)
+                closestSpirit->CastSpell(closestSpirit, SPELL_SPIRIT_HEAL, true);
+
+            player->CastSpell(player, SPELL_RESURRECTION_VISUAL, true);
+            player->ResurrectPlayer(1.0f);
+            player->CastSpell(player, 6962, true);
+            player->CastSpell(player, SPELL_SPIRIT_HEAL_MANA, true);
+            player->SpawnCorpseBones(false);
+            player->RemoveAurasDueToSpell(SPELL_WAITING_FOR_RESURRECT);
+        });
         context.Repeat();
     });
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5344,13 +5344,10 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                     {
                         case 2584: // Waiting to Resurrect
                             // Waiting to resurrect spell cancel, we must remove player from resurrect queue
+                            // bf branch omitted: it would cascade back into this handler.
                             if (target->IsPlayer())
-                            {
                                 if (Battleground* bg = target->ToPlayer()->GetBattleground())
                                     bg->RemovePlayerFromResurrectQueue(target->ToPlayer());
-                                if (Battlefield* bf = sBattlefieldMgr->GetBattlefieldToZoneId(target->GetZoneId()))
-                                    bf->RemovePlayerFromResurrectQueue(target->GetGUID());
-                            }
                             break;
                         case 43681: // Inactive
                             {

--- a/src/server/scripts/Northrend/zone_wintergrasp.cpp
+++ b/src/server/scripts/Northrend/zone_wintergrasp.cpp
@@ -215,12 +215,18 @@ public:
 
     bool OnGossipHello(Player* player, Creature* creature) override
     {
-        if (creature->IsQuestGiver())
-            player->PrepareQuestMenu(creature->GetGUID());
-
         Battlefield* wintergrasp = sBattlefieldMgr->GetBattlefieldByBattleId(BATTLEFIELD_BATTLEID_WG);
         if (!wintergrasp)
             return true;
+
+        if (!player->IsAlive())
+        {
+            wintergrasp->SendAreaSpiritHealerQueryOpcode(player, creature->GetGUID());
+            player->CastSpell(player, SPELL_WAITING_FOR_RESURRECT, true);
+        }
+
+        if (creature->IsQuestGiver())
+            player->PrepareQuestMenu(creature->GetGUID());
 
         GraveyardVect graveyard = wintergrasp->GetGraveyardVector();
         for (uint8 i = 0; i < graveyard.size(); i++)


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Refactors `BfGraveyard`'s resurrect tracking to follow CMaNGOS's model: the `SPELL_WAITING_FOR_RESURRECT` (2584) aura itself is the queue marker, instead of a per-graveyard `GuidUnorderedSet`. The WG resurrect tick scans zone players for the aura rather than iterating per-GY sets.

Surface effect for players: right-clicking a WG spirit guide as a ghost now queues you immediately (matching CMaNGOS's `GossipHello_npc_spirit_guide`), instead of requiring the spirit-healer popup's Accept click which would silently fail when the popup got dismissed by the gossip menu opening.

Detailed change list:
- `BfGraveyard`: drop `AddPlayer` / `RemovePlayer` / `HasPlayer` / `Resurrect` / `RelocateDeadPlayers` and the `ResurrectQueue` member. Expose `GetSpiritGuide(team)` so the rez tick can find a spirit guide for the visual cast.
- `Battlefield::AddPlayerToResurrectQueue` / `RemovePlayerFromResurrectQueue`: collapse to a single `CastSpell` / `RemoveAurasDueToSpell` on the aura.
- `BattlefieldWG`: scan-based resurrect tick (`ForEachPlayerInZone` + `HasAura`); removes the aura post-rez.
- `zone_wintergrasp` `npc_wg_spirit_guide::OnGossipHello`: for ghost players, send the spirit-healer popup and cast the queue aura immediately, then fall through to the existing GY-teleport gossip menu.
- `SpellAuraEffects` case 2584 OnRemove: drop the `bf` branch. The previous code called `Battlefield::RemovePlayerFromResurrectQueue` inside the OnRemove handler, which (under the new aura-as-queue model) just re-strips the same aura that's already being stripped — a self-cascade that produced two extra spurious removals per real cancel.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.7 (Claude Code, 1M context) — used for code exploration, diagnosis (the resurrect queue was being silently stripped via multiple mechanisms — channeled-aura cleanup, TALK interrupt, client `CMSG_CANCEL_AURA` after popup dismissal, and an OnRemove cascade), and the CMaNGOS-style refactor. All changes have been read, understood, and tested by me.

## Issues Addressed:

- Closes

WG spirit-guide right-click as a ghost would silently fail to queue the player for resurrection: the `SPELL_WAITING_FOR_RESURRECT` aura was applied and then immediately stripped by a combination of the gossip-hello path opening a gossip menu (dismissing the spirit-healer popup → client `CMSG_CANCEL_AURA`) and the case-2584 OnRemove handler cascading through `Battlefield::RemovePlayerFromResurrectQueue`. With the aura-as-queue model, removing the cascade is sufficient.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Ported from CMaNGOS-wotlk. The reference shape is `GossipHello_npc_spirit_guide` in [`src/game/AI/ScriptDevAI/scripts/battlegrounds/battlegrounds.cpp`](https://github.com/cmangos/mangos-wotlk/blob/master/src/game/AI/ScriptDevAI/scripts/battlegrounds/battlegrounds.cpp) — cast `SPELL_WAITING_TO_RESURRECT` on gossip-hello, no per-graveyard queue. Authored under `cmangos <cmangos@users.noreply.github.com>` via `--author`.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Verified in WG:
- Right-click spirit guide as ghost → "Waiting to Resurrect" buff applied and sticks; resurrect tick rezzes after 30s.
- Right-click the buff icon to manually cancel → cancel works (post-apply window has elapsed by the time the user mouses to the buff bar).
- Repeated right-clicks → no duplicate queueing, no flicker.
- Living players still get the existing GY-teleport gossip menu unchanged.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Join a Wintergrasp battle as either faction.
2. Die in the WG zone.
3. As a ghost, walk to any spirit guide (e.g. at one of the workshops) and right-click them.
4. Observe: the spirit-healer popup appears and the "Waiting to Resurrect" buff appears in your buff bar simultaneously.
5. Wait up to ~30s for the resurrect tick.
6. Verify you are resurrected at the spirit guide's location.
7. Repeat and instead cancel the buff (right-click the buff icon) → verify you are removed from the queue and not resurrected.

## Known Issues and TODO List:

- [ ]
- [ ]