### PR TITLE
fix(Paladin): Divine Favor ghost window for queued Holy Shock

### DIFF
--- a/data/sql/updates/pending_db_world/2026_06_16_00_spell_pal_divine_favor.sql
+++ b/data/sql/updates/pending_db_world/2026_06_16_00_spell_pal_divine_favor.sql
@@ -1,3 +1,4 @@
 -- DB update 2026_06_11_02 -> 2026_06_16_00
+DELETE FROM `spell_script_names` WHERE `spell_id` = 20216 AND `ScriptName` = 'spell_pal_divine_favor';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (20216, 'spell_pal_divine_favor');

--- a/data/sql/updates/pending_db_world/2026_06_16_00_spell_pal_divine_favor.sql
+++ b/data/sql/updates/pending_db_world/2026_06_16_00_spell_pal_divine_favor.sql
@@ -1,0 +1,3 @@
+-- DB update 2026_06_11_02 -> 2026_06_16_00
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(20216, 'spell_pal_divine_favor');

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -98,7 +98,8 @@ enum PaladinSpells
     SPELL_PALADIN_SEAL_OF_VENGEANCE_EFFECT       = 42463,
     SPELL_PALADIN_SEAL_OF_CORRUPTION_EFFECT      = 53739,
 
-    SPELL_PALADIN_SEAL_OF_COMMAND                = 20375
+    SPELL_PALADIN_SEAL_OF_COMMAND                = 20375,
+    SPELL_PALADIN_DIVINE_FAVOR                   = 20216
 };
 
 enum PaladinSpellIcons
@@ -2200,6 +2201,33 @@ class spell_pal_light_s_beacon : public AuraScript
     }
 };
 
+// Divine Favor (20216) – ghost window fix
+// After HL/FoL/HS consumes the proc charge (AURA_REMOVE_BY_DEFAULT), re-apply
+// Divine Favor for 400 ms so a queued Holy Shock still receives the crit bonus.
+// GetMaxDuration() == 400 guards against an infinite re-apply loop on the second removal.
+class spell_pal_divine_favor : public AuraScript
+{
+    PrepareAuraScript(spell_pal_divine_favor);
+
+    void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        if (GetTargetApplication()->GetRemoveMode() != AURA_REMOVE_BY_DEFAULT)
+            return;
+        if (GetAura()->GetMaxDuration() == 400)
+            return;
+        if (Aura* ghostAura = GetTarget()->AddAura(SPELL_PALADIN_DIVINE_FAVOR, GetTarget()))
+        {
+            ghostAura->SetMaxDuration(400);
+            ghostAura->SetDuration(400);
+        }
+    }
+
+    void Register() override
+    {
+        AfterEffectRemove += AuraEffectRemoveFn(spell_pal_divine_favor::OnRemove, EFFECT_0, SPELL_AURA_ADD_PCT_MODIFIER, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
 void AddSC_paladin_spell_scripts()
 {
     RegisterSpellAndAuraScriptPair(spell_pal_seal_of_command, spell_pal_seal_of_command_aura);
@@ -2256,5 +2284,6 @@ void AddSC_paladin_spell_scripts()
     RegisterSpellScriptWithArgs(spell_pal_improved_aura, "spell_pal_improved_devotion_aura", SPELL_PALADIN_IMPROVED_DEVOTION_AURA);
     RegisterSpellScriptWithArgs(spell_pal_improved_aura, "spell_pal_sanctified_retribution", SPELL_PALADIN_SANCTIFIED_RETRIBUTION_AURA);
     RegisterSpellScriptWithArgs(spell_pal_improved_aura, "spell_pal_swift_retribution", SPELL_PALADIN_SANCTIFIED_RETRIBUTION_AURA);
+    RegisterSpellScript(spell_pal_divine_favor);
     RegisterSpellScript(spell_pal_light_s_beacon);
 }

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -2224,7 +2224,7 @@ class spell_pal_divine_favor : public AuraScript
 
     void Register() override
     {
-        AfterEffectRemove += AuraEffectRemoveFn(spell_pal_divine_favor::OnRemove, EFFECT_0, SPELL_AURA_ADD_PCT_MODIFIER, AURA_EFFECT_HANDLE_REAL);
+        AfterEffectRemove += AuraEffectRemoveFn(spell_pal_divine_favor::OnRemove, EFFECT_0, SPELL_AURA_ADD_FLAT_MODIFIER, AURA_EFFECT_HANDLE_REAL);
     }
 };
 

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -2209,6 +2209,11 @@ class spell_pal_divine_favor : public AuraScript
 {
     PrepareAuraScript(spell_pal_divine_favor);
 
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_PALADIN_DIVINE_FAVOR });
+    }
+
     void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         if (GetTargetApplication()->GetRemoveMode() != AURA_REMOVE_BY_DEFAULT)
@@ -2219,6 +2224,7 @@ class spell_pal_divine_favor : public AuraScript
         {
             ghostAura->SetMaxDuration(400);
             ghostAura->SetDuration(400);
+            ghostAura->SetUsingCharges(false);
         }
     }
 


### PR DESCRIPTION
## Description

Divine Favor (spell 20216) guarantees a critical strike on the next Flash of Light, Holy Light, or Holy Shock. After the first of those spells consumes the proc charge, a Holy Shock that was queued in the same tick could miss the aura and fail to crit — the aura disappeared before the second cast's crit check ran.

**Root cause:** `ConsumeProcCharges` calls `Aura::Remove()` with `AURA_REMOVE_BY_DEFAULT`, which fires the removal handler immediately after the triggering cast resolves. A Holy Shock queued slightly before that resolution misses the window by one server tick.

**Fix:** On `AURA_REMOVE_BY_DEFAULT` removal, re-apply Divine Favor for 400 ms so the queued Holy Shock still sees the aura and crits. Two guards prevent side effects:
- `GetMaxDuration() == 400` prevents the ghost aura from re-applying itself when it expires.
- `SetUsingCharges(false)` on the ghost aura prevents the same proc event that consumed the original Divine Favor from immediately consuming the ghost charge before Holy Shock can benefit from it.

This mirrors the ghost-window approach used for Fingers of Frost (PR #26210).

## How to reproduce

1. Play a Holy Paladin with Divine Favor talented.
2. Cast Holy Light (or Flash of Light) and immediately queue Holy Shock.
3. **Before fix:** Holy Shock does not crit — Divine Favor was consumed by HL and Holy Shock missed the window.
4. **After fix:** Holy Shock crits because it sees the 400 ms ghost window.

## How to test

1. Log in as a Holy Paladin with Divine Favor.
2. Cast `Divine Favor`, then immediately cast `Holy Light` followed by `Holy Shock` in rapid succession.
3. Verify Holy Shock crits.

## Changes

- `src/server/scripts/Spells/spell_paladin.cpp`
  - Added `SPELL_PALADIN_DIVINE_FAVOR = 20216` to the `PaladinSpells` enum.
  - Added `spell_pal_divine_favor` AuraScript with `Validate()`, ghost window logic on `AfterEffectRemove`, and `SetUsingCharges(false)` on the ghost aura.
  - Registered `spell_pal_divine_favor` in `AddSC_paladin_spell_scripts`.
  - Uses `SPELL_AURA_ADD_FLAT_MODIFIER` (107) matching the DBC data for spell 20216 EFFECT_0.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Retail / reference

- [Divine Favor – WoWHead WotLK](https://www.wowhead.com/wotlk/spell=20216/divine-favor)
- [Divine Favor – Wowpedia](https://wowpedia.fandom.com/wiki/Divine_Favor)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Divine Favor aura behavior to correctly preserve and restore its intended duration when it’s removed and reapplied, keeping the resulting Holy Shock critical strike bonus accurate.
* **Database**
  * Updated the spell script mapping for Divine Favor (spell ID 20216) so the corrected behavior applies consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->