### PR TITLE
fix(Core/Battlefield): keep queued players in queue when leaving the zone

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -74,12 +74,13 @@ Battlefield::~Battlefield()
     CapturePoints.clear();
 }
 
-void Battlefield::RemovePlayerFromTracking(ObjectGuid playerGuid)
+void Battlefield::RemovePlayerFromTracking(ObjectGuid playerGuid, bool removeFromQueue /*= true*/)
 {
     for (uint8 i = 0; i < PVP_TEAMS_COUNT; ++i)
     {
         InvitedPlayers[i].erase(playerGuid);
-        PlayersInQueue[i].erase(playerGuid);
+        if (removeFromQueue)
+            PlayersInQueue[i].erase(playerGuid);
         PlayersWillBeKick[i].erase(playerGuid);
         Players[i].erase(playerGuid);
     }
@@ -152,7 +153,7 @@ void Battlefield::HandlePlayerLeaveZone(Player* player, uint32 /*zone*/)
     for (BfCapturePoint* cp : CapturePoints)
         cp->HandlePlayerLeave(player);
 
-    RemovePlayerFromTracking(player->GetGUID());
+    RemovePlayerFromTracking(player->GetGUID(), /*removeFromQueue=*/false);
     SendRemoveWorldStates(player);
     RemovePlayerFromResurrectQueue(player->GetGUID());
     OnPlayerLeaveZone(player);

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -444,7 +444,7 @@ protected:
     /// Returns true if the player is already tracked as actively in the war or invited to join it.
     bool IsPlayerInWarOrInvited(Player* player) const;
 
-    void RemovePlayerFromTracking(ObjectGuid playerGuid);
+    void RemovePlayerFromTracking(ObjectGuid playerGuid, bool removeFromQueue = true);
 
     // Player-iteration helpers: resolve each GUID to a live Player* and call fn(player).
     // Using templates avoids std::function overhead and works naturally with lambdas.


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

When a player accepts the queue invitation for a battlefield (e.g. Wintergrasp) and then leaves the zone before the battle begins, `Battlefield::HandlePlayerLeaveZone` calls `RemovePlayerFromTracking`, which erased the player from `PlayersInQueue`. The player silently lost their queue slot and was never invited to the war once the battle started — even though they had queued.

`RemovePlayerFromTracking` is shared with `HandlePlayerEnterZone`, where clearing the queue is still wanted (re-entry rebuilds a fresh, correctly-teamed queue entry). To preserve that, the queue removal is now gated behind a `removeFromQueue` parameter (default `true`), and only the leave-zone path passes `false`.

The queue is still cleared every cycle by `InvitePlayersInQueueToWar`, and players can still leave the queue explicitly via the queue-exit request (`AskToLeaveQueue`).

### AI-assisted Pull Requests

- [x] AI tools were used partially in preparing this pull request: **Claude Opus 4.8** (Claude Code), for code investigation and drafting. The author understands and can justify the change.

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. During the grouping window before a Wintergrasp battle, accept the invitation to join the queue while inside the zone.
2. Leave the Wintergrasp zone (e.g. fly out) before the battle starts.
3. When the battle starts, confirm you still receive the invitation to join the war (previously the invite never arrived).

## Known Issues and TODO List:

- [ ] None known.
