### PR TITLE
fix(Core/Groups): keep unique roll-won items on corpse instead of mailing

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1525,7 +1525,9 @@ void Group::CountTheRoll(Rolls::iterator rollI, Map* allowedMap)
                     else
                     {
                         uint32 mailOnFull = sWorld->getIntConfig(CONFIG_LFG_MAIL_ITEM_ON_FULL_INVENTORY);
-                        if (mailOnFull == MAIL_ITEM_ON_FULL_INVENTORY_EVERYWHERE || (mailOnFull == MAIL_ITEM_ON_FULL_INVENTORY_LFG_ONLY && isLFGGroup()))
+                        // Only mail when bags are genuinely full. Unique/max-count failures must
+                        // leave the item on the corpse so it can be re-rolled or freely looted.
+                        if (msg == EQUIP_ERR_INVENTORY_FULL && (mailOnFull == MAIL_ITEM_ON_FULL_INVENTORY_EVERYWHERE || (mailOnFull == MAIL_ITEM_ON_FULL_INVENTORY_LFG_ONLY && isLFGGroup())))
                         {
                             item->is_looted = true;
                             roll->getLoot()->NotifyItemRemoved(roll->itemSlot);
@@ -1607,7 +1609,9 @@ void Group::CountTheRoll(Rolls::iterator rollI, Map* allowedMap)
                         else
                         {
                             uint32 mailOnFull = sWorld->getIntConfig(CONFIG_LFG_MAIL_ITEM_ON_FULL_INVENTORY);
-                            if (mailOnFull == MAIL_ITEM_ON_FULL_INVENTORY_EVERYWHERE || (mailOnFull == MAIL_ITEM_ON_FULL_INVENTORY_LFG_ONLY && isLFGGroup()))
+                            // Only mail when bags are genuinely full. Unique/max-count failures must
+                            // leave the item on the corpse so it can be re-rolled or freely looted.
+                            if (msg == EQUIP_ERR_INVENTORY_FULL && (mailOnFull == MAIL_ITEM_ON_FULL_INVENTORY_EVERYWHERE || (mailOnFull == MAIL_ITEM_ON_FULL_INVENTORY_LFG_ONLY && isLFGGroup())))
                             {
                                 item->is_looted = true;
                                 roll->getLoot()->NotifyItemRemoved(roll->itemSlot);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Follow-up to #25909 (mail roll-won items when inventory is full).

That feature mailed **any** roll-won item whose `CanStoreNewItem` call failed. The problem is that a **unique** item the winner already owns does not fail with `EQUIP_ERR_INVENTORY_FULL` — it fails with `EQUIP_ERR_CANT_CARRY_MORE_OF_THIS` (or `EQUIP_ERR_ITEM_MAX_LIMIT_CATEGORY_COUNT_EXCEEDED`). Both errors were lumped into the "mail it" branch, so a unique duplicate was mailed to the winner instead of being left on the corpse.

This regressed the previous behaviour: a player who won a unique item they already had used to leave it on the boss, where it could be re-rolled or free-looted by others. After #25909 it was mailed to the winner, forcing them to delete their existing copy to claim the (unique) mailed duplicate, and removing the ability to pass it to someone else.

### Fix

Gate the mail path on `msg == EQUIP_ERR_INVENTORY_FULL` in both the Need and Greed branches of `Group::CountTheRoll`. Only a genuinely full inventory now mails the item; unique/max-count failures fall through to the legacy path (`is_blocked = false`, `rollWinnerGUID` set) and the item stays on the corpse.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.8 (Claude Code) was used to assist with diagnosis and the patch.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

1. Enable the mail-on-full-inventory setting (`LFG.MailItemOnFullInventory`).
2. Have a player already holding a **unique** item (e.g. a unique trinket/quest item) that drops from a boss.
3. Group-roll Need or Greed on that unique item and have that player win, with **free bag space available**.
4. Verify the item is **not** mailed and instead stays on the corpse (re-rollable / free-lootable), as it did before #25909.
5. Regression check: with bags genuinely **full** (non-unique item), confirm the winner still receives the item by mail.

## Known Issues and TODO List:

- [ ]
