### PR TITLE
fix(Core/Spells): Fix Improved Barkskin armor

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -847,7 +847,9 @@ void AuraEffect::ApplySpellMod(Unit* target, bool apply)
                     Aura* aura = iter->second->GetBase();
                     // only passive and permament auras-active auras should have amount set on spellcast and not be affected
                     // if aura is casted by others, it will not be affected
-                    if ((aura->IsPassive() || aura->IsPermanent()) && aura->GetCasterGUID() == guid && aura->GetSpellInfo()->IsAffectedBySpellMod(m_spellmod))
+                    if ((aura->IsPassive() || aura->IsPermanent()) && aura->GetCasterGUID() == guid &&
+                        aura->GetSpellInfo()->CheckShapeshift(target->GetShapeshiftForm()) == SPELL_CAST_OK &&
+                        aura->GetSpellInfo()->IsAffectedBySpellMod(m_spellmod))
                     {
                         if (GetMiscValue() == SPELLMOD_ALL_EFFECTS)
                         {


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

This prevents passive auras from being recalculated by spell modifiers when they are incompatible with the player's current shapeshift form.

Improved Barkskin's hidden armor passive could be recalculated while the player was already in Bear Form. This incorrectly applied its 80% or 160% armor bonus until the player changed forms.

Passive aura recalculation now validates the player's current shapeshift form. Improved Barkskin continues working while unshapeshifted and in Travel Form, but no longer increases armor in Bear Form.

https://github.com/user-attachments/assets/b93d90e2-6380-402a-ae60-85219f69dff5

### AI-assisted Pull Requests

- [x] AI tools were partially used in preparing this pull request.

OpenAI Codex (GPT-5) was used to review a severity ranked list of open issues, identify this issue, research and organize relevant information, investigate Blizzlike behavior, and prepare the initial draft of the PR description.

## Issues Addressed:

- Closes #20028

## SOURCE:

The expected behavior is documented by the talent description, the client spell data, and the linked issue:

- https://github.com/azerothcore/azerothcore-wotlk/issues/20028
- https://www.wowhead.com/wotlk/spell=63411/improved-barkskin

The hidden armor passive, spell 66530, permits Travel Form and excludes Bear Form through its shapeshift masks.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Additional validation:

- Built `worldserver` successfully on Windows using RelWithDebInfo.
- Confirmed that learning Improved Barkskin while in Bear Form no longer increases armor.
- Confirmed that the local server starts successfully.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue.
- [ ] This pull request requires further testing.

1. Create a Druid and enter Bear Form.
2. Record the character's current armor.
3. Learn Improved Barkskin without leaving Bear Form.
4. Confirm that armor does not increase by 80% or 160%.
5. Leave Bear Form and confirm the armor bonus works while unshapeshifted.
6. Enter Travel Form and confirm the armor bonus remains active.
7. Return to Bear Form and confirm the bonus is removed immediately.
8. Repeat the test with both talent ranks.

## Known Issues and TODO List:

None.