### PR TITLE
fix(Scripts/Ulduar): Steelbreaker's Static Disruption should target a ranged player

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
@@ -316,11 +316,20 @@ struct boss_steelbreaker : public ScriptedAI
                 events.Repeat(15s, 20s);
                 break;
             case EVENT_STATIC_DISRUPTION:
-                if (Unit* pTarget = SelectTarget(SelectTargetMethod::MinDistance, 0, 0, true))
-                    me->CastSpell(pTarget, SPELL_STATIC_DISRUPTION, false);
+            {
+                // Prefer a random player out of melee range so the nature damage debuff
+                // (and its 5y splash) stays off the melee/tank cluster; if everyone is in
+                // melee, fall back to a random player regardless of range.
+                Unit* target = SelectTarget(SelectTargetMethod::Random, 0, -10.0f, true);
+                if (!target)
+                    target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true);
+
+                if (target)
+                    me->CastSpell(target, SPELL_STATIC_DISRUPTION, false);
 
                 events.Repeat(20s, 40s);
                 break;
+            }
             case EVENT_OVERWHELMING_POWER:
                 Talk(SAY_STEELBREAKER_POWER);
                 me->CastSpell(me->GetVictim(), SPELL_OVERWHELMING_POWER, true);


### PR DESCRIPTION
## Changes Proposed:
In Ulduar's Assembly of Iron, **Steelbreaker** selected the target for **Static Disruption** (`61911`) with `SelectTargetMethod::MinDistance` — i.e. the *closest* player, which is the tank standing in melee range.

Static Disruption deals nature damage and applies a debuff that increases nature damage taken by the target **and everyone within 5 yards**. Because it kept landing on the tank, the follow-up tank-buster **Fusion Punch** was amplified to lethal values (reported as 80-100k vs. the usual 20-30k). On retail the spell is meant to hit a player away from the boss, so ranged players take/cycle it instead of the melee group.

This replaces the targeting with the logic suggested on the linked issue: **prefer a random player out of melee range**, and only **fall back to a random player when nobody is at range**. That keeps both the direct hit and its 5-yard splash off the melee/tank cluster while still spreading it among ranged players. The change covers both 10- and 25-man since they share the same script path.

```cpp
case EVENT_STATIC_DISRUPTION:
{
    Unit* target = SelectTarget(SelectTargetMethod::Random, 0, -10.0f, true);
    if (!target)
        target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true);

    if (target)
        me->CastSpell(target, SPELL_STATIC_DISRUPTION, false);

    events.Repeat(20s, 40s);
    break;
}
```

(In `DefaultTargetSelector`, a negative `dist` means "minimum distance" — targets within that combat range are excluded — so `-10.0f` selects players out of melee range. This mirrors the existing pattern in `boss_blood_prince_council` / `boss_valithria_dreamwalker`.)

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used. **Claude (Opus 4.8)** was used to investigate the reports, locate the targeting logic, and prepare this pull request. The fix is understood by the author.

## Issues Addressed:
- Reported in ChromieCraft PTR testing: chromiecraft/chromiecraft#9372 (the implemented logic follows the suggestion made in that issue's comments).
- Recurring across multiple PTR raid reports (Static Disruption always hits the tank/closest player instead of someone at range).

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

- WoWpedia, Assembly of Iron: https://wowpedia.fandom.com/wiki/Assembly_of_Iron
- Wowhead spell: https://www.wowhead.com/wotlk/spell=61912/static-disruption
- Static Disruption is expected to target a player away from the boss's melee range; the current `MinDistance` selection does the exact opposite.

## Tests Performed:
- [x] This pull request requires further testing and may have edge cases to be tested.

In-game confirmation by testers is welcome.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Start the Assembly of Iron encounter and leave only Steelbreaker alive.
2. Have the tank in melee range and at least one player standing at range.
3. Wait for Static Disruption.
4. Before: it lands on the tank/closest player (inflating Fusion Punch via the nature-damage-taken debuff). After: it lands on a player out of melee range (only hitting a melee player if nobody is at range).

## Known Issues and TODO List:

- [ ]
