### PR TITLE
feat(Scripts/Commands): default battle id to Wintergrasp when omitted

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1780189963547827100.sql
+++ b/data/sql/updates/pending_db_world/rev_1780189963547827100.sql
@@ -1,0 +1,13 @@
+--
+-- Update `command` help text for .bf subcommands: #battleid is now optional
+-- and defaults to 1 (Wintergrasp) when omitted.
+
+DELETE FROM `command` WHERE `name` IN
+    ('bf start', 'bf stop', 'bf switch', 'bf enable', 'bf timer', 'bf queue');
+INSERT INTO `command` (`name`, `security`, `help`) VALUES
+('bf start',  3, 'Syntax: .bf start [#battleid]\r\n#battleid is optional and defaults to 1 (Wintergrasp).'),
+('bf stop',   3, 'Syntax: .bf stop [#battleid]\r\n#battleid is optional and defaults to 1 (Wintergrasp).'),
+('bf switch', 3, 'Syntax: .bf switch [#battleid]\r\n#battleid is optional and defaults to 1 (Wintergrasp).'),
+('bf enable', 3, 'Syntax: .bf enable [#battleid]\r\n#battleid is optional and defaults to 1 (Wintergrasp).'),
+('bf timer',  3, 'Syntax: .bf timer [#battleid] #timer\r\n#battleid is optional and defaults to 1 (Wintergrasp).\r\n#timer: use a timestring like "1h15m30s".'),
+('bf queue',  2, 'Syntax: .bf queue [#battleid]\r\nDisplays all players currently in queue, invited, or actively in war for the specified battlefield.\r\n#battleid is optional and defaults to 1 (Wintergrasp).');

--- a/data/sql/updates/pending_db_world/rev_1780189963547827100.sql
+++ b/data/sql/updates/pending_db_world/rev_1780189963547827100.sql
@@ -2,8 +2,7 @@
 -- Update `command` help text for .bf subcommands: #battleid is now optional
 -- and defaults to 1 (Wintergrasp) when omitted.
 
-DELETE FROM `command` WHERE `name` IN
-    ('bf start', 'bf stop', 'bf switch', 'bf enable', 'bf timer', 'bf queue');
+DELETE FROM `command` WHERE `name` IN ('bf start', 'bf stop', 'bf switch', 'bf enable', 'bf timer', 'bf queue');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('bf start',  3, 'Syntax: .bf start [#battleid]\r\n#battleid is optional and defaults to 1 (Wintergrasp).'),
 ('bf stop',   3, 'Syntax: .bf stop [#battleid]\r\n#battleid is optional and defaults to 1 (Wintergrasp).'),

--- a/src/server/scripts/Commands/cs_bf.cpp
+++ b/src/server/scripts/Commands/cs_bf.cpp
@@ -49,8 +49,9 @@ public:
         return commandTable;
     }
 
-    static bool HandleBattlefieldStart(ChatHandler* handler, uint32 battleId)
+    static bool HandleBattlefieldStart(ChatHandler* handler, Optional<uint32> battleIdArg)
     {
+        uint32 const battleId = battleIdArg.value_or(BATTLEFIELD_BATTLEID_WG);
         Battlefield* bf = sBattlefieldMgr->GetBattlefieldByBattleId(battleId);
 
         if (!bf)
@@ -67,8 +68,9 @@ public:
         return true;
     }
 
-    static bool HandleBattlefieldEnd(ChatHandler* handler, uint32 battleId)
+    static bool HandleBattlefieldEnd(ChatHandler* handler, Optional<uint32> battleIdArg)
     {
+        uint32 const battleId = battleIdArg.value_or(BATTLEFIELD_BATTLEID_WG);
         Battlefield* bf = sBattlefieldMgr->GetBattlefieldByBattleId(battleId);
 
         if (!bf)
@@ -85,8 +87,9 @@ public:
         return true;
     }
 
-    static bool HandleBattlefieldEnable(ChatHandler* handler, uint32 battleId)
+    static bool HandleBattlefieldEnable(ChatHandler* handler, Optional<uint32> battleIdArg)
     {
+        uint32 const battleId = battleIdArg.value_or(BATTLEFIELD_BATTLEID_WG);
         Battlefield* bf = sBattlefieldMgr->GetBattlefieldByBattleId(battleId);
 
         if (!bf)
@@ -113,8 +116,9 @@ public:
         return true;
     }
 
-    static bool HandleBattlefieldSwitch(ChatHandler* handler, uint32 battleId)
+    static bool HandleBattlefieldSwitch(ChatHandler* handler, Optional<uint32> battleIdArg)
     {
+        uint32 const battleId = battleIdArg.value_or(BATTLEFIELD_BATTLEID_WG);
         Battlefield* bf = sBattlefieldMgr->GetBattlefieldByBattleId(battleId);
 
         if (!bf)
@@ -131,12 +135,14 @@ public:
         return true;
     }
 
-    static bool HandleBattlefieldTimer(ChatHandler* handler, uint32 battleId, std::string timeStr)
+    static bool HandleBattlefieldTimer(ChatHandler* handler, Optional<uint32> battleIdArg, std::string timeStr)
     {
         if (timeStr.empty())
         {
             return false;
         }
+
+        uint32 const battleId = battleIdArg.value_or(BATTLEFIELD_BATTLEID_WG);
 
         if (Acore::StringTo<int32>(timeStr).value_or(0) < 0)
         {
@@ -173,8 +179,9 @@ public:
         return true;
     }
 
-    static bool HandleBattlefieldQueue(ChatHandler* handler, uint32 battleId)
+    static bool HandleBattlefieldQueue(ChatHandler* handler, Optional<uint32> battleIdArg)
     {
+        uint32 const battleId = battleIdArg.value_or(BATTLEFIELD_BATTLEID_WG);
         Battlefield* bf = sBattlefieldMgr->GetBattlefieldByBattleId(battleId);
 
         if (!bf)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

Make the `#battleid` argument optional on all `.bf` subcommands (`start`, `stop`, `switch`, `enable`, `timer`, `queue`). When omitted, it now defaults to `1` (`BATTLEFIELD_BATTLEID_WG` / Wintergrasp), which is the only battlefield currently shipped — so the previously required argument was always the same value in practice.

- `src/server/scripts/Commands/cs_bf.cpp` — each handler now takes `Optional<uint32> battleIdArg` and resolves via `.value_or(BATTLEFIELD_BATTLEID_WG)`. Behavior with an explicit id is unchanged.
- `data/sql/updates/pending_db_world/rev_*.sql` — refreshes `command.help` for the six `bf` subcommands to mark `#battleid` as `[optional]` and document the Wintergrasp default.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Tool used: Claude Opus 4.7.

## Issues Addressed:
- Closes 

## SOURCE:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Quality-of-life change — no external source. Wintergrasp is currently the only registered battle id (`BATTLEFIELD_BATTLEID_WG = 1`, see `src/server/game/Battlefield/Battlefield.h`), so the existing required argument was effectively a constant.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Verified `.bf start`, `.bf stop`, `.bf switch`, `.bf enable`, `.bf timer 1m`, `.bf queue` all work both without an argument (default → Wintergrasp) and with explicit `1`. SQL update passes `apps/codestyle/codestyle-sql.py`.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply the pending SQL update and launch worldserver.
2. As a GM, run `.bf queue` (no argument) — should print the Wintergrasp queue/war state.
3. Run `.bf queue 1` — output should be identical to step 2.
4. Run `.bf timer 1m` and `.bf timer 1 1m` — both should adjust the Wintergrasp timer.
5. Run `.help bf start` (and the other subcommands) — help text should show `[#battleid]` and mention the Wintergrasp default.

## Known Issues and TODO List:

- [ ]
- [ ]