### PR TITLE
feat(Core/Battlefield): grace period for mid-war logout/relog

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -93,6 +93,8 @@ void Battlefield::HandlePlayerEnterZone(Player* player, uint32 /*zone*/)
     // any team-based battlefield containers (such as player lists or queues) are updated.
     sScriptMgr->OnBattlefieldPlayerEnterZone(this, player);
 
+    TryRejoinAfterLogout(player); // relog: auto-rejoin, skip invite below
+
     // Xinef: do not invite players on taxi
     if (!player->IsInFlight())
     {
@@ -124,12 +126,20 @@ void Battlefield::HandlePlayerEnterZone(Player* player, uint32 /*zone*/)
 
 void Battlefield::HandlePlayerLeaveZone(Player* player, uint32 /*zone*/)
 {
+    // Logout still runs full leave-war cleanup, but marks the player for grace-window auto-rejoin.
+    bool const isLogout = player->GetSession() && player->GetSession()->PlayerLogout();
+
     if (IsWarTime())
     {
         // If the player is participating to the battle
         if (PlayersInWar[player->GetTeamId()].erase(player->GetGUID()))
         {
-            player->GetSession()->SendBfLeaveMessage(BattleId);
+            if (isLogout)
+                LogoutGracePlayers[player->GetTeamId()][player->GetGUID()] =
+                    GameTime::GetGameTime().count() + LOGOUT_GRACE_SECONDS;
+            else
+                player->GetSession()->SendBfLeaveMessage(BattleId);
+
             if (Group* group = player->GetGroup()) // Remove the player from the raid group
                 if (group->isBFGroup())
                     group->RemoveMember(player->GetGUID());
@@ -321,6 +331,7 @@ void Battlefield::StartBattle()
     {
         PlayersInWar[team].clear();
         Groups[team].clear();
+        LogoutGracePlayers[team].clear();
     }
 
     Timer = BattleTime;
@@ -586,6 +597,41 @@ bool Battlefield::AddOrSetPlayerToCorrectBfGroup(Player* player)
         group->AddMember(player);
 
     return true;
+}
+
+void Battlefield::TryRejoinAfterLogout(Player* player)
+{
+    ObjectGuid const guid = player->GetGUID();
+    time_t const now = GameTime::GetGameTime().count();
+
+    // Consume the marker and honor its grace window (check both teams; team may have changed).
+    bool pending = false;
+    for (uint8 team = 0; team < PVP_TEAMS_COUNT; ++team)
+        if (auto itr = LogoutGracePlayers[team].find(guid); itr != LogoutGracePlayers[team].end())
+        {
+            pending = itr->second > now;
+            LogoutGracePlayers[team].erase(itr);
+        }
+
+    // Vacancy gate mirrors HandlePlayerEnterZone (full team -> queue path). Pre-hook:
+    // we can't abort after JoinWar, which may already have mutated module state.
+    if (!pending || !IsWarTime() || !HasWarVacancy(player->GetTeamId()))
+        return;
+
+    if (Group* current = player->GetGroup())
+        if (current->isBGGroup() || current->isBFGroup())
+            return;
+
+    // Rejoin via the normal join path: firing JoinWar lets modules rebuild
+    // per-session (Player*-keyed) state and pick the team before the raid bind.
+    sScriptMgr->OnBattlefieldPlayerJoinWar(this, player);
+
+    if (AddOrSetPlayerToCorrectBfGroup(player))
+    {
+        player->GetSession()->SendBfEntered(BattleId);
+        PlayersInWar[player->GetTeamId()].insert(guid);
+        OnPlayerJoinWar(player);
+    }
 }
 
 BfGraveyard* Battlefield::GetGraveyardById(uint32 id) const

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -278,6 +278,11 @@ public:
     /// Force player to join a battlefield group
     bool AddOrSetPlayerToCorrectBfGroup(Player* player);
 
+    /// Auto-rejoin a player who relogged within the grace window after a mid-war
+    /// logout, via the normal join hooks. No-op without a pending logout marker.
+    /// Called from HandlePlayerEnterZone (which fires on the post-login zone set).
+    void TryRejoinAfterLogout(Player* player);
+
     // Graveyard methods
     // Find which graveyard the player must be teleported to to be resurrected by spiritguide
     GraveyardStruct const* GetClosestGraveyard(Player* player);
@@ -381,6 +386,10 @@ protected:
     GuidUnorderedSet PlayersInWar[PVP_TEAMS_COUNT];         // Players in WG combat
     PlayerTimerMap InvitedPlayers[PVP_TEAMS_COUNT];
     PlayerTimerMap PlayersWillBeKick[PVP_TEAMS_COUNT];
+    // Mid-war logouts: GUID -> timestamp until which a relog auto-rejoins the war.
+    PlayerTimerMap LogoutGracePlayers[PVP_TEAMS_COUNT];
+
+    static constexpr uint32 LOGOUT_GRACE_SECONDS = 120; // relog auto-rejoin window
 
     // Variables that must exist for each battlefield
     uint32 TypeId;                                          // See enum BattlefieldTypes


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Logging out during an active battle (e.g. Wintergrasp) previously removed the player from the war immediately. On relog they were treated as a fresh arrival and re-invited with a queue/war popup, or dropped entirely.

This adds a short logout grace window (`LOGOUT_GRACE_SECONDS`, 120s):

- A mid-war logout still runs the full leave-war cleanup, but also records a per-player grace marker (`LogoutGracePlayers`).
- On the next zone entry (which always fires on login), `HandlePlayerLoggedIn` consumes the marker and, if still within the window and the war has room, auto-rejoins the player through the normal join path — no invite popup.
- The rejoin deliberately fires `OnBattlefieldPlayerJoinWar` rather than silently re-binding the raid, so script/module state tied to war membership is rebuilt and the player's team is resolved *before* `AddOrSetPlayerToCorrectBfGroup` binds the raid group.
- Expired markers are dropped on the battlefield tick; all markers reset in `StartBattle`.

The change lives in the generic `Battlefield` base class, so it applies to any battlefield (currently Wintergrasp).

### AI-assisted Pull Requests

- [x] AI tools were used in preparing this pull request: **Claude (Opus 4.7)** was used to research the behavior and implement the change. The author understands and can justify the changes.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

This adapts the logout-grace / re-join concept from the CMaNGOS battlefield framework. Credited via the commit `--author` tag (Yaki Khadafi, original framework author) and a `Co-Authored-By` for Xfurry (later grace-logic refinements). The code itself is a fresh AzerothCore-native implementation, not a literal copy.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Steps below.

1. Start a Wintergrasp battle and join the war.
2. Log out while the battle is active, then log back in within 120 seconds.
3. Confirm you rejoin the war automatically, on the same side, with no queue/invite popup.
4. Log out and wait past 120 seconds before relogging: confirm you are re-invited normally (no auto-rejoin).
5. With a cross-faction module enabled, confirm the assigned faction is preserved/rebuilt across the relog and cleared correctly at battle end.

## Known Issues and TODO List:

- [ ] Grace window (120s) is a compile-time constant; could be made configurable if desired.