### PR TITLE
fix(Scripts/Spells): detonate Seed of Corruption when the target dies

### DIFF
--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -64,6 +64,7 @@ enum WarlockSpells
     SPELL_WARLOCK_LIFE_TAP_ENERGIZE_2               = 32553,
     SPELL_WARLOCK_SEED_OF_CORRUPTION_DAMAGE_R1      = 27285,
     SPELL_WARLOCK_SEED_OF_CORRUPTION_DAMAGE_GENERIC = 32865,
+    SPELL_WARLOCK_SEED_OF_CORRUPTION_VISUAL         = 37826,
     SPELL_WARLOCK_SOULSHATTER                       = 32835,
     SPELL_WARLOCK_SIPHON_LIFE_HEAL                  = 63106,
     SPELL_WARLOCK_UNSTABLE_AFFLICTION_DISPEL        = 31117,
@@ -1530,6 +1531,18 @@ class spell_warl_seed_of_corruption_dummy : public AuraScript
         amount = caster->SpellDamageBonusDone(GetUnitOwner(), GetSpellInfo(), amount, SPELL_DIRECT_DAMAGE, aurEff->GetEffIndex());
     }
 
+    void Detonate(AuraEffect const* aurEff)
+    {
+        Unit* caster = GetCaster();
+        if (!caster)
+            return;
+
+        GetUnitOwner()->CastSpell(GetUnitOwner(), SPELL_WARLOCK_SEED_OF_CORRUPTION_VISUAL, true, nullptr, aurEff);
+
+        uint32 spellId = sSpellMgr->GetSpellWithRank(SPELL_WARLOCK_SEED_OF_CORRUPTION_DAMAGE_R1, GetSpellInfo()->GetRank());
+        caster->CastSpell(GetUnitOwner(), spellId, true, nullptr, aurEff);
+    }
+
     void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
     {
         PreventDefaultAction();
@@ -1546,18 +1559,21 @@ class spell_warl_seed_of_corruption_dummy : public AuraScript
         }
 
         Remove();
+        Detonate(aurEff);
+    }
 
-        Unit* caster = GetCaster();
-        if (!caster)
-            return;
-
-        uint32 spellId = sSpellMgr->GetSpellWithRank(SPELL_WARLOCK_SEED_OF_CORRUPTION_DAMAGE_R1, GetSpellInfo()->GetRank());
-        caster->CastSpell(eventInfo.GetActionTarget(), spellId, true, nullptr, aurEff);
+    // Seed also detonates when the seeded target dies, not only when the damage
+    // buffer threshold is reached.
+    void OnRemove(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
+    {
+        if (GetTargetApplication()->GetRemoveMode() == AURA_REMOVE_BY_DEATH)
+            Detonate(aurEff);
     }
 
     void Register() override
     {
         DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_warl_seed_of_corruption_dummy::CalculateBuffer, EFFECT_1, SPELL_AURA_DUMMY);
+        AfterEffectRemove += AuraEffectRemoveFn(spell_warl_seed_of_corruption_dummy::OnRemove, EFFECT_0, SPELL_AURA_PERIODIC_DAMAGE, AURA_EFFECT_HANDLE_REAL);
         OnEffectProc += AuraEffectProcFn(spell_warl_seed_of_corruption_dummy::HandleProc, EFFECT_1, SPELL_AURA_DUMMY);
     }
 };


### PR DESCRIPTION
## Changes Proposed:
Restore Seed of Corruption's detonation when the seeded target dies. The death-detonation handler and the explosion visual were dropped during the proc-system refactor (#24233), so when the seeded target died (rather than reaching the damage buffer), the seed silently disappeared instead of dealing its AoE to nearby enemies.

This PR adds an `AfterEffectRemove` handler that detonates the seed on `AURA_REMOVE_BY_DEATH`, and restores the detonation visual (spell 37826). The generic monster variants are intentionally left untouched (they detonate on threshold only, never on death).

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Tool used: **Claude Code** (with the **azerothMCP** server for DBC/spell data lookups).

## Issues Addressed:
- Closes #25943

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

https://www.wowhead.com/wotlk/spell=27243/seed-of-corruption — "When the target takes X total damage **or dies**, the seed will inflict damage to all enemies within 15 yards of the target." Behaviour also previously confirmed and fixed in #16059 before regressing.

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Built and tested in-game: with two enemies nearby, casting Seed of Corruption on one and killing it before the buffer threshold is reached now detonates the seed, damaging the second target. The threshold-damage detonation path is unchanged.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Create a warlock and learn Seed of Corruption.
2. Pull two enemies close together and cast Seed of Corruption on one of them.
3. Kill that target quickly (before the damage buffer fills).
4. The seed detonates on death and damages the nearby enemy.

## Known Issues and TODO List:

- [ ] Self-detonation timing when a seed is left to expire on its own (DoT-vs-threshold scaling) is a separate concern and is intentionally not addressed here.
