### PR TITLE
fix(Scripts/Ulduar): Salvaged Chopper can grab pyrite during Flame Leviathan

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1781653877222108900.sql
+++ b/data/sql/updates/pending_db_world/rev_1781653877222108900.sql
@@ -1,0 +1,12 @@
+-- Ulduar: Flame Leviathan - give the Salvaged Chopper its "Grab Pyrite" hook ability (spell 67372 -> 67387).
+-- Mirrors the Salvaged Demolisher's "Grab Crate" (62479 -> 62482).
+
+-- Add "Grab Pyrite" (67372) to the Salvaged Chopper (33062) vehicle action bar.
+DELETE FROM `creature_template_spell` WHERE `CreatureID`=33062 AND `Index`=4;
+INSERT INTO `creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES
+(33062, 4, 67372, 0);
+
+-- Bind the chopper's "Grab Crate" (67387, triggered by 67372) to the existing grab-pyrite script.
+DELETE FROM `spell_script_names` WHERE `spell_id`=67387 AND `ScriptName`='spell_vehicle_grab_pyrite';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(67387, 'spell_vehicle_grab_pyrite');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -1445,22 +1445,39 @@ class spell_vehicle_grab_pyrite : public SpellScript
 
     void HandleScript(SpellEffIndex  /*effIndex*/)
     {
-        if (Unit* target = GetHitUnit())
-            if (Unit* seat = GetCaster()->GetVehicleBase())
+        Unit* target = GetHitUnit();
+        if (!target)
+            return;
+
+        // The grabbing vehicle: the demolisher's mechanic seat, or the chopper itself.
+        Unit* seat = GetCaster()->GetVehicleBase();
+        if (!seat)
+            return;
+
+        if (Vehicle* vehicle = seat->GetVehicleKit())
+            if (Unit* passenger = vehicle->GetPassenger(1))
             {
-                if (Vehicle* vehicle = seat->GetVehicleKit())
-                    if (Unit* pyrite = vehicle->GetPassenger(1))
-                        pyrite->ExitVehicle();
+                // On the chopper the rear seat may carry a player; never eject them to grab.
+                if (passenger->IsPlayer())
+                    return;
 
-                if (Unit* parent = seat->GetVehicleBase())
-                {
-                    GetCaster()->CastSpell(parent, SPELL_ADD_PYRITE, true);
-                    target->CastSpell(seat, GetEffectValue());
-
-                    if (target->IsCreature())
-                        target->ToCreature()->DespawnOrUnsummon(1300ms);
-                }
+                passenger->ExitVehicle();
             }
+
+        if (Unit* parent = seat->GetVehicleBase())
+        {
+            // Demolisher: the seat is mounted on a parent vehicle that the pyrite fuels.
+            GetCaster()->CastSpell(parent, SPELL_ADD_PYRITE, true);
+            target->CastSpell(seat, GetEffectValue());
+
+            if (target->IsCreature())
+                target->ToCreature()->DespawnOrUnsummon(1300ms);
+        }
+        else
+        {
+            // Chopper: load the crate into the rear seat so it can be ferried to other vehicles.
+            target->CastSpell(seat, GetEffectValue());
+        }
     }
 
     void Register() override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

The Salvaged Chopper in the Flame Leviathan encounter is missing its **Grab Pyrite** hook ability — players have no way to collect pyrite with the chopper.

In retail 3.3.5a the chopper's kit is **Sonic Horn / Tar / Speed Boost / Grab Pyrite / First Aid Kit**; AzerothCore only had the first three plus First Aid Kit, with no grab.

The grab mechanic itself was already implemented for the Salvaged Demolisher's mechanic seat: `Grab Crate` (62479) triggers `Grab Crate` (62482), which is bound to the `spell_vehicle_grab_pyrite` script. The chopper has a parallel spell chain that was never wired up: **`Grab Pyrite` (67372) → `Grab Crate` (67387)**.

This PR:
- Adds `Grab Pyrite` (67372) to the chopper's (`33062`) action bar.
- Binds the chopper's `Grab Crate` (67387) to the existing `spell_vehicle_grab_pyrite` script.
- Generalizes that script to also handle the chopper. The demolisher mounts the grabbing vehicle (mechanic seat) on a *parent* vehicle that the pyrite fuels; the chopper *is* the grabbing vehicle, so it has no parent. The script now:
  - never ejects a **player** sitting in the chopper's rear seat to grab (retail only allows the grab when the rear seat is empty);
  - for the demolisher, keeps the existing behavior exactly (add pyrite to the parent vehicle, then consume the crate);
  - for the chopper, loads the crate into the rear seat instead of consuming it.

### AI-assisted Pull Requests
- [x] AI tools were used. **Claude (Opus 4.8)** was used to research the mechanic and draft the change. I have reviewed and understand the changes.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9665

## SOURCE:
- [x] Video evidence, knowledge databases or other public sources (Wowhead, wikis).
  - [Warcraft Wiki – Flame Leviathan](https://warcraft.wiki.gg/wiki/Flame_Leviathan): chopper abilities are Sonic Horn, Tar, Speed Boost, **Grab Pyrite** (*"uses hook and chain to collect targeted pyrite crates"*), First Aid Kit.
  - [Wowhead – Grab Pyrite (67372)](https://www.wowhead.com/wotlk/spell=67372/grab-pyrite), which triggers [Grab Crate (67387)](https://www.wowhead.com/wotlk/spell=67387) — the chopper analog of the demolisher's 62479 → 62482.
  - Patch history: chopper Grab Pyrite is a post-launch addition to the original WotLK encounter (not in the 3.1.0 Ulduar launch build) and is part of the standard 3.3.5a state. Confirmed by the WotLK Classic Patch 3.4.1 dev notes (2022-12-08), which note *"Grab Pyrite may not be used on Salvaged Choppers in the encounter's pre-nerf state"* — i.e. it is enabled in the default (post-nerf) encounter that 3.3.5a represents.

## Tests Performed:
- [x] Builds / passes `codestyle-cpp.py` and `codestyle-sql.py`.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
1. Start the Flame Leviathan encounter and mount a Salvaged Chopper.
2. Confirm the **Grab Pyrite** button is now present on the chopper's action bar.
3. Target a pyrite crate within range and use Grab Pyrite; confirm the crate is grabbed into the chopper's rear seat (with the hook/chain visual).
4. Regression: on a Salvaged Demolisher's mechanic seat, confirm **Grab Crate** still works exactly as before (adds pyrite to the demolisher, crate is consumed).
5. Edge case: with a player riding the chopper's rear seat, confirm Grab Pyrite does not eject them.

## Known Issues and TODO List:
- [ ] The downstream "ferry pyrite to another vehicle" step needs in-game verification; this PR makes the chopper able to grab and carry the crate, matching the reported missing ability, but the full pyrite-transfer loop may warrant follow-up.
