### PR TITLE
feat(Core/Item): Implement ITEM_FLAG2_EVERYONE_CAN_ROLL_NEED

### DIFF
--- a/src/server/game/Entities/Item/ItemTemplate.h
+++ b/src/server/game/Entities/Item/ItemTemplate.h
@@ -180,38 +180,38 @@ enum ItemFlags : uint32
 
 enum ItemFlags2 : uint32
 {
-    ITEM_FLAG2_FACTION_HORDE                            = 0x00000001,
-    ITEM_FLAG2_FACTION_ALLIANCE                         = 0x00000002,
+    ITEM_FLAG2_FACTION_HORDE                            = 0x00000001, // Only Horde can equip, loot, or buy back this item
+    ITEM_FLAG2_FACTION_ALLIANCE                         = 0x00000002, // Only Alliance can equip, loot, or buy back this item
     ITEM_FLAG2_DONT_IGNORE_BUY_PRICE                    = 0x00000004, // when item uses extended cost, gold is also required
-    ITEM_FLAG2_CLASSIFY_AS_CASTER                       = 0x00000008, // NYI
+    ITEM_FLAG2_CLASSIFY_AS_CASTER                       = 0x00000008, // unused
     ITEM_FLAG2_CLASSIFY_AS_PHYSICAL                     = 0x00000010, // NYI
-    ITEM_FLAG2_EVERYONE_CAN_ROLL_NEED                   = 0x00000020, // NYI
-    ITEM_FLAG2_NO_TRADE_BIND_ON_ACQUIRE                 = 0x00000040, // NYI
-    ITEM_FLAG2_CAN_TRADE_BIND_ON_ACQUIRE                = 0x00000080, // NYI
-    ITEM_FLAG2_CAN_ONLY_ROLL_GREED                      = 0x00000100,
+    ITEM_FLAG2_EVERYONE_CAN_ROLL_NEED                   = 0x00000020, // Anyone can roll need
+    ITEM_FLAG2_NO_TRADE_BIND_ON_ACQUIRE                 = 0x00000040, // NYI - unused
+    ITEM_FLAG2_CAN_TRADE_BIND_ON_ACQUIRE                = 0x00000080, // NYI - unused
+    ITEM_FLAG2_CAN_ONLY_ROLL_GREED                      = 0x00000100, // Need rolls disallowed, only Greed / Disenchant / Pass
     ITEM_FLAG2_CASTER_WEAPON                            = 0x00000200, // NYI
-    ITEM_FLAG2_DELETE_ON_LOGIN                          = 0x00000400, // NYI
-    ITEM_FLAG2_INTERNAL_ITEM                            = 0x00000800, // NYI
-    ITEM_FLAG2_NO_VENDOR_VALUE                          = 0x00001000, // NYI
+    ITEM_FLAG2_DELETE_ON_LOGIN                          = 0x00000400, // NYI - unused
+    ITEM_FLAG2_INTERNAL_ITEM                            = 0x00000800, // NYI - unused
+    ITEM_FLAG2_NO_VENDOR_VALUE                          = 0x00001000, // NYI - unused
     ITEM_FLAG2_SHOW_BEFORE_DISCOVERED                   = 0x00002000, // NYI
-    ITEM_FLAG2_OVERRIDE_GOLD_COST                       = 0x00004000, // NYI
+    ITEM_FLAG2_OVERRIDE_GOLD_COST                       = 0x00004000, // NYI - unused
     ITEM_FLAG2_IGNORE_DEFAULT_RATED_BG_RESTRICTIONS     = 0x00008000, // NYI
     ITEM_FLAG2_NOT_USABLE_IN_RATED_BG                   = 0x00010000, // NYI
     ITEM_FLAG2_BNET_ACCOUNT_TRADE_OK                    = 0x00020000, // NYI
-    ITEM_FLAG2_CONFIRM_BEFORE_USE                       = 0x00040000, // NYI
-    ITEM_FLAG2_REEVALUATE_BONDING_ON_TRANSFORM          = 0x00080000, // NYI
-    ITEM_FLAG2_NO_TRANSFORM_ON_CHARGE_DEPLETION         = 0x00100000, // NYI
+    ITEM_FLAG2_CONFIRM_BEFORE_USE                       = 0x00040000, // NYI - unused
+    ITEM_FLAG2_REEVALUATE_BONDING_ON_TRANSFORM          = 0x00080000, // NYI - unused
+    ITEM_FLAG2_NO_TRANSFORM_ON_CHARGE_DEPLETION         = 0x00100000, // NYI - unused
     ITEM_FLAG2_NO_ALTER_ITEM_VISUAL                     = 0x00200000, // NYI
     ITEM_FLAG2_NO_SOURCE_FOR_ITEM_VISUAL                = 0x00400000, // NYI
-    ITEM_FLAG2_IGNORE_QUALITY_FOR_ITEM_VISUAL_SOURCE    = 0x00800000, // NYI
-    ITEM_FLAG2_NO_DURABILITY                            = 0x01000000, // NYI
-    ITEM_FLAG2_ROLE_TANK                                = 0x02000000, // NYI
-    ITEM_FLAG2_ROLE_HEALER                              = 0x04000000, // NYI
-    ITEM_FLAG2_ROLE_DAMAGE                              = 0x08000000, // NYI
-    ITEM_FLAG2_CAN_DROP_IN_CHALLENGE_MODE               = 0x10000000, // NYI
-    ITEM_FLAG2_NEVER_STACK_IN_LOOT_UI                   = 0x20000000, // NYI
-    ITEM_FLAG2_DISENCHANT_TO_LOOT_TABLE                 = 0x40000000, // NYI
-    ITEM_FLAG2_USED_IN_A_TRADESKILL                     = 0x80000000 // NYI
+    ITEM_FLAG2_IGNORE_QUALITY_FOR_ITEM_VISUAL_SOURCE    = 0x00800000, // NYI - unused
+    ITEM_FLAG2_NO_DURABILITY                            = 0x01000000, // NYI - unused
+    ITEM_FLAG2_ROLE_TANK                                = 0x02000000, // NYI - unused
+    ITEM_FLAG2_ROLE_HEALER                              = 0x04000000, // NYI - unused
+    ITEM_FLAG2_ROLE_DAMAGE                              = 0x08000000, // NYI - unused
+    ITEM_FLAG2_CAN_DROP_IN_CHALLENGE_MODE               = 0x10000000, // NYI - unused
+    ITEM_FLAG2_NEVER_STACK_IN_LOOT_UI                   = 0x20000000, // NYI - unused
+    ITEM_FLAG2_DISENCHANT_TO_LOOT_TABLE                 = 0x40000000, // NYI - unused
+    ITEM_FLAG2_USED_IN_A_TRADESKILL                     = 0x80000000  // NYI - unused
 };
 
 enum ItemFlagsCustom : uint32

--- a/src/server/game/Entities/Item/ItemTemplate.h
+++ b/src/server/game/Entities/Item/ItemTemplate.h
@@ -183,7 +183,7 @@ enum ItemFlags2 : uint32
     ITEM_FLAG2_FACTION_HORDE                            = 0x00000001, // Only Horde can equip, loot, or buy back this item
     ITEM_FLAG2_FACTION_ALLIANCE                         = 0x00000002, // Only Alliance can equip, loot, or buy back this item
     ITEM_FLAG2_DONT_IGNORE_BUY_PRICE                    = 0x00000004, // when item uses extended cost, gold is also required
-    ITEM_FLAG2_CLASSIFY_AS_CASTER                       = 0x00000008, // unused
+    ITEM_FLAG2_CLASSIFY_AS_CASTER                       = 0x00000008, // NYI - unused
     ITEM_FLAG2_CLASSIFY_AS_PHYSICAL                     = 0x00000010, // NYI
     ITEM_FLAG2_EVERYONE_CAN_ROLL_NEED                   = 0x00000020, // Anyone can roll need
     ITEM_FLAG2_NO_TRADE_BIND_ON_ACQUIRE                 = 0x00000040, // NYI - unused

--- a/src/server/game/Entities/Player/PlayerStorage.cpp
+++ b/src/server/game/Entities/Player/PlayerStorage.cpp
@@ -2431,7 +2431,7 @@ InventoryResult Player::CanRollForItemInLFG(ItemTemplate const* proto, WorldObje
     }; //Copy from function Item::GetSkill()
 
     // Anyone can roll need on this item
-    if (proto && proto->HasFlag2(ITEM_FLAG2_EVERYONE_CAN_ROLL_NEED))
+    if (proto->HasFlag2(ITEM_FLAG2_EVERYONE_CAN_ROLL_NEED))
         return EQUIP_ERR_OK;
 
     if ((proto->AllowableClass & getClassMask()) == 0 || (proto->AllowableRace & getRaceMask()) == 0)

--- a/src/server/game/Entities/Player/PlayerStorage.cpp
+++ b/src/server/game/Entities/Player/PlayerStorage.cpp
@@ -2430,6 +2430,10 @@ InventoryResult Player::CanRollForItemInLFG(ItemTemplate const* proto, WorldObje
         SKILL_FISHING
     }; //Copy from function Item::GetSkill()
 
+    // Anyone can roll need on this item
+    if (proto && proto->HasFlag2(ITEM_FLAG2_EVERYONE_CAN_ROLL_NEED))
+        return EQUIP_ERR_OK;
+
     if ((proto->AllowableClass & getClassMask()) == 0 || (proto->AllowableRace & getRaceMask()) == 0)
         return EQUIP_ERR_YOU_CAN_NEVER_USE_THAT_ITEM;
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Implement ITEM_FLAG2_EVERYONE_CAN_ROLL_NEED and update the comment of the others

All flags with `// NYI - unused` are not used by any item in the database


<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
