### PR TITLE
fix(Core/Groups): preserve BoP trade window when mailing roll-won items

### DIFF
--- a/src/server/game/Entities/Player/PlayerStorage.cpp
+++ b/src/server/game/Entities/Player/PlayerStorage.cpp
@@ -6209,6 +6209,32 @@ Item* Player::_LoadMailedItem(ObjectGuid const& playerGuid, Player* player, uint
         return nullptr;
     }
 
+    // Rehydrate looters for BoP-tradeable mail items; only the LFG mail path writes this flag, gated on the same config.
+    if (item->IsBOPTradable() && sWorld->getBoolConfig(CONFIG_SET_BOP_ITEM_TRADEABLE))
+    {
+        CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_ITEM_BOP_TRADE);
+        stmt->SetData(0, item->GetGUID().GetCounter());
+
+        if (PreparedQueryResult result = CharacterDatabase.Query(stmt))
+        {
+            AllowedLooterSet looters;
+            for (std::string_view guidStr : Acore::Tokenize((*result)[0].Get<std::string_view>(), ' ', false))
+            {
+                if (Optional<ObjectGuid::LowType> guid = Acore::StringTo<ObjectGuid::LowType>(guidStr))
+                    looters.insert(ObjectGuid::Create<HighGuid::Player>(*guid));
+                else
+                    LOG_WARN("entities.player.loading", "Player::_LoadMailedItem: invalid item_soulbound_trade_data GUID '{}' for item {}. Skipped.", guidStr, item->GetGUID().ToString());
+            }
+
+            if (looters.size() > 1 && proto->GetMaxStackSize() == 1 && item->IsSoulBound())
+                item->SetSoulboundTradeable(looters);
+            else
+                item->RemoveFlag(ITEM_FIELD_FLAGS, ITEM_FIELD_FLAG_BOP_TRADEABLE);
+        }
+        else
+            item->RemoveFlag(ITEM_FIELD_FLAGS, ITEM_FIELD_FLAG_BOP_TRADEABLE);
+    }
+
     if (mail)
     {
         mail->AddItem(itemGuid, itemEntry);

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -63,6 +63,40 @@ Loot* Roll::getLoot()
     return getTarget();
 }
 
+static void SendRollWonItemViaMail(Player* player, LootItem const* lootItem, uint32 itemId)
+{
+    Item* mailItem = Item::CreateItem(itemId, lootItem->count, player, false, lootItem->randomPropertyId);
+    if (!mailItem)
+        return;
+
+    AllowedLooterSet looters = lootItem->GetAllowedLooters();
+    ItemTemplate const* proto = mailItem->GetTemplate();
+    // Preserve the 2-hour group trade window the item would have had if stored directly.
+    if (looters.size() > 1 && proto->GetMaxStackSize() == 1 &&
+        (proto->Bonding == BIND_WHEN_PICKED_UP || proto->Bonding == BIND_QUEST_ITEM) &&
+        sWorld->getBoolConfig(CONFIG_SET_BOP_ITEM_TRADEABLE))
+    {
+        mailItem->SetBinding(true);
+        mailItem->SetSoulboundTradeable(looters);
+        mailItem->SetUInt32Value(ITEM_FIELD_CREATE_PLAYED_TIME, player->GetTotalPlayedTime());
+
+        std::string lootersStr;
+        for (ObjectGuid const& guid : looters)
+        {
+            if (!lootersStr.empty())
+                lootersStr += ' ';
+            lootersStr += std::to_string(guid.GetCounter());
+        }
+
+        CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_ITEM_BOP_TRADE);
+        stmt->SetData(0, mailItem->GetGUID().GetCounter());
+        stmt->SetData(1, lootersStr);
+        CharacterDatabase.Execute(stmt);
+    }
+
+    player->SendItemRetrievalMail(mailItem);
+}
+
 Group::Group() : m_leaderName(""), m_groupType(GROUPTYPE_NORMAL),
     m_dungeonDifficulty(DUNGEON_DIFFICULTY_NORMAL), m_raidDifficulty(RAID_DIFFICULTY_10MAN_NORMAL),
     m_bfGroup(nullptr), m_bgGroup(nullptr), m_lootMethod(FREE_FOR_ALL), m_lootThreshold(ITEM_QUALITY_UNCOMMON),
@@ -1497,8 +1531,7 @@ void Group::CountTheRoll(Rolls::iterator rollI, Map* allowedMap)
                             roll->getLoot()->NotifyItemRemoved(roll->itemSlot);
                             roll->getLoot()->unlootedCount--;
                             player->SendEquipError(msg, nullptr, nullptr, roll->itemid);
-                            if (Item* mailItem = Item::CreateItem(roll->itemid, item->count, player, false, item->randomPropertyId))
-                                player->SendItemRetrievalMail(mailItem);
+                            SendRollWonItemViaMail(player, item, roll->itemid);
                         }
                         else
                         {
@@ -1580,8 +1613,7 @@ void Group::CountTheRoll(Rolls::iterator rollI, Map* allowedMap)
                                 roll->getLoot()->NotifyItemRemoved(roll->itemSlot);
                                 roll->getLoot()->unlootedCount--;
                                 player->SendEquipError(msg, nullptr, nullptr, roll->itemid);
-                                if (Item* mailItem = Item::CreateItem(roll->itemid, item->count, player, false, item->randomPropertyId))
-                                    player->SendItemRetrievalMail(mailItem);
+                                SendRollWonItemViaMail(player, item, roll->itemid);
                             }
                             else
                             {


### PR DESCRIPTION
## Changes Proposed:

Follow-up to #25909. When a roll-won item is mailed via `LFG.MailItemOnFullInventory` instead of stored directly, the mail path bypassed the BoP-tradeable plumbing that `Player::StoreNewItem` applies: the `ITEM_FIELD_FLAG_BOP_TRADEABLE` flag, `CREATE_PLAYED_TIME` stamp, looter set, and `item_soulbound_trade_data` row. The mailed item arrived fully soulbound with an empty `allowedGUIDs`, so `Item::IsBindedNotWith` rejected every trade attempt — a player who accidentally clicked Need could no longer hand the item over to anyone in the original looter group during the 2-hour window.

- `Group.cpp` routes both Need and Greed mail paths through a new `SendRollWonItemViaMail` helper that mirrors `Player::StoreNewItem`'s BoP-tradeable application when conditions match (multi-looter, non-stackable, `BIND_WHEN_PICKED_UP`, `Item.SetItemTradeable` enabled).
- `Player::_LoadMailedItem` rehydrates the looter set from `item_soulbound_trade_data` when the flag is present, mirroring the existing `_LoadInventory` logic, so the trade window survives a logout while the item is still in the mailbox.
- The expire timer starts ticking when the recipient pulls the item out via the existing `_StoreItem` → `AddTradeableItem` path.

BoE items, single-looter loot, and the `Item.SetItemTradeable = 0` case are unchanged.

-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

  > Claude Sonnet 4.6 (claude.ai/code) was used to assist with implementation.

## Issues Addressed:
- Follow-up to #25909 — addresses https://github.com/azerothcore/azerothcore-wotlk/pull/25909#issuecomment-4577909446

## SOURCE:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Set `LFG.MailItemOnFullInventory = 1` and `Item.SetItemTradeable = 1` in `worldserver.conf`.
2. Queue and complete a random dungeon with two or more characters eligible for the same boss-loot table.
3. Fill the prospective winner's inventory completely.
4. Win a Need roll on a BoP item that drops from the boss.
5. Open the recipient's mailbox — the item should be delivered by The Postmaster.
6. Take the item from the mailbox into inventory.
7. Right-click → Trade with one of the other dungeon members who was eligible for the drop — the trade window should accept the item (no "this item is bound to you" error).
8. Confirm the trade succeeds and the new holder also retains the 2-hour window.
9. Log out and back in with the item still sitting in mail, then repeat steps 6-8 — behaviour should be identical (looters survive the relog).
10. Confirm `Item.SetItemTradeable = 0` still produces fully-soulbound mailed items (original behaviour preserved).
11. Confirm a Greed-rolled BoE that gets mailed lands without the `BOP_TRADEABLE` flag and trades freely (no regression on BoE mailing).

## Known Issues and TODO List:

- [ ]

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.