### PR TITLE
fix(DB/Loot): Add Design: Infused Twilight Opal to Anub'Arak heroic drop table

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1780897569814580900.sql
+++ b/data/sql/updates/pending_db_world/rev_1780897569814580900.sql
@@ -1,0 +1,3 @@
+DELETE FROM `creature_loot_template` WHERE `Entry` = 31610 AND `Item` = 41796;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(31610, 41796, 0, 100, 0, 1, 0, 1, 1, 'Anub\'arak (1) - Design: Infused Twilight Opal');


### PR DESCRIPTION
Adds the Design: Infused Twilight Opal item as a 100% drop chance. This fits the drop rate of all other heroic recipes found in the `creature_loot_template.sql` :
- (30540,41794,0,100,0,1,0,1,1,'Keristrasza (1) - Design: Deadly Monarch Topaz'),
- (31386,41792,0,100,0,1,0,1,1,'Sjonnir The Ironshaper (1) - Design: Deft Monarch Topaz'),
- (31673,41793,0,100,0,1,0,1,1,'Ingvar the Plunderer (1) - Design: Fierce Monarch Topaz'),
- (31464,41790,0,100,0,1,0,1,1,'Herald Volazj (1) - Design: Precise Scarlet Ruby'),
- (31360,41795,0,100,0,1,0,1,1,'The Prophet Tharon\'ja (1) - Design: Timeless Forest Emerald'),
- (31506,41791,0,100,0,1,0,1,1,'Cyanigosa (1) - Design: Thick Autumn\'s Glow'),

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
  - Claude Sonnet 4.6

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes the following issue: https://github.com/azerothcore/azerothcore-wotlk/issues/26136

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

WoWhead confirms the item drops off Anub'arak. Set it to 100% drop rate like all the other recipes on azerothcore.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Verified the item drops from Anub'arak in Azjol-Nerub heroic on a fresh character with Grand Master Jewelcrafting. Confirmed the item lets me learn the recipe to craft the gem.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create or use a character without Design: Infused Twilight Opal already learned.
2. Learn Grand Master Jewelcrafting
  - `.learn 25230` -> `.learn 28894` -> `.learn 28897` -> `.learn 51311` -> `..setskill 755 450 450`
3. Run Azjol-Nerub on Heroic difficulty and kill Anub'arak (final boss).
4. Confirm Design: Infused Twilight Opal appears in the loot.
5. Confirm you can right click recipe to learn it


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
