### PR TITLE
feat(coderabbit-config): add CodeRabbit review config mirroring CLAUDE.md

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -56,7 +56,7 @@ reviews:
     - path: "data/sql/updates/pending_db_*/**/*.sql"
       instructions: |
         AzerothCore SQL update conventions (enforced by apps/codestyle/codestyle-sql.py):
-        - Every INSERT must be preceded by a matching DELETE for idempotency.
+        - Every INSERT must be preceded by a matching DELETE for idempotency, and that DELETE must include a WHERE clause scoped precisely to the intended rows. A predicate that is too broad will remove unrelated data, so confirm it matches exactly what the INSERT will re-add.
         - 4-space indent (no tabs), trailing newline, no double semicolons, no multiple blank lines.
         - Tables must use the InnoDB engine.
     - path: "data/sql/base/**"

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -29,8 +29,8 @@ reviews:
         - Use fmt-style `{}` format specifiers, never printf-style `%u`/`%s`.
         - Logging: `LOG_INFO("category.sub", "msg {}", arg)` (also LOG_WARN/ERROR/DEBUG/TRACE).
           No printf, no `sLog->`, no `TC_LOG_*`.
-        - Random: use Random.h helpers (urand, irand, frand, rand_chance, roll_chance_f/i).
-          Never `std::rand` or `<random>` directly.
+        - Random: use Random.h helpers (urand, irand, frand, rand32, rand_chance,
+          roll_chance_f/i). Never `std::rand` or `<random>` directly.
         - Strings: `Acore::StringFormat(fmt, args...)`.
         - Config: `sConfigMgr->GetOption<T>("Name", default)`.
         - Namespace is `Acore::` — flag any leftover `Trinity::` from upstream ports.
@@ -39,22 +39,33 @@ reviews:
           IsRefundable()/IsBOPTradable()/IsWrapped(); HasFlag(ItemFlag)/HasFlag2()/HasFlagCu();
           ObjectGuid::ToString().c_str() instead of GetCounter().
         - Never store a raw Player*/Creature*/Unit* past the current call/tick — store the
-          ObjectGuid and resolve at use time (ObjectAccessor::FindPlayer, Map::GetCreature, …).
+          ObjectGuid and resolve at use time (ObjectAccessor::FindPlayer,
+          ObjectAccessor::GetCreature(*from, guid), Map::GetCreature, …).
         - DB access: use PreparedStatement, not raw query strings. Non-blocking reads go through
           the async path (_queryProcessor.AddCallback(db.AsyncQuery(...))). Multi-statement
           writes wrap in SQLTransaction.
         - Timed AI actions: use EventMap or TaskScheduler, not hand-rolled tick counters.
         - Prefer SmartAI (DB) for new creature behaviour; reach for CreatureScript only when the
           SmartAI vocabulary isn't enough. New creature AI prefers RegisterCreatureAI(ClassName).
+        - Script registration: spell/aura scripts use RegisterSpellScript(ClassName) or
+          RegisterSpellAndAuraScriptPair(...) inside AddSC_(); creature AI uses
+          RegisterCreatureAI(ClassName) (preferred) or new ClassName() (legacy). Declare and
+          call AddSC_() from the regional loader (e.g. Spells/spells_script_loader.cpp,
+          EasternKingdoms/eastern_kingdoms_script_loader.cpp). Module hooks inherit from
+          PlayerScript/WorldScript/etc. and register with new MyClass() in AddSC_().
     - path: "data/sql/updates/pending_db_*/**/*.sql"
       instructions: |
         AzerothCore SQL update conventions (enforced by apps/codestyle/codestyle-sql.py):
         - Every INSERT must be preceded by a matching DELETE for idempotency.
         - 4-space indent (no tabs), trailing newline, no double semicolons, no multiple blank lines.
         - Tables must use the InnoDB engine.
-    - path: "data/sql/{base,archive}/**"
+    - path: "data/sql/base/**"
       instructions: |
-        These SQL directories are immutable. Changes here should not happen in a normal PR —
+        This SQL directory is immutable. Changes here should not happen in a normal PR —
+        flag any modification. New SQL belongs in data/sql/updates/pending_db_*/.
+    - path: "data/sql/archive/**"
+      instructions: |
+        This SQL directory is immutable. Changes here should not happen in a normal PR —
         flag any modification. New SQL belongs in data/sql/updates/pending_db_*/.
 
 knowledge_base:

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,69 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit review config. Mirrors the hard rules in CLAUDE.md so the AI
+# reviewer enforces project conventions on every PR.
+language: en-US
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+
+  # Skip generated, vendored, and immutable content so reviews stay focused.
+  path_filters:
+    - "!deps/**"
+    - "!data/sql/updates/db_*/**"
+
+  path_instructions:
+    - path: "**/*.{cpp,h,hpp}"
+      instructions: |
+        AzerothCore C++ conventions (CI enforces these with -Werror; flag violations):
+        - C++20. 4-space indent, tabs forbidden. UTF-8, LF, max 80 columns, trailing newline.
+        - Allman braces. No braces around single-line statements. `if (x)`, never `if(x)` or `if ( x )`.
+        - `auto const&` (not `const auto&`); `Type const*` (not `const Type*`).
+        - Use fmt-style `{}` format specifiers, never printf-style `%u`/`%s`.
+        - Logging: `LOG_INFO("category.sub", "msg {}", arg)` (also LOG_WARN/ERROR/DEBUG/TRACE).
+          No printf, no `sLog->`, no `TC_LOG_*`.
+        - Random: use Random.h helpers (urand, irand, frand, rand_chance, roll_chance_f/i).
+          Never `std::rand` or `<random>` directly.
+        - Strings: `Acore::StringFormat(fmt, args...)`.
+        - Config: `sConfigMgr->GetOption<T>("Name", default)`.
+        - Namespace is `Acore::` — flag any leftover `Trinity::` from upstream ports.
+        - Use typed helpers instead of raw flag access: IsPlayer()/IsCreature()/IsItem();
+          GetNpcFlags()/HasNpcFlag()/SetNpcFlag()/RemoveNpcFlag()/ReplaceAllNpcFlags();
+          IsRefundable()/IsBOPTradable()/IsWrapped(); HasFlag(ItemFlag)/HasFlag2()/HasFlagCu();
+          ObjectGuid::ToString().c_str() instead of GetCounter().
+        - Never store a raw Player*/Creature*/Unit* past the current call/tick — store the
+          ObjectGuid and resolve at use time (ObjectAccessor::FindPlayer, Map::GetCreature, …).
+        - DB access: use PreparedStatement, not raw query strings. Non-blocking reads go through
+          the async path (_queryProcessor.AddCallback(db.AsyncQuery(...))). Multi-statement
+          writes wrap in SQLTransaction.
+        - Timed AI actions: use EventMap or TaskScheduler, not hand-rolled tick counters.
+        - Prefer SmartAI (DB) for new creature behaviour; reach for CreatureScript only when the
+          SmartAI vocabulary isn't enough. New creature AI prefers RegisterCreatureAI(ClassName).
+    - path: "data/sql/updates/pending_db_*/**/*.sql"
+      instructions: |
+        AzerothCore SQL update conventions (enforced by apps/codestyle/codestyle-sql.py):
+        - Every INSERT must be preceded by a matching DELETE for idempotency.
+        - 4-space indent (no tabs), trailing newline, no double semicolons, no multiple blank lines.
+        - Tables must use the InnoDB engine.
+    - path: "data/sql/{base,archive}/**"
+      instructions: |
+        These SQL directories are immutable. Changes here should not happen in a normal PR —
+        flag any modification. New SQL belongs in data/sql/updates/pending_db_*/.
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    # CLAUDE.md is in CodeRabbit's defaults, but list it explicitly so the project's
+    # full guideline doc is always pulled into review context.
+    filePatterns:
+      - "CLAUDE.md"
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
## Changes Proposed:
Adds a `.coderabbit.yml` so CodeRabbit's automated reviews follow the project conventions documented in `CLAUDE.md`. This is repository tooling/config only, no core, script, or database behavior is affected.

- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

(None of the above: this is CI/review tooling configuration.)

What the config does:
- `knowledge_base.code_guidelines` lists `CLAUDE.md` explicitly so the full guideline doc is always in review context (it is also a CodeRabbit default pattern).
- `reviews.path_instructions` distill the hard rules per file type: C++ conventions for `*.{cpp,h,hpp}` (C++20, 4-space indent, 80 cols, Allman braces, `auto const&` / `Type const*`, fmt-style `{}` logging, project Random/StringFormat/Config helpers, `Acore::` namespace, typed flag helpers, `ObjectGuid` over long-lived raw pointers, `PreparedStatement` + async query path, `EventMap`/`TaskScheduler`, SmartAI preference), and the pending-SQL rules for `data/sql/updates/pending_db_*/**/*.sql` (matching `DELETE` before every `INSERT`, 4-space indent, trailing newline, no double semicolons, InnoDB), plus a guard flagging edits to the immutable `data/sql/{base,archive}`.
- `reviews.path_filters` skip `deps/` and the merged `data/sql/updates/db_*` tree to keep reviews focused.
- Review profile left at `chill` (CodeRabbit default).

### AI-assisted Pull Requests

- [x] AI tools were used. Authored with Claude (Opus 4.8) via Claude Code, used to draft the config file and this PR. The changes are fully understood and can be explained on request.

## Issues Addressed:
N/A, no related issue.

## SOURCE:
N/A for a tooling-config change. Settings follow CodeRabbit's documented schema (`reviews.path_instructions`, `path_filters`, `knowledge_base.code_guidelines`).

- [ ] Live research
- [ ] Sniffs
- [ ] Video evidence, knowledge databases or other public sources
- [ ] Cherry-pick

## Tests Performed:
- [x] Validated by CodeRabbit's own review run on this PR: the config loaded successfully (`Configuration used: Path: .coderabbit.yml`, profile CHILL) with no actionable comments. CodeRabbit accepts both `.coderabbit.yaml` and `.coderabbit.yml`; the file uses `.yml` to match the repo `.editorconfig` 2-space rule.

## How to Test the Changes:
Open any PR touching C++ or `pending_db_*` SQL and confirm CodeRabbit's review applies the path-specific instructions. CodeRabbit also reports the loaded config path in its review summary.

## Known Issues and TODO List:
- [ ] None. To make CodeRabbit gate merges, set `request_changes_workflow: true`; for stricter feedback, set `profile: assertive`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project’s automated review configuration to improve review quality and consistency, including incremental draft behavior, tailored guidance for C/C++ and SQL changes, and clearer automated review summaries and status output.

* **Note**
  * This is an infrastructure update with no direct end-user impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->