### PR TITLE
fix(DB/Creature): Freya's Detonating Lasher should be susceptible to crowd control

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1781475932164983700.sql
+++ b/data/sql/updates/pending_db_world/rev_1781475932164983700.sql
@@ -1,0 +1,2 @@
+-- Freya: Detonating Lasher (32918/33399) CC-able like TC/retail (was -273).
+UPDATE `creature_template` SET `CreatureImmunitiesId` = 0 WHERE `entry` IN (32918, 33399);


### PR DESCRIPTION
## Changes Proposed:
Ulduar's **Detonating Lasher** (Freya add) is currently immune to crowd control. Both the 10-man (`32918`) and 25-man (`33399`) entries share `CreatureImmunitiesId = -273`, a shared immunity profile whose `MechanicsMask` includes `ROOT | SNARE | STUN | FREEZE`. As a result the add cannot be slowed, rooted, stunned or trapped, which removes the intended way of handling it.

On retail and TrinityCore this add has no mechanic immunity (`mechanic_immune_mask = 0`). This PR repoints both difficulty entries to the empty default immunity profile (`0`) to restore crowd control.

Scope is deliberately limited to the Detonating Lasher. The sibling adds **Storm Lasher** (`32919` / `33401`, also on `-273`) and **Snaplasher** (`32916` / `33400`, on `-269`) are left untouched, as the player reports only concern the Detonating Lasher.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used. **Claude (Opus 4.8)** was used to investigate the reports, cross-reference the immunity data against TrinityCore, and prepare the SQL update. The change has been reviewed and is understood by the author.

## Issues Addressed:
- Reported in ChromieCraft PTR testing: chromiecraft/chromiecraft#9657
- Recurring across multiple PTR raid reports (Detonating Lashers cannot be slowed/snared/stunned/trapped).

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.) — multiple PTR test reports with video, and cross-referenced against TrinityCore where all lasher entries have `mechanic_immune_mask = 0`.

Comparison (AzerothCore vs TrinityCore) for the Detonating Lasher entries:

| Entry | Difficulty | AzerothCore | TrinityCore |
|-------|-----------|-------------|-------------|
| 32918 | 10-man | `-273` (ROOT\|SNARE\|STUN\|FREEZE...) | `0` (no immunity) |
| 33399 | 25-man | `-273` (ROOT\|SNARE\|STUN\|FREEZE...) | `0` (no immunity) |

## Tests Performed:
- [x] This pull request requires further testing and may have edge cases to be tested.

The fix is data-only and verified by comparison against TrinityCore and the reported behavior; in-game confirmation by testers is welcome.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Engage Freya in Ulduar (10 or 25-man) until Detonating Lashers are summoned.
2. Attempt to slow, root, stun, or trap a Detonating Lasher (e.g. Frost Nova, Entangling Roots, Bash/Shockwave, Freezing Trap).
3. Before: the crowd-control effect does not apply. After: the effects apply normally, as on retail/TrinityCore.

## Known Issues and TODO List:

- [ ] Separate from this PR: PTR reports also note the Detonating Lashers move too quickly / without the expected short delay before moving. That is script-side behaviour, not creature_template data, and is out of scope here.
