### PR TITLE
fix(Scripts/UtgardePinnacle): fix Svala Sorrowgrave intro flight and aerial combat

### DIFF
--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -121,31 +121,6 @@ public:
         EventMap events2;
         SummonList summons;
 
-        // Teleports straight up/down in place, keeping X/Y/orientation - used
-        // for every aerial phase transition instead of MoveFall/SetHover,
-        // which either silently no-op (CanFly() is true for this creature)
-        // or never send a movement packet to clients.
-        void TeleportToZ(float z)
-        {
-            me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), z, me->GetOrientation());
-        }
-
-        // GetFloorZ() starts its search from MAX_HEIGHT, which hits the
-        // ceiling in this indoor room instead of the floor - search from the
-        // creature's current Z instead.
-        float GetGroundZ() const
-        {
-            return me->GetMap()->GetHeight(me->GetPhaseMask(), me->GetPositionX(),
-                                            me->GetPositionY(), me->GetPositionZ(), true);
-        }
-
-        void SetGrounded()
-        {
-            me->SetAnimTier(AnimTier::Ground);
-            me->SetFloatValue(UNIT_FIELD_HOVERHEIGHT, 0.0f);
-            me->ClearUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
-        }
-
         void Reset() override
         {
             if (instance)
@@ -163,7 +138,9 @@ public:
             {
                 me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                 me->SetImmuneToAll(false);
-                SetGrounded();
+                me->SetAnimTier(AnimTier::Ground);
+                me->SetFloatValue(UNIT_FIELD_HOVERHEIGHT, 0.0f);
+                me->ClearUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
             }
         }
 
@@ -254,7 +231,7 @@ public:
                     events2.ScheduleEvent(EVENT_SVALA_TALK3, 3s);
                     break;
                 case EVENT_SVALA_TALK3:
-                    TeleportToZ(me->GetPositionZ() + 6.0f);
+                    me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 6.0f, me->GetOrientation());
                     me->AddUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
                     me->SetAnimTier(AnimTier::Fly);
                     events2.ScheduleEvent(EVENT_SVALA_TALK4, 9s);
@@ -298,8 +275,11 @@ public:
                     break;
                 case EVENT_SVALA_TALK8:
                     {
-                        SetGrounded();
-                        TeleportToZ(GetGroundZ());
+                        me->SetAnimTier(AnimTier::Ground);
+                        me->SetFloatValue(UNIT_FIELD_HOVERHEIGHT, 0.0f);
+                        me->ClearUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
+                        float groundZ = me->GetMap()->GetHeight(me->GetPhaseMask(), me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), true);
+                        me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), groundZ, me->GetOrientation());
                         events2.ScheduleEvent(EVENT_SVALA_TALK9, 3s);
                         break;
                     }
@@ -308,7 +288,7 @@ public:
                     me->LoadEquipment(1, true);
                     me->setActive(false);
                     me->SetAnimTier(AnimTier::Fly);
-                    TeleportToZ(me->GetPositionZ() + 2.0f);
+                    me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 2.0f, me->GetOrientation());
                     if (Player* target = SelectTargetFromPlayerList(100.0f))
                         AttackStart(target);
                     return;
@@ -375,7 +355,8 @@ public:
                         me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                         me->SetControlled(false, UNIT_STATE_ROOT);
                         me->ClearUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
-                        TeleportToZ(GetGroundZ() + 2.0f);
+                        float groundZ = me->GetMap()->GetHeight(me->GetPhaseMask(), me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), true);
+                        me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), groundZ + 2.0f, me->GetOrientation());
                         AttackStart(me->GetVictim());
                         summons.DespawnAll();
                         break;

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -121,6 +121,31 @@ public:
         EventMap events2;
         SummonList summons;
 
+        // Teleports straight up/down in place, keeping X/Y/orientation - used
+        // for every aerial phase transition instead of MoveFall/SetHover,
+        // which either silently no-op (CanFly() is true for this creature)
+        // or never send a movement packet to clients.
+        void TeleportToZ(float z)
+        {
+            me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), z, me->GetOrientation());
+        }
+
+        // GetFloorZ() starts its search from MAX_HEIGHT, which hits the
+        // ceiling in this indoor room instead of the floor - search from the
+        // creature's current Z instead.
+        float GetGroundZ() const
+        {
+            return me->GetMap()->GetHeight(me->GetPhaseMask(), me->GetPositionX(),
+                                            me->GetPositionY(), me->GetPositionZ(), true);
+        }
+
+        void SetGrounded()
+        {
+            me->SetAnimTier(AnimTier::Ground);
+            me->SetFloatValue(UNIT_FIELD_HOVERHEIGHT, 0.0f);
+            me->ClearUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
+        }
+
         void Reset() override
         {
             if (instance)
@@ -138,9 +163,7 @@ public:
             {
                 me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                 me->SetImmuneToAll(false);
-                me->SetAnimTier(AnimTier::Ground);
-                me->SetFloatValue(UNIT_FIELD_HOVERHEIGHT, 0.0f);
-                me->ClearUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
+                SetGrounded();
             }
         }
 
@@ -231,7 +254,7 @@ public:
                     events2.ScheduleEvent(EVENT_SVALA_TALK3, 3s);
                     break;
                 case EVENT_SVALA_TALK3:
-                    me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 6.0f, me->GetOrientation());
+                    TeleportToZ(me->GetPositionZ() + 6.0f);
                     me->AddUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
                     me->SetAnimTier(AnimTier::Fly);
                     events2.ScheduleEvent(EVENT_SVALA_TALK4, 9s);
@@ -275,11 +298,8 @@ public:
                     break;
                 case EVENT_SVALA_TALK8:
                     {
-                        me->SetAnimTier(AnimTier::Ground);
-                        me->SetFloatValue(UNIT_FIELD_HOVERHEIGHT, 0.0f);
-                        me->ClearUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
-                        float groundZ = me->GetMap()->GetHeight(me->GetPhaseMask(), me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), true);
-                        me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), groundZ, me->GetOrientation());
+                        SetGrounded();
+                        TeleportToZ(GetGroundZ());
                         events2.ScheduleEvent(EVENT_SVALA_TALK9, 3s);
                         break;
                     }
@@ -288,7 +308,7 @@ public:
                     me->LoadEquipment(1, true);
                     me->setActive(false);
                     me->SetAnimTier(AnimTier::Fly);
-                    me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 2.0f, me->GetOrientation());
+                    TeleportToZ(me->GetPositionZ() + 2.0f);
                     if (Player* target = SelectTargetFromPlayerList(100.0f))
                         AttackStart(target);
                     return;
@@ -355,8 +375,7 @@ public:
                         me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                         me->SetControlled(false, UNIT_STATE_ROOT);
                         me->ClearUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
-                        float groundZ = me->GetMap()->GetHeight(me->GetPhaseMask(), me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), true);
-                        me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), groundZ + 2.0f, me->GetOrientation());
+                        TeleportToZ(GetGroundZ() + 2.0f);
                         AttackStart(me->GetVictim());
                         summons.DespawnAll();
                         break;

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -138,7 +138,9 @@ public:
             {
                 me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                 me->SetImmuneToAll(false);
-                me->SetHover(true);
+                me->SetAnimTier(AnimTier::Ground);
+                me->SetFloatValue(UNIT_FIELD_HOVERHEIGHT, 0.0f);
+                me->ClearUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
             }
         }
 
@@ -229,25 +231,18 @@ public:
                     events2.ScheduleEvent(EVENT_SVALA_TALK3, 3s);
                     break;
                 case EVENT_SVALA_TALK3:
-                    me->SetFloatValue(UNIT_FIELD_HOVERHEIGHT, 6.0f);
-                    me->SetHover(true);
+                    me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 6.0f, me->GetOrientation());
                     me->AddUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
-                    events2.ScheduleEvent(30, 1s);
+                    me->SetAnimTier(AnimTier::Fly);
                     events2.ScheduleEvent(EVENT_SVALA_TALK4, 9s);
                     break;
-                case 30:
-                    {
-                        WorldPacket data(SMSG_SPLINE_MOVE_SET_HOVER, 9);
-                        data << me->GetPackGUID();
-                        me->SendMessageToSet(&data, false);
-                        break;
-                    }
                 case EVENT_SVALA_TALK4:
                     {
                         me->CastSpell(me, SPELL_SVALA_TRANSFORMING1, true);
                         me->UpdateEntry(NPC_SVALA_SORROWGRAVE);
                         me->SetCorpseDelay(sWorld->getIntConfig(CONFIG_CORPSE_DECAY_ELITE));
                         me->SetFloatValue(UNIT_FIELD_HOVERHEIGHT, 6.0f);
+                        me->SetAnimTier(AnimTier::Fly);
                         me->SetImmuneToAll(true);
                         if (Creature* Arthas = ObjectAccessor::GetCreature(*me, ArthasGUID))
                             Arthas->InterruptNonMeleeSpells(false);
@@ -279,14 +274,21 @@ public:
                     events2.ScheduleEvent(EVENT_SVALA_TALK8, 13s);
                     break;
                 case EVENT_SVALA_TALK8:
-                    me->GetMotionMaster()->MoveFall(0, true);
-                    events2.ScheduleEvent(EVENT_SVALA_TALK9, 2s);
-                    break;
+                    {
+                        me->SetAnimTier(AnimTier::Ground);
+                        me->SetFloatValue(UNIT_FIELD_HOVERHEIGHT, 0.0f);
+                        me->ClearUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
+                        float groundZ = me->GetMap()->GetHeight(me->GetPhaseMask(), me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), true);
+                        me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), groundZ, me->GetOrientation());
+                        events2.ScheduleEvent(EVENT_SVALA_TALK9, 3s);
+                        break;
+                    }
                 case EVENT_SVALA_TALK9:
-                    me->SetFloatValue(UNIT_FIELD_HOVERHEIGHT, 3.0f);
                     me->SetImmuneToAll(false);
                     me->LoadEquipment(1, true);
                     me->setActive(false);
+                    me->SetAnimTier(AnimTier::Fly);
+                    me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 2.0f, me->GetOrientation());
                     if (Player* target = SelectTargetFromPlayerList(100.0f))
                         AttackStart(target);
                     return;
@@ -336,6 +338,8 @@ public:
                         DoTeleportPlayer(target, 296.632f, -346.075f, 90.63f, 4.6f);
                         me->NearTeleportTo(296.632f, -346.075f, 110.0f, 4.6f, false);
                         me->SetControlled(true, UNIT_STATE_ROOT);
+                        me->AddUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
+                        me->SetAnimTier(AnimTier::Fly);
                     }
 
                     events.DelayEvents(25001ms); // +1 just to be sure
@@ -347,12 +351,16 @@ public:
                     me->CastSpell(me, SPELL_RITUAL_STRIKE, true);
                     return;
                 case EVENT_SORROWGRAVE_FINISH_RITUAL:
-                    me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
-                    me->SetControlled(false, UNIT_STATE_ROOT);
-                    AttackStart(me->GetVictim());
-                    me->GetMotionMaster()->MoveFall(0, true);
-                    summons.DespawnAll();
-                    break;
+                    {
+                        me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+                        me->SetControlled(false, UNIT_STATE_ROOT);
+                        me->ClearUnitState(UNIT_STATE_NO_ENVIRONMENT_UPD);
+                        float groundZ = me->GetMap()->GetHeight(me->GetPhaseMask(), me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), true);
+                        me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), groundZ + 2.0f, me->GetOrientation());
+                        AttackStart(me->GetVictim());
+                        summons.DespawnAll();
+                        break;
+                    }
             }
 
             DoMeleeAttackIfReady();


### PR DESCRIPTION
## Description

Fixes multiple movement issues with Svala Sorrowgrave in Utgarde Pinnacle:

- Pre-transformation Svala (human form) now visually rises into the air during the transformation cutscene
- Wing animation (`AnimTier::Fly`) is correctly applied during all aerial phases (intro, combat, ritual sacrifice)
- Svala now engages in combat while hovering in the air, matching retail behavior
- `MoveFall` calls that silently did nothing are replaced with explicit `NearTeleportTo` using the correct floor height
- The ritual sacrifice phase correctly maintains elevation and wing animation throughout

### Root Cause

Five interconnected issues:

1. **`MoveFall` silently bailing**: `Creature::CanFly()` checks `GetMovementTemplate().IsFlightAllowed()`. Since NPC 26668 has `Flight=1 (DisableGravity)` in `creature_template_movement`, `CanFly()` always returns `true`. `Unit::MoveFall()` exits early when `CanFly()` is true, so both `TALK8` (intro landing) and `FINISH_RITUAL` (post-ritual landing) never executed — Svala was stuck at Z=110 during combat.

2. **`SetHover(true)` not visible to clients**: The intro used `SetHover(true)` to lift Svala in `TALK3` and `Reset()`. `SetHover` calls `Relocate()` internally (server-side only) — no movement packet is sent to clients, so players saw Svala with wing animation at ground level rather than actually rising.

3. **`GetFloorZ()` returning ceiling in indoor areas**: `GetFloorZ()` uses `MAX_HEIGHT` as search start, which in Utgarde Pinnacle hits the ceiling (~Z 120) instead of the floor (~Z 90). Any landing calculation using `GetFloorZ()` placed Svala at the wrong height.

4. **`AnimTier::Fly` reset by `UpdateEntry`**: `UpdateEntry(NPC_SVALA_SORROWGRAVE)` in `TALK4` resets `UNIT_FIELD_BYTES_1` (which holds the AnimTier byte), clearing the wing animation that was set in `TALK3`.

5. **Missing `UNIT_STATE_NO_ENVIRONMENT_UPD`**: Without this state, the per-tick Z correction drops Svala to the floor during elevated phases even when `MOVEMENTFLAG_DISABLE_GRAVITY` is set, because `UpdateMovementFlags` (triggered by any `NearTeleportTo`) immediately re-evaluates and resets gravity flags.

### Fix

- Replace `SetHover(true)` / `MoveFall` with `NearTeleportTo` calls that send proper movement packets to all clients
- Use `GetMap()->GetHeight(phaseMask, x, y, z, true)` with the creature's current Z as search start — correctly finds the floor in indoor areas instead of the ceiling
- Add `UNIT_STATE_NO_ENVIRONMENT_UPD` during aerial phases (intro `TALK3`→`TALK8`, ritual elevation) to block per-tick gravity correction while elevated
- Explicitly manage `AnimTier::Fly` / `AnimTier::Ground` at each phase transition
- Re-apply `AnimTier::Fly` after `UpdateEntry(NPC_SVALA_SORROWGRAVE)` in `TALK4` since `UpdateEntry` resets `UNIT_FIELD_BYTES_1`
- In `Reset()`, replace `SetHover(true)` with explicit state cleanup (`AnimTier::Ground`, `hoverHeight=0`, `ClearUnitState`)
- At combat start (`TALK9`): `NearTeleportTo(Z+2)` + `AnimTier::Fly` — Svala begins combat hovering 2 yards above ground with wing animation (retail behavior)
- In `FINISH_RITUAL`: `NearTeleportTo(groundZ+2)` returns Svala to aerial combat position instead of floor

### Sources (WotLK 3.3.5a)

- https://www.wowhead.com/wotlk/npc=26668/svala-sorrowgrave — Val'kyr who fights while hovering in the air
- https://www.wowhead.com/wotlk/npc=29281 — Human Svala (pre-transformation), rises into the air during cutscene before becoming a Val'kyr
- https://www.icy-veins.com/wotlk-classic/utgarde-pinnacle-dungeon-guide — confirms aerial combat behavior and ritual mechanic

### How to test

1. Enter Utgarde Pinnacle (normal or heroic) and approach Svala to trigger the intro cutscene
2. During `TALK3` (transformation begins): human Svala should visually rise ~6 yards into the air with wing animation
3. After `UpdateEntry` (`TALK4`): wing animation should persist on the Val'kyr model
4. At `TALK8`: she snaps to floor with ground animation (brief moment before combat)
5. At `TALK9` (combat start): she lifts back up ~2 yards and engages combat while hovering with wing animation — melee DPS should be able to reach her
6. Trigger the Ritual of the Sword sacrifice mechanic: Svala teleports to Z=110 above the altar, maintains wing animation while elevated, and returns to aerial combat position (~2 yards above floor) after the ritual ends