### PR TITLE
fix(Core/Battlefield): disband raid groups on battle end

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -396,6 +396,14 @@ void Battlefield::EndBattle(bool endByTimer)
     OnBattleEnd(endByTimer);
     sScriptMgr->OnBattlefieldWarEnd(this, endByTimer);
 
+    for (uint8 team = 0; team < PVP_TEAMS_COUNT; ++team)
+    {
+        for (ObjectGuid const& guid : Groups[team])
+            if (Group* group = sGroupMgr->GetGroupByGUID(guid.GetCounter()))
+                group->Disband();
+        Groups[team].clear();
+    }
+
     // Reset battlefield timer
     Timer = NoWarBattleTime;
     SendInitWorldStatesToAll();


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

When `Battlefield::EndBattle` runs, the BF raid groups built up over the war stay registered in `GroupMgr`, and players still standing in the zone keep their `isBFGroup()` flag pointing at a defunct raid until they finally walk out of Wintergrasp (where `HandlePlayerLeaveZone` removes them one by one). The next `StartBattle` then wipes `Groups[team]` by GUID, but the underlying `Group*` objects themselves were never disbanded — they linger with stale membership.

This mirrors cmangos' behaviour: at the end of the battle, iterate the BF raids for both teams and call `Group::Disband()`. AzerothCore's `Group::Disband()` already removes each member's BG/BF raid flag (`player->RemoveFromBattlegroundOrBattlefieldRaid()`) and self-deletes via `sGroupMgr->RemoveGroup(this); delete this;`, so no manual `delete` is needed (unlike cmangos, where `Disband()` doesn't self-destruct).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. — Claude Opus 4.7 assisted in locating the cmangos commit and adapting it to AzerothCore's `Group::Disband()` semantics.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Cherry-picked from cmangos/mangos-wotlk@[08491d4f](https://github.com/cmangos/mangos-wotlk/commit/08491d4fff1795cb448e989d740fa0dbb00404ef) — "Battlefield: Disband groups when battle is finished", by Xfurry. Committed under `--author="Xfurry <xfurry.cmangos@outlook.com>"`.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Built locally and the C++ codestyle check passes.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Join Wintergrasp on two characters from the same team during a war.
2. Confirm they are pulled into a battlefield raid (`/who`, group panel).
3. Let the battle end (or wait for the timer). Stay in the zone.
4. Before the change: both players remain in a stale BF raid until they leave Wintergrasp. After the change: the raid is disbanded as soon as the battle ends; players see `SMSG_GROUP_DESTROYED` and are no longer in a group (or, if they had an original party, are restored to it).
5. Start the next war and verify a fresh BF raid is built from scratch with no leftover slots.

## Known Issues and TODO List:

- [ ]
- [ ]