### PR TITLE
fix(Core/Shaman): Rockbiter Weapon flat damage persists after removal

### DIFF
--- a/src/server/game/Entities/Player/PlayerStorage.cpp
+++ b/src/server/game/Entities/Player/PlayerStorage.cpp
@@ -4701,7 +4701,7 @@ void Player::ApplyEnchantment(Item* item, EnchantmentSlot slot, bool apply, bool
                 {
                     WeaponAttackType const attackType = Player::GetAttackBySlot(item->GetSlot());
                     if (attackType != MAX_ATTACK)
-                        UpdateDamageDoneMods(attackType);
+                        UpdateDamageDoneMods(attackType, apply ? -1 : slot);
                     break;
                 }
                 case ITEM_ENCHANTMENT_TYPE_USE_SPELL:


### PR DESCRIPTION
ITEM_ENCHANTMENT_TYPE_TOTEM did not pass the apply parameter to
UpdateDamageDoneMods, causing Rockbiter Weapon flat melee damage
bonus to persist after the enchantment was removed or replaced
by another weapon imbue.

## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Sonnet 4.6 - Max (Anthropic) was used to assist in preparing this pull request.

## Issues Addressed:
- Closes #26192

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Create a Shaman character
2. `.learn all my class`
3. `.levelup 17`
4. `.add 2495` and equip the weapon
5. Apply Rockbiter Weapon and note the melee damage increase
6. Apply Flametongue Weapon or right-click Rockbiter off
7. Verify Rockbiter flat melee damage bonus is removed correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed totem item enchantments to correctly recalculate damage modifiers when applied or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->