### PR TITLE
fix(Paladin): Swift Retribution ranks give haste instead of attack speed slow

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -531,6 +531,24 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].SpellClassMask[2] = 0x8000000;
     });
 
+    // Swift Retribution: SPELL_AURA_MELEE_SLOW (aura 193) requires negative amounts for haste;
+    // positive amounts cause attack speed reduction. DBC BasePoints are +1/+2/+3 for ranks 1/2/3.
+    // Negate so CalcValue = BasePoints + DieSides(1) produces -1/-2/-3 (1/2/3% haste).
+    ApplySpellFix({ 53379 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = -2;
+    });
+
+    ApplySpellFix({ 53484 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = -3;
+    });
+
+    ApplySpellFix({ 53648 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = -4;
+    });
+
     // Sanctified Retribution
     ApplySpellFix({ 31869 }, [](SpellInfo* spellInfo)
     {


### PR DESCRIPTION
<!-- Paste video here -->

## Current behavior

Swift Retribution talent ranks (53379 / 53484 / 53648) use `SPELL_AURA_MELEE_SLOW` (aura 193) to grant haste to party/raid members. However, the DBC `BasePoints` are stored as positive values (+1/+2/+3), and `SPELL_AURA_MELEE_SLOW` treats **positive values as attack speed reduction (slow)** — the opposite of the intended haste effect.

Fixes #26050

> **Note:** This is a revised version of the previously closed PR #26179. The original PR included an incorrect `DoCheckAreaTarget` restriction gating the buff on Retribution Aura only. As confirmed by contributor amed80 and retail sources (Patch 3.1.0 note: *"Now affects all auras instead of only affecting Retribution Aura"*), Swift Retribution correctly applies with **any** Paladin aura active — that behavior is intentional and has been removed from this fix.

## Expected behavior

Swift Retribution should grant **1%/2%/3% haste** (ranks 1/2/3) to all nearby party and raid members whenever any Paladin aura is active. `SPELL_AURA_MELEE_SLOW` requires **negative** values to produce haste: `CalcValue = BasePoints + DieSides(1)`, so `BasePoints = -2/-3/-4` yields `CalcValue = -1/-2/-3`.

## Changes introduced

**`src/server/game/Spells/SpellInfoCorrections.cpp`**

Negate `BasePoints` for all three Swift Retribution ranks so `CalcValue` produces the correct negative (haste) value:

```cpp
// Swift Retribution rank 1 (53379): BasePoints -2 → CalcValue -1 (1% haste)
ApplySpellFix({ 53379 }, [](SpellInfo* spellInfo)
{
    spellInfo->Effects[EFFECT_0].BasePoints = -2;
});

// Rank 2 (53484): BasePoints -3 → CalcValue -2 (2% haste)
ApplySpellFix({ 53484 }, [](SpellInfo* spellInfo)
{
    spellInfo->Effects[EFFECT_0].BasePoints = -3;
});

// Rank 3 (53648): BasePoints -4 → CalcValue -3 (3% haste)
ApplySpellFix({ 53648 }, [](SpellInfo* spellInfo)
{
    spellInfo->Effects[EFFECT_0].BasePoints = -4;
});
```

No SQL changes. No C++ script changes.

## How to test

1. Paladin with Swift Retribution talented (any rank)
2. Activate any Paladin aura
3. Check party members' attack speed / spell cast time
4. **Before fix**: party members attack/cast slower (attack speed slow applied)
5. **After fix**: party members attack/cast faster (1%/2%/3% haste applied)

## Retail sources

- **Patch 3.1.0** ([Warcraft Wiki](https://warcraft.wiki.gg/wiki/Swift_Retribution)): *"Now affects all auras instead of only affecting Retribution Aura"* — confirms buff should apply with any aura (not gated on Retribution Aura specifically)
- **Patch 3.3.3** ([Warcraft Wiki](https://warcraft.wiki.gg/wiki/Swift_Retribution)): *"Fixed a bug preventing this ability from extending its benefit to the full radius of the paladin's auras"* — the applied aura (spell 63531) should use the same 40-yard radius as paladin auras. Verified: 3.3.5a DBC already contains the corrected 40-yard `EffectRadiusIndex` for spell 63531 effects, so no additional correction is required.
- `SPELL_AURA_MELEE_SLOW` sign convention: negative = haste, positive = slow (`HandleModCombatSpeedPct` → `ApplyAttackTimePercentMod(GetAmount())`)