### PR TITLE
fix(Core/Spells): complete InfiniteAmmo support in CheckCast ammo validation

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -7679,7 +7679,27 @@ SpellCastResult Spell::CheckItems(uint32* param1, uint32* param2)
                                     if (m_caster->HasAura(46699))
                                         break;                      // skip other checks
 
-                                    return SPELL_FAILED_NO_AMMO;
+                                    if (sWorld->getBoolConfig(CONFIG_ENABLE_INFINITEAMMO))
+                                    {
+                                        // Auto-assign ammo based on weapon type so CheckAmmoCompatibility passes
+                                        switch (pItem->GetTemplate()->SubClass)
+                                        {
+                                            case ITEM_SUBCLASS_WEAPON_BOW:
+                                            case ITEM_SUBCLASS_WEAPON_CROSSBOW:
+                                                m_caster->ToPlayer()->SetAmmo(41165); // Iceblade Arrow
+                                                break;
+                                            case ITEM_SUBCLASS_WEAPON_GUN:
+                                                m_caster->ToPlayer()->SetAmmo(41584); // Mammoth Cutters
+                                                break;
+                                            default:
+                                                break;
+                                        }
+                                        ammo = m_caster->ToPlayer()->GetUInt32Value(PLAYER_AMMO_ID);
+                                        if (!ammo)
+                                            return SPELL_FAILED_NO_AMMO;
+                                    }
+                                    else
+                                        return SPELL_FAILED_NO_AMMO;
                                 }
 
                                 ItemTemplate const* ammoProto = sObjectMgr->GetItemTemplate(ammo);
@@ -7689,17 +7709,31 @@ SpellCastResult Spell::CheckItems(uint32* param1, uint32* param2)
                                 if (ammoProto->Class != ITEM_CLASS_PROJECTILE)
                                     return SPELL_FAILED_NO_AMMO;
 
-                                // check ammo ws. weapon compatibility
+                                // check ammo vs. weapon compatibility; auto-correct type on weapon swap
                                 switch (pItem->GetTemplate()->SubClass)
                                 {
                                     case ITEM_SUBCLASS_WEAPON_BOW:
                                     case ITEM_SUBCLASS_WEAPON_CROSSBOW:
                                         if (ammoProto->SubClass != ITEM_SUBCLASS_ARROW)
+                                        {
+                                            if (sWorld->getBoolConfig(CONFIG_ENABLE_INFINITEAMMO))
+                                            {
+                                                m_caster->ToPlayer()->SetAmmo(41165);
+                                                break;
+                                            }
                                             return SPELL_FAILED_NO_AMMO;
+                                        }
                                         break;
                                     case ITEM_SUBCLASS_WEAPON_GUN:
                                         if (ammoProto->SubClass != ITEM_SUBCLASS_BULLET)
+                                        {
+                                            if (sWorld->getBoolConfig(CONFIG_ENABLE_INFINITEAMMO))
+                                            {
+                                                m_caster->ToPlayer()->SetAmmo(41584);
+                                                break;
+                                            }
                                             return SPELL_FAILED_NO_AMMO;
+                                        }
                                         break;
                                     default:
                                         return SPELL_FAILED_NO_AMMO;
@@ -7707,8 +7741,11 @@ SpellCastResult Spell::CheckItems(uint32* param1, uint32* param2)
 
                                 if (!m_caster->ToPlayer()->HasItemCount(ammo))
                                 {
-                                    m_caster->ToPlayer()->SetUInt32Value(PLAYER_AMMO_ID, 0);
-                                    return SPELL_FAILED_NO_AMMO;
+                                    if (!sWorld->getBoolConfig(CONFIG_ENABLE_INFINITEAMMO))
+                                    {
+                                        m_caster->ToPlayer()->SetUInt32Value(PLAYER_AMMO_ID, 0);
+                                        return SPELL_FAILED_NO_AMMO;
+                                    }
                                 }
                             };
                             break;


### PR DESCRIPTION
## Description

`InfiniteAmmo.Enabled` already skips ammo consumption in `TakeAmmo()`, but `CheckCast()` was never updated to match. Hunters with `InfiniteAmmo.Enabled = 1` still get `SPELL_FAILED_NO_AMMO` the moment their ammo runs out or they log in without any in their inventory.

### Root Cause

`Spell::CheckCast()` contains three ammo checks that ignore `CONFIG_ENABLE_INFINITEAMMO`:

1. **`PLAYER_AMMO_ID == 0`** → returns `SPELL_FAILED_NO_AMMO` unconditionally, even when infinite ammo is enabled.
2. **Ammo type mismatch** (e.g. player swapped from bow to gun mid-session) → returns `SPELL_FAILED_NO_AMMO` unconditionally.
3. **`!HasItemCount(ammo)`** → clears `PLAYER_AMMO_ID` and returns `SPELL_FAILED_NO_AMMO`, even when the server is configured not to consume ammo.

The result: `TakeAmmo()` never fires because `CheckCast()` already blocked the attack.

### Fix

Three guard additions to `CheckCast()`, all gated on `sWorld->getBoolConfig(CONFIG_ENABLE_INFINITEAMMO)`:

1. When `PLAYER_AMMO_ID == 0` and infinite ammo is on, auto-assign the appropriate ammo entry (Iceblade Arrow for bows/crossbows, Mammoth Cutters for guns) via `SetAmmo()` so the subsequent template and compatibility checks can proceed normally.
2. When ammo type doesn't match the weapon, auto-correct the ammo entry instead of failing — handles mid-session weapon type swaps without requiring a relog.
3. When the player doesn't have the ammo item in inventory (`!HasItemCount`), skip the check instead of clearing `PLAYER_AMMO_ID` and failing.

No new config keys. `InfiniteAmmo.Enabled` continues to control all behaviour.

### Sources

- `worldserver.conf.dist` line 4715–4719: `InfiniteAmmo.Enabled` — existing config, already documented.
- `Spell.cpp` `TakeAmmo()` lines 5366, 5373: existing `CONFIG_ENABLE_INFINITEAMMO` guards that this PR makes consistent with `CheckCast()`.

### How to test

1. Set `InfiniteAmmo.Enabled = 1` in `worldserver.conf`
2. Log in as a Hunter with a bow/crossbow equipped and **no ammo in inventory**
3. **Before fix:** auto-attack fails with "No Ammo" error
4. **After fix:** auto-attack fires normally; ammo DPS bonus is applied automatically
5. Swap to a gun mid-session and fire — ammo type auto-corrects without a relog
6. Verify that with `InfiniteAmmo.Enabled = 0` (default), normal ammo consumption and validation still work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ammo handling for weapon-based spells when infinite ammo mode is enabled; the system now auto-assigns appropriate default ammo when none is equipped and auto-corrects incompatible ammo types to match the weapon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->