### PR TITLE
chore(editorconfig): relax max_line_length

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ indent_size = 4
 tab_width = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
-max_line_length = 80
+max_line_length = 120
 
 [*.{json,ts,js,yml,sh}]
 charset = utf-8
@@ -14,4 +14,4 @@ indent_size = 2
 tab_width = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
-max_line_length = 80
+max_line_length = 120


### PR DESCRIPTION
Reasoning: currently the limit of 80 chars is not respected almost nowhere and the only ones who seem to pay attention to it are actually AI Agents.

This is resulting in very different generated code/comments when it comes from AI.

Relaxing it to 120 makes more sense and keeps it more consistent to what we already have almost everywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development editor configuration to increase the maximum line length allowance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->