### PR TITLE
fix(Core/Maps): exclude temporary spawns from dynamic respawn scaling

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -1732,25 +1732,25 @@ uint32 Map::ApplyDynamicModeRespawnScaling(WorldObject const* obj, uint32 respaw
     if (obj->GetMap()->Instanceable())
         return respawnDelay;
 
-    // Temporary spawns (no DB spawn id, e.g. summons / battlefield-spawned objects)
-    // are not part of the dynamic respawn system.
     if (Creature const* creature = obj->ToCreature())
     {
+        // Temporary spawns (no DB spawn id, e.g. summons / battlefield-spawned
+        // creatures such as Wintergrasp turrets) are not part of the respawn system.
         if (!creature->GetSpawnId())
             return respawnDelay;
+
+        // No quest givers or world bosses
+        if (creature->IsQuestGiver() || creature->isWorldBoss()
+            || (creature->GetCreatureTemplate()->rank == CREATURE_ELITE_RARE)
+            || (creature->GetCreatureTemplate()->rank == CREATURE_ELITE_RAREELITE))
+            return respawnDelay;
     }
+    // Temporary gameobjects (no DB spawn id) are likewise excluded.
     else if (GameObject const* go = obj->ToGameObject())
     {
         if (!go->GetSpawnId())
             return respawnDelay;
     }
-
-    // No quest givers or world bosses
-    if (Creature const* creature = obj->ToCreature())
-        if (creature->IsQuestGiver() || creature->isWorldBoss()
-            || (creature->GetCreatureTemplate()->rank == CREATURE_ELITE_RARE)
-            || (creature->GetCreatureTemplate()->rank == CREATURE_ELITE_RAREELITE))
-            return respawnDelay;
 
     auto it = _zonePlayerCountMap.find(obj->GetZoneId());
     if (it == _zonePlayerCountMap.end())

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -1732,6 +1732,19 @@ uint32 Map::ApplyDynamicModeRespawnScaling(WorldObject const* obj, uint32 respaw
     if (obj->GetMap()->Instanceable())
         return respawnDelay;
 
+    // Temporary spawns (no DB spawn id, e.g. summons / battlefield-spawned objects)
+    // are not part of the dynamic respawn system.
+    if (Creature const* creature = obj->ToCreature())
+    {
+        if (!creature->GetSpawnId())
+            return respawnDelay;
+    }
+    else if (GameObject const* go = obj->ToGameObject())
+    {
+        if (!go->GetSpawnId())
+            return respawnDelay;
+    }
+
     // No quest givers or world bosses
     if (Creature const* creature = obj->ToCreature())
         if (creature->IsQuestGiver() || creature->isWorldBoss()


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`Map::ApplyDynamicModeRespawnScaling` scales a spawn's respawn delay based on the number of players in its zone. This is only meaningful for DB-persistent spawns, whose respawn timers are owned by the respawn system.

Temporary spawns — those with no DB spawn id (`GetSpawnId() == 0`), such as summons and battlefield-spawned creatures/gameobjects (e.g. Wintergrasp turrets and siege vehicles) — are not part of the respawn system and should not have their delay altered by zone population. This PR adds an early-out so temp spawns (both creatures and gameobjects) keep their original delay.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (Anthropic, Claude Code) was used to assist in locating the relevant code and drafting the change. The author understands and stands behind the change.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

This is a logic/correctness change: temp spawns have no DB-owned respawn timer, so scaling their delay against zone population is not intended behavior.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes.

1. Enable dynamic respawn by setting `Respawn.DynamicRateCreature` (and/or `Respawn.DynamicRateGameobject`) above `1.0` in `worldserver.conf`.
2. In a populated non-instance zone, observe that DB-spawned creatures/gameobjects still have their respawn delay scaled down by player count (unchanged behavior).
3. Confirm that temporary spawns (summons, Wintergrasp turrets/siege vehicles — `spawnId == 0`) retain their original respawn/despawn timing and are no longer affected by zone population.

## Known Issues and TODO List:

- [ ]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
