### PR TITLE
fix(Spells): Living Bomb explosion should not be reflectable by Spell Reflection

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -1068,6 +1068,8 @@ void SpellMgr::LoadSpellInfoCorrections()
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_SUPPRESS_TARGET_PROCS;
         spellInfo->AttributesEx4 |= SPELL_ATTR4_DAMAGE_DOESNT_BREAK_AURAS;
+        // Explosion is AoE triggered on aura expiry - cannot be reflected (retail: Spell Reflection only works on single-target spells)
+        spellInfo->AttributesEx |= SPELL_ATTR1_NO_REFLECTION;
     });
 
     // Evocation


### PR DESCRIPTION


https://github.com/user-attachments/assets/1711b719-0c30-46ff-b050-68ea5af29f4c



## Current behavior

When a Warrior activates **Spell Reflection** just before a **Living Bomb** debuff expires, the final AoE explosion is reflected back to the Mage, damaging the caster instead of the target.

Fixes #26177

## Expected behavior

The Living Bomb explosion (`44461`, `55361`, `55362`) is an **AoE** spell triggered automatically on aura expiry — it is not a directly targeted spell cast by the player. Per retail behavior, Spell Reflection only intercepts single-target spells aimed directly at the Warrior. AoE effects cannot be reflected.

> WoWHead comment on Spell Reflection: *"Doesn't work on AoE... only single target spells."*

## Changes introduced

**`src/server/game/Spells/SpellInfoCorrections.cpp`**

Added `SPELL_ATTR1_NO_REFLECTION` to all three ranks of the Living Bomb explosion spell (`44461`, `55361`, `55362`), inside the existing correction block:

```cpp
// Living Bomb
ApplySpellFix({ 44461, 55361, 55362 }, [](SpellInfo* spellInfo)
{
    spellInfo->AttributesEx3 |= SPELL_ATTR3_SUPPRESS_TARGET_PROCS;
    spellInfo->AttributesEx4 |= SPELL_ATTR4_DAMAGE_DOESNT_BREAK_AURAS;
    // Explosion is AoE triggered on aura expiry - cannot be reflected
    spellInfo->AttributesEx |= SPELL_ATTR1_NO_REFLECTION;
});
```

`SPELL_ATTR1_NO_REFLECTION` causes `m_canReflect = false` in the `Spell` constructor, preventing Spell Reflection (and similar effects) from ever intercepting the explosion.

## How to test

1. Mage with Living Bomb, Warrior with Spell Reflection
2. Mage casts Living Bomb on the Warrior
3. Warrior activates Spell Reflection just before the debuff expires
4. **Before fix**: explosion reflects back to the Mage
5. **After fix**: explosion hits the Warrior normally; Spell Reflection has no effect on it

## Extra notes

- No SQL changes required
- Fix applies to all three ranks of the explosion (ranks 1/2/3)
- The DoT aura itself is unaffected — only the triggered AoE explosion gets the flag