### PR TITLE
fix(warrior): allow Juggernaut crit bonus with Recklessness

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -9795,11 +9795,12 @@ void Player::ApplySpellMod(uint32 spellId, SpellModOp op, T& basevalue, Spell* s
 
         if (mod->type == SPELLMOD_FLAT)
         {
-            // xinef: do not allow to consume more than one 100% crit increasing spell
-            if (mod->op == SPELLMOD_CRITICAL_CHANCE && totalflat >= 100)
-                return;
-
             int32 flatValue = mod->value;
+
+            // xinef: do not allow to consume more than one 100% crit increasing spell,
+            // but still allow smaller crit bonuses to stack with a 100% crit modifier.
+            if (mod->op == SPELLMOD_CRITICAL_CHANCE && flatValue >= 100 && totalflat >= 100)
+                return;
 
             // SPELL_MOD_THREAT - divide by 100 (in packets we send threat * 100)
             if (mod->op == SPELLMOD_THREAT)


### PR DESCRIPTION
## Summary
- Allows non-100% critical chance spell modifiers to stack after a 100% critical chance modifier has already been applied.
- Preserves the existing guard that prevents consuming multiple 100% critical chance modifiers for the same spell.
- Fixes the Recklessness + Juggernaut case where Mortal Strike/Slam could remain below guaranteed crit chance after the 100% Recklessness modifier blocked Juggernaut's smaller bonus.

Bounty #20741

## Test Plan
- `python3 apps/codestyle/codestyle-cpp.py src/server/game/Entities/Player/Player.cpp`
- `git diff --check`

Note: no full C++ build was run; this is a focused one-line spell modifier logic fix in a large codebase.
