### PR TITLE
fix(CMake/Boost): Fix configure warnings on CMake 4.x and MSVC 19.40+

### DIFF
--- a/deps/boost/CMakeLists.txt
+++ b/deps/boost/CMakeLists.txt
@@ -18,6 +18,18 @@ if(WIN32)
   set(Boost_USE_STATIC_LIBS        ON)
   set(Boost_USE_MULTITHREADED      ON)
   set(Boost_USE_STATIC_RUNTIME     OFF)
+
+  # Boost 1.81 maps vc143 only up to MSVC_VERSION 1939; MSVC 19.40-19.49 (VS 2022 17.10+)
+  # is ABI-compatible with vc143 but unrecognised by BoostDetectToolset-1.81.0.cmake.
+  # Pre-set both variables: Boost_COMPILER controls variant selection; BOOST_DETECTED_TOOLSET
+  # prevents the "toolset is unknown" message (the detect file does not reset it, only assigns
+  # it on a matched branch, so our value survives the include when no branch fires).
+  if(MSVC AND MSVC_VERSION GREATER_EQUAL 1940 AND MSVC_VERSION LESS 1950)
+    if(NOT DEFINED Boost_COMPILER)
+      set(Boost_COMPILER "vc143")
+    endif()
+    set(BOOST_DETECTED_TOOLSET "vc143")
+  endif()
 endif()
 
 set(Boost_NO_WARN_NEW_VERSIONS ON)
@@ -29,6 +41,30 @@ if (WIN32)
   set(BOOST_REQUIRED_VERSION 1.78)
 else()
   set(BOOST_REQUIRED_VERSION 1.74)
+endif()
+
+if (POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+  # Windows pre-built Boost binaries place cmake config files under lib<arch>-msvc-<ver>/cmake/
+  # which is not in CMake's standard config-mode search path; auto-discover and set Boost_DIR.
+  if (WIN32 AND NOT DEFINED Boost_DIR)
+    set(_boost_hint "")
+    if (DEFINED Boost_ROOT)
+      set(_boost_hint "${Boost_ROOT}")
+    elseif (DEFINED ENV{Boost_ROOT})
+      set(_boost_hint "$ENV{Boost_ROOT}")
+    elseif (DEFINED ENV{BOOST_ROOT})
+      set(_boost_hint "$ENV{BOOST_ROOT}")
+    endif()
+    if (_boost_hint)
+      file(GLOB _boost_cmake_dirs "${_boost_hint}/lib*/cmake/Boost-*")
+      if (_boost_cmake_dirs)
+        list(GET _boost_cmake_dirs 0 Boost_DIR)
+      endif()
+      unset(_boost_cmake_dirs)
+    endif()
+    unset(_boost_hint)
+  endif()
 endif()
 
 # Boost.System is header-only since 1.69; do not require it explicitly.


### PR DESCRIPTION
## Changes Proposed:

Three related issues fixed in `deps/boost/CMakeLists.txt`, all triggered by the
migration from CMake's `FindBoost` module (removed in CMake 4.x) to Boost's own
config-mode files (`BoostConfig.cmake`):

**1. CMP0167 policy warning (CMake 3.30+)**

CMake 3.30 introduced `CMP0167` to signal that `FindBoost` is removed in CMake 4.x.
When unset, every configure run emits:

```
CMake Warning (dev) at deps/boost/CMakeLists.txt:35 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.
```

Fix: set `CMP0167 NEW` wrapped in `if (POLICY CMP0167)` — a no-op on CMake < 3.30.

**2. Windows config-mode path discovery**

Windows pre-built Boost binaries (boost.org) place cmake config files under
`lib<arch>-msvc-<ver>/cmake/Boost-<ver>/` (e.g. `lib64-msvc-14.3/cmake/Boost-1.81.0/`),
not in the standard `lib/cmake/` path that CMake CONFIG mode expects. `FindBoost` had
its own heuristics; config mode does not.

Fix: auto-discover the correct directory via `file(GLOB)` and set `Boost_DIR` when on
Windows and `Boost_DIR` is not already user-defined.

**3. MSVC 19.40+ toolset unknown (VS 2022 17.10+)**

`BoostDetectToolset-1.81.0.cmake` maps `vc143` only for `MSVC_VERSION` 1930–1939. VS 2022
17.10+ ships MSVC 19.40–19.49 (`MSVC_VERSION` 1940–1949), which is ABI-compatible with
`vc143` but falls outside that range. The file emits a STATUS message for every component
found (7 times):

```
Boost toolset is unknown (compiler MSVC 19.44.35222.0)
```

Fix: pre-set `Boost_COMPILER` and `BOOST_DETECTED_TOOLSET` to `"vc143"` for that range.
`Boost_COMPILER` drives variant selection; `BOOST_DETECTED_TOOLSET` suppresses the message
(the detect file never resets it — it only assigns on a matched branch, so our value
survives the include when no branch fires). Boost 1.83 fixed this upstream by extending
the range to `LESS 1950`.

All three fixes are guarded so they are no-ops on unaffected platforms and CMake versions.

-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Tool used: Claude (claude-sonnet-4-6)**.

## Issues Addressed:
- Closes N/A

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - CMake policy CMP0167: https://cmake.org/cmake/help/v3.30/policy/CMP0167.html
  - Boost 1.83 upstream fix for MSVC 19.40+ range in BoostDetectToolset.
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
  - Configured with **CMake 4.0.0 + MSVC 19.44 (VS 2022 17.14) + Boost 1.81.0** on Windows.
    Configure output is clean: no `CMP0167` warning, no `Boost toolset is unknown` messages,
    Boost found correctly, configuring done without errors.
  - Verified that CMake < 3.30 is unaffected: the `if (POLICY CMP0167)` block is skipped
    entirely and the MSVC/BOOST_DETECTED_TOOLSET block only fires for MSVC_VERSION 1940–1949.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Install CMake 4.x (e.g. 4.0.0) and VS 2022 17.10+ (MSVC 19.40+).
2. Run CMake configure on the AzerothCore source tree.
3. Verify the configure output contains **none** of the following:
   - `CMake Warning (dev) ... Policy CMP0167 is not set`
   - `Boost toolset is unknown`
4. Verify that Boost is found correctly and configuring completes without errors.
5. Optionally repeat with CMake 3.22 or older to confirm no regression on older versions.

## Known Issues and TODO List:

- [ ] None.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.