### PR TITLE
fix(DB/Hunter): Dust Cloud debuff not removed after first miss

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1781559665924959595.sql
+++ b/data/sql/updates/pending_db_world/rev_1781559665924959595.sql
@@ -1,0 +1,4 @@
+-- Dust Cloud (54404) - remove on the affected unit's first missed melee swing
+DELETE FROM `spell_proc` WHERE `SpellId` = 54404;
+INSERT INTO `spell_proc` (`SpellId`, `ProcFlags`, `HitMask`, `Chance`, `Charges`)
+    VALUES (54404, 0x00000004, 0x00000004, 100, 1);


### PR DESCRIPTION
Dust Cloud (54404) was not removed after the target's first missed
attack as stated in the tooltip. The debuff persisted for the full
8 sec duration instead of being consumed on first miss.

Added spell_proc entry to remove the debuff after the affected unit
performs a missed melee auto attack.

Co-authored-by: blinkysc <blinkysc@users.noreply.github.com>

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Sonnet 4.6 - Max (Anthropic) was used to assist in preparing this pull request.

## Issues Addressed:
- Closes #25974

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  Spell tooltip and Wowhead (https://www.wowhead.com/wotlk/spell=54404/dust-cloud) confirm the debuff should be removed after first miss.
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes.

1. Create a Hunter character
2. `.levelup 9` and `.learn all my class`
3. Tame a plainstrider (`.go creature id 2957`)
4. Attack a nearby mob and have pet use Dust Cloud
5. Verify Dust Cloud debuff is removed after the target's first missed attack
6. Verify Dust Cloud debuff persists if the target hits (not misses)

## Screenshots
Screenshot of Combat log before the fix:
<img width="568" height="343" alt="Screenshot of Combat log before the fix" src="https://github.com/user-attachments/assets/f316d75e-8093-421c-9281-20a11f412dfa" />

Screenshot of Combat log after the fix:
<img width="573" height="358" alt="Screenshot of Combat log after the fix" src="https://github.com/user-attachments/assets/4ee79f77-1770-41b9-a79e-d1983c32d53b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated spell ID 54404 configuration to adjust its procedural effects behavior and hit mask settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->