### PR TITLE
chore(coderabbit-config): reduce review noise

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -6,12 +6,15 @@ language: en-US
 reviews:
   profile: chill
   request_changes_workflow: false
-  high_level_summary: true
+  high_level_summary: false
   poem: false
-  review_status: true
+  review_status: false
+  collapse_walkthrough: true
+  sequence_diagrams: false
   auto_review:
     enabled: true
-    auto_incremental_review: true
+    # Review on PR open only; don't re-post a walkthrough on every push.
+    auto_incremental_review: false
     drafts: false
 
   # Skip generated, vendored, and immutable content so reviews stay focused.


### PR DESCRIPTION
## Changes Proposed:

Tune the CodeRabbit config to cut the per-push noise. Reviewers have been getting a fresh walkthrough, summary, and status comment on every commit, which buries the actual review feedback.

- `auto_incremental_review: false` — review on PR open only, not on every push
- `review_status: false` — drop the in-progress status comments
- `high_level_summary: false` + `collapse_walkthrough: true` — keep the walkthrough available but folded by default instead of expanded on every PR
- `sequence_diagrams: false` — skip the generated diagrams

`poem: false` was already set, so the poem/ASCII art is unaffected here.

## Issues Addressed:

CodeRabbit posting repeated walkthroughs/summaries on every push.

## Tests Performed:

Config-only change, validated against the v2 schema referenced at the top of the file. No code paths affected.

## How to Test the Changes:

Open a PR and push a follow-up commit; CodeRabbit should not re-post a full walkthrough on the incremental push.