### PR TITLE
fix(Core/AI): restore missing EngagementOver in GuardAI::EnterEvadeMode

### DIFF
--- a/src/server/game/AI/CoreAI/GuardAI.cpp
+++ b/src/server/game/AI/CoreAI/GuardAI.cpp
@@ -42,6 +42,7 @@ void GuardAI::EnterEvadeMode(EvadeReason /*why*/)
         me->GetMotionMaster()->MoveIdle();
         me->CombatStop(true);
         me->GetThreatMgr().ClearAllThreat();
+        EngagementOver();
         return;
     }
 
@@ -50,6 +51,8 @@ void GuardAI::EnterEvadeMode(EvadeReason /*why*/)
     me->RemoveAllAuras();
     me->GetThreatMgr().ClearAllThreat();
     me->CombatStop(true);
+
+    EngagementOver();
 
     // Remove ChaseMovementGenerator from MotionMaster stack list, and add HomeMovementGenerator instead
     if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() == CHASE_MOTION_TYPE)


### PR DESCRIPTION
## Changes Proposed:
`GuardAI::EnterEvadeMode` tears down combat (`RemoveAllAuras`, `ClearAllThreat`, `CombatStop`, `MoveTargetedHome`) but never calls `EngagementOver()`, so the AI-level `_isEngaged` flag stays `true` after a guard evades. `CreatureAI::MoveInLineOfSight` then bails on `if (me->IsEngaged()) return;`, so the guard can never re-acquire a target and stops attacking after combat (e.g. Darnassus Sentinels, Ancients of War).

Every other evade path clears engagement through `CreatureAI::_EnterEvadeMode` (which calls `EngagementOver()`); `GuardAI` is the lone override that skipped it. The defect was latent until `CreatureAI::JustExitedCombat` was made a no-op — that hook previously called `EngagementOver()` directly and masked the omission. TrinityCore calls `EngagementOver()` in **both** branches of `GuardAI::EnterEvadeMode`; this restores that behaviour, so the fix stays in `GuardAI` and leaves `JustExitedCombat` untouched (avoiding the crash/encounter-reset regressions that reverting it would reintroduce).

This is an alternative to #26189, which addresses the same report by reverting the `JustExitedCombat` no-op.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude Code with azerothMCP**

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Find a guard creature (e.g. Darnassus Sentinel `4262`, Ancient of War `3469`) — `.go creature id 4262`.
2. Engage it in combat, then break combat and let it evade / return home.
3. Approach or attack it again.
4. Before: the guard ignores you (stuck `_isEngaged`). After: the guard re-aggros normally.

## Known Issues and TODO List:

- [ ] `TotemAI::EnterEvadeMode` has the same missing `EngagementOver()`, but totems do not re-acquire targets so they are not affected; could be aligned in a follow-up.
