### PR TITLE
fix(DB/Spell): make Earthgrab break stealth

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1780779956682.sql
+++ b/data/sql/updates/pending_db_world/rev_1780779956682.sql
@@ -1,2 +1,2 @@
 -- Earthgrab is a hostile root and should reveal stealthed targets.
-UPDATE `spell_custom_attr` SET `attributes` = `attributes` & ~64 WHERE `spell_id` = 64695;
+DELETE FROM `spell_custom_attr` WHERE `spell_id` = 64695;

--- a/data/sql/updates/pending_db_world/rev_1780779956682.sql
+++ b/data/sql/updates/pending_db_world/rev_1780779956682.sql
@@ -1,0 +1,2 @@
+-- Earthgrab is a hostile root and should reveal stealthed targets.
+UPDATE `spell_custom_attr` SET `attributes` = `attributes` & ~64 WHERE `spell_id` = 64695;


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were partially used in preparing this pull request.

OpenAI Codex (GPT-5) was used to review a severity ranked list of open issues, identify this issue, research and organize relevant information, investigate Blizzlike behavior, and prepare the initial draft of the PR description.

This removes `SPELL_ATTR0_CU_DONT_BREAK_STEALTH` (`0x40`) from Earthgrab (`64695`).

The Blizzlike behavior distinguishes the two effects:
- The normal Earthbind slow (`3600`) does not break Stealth or Prowl.
- The talented Earthgrab root (`64695`) roots the hostile target and removes Stealth or Prowl when it successfully applies.

The SQL update clears only bit `64` from Earthgrab, preserving any other custom attributes. Earthbind (`3600`) remains unchanged and retains `DONT_BREAK_STEALTH`.

### Relation to #24898

PR #24898 correctly made the stealth proc guard respect `SPELL_ATTR0_CU_DONT_BREAK_STEALTH`. This PR does not revert or bypass that core behavior.

The issue is specific to Earthgrab's database entry. Before `DONT_BREAK_STEALTH` was moved to database-driven attributes in #3056, the old core logic explicitly allowed the totem spell `64695` to remove stealth while other totem effects did not. During that migration, Earthgrab was also assigned bit `64`, contradicting the previous special case and the WotLK behavior. Once #24898 consistently honored the attribute, the incorrect Earthgrab row caused the root to preserve stealth.

Removing bit `64` only from `64695` restores the intended distinction without changing the generic stealth handling introduced by #24898.

https://github.com/user-attachments/assets/e7a0cf8d-9c1e-42a8-9060-7db15254b508

## Issues Addressed:

- Closes #26065

## SOURCE:

Blizzlike behavior is supported by:
- Blizzard patch 2.2.0 notes: normal Earthbind Totem was changed to no longer break Rogue Stealth: https://www.bluetracker.gg/wow/topic/us-en/1777875139-world-of-warcraft-client-patch-220-notes/
- Original WotLK PvP footage showing the talented Earthgrab interaction: https://youtu.be/dI7v7Rygw1E?t=443
- Additional original WotLK PvP footage: https://youtu.be/i3IMZL7R72Q?t=57
- Contemporary WotLK PvP discussion describing Earth's Grasp as taking Rogues and Ferals out of stealth: https://www.mmo-champion.com/threads/647767-Ele-PvP-Help?highlight=earthbind+stealth
- Confirmed bug report and reproduction details: https://github.com/azerothcore/azerothcore-wotlk/issues/26065

AzerothCore implementation history:
- #3056 migrated the stealth exceptions to `SPELL_ATTR0_CU_DONT_BREAK_STEALTH`; the previous core condition explicitly exempted Earthgrab (`64695`) from the totem restriction.
- #24898 correctly extended the attribute check to the stealth proc guard.

## Tests Performed:

- Passed AzerothCore's SQL Codestyle checker.
- Applied the update to a local world database.
- Verified that spell `64695` no longer has attribute bit `64`.
- Verified that Earthbind slow (`3600`) still retains attribute bit `64`.
- Confirmed that worldserver starts without SQL errors.
- Further in-game testing is recommended.

## How to Test the Changes:

1. Create a shaman with Storm, Earth and Fire.
2. Create a hostile rogue or druid.
3. Enter Stealth or Prowl.
4. Place Earthbind Totem within range.
5. Confirm that Earthgrab (`64695`) roots the target and removes Stealth or Prowl.
6. Repeat with a shaman without Storm, Earth and Fire so that only Earthbind (`3600`) applies.
7. Confirm that the normal Earthbind slow does not remove Stealth or Prowl.

## Known Issues and TODO List:

None.