### PR TITLE
fix(DB/Loot): Fel Creep requires Cenarion Beacon to drop from Felwood herbs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1781654104088564177.sql
+++ b/data/sql/updates/pending_db_world/rev_1781654104088564177.sql
@@ -1,21 +1,10 @@
 -- Fel Creep - requires Cenarion Beacon in inventory
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 4 AND `SourceEntry` = 11514;
-INSERT INTO `conditions`
-    (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`,
-    `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`,
-    `Comment`)
-VALUES
-(4, 13965, 11514, 2, 11511, 1,
-    'Sungrass - Fel Creep requires Cenarion Beacon'),
-(4, 13966, 11514, 2, 11511, 1,
-    'Gromsblood - Fel Creep requires Cenarion Beacon'),
-(4, 13967, 11514, 2, 11511, 1,
-    'Golden Sansam - Fel Creep requires Cenarion Beacon'),
-(4, 13968, 11514, 2, 11511, 1,
-    'Dreamfoil - Fel Creep requires Cenarion Beacon'),
-(4, 13969, 11514, 2, 11511, 1,
-    'Mountain Silversage - Fel Creep requires Cenarion Beacon'),
-(4, 13970, 11514, 2, 11511, 1,
-    'Arthas'' Tears - Fel Creep requires Cenarion Beacon'),
-(4, 13971, 11514, 2, 11511, 1,
-    'Plaguebloom - Fel Creep requires Cenarion Beacon');
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `Comment`) VALUES
+(4, 13965, 11514, 2, 11511, 1, 'Sungrass - Fel Creep requires Cenarion Beacon'),
+(4, 13966, 11514, 2, 11511, 1, 'Gromsblood - Fel Creep requires Cenarion Beacon'),
+(4, 13967, 11514, 2, 11511, 1, 'Golden Sansam - Fel Creep requires Cenarion Beacon'),
+(4, 13968, 11514, 2, 11511, 1, 'Dreamfoil - Fel Creep requires Cenarion Beacon'),
+(4, 13969, 11514, 2, 11511, 1, 'Mountain Silversage - Fel Creep requires Cenarion Beacon'),
+(4, 13970, 11514, 2, 11511, 1, 'Arthas\' Tears - Fel Creep requires Cenarion Beacon'),
+(4, 13971, 11514, 2, 11511, 1, 'Plaguebloom - Fel Creep requires Cenarion Beacon');

--- a/data/sql/updates/pending_db_world/rev_1781654104088564177.sql
+++ b/data/sql/updates/pending_db_world/rev_1781654104088564177.sql
@@ -1,0 +1,21 @@
+-- Fel Creep - requires Cenarion Beacon in inventory
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 4 AND `SourceEntry` = 11514;
+INSERT INTO `conditions`
+    (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`,
+    `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`,
+    `Comment`)
+VALUES
+(4, 13965, 11514, 2, 11511, 1,
+    'Sungrass - Fel Creep requires Cenarion Beacon'),
+(4, 13966, 11514, 2, 11511, 1,
+    'Gromsblood - Fel Creep requires Cenarion Beacon'),
+(4, 13967, 11514, 2, 11511, 1,
+    'Golden Sansam - Fel Creep requires Cenarion Beacon'),
+(4, 13968, 11514, 2, 11511, 1,
+    'Dreamfoil - Fel Creep requires Cenarion Beacon'),
+(4, 13969, 11514, 2, 11511, 1,
+    'Mountain Silversage - Fel Creep requires Cenarion Beacon'),
+(4, 13970, 11514, 2, 11511, 1,
+    'Arthas'' Tears - Fel Creep requires Cenarion Beacon'),
+(4, 13971, 11514, 2, 11511, 1,
+    'Plaguebloom - Fel Creep requires Cenarion Beacon');


### PR DESCRIPTION
Fel Creep (11514) was dropping from Felwood herb nodes without
the player having a Cenarion Beacon (11511) in their inventory.

Added loot conditions to all affected gameobject loot entries
so Fel Creep only drops when the player has the Cenarion Beacon.

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Sonnet 4.6 - Max (Anthropic) was used to assist in preparing this pull request.

## Issues Addressed:
- Closes #25734

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  Wowhead comment (https://www.wowhead.com/wotlk/item=11514/fel-creep#comments:id=8808:reply=3943) and item condition source (https://wowgaming.altervista.org/aowow/?item=11511#condition-for) confirm Cenarion Beacon is required.
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Create a character with Herbalism skill 300
2. `.tele felwood`
3. Gather Felwood herbs without Cenarion Beacon — verify Fel Creep does NOT drop
4. Obtain Cenarion Beacon (item 11511) and gather herbs again
5. Verify Fel Creep now drops correctly