### PR TITLE
fix(DB/SpellArea): Dun Niffelem phase not retained after Battling the Elements (#25365)

### DIFF
--- a/data/sql/updates/pending_db_world/2026_06_12_02_spell_area_dun_niffelem_phasing.sql
+++ b/data/sql/updates/pending_db_world/2026_06_12_02_spell_area_dun_niffelem_phasing.sql
@@ -6,5 +6,6 @@
 -- causing players who finished Battling the Elements to lose the phase needed to
 -- interact with NPCs and pick up follow-up quests in Dun Niffelem.
 -- Fixes: https://github.com/azerothcore/azerothcore-wotlk/issues/25365
+DELETE FROM `spell_area` WHERE `spell` = 55858 AND `area` = 4495 AND `quest_start` = 12967 AND `aura_spell` = 0 AND `racemask` = 0 AND `gender` = 2;
 INSERT INTO `spell_area` (`spell`, `area`, `quest_start`, `quest_end`, `aura_spell`, `racemask`, `gender`, `autocast`, `quest_start_status`, `quest_end_status`)
 VALUES (55858, 4495, 12967, 0, 0, 0, 2, 1, 64, 11);

--- a/data/sql/updates/pending_db_world/2026_06_12_02_spell_area_dun_niffelem_phasing.sql
+++ b/data/sql/updates/pending_db_world/2026_06_12_02_spell_area_dun_niffelem_phasing.sql
@@ -1,0 +1,10 @@
+-- Dun Niffelem (area 4495): add missing spell_area entry so spell 55858 continues
+-- to apply after quest 12967 (Battling the Elements) is rewarded.
+-- All surrounding areas (4437-4440, 4455) have two entries for spell 55858:
+--   one for while quest 12924 is active, and one for after quest 12967 is rewarded.
+-- Area 4495 only had the first entry (with quest_end=12967 removing it on completion),
+-- causing players who finished Battling the Elements to lose the phase needed to
+-- interact with NPCs and pick up follow-up quests in Dun Niffelem.
+-- Fixes: https://github.com/azerothcore/azerothcore-wotlk/issues/25365
+INSERT INTO `spell_area` (`spell`, `area`, `quest_start`, `quest_end`, `aura_spell`, `racemask`, `gender`, `autocast`, `quest_start_status`, `quest_end_status`)
+VALUES (55858, 4495, 12967, 0, 0, 0, 2, 1, 64, 11);


### PR DESCRIPTION
## Description

After completing quest 12967 (Battling the Elements), players in area 4495 (Dun Niffelem) lose phase mask 4 (spell 55858 — Phase Shift 2: Frost Giants), making King Jokkum and other phase-4 NPCs invisible and preventing progress in the Sons of Hodir quest chain.

### Root Cause

The `spell_area` table is missing an entry that keeps spell 55858 active in area 4495 after quest 12967 is rewarded.

All adjacent areas (4437, 4438, 4439, 4440, 4455) have **two** entries for spell 55858 — one active while quest 12924 is in progress, and one active after quest 12967 is rewarded (`quest_start=12967, quest_start_status=64`). Area 4495 only had the first entry, with `quest_end=12967` which removes the spell upon rewarding quest 12967. The second entry was missing, leaving players without phase mask 4 after completing Battling the Elements.

Fixes #25365.

### Fix

Add the missing `spell_area` entry:
```
(55858, 4495, 12967, 0, 0, 0, 2, 1, 64, 11)
```
This re-applies spell 55858 (phase mask 4) in area 4495 when quest 12967 is rewarded, matching the pattern used by all adjacent areas.

### Sources (WotLK 3.3.5a)

- https://www.wowhead.com/wotlk/quest=12967 — Battling the Elements; Njormeld says "I shall see you in Dun Niffelem soon" confirming the player must transition to Dun Niffelem with the correct phase after completion
- https://www.wowhead.com/wotlk/quest=12924 — Forging an Alliance; requires speaking with King Jokkum (NPC 30105, phaseMask 4) — inaccessible without phase mask 4
- https://www.wowhead.com/wotlk/spell=55858 — Phase Shift 2: Frost Giants — permanent phase aura with mask 4; must remain active after quest 12967 for NPCs to be visible
- https://www.wowhead.com/wotlk/spell=55952 — Phase Shift 3: Fjorn's Anvil — permanent phase aura with mask 8; distinct phase for Fjorn's Anvil subzone
- https://www.wowhead.com/wotlk/npc=30105 — King Jokkum at Dun Niffelem; phaseMask 4, only visible under spell 55858

### How to test

1. Complete the prerequisite chain up to quest 12924 (Forging an Alliance)
2. Pick up quest 12966 (You Can't Miss Him) from King Jokkum, then quest 12967 (Battling the Elements) from Njormeld at Fjorn's Anvil
3. Complete and turn in quest 12967 to Njormeld at Fjorn's Anvil
4. Return to Dun Niffelem (area 4495)
5. **Before fix:** King Jokkum is invisible (phase mask 4 lost); cannot advance the quest chain
6. **After fix:** King Jokkum remains visible; Njormeld at Dun Niffelem is visible; quest 12924 (Forging an Alliance) can be turned in