### PR TITLE
fix(Core/Spells): preserve aura instances when dispelling

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2629,10 +2629,11 @@ void Spell::EffectDispel(SpellEffIndex effIndex)
                 bool alreadyListed = false;
                 for (DispelChargesList::iterator successItr = success_list.begin(); successItr != success_list.end(); ++successItr)
                 {
-                    if (successItr->first->GetId() == itr->first->GetId())
+                    if (successItr->first == itr->first)
                     {
                         ++successItr->second;
                         alreadyListed = true;
+                        break;
                     }
                 }
                 if (!alreadyListed)


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were partially used in preparing this pull request.

OpenAI Codex (GPT-5) was used to review a severity ranked list of open issues, identify this issue, research and organize relevant information, investigate Blizzlike behavior, and prepare the initial draft of the PR description.

## Issues Addressed:
- Closes #25798

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

https://github.com/user-attachments/assets/9ca4f5ba-60d2-4097-bc8d-e9fd44a50ac9

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Create or use a Priest character level 20 or higher.
2. Learn Dispel Magic Rank 2, spell ID `988`.
3. Apply two dispellable magic debuffs with the same spell ID but from different casters, such as two separate NPCs casting Corruption.
4. Cast Dispel Magic Rank 2 on the affected target.
5. Before this change, only one aura could be removed when both auras shared the same spell ID.
6. After this change, Dispel Magic Rank 2 can correctly remove both aura instances.

## Known Issues and TODO List:

- [x] None known.