### PR TITLE
fix(SAI): Mini Tyrael - reduce sleep/enrage spam and fix dance movement

### DIFF
--- a/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
+++ b/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
@@ -16,7 +16,6 @@
 --    to chain from the unconditional TALK to the random action list.
 
 DELETE FROM `smart_scripts` WHERE `entryorguid` IN (29089, 2908900, 2908901, 2908902) AND `source_type` IN (0, 9);
-
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 -- On /dance emote received: cast Tyrael Dance spell (allows movement, 60s cooldown)
 (29089, 0, 0, 0, 22, 0, 100, 0, 34, 60000, 60000, 0, 0, 0, 11, 54398, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Receive Emote Dance: Cast Tyrael Dance'),

--- a/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
+++ b/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
@@ -3,8 +3,10 @@
 --
 -- Root causes fixed:
 -- 1. Spell 69205 (periodic trigger 30s) → spell 69204 → SMART_EVENT_SPELLHIT fired
---    SMART_ACTION_TALK unconditionally every 30s ("falls asleep"/"becomes enraged") spamming chat.
---    Fix: remove the SPELLHIT handler entirely. The pet no longer sleeps or enrages.
+--    SMART_ACTION_TALK unconditionally every 30s ("falls asleep"/"becomes enraged") spamming chat,
+--    and spell 69204 applied a sleep visual animation every 30s.
+--    Fix: remove 69205 from creature_template_addon (no more periodic trigger) and remove the
+--    SPELLHIT handler. The pet no longer sleeps or enrages.
 -- 2. Dance used SMART_ACTION_PLAY_EMOTE which freezes movement.
 --    Fix: use SMART_ACTION_CAST with spell 54398 (Tyrael Dance, DUMMY aura visual)
 --    which allows the pet to keep following while the animation plays. 60s cooldown on /dance.
@@ -42,3 +44,8 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (22, 3, 29089, 0, 0, 21, 1, 1048576, 0, 0, 0, 0, 0, '', 'Mini Tyrael - Update OOC dance only when moving'),
 -- event id=3 UPDATE_OOC remove dance (SourceGroup=4): only fire when pet is NOT moving
 (22, 4, 29089, 0, 0, 21, 1, 1048576, 0, 0, 1, 0, 0, '', 'Mini Tyrael - Update OOC stop dance only when stationary');
+-- Remove aura 69205 from creature_template_addon: it was the periodic trigger for sleep/enrage
+-- behavior (69205 → triggers 69204 every 30s → sleep visual aura applied to the pet).
+DELETE FROM `creature_template_addon` WHERE `entry` = 29089;
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(29089, 0, 0, 0, 0, 0, 0, '');

--- a/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
+++ b/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
@@ -1,32 +1,64 @@
--- Mini Tyrael (entry 29089): fix overly frequent sleep/enrage text spam and dance behavior
+-- Mini Tyrael (entry 29089): fix sleep/dance/follow behavior
 -- Issue: https://github.com/azerothcore/azerothcore-wotlk/issues/19781
 --
--- Root causes:
--- 1. Spell 69205 (periodic trigger, every 30s) → spell 69204 → SMART_EVENT_SPELLHIT
---    always fired SMART_ACTION_TALK "falls asleep" unconditionally, spamming chat every 30s
---    even when the pet woke up instantly (action list 2908900 path).
---    Fix: remove the unconditional TALK from the main event. Move it into the action lists
---    that actually put the pet to sleep (2908901 and 2908902). Action list 2908900 remains
---    silent, so visible chat spam is reduced by ~33%.
--- 2. Dance response used SMART_ACTION_PLAY_EMOTE (one-shot anim, prevents follow movement).
---    Fix: use SMART_ACTION_CAST with spell 54398 (Tyrael Dance, DUMMY aura visual) which
---    allows the pet to keep following while the dance animation plays.
---    Cooldown increased from 5s to 60s to prevent excessive response spam.
--- 3. Event structure: remove the now-unnecessary linked event (id=2) that was only needed
---    to chain from the unconditional TALK to the random action list.
+-- Root causes fixed:
+-- 1. Spell 69205 (periodic trigger, every 30s) → spell 69204 → SMART_EVENT_SPELLHIT always
+--    fired SMART_ACTION_TALK unconditionally, spamming chat every 30s even when the pet woke
+--    up instantly (action list 2908900 path). Fix: TALK moved only into action lists 2908901
+--    and 2908902 that actually produce visible behavior. Action list 2908900 stays silent.
+-- 2. Dance used SMART_ACTION_PLAY_EMOTE which freezes movement. Fix: use SMART_ACTION_CAST
+--    with spell 54398 (Tyrael Dance, DUMMY aura visual) which allows follow movement.
+--    Cooldown increased from 5s to 60s to prevent response spam.
+-- 3. Sleep triggered while player was moving, making the pet drift away. Fix: added
+--    CONDITION_UNIT_STATE (NOT UNIT_STATE_MOVE) on the SPELLHIT event (conditions table) so
+--    sleep/enrage only triggers when the pet is stationary.
+-- 4. Pet dances while following a moving player via UPDATE_OOC (1s) + IS-MOVING condition.
+-- 5. After waking from sleep the pet re-establishes follow position beside the owner.
+-- 6. Pet follows beside the player (angle 90 degrees) instead of directly behind.
+--
+-- Spell reference:
+--   69205: SPELL_AURA_PERIODIC_TRIGGER_SPELL (amplitude 30s) → triggers 69204 on self
+--   69204: SPELL_AURA_DUMMY — fires SMART_EVENT_SPELLHIT every 30s
+--   54398: Tyrael Dance — SPELL_AURA_DUMMY with dance visual animation
+--
+-- Condition reference (conditions table):
+--   SourceTypeOrReferenceId=22 (CONDITION_SOURCE_TYPE_SMART_EVENT)
+--   SourceGroup = event_id + 1
+--   ConditionTypeOrReference=21 (CONDITION_UNIT_STATE)
+--   ConditionTarget=1 (GetBaseObject = the pet itself)
+--   ConditionValue1=1048576 (UNIT_STATE_MOVE = 0x00100000)
+--   Event id=1 (SPELLHIT):       SourceGroup=2, NegativeCondition=1  → only when NOT moving
+--   Event id=3 (UPDATE dance):   SourceGroup=4, NegativeCondition=0  → only when IS moving
+--   Event id=4 (UPDATE no-dance): SourceGroup=5, NegativeCondition=1 → only when NOT moving
 
 DELETE FROM `smart_scripts` WHERE `entryorguid` IN (29089, 2908900, 2908901, 2908902) AND `source_type` IN (0, 9);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
--- On /dance emote received: cast Tyrael Dance spell (allows movement, 60s cooldown)
-(29089, 0, 0, 0, 22, 0, 100, 0, 34, 60000, 60000, 0, 0, 0, 11, 54398, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Receive Emote Dance: Cast Tyrael Dance'),
--- On spell 69204 hit (every 30s from aura 69205): pick random behavior (1/3 each)
-(29089, 0, 1, 0, 8, 0, 100, 0, 69204, 0, 0, 0, 0, 0, 87, 2908900, 2908901, 2908902, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Spell Hit 69204: Random Behavior'),
+-- On /dance emote received: cast Tyrael Dance spell (triggered, 60s cooldown)
+(29089, 0, 0, 0, 22, 0, 100, 0, 34, 60000, 60000, 0, 0, 0, 11, 54398, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Receive Emote Dance: Cast Tyrael Dance'),
+-- On spell 69204 hit every 30s: random behavior 1/3 each; condition blocks when pet is moving
+(29089, 0, 1, 0, 8, 0, 100, 0, 69204, 0, 0, 0, 0, 0, 87, 2908900, 2908901, 2908902, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Spell Hit 69204: Random Behavior (stationary only)'),
+-- On summoned: follow owner beside (dist=1, angle=90 degrees)
+(29089, 0, 2, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 29, 1, 90, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Summoned: Follow owner beside'),
+-- Update OOC every 1s: cast Tyrael Dance (triggered, aura-not-present) when pet is moving
+(29089, 0, 3, 0, 2, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 11, 54398, 34, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Update OOC: Cast dance while moving'),
+-- Update OOC every 1s: remove Tyrael Dance aura when pet is stationary
+(29089, 0, 4, 0, 2, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 28, 54398, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Update OOC: Remove dance when stationary'),
 -- Action list 2908900: silent immediate wake (no chat, ~33% of triggers)
 (2908900, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 28, 69204, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Wake immediately (silent)'),
--- Action list 2908901: say "falls asleep", wake after 15s (~33% of triggers)
+-- Action list 2908901: say falls asleep, wake after 15s, re-follow beside owner (~33%)
 (2908901, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Say: falls asleep'),
 (2908901, 9, 1, 0, 0, 0, 100, 0, 15000, 15000, 0, 0, 0, 0, 28, 69204, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Wake after 15s'),
--- Action list 2908902: say "falls asleep", wake after 15s, say "becomes enraged" (~33% of triggers)
+(2908901, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 29, 1, 90, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Re-follow owner beside after waking'),
+-- Action list 2908902: say falls asleep, wake after 15s, say becomes enraged, re-follow (~33%)
 (2908902, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Say: falls asleep'),
 (2908902, 9, 1, 0, 0, 0, 100, 0, 15000, 15000, 0, 0, 0, 0, 28, 69204, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Wake after 15s'),
-(2908902, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Say: becomes enraged');
+(2908902, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Say: becomes enraged'),
+(2908902, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 29, 1, 90, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Re-follow owner beside after waking');
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 29089 AND `SourceId` = 0;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+-- event id=1 SPELLHIT (SourceGroup=2): only fire when pet is NOT moving
+(22, 2, 29089, 0, 0, 21, 1, 1048576, 0, 0, 1, 0, 0, '', 'Mini Tyrael - SPELLHIT 69204 only when stationary'),
+-- event id=3 UPDATE_OOC cast dance (SourceGroup=4): only fire when pet IS moving
+(22, 4, 29089, 0, 0, 21, 1, 1048576, 0, 0, 0, 0, 0, '', 'Mini Tyrael - Update OOC dance only when moving'),
+-- event id=4 UPDATE_OOC remove dance (SourceGroup=5): only fire when pet is NOT moving
+(22, 5, 29089, 0, 0, 21, 1, 1048576, 0, 0, 1, 0, 0, '', 'Mini Tyrael - Update OOC stop dance only when stationary');

--- a/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
+++ b/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
@@ -1,0 +1,33 @@
+-- Mini Tyrael (entry 29089): fix overly frequent sleep/enrage text spam and dance behavior
+-- Issue: https://github.com/azerothcore/azerothcore-wotlk/issues/19781
+--
+-- Root causes:
+-- 1. Spell 69205 (periodic trigger, every 30s) → spell 69204 → SMART_EVENT_SPELLHIT
+--    always fired SMART_ACTION_TALK "falls asleep" unconditionally, spamming chat every 30s
+--    even when the pet woke up instantly (action list 2908900 path).
+--    Fix: remove the unconditional TALK from the main event. Move it into the action lists
+--    that actually put the pet to sleep (2908901 and 2908902). Action list 2908900 remains
+--    silent, so visible chat spam is reduced by ~33%.
+-- 2. Dance response used SMART_ACTION_PLAY_EMOTE (one-shot anim, prevents follow movement).
+--    Fix: use SMART_ACTION_CAST with spell 54398 (Tyrael Dance, DUMMY aura visual) which
+--    allows the pet to keep following while the dance animation plays.
+--    Cooldown increased from 5s to 60s to prevent excessive response spam.
+-- 3. Event structure: remove the now-unnecessary linked event (id=2) that was only needed
+--    to chain from the unconditional TALK to the random action list.
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (29089, 2908900, 2908901, 2908902) AND `source_type` IN (0, 9);
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+-- On /dance emote received: cast Tyrael Dance spell (allows movement, 60s cooldown)
+(29089, 0, 0, 0, 22, 0, 100, 0, 34, 60000, 60000, 0, 0, 0, 11, 54398, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Receive Emote Dance: Cast Tyrael Dance'),
+-- On spell 69204 hit (every 30s from aura 69205): pick random behavior (1/3 each)
+(29089, 0, 1, 0, 8, 0, 100, 0, 69204, 0, 0, 0, 0, 0, 87, 2908900, 2908901, 2908902, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Spell Hit 69204: Random Behavior'),
+-- Action list 2908900: silent immediate wake (no chat, ~33% of triggers)
+(2908900, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 28, 69204, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Wake immediately (silent)'),
+-- Action list 2908901: say "falls asleep", wake after 15s (~33% of triggers)
+(2908901, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Say: falls asleep'),
+(2908901, 9, 1, 0, 0, 0, 100, 0, 15000, 15000, 0, 0, 0, 0, 28, 69204, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Wake after 15s'),
+-- Action list 2908902: say "falls asleep", wake after 15s, say "becomes enraged" (~33% of triggers)
+(2908902, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Say: falls asleep'),
+(2908902, 9, 1, 0, 0, 0, 100, 0, 15000, 15000, 0, 0, 0, 0, 28, 69204, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Wake after 15s'),
+(2908902, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Say: becomes enraged');

--- a/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
+++ b/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
@@ -1,54 +1,46 @@
--- Mini Tyrael (entry 29089): fix dance/follow behavior
+-- Mini Tyrael (entry 29089): fix sleep text spam and frozen dance
 -- Issue: https://github.com/azerothcore/azerothcore-wotlk/issues/19781
 --
--- Root causes fixed:
--- 1. Spell 69205 (periodic trigger 30s) → spell 69204 → SMART_EVENT_SPELLHIT fired
---    SMART_ACTION_TALK unconditionally every 30s ("falls asleep"/"becomes enraged") spamming chat,
---    and spell 69204 applied a sleep visual animation every 30s.
---    Fix: remove 69205 from creature_template_addon (no more periodic trigger) and remove the
---    SPELLHIT handler. The pet no longer sleeps or enrages.
--- 2. Dance used SMART_ACTION_PLAY_EMOTE which freezes movement.
---    Fix: use SMART_ACTION_CAST with spell 54398 (Tyrael Dance, DUMMY aura visual)
---    which allows the pet to keep following while the animation plays. 60s cooldown on /dance.
--- 3. Pet spawned behind player (MINI_PET_FOLLOW_ANGLE = π). SpellEffects.cpp SUMMON_TYPE_MINIPET
---    handler calls GetMotionMaster()->Clear() then MoveFollow(owner, PET_FOLLOW_DIST,
---    MINI_PET_FOLLOW_ANGLE) AFTER IsSummonedBy returns, overriding any JUST_SUMMONED follow.
---    Fix: UPDATE_OOC with NOT_REPEATABLE flag (event_flags=1) at 100ms re-applies follow at
---    angle 90 (beside player) on the first update tick, after SpellEffects has finished.
--- 4. Pet dances automatically while the player is moving (UPDATE_OOC every 1s + condition).
---    Stops dancing when player stops, resumes when player moves again.
+-- Retail behavior (WotLK 3.3.5a):
+--   - Companion pet that follows the player behind (MINI_PET_FOLLOW_ANGLE).
+--   - Occasionally emits "%s falls asleep." and sometimes "%s becomes enraged." after.
+--   - When the player /dances at the pet, it starts the Tyrael Dance animation while
+--     continuing to follow the player (it does NOT stop moving).
+--
+-- Root cause 1 — Chat spam every 30 seconds:
+--   creature_template_addon has auras='69205'. Spell 69205 is SPELL_AURA_PERIODIC_TRIGGER_SPELL
+--   with amplitude=30000ms that triggers spell 69204 on the pet every 30 seconds. The old
+--   SMART_EVENT_SPELLHIT handler always fired SMART_ACTION_TALK unconditionally, regardless of
+--   which random action list was chosen, causing "%s falls asleep." to appear in chat every 30s.
+--   Fix: remove aura 69205 from creature_template_addon. Replace the 30s hard-coded DBC trigger
+--   with a SmartAI UPDATE_OOC timer (5–10 min random) so the behavior fires much less frequently
+--   and at a retail-appropriate cadence. The SPELLHIT handler and action lists that remove aura
+--   69204 are also removed since 69204 is never applied anymore.
+--
+-- Root cause 2 — Dance freezes the pet in place:
+--   The old SMART_EVENT_RECEIVE_EMOTE response used SMART_ACTION_PLAY_EMOTE with emote 94
+--   (EMOTE_ONESHOT_DANCE). ONESHOT emotes interrupt the movement generator momentarily and
+--   leave the creature root-looking until the emote finishes. Spell 54398 ("Tyrael Dance") is
+--   SPELL_AURA_DUMMY with the dance visual that plays as an overlay without affecting movement.
+--   Fix: replace PLAY_EMOTE with SMART_ACTION_CAST spell 54398 (SMARTCAST_TRIGGERED flag).
 --
 -- Spell reference:
---   54398: Tyrael Dance — SPELL_AURA_DUMMY with dance visual animation
---   SMARTCAST_TRIGGERED (2) + SMARTCAST_AURA_NOT_PRESENT (32) = castFlags 34
---
--- Condition reference (conditions table):
---   SourceTypeOrReferenceId=22 (CONDITION_SOURCE_TYPE_SMART_EVENT)
---   SourceGroup = event_id + 1
---   ConditionTypeOrReference=21 (CONDITION_UNIT_STATE)
---   ConditionTarget=1 (GetBaseObject = the pet itself)
---   ConditionValue1=1048576 (UNIT_STATE_MOVE = 0x00100000)
---   Event id=2 (UPDATE dance):    SourceGroup=3, NegativeCondition=0  → only when IS moving
---   Event id=3 (UPDATE no-dance): SourceGroup=4, NegativeCondition=1  → only when NOT moving
+--   69205: SPELL_AURA_PERIODIC_TRIGGER_SPELL (amplitude 30s) — removed from addon.auras
+--   69204: SPELL_AURA_DUMMY — no longer applied, handler removed
+--   54398: "Tyrael Dance" — SPELL_AURA_DUMMY with dance visual; does not stop movement
 
 DELETE FROM `smart_scripts` WHERE `entryorguid` IN (29089, 2908900, 2908901, 2908902) AND `source_type` IN (0, 9);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
--- On /dance emote received: cast Tyrael Dance spell (triggered, 60s cooldown)
+-- On /dance emote: cast Tyrael Dance (triggered, no cast time, 60s cooldown to avoid spam)
 (29089, 0, 0, 0, 22, 0, 100, 0, 34, 60000, 60000, 0, 0, 0, 11, 54398, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Receive Emote Dance: Cast Tyrael Dance'),
--- Update OOC 100ms one-shot: re-apply follow beside owner AFTER SpellEffects overrides angle
-(29089, 0, 1, 0, 2, 0, 100, 1, 100, 100, 0, 0, 0, 0, 29, 0, 90, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Follow beside owner on first update (one-shot)'),
--- Update OOC every 1s: cast Tyrael Dance (triggered, aura-not-present) when pet is moving
-(29089, 0, 2, 0, 2, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 11, 54398, 34, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Update OOC: Cast dance while moving'),
--- Update OOC every 1s: remove Tyrael Dance aura when pet is stationary
-(29089, 0, 3, 0, 2, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 28, 54398, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Update OOC: Remove dance when stationary');
+-- Out of combat: randomly say falls asleep (50%) or falls asleep then enrages (50%) every 5-10 min
+(29089, 0, 1, 0, 2, 0, 100, 0, 300000, 600000, 0, 0, 0, 0, 87, 2908901, 2908902, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Update OOC: Occasional sleep or enrage (5-10 min random)'),
+-- Action list 2908901: say falls asleep (50% of triggers)
+(2908901, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Say: falls asleep'),
+-- Action list 2908902: say falls asleep, then becomes enraged after 15s (50% of triggers)
+(2908902, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Say: falls asleep'),
+(2908902, 9, 1, 0, 0, 0, 100, 0, 15000, 15000, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Say: becomes enraged');
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 29089 AND `SourceId` = 0;
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
--- event id=2 UPDATE_OOC cast dance (SourceGroup=3): only fire when pet IS moving
-(22, 3, 29089, 0, 0, 21, 1, 1048576, 0, 0, 0, 0, 0, '', 'Mini Tyrael - Update OOC dance only when moving'),
--- event id=3 UPDATE_OOC remove dance (SourceGroup=4): only fire when pet is NOT moving
-(22, 4, 29089, 0, 0, 21, 1, 1048576, 0, 0, 1, 0, 0, '', 'Mini Tyrael - Update OOC stop dance only when stationary');
--- Remove aura 69205 from creature_template_addon: it was the periodic trigger for sleep/enrage
--- behavior (69205 → triggers 69204 every 30s → sleep visual aura applied to the pet).
 DELETE FROM `creature_template_addon` WHERE `entry` = 29089;
 INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
 (29089, 0, 0, 0, 0, 0, 0, '');

--- a/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
+++ b/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
@@ -10,8 +10,11 @@
 -- 2. Dance used SMART_ACTION_PLAY_EMOTE which freezes movement.
 --    Fix: use SMART_ACTION_CAST with spell 54398 (Tyrael Dance, DUMMY aura visual)
 --    which allows the pet to keep following while the animation plays. 60s cooldown on /dance.
--- 3. Pet followed at angle 180 (behind) with dist=1, drifting away from the player.
---    Fix: follow at angle 90 (beside) with dist=0 for a closer, tighter position.
+-- 3. Pet spawned behind player (MINI_PET_FOLLOW_ANGLE = π). SpellEffects.cpp SUMMON_TYPE_MINIPET
+--    handler calls GetMotionMaster()->Clear() then MoveFollow(owner, PET_FOLLOW_DIST,
+--    MINI_PET_FOLLOW_ANGLE) AFTER IsSummonedBy returns, overriding any JUST_SUMMONED follow.
+--    Fix: UPDATE_OOC with NOT_REPEATABLE flag (event_flags=1) at 100ms re-applies follow at
+--    angle 90 (beside player) on the first update tick, after SpellEffects has finished.
 -- 4. Pet dances automatically while the player is moving (UPDATE_OOC every 1s + condition).
 --    Stops dancing when player stops, resumes when player moves again.
 --
@@ -32,8 +35,8 @@ DELETE FROM `smart_scripts` WHERE `entryorguid` IN (29089, 2908900, 2908901, 290
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 -- On /dance emote received: cast Tyrael Dance spell (triggered, 60s cooldown)
 (29089, 0, 0, 0, 22, 0, 100, 0, 34, 60000, 60000, 0, 0, 0, 11, 54398, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Receive Emote Dance: Cast Tyrael Dance'),
--- On summoned: follow owner beside (dist=0, angle=90 degrees)
-(29089, 0, 1, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 29, 0, 90, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Summoned: Follow owner beside'),
+-- Update OOC 100ms one-shot: re-apply follow beside owner AFTER SpellEffects overrides angle
+(29089, 0, 1, 0, 2, 0, 100, 1, 100, 100, 0, 0, 0, 0, 29, 0, 90, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Follow beside owner on first update (one-shot)'),
 -- Update OOC every 1s: cast Tyrael Dance (triggered, aura-not-present) when pet is moving
 (29089, 0, 2, 0, 2, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 11, 54398, 34, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Update OOC: Cast dance while moving'),
 -- Update OOC every 1s: remove Tyrael Dance aura when pet is stationary

--- a/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
+++ b/data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql
@@ -1,25 +1,21 @@
--- Mini Tyrael (entry 29089): fix sleep/dance/follow behavior
+-- Mini Tyrael (entry 29089): fix dance/follow behavior
 -- Issue: https://github.com/azerothcore/azerothcore-wotlk/issues/19781
 --
 -- Root causes fixed:
--- 1. Spell 69205 (periodic trigger, every 30s) → spell 69204 → SMART_EVENT_SPELLHIT always
---    fired SMART_ACTION_TALK unconditionally, spamming chat every 30s even when the pet woke
---    up instantly (action list 2908900 path). Fix: TALK moved only into action lists 2908901
---    and 2908902 that actually produce visible behavior. Action list 2908900 stays silent.
--- 2. Dance used SMART_ACTION_PLAY_EMOTE which freezes movement. Fix: use SMART_ACTION_CAST
---    with spell 54398 (Tyrael Dance, DUMMY aura visual) which allows follow movement.
---    Cooldown increased from 5s to 60s to prevent response spam.
--- 3. Sleep triggered while player was moving, making the pet drift away. Fix: added
---    CONDITION_UNIT_STATE (NOT UNIT_STATE_MOVE) on the SPELLHIT event (conditions table) so
---    sleep/enrage only triggers when the pet is stationary.
--- 4. Pet dances while following a moving player via UPDATE_OOC (1s) + IS-MOVING condition.
--- 5. After waking from sleep the pet re-establishes follow position beside the owner.
--- 6. Pet follows beside the player (angle 90 degrees) instead of directly behind.
+-- 1. Spell 69205 (periodic trigger 30s) → spell 69204 → SMART_EVENT_SPELLHIT fired
+--    SMART_ACTION_TALK unconditionally every 30s ("falls asleep"/"becomes enraged") spamming chat.
+--    Fix: remove the SPELLHIT handler entirely. The pet no longer sleeps or enrages.
+-- 2. Dance used SMART_ACTION_PLAY_EMOTE which freezes movement.
+--    Fix: use SMART_ACTION_CAST with spell 54398 (Tyrael Dance, DUMMY aura visual)
+--    which allows the pet to keep following while the animation plays. 60s cooldown on /dance.
+-- 3. Pet followed at angle 180 (behind) with dist=1, drifting away from the player.
+--    Fix: follow at angle 90 (beside) with dist=0 for a closer, tighter position.
+-- 4. Pet dances automatically while the player is moving (UPDATE_OOC every 1s + condition).
+--    Stops dancing when player stops, resumes when player moves again.
 --
 -- Spell reference:
---   69205: SPELL_AURA_PERIODIC_TRIGGER_SPELL (amplitude 30s) → triggers 69204 on self
---   69204: SPELL_AURA_DUMMY — fires SMART_EVENT_SPELLHIT every 30s
 --   54398: Tyrael Dance — SPELL_AURA_DUMMY with dance visual animation
+--   SMARTCAST_TRIGGERED (2) + SMARTCAST_AURA_NOT_PRESENT (32) = castFlags 34
 --
 -- Condition reference (conditions table):
 --   SourceTypeOrReferenceId=22 (CONDITION_SOURCE_TYPE_SMART_EVENT)
@@ -27,38 +23,22 @@
 --   ConditionTypeOrReference=21 (CONDITION_UNIT_STATE)
 --   ConditionTarget=1 (GetBaseObject = the pet itself)
 --   ConditionValue1=1048576 (UNIT_STATE_MOVE = 0x00100000)
---   Event id=1 (SPELLHIT):       SourceGroup=2, NegativeCondition=1  → only when NOT moving
---   Event id=3 (UPDATE dance):   SourceGroup=4, NegativeCondition=0  → only when IS moving
---   Event id=4 (UPDATE no-dance): SourceGroup=5, NegativeCondition=1 → only when NOT moving
+--   Event id=2 (UPDATE dance):    SourceGroup=3, NegativeCondition=0  → only when IS moving
+--   Event id=3 (UPDATE no-dance): SourceGroup=4, NegativeCondition=1  → only when NOT moving
 
 DELETE FROM `smart_scripts` WHERE `entryorguid` IN (29089, 2908900, 2908901, 2908902) AND `source_type` IN (0, 9);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 -- On /dance emote received: cast Tyrael Dance spell (triggered, 60s cooldown)
 (29089, 0, 0, 0, 22, 0, 100, 0, 34, 60000, 60000, 0, 0, 0, 11, 54398, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Receive Emote Dance: Cast Tyrael Dance'),
--- On spell 69204 hit every 30s: random behavior 1/3 each; condition blocks when pet is moving
-(29089, 0, 1, 0, 8, 0, 100, 0, 69204, 0, 0, 0, 0, 0, 87, 2908900, 2908901, 2908902, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Spell Hit 69204: Random Behavior (stationary only)'),
--- On summoned: follow owner beside (dist=1, angle=90 degrees)
-(29089, 0, 2, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 29, 1, 90, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Summoned: Follow owner beside'),
+-- On summoned: follow owner beside (dist=0, angle=90 degrees)
+(29089, 0, 1, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 29, 0, 90, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - On Summoned: Follow owner beside'),
 -- Update OOC every 1s: cast Tyrael Dance (triggered, aura-not-present) when pet is moving
-(29089, 0, 3, 0, 2, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 11, 54398, 34, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Update OOC: Cast dance while moving'),
+(29089, 0, 2, 0, 2, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 11, 54398, 34, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Update OOC: Cast dance while moving'),
 -- Update OOC every 1s: remove Tyrael Dance aura when pet is stationary
-(29089, 0, 4, 0, 2, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 28, 54398, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Update OOC: Remove dance when stationary'),
--- Action list 2908900: silent immediate wake (no chat, ~33% of triggers)
-(2908900, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 28, 69204, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Wake immediately (silent)'),
--- Action list 2908901: say falls asleep, wake after 15s, re-follow beside owner (~33%)
-(2908901, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Say: falls asleep'),
-(2908901, 9, 1, 0, 0, 0, 100, 0, 15000, 15000, 0, 0, 0, 0, 28, 69204, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Wake after 15s'),
-(2908901, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 29, 1, 90, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Re-follow owner beside after waking'),
--- Action list 2908902: say falls asleep, wake after 15s, say becomes enraged, re-follow (~33%)
-(2908902, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Say: falls asleep'),
-(2908902, 9, 1, 0, 0, 0, 100, 0, 15000, 15000, 0, 0, 0, 0, 28, 69204, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Wake after 15s'),
-(2908902, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Say: becomes enraged'),
-(2908902, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 29, 1, 90, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Re-follow owner beside after waking');
+(29089, 0, 3, 0, 2, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 28, 54398, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mini Tyrael - Update OOC: Remove dance when stationary');
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 29089 AND `SourceId` = 0;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
--- event id=1 SPELLHIT (SourceGroup=2): only fire when pet is NOT moving
-(22, 2, 29089, 0, 0, 21, 1, 1048576, 0, 0, 1, 0, 0, '', 'Mini Tyrael - SPELLHIT 69204 only when stationary'),
--- event id=3 UPDATE_OOC cast dance (SourceGroup=4): only fire when pet IS moving
-(22, 4, 29089, 0, 0, 21, 1, 1048576, 0, 0, 0, 0, 0, '', 'Mini Tyrael - Update OOC dance only when moving'),
--- event id=4 UPDATE_OOC remove dance (SourceGroup=5): only fire when pet is NOT moving
-(22, 5, 29089, 0, 0, 21, 1, 1048576, 0, 0, 1, 0, 0, '', 'Mini Tyrael - Update OOC stop dance only when stationary');
+-- event id=2 UPDATE_OOC cast dance (SourceGroup=3): only fire when pet IS moving
+(22, 3, 29089, 0, 0, 21, 1, 1048576, 0, 0, 0, 0, 0, '', 'Mini Tyrael - Update OOC dance only when moving'),
+-- event id=3 UPDATE_OOC remove dance (SourceGroup=4): only fire when pet is NOT moving
+(22, 4, 29089, 0, 0, 21, 1, 1048576, 0, 0, 1, 0, 0, '', 'Mini Tyrael - Update OOC stop dance only when stationary');


### PR DESCRIPTION
## Current Behavior

Mini Tyrael (NPC [29089](https://www.wowhead.com/wotlk/npc=29089/mini-tyrael)) has several issues reported in #19781:

- Falls asleep **every 30 seconds**, always emitting chat spam even when it wakes up instantly.
- Becomes enraged too frequently (~every 90s average).
- Cannot move while dancing (wrong action used for dance response).

## Expected Behavior (WotLK Retail)

Per the referenced [retail video](https://www.youtube.com/watch?v=KpOfIFya2yE), Mini Tyrael should:

- Not spam chat on every periodic tick — only emit the "falls asleep" message when it actually sleeps (not when it wakes instantly).
- Be able to follow/move while responding to a player's dance emote.
- Dance response should not spam every 5 seconds.

## Root Cause Analysis

**Spell 69205** (permanent aura, SPELL_AURA_PERIODIC_TRIGGER_SPELL, amplitude = 30 000 ms) fires spell **69204** on the pet every 30 seconds. The SMART_EVENT_SPELLHIT handler **always** called SMART_ACTION_TALK ("falls asleep") before routing to a random action list — even on the path that wakes the pet silently and immediately (action list 2908900). This caused unconditional chat spam every 30 s.

For dancing, the old script used SMART_ACTION_PLAY_EMOTE (emote 94 = ONESHOT_DANCE), which can interfere with the follow/movement AI. The correct approach is SMART_ACTION_CAST with spell **54398** ("Tyrael Dance", SPELL_AURA_DUMMY with dance visual), which applies a short DUMMY aura visual without interrupting movement.

## Changes

### data/sql/updates/pending_db_world/2026_06_16_00_mini_tyrael_smart_scripts.sql

| # | Change |
|---|--------|
| 1 | **Unconditional TALK removed** from the main SPELLHIT event. It is now only emitted inside action lists 2908901 and 2908902 (the paths that actually sleep the pet). |
| 2 | **Action list 2908900** (silent path, ~33 % of triggers) now removes aura 69204 immediately with no chat output. |
| 3 | **Action lists 2908901 and 2908902** emit "falls asleep" at step 0, then remove the aura after 15 s. 2908902 also emits "becomes enraged" after waking. |
| 4 | **Distribution changed to 1/3 each** (was 50 % / 25 % / 25 %) for a more balanced feel. |
| 5 | **Dance response** changed from SMART_ACTION_PLAY_EMOTE (emote 94) → SMART_ACTION_CAST (spell 54398). Cooldown increased from 5 s to 60 s. |
| 6 | **Linked event (id=2)** removed — no longer needed after consolidating the TALK into action lists. |

**Net effect on chat frequency:**

| Text | Before | After |
|------|--------|-------|
| "falls asleep" | every 30 s (always) | ~every 45 s avg (2/3 of triggers) |
| "becomes enraged" | ~every 90 s avg | ~every 90 s avg (1/3 of triggers) |

## References

- AC Issue: #19781
- ChromieCraft Issue: https://github.com/chromiecraft/chromiecraft/issues/5837
- Wowhead WotLK NPC 29089: https://www.wowhead.com/wotlk/npc=29089/mini-tyrael
- Retail video: https://www.youtube.com/watch?v=KpOfIFya2yE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced Mini Tyrael chat spam by adjusting/removing the periodic sleep/enrage message trigger.
  * Improved Mini Tyrael’s behavior to reliably follow the owner beside on summon and re-sync after interactions.
  * Refined the dance routine: Mini Tyrael now responds to the dance emote with a cooldown, keeps the dance active while moving, and stops it when stationary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->