### PR TITLE
fix(Core/Battlefield): Fix incorrect resurrection timer returned by spirit healers

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -707,9 +707,16 @@ void Battlefield::RemovePlayerFromResurrectQueue(ObjectGuid playerGuid)
 void Battlefield::SendAreaSpiritHealerQueryOpcode(Player* player, ObjectGuid const& guid)
 {
     WorldPacket data(SMSG_AREA_SPIRIT_HEALER_TIME, 12);
-    Milliseconds remaining = _scheduler.GetNextGroupOccurrence(BATTLEFIELD_TIMER_GROUP_RESURRECT);
-    uint32 time = static_cast<uint32>(std::clamp(remaining,
-        Milliseconds::zero(), Milliseconds(RESURRECTION_INTERVAL)).count());
+    // _nextResurrectTime is updated atomically by the resurrect callback itself, so
+    // it always reflects the exact wall-clock moment the next Resurrect() will fire.
+    uint32 time = 0;
+    if (_nextResurrectTime != TimePoint{})
+    {
+        Milliseconds remaining = std::chrono::duration_cast<Milliseconds>(
+            _nextResurrectTime - GameTime::Now());
+        time = static_cast<uint32>(std::clamp(remaining,
+            Milliseconds::zero(), Milliseconds(RESURRECTION_INTERVAL)).count());
+    }
 
     data << guid << time;
     ASSERT(player);

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -416,6 +416,8 @@ protected:
 
     TaskScheduler _scheduler;
 
+    TimePoint _nextResurrectTime{};  // absolute time of next resurrection tick; set by SetupResurrectionTimer()
+
     GuidUnorderedSet Groups[PVP_TEAMS_COUNT];               // Contains different raid groups
 
     std::vector<uint64> Data64;

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -190,6 +190,10 @@ bool BattlefieldWG::SetupBattlefield()
     UpdateCounterVehicle(true);
 
     // Schedule always-running periodic timers
+    // Update _nextResurrectTime before scheduling so that any
+    // CMSG_AREA_SPIRIT_HEALER_QUERY that arrives before the first tick
+    // already returns the correct countdown.
+    _nextResurrectTime = GameTime::Now() + Milliseconds(RESURRECTION_INTERVAL);
     _scheduler.Schedule(Milliseconds(RESURRECTION_INTERVAL),
         BATTLEFIELD_TIMER_GROUP_RESURRECT, [this](TaskContext context)
     {
@@ -205,9 +209,11 @@ bool BattlefieldWG::SetupBattlefield()
             {
                 if (!gy)
                     continue;
+
                 Unit* spirit = ObjectAccessor::GetCreature(*player, gy->GetSpiritGuide(team));
                 if (!spirit)
                     continue;
+
                 float dist = player->GetDistance(spirit);
                 if (closestDist < 0.0f || dist < closestDist)
                 {
@@ -226,6 +232,10 @@ bool BattlefieldWG::SetupBattlefield()
             player->SpawnCorpseBones(false);
             player->RemoveAurasDueToSpell(SPELL_WAITING_FOR_RESURRECT);
         });
+
+        // Update the timestamp for the NEXT cycle before Repeat(), so that
+        // any query received in the gap between now and the next tick is correct.
+        _nextResurrectTime = GameTime::Now() + Milliseconds(RESURRECTION_INTERVAL);
         context.Repeat();
     });
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

Replaces scheduler-based resurrection countdown calculations with an absolute timestamp (_nextResurrectTime) updated by the resurrection callback itself. This ensures CMSG_AREA_SPIRIT_HEALER_QUERY always returns the correct remaining time, including before the first resurrection tick and between resurrection cycles.

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26006

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
