### PR TITLE
fix(Core/Combat): let asymmetric-faction aggressors engage friendly-back targets

### DIFF
--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -59,7 +59,8 @@
     // ... both units must be allowed to enter combat
     if (a->IsCombatDisallowed() || b->IsCombatDisallowed())
         return false;
-    if (a->IsFriendlyTo(b) || b->IsFriendlyTo(a))
+    // ...not friendly, unless one side is hostile (asymmetric aggressor wins)
+    if ((a->IsFriendlyTo(b) || b->IsFriendlyTo(a)) && !a->IsHostileTo(b) && !b->IsHostileTo(a))
         return false;
     Player const* playerA = a->GetCharmerOrOwnerPlayerOrPlayerItself();
     Player const* playerB = b->GetCharmerOrOwnerPlayerOrPlayerItself();

--- a/src/test/server/game/Combat/CombatManagerTest.cpp
+++ b/src/test/server/game/Combat/CombatManagerTest.cpp
@@ -1103,6 +1103,49 @@ TEST_F(CombatManagerIntegrationTest, CanBeginCombat_ValidUnits_Succeeds)
     EXPECT_TRUE(CombatManager::CanBeginCombat(_creatureA, _creatureB));
 }
 
+// Asymmetric factions: A is hostile to the target, but the target's faction still considers A
+// friendly (e.g. Dragonblight Mage Hunters vs Moonrest Highborne). The aggressor's hostility must
+// win so combat can begin.
+TEST_F(CombatManagerIntegrationTest, CanBeginCombat_AsymmetricHostileVsFriendly_Succeeds)
+{
+    auto* factionC = new FactionTemplateEntry{};
+    factionC->ID = 90003;
+    factionC->faction = 90003;
+    factionC->factionFlags = 0;
+    factionC->ourMask = 2;       // A (hostileMask=2) is hostile to this group...
+    factionC->friendlyMask = 1;  // ...but this faction considers A's group (ourMask=1) friendly
+    factionC->hostileMask = 0;
+    for (auto& e : factionC->enemyFaction) e = 0;
+    for (auto& f : factionC->friendFaction) f = 0;
+    sFactionTemplateStore.SetEntry(90003, factionC);
+
+    _creatureB->SetFaction(90003);
+    ASSERT_TRUE(_creatureA->IsHostileTo(_creatureB));
+    ASSERT_TRUE(_creatureB->IsFriendlyTo(_creatureA));
+    EXPECT_TRUE(CombatManager::CanBeginCombat(_creatureA, _creatureB));
+}
+
+// One side friendly and neither side hostile: combat must still be blocked so neutral/friendly
+// bystanders are not dragged into combat.
+TEST_F(CombatManagerIntegrationTest, CanBeginCombat_FriendlyWithoutHostility_Fails)
+{
+    auto* factionD = new FactionTemplateEntry{};
+    factionD->ID = 90004;
+    factionD->faction = 90004;
+    factionD->factionFlags = 0;
+    factionD->ourMask = 4;       // A (hostileMask=2) is NOT hostile to this group...
+    factionD->friendlyMask = 1;  // ...and this faction considers A's group friendly
+    factionD->hostileMask = 0;
+    for (auto& e : factionD->enemyFaction) e = 0;
+    for (auto& f : factionD->friendFaction) f = 0;
+    sFactionTemplateStore.SetEntry(90004, factionD);
+
+    _creatureB->SetFaction(90004);
+    ASSERT_FALSE(_creatureA->IsHostileTo(_creatureB));
+    ASSERT_FALSE(_creatureB->IsHostileTo(_creatureA));
+    EXPECT_FALSE(CombatManager::CanBeginCombat(_creatureA, _creatureB));
+}
+
 // ============================================================================
 // GAP COVERAGE: CombatManager::IsInCombatWith (ObjectGuid variant)
 // ============================================================================


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

`CombatManager::CanBeginCombat` (ported from TrinityCore) blocked combat whenever **either** party considered the other friendly:

```cpp
if (a->IsFriendlyTo(b) || b->IsFriendlyTo(a))
    return false;
```

Faction relationships can be **asymmetric**. The Dragonblight Mage Hunters/Stalkers (faction `1985`) are hostile to the Moonrest Highborne (faction `21`, sniffed — `VerifiedBuild = 12340`) via an explicit `enemies` entry, but the Highborne are *friendly back* to the hunters via `friendlyMask & ourMask`. Because one direction is friendly, the `||` gate refused to create the combat reference, so the hunters' `AttackStart` succeeded and they chased, but `EngageWithTarget → AddThreat → SetInCombatWith` always failed — no threat ref, victim selection kept dropping the target, producing the "follow forever but never engage" behaviour reported in the issue.

Before the threat/combat rewrite, AC's `CombatStart`/`SetInCombatWith` had no friendliness gate, so a hostile aggressor engaged a friendly-back target (matching retail). This restores that behaviour while keeping the rest of the gate:

```cpp
// ...not friendly, unless one side is hostile (asymmetric aggressor wins)
if ((a->IsFriendlyTo(b) || b->IsFriendlyTo(a)) && !a->IsHostileTo(b) && !b->IsHostileTo(a))
    return false;
```

The new condition is the old one AND-ed with an extra term, so it is **strictly more permissive** — it can never block combat that was previously allowed (no existing encounter can stop working). It also avoids dragging neutral/friendly bystanders in: a friendly target with no hostile party is still blocked. The faction data (`21`) is sniffed and is left untouched.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code with azerothMCP

## Issues Addressed:
- Closes #26180

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Retail reference (hunters finishing off the Highborne ghosts) is linked in the issue: https://youtu.be/H1RWH-nIg6g?t=145

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Unit tests added to `CombatManagerTest.cpp` covering the asymmetric case (combat now begins) and the friendly-without-hostility case (combat still blocked). The existing `CanBeginCombat_FriendlyFactions_Fails` (mutually-friendly) still passes.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.go xyz 3308.9941 2389.7688 31.868546 571` (Moonrest Gardens, Dragonblight) — **with `.gm off`** (a GM is not a valid combat target, which masks the behaviour).
2. Observe the Dragonblight Mage Hunters/Stalkers now engage and kill the Moonrest Highborne instead of just following them.

**Regression check (generic change — please test for regressions):** the only pairs whose behaviour changes are asymmetric faction relationships where one side is friendly and the other hostile. Of 1,897 such faction-template pairs, only 44 have creatures spawning on the same map, and almost all are intended ambient battles (e.g. Scarlet Crusade vs Scourge in Stratholme, demons vs undead, the Wrathgate event) or passive quest NPCs/wildlife that won't initiate. Full breakdown with creature names: https://gist.github.com/blinkysc/3a7ef49d4c164f2b50d94238595b69da

Worth a spot-check in-game:
- Stratholme / Plaguelands ambient Scarlet-vs-Scourge fights still behave correctly.
- Argent Dawn NPCs and Wrathgate event creatures are not pulled into unintended combat.

## Known Issues and TODO List:
- [ ] Diverges from TrinityCore's stricter `||` check; a future TC combat port would need to re-apply this.
- [ ] Because the faction data is asymmetric, the Highborne do not proactively attack the hunters (their faction still considers the hunters friendly); the hunters hunt and kill them, matching the retail footage.
