### PR TITLE
fix(Scripts/ShadowLabyrinth): engage Murmur on spell damage

### DIFF
--- a/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_murmur.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_murmur.cpp
@@ -105,11 +105,6 @@ struct boss_murmur : public BossAI
         return true;
     }
 
-    bool IsPlayerControlledEngager(Unit* who) const
-    {
-        return who && (who->IsPlayer() || who->IsPet() || who->IsGuardian());
-    }
-
     void SetGUID(ObjectGuid const& guid, int32 index) override
     {
         if (index == GUID_MURMUR_NPCS)
@@ -125,19 +120,15 @@ struct boss_murmur : public BossAI
     {
         BossAI::DamageTaken(attacker, damage, damagetype, damageSchoolMask);
 
-        if (!me->GetVictim() && IsPlayerControlledEngager(attacker))
-        {
+        if (!me->GetVictim() && attacker->IsControlledByPlayer())
             AttackStart(attacker);
-        }
     }
 
     void JustEngagedWith(Unit* who) override
     {
         // Boss engages mobs during roleplay, this checks prevents it from setting the zone in combat before players engage it.
-        if (IsPlayerControlledEngager(who))
-        {
+        if (who->IsControlledByPlayer())
             _JustEngagedWith();
-        }
 
         scheduler.Schedule(28s, [this](TaskContext context)
         {

--- a/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_murmur.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_murmur.cpp
@@ -105,6 +105,11 @@ struct boss_murmur : public BossAI
         return true;
     }
 
+    bool IsPlayerControlledEngager(Unit* who) const
+    {
+        return who && (who->IsPlayer() || who->IsPet() || who->IsGuardian());
+    }
+
     void SetGUID(ObjectGuid const& guid, int32 index) override
     {
         if (index == GUID_MURMUR_NPCS)
@@ -116,10 +121,20 @@ struct boss_murmur : public BossAI
         }
     }
 
+    void DamageTaken(Unit* attacker, uint32& damage, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask) override
+    {
+        BossAI::DamageTaken(attacker, damage, damagetype, damageSchoolMask);
+
+        if (!me->GetVictim() && IsPlayerControlledEngager(attacker))
+        {
+            AttackStart(attacker);
+        }
+    }
+
     void JustEngagedWith(Unit* who) override
     {
         // Boss engages mobs during roleplay, this checks prevents it from setting the zone in combat before players engage it.
-        if (who->IsPlayer() || who->IsPet() || who->IsGuardian())
+        if (IsPlayerControlledEngager(who))
         {
             _JustEngagedWith();
         }


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were partially used in preparing this pull request.

OpenAI Codex (GPT-5) was used to review a severity ranked list of open issues, identify this issue, research and organize relevant information, investigate Blizzlike behavior, and prepare the initial draft of the PR description.

This fixes Murmur remaining idle when engaged with spell damage from outside melee range.

Before this fix, pulling Murmur with spell damage could damage the boss without properly starting his encounter behavior. Murmur would remain idle, would not attack, and would not use his scripted mechanics. Entering melee range or using physical attacks could make the encounter start correctly.

Murmur is intended to be a stationary boss, but he should still enter combat and run his encounter script regardless of how players engage him. Spell pulls, ranged physical pulls, and melee pulls should all start the encounter.

After this fix, when Murmur takes damage from a player-controlled unit and has no active victim, he starts attacking that unit without enabling movement. This keeps Murmur stationary while allowing his combat script and mechanics to start correctly.

Since Murmur is stationary, he may still appear visually still after the pull. That is expected. The important behavior is that he enters combat, targets the player, and starts his scripted ability timers. Some mechanics are delayed by design, for example Magnetic Pull starts after 15-30 seconds, Murmur's Touch after 14.6-25.5 seconds, and Sonic Boom after around 28 seconds.

https://youtu.be/cM3JV1tCXxM

## Issues Addressed:

- Closes #17035

## SOURCE:

The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources.

Sources:
- https://github.com/azerothcore/azerothcore-wotlk/issues/17035
- https://www.wowhead.com/wotlk/npc=18708/murmur
- https://www.wowhead.com/tbc/guide/shadow-labyrinth-dungeon-strategy-burning-crusade-classic
- https://www.icy-veins.com/tbc-classic/shadow-labyrinth-dungeon-guide

## Tests Performed:

Built `worldserver` successfully on Windows Release.

This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:

1. Enter Shadow Labyrinth.
2. Go to Murmur.
3. Stand outside melee range.
4. Pull Murmur with a spell, for example Pyroblast.
5. Confirm Murmur no longer remains idle.
6. Confirm Murmur stays stationary.
7. Confirm Murmur targets the player and enters combat.
8. Wait long enough for his scripted timers to run.
9. Confirm Murmur uses his mechanics.
10. Confirm physical/melee pulls still work normally.

Example GM test commands:

```txt
.gm on
.tele shadowlab
.go c 146206
.learn 11366
.cast 11366
