### PR TITLE
fix(DB/Creature): Auriaya should reset to her patrol start on evade

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1781480954188803100.sql
+++ b/data/sql/updates/pending_db_world/rev_1781480954188803100.sql
@@ -1,0 +1,2 @@
+-- Auriaya (33515/34175): HARD_RESET - despawn/respawn at spawn on evade.
+UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 0x80000000 WHERE `entry` IN (33515, 34175);


### PR DESCRIPTION
## Changes Proposed:
Ulduar's **Auriaya** (NPC `33515`, 25-man `34175`) is a waypoint patroller (the Observation Ring). On a wipe she did **not** reset cleanly: she resumed her patrol from where she was pulled, and her summoned **Sanctum Sentries** ("cats") could linger or fall through the floor.

This sets `CREATURE_FLAG_EXTRA_HARD_RESET` (`0x80000000`) on both difficulty entries. In `CreatureAI::_EnterEvadeMode`, that flag triggers `Creature::DespawnOnEvade()`, which:
- despawns her summons (fixing the lingering / fall-through-floor cats), and
- for a DB-spawned creature, despawns her and respawns her at her spawn point — the start of her patrol — after the reset delay.

This is the same reset type already used by many comparable patrolling/instance bosses (e.g. Skadi the Ruthless, Novos, Krik'thir, Hadronox, Malygos, Sartharion).

```sql
UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 0x80000000 WHERE `entry` IN (33515, 34175);
```

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used. **Claude (Opus 4.8)** was used to investigate the reports, identify the appropriate reset flag, and prepare this pull request. The change is understood by the author.

## Issues Addressed:
- Closes #18953
- Also reported in ChromieCraft PTR testing (Auriaya does not reset correctly on a wipe; cats fall through the floor).

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

- Expected behaviour described in #18953: Auriaya should despawn and respawn at the beginning of her patrol after a wipe.
- `CREATURE_FLAG_EXTRA_HARD_RESET` is the established despawn-on-evade mechanism in the core, used by numerous other bosses.

## Tests Performed:
- [x] This pull request requires further testing and may have edge cases to be tested.

Data-only flag change; in-game confirmation that she despawns on wipe and respawns at her patrol start is welcome.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.go c 137496` to reach Auriaya.
2. Pull her with `.gm off`, then `.gm on` to force a reset (or wipe normally).
3. Before: she resumes her patrol from where she was pulled, cats may linger/fall through the floor. After: she (and her cats) despawn and she respawns at the start of her patrol.

## Known Issues and TODO List:

- [ ] Leashing (she can still be kited far from the Observation Ring) is a separate issue and out of scope for this reset fix.
