### PR TITLE
fix(Scripts/Ulduar): Freya's Ancient Conservator should cast Nature's Fury on a random player

### DIFF
--- a/src/server/game/AI/CoreAI/UnitAI.cpp
+++ b/src/server/game/AI/CoreAI/UnitAI.cpp
@@ -292,10 +292,14 @@ SpellCastResult UnitAI::DoCastAOE(uint32 spellId, bool triggered)
 
 /**
  * @brief Cast the spell on a random unit from the threat list
+ *
+ * @param aura Optional aura filter forwarded to SelectTarget: a positive value
+ *             requires the aura on the target, a negative value excludes targets
+ *             that already have it.
  */
-SpellCastResult UnitAI::DoCastRandomTarget(uint32 spellId, uint32 threatTablePosition, float dist, bool playerOnly, bool triggered, bool withTank)
+SpellCastResult UnitAI::DoCastRandomTarget(uint32 spellId, uint32 threatTablePosition, float dist, bool playerOnly, bool triggered, bool withTank, int32 aura)
 {
-    if (Unit* target = SelectTarget(SelectTargetMethod::Random, threatTablePosition, dist, playerOnly, withTank))
+    if (Unit* target = SelectTarget(SelectTargetMethod::Random, threatTablePosition, dist, playerOnly, withTank, aura))
     {
         return DoCast(target, spellId, triggered);
     }

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -395,7 +395,8 @@ public:
     SpellCastResult DoCastToAllHostilePlayers(uint32 spellid, bool triggered = false);
     SpellCastResult DoCastVictim(uint32 spellId, bool triggered = false);
     SpellCastResult DoCastAOE(uint32 spellId, bool triggered = false);
-    SpellCastResult DoCastRandomTarget(uint32 spellId, uint32 threatTablePosition = 0, float dist = 0.0f, bool playerOnly = true, bool triggered = false, bool withTank = true);
+    // aura: forwarded to SelectTarget - if 0: ignored, if > 0: the target shall have the aura, if < 0: the target shall NOT have the aura
+    SpellCastResult DoCastRandomTarget(uint32 spellId, uint32 threatTablePosition = 0, float dist = 0.0f, bool playerOnly = true, bool triggered = false, bool withTank = true, int32 aura = 0);
 
     /// @brief Cast spell on the top threat target, which may not be the current victim.
     SpellCastResult DoCastMaxThreat(uint32 spellId, uint32 threatTablePosition = 0, float dist = 0.0f, bool playerOnly = true, bool triggered = false);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -1058,7 +1058,7 @@ struct boss_freya_summons : public ScriptedAI
         switch (events.ExecuteEvent())
         {
             case EVENT_ANCIENT_CONSERVATOR_NATURE_FURY:
-                me->CastSpell(me->GetVictim(), SPELL_NATURE_FURY, false);
+                DoCastRandomTarget(SPELL_NATURE_FURY, 0, 100.0f, true, false, true, -SPELL_NATURE_FURY);
                 events.Repeat(14s);
                 break;
             case EVENT_ANCIENT_CONSERVATOR_GRIP:


### PR DESCRIPTION
## Changes Proposed:
Ulduar's **Ancient Conservator** (Freya add, NPC `33203`) casts **Nature's Fury** (`62589`) on its current victim, so the debuff lands on the tank/main target every time. On retail and TrinityCore the ability targets a **random player** in the raid (the afflicted player then has to be healed through it or moved to a mushroom).

This makes the Conservator pick a random player (players only, tank eligible) that does **not** already have the Nature's Fury aura, so the debuff spreads across the raid instead of refreshing on a single player — matching TrinityCore's behaviour.

To express this with AzerothCore's modern helper, `DoCastRandomTarget` is extended with an optional `aura` filter that is forwarded to `SelectTarget` (positive = require aura, negative = exclude targets that have it). The parameter defaults to `0`, so all existing callers are unaffected.

```cpp
// boss_freya.cpp
DoCastRandomTarget(SPELL_NATURE_FURY, 0, 100.0f, true, false, true, -SPELL_NATURE_FURY);
```

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems). <!-- DoCastRandomTarget gains an optional aura filter -->
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used. **Claude (Opus 4.8)** was used to evaluate the change against TrinityCore, port the behaviour, and prepare this pull request. The fix is understood by the author.

## Issues Addressed:
- Reported in ChromieCraft PTR testing: chromiecraft/chromiecraft#9659
- Recurring across multiple PTR raid reports (Nature's Fury always cast on the tank/main target).

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

- Behaviour ported from TrinityCore; the commit is attributed to the original author (`Lopin <Lopin@TwinStar.cz>`) via the `--author` tag. The `DoCastRandomTarget` aura-filter extension is new AzerothCore code.
- Wowhead Freya strategy: *"the Ancient Conservator will also cast Nature's Fury on a random player every 6 seconds"* — https://www.wowhead.com/wotlk/guide/raids/ulduar/freya-strategy

## Tests Performed:
- [x] This pull request requires further testing and may have edge cases to be tested.

Change matches TrinityCore's implementation and the reported behaviour; in-game confirmation by testers is welcome.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Engage Freya in Ulduar with several players in the raid.
2. Wait for an Ancient Conservator to be summoned and cast Nature's Fury.
3. Before: the debuff always lands on the tank/current victim. After: it lands on a random player that does not already have the debuff.

## Known Issues and TODO List:

- [ ] The recast interval (currently 14s) is slower than the ~5-6s seen on retail/TrinityCore. That is a separate tuning concern and is out of scope for this targeting fix.
