### PR TITLE
fix(Core/GameObject): allow ritual helpers on cooldown

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1846,13 +1846,18 @@ void GameObject::Use(Unit* user)
                 if (GetUniqueUseCount() == info->summoningRitual.reqParticipants)
                     return;
 
+                SpellCastResult castResult;
                 if (info->summoningRitual.animSpell)
-                    player->CastSpell(player, info->summoningRitual.animSpell, true);
+                    castResult = player->CastSpell(player, info->summoningRitual.animSpell, true);
                 else
-                    player->CastSpell(player, GetSpellId(),
+                    castResult = player->CastSpell(player, GetSpellId(),
                         TriggerCastFlags(TRIGGERED_IGNORE_EFFECTS
+                                       | TRIGGERED_IGNORE_SPELL_AND_CATEGORY_CD
                                        | TRIGGERED_IGNORE_POWER_AND_REAGENT_COST
                                        | TRIGGERED_CAST_DIRECTLY));
+
+                if (castResult != SPELL_CAST_OK)
+                    return;
 
                 AddUniqueUse(player);
 


### PR DESCRIPTION
﻿## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were partially used in preparing this pull request.

OpenAI Codex (GPT-5) was used to review a severity ranked list of open issues, identify this issue, research and organize relevant information, investigate Blizzlike behavior, and prepare the initial draft of the PR description.

This allows players to participate in another player's summoning ritual even when their own ritual spell is on cooldown.

When a ritual does not define a separate animation spell, the helper channel is started by internally casting the ritual's source spell with its effects and resource costs disabled. However, this internal cast still checked the helper's spell and category cooldowns.

As a result, a Warlock whose own Ritual of Summoning was on cooldown received `SPELL_FAILED_NOT_READY` when clicking another Warlock's summoning portal.

The helper channel now ignores spell and category cooldowns. This only applies when interacting with an existing ritual portal and does not allow the player to start their own ritual while it is on cooldown.

The player is also registered as a ritual participant only when the helper channel starts successfully.

## Issues Addressed:

- Closes #26139
- Original report: https://github.com/chromiecraft/chromiecraft/issues/9681

## SOURCE:

The behavior and reproduction are documented in the linked issue and test video.

The ritual helper channel was introduced in #19602 to reproduce the original ritual animation without executing the spell effects or consuming its resources. Participating in another caster's ritual is an interaction with that ritual and should not be blocked by the helper's cooldown for starting their own ritual.

Related implementation:
https://github.com/cmangos/mangos-wotlk/commit/6eaef417163174ffa2f6e4943ded4b11784fa62d

## Tests Performed:

- Built `worldserver` successfully on Windows Release.
- Tested in-game with two Warlocks.
- Confirmed that a Warlock with Ritual of Summoning on cooldown can click and channel another Warlock's ritual.

https://github.com/user-attachments/assets/82b676fd-a495-4f56-be0b-7fe68a57c5ed

## How to Test the Changes:

1. Create two Warlocks and place them in the same group.
2. Teach both Warlocks Ritual of Summoning and give them Soul Shards.
3. Cast Ritual of Summoning with the second Warlock and interrupt it by moving, placing the spell on cooldown.
4. Cast Ritual of Summoning with the first Warlock.
5. Click the first Warlock's summoning portal with the second Warlock.
6. Confirm that the second Warlock begins channeling without receiving `Spell is not ready yet`.
7. Confirm that the ritual completes after receiving the required participants.
8. Confirm that the second Warlock still cannot start their own ritual until its cooldown expires.

## Known Issues and TODO List:

None.
