### PR TITLE
fix(CI/Windows): fix MySQL installation

### DIFF
--- a/apps/compiler/includes/functions.sh
+++ b/apps/compiler/includes/functions.sh
@@ -90,7 +90,9 @@ function comp_configure() {
         OSOPTIONS=" -DMYSQL_ADD_INCLUDE_PATH=/usr/local/include -DMYSQL_LIBRARY=/usr/local/lib/libmysqlclient.dylib -DREADLINE_INCLUDE_DIR=/usr/local/opt/readline/include -DREADLINE_LIBRARY=/usr/local/opt/readline/lib/libreadline.dylib -DOPENSSL_INCLUDE_DIR=/usr/local/opt/openssl@3/include -DOPENSSL_SSL_LIBRARIES=/usr/local/opt/openssl@3/lib/libssl.dylib -DOPENSSL_CRYPTO_LIBRARIES=/usr/local/opt/openssl@3/lib/libcrypto.dylib "
         ;;
       msys*)
-        OSOPTIONS=" -DMYSQL_INCLUDE_DIR=C:\tools\mysql\current\include -DMYSQL_LIBRARY=C:\tools\mysql\current\lib\mysqlclient.lib "
+        if [[ -d "C:/tools/mysql/current/include" ]]; then
+            OSOPTIONS=" -DMYSQL_INCLUDE_DIR=C:/tools/mysql/current/include -DMYSQL_LIBRARY=C:/tools/mysql/current/lib/mysqlclient.lib "
+        fi
         ;;
     esac
 

--- a/apps/installer/includes/os_configs/windows.sh
+++ b/apps/installer/includes/os_configs/windows.sh
@@ -26,4 +26,4 @@ choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  cmake.install -y --insta
 choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  visualstudio2022-workload-nativedesktop
 choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  openssl --force --version=3.6.2
 choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  boost-msvc-14.3 --force --version=1.87.0
-choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  mysql --force --version=8.4.9
+choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  mysql --force --version=8.4.6

--- a/apps/installer/includes/os_configs/windows.sh
+++ b/apps/installer/includes/os_configs/windows.sh
@@ -26,8 +26,6 @@ choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  cmake.install -y --insta
 choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  visualstudio2022-workload-nativedesktop
 choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  openssl --force --version=3.6.2
 choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  boost-msvc-14.3 --force --version=1.87.0
-if [[ $CONTINUOUS_INTEGRATION ]]; then
-    choco install -y --skip-checksums --no-progress mysql
-else
-    choco install -y --skip-checksums mysql --force
+if [[ ! $CONTINUOUS_INTEGRATION && $SKIP_MYSQL_INSTALL != 1 ]]; then
+    choco install -y --skip-checksums "${INSTALL_ARGS[@]}" mysql --force
 fi

--- a/apps/installer/includes/os_configs/windows.sh
+++ b/apps/installer/includes/os_configs/windows.sh
@@ -26,4 +26,8 @@ choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  cmake.install -y --insta
 choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  visualstudio2022-workload-nativedesktop
 choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  openssl --force --version=3.6.2
 choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  boost-msvc-14.3 --force --version=1.87.0
-choco install -y --skip-checksums "${INSTALL_ARGS[@]}"  mysql --force --version=8.4.6
+if [[ $CONTINUOUS_INTEGRATION ]]; then
+    choco install -y --skip-checksums --no-progress mysql
+else
+    choco install -y --skip-checksums mysql --force
+fi


### PR DESCRIPTION
## Changes Proposed:

This PR fixes the Windows CI pipeline, which was installing MySQL 9.x from the
Chocolatey CDN instead of using the MySQL 8.x already pre-installed on the
GitHub Actions runner.

-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).
-  [x] CI / build infrastructure (Windows installer script, compiler helper).

**Details:**

- `apps/installer/includes/os_configs/windows.sh`: The CI branch was still
  calling `choco install mysql` without a version pin, which caused Chocolatey
  to download and install MySQL 9.x. The fix skips the MySQL installation
  entirely when `CONTINUOUS_INTEGRATION` is set (the runner image already ships
  MySQL 8.x at `C:\tools\mysql\current\`). The same skip is triggered by
  `SKIP_MYSQL_INSTALL=1`, mirroring the pattern already used in `ubuntu.sh`.

- `apps/compiler/includes/functions.sh`: The MySQL CMake flags for `msys*` were
  unconditionally hardcoded to the Chocolatey path. They are now conditional on
  that path actually existing, so `FindMySQL.cmake` auto-detection via the
  Windows registry and `Program Files` glob is used as a fallback when MySQL was
  not installed through Chocolatey.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or
  partially in preparing this pull request. **Claude (claude-sonnet-4-6)** was
  used to analyse the root cause and draft the fix.

## Issues Addressed:

- Closes <!-- no linked issue -->

The Windows CI was installing MySQL 9.x from the Chocolatey CDN due to a
missing version pin, breaking or potentially breaking the build against a MySQL
version not validated by the project.

## SOURCE:

The changes have been validated through:
- [x] The root cause is directly observable in the CI logs (MySQL 9.x reported
  as installed) and traceable to the missing version pin introduced in commit
  `0ec122510`.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members.
- [x] This pull request requires further testing and may have edge cases to be
  tested. The fix must be validated by a successful CI run on the `windows-latest`
  runner to confirm that MySQL 8.x from the base image is picked up correctly by
  CMake.

## How to Test the Changes:

- [x] This pull request requires further testing. Steps:

1. Push the branch or open the PR to trigger the `windows-build` workflow.
2. Inspect the "Configure OS" step log and confirm that the MySQL Chocolatey
   install is skipped.
3. Inspect the "Build" step log and confirm that CMake finds MySQL 8.x
   (look for `Found MySQL version: 8.x.x` or the path resolved under
   `C:/tools/mysql/current`).
4. Confirm the build completes without errors.

## Known Issues and TODO List:

- [ ] The `ccache-action` step is present in `windows_build.yml` but
  `AC_CCACHE` is never set to `true`, so compiler caching is silently disabled
  on Windows. This can be addressed in a follow-up PR.
- [ ] OpenSSL and Boost are still installed via Chocolatey CDN with pinned
  versions; those pins should be reviewed periodically.