### PR TITLE
fix(DB/Quest): To Dragon's Fall requires all three Wanted quests

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1781647521100364878.sql
+++ b/data/sql/updates/pending_db_world/rev_1781647521100364878.sql
@@ -1,0 +1,3 @@
+-- To Dragon's Fall - requires all three Wanted quests
+UPDATE `quest_template_addon` SET `PrevQuestID` = 12089 WHERE `ID` = 12095;
+UPDATE `quest_template_addon` SET `ExclusiveGroup` = -12089 WHERE `ID` IN (12089, 12090, 12091);


### PR DESCRIPTION
Quest To Dragon's Fall (12095) was available without completing
the prerequisite Wanted quests (12089, 12090, 12091).

Set exclusivegroup and prevquestid so all three Wanted quests
must be completed before To Dragon's Fall becomes available.

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Sonnet 4.6 - Max (Anthropic) was used to assist in preparing this pull request.

## Issues Addressed:
- Closes #26104

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  Wowhead (https://www.wowhead.com/wotlk/quest=12095/to-dragons-fall) and retail videos linked in the issue confirm all three Wanted quests must be completed first.
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Be Horde, `.levelup 79`
2. `.go c i 26618`
3. Verify To Dragon's Fall is NOT available without completing the Wanted quests
4. Complete all three Wanted quests:
   - Wanted: Magister Keldonus (12089) `.q a 12089` and `.q rew 12089` 
   - Wanted: Gigantaur (12090) `.q a 12090` and `.q rew 12090` 
   - Wanted: Dreadtalon (12091) `.q a 12091` and `.q rew 12091` 
6. Verify To Dragon's Fall becomes available only after completing all three