### PR TITLE
fix(Scripts/Spells): correct Lock and Load proc behavior

### DIFF
--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -1258,7 +1258,9 @@ class spell_hun_lock_and_load : public AuraScript
         if (!(eventInfo.GetTypeMask() & PROC_FLAG_DONE_PERIODIC))
             return false;
 
-        return roll_chance_i(aurEff->GetAmount());
+        // Rank 3 used a hidden 20% periodic proc chance in 3.3.5.
+        uint32 procChance = GetSpellInfo()->GetRank() == 3 ? 20 : aurEff->GetAmount();
+        return roll_chance_i(procChance);
     }
 
     void HandleProc(ProcEventInfo& eventInfo)
@@ -1267,6 +1269,15 @@ class spell_hun_lock_and_load : public AuraScript
 
         Unit* caster = eventInfo.GetActor();
         caster->CastSpell(caster, SPELL_LOCK_AND_LOAD_TRIGGER, true);
+
+        SpellInfo const* spellInfo = eventInfo.GetSpellInfo();
+        // Frost Trap can be blocked by an existing ICD, but does not start one itself.
+        if (spellInfo && spellInfo->SpellFamilyFlags[0] & 0x10)
+        {
+            GetAura()->ResetProcCooldown();
+            return;
+        }
+
         caster->CastSpell(caster, SPELL_LOCK_AND_LOAD_MARKER, true);
     }
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were partially used in preparing this pull request.

OpenAI Codex (GPT-5) was used to review a severity ranked list of open issues, identify this issue, research and organize relevant information, investigate Blizzlike behavior, and prepare the initial draft of the PR description.

This corrects two Lock and Load behaviors:

- Rank 3 now uses the hidden 20% periodic proc chance, resulting in the expected 2% / 4% / 20% progression.
- A successful Frost Trap proc no longer starts the 22-second internal cooldown.

Frost Trap remains blocked by an internal cooldown started by another source. Other Lock and Load sources continue to start the cooldown normally.

## Issues Addressed:

- Closes #26138

## SOURCE:

The expected behavior is documented in the linked issue using original WotLK testing and retail footage:

- https://github.com/azerothcore/azerothcore-wotlk/issues/26138
- https://web.archive.org/web/20101109042411/http://elitistjerks.com/f74/t38137-survival_hunter_wotlk/p121/
- https://youtu.be/MLCP_AHq3cw?t=52

## Tests Performed:

- Built `worldserver` successfully on Windows Release.
- Confirmed that the local server starts successfully with the change.
- Further focused in-game validation is recommended.

## How to Test the Changes:

1. Create a Hunter with Lock and Load rank 3.
2. Trigger Frost Trap on a non-immune target.
3. Confirm that Lock and Load activates.
4. Consume its charges and immediately apply Black Arrow.
5. Confirm that Black Arrow can proc Lock and Load before 22 seconds have passed.
6. Trigger Lock and Load from Black Arrow.
7. Trigger Frost Trap during the resulting 22-second internal cooldown.
8. Confirm that Frost Trap does not proc Lock and Load during that cooldown.
9. Record eligible Black Arrow or fire-trap ticks outside the cooldown and confirm an approximately 20% proc rate.

## Known Issues and TODO List:

None.