### PR TITLE
fix(Conf): improve ChatFilter config documentation

### DIFF
--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -2262,9 +2262,8 @@ Achievement.RealmFirstKillWindow = 60
 
 #
 #    Achievement.RealmFirstRaceLimitOnePerCharacter
-#        Description: Limit 'Realm First!' race achievements (e.g. 'First Gnome!') to one per
-#                     character. Prevents abuse of the race/faction change service to obtain
-#                     multiple realm first achievements on the same account.
+#        Description: Limit 'Realm First!' race achievements to one per character. Prevents abuse
+#                     of the race/faction change service to obtain multiple achievements.
 #        Default:     1 - (Enabled)
 #                     0 - (Disabled)
 

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -2262,8 +2262,9 @@ Achievement.RealmFirstKillWindow = 60
 
 #
 #    Achievement.RealmFirstRaceLimitOnePerCharacter
-#        Description: Limit 'Realm First!' race achievements to one per character. Prevents abuse
-#                     of the race/faction change service to obtain multiple achievements.
+#        Description: Limit 'Realm First!' race achievements (e.g. 'First Gnome!') to one per
+#                     character. Prevents abuse of the race/faction change service to obtain
+#                     multiple realm first achievements on the same account.
 #        Default:     1 - (Enabled)
 #                     0 - (Disabled)
 
@@ -4391,13 +4392,16 @@ PreserveCustomChannels = 0
 PreserveCustomChannelDuration = 14
 
 #
-#    ChatFilter
-#        Description: Blocks chat messages when they contain any entry from the `chat_filter`
-#                     table (substring, case-insensitive).
-#                     Manage entries with .chatfilter add / remove / list and .reload chat_filter.
-#                     Blizzlike is only whispers are enabled.
-#        Default:     0 - (Disbaled)
-#                     1 - (Enabled)
+#    ChatFilter.Whisper / ChatFilter.Say / ChatFilter.Yell / ChatFilter.Emote
+#        Description: Block chat messages that contain any entry from the `chat_filter` table
+#                     (substring match, case-insensitive).
+#                     Manage entries with: .chatfilter add / .chatfilter remove / .chatfilter list
+#                     and .reload chat_filter.
+#                     Blizzlike: only Whisper filtering is enabled.
+#        Default:     ChatFilter.Whisper = 1 - (Enabled)
+#                     ChatFilter.Say     = 0 - (Disabled)
+#                     ChatFilter.Yell    = 0 - (Disabled)
+#                     ChatFilter.Emote   = 0 - (Disabled)
 #
 
 ChatFilter.Whisper = 1


### PR DESCRIPTION
## Changes

Follow-up documentation fixes for #26051 and #26053.

**ChatFilter** (`ChatFilter.Whisper / .Say / .Yell / .Emote`):
- Fix typo `Disbaled` → `Disabled`
- Rename header comment to list all four keys explicitly
- Document the default value of each key individually instead of a generic `0`/`1` description
- Reword "Blizzlike is only whispers are enabled." → "Blizzlike: only Whisper filtering is enabled."

**Achievement.RealmFirstRaceLimitOnePerCharacter**:
- Expand the description to clarify it limits race-specific 'Realm First!' achievements and prevents abuse via race/faction change service