### PR TITLE
fix(Scripts/Ulduar): fix keeper loot chests despawning during RP outro

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -292,7 +292,7 @@ struct boss_freya : public BossAI
                 uint32 chestId = RAID_MODE(GO_FREYA_CHEST, GO_FREYA_CHEST_HERO);
                 chestId -= 2 * _elderCount; // offset
 
-                if (GameObject* go = me->SummonGameObject(chestId, 2345.61f, -71.20f, 425.104f, 3.0f, 0, 0, 0, 0, 0))
+                if (GameObject* go = me->SummonGameObject(chestId, 2345.61f, -71.20f, 425.104f, 3.0f, 0, 0, 0, 0, 0, true, GO_SUMMON_TIMED_DESPAWN))
                 {
                     go->ReplaceAllGameObjectFlags((GameObjectFlags)0);
                     go->SetLootRecipient(me->GetMap());

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -550,7 +550,7 @@ struct boss_thorim : public BossAI
                 if (_hardMode)
                     chestId += 1; // hard mode offset
 
-                if ((go = me->SummonGameObject(chestId, 2134.73f, -286.32f, 419.51f, 4.65f, 0, 0, 0, 0, 0)))
+                if ((go = me->SummonGameObject(chestId, 2134.73f, -286.32f, 419.51f, 4.65f, 0, 0, 0, 0, 0, true, GO_SUMMON_TIMED_DESPAWN)))
                 {
                     go->ReplaceAllGameObjectFlags((GameObjectFlags)0);
                     go->SetLootRecipient(me->GetMap());

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -397,7 +397,7 @@ public:
                             normalChestPosition.GetPositionX(),
                             normalChestPosition.GetPositionY(),
                             normalChestPosition.GetPositionZ(),
-                            normalChestPosition.GetOrientation(), 0, 0, 0, 0, 0))
+                            normalChestPosition.GetOrientation(), 0, 0, 0, 0, 0, true, GO_SUMMON_TIMED_DESPAWN))
                         {
                             go->SetGameObjectFlag(GO_FLAG_NOT_SELECTABLE);
                         }
@@ -409,7 +409,7 @@ public:
                             hardChestPosition.GetPositionX(),
                             hardChestPosition.GetPositionY(),
                             hardChestPosition.GetPositionZ(),
-                            hardChestPosition.GetOrientation(), 0, 0, 0, 0, 0))
+                            hardChestPosition.GetOrientation(), 0, 0, 0, 0, 0, true, GO_SUMMON_TIMED_DESPAWN))
                         {
                             go->SetGameObjectFlag(GO_FLAG_NOT_SELECTABLE);
                             _hmHodir = true;
@@ -426,7 +426,7 @@ public:
                             normalChestPosition.GetPositionX(),
                             normalChestPosition.GetPositionY(),
                             normalChestPosition.GetPositionZ(),
-                            normalChestPosition.GetOrientation(), 0, 0, 0, 0, 0))
+                            normalChestPosition.GetOrientation(), 0, 0, 0, 0, 0, true, GO_SUMMON_TIMED_DESPAWN))
                         {
                             go->SetGameObjectFlag(GO_FLAG_NOT_SELECTABLE);
                         }
@@ -438,7 +438,7 @@ public:
                             hardChestPosition.GetPositionX(),
                             hardChestPosition.GetPositionY(),
                             hardChestPosition.GetPositionZ(),
-                            hardChestPosition.GetOrientation(), 0, 0, 0, 0, 0))
+                            hardChestPosition.GetOrientation(), 0, 0, 0, 0, 0, true, GO_SUMMON_TIMED_DESPAWN))
                         {
                             go->SetGameObjectFlag(GO_FLAG_NOT_SELECTABLE);
                             _hmHodir = true;


### PR DESCRIPTION
## Changes Proposed

After defeating Hodir, Freya, and Thorim in Ulduar, the loot chest spawns but immediately disappears during the RP outro sequence before players can loot it.

All four chest `SummonGameObject` calls (Hodir 10/25 normal and hard, Freya, Thorim) use the default `GO_SUMMON_TIMED_OR_CORPSE_DESPAWN` summon type, which registers the GO in the summoner's `m_gameObj` list via `Unit::AddGameObject()`. When the boss unit is later cleaned up, `Unit::RemoveFromWorld()` → `RemoveAllGameObjects()` removes every linked GO — including the loot chest. The same root cause was already fixed for Mimiron in #26106.

Fix: pass `GO_SUMMON_TIMED_DESPAWN` to all affected `SummonGameObject` calls so the chest is **not** added to the summoner's GO list and persists independently until its timer expires.

This PR proposes changes to:
- [x] Scripts (`instance_ulduar.cpp`, `boss_freya.cpp`, `boss_thorim.cpp`)

**AI-assisted Pull Requests**
- [x] AI tools were used partially in preparing this pull request.

## Issues Addressed

Related to #26106

## Tests Performed

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes

1. Enter Ulduar (10 or 25 man, normal or hard mode).
2. Defeat Hodir, Freya, and Thorim.
3. Verify the loot chest spawns and remains present and lootable throughout the entire outro RP sequence.