### PR TITLE
fix(Scripts/Ulduar): Razorscale rebuilds turrets in correct left-to-right order

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -819,6 +819,8 @@ struct npc_ulduar_expedition_engineer : public NullCreatureAI
 
                     std::list<Creature*> hfsList;
                     me->GetCreaturesWithEntryInRange(hfsList, 300.0f, NPC_HARPOON_FIRE_STATE);
+                    // Rebuild the turrets left-to-right (1 -> 4) instead of in grid/spawn order
+                    hfsList.sort([](Creature const* a, Creature const* b) { return a->GetPositionX() < b->GetPositionX(); });
                     for (Creature* fs : hfsList)
                         if (!fs->AI()->GetData(2))
                         {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

During the Razorscale encounter the Expedition Engineers decide which harpoon turret to repair by iterating the Harpoon Fire State NPCs (entry `33282`) in the order returned by `GetCreaturesWithEntryInRange`, which is grid/spawn (GUID) order. With the current spawn layout that order corresponds to turrets **1, 3, 2, 4** by X position, so the turrets are rebuilt in the wrong order (1, 3, 2, 4) instead of left-to-right **1, 2, 3, 4**.

The fix sorts the candidate list ascending by X coordinate before picking, so the lowest-numbered un-repaired turret is always chosen first. Idle engineers therefore converge on the leftmost remaining turret, rebuilding them in the correct `1 -> 2 -> 3 -> 4` order.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Claude Code (Claude Opus 4.8)** was used to investigate the issue and prepare the one-line fix; the change has been reviewed and is understood by the author.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9723
- Closes #26236

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Off-source video showing the correct `1, 2, 3, 4` rebuild order: https://youtu.be/HbYb8A31zq8?si=gqgVVuBuwFTfpc2L&t=2289

## Tests Performed:
- [x] This pull request requires further testing and may have edge cases to be tested.

The fix is a deterministic ordering change and does not alter repair speed, spawn logic, or chain mechanics.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Be level 80, set raid difficulty to 25-man.
2. `.go c i 33210` and start the encounter from that NPC.
3. Wait for the dwarves to build the turrets and observe that they are now rebuilt in left-to-right order (1, 2, 3, 4).

## Known Issues and TODO List:

- [ ] None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the order in which harpoon turrets are selected for repair in Ulduar, ensuring a consistent left-to-right sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->