### PR TITLE
fix(Spell): proc-triggered spells should not re-establish combat via SetInCombatWith

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2612,7 +2612,9 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
 
     m_spellAura = nullptr; // Set aura to null for every target-make sure that pointer is not used for unit without aura applied
 
-    if (m_originalCaster && missInfo != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(effectUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || effectUnit->IsEngaged()))
+    // Proc-triggered spells (IsTriggered) should not independently re-establish combat;
+    // the original spell that caused the proc already set up the combat link.
+    if (m_originalCaster && missInfo != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(effectUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && !IsTriggered() && (m_spellInfo->HasInitialAggro() || effectUnit->IsEngaged()))
         effectUnit->SetInCombatWith(m_originalCaster);
 
     PrepareScriptHitHandlers();
@@ -8331,7 +8333,7 @@ void Spell::HandleLaunchPhase()
         if (m_originalCaster && target.missCondition != SPELL_MISS_EVADE)
         {
             Unit* targetUnit = m_caster->GetGUID() == target.targetGUID ? m_caster : ObjectAccessor::GetUnit(*m_caster, target.targetGUID);
-            if (targetUnit && !m_originalCaster->IsFriendlyTo(targetUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || targetUnit->IsEngaged()))
+            if (targetUnit && !m_originalCaster->IsFriendlyTo(targetUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && !IsTriggered() && (m_spellInfo->HasInitialAggro() || targetUnit->IsEngaged()))
                 m_originalCaster->SetInCombatWith(targetUnit, true);
         }
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/0114fa1b-6e8a-4283-b96c-d872d5cb602b


https://github.com/user-attachments/assets/650f867c-e0ac-47fa-b538-3568de1227f3



## Current behavior

When a Mage has **Living Bomb** (or any periodic fire DoT) ticking on an enemy and that DoT scores a **critical hit**, the **Ignite** talent procs and applies the Ignite DoT. The Ignite cast is processed through `Spell::DoAllEffectOnTarget`, which calls `SetInCombatWith` because `HasInitialAggro()` is `true` for the Ignite spell. This incorrectly re-establishes or maintains the caster's combat state independently of the original spell.

**Steps to reproduce:**
1. Play Mage with Ignite talented (Fire spec)
2. Cast Living Bomb on an enemy
3. Use Invisibility and wait for combat to drop
4. Living Bomb continues ticking — a critical tick procs Ignite → mage is incorrectly pulled back into combat

Fixes #26176

## Expected behavior

The Ignite proc (and any spell cast as `TRIGGERED_FULL_MASK`) should **not** independently call `SetInCombatWith`. The original fire spell (Living Bomb, Fireball, etc.) already established the combat link. A reactive proc is a secondary effect and should inherit that state, not create a new one.

## Changes introduced

**`src/server/game/Spells/Spell.cpp`**

Two `SetInCombatWith` call sites in `DoAllEffectOnTarget` (line 2615) and `HandleLaunchPhase` (line 8334) are guarded with `!IsTriggered()`:

```cpp
// Before
if (m_originalCaster && ... && (m_spellInfo->HasInitialAggro() || effectUnit->IsEngaged()))
    effectUnit->SetInCombatWith(m_originalCaster);

// After
if (m_originalCaster && ... && !IsTriggered() && (m_spellInfo->HasInitialAggro() || effectUnit->IsEngaged()))
    effectUnit->SetInCombatWith(m_originalCaster);
```

`IsTriggered()` returns `true` when `_triggeredCastFlags & TRIGGERED_FULL_MASK != 0` — the case for all internally-triggered casts (procs, system casts). Player-cast spells use `TRIGGERED_NONE` and are unaffected.

This is consistent with two existing guards in the same file:
- `AtTargetAttacked` at line 2919: already suppressed for `m_triggeredByAuraSpell` proc spells
- Combat prolonging at line 3050: already suppressed with `!m_triggeredByAuraSpell` (Xinef comment: *"triggered spells should not prolong combat"*)

## How to test

1. Mage with Ignite (Fire spec)
2. Cast Living Bomb on a mob
3. Use Invisibility → wait for combat to drop
4. Let Living Bomb finish ticking — combat should **not** return even if ticks crit and proc Ignite

_Previously: crit ticks would re-enter the mage into combat. After fix: Ignite procs correctly but do not affect combat state._

## Extra notes

- No SQL changes required
- No other spell behavior is affected: non-triggered (player-cast) hostile spells still call `SetInCombatWith` as before
- Threat generation from Ignite is unaffected (handled by `HandleThreatSpells`, not by these lines)