### PR TITLE
fix(Core/Battlefield): block invites and kicks from BF raids

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13109,8 +13109,8 @@ PartyResult Player::CanUninviteFromGroup(ObjectGuid targetPlayerGUID) const
         if (InBattleground())
             return ERR_INVITE_RESTRICTED;
 
-        // BF raids are owned by the Battlefield system; members must not be kicked
-        // by the synthetic raid leader (would drop their team assignment mid-battle).
+        // BF raids are owned by the Battlefield system; leaders/assistants must not
+        // be able to kick members (would drop their team assignment mid-battle).
         if (grp->isBFGroup())
             return ERR_NOT_LEADER;
     }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13108,6 +13108,11 @@ PartyResult Player::CanUninviteFromGroup(ObjectGuid targetPlayerGUID) const
 
         if (InBattleground())
             return ERR_INVITE_RESTRICTED;
+
+        // BF raids are owned by the Battlefield system; members must not be kicked
+        // by the synthetic raid leader (would drop their team assignment mid-battle).
+        if (grp->isBFGroup())
+            return ERR_NOT_LEADER;
     }
 
     return ERR_PARTY_RESULT_OK;

--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -126,6 +126,16 @@ void WorldSession::HandleGroupInviteOpcode(WorldPacket& recvData)
         return;
     }
 
+    // Battlefield raids (e.g. Wintergrasp) are owned by the BF system. Unlike BG raids,
+    // BF raids do not preserve the player's original group as a fallback, so an outsider
+    // joining via invite would bypass the queue/team-balance path and end up in a broken
+    // state where Battlefield::AddOrSetPlayerToCorrectBfGroup refuses to add them.
+    if (Group* invitingGroup = invitingPlayer->GetGroup(); invitingGroup && invitingGroup->isBFGroup())
+    {
+        SendPartyResult(PARTY_OP_INVITE, membername, ERR_NOT_LEADER);
+        return;
+    }
+
     Group* group = invitingPlayer->GetGroup();
     if (group && group->isBGGroup())
         group = invitingPlayer->GetOriginalGroup();

--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -126,10 +126,10 @@ void WorldSession::HandleGroupInviteOpcode(WorldPacket& recvData)
         return;
     }
 
-    // Battlefield raids (e.g. Wintergrasp) are owned by the BF system. Unlike BG raids,
-    // BF raids do not preserve the player's original group as a fallback, so an outsider
-    // joining via invite would bypass the queue/team-balance path and end up in a broken
-    // state where Battlefield::AddOrSetPlayerToCorrectBfGroup refuses to add them.
+    // Battlefield raids (e.g. Wintergrasp) have their composition managed by the BF
+    // system based on queue and team balance. Letting raid members recruit outsiders
+    // bypasses Battlefield::AddOrSetPlayerToCorrectBfGroup, which on WG entry then
+    // refuses to add the invitee because they are already in a BF group.
     if (Group* invitingGroup = invitingPlayer->GetGroup(); invitingGroup && invitingGroup->isBFGroup())
     {
         SendPartyResult(PARTY_OP_INVITE, membername, ERR_NOT_LEADER);


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

The Battlefield (BF) invite and kick handlers only filtered BG groups, so a Wintergrasp raid leader could:

1. **Invite outsiders to their WG raid** — `WorldSession::HandleGroupInviteOpcode` only swaps to `GetOriginalGroup()` when `isBGGroup()`, with no equivalent for `isBFGroup()`. BF raids do not preserve an original group, so the invite proceeds against the BF raid itself. The invited player then gets added to the WG raid without going through the BF queue/team-balance path. If they later queue for WG on the opposite team, `Battlefield::AddOrSetPlayerToCorrectBfGroup` refuses to add them (they're already in a BF group) — leaving the player in a broken state that never gets teleported into the battle.
2. **Kick BF raid members mid-battle** — `Player::CanUninviteFromGroup` blocks kicks via `InBattleground()` only, which checks `m_bgData.bgInstanceID != 0` and is never set for Battlefield. A WG raid leader/assistant could boot players from the WG raid, dropping their team assignment without notifying the BF system.

Both fixes mirror the existing BG guards. The invite path returns `ERR_NOT_LEADER` rather than swapping to the original group (since BF raids don't have one); the kick path returns `ERR_NOT_LEADER` next to the existing `InBattleground()` check.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.7 (1M context) was used to locate the affected code paths and draft the patch.

## Issues Addressed:

- Closes

## SOURCE:

The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Retail did not expose this case because BF raid leadership was not player-controlled in the same way. Neither TrinityCore nor cmangos guard the invite/kick paths against BF groups either, so this fix is novel.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Invite block (requires 2+ characters):**
1. Queue a character for Wintergrasp and enter the battle so they end up in a BF raid (they will be made leader if first in the raid).
2. Have that character try to invite another character who is not in WG.
3. Expected: invite is rejected with "You are not the party leader."
4. Confirm the outsider was not added to the WG raid.

**Kick block (requires 2+ characters in the same WG raid):**
1. Two characters in the same WG BF raid where one is the leader/assistant.
2. Leader attempts to kick the other.
3. Expected: kick is rejected with "You are not the party leader." and the target remains in the raid.

**Regression checks:**
- Normal (non-BF) raid invites and kicks behave as before.
- BG raid invites and kicks behave as before (the existing `isBGGroup()` / `InBattleground()` paths are untouched).
- Leaving WG normally still removes the player from the BF raid via the Battlefield system.

## Known Issues and TODO List:

- [ ] None known.