### PR TITLE
fix(Core/Battlegrounds): aggregate BG queue announcer on burst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # AzerothCore
 #
 
+.cache
 /conf/*
 !/conf/dist
 /modules/*

--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -1046,13 +1046,9 @@ void BattlegroundQueue::BattlegroundQueueAnnouncerUpdate(uint32 diff, Battlegrou
     uint32 qPlayers = 0;
 
     if (_queueAnnouncementCrossfactioned)
-    {
         qPlayers = GetPlayersCountInGroupsQueue(bracket_id, BG_QUEUE_CFBG);
-    }
     else
-    {
         qPlayers = GetPlayersCountInGroupsQueue(bracket_id, BG_QUEUE_NORMAL_HORDE) + GetPlayersCountInGroupsQueue(bracket_id, BG_QUEUE_NORMAL_ALLIANCE);
-    }
 
     if (!qPlayers)
     {
@@ -1069,9 +1065,7 @@ void BattlegroundQueue::BattlegroundQueueAnnouncerUpdate(uint32 diff, Battlegrou
             uint32 q_min_level = std::min(bracketEntry->minLevel, (uint32) 80);
 
             if (!isTimed && !sBGSpam->CanAnnounce(bg_template, bracket_id, q_min_level, qPlayers))
-            {
                 return;
-            }
 
             auto bgName = bg_template->GetName();
             uint32 MaxPlayers = GetMinPlayersPerTeam(bg_template, bracketEntry) * 2;
@@ -1155,9 +1149,7 @@ void BattlegroundQueue::SendMessageBGQueue(Player* leader, Battleground* bg, PvP
             // Arm the per-bracket debounce; first join arms, rest are no-ops.
             // BattlegroundQueueAnnouncerUpdate emits the aggregated line later.
             if (_queueAnnouncementTimer[bracketId] < 0)
-            {
                 SetQueueAnnouncementTimer(bracketId, BG_QUEUE_ANNOUNCER_IMMEDIATE_DEBOUNCE, false);
-            }
         }
     }
 }

--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -1039,10 +1039,8 @@ void BattlegroundQueue::BattlegroundQueueAnnouncerUpdate(uint32 diff, Battlegrou
         return;
     }
 
-    // The armed per-bracket timer drives both Timed mode and the deferred
-    // immediate-mode world announcement. They are mutually exclusive by config;
-    // the per-bracket spam-window/Limit throttle is consulted only in immediate
-    // mode (Timed mode keeps its original behaviour).
+    // Armed per-bracket timer drives both Timed mode and the deferred immediate
+    // announcement; the spam-window/Limit throttle gates only immediate mode.
     bool const isTimed = sWorld->getBoolConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_TIMED);
 
     uint32 qPlayers = 0;
@@ -1154,10 +1152,8 @@ void BattlegroundQueue::SendMessageBGQueue(Player* leader, Battleground* bg, PvP
         }
         else
         {
-            // Collapse a same-tick queue burst into a single deferred line: the
-            // first join arms the per-bracket debounce, the rest are no-ops. The
-            // aggregated line (with post-burst total + spam-window/Limit gating)
-            // is emitted by BattlegroundQueueAnnouncerUpdate on the next pass.
+            // Arm the per-bracket debounce; first join arms, rest are no-ops.
+            // BattlegroundQueueAnnouncerUpdate emits the aggregated line later.
             if (_queueAnnouncementTimer[bracketId] < 0)
             {
                 SetQueueAnnouncementTimer(bracketId, BG_QUEUE_ANNOUNCER_IMMEDIATE_DEBOUNCE, false);

--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -1039,42 +1039,51 @@ void BattlegroundQueue::BattlegroundQueueAnnouncerUpdate(uint32 diff, Battlegrou
         return;
     }
 
-    if (sWorld->getBoolConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_TIMED))
-    {
-        uint32 qPlayers = 0;
+    // The armed per-bracket timer drives both Timed mode and the deferred
+    // immediate-mode world announcement. They are mutually exclusive by config;
+    // the per-bracket spam-window/Limit throttle is consulted only in immediate
+    // mode (Timed mode keeps its original behaviour).
+    bool const isTimed = sWorld->getBoolConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_TIMED);
 
-        if (_queueAnnouncementCrossfactioned)
+    uint32 qPlayers = 0;
+
+    if (_queueAnnouncementCrossfactioned)
+    {
+        qPlayers = GetPlayersCountInGroupsQueue(bracket_id, BG_QUEUE_CFBG);
+    }
+    else
+    {
+        qPlayers = GetPlayersCountInGroupsQueue(bracket_id, BG_QUEUE_NORMAL_HORDE) + GetPlayersCountInGroupsQueue(bracket_id, BG_QUEUE_NORMAL_ALLIANCE);
+    }
+
+    if (!qPlayers)
+    {
+        _queueAnnouncementTimer[bracket_id] = -1;
+        return;
+    }
+
+    if (_queueAnnouncementTimer[bracket_id] >= 0)
+    {
+        if (_queueAnnouncementTimer[bracket_id] <= static_cast<int32>(diff))
         {
-            qPlayers = GetPlayersCountInGroupsQueue(bracket_id, BG_QUEUE_CFBG);
+            _queueAnnouncementTimer[bracket_id] = -1;
+
+            uint32 q_min_level = std::min(bracketEntry->minLevel, (uint32) 80);
+
+            if (!isTimed && !sBGSpam->CanAnnounce(bg_template, bracket_id, q_min_level, qPlayers))
+            {
+                return;
+            }
+
+            auto bgName = bg_template->GetName();
+            uint32 MaxPlayers = GetMinPlayersPerTeam(bg_template, bracketEntry) * 2;
+            uint32 q_max_level = std::min(bracketEntry->maxLevel, (uint32) 80);
+
+            ChatHandler(nullptr).SendWorldTextOptional(LANG_BG_QUEUE_ANNOUNCE_WORLD, ANNOUNCER_FLAG_DISABLE_BG_QUEUE, bgName.c_str(), q_min_level, q_max_level, qPlayers, MaxPlayers);
         }
         else
         {
-            qPlayers = GetPlayersCountInGroupsQueue(bracket_id, BG_QUEUE_NORMAL_HORDE) + GetPlayersCountInGroupsQueue(bracket_id, BG_QUEUE_NORMAL_ALLIANCE);
-        }
-
-        if (!qPlayers)
-        {
-            _queueAnnouncementTimer[bracket_id] = -1;
-            return;
-        }
-
-        if (_queueAnnouncementTimer[bracket_id] >= 0)
-        {
-            if (_queueAnnouncementTimer[bracket_id] <= static_cast<int32>(diff))
-            {
-                _queueAnnouncementTimer[bracket_id] = -1;
-
-                auto bgName = bg_template->GetName();
-                uint32 MaxPlayers = GetMinPlayersPerTeam(bg_template, bracketEntry) * 2;
-                uint32 q_min_level = std::min(bracketEntry->minLevel, (uint32) 80);
-                uint32 q_max_level = std::min(bracketEntry->maxLevel, (uint32) 80);
-
-                ChatHandler(nullptr).SendWorldTextOptional(LANG_BG_QUEUE_ANNOUNCE_WORLD, ANNOUNCER_FLAG_DISABLE_BG_QUEUE, bgName.c_str(), q_min_level, q_max_level, qPlayers, MaxPlayers);
-            }
-            else
-            {
-                _queueAnnouncementTimer[bracket_id] -= static_cast<int32>(diff);
-            }
+            _queueAnnouncementTimer[bracket_id] -= static_cast<int32>(diff);
         }
     }
 }
@@ -1145,12 +1154,14 @@ void BattlegroundQueue::SendMessageBGQueue(Player* leader, Battleground* bg, PvP
         }
         else
         {
-            if (!sBGSpam->CanAnnounce(leader, bg, q_min_level, qTotal))
+            // Collapse a same-tick queue burst into a single deferred line: the
+            // first join arms the per-bracket debounce, the rest are no-ops. The
+            // aggregated line (with post-burst total + spam-window/Limit gating)
+            // is emitted by BattlegroundQueueAnnouncerUpdate on the next pass.
+            if (_queueAnnouncementTimer[bracketId] < 0)
             {
-                return;
+                SetQueueAnnouncementTimer(bracketId, BG_QUEUE_ANNOUNCER_IMMEDIATE_DEBOUNCE, false);
             }
-
-            ChatHandler(nullptr).SendWorldTextOptional(LANG_BG_QUEUE_ANNOUNCE_WORLD, ANNOUNCER_FLAG_DISABLE_BG_QUEUE, bgName.c_str(), q_min_level, q_max_level, qAlliance + qHorde, MaxPlayers);
         }
     }
 }

--- a/src/server/game/Battlegrounds/BattlegroundQueue.h
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.h
@@ -27,10 +27,8 @@
 
 constexpr auto COUNT_OF_PLAYERS_TO_AVERAGE_WAIT_TIME = 10;
 
-// Tiny debounce (ms) used by the immediate-mode world announcer: arming the
-// per-bracket timer with this value makes it fire on the next periodic announcer
-// pass, by which point the whole same-tick queue burst has been collapsed into
-// one aggregated line.
+// Immediate-mode announcer debounce (ms): fires on the next periodic pass, by
+// which point a same-tick queue burst has collapsed into one aggregated line.
 constexpr int32 BG_QUEUE_ANNOUNCER_IMMEDIATE_DEBOUNCE = 1;
 
 struct GroupQueueInfo                                       // stores information about the group in queue (also used when joined as solo!)

--- a/src/server/game/Battlegrounds/BattlegroundQueue.h
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.h
@@ -27,6 +27,12 @@
 
 constexpr auto COUNT_OF_PLAYERS_TO_AVERAGE_WAIT_TIME = 10;
 
+// Tiny debounce (ms) used by the immediate-mode world announcer: arming the
+// per-bracket timer with this value makes it fire on the next periodic announcer
+// pass, by which point the whole same-tick queue burst has been collapsed into
+// one aggregated line.
+constexpr int32 BG_QUEUE_ANNOUNCER_IMMEDIATE_DEBOUNCE = 1;
+
 struct GroupQueueInfo                                       // stores information about the group in queue (also used when joined as solo!)
 {
     GuidSet Players;                                        // player guid set

--- a/src/server/game/Battlegrounds/BattlegroundSpamProtect.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundSpamProtect.cpp
@@ -25,6 +25,7 @@
 namespace
 {
     std::unordered_map<ObjectGuid /*player guid*/, uint32 /*time*/> _players;
+    std::unordered_map<uint32 /*bracket+bg key*/, uint32 /*time*/> _brackets;
 
     void AddTime(ObjectGuid guid)
     {
@@ -46,6 +47,28 @@ namespace
     {
         // Skip if spam time < 30 secs (default)
         return GameTime::GetGameTime().count() - GetTime(guid) >= sWorld->getIntConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_SPAM_DELAY);
+    }
+
+    void AddTime(uint32 key)
+    {
+        _brackets.insert_or_assign(key, GameTime::GetGameTime().count());
+    }
+
+    uint32 GetTime(uint32 key)
+    {
+        auto const& itr = _brackets.find(key);
+        if (itr != _brackets.end())
+        {
+            return itr->second;
+        }
+
+        return 0;
+    }
+
+    bool IsCorrectDelay(uint32 key)
+    {
+        // Skip if spam time < 30 secs (default)
+        return GameTime::GetGameTime().count() - GetTime(key) >= sWorld->getIntConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_SPAM_DELAY);
     }
 }
 
@@ -82,5 +105,37 @@ bool BGSpamProtect::CanAnnounce(Player* player, Battleground* bg, uint32 minLeve
     }
 
     AddTime(guid);
+    return true;
+}
+
+bool BGSpamProtect::CanAnnounce(Battleground* bg, BattlegroundBracketId bracketId, uint32 minLevel, uint32 queueTotal)
+{
+    if (!bg)
+    {
+        return false;
+    }
+
+    uint32 key = uint32(bg->GetBgTypeID()) * MAX_BATTLEGROUND_BRACKETS + uint32(bracketId);
+
+    // Check prev time
+    if (!IsCorrectDelay(key))
+    {
+        return false;
+    }
+
+    // When limited, it announces only if there are at least CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_LIMIT_MIN_PLAYERS in queue
+    auto limitQueueMinLevel = sWorld->getIntConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_LIMIT_MIN_LEVEL);
+    if (limitQueueMinLevel && minLevel >= limitQueueMinLevel)
+    {
+        // limit only RBG for 80, WSG for lower levels
+        auto bgTypeToLimit = minLevel == 80 ? BATTLEGROUND_RB : BATTLEGROUND_WS;
+
+        if (bg->GetBgTypeID() == bgTypeToLimit && queueTotal < sWorld->getIntConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_LIMIT_MIN_PLAYERS))
+        {
+            return false;
+        }
+    }
+
+    AddTime(key);
     return true;
 }

--- a/src/server/game/Battlegrounds/BattlegroundSpamProtect.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundSpamProtect.cpp
@@ -58,9 +58,7 @@ namespace
     {
         auto const& itr = _brackets.find(key);
         if (itr != _brackets.end())
-        {
             return itr->second;
-        }
 
         return 0;
     }
@@ -111,17 +109,13 @@ bool BGSpamProtect::CanAnnounce(Player* player, Battleground* bg, uint32 minLeve
 bool BGSpamProtect::CanAnnounce(Battleground* bg, BattlegroundBracketId bracketId, uint32 minLevel, uint32 queueTotal)
 {
     if (!bg)
-    {
         return false;
-    }
 
     uint32 key = uint32(bg->GetBgTypeID()) * MAX_BATTLEGROUND_BRACKETS + uint32(bracketId);
 
     // Check prev time
     if (!IsCorrectDelay(key))
-    {
         return false;
-    }
 
     // When limited, it announces only if there are at least CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_LIMIT_MIN_PLAYERS in queue
     auto limitQueueMinLevel = sWorld->getIntConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_LIMIT_MIN_LEVEL);
@@ -131,9 +125,7 @@ bool BGSpamProtect::CanAnnounce(Battleground* bg, BattlegroundBracketId bracketI
         auto bgTypeToLimit = minLevel == 80 ? BATTLEGROUND_RB : BATTLEGROUND_WS;
 
         if (bg->GetBgTypeID() == bgTypeToLimit && queueTotal < sWorld->getIntConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_LIMIT_MIN_PLAYERS))
-        {
             return false;
-        }
     }
 
     AddTime(key);

--- a/src/server/game/Battlegrounds/BattlegroundSpamProtect.h
+++ b/src/server/game/Battlegrounds/BattlegroundSpamProtect.h
@@ -19,6 +19,7 @@
 #define _BATTLEGROUND_SPAM_PROTECT_H_
 
 #include "Define.h"
+#include "DBCEnums.h"
 
 class Player;
 class Battleground;
@@ -29,6 +30,7 @@ public:
     static BGSpamProtect* instance();
 
     bool CanAnnounce(Player* player, Battleground* bg, uint32 minLevel, uint32 queueTotal);
+    bool CanAnnounce(Battleground* bg, BattlegroundBracketId bracketId, uint32 minLevel, uint32 queueTotal);
 };
 
 #define sBGSpam BGSpamProtect::instance()


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.8

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-bg-auto-queue/issues/6

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
