### PR TITLE
fix(Paladin): Swift/Sanctified Retribution apply without Retribution Aura

### DIFF
--- a/data/sql/updates/pending_db_world/2026_06_13_00_spell_script_sanctified_retribution_aura.sql
+++ b/data/sql/updates/pending_db_world/2026_06_13_00_spell_script_sanctified_retribution_aura.sql
@@ -1,0 +1,8 @@
+-- DB update 2026_06_12_02 -> 2026_06_13_00
+--
+-- Fixes: https://github.com/azerothcore/azerothcore-wotlk/issues/26050
+-- Sanctified Retribution / Swift Retribution (spell 63531) should only apply
+-- their bonus to nearby allies when the Paladin has Retribution Aura active.
+DELETE FROM `spell_script_names` WHERE `spell_id` = 63531 AND `ScriptName` = 'spell_pal_sanctified_retribution_aura';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(63531, 'spell_pal_sanctified_retribution_aura');

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -531,6 +531,24 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].SpellClassMask[2] = 0x8000000;
     });
 
+    // Swift Retribution: SPELL_AURA_MELEE_SLOW (aura 193) requires negative amounts for haste;
+    // positive amounts cause attack speed reduction. DBC BasePoints are +1/+2/+3 for ranks 1/2/3.
+    // Negate so CalcValue = BasePoints + DieSides(1) produces -1/-2/-3 (1/2/3% haste).
+    ApplySpellFix({ 53379 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = -2;
+    });
+
+    ApplySpellFix({ 53484 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = -3;
+    });
+
+    ApplySpellFix({ 53648 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = -4;
+    });
+
     // Sanctified Retribution
     ApplySpellFix({ 31869 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -71,6 +71,8 @@ enum PaladinSpells
 
     SPELL_PALADIN_SEAL_OF_RIGHTEOUSNESS          = 25742,
 
+    SPELL_PALADIN_RETRIBUTION_AURA               = 7294,
+    SPELL_PALADIN_BATTLE_AURA                    = 41106,
     SPELL_PALADIN_CONCENTRACTION_AURA            = 19746,
     SPELL_PALADIN_SANCTIFIED_RETRIBUTION_R1      = 31869,
     SPELL_PALADIN_SWIFT_RETRIBUTION_R1           = 53379,
@@ -2133,6 +2135,29 @@ private:
     uint32 _spellId;
 };
 
+// 63531 - Sanctified Retribution Aura
+// Applied by Sanctified Retribution (31869) and Swift Retribution (-53379) talents.
+// Only applies to nearby allies when the Paladin has Retribution Aura active.
+class spell_pal_sanctified_retribution_aura : public AuraScript
+{
+    PrepareAuraScript(spell_pal_sanctified_retribution_aura);
+
+    bool CheckAreaTarget(Unit* /*target*/)
+    {
+        Unit* caster = GetCaster();
+        if (!caster)
+            return false;
+
+        return caster->GetAuraOfRankedSpell(SPELL_PALADIN_RETRIBUTION_AURA) ||
+               caster->HasAura(SPELL_PALADIN_BATTLE_AURA);
+    }
+
+    void Register() override
+    {
+        DoCheckAreaTarget += AuraCheckAreaTargetFn(spell_pal_sanctified_retribution_aura::CheckAreaTarget);
+    }
+};
+
 // 53651 - Light's Beacon - Beacon of Light
 // Each source heal has a dedicated beacon copy spell:
 //   53652 - Holy Light, 53653 - Flash of Light, 53654 - Holy Shock
@@ -2256,5 +2281,6 @@ void AddSC_paladin_spell_scripts()
     RegisterSpellScriptWithArgs(spell_pal_improved_aura, "spell_pal_improved_devotion_aura", SPELL_PALADIN_IMPROVED_DEVOTION_AURA);
     RegisterSpellScriptWithArgs(spell_pal_improved_aura, "spell_pal_sanctified_retribution", SPELL_PALADIN_SANCTIFIED_RETRIBUTION_AURA);
     RegisterSpellScriptWithArgs(spell_pal_improved_aura, "spell_pal_swift_retribution", SPELL_PALADIN_SANCTIFIED_RETRIBUTION_AURA);
+    RegisterSpellScript(spell_pal_sanctified_retribution_aura);
     RegisterSpellScript(spell_pal_light_s_beacon);
 }


### PR DESCRIPTION
## Description of the problem

Spell 63531 (the shared area buff applied by Sanctified Retribution and Swift Retribution talents) was applying its bonus to nearby allies regardless of which Paladin aura was active — including no aura at all.

Additionally, Swift Retribution talent spells (53379/53484/53648) had positive BasePoints in the DBC (+1/+2/+3), causing `SPELL_AURA_MELEE_SLOW` to **reduce** attack speed instead of increasing it.

Fixes #26050

## Changes

**`SpellInfoCorrections.cpp`** — Negate Swift Retribution BasePoints:
- Rank 1 (53379): `BasePoints = -2` → CalcValue = -1% (1% haste)
- Rank 2 (53484): `BasePoints = -3` → CalcValue = -2% (2% haste)
- Rank 3 (53648): `BasePoints = -4` → CalcValue = -3% (3% haste)

`SPELL_AURA_MELEE_SLOW` requires negative amounts for haste; positive amounts reduce attack speed. DBC values were wrong.

**`spell_paladin.cpp`** — Add `spell_pal_sanctified_retribution_aura` AuraScript for spell 63531:
- `DoCheckAreaTarget` restricts application to when the Paladin has **Retribution Aura** (any rank) or **Battle Aura** active
- Matches the talent descriptions ("Your Retribution Aura also causes...") and the DBC affected-spell list (Retribution Aura ranks + Battle Aura)

**`spell_script_names` SQL** — Binds spell 63531 to the new script.

## How to test

1. Create a Paladin with Sanctified Retribution and/or Swift Retribution talented
2. Activate **Devotion Aura** (no Retribution Aura) — party members should **not** receive the haste/damage bonus from spell 63531
3. Switch to **Retribution Aura** — party members should now receive the bonus
4. Verify Swift Retribution grants attack speed **increase** (not decrease)

## Extra Notes

The `DoCheckAreaTarget` approach is used instead of handling aura-switch events because spell 63531 is cast once when the talent is learned and persists as a continuous area aura. The target check is re-evaluated on each pulse, correctly reflecting the Paladin's active aura state.