### PR TITLE
fix(Spells): dual-school spells bypass single-school immunity incorrectly

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10092,7 +10092,7 @@ bool Unit::IsImmunedToSpell(SpellInfo const* spellInfo, Unit const* caster, Spel
                     continue;
 
                 SpellInfo const* immuneSpellInfo = sSpellMgr->GetSpellInfo(itr->second);
-                if (!(itr->first & spellSchoolMask))
+                if ((itr->first & spellSchoolMask) != spellSchoolMask)
                     continue;
 
                 if (IgnoresSchoolImmunityFromFriendlyCaster(caster, itr->second, immuneSpellInfo))

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10085,30 +10085,26 @@ bool Unit::IsImmunedToSpell(SpellInfo const* spellInfo, Unit const* caster, Spel
     {
         if (spellSchoolMask != SPELL_SCHOOL_MASK_NONE)
         {
+            // Accumulate valid school-immunity bits that overlap the spell's
+            // schools. A multi-school spell (e.g. Frostfire Bolt) can be
+            // covered by separate per-school entries (as produced by
+            // creature_immunities), so the combined mask must be checked
+            // instead of requiring any single entry to cover every school.
             SpellImmuneContainer const& schoolList = m_spellImmune[IMMUNITY_SCHOOL];
-            // Accumulate all valid school immunity bits that overlap with the spell's schools.
-            // A multi-school spell (e.g. Frostfire Bolt) may have its schools covered by
-            // separate per-school entries (as produced by creature_immunities), so we must
-            // check the combined mask rather than requiring any single entry to cover all schools.
             uint32 coveredSchoolMask = 0;
-            for (auto itr = schoolList.begin(); itr != schoolList.end(); ++itr)
+            for (auto const& [immunitySchoolMask, immunityAuraId] : schoolList)
             {
-                if (itr->second == spellInfo->Id)
+                if (immunityAuraId == spellInfo->Id || !(immunitySchoolMask & spellSchoolMask))
                     continue;
 
-                if (!(itr->first & spellSchoolMask))
+                SpellInfo const* immuneSpellInfo = sSpellMgr->GetSpellInfo(immunityAuraId);
+                if (IgnoresSchoolImmunityFromFriendlyCaster(caster, immunityAuraId, immuneSpellInfo) ||
+                    spellInfo->CanPierceImmuneAura(immuneSpellInfo))
                     continue;
 
-                SpellInfo const* immuneSpellInfo = sSpellMgr->GetSpellInfo(itr->second);
-
-                if (IgnoresSchoolImmunityFromFriendlyCaster(caster, itr->second, immuneSpellInfo))
-                    continue;
-
-                if (spellInfo->CanPierceImmuneAura(immuneSpellInfo))
-                    continue;
-
-                coveredSchoolMask |= itr->first;
+                coveredSchoolMask |= immunitySchoolMask;
             }
+
             if ((coveredSchoolMask & spellSchoolMask) == spellSchoolMask)
                 return true;
         }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10086,14 +10086,20 @@ bool Unit::IsImmunedToSpell(SpellInfo const* spellInfo, Unit const* caster, Spel
         if (spellSchoolMask != SPELL_SCHOOL_MASK_NONE)
         {
             SpellImmuneContainer const& schoolList = m_spellImmune[IMMUNITY_SCHOOL];
+            // Accumulate all valid school immunity bits that overlap with the spell's schools.
+            // A multi-school spell (e.g. Frostfire Bolt) may have its schools covered by
+            // separate per-school entries (as produced by creature_immunities), so we must
+            // check the combined mask rather than requiring any single entry to cover all schools.
+            uint32 coveredSchoolMask = 0;
             for (auto itr = schoolList.begin(); itr != schoolList.end(); ++itr)
             {
                 if (itr->second == spellInfo->Id)
                     continue;
 
-                SpellInfo const* immuneSpellInfo = sSpellMgr->GetSpellInfo(itr->second);
-                if ((itr->first & spellSchoolMask) != spellSchoolMask)
+                if (!(itr->first & spellSchoolMask))
                     continue;
+
+                SpellInfo const* immuneSpellInfo = sSpellMgr->GetSpellInfo(itr->second);
 
                 if (IgnoresSchoolImmunityFromFriendlyCaster(caster, itr->second, immuneSpellInfo))
                     continue;
@@ -10101,8 +10107,10 @@ bool Unit::IsImmunedToSpell(SpellInfo const* spellInfo, Unit const* caster, Spel
                 if (spellInfo->CanPierceImmuneAura(immuneSpellInfo))
                     continue;
 
-                return true;
+                coveredSchoolMask |= itr->first;
             }
+            if ((coveredSchoolMask & spellSchoolMask) == spellSchoolMask)
+                return true;
         }
     }
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/23412b11-ffd7-4395-b829-707ae42edf64



## Background

Spells with a dual school mask (e.g. Frostfire Bolt — `FROST|FIRE`) should only be fully blocked by school immunity if the target is immune to **all** of the spell's schools. If the target is immune to only one of the schools, the spell should still deal damage via the other component.

> Retail reference: https://www.wowhead.com/wotlk/spell=47610/frostfire-bolt — *"Checked against the lower of the target's Frost and Fire resistances"*

## Bug

**Frostfire Bolt** (spell 47610, school mask `FROST|FIRE`) deals no damage against frost-immune NPCs (e.g. Crazed Water Spirit, NPC 16570), despite the fire component being unresisted.

Reported in: #26193

## Root cause

In `Unit::IsImmunedToSpell(SpellInfo const*, Unit const*, SpellSchoolMask)`, the school immunity check used an **ANY-overlap** condition:

```cpp
if (!(itr->first & spellSchoolMask))
    continue;
```

For Frostfire Bolt (`FROST|FIRE`) against a FROST-only immune target:
- `!(FROST & FROST|FIRE)` → `false` → does **not** skip → returns `true` (immune) ❌

This is inconsistent with every other immunity check in the codebase (`IsImmunedToSpell` line 960, `IsImmunedToDamage`, `IsImmunedToSchool`), which all require the immunity mask to cover **all** schools in the spell.

## Fix

The `creature_immunities` table applies school immunities as **one entry per school bit** (e.g. a fire+frost immune creature gets two separate entries: key=`FIRE` and key=`FROST`, not one combined key=`FIRE|FROST`). A naive "all-schools-covered" single-entry check would therefore break creatures that are immune to both schools via separate entries.

Instead of checking each entry individually, the fix **accumulates** all valid (non-pierceable) school immunity entries that overlap with the spell's schools, then checks whether their **combined mask** covers the full spell school mask:

```cpp
// Before — ANY overlap → immediate immune (too permissive for multi-school spells)
if (!(itr->first & spellSchoolMask))
    continue;
return true;

// After — accumulate, then check combined coverage
if (!(itr->first & spellSchoolMask))
    continue;
// ... IgnoresSchoolImmunityFromFriendlyCaster / CanPierceImmuneAura checks ...
coveredSchoolMask |= itr->first;
// end of loop:
if ((coveredSchoolMask & spellSchoolMask) == spellSchoolMask)
    return true;
```

This correctly handles all cases:
| Scenario | Result |
|---|---|
| Frost-only immune vs Frostfire Bolt (`FROST\|FIRE`) | covered=`FROST`, `FROST != FROST\|FIRE` → **not immune** ✓ |
| Fire+Frost immune (separate entries) vs Frostfire Bolt | covered=`FROST\|FIRE` → **immune** ✓ |
| Fire+Frost immune (combined entry) vs Frostfire Bolt | covered=`FROST\|FIRE` → **immune** ✓ |
| Fire-only immune vs Fireball (`FIRE`) | covered=`FIRE`, `FIRE == FIRE` → **immune** ✓ |
| Anti-Magic Shell (all magic) vs any magic spell | covered covers all → **immune** ✓ |

## Test plan

1. Find a frost-immune NPC (e.g. Crazed Water Spirit, NPC 16570)
2. Cast Frostfire Bolt at it
3. Verify it now deals damage (fire component) instead of showing **Immune**
4. Verify single-school fire spells (Fireball) are still fully blocked by fire-immune NPCs
5. Verify Anti-Magic Shell still blocks all magic spells including Frostfire Bolt
6. Verify a creature immune to both Fire and Frost (e.g. Emperor Vek'nilash, entry 15275) is still fully immune to Frostfire Bolt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spell immunity logic for multi-school spells. Units now correctly evaluate immunity by combining overlapping immunity sources, so protection is applied only when the combined coverage fully includes every spell school (while preserving existing filtering behavior like exclusions and pierce-immune-aura handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->