### PR TITLE
fix(Core/Wintergrasp): remove redundant chamber teleport on battle start

### DIFF
--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -296,19 +296,7 @@ void BattlefieldWG::OnBattleStart()
         capturePoint->SetCapturePointData(capturePoint->GetCapturePointGo(),
             capturePoint->GetCapturePointGo()->GetEntry() == GO_WINTERGRASP_FACTORY_BANNER_SE || capturePoint->GetCapturePointGo()->GetEntry() == GO_WINTERGRASP_FACTORY_BANNER_SW ? GetAttackerTeam() : GetDefenderTeam());
 
-    for (uint8 team = 0; team < 2; ++team)
-        for (ObjectGuid const& guid : Players[team])
-        {
-            // Kick player in orb room, TODO: offline player ?
-            if (Player* player = ObjectAccessor::FindPlayer(guid))
-            {
-                float x, y, z;
-                player->GetPosition(x, y, z);
-                if (5500 > x && x > 5392 && y < 2880 && y > 2800 && z < 480)
-                    player->TeleportTo(MAP_NORTHREND, 5349.8686f, 2838.481f, 409.240f, 0.046328f);
-                SendInitWorldStatesTo(player);
-            }
-        }
+    SendInitWorldStatesToAll();
     // Initialize vehicle counter
     UpdateCounterVehicle(true);
     // Send start warning to all players


### PR DESCRIPTION
## Changes Proposed:

Removes the AABB-based eject loop in `BattlefieldWG::OnBattleStart` that teleported any player standing inside the Titan Relic chamber to a fixed point in the keep when battle started.

The queue-invite flow already covers both branches when the battle begins:

- `InvitePlayersInZoneToWar` sends the war popup to every in-zone player, including chamber dwellers.
- **Accept** -> `PlayerAcceptInviteToWar` -> `OnPlayerJoinWar` teleports the player to their team spawn.
- **Reject / timeout** -> `KickPlayerFromBattlefield` teleports the player to `KickPosition`.

The old eject pre-empted that decision and forced everyone into the keep regardless of choice. The surrounding `SendInitWorldStatesTo` loop was identical to the existing `SendInitWorldStatesToAll` helper, so it collapses to a single call.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Model:** Claude Opus 4.7 (1M context). Used to locate the eject loop, cross-reference the queue-invite flow, compare against TrinityCore 3.3.5 and CMaNGOS, and draft the patch. Logic and reasoning have been reviewed by the author.

## Issues Addressed:
- Closes 

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Aligned with [CMaNGOS `BattlefieldWG.cpp`](https://github.com/cmangos/mangos-wotlk/blob/master/src/game/Battlefield/BattlefieldWG.cpp), whose battle-start path has never carried this eject — it relies on the standard invite/accept/reject flow. Commit attributed via `--author` to Xfurry, primary CMaNGOS Wintergrasp author.

For contrast, [TrinityCore 3.3.5](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Battlefield/BattlefieldWG.cpp) still carries the same loop AzerothCore inherited; this is a deliberate divergence from TC toward the cleaner CMaNGOS model.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Code-style linter (`apps/codestyle/codestyle-cpp.py`) passes.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. With Wintergrasp set to start shortly, position a player inside the Titan Relic chamber (defender keep, interior).
2. Wait for the battle to start; confirm the player receives the war-invite popup like any other in-zone player.
3. **Accept** -> player teleports to the team spawn point.
4. **Reject (or let the timer expire)** -> player teleports to the kick position (homebind / kick exit) instead of being dropped inside the keep.
5. Verify world states (timer, building/workshop states) refresh correctly on battle start for all in-zone players.

## Known Issues and TODO List:

- [ ] None known.