### PR TITLE
fix(DB/Ulduar): Brann Bronzebeard Archivum event condition uses wrong INSTANCE_INFO type

### DIFF
--- a/data/sql/updates/pending_db_world/2026_06_15_00_fix_brann_archivum_condition.sql
+++ b/data/sql/updates/pending_db_world/2026_06_15_00_fix_brann_archivum_condition.sql
@@ -1,0 +1,9 @@
+-- DB update 2026_06_11_02 -> 2026_06_15_00
+--
+-- Fix Brann Bronzebeard (33235) SAI condition for Assembly of Iron completion check.
+-- ConditionValue3=0 (INSTANCE_INFO_DATA) calls GetData() which has no handler for
+-- BOSS_ASSEMBLY_OF_IRON (4) in Ulduar, always returning 0. The correct type is
+-- ConditionValue3=2 (INSTANCE_INFO_BOSS_STATE) which calls GetBossState(4) == DONE(3).
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceGroup` = 13 AND `SourceEntry` = 33235;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionType`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(22, 13, 33235, 0, 0, 13, 1, 4, 3, 2, 0, 0, 0, '', 'Execute SAI only if Assembly of Iron Done');

--- a/data/sql/updates/pending_db_world/2026_06_15_00_fix_brann_archivum_condition.sql
+++ b/data/sql/updates/pending_db_world/2026_06_15_00_fix_brann_archivum_condition.sql
@@ -5,5 +5,5 @@
 -- BOSS_ASSEMBLY_OF_IRON (4) in Ulduar, always returning 0. The correct type is
 -- ConditionValue3=2 (INSTANCE_INFO_BOSS_STATE) which calls GetBossState(4) == DONE(3).
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceGroup` = 13 AND `SourceEntry` = 33235;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionType`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (22, 13, 33235, 0, 0, 13, 1, 4, 3, 2, 0, 0, 0, '', 'Execute SAI only if Assembly of Iron Done');


### PR DESCRIPTION
## Description

Brann Bronzebeard (NPC 33235) fails to appear in the Ulduar Archivum after a server restart even when Assembly of Iron has already been defeated. The SmartAI OOC event that triggers the Archivum data-recovery RP sequence is gated by a `CONDITION_INSTANCE_INFO` row that permanently evaluates to false due to a wrong subtype value, making the condition unable to detect that the encounter is complete.

Fixes #26038.

### Root Cause

In `data/sql/base/db_world/conditions.sql`, the condition row for Brann 33235 (`SourceTypeOrReferenceId=22` / `SourceGroup=13` / `SourceEntry=33235`) had `ConditionValue3=0` (`INSTANCE_INFO_DATA`).

In `ConditionMgr.cpp`, `CONDITION_INSTANCE_INFO` dispatches on `ConditionValue3`:

```
case INSTANCE_INFO_DATA (0):      condMeets = instance->GetData(ConditionValue1)      == ConditionValue2;
case INSTANCE_INFO_BOSS_STATE(2): condMeets = instance->GetBossState(ConditionValue1) == EncounterState(ConditionValue2);
```

Ulduar's `GetData()` override only handles tower events, `DATA_MAGE_BARRIER`, and `DATA_CALL_TRAM`. It has no case for boss indices, so `GetData(BOSS_ASSEMBLY_OF_IRON)` (index 4) falls through and returns 0. The condition `0 == 3 (DONE)` is permanently false. `GetBossState()` is the correct path used by the entire Ulduar instance script for tracking encounter completion.

### Fix

Changed `ConditionValue3` from `0` (`INSTANCE_INFO_DATA`) to `2` (`INSTANCE_INFO_BOSS_STATE`) on the Brann 33235 condition row. This routes the check through `instance->GetBossState(4) == DONE(3)`, which is how every other boss-completion check in the Ulduar instance works and correctly returns `DONE` after a server restart.

### Sources (WotLK 3.3.5a)

- https://www.wowhead.com/wotlk/npc=33235 — Brann Bronzebeard in Ulduar; comments confirm he appears at the Archivum after Assembly of Iron is killed and initiates the data-recovery event
- https://www.wowhead.com/wotlk/npc=32867 — Assembly of Iron (Steelbreaker); the encounter whose completion gates the Archivum RP

### How to test

1. Enter Ulduar (603) on a fresh instance and defeat the Assembly of Iron encounter fully.
2. Log out and back in (or restart the server) while still in the instance.
3. **Before fix:** Brann Bronzebeard does not appear in the Archivum; the data-recovery RP never fires.
4. **After fix:** Brann spawns at the Archivum console and begins the RP sequence as expected.
5. Verify that entering a saved instance where Assembly of Iron is already `DONE` also shows Brann present immediately.

### Extra notes

- No C++ change is required. The core condition evaluation logic is correct; only the DB value selecting which instance accessor to call was wrong.
- The same condition row correctly keeps `ConditionValue1=4` (boss index) and `ConditionValue2=3` (`DONE`); only `ConditionValue3` was wrong.
- A `pending_db_world` update file (`2026_06_15_00_fix_brann_archivum_condition.sql`) is included alongside the `conditions.sql` base file correction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the script condition for Brann Bronzebeard to properly detect Assembly of Iron completion, ensuring the character's interaction triggers correctly after defeating the boss encounter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->