### PR TITLE
fix(Core/Combat): After evade NPC not Attack

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -309,9 +309,12 @@ void CreatureAI::EngagementOver()
 
 void CreatureAI::JustExitedCombat()
 {
-    // No-op: synchronous EnterEvadeMode cascades via MemberEvaded and frees
-    // refs held by upstream iterators (StopAttackFaction crash). EngagementOver
-    // here also resets scripted fights on brief combat gaps (Valithria).
+   EngagementOver();
+
+    // If creature is alive, in world, and not already evading, trigger evade to return home
+    // Check IsInWorld to avoid evade during server shutdown/cleanup
+    if (me->IsAlive() && me->IsInWorld() && !me->IsInEvadeMode())
+        EnterEvadeMode(EVADE_REASON_NO_HOSTILES);
 }
 
 /*void CreatureAI::AttackedBy(Unit* attacker)


### PR DESCRIPTION
## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ -] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Issues Addressed:
After evade NPC not Attack. Not all. I notice this bug in Darnassus NPC (guards and Ancien of War).
<img width="1920" height="751" alt="Image" src="https://github.com/user-attachments/assets/a7847b2c-c16d-4c7b-b690-8126295889cd" />
and if i am attack one other (after evade) not attack:
<img width="1600" height="635" alt="Image" src="https://github.com/user-attachments/assets/68b29b70-42ad-430c-b1e9-34b5aacbcdf6" />

Revert some missing code from https://github.com/azerothcore/azerothcore-wotlk/pull/25516
