### PR TITLE
fix(Core/Battlefield): collapse BfCapturePoint::ActivePlayers to single set

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -857,7 +857,7 @@ bool BfCapturePoint::HandlePlayerEnter(Player* player)
         player->SendUpdateWorldState(go->GetGOInfo()->capturePoint.worldstate2, uint32(std::ceil((Value + MaxValue) / (2 * MaxValue) * 100.0f)));
         player->SendUpdateWorldState(go->GetGOInfo()->capturePoint.worldstate3, NeutralValuePct);
     }
-    return ActivePlayers[player->GetTeamId()].insert(player->GetGUID()).second;
+    return ActivePlayers.insert(player->GetGUID()).second;
 }
 
 GuidUnorderedSet::iterator BfCapturePoint::HandlePlayerLeave(Player* player)
@@ -865,13 +865,12 @@ GuidUnorderedSet::iterator BfCapturePoint::HandlePlayerLeave(Player* player)
     if (GameObject* go = GetCapturePointGo(player))
         player->SendUpdateWorldState(go->GetGOInfo()->capturePoint.worldState1, 0);
 
-    GuidUnorderedSet::iterator current = ActivePlayers[player->GetTeamId()].find(player->GetGUID());
+    GuidUnorderedSet::iterator current = ActivePlayers.find(player->GetGUID());
 
-    if (current == ActivePlayers[player->GetTeamId()].end())
+    if (current == ActivePlayers.end())
         return current; // return end()
 
-    current = ActivePlayers[player->GetTeamId()].erase(current);
-    return current;
+    return ActivePlayers.erase(current);
 }
 
 void BfCapturePoint::SendChangePhase()
@@ -880,17 +879,16 @@ void BfCapturePoint::SendChangePhase()
     if (!capturePoint)
         return;
 
-    for (uint8 team = 0; team < 2; ++team)
-        for (ObjectGuid const& guid : ActivePlayers[team])  // send to all players present in the area
-            if (Player* player = ObjectAccessor::FindPlayer(guid))
-            {
-                // send this too, sometimes the slider disappears, dunno why :(
-                player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldState1, 1);
-                // send these updates to only the ones in this objective
-                player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate2, (uint32) std::ceil((Value + MaxValue) / (2 * MaxValue) * 100.0f));
-                // send this too, sometimes it resets :S
-                player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate3, NeutralValuePct);
-            }
+    for (ObjectGuid const& guid : ActivePlayers)  // send to all players present in the area
+        if (Player* player = ObjectAccessor::FindPlayer(guid))
+        {
+            // send this too, sometimes the slider disappears, dunno why :(
+            player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldState1, 1);
+            // send these updates to only the ones in this objective
+            player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate2, (uint32) std::ceil((Value + MaxValue) / (2 * MaxValue) * 100.0f));
+            // send this too, sometimes it resets :S
+            player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate3, NeutralValuePct);
+        }
 }
 
 bool BfCapturePoint::SetCapturePointData(GameObject* capturePoint, TeamId team)
@@ -962,19 +960,19 @@ bool BfCapturePoint::Update(uint32 diff)
 
     float radius = capturePoint->GetGOInfo()->capturePoint.radius;
 
-    for (uint8 team = 0; team < 2; ++team)
+    // Single pass over the existing set: drop leavers, count survivors per team.
+    uint32 counts[PVP_TEAMS_COUNT] = { 0, 0 };
+    for (auto itr = ActivePlayers.begin(); itr != ActivePlayers.end();)
     {
-        for (auto itr = ActivePlayers[team].begin(); itr != ActivePlayers[team].end();)
+        Player* player = ObjectAccessor::FindPlayer(*itr);
+        if (player && capturePoint->IsWithinDistInMap(player, radius) && player->IsOutdoorPvPActive())
         {
-            if (Player* player = ObjectAccessor::FindPlayer(*itr))
-                if (!capturePoint->IsWithinDistInMap(player, radius) || !player->IsOutdoorPvPActive())
-                {
-                    itr = HandlePlayerLeave(player);
-                    continue;
-                }
-
+            ++counts[player->GetTeamId()];
             ++itr;
+            continue;
         }
+
+        itr = (player ? HandlePlayerLeave(player) : ActivePlayers.erase(itr));
     }
 
     std::list<Player*> players;
@@ -984,11 +982,14 @@ bool BfCapturePoint::Update(uint32 diff)
 
     for (Player* player : players)
         if (player->IsOutdoorPvPActive())
-            if (ActivePlayers[player->GetTeamId()].insert(player->GetGUID()).second)
+            if (ActivePlayers.insert(player->GetGUID()).second)
+            {
                 HandlePlayerEnter(player);
+                ++counts[player->GetTeamId()];
+            }
 
     // get the difference of numbers
-    float factDiff = ((float) ActivePlayers[0].size() - (float) ActivePlayers[1].size()) * diff / BATTLEFIELD_OBJECTIVE_UPDATE_INTERVAL;
+    float factDiff = ((float)counts[TEAM_ALLIANCE] - (float)counts[TEAM_HORDE]) * diff / BATTLEFIELD_OBJECTIVE_UPDATE_INTERVAL;
     if (G3D::fuzzyEq(factDiff, 0.0f))
         return false;
 
@@ -1074,34 +1075,36 @@ bool BfCapturePoint::Update(uint32 diff)
 
 void BfCapturePoint::SendUpdateWorldState(uint32 field, uint32 value)
 {
-    for (uint8 team = 0; team < 2; ++team)
-        for (ObjectGuid const& guid : ActivePlayers[team])  // send to all players present in the area
-            if (Player* player = ObjectAccessor::FindPlayer(guid))
-                player->SendUpdateWorldState(field, value);
+    for (ObjectGuid const& guid : ActivePlayers)  // send to all players present in the area
+        if (Player* player = ObjectAccessor::FindPlayer(guid))
+            player->SendUpdateWorldState(field, value);
 }
 
 void BfCapturePoint::SendObjectiveComplete(uint32 id, ObjectGuid guid)
 {
-    uint8 team;
+    TeamId winner;
     switch (State)
     {
         case BF_CAPTUREPOINT_OBJECTIVESTATE_ALLIANCE:
-            team = 0;
+            winner = TEAM_ALLIANCE;
             break;
         case BF_CAPTUREPOINT_OBJECTIVESTATE_HORDE:
-            team = 1;
+            winner = TEAM_HORDE;
             break;
         default:
             return;
     }
 
-    // send to all players present in the area
-    for (ObjectGuid const& playerGuid : ActivePlayers[team])
+    // Credit only players on the controlling team. Team is read from the
+    // player now (not at insert time) so CFBG-faked players get credit on
+    // their assigned side.
+    for (ObjectGuid const& playerGuid : ActivePlayers)
         if (Player* player = ObjectAccessor::FindPlayer(playerGuid))
-            player->KilledMonsterCredit(id, guid);
+            if (player->GetTeamId() == winner)
+                player->KilledMonsterCredit(id, guid);
 }
 
 bool BfCapturePoint::IsInsideObjective(Player* player) const
 {
-    return ActivePlayers[player->GetTeamId()].find(player->GetGUID()) != ActivePlayers[player->GetTeamId()].end();
+    return ActivePlayers.find(player->GetGUID()) != ActivePlayers.end();
 }

--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -1096,8 +1096,8 @@ void BfCapturePoint::SendObjectiveComplete(uint32 id, ObjectGuid guid)
     }
 
     // Credit only players on the controlling team. Team is read from the
-    // player now (not at insert time) so CFBG-faked players get credit on
-    // their assigned side.
+    // player at iteration time, not at insert time, so players whose
+    // GetTeamId() changed mid-stay get credit on their current side.
     for (ObjectGuid const& playerGuid : ActivePlayers)
         if (Player* player = ObjectAccessor::FindPlayer(playerGuid))
             if (player->GetTeamId() == winner)

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -121,8 +121,7 @@ protected:
 
     // Active players in the area of the objective. Single set keyed by GUID:
     // team is computed from Player::GetTeamId() at the point it is needed.
-    // Splitting by team here would desync if GetTeamId() changes mid-stay
-    // (CFBG faking flips the team after the player is already tracked).
+    // Splitting by team here would desync if GetTeamId() changes mid-stay.
     GuidUnorderedSet ActivePlayers;
 
     // Total shift needed to capture the objective

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -119,8 +119,11 @@ public:
 protected:
     bool DelCapturePoint();
 
-    // Active players in the area of the objective, 0 - alliance, 1 - horde
-    GuidUnorderedSet ActivePlayers[2];
+    // Active players in the area of the objective. Single set keyed by GUID:
+    // team is computed from Player::GetTeamId() at the point it is needed.
+    // Splitting by team here would desync if GetTeamId() changes mid-stay
+    // (CFBG faking flips the team after the player is already tracked).
+    GuidUnorderedSet ActivePlayers;
 
     // Total shift needed to capture the objective
     float MaxValue;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`BfCapturePoint::ActivePlayers` was a two-element array of sets indexed by `player->GetTeamId()` at both insert and erase. When a player's `GetTeamId()` changes between those events — e.g. a cross-faction Wintergrasp player whose team flips via faking after they were already tracked by a capture point — the erase looks in the wrong set and returns an iterator into a different container than the caller's loop is iterating over. `BfCapturePoint::Update` then compares that iterator against the wrong set's `end()`, tripping MSVC's checked-iterator assert ("list iterators incompatible") and crashing the world tick.

Collapsing into a single `GuidUnorderedSet` removes the team-indexed lookup entirely; team is computed from `Player::GetTeamId()` at the point it's actually needed (per-tick factDiff counts folded into the existing `FindPlayer` pass, and `SendObjectiveComplete` filters by the controlling team at iteration time). `SendObjectiveComplete` also got more correct as a side effect — faked players now get capture-point credit aligned with `GetTeamId()` (their assigned side), where before they could be tracked under the wrong team's bucket and miss credit or get cross-faction credit.

The desync is impossible by construction now, not by convention.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Opus 4.7** was used for crash diagnosis (from a Wheaty dump), root-cause analysis, and drafting the patch. The author reviewed, directed the refactor (initial draft used a smaller API-level fix; this larger structural fix was chosen explicitly to eliminate the bug class rather than route around it), and is able to explain and justify the changes.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

No upstream issue filed; reproduced locally against `master` (revision `919eefef7`).

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Crash dump (MSVC Debug build, Windows) and source-level analysis:

```
Exception code: C0000005 ACCESS_VIOLATION
std::_List_const_iterator<...ObjectGuid>::operator==   include/list line 194
BfCapturePoint::Update                                  Battlefield.cpp line 967
Battlefield::Update                                     Battlefield.cpp line 202
BattlefieldWG::Update                                   BattlefieldWG.cpp line 246
BattlefieldMgr::Update                                  BattlefieldMgr.cpp line 128
World::Update                                           World.cpp line 1255
```

(The `_List_*` iterator type appears because `std::unordered_set`'s MSVC implementation stores elements in an internal `std::list`.)

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

The pre-fix crash was reliably reproduced on Windows / MSVC Debug builds via a CFBG-style hook that forces every Horde joiner onto Alliance at `OnBattlefieldPlayerJoinWar`: every WG invite-accept produced the assert on the next world tick. The new single-set implementation builds cleanly and `apps/codestyle/codestyle-cpp.py` passes; runtime testing of the new behavior is pending.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Build worldserver in **Debug** on Windows (MSVC) so checked iterators are enabled.
2. Run an active Wintergrasp battle with a flow that flips a player's `GetTeamId()` after they have been tracked by a capture point (e.g. via the CFBG module's WG faking, which can hit this whenever balance triggers a morph; force every Horde→Alliance to make it deterministic).
3. Have the morphed player walk through a Wintergrasp capture point's radius.
4. Without the fix: worldserver crashes on the next `BfCapturePoint::Update` tick with `list iterators incompatible`. With the fix: no crash; capture-point progress and credit work normally for both real-faction and faked players.

Regression checks to perform (since this touches code that handles **all** Battlefield capture points, not just CFBG-faked players):
- Non-crossfaction Wintergrasp: capture-point progress bar moves correctly when one side has more players in the radius; control flips at the right times.
- `SendObjectiveComplete` (workshop / tower captures): only players on the controlling team receive `KilledMonsterCredit`.
- `IsInsideObjective`: still returns true/false correctly for players in / out of the capture radius.
- Any other `Battlefield`-derived zone (none currently in core besides WG, but the change is generic).

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] None known.