### PR TITLE
fix(Scripts/UtgardePinnacle): Ritual Channelers immune to knockback, reapply Paralyze

### DIFF
--- a/data/sql/updates/pending_db_world/2026_06_12_02_ritual_channeler_knockback_immunity.sql
+++ b/data/sql/updates/pending_db_world/2026_06_12_02_ritual_channeler_knockback_immunity.sql
@@ -1,0 +1,6 @@
+-- Ritual Channeler (NPC 27281) should be immune to knockback effects.
+-- Retail behavior: Ritual Channelers are stationary during the sacrifice ritual and
+-- cannot be knocked away from their channeling positions by player abilities.
+-- creature_immunities ID=-3 grants immunity to KNOCK_BACK (98), PULL_TOWARDS (124),
+-- KNOCK_BACK_DEST (144), PULL_TOWARDS_DEST (145).
+UPDATE `creature_template` SET `CreatureImmunitiesId` = -3 WHERE `entry` = 27281;

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -374,9 +374,15 @@ public:
         return GetUtgardePinnacleAI<npc_ritual_channelerAI>(pCreature);
     }
 
-    struct npc_ritual_channelerAI : public NullCreatureAI
+    struct npc_ritual_channelerAI : public ScriptedAI
     {
-        npc_ritual_channelerAI(Creature* pCreature) : NullCreatureAI(pCreature) {}
+        npc_ritual_channelerAI(Creature* pCreature) : ScriptedAI(pCreature), _paralyzeTarget(), _paralyzeTimer(2000)
+        {
+            me->SetCombatMovement(false);
+        }
+
+        ObjectGuid _paralyzeTarget;
+        uint32 _paralyzeTimer;
 
         void AttackStart(Unit* pWho) override
         {
@@ -385,9 +391,26 @@ public:
 
             if (pWho)
             {
+                _paralyzeTarget = pWho->GetGUID();
                 me->AddThreat(pWho, 10000000.0f);
                 me->CastSpell(pWho, SPELL_PARALYZE, false);
             }
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            if (_paralyzeTarget.IsEmpty())
+                return;
+
+            if (_paralyzeTimer <= diff)
+            {
+                if (Unit* target = ObjectAccessor::GetUnit(*me, _paralyzeTarget))
+                    if (!target->HasAura(SPELL_PARALYZE))
+                        me->CastSpell(target, SPELL_PARALYZE, false);
+                _paralyzeTimer = 2000;
+            }
+            else
+                _paralyzeTimer -= diff;
         }
     };
 };


### PR DESCRIPTION
## Description

Ritual Channelers (NPC 27281) in Utgarde Pinnacle can be knocked out of their channeling positions by player knockback abilities, breaking the sacrifice ritual mechanic. Additionally, the Paralyze aura they apply to the sacrificed player is never reapplied if it falls off, allowing the player to move and interrupt the ritual.

### Root Cause

`npc_ritual_channelerAI` inherits from `NullCreatureAI`, which provides no `UpdateAI` tick and makes the creature passive to all movement effects:

1. **No knockback immunity**: `creature_template.CreatureImmunitiesId` for NPC 27281 is `0` — no immunities assigned. Any player ability with `SPELL_EFFECT_KNOCK_BACK`, `SPELL_EFFECT_PULL_TOWARDS`, `SPELL_EFFECT_KNOCK_BACK_DEST`, or `SPELL_EFFECT_PULL_TOWARDS_DEST` can displace the Channeler from its position, stopping the channel.

2. **No Paralyze reapplication**: `SPELL_PARALYZE` (48278) is cast once in `AttackStart`. If the aura expires or is dispelled, there is no mechanism to reapply it. `NullCreatureAI` has no `UpdateAI`, so no periodic reapplication can occur.

### Fix

- **SQL**: Set `CreatureImmunitiesId = -3` for NPC 27281. Entry `-3` in `creature_immunities` grants immunity to effects 98 (`KNOCK_BACK`), 124 (`PULL_TOWARDS`), 144 (`KNOCK_BACK_DEST`), and 145 (`PULL_TOWARDS_DEST`).

- **C++**: Change `npc_ritual_channelerAI` from `NullCreatureAI` to `ScriptedAI`. Add `UpdateAI` that checks every 2 seconds whether the paralyzed target still has the `SPELL_PARALYZE` aura and reapplies it if missing. Call `SetCombatMovement(false)` so Channelers stay stationary at their summoned positions.

### Sources (WotLK 3.3.5a)

- https://www.wowhead.com/wotlk/spell=48278 — Paralyze: stuns the target; should be maintained for the ritual duration
- https://www.wowhead.com/wotlk/npc=27281 — Ritual Channeler: stationary NPC that channels during Svala's sacrifice ritual
- https://www.wowhead.com/wotlk/npc=26668 — Svala Sorrowgrave: confirms the ritual requires three Channelers holding the target in place
- `creature_immunities` ID=-3: `Effects=98,124,144,145` (`KNOCK_BACK`, `PULL_TOWARDS`, `KNOCK_BACK_DEST`, `PULL_TOWARDS_DEST`) — knockback immunity group already in DB

### How to test

1. Enter Utgarde Pinnacle (any difficulty) and engage Svala Sorrowgrave.
2. Wait for her to trigger the sacrifice ritual — three Ritual Channelers spawn around a random player.
3. **Knockback test**: Use any knockback ability (e.g. Heroic Throw, Thunderstorm, Typhoon) on a Ritual Channeler — it should not move.
4. **Paralyze persistence test**: If you have a dispel (Cleanse, Dispel Magic, etc.), dispel the Paralyze from the sacrifice target — the Channeler should reapply it within 2 seconds.
5. Verify the full ritual completes normally and Svala resumes combat.
