### PR TITLE
fix(DB/SpellCone): remove spell 30213 (Felguard Cleave) — no cone implicit target

### DIFF
--- a/data/sql/updates/pending_db_world/2026_06_11_03_spell_cone_remove_30213.sql
+++ b/data/sql/updates/pending_db_world/2026_06_11_03_spell_cone_remove_30213.sql
@@ -1,0 +1,4 @@
+-- DB update 2026_06_11_02 -> 2026_06_11_03
+-- Spell (ID: 30213) was added to spell_cone in 2026_06_11_02 but does not have
+-- a cone implicit target, causing a server warning on startup.
+DELETE FROM `spell_cone` WHERE `ID` = 30213;


### PR DESCRIPTION
## Description

Removes spell 30213 (`Felguard Cleave`) from the `spell_cone` table, which was added in #26039 but generates a server warning on startup:

```
Spell (ID:30213) listed in `spell_cone` does not have a cone implicit target.
```

### Root Cause

Spell 30213 is the Felguard pet's **Cleave** ability (Rank 1). Its retail mechanic is **not a frontal cone** — it strikes the primary target plus the nearest enemy to that target (chain-to-nearest mechanic). The spell uses `TARGET_UNIT_NEARBY_ENEMY` (`TARGET_SELECT_CATEGORY_NEARBY`), not a cone target type.

`SpellMgr::LoadSpellCones()` validates that every entry in `spell_cone` has `TARGET_SELECT_CATEGORY_CONE` in at least one effect. Since spell 30213 does not, the server correctly rejects it with the warning above.

Changing the target to `TARGET_UNIT_CONE_ENEMY_54` would be incorrect — it would alter the retail mechanic from "hit nearest enemy to the target" to "hit everything in a frontal cone", breaking the Felguard Cleave behavior.

The spell is exclusive to the Warlock Demonology Felguard pet. It does not appear in any `creature_template_spell` entry and has no C++ script references — confirmed by the `spell_bonus_data` comment `'Pet Warlock - Cleave'`.

### Fix

Simply remove the entry from `spell_cone`. The Felguard Cleave mechanic already works correctly via its existing `TARGET_UNIT_NEARBY_ENEMY` target type in the DBC — no `spell_cone` entry is needed.

### Sources (WotLK 3.3.5a)

- https://www.wowhead.com/wotlk/spell=30213 — spell description confirms "target and his nearest ally" (not a cone)
- https://www.wowhead.com/wotlk/spell=30219 — Rank 2 of Felguard Cleave, same mechanic
- https://www.wowhead.com/wotlk/spell=30223 — Rank 3 of Felguard Cleave, same mechanic
- https://www.wowhead.com/wotlk/npc=17252/felguard — Felguard pet that uses this ability
- `spell_bonus_data` entry `(30213, 0, 0, 0.1429, 0, 'Pet Warlock - Cleave')` — AzerothCore DB confirms it is a pet-exclusive spell
- https://wowdev.wiki/Spell.dbc/EffectImplicitTarget — DBC target type reference (TARGET_UNIT_NEARBY_ENEMY vs cone types)

### How to test

1. Apply the SQL.
2. Start the worldserver — the warning `Spell (ID:30213) listed in spell_cone does not have a cone implicit target` should no longer appear.
3. Log in as a Demonology Warlock with a Felguard and verify Cleave still hits the primary target + nearest enemy correctly.