### PR TITLE
fix(Mage): Fingers of Frost ghost charge — prevent self-consumption and add ghost window (#25117)

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -956,6 +956,11 @@ class spell_mage_fingers_of_frost : public AuraScript
         return ValidateSpellInfo({ SPELL_MAGE_FINGERS_OF_FROST_AURASTATE_AURA });
     }
 
+    void HandleApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        _freshlyApplied = true;
+    }
+
     void PrepareProc(ProcEventInfo& eventInfo)
     {
         if (Spell const* spell = eventInfo.GetProcSpell())
@@ -966,11 +971,21 @@ class spell_mage_fingers_of_frost : public AuraScript
             bool prevent = false;
 
             if (isTriggered)
+            {
+                // Triggered procs (e.g. Blizzard ticks) consume charges normally and clear the guard
+                _freshlyApplied = false;
                 prevent = false;
+            }
             else if (isChanneled)
                 prevent = true;
             else if (!isCastPhase)
                 prevent = true;
+            else if (_freshlyApplied)
+            {
+                // The spell that procced FoF into existence must not also consume a charge
+                prevent = true;
+                _freshlyApplied = false;
+            }
 
             if (prevent)
                 PreventDefaultAction();
@@ -979,14 +994,22 @@ class spell_mage_fingers_of_frost : public AuraScript
 
     void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
-        GetTarget()->RemoveAurasDueToSpell(SPELL_MAGE_FINGERS_OF_FROST_AURASTATE_AURA);
+        // Keep the aura state active briefly so a spell queued before the last charge
+        // was consumed can still benefit (ghost charge window, ~400ms spell queue window)
+        if (Aura* auraState = GetTarget()->GetAura(SPELL_MAGE_FINGERS_OF_FROST_AURASTATE_AURA))
+            auraState->SetDuration(400);
+        else
+            GetTarget()->RemoveAurasDueToSpell(SPELL_MAGE_FINGERS_OF_FROST_AURASTATE_AURA);
     }
 
     void Register() override
     {
+        AfterEffectApply += AuraEffectApplyFn(spell_mage_fingers_of_frost::HandleApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
         DoPrepareProc += AuraProcFn(spell_mage_fingers_of_frost::PrepareProc);
         AfterEffectRemove += AuraEffectRemoveFn(spell_mage_fingers_of_frost::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
     }
+
+    bool _freshlyApplied = false;
 };
 
 // -31571 - Arcane Potency


### PR DESCRIPTION
## Description

Fingers of Frost ghost charge is non-functional after the QAston proc overhaul (#24233). Two independent bugs prevent it: the proccing spell immediately consumes one of the two fresh charges, and the aura state is removed instantly when the last charge is consumed, leaving no window for a queued instant spell.

### Root Cause

The QAston overhaul replaced the previous two-script system (`spell_mage_fingers_of_frost_proc_aura` + `spell_mage_fingers_of_frost_proc`) with a minimal single-script that delegates charge consumption to `PrepareProcToTrigger`. This introduced two regressions:

**1 — Self-consumption:** The old `spell_mage_fingers_of_frost_proc` script (on spell 44543) blocked the spell that triggered FoF from also consuming a charge from the newly-applied buff (74396). Without this guard, the proccing Frostbolt consumes one of the two charges in the same proc pass, effectively leaving only one usable charge instead of two.

**2 — No ghost charge window:** When the last charge is consumed, `OnRemove` called `RemoveAurasDueToSpell(44544)` immediately. The aura state (44544) was gone before the spell queue could fire a queued instant cast, so no ghost charge was possible. In retail WotLK, a small latency/batching window allowed a queued instant cast to still see the FoF aura state active.

Reference: https://github.com/azerothcore/azerothcore-wotlk/issues/25117

### Fix

**Fix 1 — Anti-self-consumption (`_freshlyApplied` flag):**
`HandleApply` sets `_freshlyApplied = true` when the aura is applied. `PrepareProc` blocks the first non-triggered, non-channeled CAST-phase proc after fresh application and clears the flag. Triggered procs (e.g. Blizzard ticks) also clear the flag so the guard doesn't persist into unrelated casts.

**Fix 2 — Ghost charge window (`SetDuration(400)`):**
Instead of immediately removing aura state 44544 in `OnRemove`, its duration is set to 400ms — matching AC's spell queue window (PR #20797). A queued instant cast (Ice Lance, Deep Freeze, Brain Freeze proc) that fires within that window still sees 44544 active and benefits from Shatter crit.

**Expected combo sequence:**
```
FB1 → procs FoF (2 charges), self-consume blocked
FB2 → consumes charge 1 (1 remaining)
FB3 → consumes charge 2 (0) → 44544.SetDuration(400ms)
IL  → queued, fires ~10ms later → sees 44544 → ghost charge ✓
```

### Sources (WotLK 3.3.5a)

- https://www.wowhead.com/wotlk/spell=44545/fingers-of-frost#comments — comment chain confirming ghost charge behavior in 3.3.5a retail
- https://web.archive.org/web/20101204052143/http://www.worldofwarcraft.com/patchnotes/patch3p3.html — Patch 3.3: *"Fingers of Frost: This talent now triggers immediately on casting a spell rather than being delayed until the spell strikes the target"* (confirms CAST consumption is correct, ghost charge is a separate mechanic)
- https://www.mmo-champion.com/threads/677129-Fingers-of-Frost-Change — *"Ghost charge is all latency. The buff fades on spell cast, not hit."*
- https://wowpedia.fandom.com/wiki/Fingers_of_Frost?oldid=2301949 — documents ghost charge behavior in 3.3.5a

### How to test

1. Frost Mage with 2/2 Fingers of Frost + Frostbolt + Ice Lance + Deep Freeze
2. Spam Frostbolt on a target dummy until FoF procs (2 stacks appear)
3. **Fix 1 check:** Stop casting immediately — buff should show 2 stacks without auto-decrementing to 1
4. **Ghost charge check:** Cast Frostbolt (1 stack consumed) → Frostbolt again (last stack consumed) → immediately cast Ice Lance
5. Ice Lance should receive the Shatter crit bonus even though FoF stacks already hit 0
6. **Regression check:** Cast Blizzard on mobs with FoF — each tick should consume exactly 1 charge normally

cc @bonfax4 — you identified the root cause in https://github.com/azerothcore/azerothcore-wotlk/issues/25117 and https://github.com/chromiecraft/chromiecraft/issues/3123, wanted to get your eyes on this approach.