### PR TITLE
fix(Core/Vehicle): avoid Vehicle-kit use-after-free in TeleportVehicle

### DIFF
--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -593,8 +593,18 @@ void Vehicle::TeleportVehicle(float x, float y, float z, float ang)
     _me->GetMap()->LoadGrid(x, y);
     _me->NearTeleportTo(x, y, z, ang, true);
 
+    // Copy passenger GUIDs to a temporary vector before iteration
+    // to avoid iterator invalidation when TeleportVehicle is called recursively
+    // (e.g., when a passenger is also a vehicle carrying its own passengers)
+    GuidVector passengerGuids;
     for (SeatMap::const_iterator itr = Seats.begin(); itr != Seats.end(); ++itr)
-        if (Unit* passenger = ObjectAccessor::GetUnit(*GetBase(), itr->second.Passenger.Guid))
+    {
+        if (!itr->second.Passenger.Guid.IsEmpty())
+            passengerGuids.push_back(itr->second.Passenger.Guid);
+    }
+
+    for (ObjectGuid const& guid : passengerGuids)
+        if (Unit* passenger = ObjectAccessor::GetUnit(*GetBase(), guid))
         {
             if (passenger->IsPlayer())
             {
@@ -603,7 +613,11 @@ void Vehicle::TeleportVehicle(float x, float y, float z, float ang)
                 passenger->ToPlayer()->ScheduleDelayedOperation(DELAYED_VEHICLE_TELEPORT);
             }
             else if (passenger->IsCreature() && passenger->GetVehicleKit())
+            {
+                // This recursive call may modify Seats map of the nested vehicle,
+                // but our local passengerGuids vector is already a safe copy
                 passenger->GetVehicleKit()->TeleportVehicle(x, y, z, ang);
+            }
         }
 }
 

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -585,12 +585,32 @@ bool Vehicle::IsControllableVehicle() const
 
 void Vehicle::TeleportVehicle(float x, float y, float z, float ang)
 {
-    _me->GetMap()->LoadGrid(x, y);
-    _me->NearTeleportTo(x, y, z, ang, true);
+    // Snapshot passenger GUIDs and cache the base BEFORE teleporting.
+    // Teleporting the base (Player::TeleportTo) may drop the mount/vehicle aura
+    // on a long hop (>100 yd) and call ExitVehicle() -> Unit::RemoveVehicleKit()
+    // -> delete m_vehicleKit, freeing THIS Vehicle (and its Seats) mid-call.
+    // Reading Seats after that is a use-after-free (see upstream PR #26116 review).
+    Unit* base = _me;
+    Vehicle* self = this;
+    std::vector<ObjectGuid> passengers;
+    passengers.reserve(Seats.size());
+    for (auto const& seat : Seats)
+        if (!seat.second.IsEmpty())
+            passengers.push_back(seat.second.Passenger.Guid);
 
-    for (SeatMap::const_iterator itr = Seats.begin(); itr != Seats.end(); ++itr)
-        if (Unit* passenger = ObjectAccessor::GetUnit(*GetBase(), itr->second.Passenger.Guid))
+    base->GetMap()->LoadGrid(x, y);
+    base->NearTeleportTo(x, y, z, ang, true, true); // vehicleTeleport=true: do not dismount base mid-call
+
+    // THIS Vehicle may have been deleted by the base teleport above (kit freed).
+    // If so, bail out - passengers were already ejected by ~Vehicle::Uninstall().
+    if (base->GetVehicleKit() != self)
+        return;
+
+    for (ObjectGuid const& guid : passengers)
+        if (Unit* passenger = ObjectAccessor::GetUnit(*base, guid))
         {
+            if (!passenger->IsInWorld())
+                continue;
             if (passenger->IsPlayer())
             {
                 passenger->ToPlayer()->SetMover(passenger);

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -611,6 +611,7 @@ void Vehicle::TeleportVehicle(float x, float y, float z, float ang)
         {
             if (!passenger->IsInWorld())
                 continue;
+
             if (passenger->IsPlayer())
             {
                 passenger->ToPlayer()->SetMover(passenger);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
-  [ ] AI tools were used entirely or partially in preparing this pull request.

## Issues Addressed:
- Closes #26095
- Closes #24000

## Root Cause Analysis

Per review by sudlud on the original PR:

The crash is **not** an iterator-invalidation issue. `std::map::operator[]` does not invalidate iterators on value modification, and `Seats` is never erased during `TeleportVehicle`.

The real cause is a **use-after-free**: when a Player is on a vehicle and is teleported with a hop distance >100 yards, `Player::TeleportTo` calls `ExitVehicle()` -> `Unit::RemoveVehicleKit()` -> **deletes the `m_vehicleKit`** (the `Vehicle` object). The code then continues to read `this->Seats` — but `this` has already been freed.

Confirmed by three crash logs with identical call chains:
1. Dalaran ring (spell 53141, GameObject trigger)
2. Dalaran mage guard AI (spell 54029, `MoveInLineOfSight`)
3. Dalaran gossip spell 30719, gossip action 113

## Fix

Three-layer protection:

1. **Snapshot passenger GUIDs + cache `_me` pointer before the base teleport** (`Vehicle::TeleportVehicle` is called on the vehicle kit; after `delete m_vehicleKit`, the `Vehicle* this` pointer is dangling but `_me` still holds a valid `Unit*`).

2. **Kit-loss detection**: after the base teleport, compare `base->GetVehicleKit()` against the cached `Vehicle*` pointer captured before the teleport. If they differ, `this` was deleted during the hop and `~Vehicle::Uninstall()` already ejected all passengers — bail out safely.

3. **Base teleport with `vehicleTeleport=true`**: prevents `Player::TeleportTo` from triggering mid-hop `ExitVehicle()` for the base unit. Passengers are still teleported with `vehicleTeleport=false` so their own state is unaffected.

Also preserves the null-pointer guards on `GetUnit` lookups.

## SOURCE:
-  [x] Crash log analysis from the linked issue (#26095)
-  [x] Code review feedback (sudlud)

## Tests Performed:
-  [x] This pull request requires further testing and may have edge cases to be tested.
-  Recommended test: ride any vehicle in Dalaran, trigger mage guard gossip or ring — previously crashes, after fix should complete without crash.

## Known Issues and TODO List:
-  Requires in-game testing with actual vehicle passenger scenarios.

