### PR TITLE
fix(Core/Combat): drop dangling current victim on phase change crash

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -15321,29 +15321,9 @@ void Unit::SetPhaseMask(uint32 newPhaseMask, bool update)
 
         if (!sScriptMgr->CanSetPhaseMask(this, newPhaseMask, update))
             return;
-
-        // Phase-related threat updates are done AFTER the phase change below
     }
 
     WorldObject::SetPhaseMask(newPhaseMask, false);
-
-    // Now update threat online states with the new phase mask applied
-    if (IsCreature() || (IsPlayer() && !ToPlayer()->IsGameMaster() && !ToPlayer()->GetSession()->PlayerLogout()))
-    {
-        // Update online state for units that have me on their threat list
-        for (auto const& pair : GetThreatMgr().GetThreatenedByMeList())
-        {
-            if (ThreatReference* ref = pair.second)
-                ref->UpdateOffline();
-        }
-
-        // Update online state for units on my threat list
-        if (!IsPlayer())
-        {
-            for (ThreatReference* ref : GetThreatMgr().GetModifiableThreatList())
-                ref->UpdateOffline();
-        }
-    }
 
     if (!IsInWorld())
     {

--- a/src/test/server/game/Combat/ThreatManagerTest.cpp
+++ b/src/test/server/game/Combat/ThreatManagerTest.cpp
@@ -734,7 +734,7 @@ TEST_F(ThreatManagerIntegrationTest,
 }
 
 // ============================================================================
-// Phase Change + Threat Offline State Tests (SetPhaseMask order fix)
+// Phase Change + Threat Offline State Tests
 // ============================================================================
 
 TEST_F(ThreatManagerIntegrationTest,
@@ -747,6 +747,10 @@ TEST_F(ThreatManagerIntegrationTest,
 
     // Move B to a different phase
     _creatureB->SetPhase(2);
+
+    // Online state is refreshed lazily on the next threat update tick (matches
+    // TrinityCore - SetPhaseMask itself does not touch threat)
+    _creatureA->TestGetThreatMgr().Update(ThreatManager::THREAT_UPDATE_INTERVAL);
 
     // B should now be offline on A's threat list (different phases)
     // The list is not empty if we include offline, but empty if we don't


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Fixes a `worldserver` crash on the map update thread:

```
ASSERTION FAILED
!_currentVictimRef || _currentVictimRef->IsAvailable()
ThreatManager::GetCurrentVictim (ThreatManager.cpp:252)
Creature::SelectVictim -> CreatureAI::UpdateVictim -> ...AI::UpdateAI -> Creature::Update -> Map::Update
```

**Root cause:** `ThreatManager::GetCurrentVictim` only reselects when the *live* `ShouldBeOffline()` is true, then asserts the *cached* `IsAvailable()`. `Unit::SetPhaseMask` eagerly called `ThreatReference::UpdateOffline()` on threat refs (added in #24715). When a phase change flipped the **current victim's** ref to `ONLINE_STATE_OFFLINE`, nothing cleared `_currentVictimRef`, leaving it dangling at an offline reference. When the offline-triggering condition later flickered off, `GetCurrentVictim` skipped the reselect and tripped the assert. The path is AI-agnostic — any creature in combat that reaches `CreatureAI::UpdateVictim` during/after a phase change can hit it.

**Fix:** Remove the eager threat online-state update from `Unit::SetPhaseMask` to match upstream TrinityCore, whose `SetPhaseMask` does not touch threat at all. Online states are refreshed lazily on the next `ThreatManager::ReselectVictim` tick — which is already phase-aware via the live `ShouldBeOffline()` check in `GetCurrentVictim` and runs every combat AI tick — so combat retargeting and evade behavior are unaffected. The only observable difference is that client threat-meter updates may lag by up to one tick.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude Code with AzerothMCP**

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Behavior aligned with upstream TrinityCore: its `Unit::SetPhaseMask` does not update threat online-states, deferring to the lazy `ThreatManager::ReselectVictim` path. No TrinityCore code is copied in this PR (it is a removal of an AzerothCore-specific divergence), so no cherry-pick attribution applies.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

The crash is AI-agnostic — it reproduces with any attackable creature via the `.modify phase` GM command, which drives `Unit::SetPhaseMask` directly. Tested with an unkillable test dummy so combat can be sustained across phase toggles:

1. `.npc add 14830` to spawn an unkillable test dummy (entry 14830, faction-hostile, `HealthModifier` 2000), then pull it so it has you as its current victim. (Any attackable creature works.)
2. **Select the creature** and toggle its phase mid-combat: `.modify phase 2`, then `.modify phase 1`.
   - Expected: within ~1 tick the creature drops/re-acquires you correctly; no crash.
3. Re-engage, **select yourself**, and rapidly toggle `.modify phase 2` / `.modify phase 1` a few times while it attacks you.
   - Expected: aggro drops/resumes cleanly each toggle, no assertion crash. Toggling fast is the best stress for the cached-offline / live-online flicker that triggered the original crash.

Before the fix this asserts in `ThreatManager::GetCurrentVictim`; after the fix the creature retargets/evades cleanly.

## Known Issues and TODO List:

- [ ] None known.
