### PR TITLE
fix(Scripts/Spells): Combustion charges are no longer eaten by Molten Armor

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -1042,6 +1042,13 @@ class spell_mage_combustion : public AuraScript
 
     bool CheckProc(ProcEventInfo& eventInfo)
     {
+        // Combustion only interacts with directly cast fire spells.
+        // Reactive/proc-triggered spells (e.g. Molten Armor) bypass the system
+        // triggered-spell guard via SPELL_ATTR3_NOT_A_PROC, so filter them here.
+        if (Spell const* procSpell = eventInfo.GetProcSpell())
+            if (procSpell->IsTriggered())
+                return false;
+
         // Do not take charges, add a stack of crit buff
         if (!(eventInfo.GetHitMask() & PROC_HIT_CRITICAL))
         {

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -1042,11 +1042,10 @@ class spell_mage_combustion : public AuraScript
 
     bool CheckProc(ProcEventInfo& eventInfo)
     {
-        // Combustion only interacts with directly cast fire spells.
-        // Reactive/proc-triggered spells (e.g. Molten Armor) bypass the system
-        // triggered-spell guard via SPELL_ATTR3_NOT_A_PROC, so filter them here.
-        if (Spell const* procSpell = eventInfo.GetProcSpell())
-            if (procSpell->IsTriggered())
+        // Molten Armor's damage is a reactive proc, not a fire spell the mage cast.
+        // spell_mage_ignite::CheckProc filters it out the same way, for the same reason.
+        if (SpellInfo const* spellInfo = eventInfo.GetSpellInfo())
+            if (spellInfo->SpellFamilyFlags[1] & 0x8)
                 return false;
 
         // Do not take charges, add a stack of crit buff


### PR DESCRIPTION
https://github.com/user-attachments/assets/240a1f79-8297-4931-a3b4-c0e6572a6755

## Changes Proposed:

Molten Armor's damage procs feed Combustion: non-crits add stacks to the crit buff (28682) and crits eat a charge, so Combustion runs out while the mage is just standing there taking melee hits.

Why it reaches the script at all: the generic guard in `src/server/game/Spells/Auras/SpellAuras.cpp:2152-2158` only blocks triggered spells when the aura lacks `SPELL_ATTR3_CAN_PROC_FROM_PROCS`. Combustion has it (`AttributesEx3 = 0x04000000`), so the whole guard is skipped and every triggered fire spell lands in `spell_mage_combustion::CheckProc`.

The fix filters Molten Armor on its own family flag:

```cpp
if (SpellInfo const* spellInfo = eventInfo.GetSpellInfo())
    if (spellInfo->SpellFamilyFlags[1] & 0x8)
        return false;
```

That flag covers all three ranks of the damage spell (34913, 43043, 43044), each `SPELLFAMILY_MAGE` with `SpellFamilyFlags[1] = 0x8`.

`spell_mage_ignite::CheckProc` already filters Molten Armor with the exact same check, a few hundred lines up in the same file, so this keeps the two consistent.

An earlier version of this PR used a blanket `if (procSpell->IsTriggered()) return false;`. That was too wide: it also caught Living Bomb's explosion (44461), which is triggered but is still a fire spell the mage cast. Its writeup also claimed Molten Armor carries `SPELL_ATTR3_NOT_A_PROC` and that this is what let it through, which is wrong - `AttributesEx3` on 34913 is `0x0`. Both are corrected here.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26195
- Same report on the ChromieCraft tracker: chromiecraft/chromiecraft#9711

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The issue carries a test video from the ChromieCraft triage showing the charges burning down off Molten Armor alone.

Precedent in the codebase: `spell_mage_ignite::CheckProc`, `src/server/scripts/Spells/spell_mage.cpp:722-728` on master:

```cpp
// Molten Armor
if (SpellInfo const* spellInfo = eventInfo.GetSpellInfo())
{
    if (spellInfo->SpellFamilyFlags[1] & 0x8)
    {
        return false;
    }
}
```

Spell data checked against Spell.dbc (3.3.5a 12340):

- Combustion 11129: `AttributesEx3 = 0x04000000`, `ProcFlags = 0x10000` (`PROC_FLAG_DONE_SPELL_MAGIC_DMG_CLASS_NEG`), `ProcCharges = 3`.
- Molten Armor damage 34913 / 43043 / 43044: `SpellFamilyName = 3`, `SpellFamilyFlags = [0, 8, 0]`, `AttributesEx3 = 0x0`.
- Living Bomb explosion 44461: `AttributesEx3 = 0x0`, so the generic guard already stops it and this change leaves it alone.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

The attached video was recorded against the earlier `IsTriggered()` version. The in-game result is the same either way, but the implementation changed after that recording, so a fresh check is worth doing.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Fire mage with Combustion and Molten Armor, plus an alt
2. `.levelup 79`, `.learn all my class`, `.learn all my talent`
3. Cast Molten Armor, pop Combustion, then let the alt melee you without casting anything
4. Combustion charges and the 28682 stacks should not move
5. Cast Fireball or Scorch and confirm crits still spend charges and hits still add stacks
6. Drop a Living Bomb and let it explode on a crit, it should still spend a charge

## Known Issues and TODO List:

Worth a second opinion, and it is the reason the issue is still open: the client data leans the other way. Combustion carries `SPELL_ATTR3_CAN_PROC_FROM_PROCS` deliberately, Molten Armor sits inside Combustion's affected-spells mask on effect 0 (`0x00031048 & 0x8` matches), and the tooltip says "until you have caused 3 non-periodic critical strikes with Fire spells", which Molten Armor's damage technically is. @blinkysc raised this on the issue and it has not been settled.

So this rests on the triage video and on Ignite already treating Molten Armor as not-a-cast-spell, not on a sniff. If someone has a WotLK sniff or a Classic test either way, that would settle it.

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
