### PR TITLE
fix(Core/DB): Pause SmartAI escort movement on vendor interaction

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1780530454211603800.sql
+++ b/data/sql/updates/pending_db_world/rev_1780530454211603800.sql
@@ -1,3 +1,0 @@
-DELETE FROM `creature_template_movement` WHERE `CreatureId` = 844;
-INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES
-(844, NULL, NULL, NULL, NULL, NULL, NULL, 60000);

--- a/data/sql/updates/pending_db_world/rev_1780530454211603800.sql
+++ b/data/sql/updates/pending_db_world/rev_1780530454211603800.sql
@@ -1,0 +1,3 @@
+DELETE FROM `creature_template_movement` WHERE `CreatureId` = 844;
+INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES
+(844, NULL, NULL, NULL, NULL, NULL, NULL, 60000);

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -121,6 +121,9 @@ public:
     // Whether this creature is an escort NPC (override in escort AI)
     virtual bool IsEscortNPC(bool /*onlyIfActive*/ = true) const { return false; }
 
+    // Called by PauseMovementForInteraction when the creature is using escort movement.
+    virtual void OnInteractionPause(uint32 /*pauseTimer*/) {}
+
     // Called for reaction at stopping attack at no attackers or targets
     virtual void EnterEvadeMode(EvadeReason why = EVADE_REASON_OTHER);
 

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -1138,6 +1138,11 @@ void SmartAI::SetEvadeDisabled(bool disable)
     mEvadeDisabled = disable;
 }
 
+void SmartAI::OnInteractionPause(uint32 pauseTimer)
+{
+    PausePath(pauseTimer, true);
+}
+
 void SmartAI::sGossipHello(Player* player)
 {
     GetScript()->ProcessEventsFor(SMART_EVENT_GOSSIP_HELLO, player);

--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -188,6 +188,8 @@ public:
 
     void SetInvincibilityHpLevel(uint32 level) { mInvincibilityHpLevel = level; }
 
+    void OnInteractionPause(uint32 pauseTimer) override;
+
     void sGossipHello(Player* player) override;
     void sGossipSelect(Player* player, uint32 sender, uint32 action) override;
     void sGossipSelectCode(Player* player, uint32 sender, uint32 action, const char* code) override;

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3104,6 +3104,12 @@ void Creature::PauseMovementForInteraction()
             pauseSlot = MOTION_SLOT_ACTIVE;
         else if (GetMotionMaster()->GetMotionSlotType(MOTION_SLOT_CONTROLLED) == POINT_MOTION_TYPE)
             pauseSlot = MOTION_SLOT_CONTROLLED;
+        else if (GetMotionMaster()->GetMotionSlotType(MOTION_SLOT_ACTIVE) == ESCORT_MOTION_TYPE)
+        {
+            if (IsAIEnabled)
+                AI()->OnInteractionPause(pause);
+            return;
+        }
 
         PauseMovement(pause, pauseSlot);
     }


### PR DESCRIPTION
### Changes proposed

- [x] Core — Creature::PauseMovementForInteraction: added handling for ESCORT_MOTION_TYPE in MOTION_SLOT_ACTIVE, delegating to CreatureAI::OnInteractionPause(pauseTimer) instead of the POINT-only path.
- [x] Core — CreatureAI: new virtual OnInteractionPause(uint32) (default no-op) so any AI subclass can customise pause behaviour without touching Creature.cpp.
- [x] Core — SmartAI: overrides OnInteractionPause to call PausePath(pauseTimer, forced=true), which explicitly expires the EscortMovementGenerator and calls MoveIdle() to hold the NPC stationary for the given duration before auto-resuming the path.
- [x] Database — creature_template_movement: adds InteractionPauseTimer = 60000 (60 s) for Antonio Perelli (entry 844). Without a non-zero value the pause is never triggered.

### AI-assisted Pull Request

This PR was developed with AI assistance (Claude Sonnet 4.6 via Claude Code).

### Issues addressed

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/19607
- Closes https://github.com/chromiecraft/chromiecraft/issues/6307

### Source

Logic deduced from server code: NPCHandler.cpp → SendListInventory → PauseMovementForInteraction; SmartAI::PausePath for the correct way to stop escort movement; EscortMovementGenerator for confirming Pause() was a no-op.

### Tests performed

- [x] Tested in-game by author
- Spawned Antonio Perelli, waited until he was actively walking between waypoints, right-clicked to open the vendor window — NPC stops immediately and remains stationary for ~60 s before resuming the path.
- Verified the NPC also stops correctly when interacted with while already at a waypoint stop (actionlist delay in progress).
- No regressions observed on other SmartAI escort creatures tested.

### How to test

1. Find Antonio Perelli in Elwynn Forest / Westfall / Duskwood / Redridge route. (.go c id 844)
2. Wait until he is walking between two waypoints.
3. Right-click him to open the vendor window.
4. Expected: he stops walking immediately and stays still while the window is open (up to 60 s).
5. Expected: after closing the window / timer expires, he resumes walking normally.

### Known issues and TODO

- The 60 s InteractionPauseTimer is a fixed upper bound; if the player closes the window earlier the NPC will stand idle until the timer expires. There is currently no "gossip closed" event in SmartAI to resume sooner.
- OnInteractionPause currently only benefits SmartAI. Other escort AIs (e.g. ScriptedEscortAI) fall through to the existing no-op; they can be handled in follow-up PRs by overriding the same virtual.