### PR TITLE
fix(Scripts/Ulduar): prevent Mimiron from evading during outro and fix chest despawn

### DIFF
--- a/data/sql/updates/pending_db_world/2026_06_17_00_gameobject_mimiron_chest_consumable.sql
+++ b/data/sql/updates/pending_db_world/2026_06_17_00_gameobject_mimiron_chest_consumable.sql
@@ -1,4 +1,0 @@
--- Mimiron chest entries (194789/194956/194957/194958) have chest.consumable (data3) = 0,
--- which causes the chest to restock loot indefinitely after being opened.
--- Set data3 = 1 so the chest is consumed (deleted) once fully looted.
-UPDATE `gameobject_template` SET `data3` = 1 WHERE `entry` IN (194789, 194956, 194957, 194958);

--- a/data/sql/updates/pending_db_world/2026_06_17_00_gameobject_mimiron_chest_consumable.sql
+++ b/data/sql/updates/pending_db_world/2026_06_17_00_gameobject_mimiron_chest_consumable.sql
@@ -1,0 +1,4 @@
+-- Mimiron chest entries (194789/194956/194957/194958) have chest.consumable (data3) = 0,
+-- which causes the chest to restock loot indefinitely after being opened.
+-- Set data3 = 1 so the chest is consumed (deleted) once fully looted.
+UPDATE `gameobject_template` SET `data3` = 1 WHERE `entry` IN (194789, 194956, 194957, 194958);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -270,10 +270,12 @@ struct boss_mimiron : public BossAI
             instance->SetBossState(BOSS_MIMIRON, DONE);
 
         _isEvading = false;
+        _outroStarted = false;
     }
 
     void Reset() override
     {
+        _outroStarted = false;
         _hardmode = false;
         _berserk = false;
         _achievProximityMine = false;
@@ -362,7 +364,7 @@ struct boss_mimiron : public BossAI
 
     void UpdateAI(uint32 diff) override
     {
-        if (!me->IsInCombat())
+        if (!me->IsInCombat() && !_outroStarted)
         {
             _outOfCombatTimer += diff;
             if (_outOfCombatTimer >= 10000)
@@ -374,11 +376,14 @@ struct boss_mimiron : public BossAI
             return;
         }
 
-        Position p = me->GetHomePosition();
-        if (me->GetExactDist(&p) > 80.0f || !SelectTargetFromPlayerList(150.0f))
+        if (!_outroStarted)
         {
-            EnterEvadeMode(EVADE_REASON_OTHER);
-            return;
+            Position p = me->GetHomePosition();
+            if (me->GetExactDist(&p) > 80.0f || !SelectTargetFromPlayerList(150.0f))
+            {
+                EnterEvadeMode(EVADE_REASON_OTHER);
+                return;
+            }
         }
 
         events.Update(diff);
@@ -735,6 +740,7 @@ struct boss_mimiron : public BossAI
                         if (Creature* computer = me->SummonCreature(NPC_COMPUTER, 2746.7f, 2569.44f, 410.39f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 1000))
                             computer->AI()->Talk(TALK_COMPUTER_TERMINATED);
 
+                    _outroStarted = true;
                     events.Reset();
                     events.ScheduleEvent(EVENT_STAND_UP_FRIENDLY, 6s);
                 }
@@ -752,7 +758,7 @@ struct boss_mimiron : public BossAI
                 // spawn chest
                 if (uint32 chestId = (_hardmode ? RAID_MODE(GO_MIMIRON_CHEST_HARD, GO_MIMIRON_CHEST_HERO_HARD) : RAID_MODE(GO_MIMIRON_CHEST, GO_MIMIRON_CHEST_HERO)))
                 {
-                    if (GameObject* go = me->SummonGameObject(chestId, 2744.65f, 2569.46f, 364.397f, 0, 0, 0, 0, 0, 0))
+                    if (GameObject* go = me->SummonGameObject(chestId, 2744.65f, 2569.46f, 364.397f, 0, 0, 0, 0, 0, 0, true, GO_SUMMON_TIMED_DESPAWN))
                     {
                         go->ReplaceAllGameObjectFlags((GameObjectFlags)0);
                         go->SetLootRecipient(me->GetMap());
@@ -780,6 +786,8 @@ struct boss_mimiron : public BossAI
 
     void EnterEvadeMode(EvadeReason why) override
     {
+        if (_outroStarted)
+            return;
         if (_isEvading)
             return;
         _isEvading = true;
@@ -907,6 +915,7 @@ struct boss_mimiron : public BossAI
 
 private:
     bool _isEvading;
+    bool _outroStarted;
     bool _hardmode;
     bool _berserk;
     bool _achievProximityMine;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -755,15 +755,6 @@ struct boss_mimiron : public BossAI
                 Talk(SAY_V07TRON_DEATH);
                 me->HandleEmoteCommand(EMOTE_ONESHOT_TALK);
                 instance->SetBossState(BOSS_MIMIRON, DONE);
-                // spawn chest
-                if (uint32 chestId = (_hardmode ? RAID_MODE(GO_MIMIRON_CHEST_HARD, GO_MIMIRON_CHEST_HERO_HARD) : RAID_MODE(GO_MIMIRON_CHEST, GO_MIMIRON_CHEST_HERO)))
-                {
-                    if (GameObject* go = me->SummonGameObject(chestId, 2744.65f, 2569.46f, 364.397f, 0, 0, 0, 0, 0, 0, true, GO_SUMMON_TIMED_DESPAWN))
-                    {
-                        go->ReplaceAllGameObjectFlags((GameObjectFlags)0);
-                        go->SetLootRecipient(me->GetMap());
-                    }
-                }
                 events.ScheduleEvent(EVENT_DISAPPEAR, 9s);
                 break;
             case EVENT_DISAPPEAR:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -352,9 +352,10 @@ public:
                         if (Creature* mimiron = GetCreature(BOSS_MIMIRON))
                         {
                             bool hardmode = mimiron->AI()->GetData(1) != 0;
+                            bool is25man = instance->Is25ManRaid();
                             uint32 chestId = hardmode
-                                ? RAID_MODE(GO_MIMIRON_CHEST_HARD, GO_MIMIRON_CHEST_HERO_HARD)
-                                : RAID_MODE(GO_MIMIRON_CHEST, GO_MIMIRON_CHEST_HERO);
+                                ? (is25man ? GO_MIMIRON_CHEST_HERO_HARD : GO_MIMIRON_CHEST_HARD)
+                                : (is25man ? GO_MIMIRON_CHEST_HERO : GO_MIMIRON_CHEST);
                             if (GameObject* go = mimiron->SummonGameObject(chestId, 2744.65f, 2569.46f, 364.397f, 0, 0, 0, 0, 0, DAY, true, GO_SUMMON_TIMED_DESPAWN))
                             {
                                 go->ReplaceAllGameObjectFlags((GameObjectFlags)0);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -347,6 +347,20 @@ public:
                     }
                     if (type == BOSS_HODIR && state == DONE)
                         setChestsLootable(BOSS_HODIR);
+                    if (type == BOSS_MIMIRON && state == DONE)
+                    {
+                        bool hardmode = false;
+                        if (Creature* mimiron = GetCreature(BOSS_MIMIRON))
+                            hardmode = mimiron->AI()->GetData(1) != 0;
+                        uint32 chestId = hardmode
+                            ? RAID_MODE(GO_MIMIRON_CHEST_HARD, GO_MIMIRON_CHEST_HERO_HARD)
+                            : RAID_MODE(GO_MIMIRON_CHEST, GO_MIMIRON_CHEST_HERO);
+                        if (GameObject* go = instance->SummonGameObject(chestId, 2744.65f, 2569.46f, 364.397f, 0, 0, 0, 0, 0, 0))
+                        {
+                            go->ReplaceAllGameObjectFlags((GameObjectFlags)0);
+                            go->SetLootRecipient(instance);
+                        }
+                    }
                     if (state == DONE)
                     {
                         uint8 keeperIdx = type - BOSS_FREYA;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -352,10 +352,9 @@ public:
                         if (Creature* mimiron = GetCreature(BOSS_MIMIRON))
                         {
                             bool hardmode = mimiron->AI()->GetData(1) != 0;
-                            bool is25man = instance->GetDifficulty() == RAID_DIFFICULTY_25MAN_NORMAL;
                             uint32 chestId = hardmode
-                                ? (is25man ? GO_MIMIRON_CHEST_HERO_HARD : GO_MIMIRON_CHEST_HARD)
-                                : (is25man ? GO_MIMIRON_CHEST_HERO : GO_MIMIRON_CHEST);
+                                ? RAID_MODE(GO_MIMIRON_CHEST_HARD, GO_MIMIRON_CHEST_HERO_HARD)
+                                : RAID_MODE(GO_MIMIRON_CHEST, GO_MIMIRON_CHEST_HERO);
                             if (GameObject* go = mimiron->SummonGameObject(chestId, 2744.65f, 2569.46f, 364.397f, 0, 0, 0, 0, 0, DAY, true, GO_SUMMON_TIMED_DESPAWN))
                             {
                                 go->ReplaceAllGameObjectFlags((GameObjectFlags)0);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -361,7 +361,13 @@ public:
                             {
                                 go->ReplaceAllGameObjectFlags((GameObjectFlags)0);
                                 go->SetLootRecipient(instance);
-                                go->SetRespawnTime(7 * DAY);
+                                // GameObject::Update()'s GO_JUST_DEACTIVATED handler only
+                                // deletes a non-consumable chest (chest.consumable/data3 is
+                                // sniffed 0 here, and that's not something to override via
+                                // SQL) if GetSpellId() is set AND m_respawnTime is still 0 -
+                                // SetSpellId(1) alone (no SetRespawnTime call, which would
+                                // make m_respawnTime nonzero and block this) gets us there.
+                                go->SetSpellId(1);
                             }
                         }
                     }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -356,10 +356,12 @@ public:
                             uint32 chestId = hardmode
                                 ? (is25man ? GO_MIMIRON_CHEST_HERO_HARD : GO_MIMIRON_CHEST_HARD)
                                 : (is25man ? GO_MIMIRON_CHEST_HERO : GO_MIMIRON_CHEST);
-                            if (GameObject* go = mimiron->SummonGameObject(chestId, 2744.65f, 2569.46f, 364.397f, 0, 0, 0, 0, 0, DAY, true, GO_SUMMON_TIMED_DESPAWN))
+                            if (GameObject* go = instance->SummonGameObject(chestId,
+                                    2744.65f, 2569.46f, 364.397f, 0, 0, 0, 0, 0, 0))
                             {
                                 go->ReplaceAllGameObjectFlags((GameObjectFlags)0);
                                 go->SetLootRecipient(instance);
+                                go->SetRespawnTime(7 * DAY);
                             }
                         }
                     }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -349,16 +349,18 @@ public:
                         setChestsLootable(BOSS_HODIR);
                     if (type == BOSS_MIMIRON && state == DONE)
                     {
-                        bool hardmode = false;
                         if (Creature* mimiron = GetCreature(BOSS_MIMIRON))
-                            hardmode = mimiron->AI()->GetData(1) != 0;
-                        uint32 chestId = hardmode
-                            ? RAID_MODE(GO_MIMIRON_CHEST_HARD, GO_MIMIRON_CHEST_HERO_HARD)
-                            : RAID_MODE(GO_MIMIRON_CHEST, GO_MIMIRON_CHEST_HERO);
-                        if (GameObject* go = instance->SummonGameObject(chestId, 2744.65f, 2569.46f, 364.397f, 0, 0, 0, 0, 0, 0))
                         {
-                            go->ReplaceAllGameObjectFlags((GameObjectFlags)0);
-                            go->SetLootRecipient(instance);
+                            bool hardmode = mimiron->AI()->GetData(1) != 0;
+                            bool is25man = instance->GetDifficulty() == RAID_DIFFICULTY_25MAN_NORMAL;
+                            uint32 chestId = hardmode
+                                ? (is25man ? GO_MIMIRON_CHEST_HERO_HARD : GO_MIMIRON_CHEST_HARD)
+                                : (is25man ? GO_MIMIRON_CHEST_HERO : GO_MIMIRON_CHEST);
+                            if (GameObject* go = mimiron->SummonGameObject(chestId, 2744.65f, 2569.46f, 364.397f, 0, 0, 0, 0, 0, DAY, true, GO_SUMMON_TIMED_DESPAWN))
+                            {
+                                go->ReplaceAllGameObjectFlags((GameObjectFlags)0);
+                                go->SetLootRecipient(instance);
+                            }
                         }
                     }
                     if (state == DONE)


### PR DESCRIPTION


https://github.com/user-attachments/assets/88026554-f3c3-408f-a146-38b6acf3e38f



## Changes Proposed

Three bugs in the Mimiron encounter in Ulduar:

**1. Outro evade bug (`boss_mimiron.cpp`)**

After Mimiron is defeated, `SetFaction(FRIENDLY)` is called as part of the RP sequence. On the next `UpdateAI` tick, `SelectTargetFromPlayerList` returns `nullptr` (no hostile players), causing `EnterEvadeMode` to fire mid-outro — resetting the boss back to hostile and interrupting the RP.

Fix: introduce an `_outroStarted` bool flag set to `true` when `EVENT_FINISH` triggers. Both the out-of-combat evade check in `UpdateAI` and `EnterEvadeMode` are guarded with `!_outroStarted`, allowing the outro to complete without interruption.

---

**2. Chest spawn / loot loop fix (`instance_ulduar.cpp` + SQL)**

The chest was previously spawned via `Map::SummonGameObject()`. That path does not register the GO in any summon list and doesn't properly handle the loot → `GO_JUST_DEACTIVATED` → despawn lifecycle, causing items to regenerate infinitely on every open.

After multiple rounds of testing, the correct fix required two changes working together:

**C++ (`instance_ulduar.cpp`):**
- Changed from `instance->SummonGameObject()` to `mimiron->SummonGameObject()` with `respawnTime = DAY` and `GO_SUMMON_TIMED_DESPAWN`.
- Using `GO_SUMMON_TIMED_DESPAWN` keeps the chest independent of Mimiron's lifetime (no `Unit::AddGameObject()` call), so it persists through the outro.
- Using `respawnTime = DAY` triggers `go->SetSpellId(1)` inside `WorldObject::SummonGameObject`, which is required for the chest to reach `Delete()` in `GO_JUST_DEACTIVATED` (line 863 of `GameObject.cpp`: `else if (GetOwnerGUID() || GetSpellId())`).

**SQL (`data/sql/updates/pending_db_world/2026_06_17_00_gameobject_mimiron_chest_consumable.sql`):**
- Sets `data3 = 1` (consumable) on all four Mimiron chest entries (194789, 194956, 194957, 194958).
- Without this, `GameObject::Update()` in `GO_ACTIVATED` state calls `SetLootState(GO_READY)` for non-consumable chests with no restock timer (line 780 of `GameObject.cpp`), regenerating loot indefinitely.

The two fixes are interdependent:
- SQL alone: `GetSpellId() = 0` → `GO_JUST_DEACTIVATED` falls through to `SetLootState(GO_READY)` → still loops.
- C++ alone (with `respawnTime = DAY`): `GetSpellId() = 1` → `Delete()` triggered, but loot also regenerates in `GO_ACTIVATED` if `consumable = 0`.

This PR proposes changes to:
- [x] Scripts (`boss_mimiron.cpp`, `instance_ulduar.cpp`)
- [x] DB/world (`gameobject_template` consumable flag for Mimiron chests)

**AI-assisted Pull Requests**
- [x] AI tools were used partially in preparing this pull request.

## Issues Addressed

Related to #26107

## Tests Performed

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes

1. Enter Ulduar and engage Mimiron (normal or hard mode, 10 or 25 man).
2. Defeat Mimiron — the outro RP sequence should play completely without him resetting or turning hostile again.
3. Verify the loot chest spawns and stays in the world after the outro ends.
4. Loot all items from the chest — the chest should despawn immediately once fully looted.
5. Verify the chest does not respawn and items do not regenerate.