### PR TITLE
refactor(Core/Battlefield): fire OnBattlefieldWarEnd before OnBattleEnd

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -404,8 +404,11 @@ void Battlefield::EndBattle(bool endByTimer)
     else
         DoPlaySoundToAll(BF_HORDE_WINS);
 
-    OnBattleEnd(endByTimer);
+    // Hook runs BEFORE OnBattleEnd so subscribers can read PlayersInWar
+    // while it is still populated (OnBattleEnd hands out rewards and then
+    // clears the set).
     sScriptMgr->OnBattlefieldWarEnd(this, endByTimer);
+    OnBattleEnd(endByTimer);
 
     for (uint8 team = 0; team < PVP_TEAMS_COUNT; ++team)
     {

--- a/src/server/game/Scripting/ScriptDefines/BattlefieldScript.h
+++ b/src/server/game/Scripting/ScriptDefines/BattlefieldScript.h
@@ -28,7 +28,7 @@ enum BattlefieldHook
     BATTLEFIELDHOOK_ON_PLAYER_JOIN_WAR,            // 2 - fires after player is added to the active war
     BATTLEFIELDHOOK_ON_PLAYER_LEAVE_WAR,           // 3 - fires after player is removed from the active war
     BATTLEFIELDHOOK_BEFORE_INVITE_PLAYER_TO_WAR,   // 4 - fires in InvitePlayerToWar before InvitedPlayers insert
-    BATTLEFIELDHOOK_ON_WAR_END,                    // 5 - fires in EndBattle after OnBattleEnd(), before timer reset
+    BATTLEFIELDHOOK_ON_WAR_END,                    // 5 - fires in EndBattle before OnBattleEnd(), while PlayersInWar is still populated
     BATTLEFIELDHOOK_ON_PLAYER_KILL,                // 6 - fires in HandleKill for every player-kills-player event
     BATTLEFIELDHOOK_END
 };


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Reorders `sScriptMgr->OnBattlefieldWarEnd(...)` to fire **before** `OnBattleEnd(...)` inside `Battlefield::EndBattle`, and updates the inline doc on `BATTLEFIELDHOOK_ON_WAR_END` to match the new timing.

Until now, the hook fired *after* the virtual `OnBattleEnd`, at which point `BattlefieldWG::OnBattleEnd` had already iterated `PlayersInWar` to hand out rewards and then cleared both teams' sets. Subscribers that needed to enumerate who actually participated in the war (e.g. to restore per-player state for crossfaction modules) had no authoritative source to iterate, and were forced to mirror `PlayersInWar` themselves through `OnBattlefieldPlayerJoinWar` / `OnBattlefieldPlayerLeaveWar` / `OnBattlefieldPlayerLeaveZone`.

After this PR, subscribers can read `bf->GetPlayersInWarSet(team)` directly inside `OnBattlefieldWarEnd` and drop the parallel state. mod-cfbg's WG crossfaction support is the first beneficiary (paired PR: azerothcore/mod-cfbg#154).

#### Behavioral note

`OnBattleEnd`'s reward distribution still runs in the same `EndBattle` call, just after the hook instead of before. Reward effects are unaffected by subscribers that mutate player faction inside the hook:

- `SPELL_VICTORY_REWARD` / `SPELL_DEFEAT_REWARD` / `SPELL_ESSENCE_OF_WINTERGRASP` / tower spells: self-cast, faction-neutral effects.
- `AreaExploredOrEventHappens(13183 | 13181)`: keys on whether the player already holds the quest, not on current faction.
- Post-capture phase-shift aura: keys on `DefenderTeam`, not on player faction.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.7 (1M context, via Claude Code) was used for codebase analysis, drafting the patch, and writing the PR description. The author has reviewed the change end-to-end.

## Issues Addressed:

- N/A — internal hook-timing change, no linked issue.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

N/A — internal hook ordering refactor; no gameplay-accuracy claim. The behavioral analysis above is derived from reading `Battlefield::EndBattle`, `BattlefieldWG::OnBattleEnd`, and the affected reward spells.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Build the core with this PR applied. No module changes are required for core-only verification; for the end-to-end test, build with the paired mod-cfbg PR (azerothcore/mod-cfbg#154).
2. Start Wintergrasp and let a war run to completion. Test both timer-expiry (defender wins by clock) and an attacker-wins (relic captured) scenario.
3. Confirm victory/defeat rewards, win-quest credits, damaged/destroyed tower spells, and the post-capture phase-shift aura are still applied to every war participant. Compare honor and Wintergrasp Mark of Honor tallies to a master baseline if available.
4. With the paired mod-cfbg PR loaded: verify crossfaction-faked players have their real race/team/faction restored at war end (use `.cfbg debug <name>` immediately after the war ends, both on a player who leaves the zone and on one who stays).

## Known Issues and TODO List:

- [ ] None known.
- [ ]