### PR TITLE
fix(Scripts/Ulduar): correct Ignis Iron Construct Brittle shatter threshold

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1781737630533813500.sql
+++ b/data/sql/updates/pending_db_world/rev_1781737630533813500.sql
@@ -1,0 +1,8 @@
+--
+-- Ignis the Furnace Master: bind the Brittle aura proc script (spell_ignis_brittle_aura)
+-- to both raid difficulty variants so Iron Constructs shatter at the correct,
+-- tooltip-accurate damage threshold (62382 = 10m/5000, 67114 = 25m/3000).
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (62382, 67114);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(62382, 'spell_ignis_brittle_aura'),
+(67114, 'spell_ignis_brittle_aura');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
@@ -77,6 +77,16 @@ enum eEvents
     EVENT_GRAB,
 };
 
+enum IgnisActions
+{
+    ACTION_CONSTRUCT_SHATTERED = 0,
+};
+
+enum IgnisData
+{
+    DATA_SHATTERED = 0,
+};
+
 struct npc_ulduar_iron_construct : public ScriptedAI
 {
     npc_ulduar_iron_construct(Creature* pCreature) : ScriptedAI(pCreature)
@@ -127,19 +137,6 @@ struct npc_ulduar_iron_construct : public ScriptedAI
                     me->GetThreatMgr().ResetAllThreat();
                 }
             }
-        }
-    }
-
-    void DamageTaken(Unit* attacker, uint32& damage, DamageEffectType, SpellSchoolMask) override
-    {
-        if (damage >= RAID_MODE(3000U, 5000U) && me->GetAura(sSpellMgr->GetSpellIdForDifficulty(SPELL_BRITTLE, me)))
-        {
-            me->CastSpell(me, SPELL_SHATTER, true);
-            Unit::Kill(attacker, me);
-
-            if (InstanceScript* instance = me->GetInstanceScript())
-                if (Creature* ignis = instance->GetCreature(BOSS_IGNIS))
-                    ignis->AI()->SetData(1337, 0);
         }
     }
 
@@ -233,9 +230,9 @@ struct boss_ignis : public BossAI
         }
     }
 
-    void SetData(uint32 id, uint32  /*value*/) override
+    void DoAction(int32 action) override
     {
-        if (id == 1337)
+        if (action == ACTION_CONSTRUCT_SHATTERED)
         {
             if (lastShatterMSTime)
                 if (getMSTimeDiff(lastShatterMSTime, GameTime::GetGameTimeMS().count()) <= 5000)
@@ -247,7 +244,7 @@ struct boss_ignis : public BossAI
 
     uint32 GetData(uint32 id) const override
     {
-        if (id == 1337)
+        if (id == DATA_SHATTERED)
             return (bShattered ? 1 : 0);
         return 0;
     }
@@ -498,6 +495,42 @@ class spell_ignis_slag_pot_aura : public AuraScript
     }
 };
 
+// 62382, 67114 - Brittle
+class spell_ignis_brittle_aura : public AuraScript
+{
+    PrepareAuraScript(spell_ignis_brittle_aura);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_SHATTER });
+    }
+
+    bool CheckProc(ProcEventInfo& eventInfo)
+    {
+        DamageInfo* damageInfo = eventInfo.GetDamageInfo();
+        return damageInfo && damageInfo->GetDamage() >= (GetId() == SPELL_BRITTLE ? 5000u : 3000u);
+    }
+
+    void HandleProc(ProcEventInfo& eventInfo)
+    {
+        Unit* construct = GetTarget();
+        construct->CastSpell(construct, SPELL_SHATTER, true);
+
+        Unit* attacker = eventInfo.GetActor();
+        Unit::Kill(attacker ? attacker : construct, construct);
+
+        if (InstanceScript* instance = construct->GetInstanceScript())
+            if (Creature* ignis = instance->GetCreature(BOSS_IGNIS))
+                ignis->AI()->DoAction(ACTION_CONSTRUCT_SHATTERED);
+    }
+
+    void Register() override
+    {
+        DoCheckProc += AuraCheckProcFn(spell_ignis_brittle_aura::CheckProc);
+        OnProc += AuraProcFn(spell_ignis_brittle_aura::HandleProc);
+    }
+};
+
 class achievement_ignis_shattered : public AchievementCriteriaScript
 {
 public:
@@ -507,7 +540,7 @@ public:
     {
         if (!target || !target->IsCreature())
             return false;
-        return !!target->ToCreature()->AI()->GetData(1337);
+        return !!target->ToCreature()->AI()->GetData(DATA_SHATTERED);
     }
 };
 
@@ -518,5 +551,6 @@ void AddSC_boss_ignis()
     RegisterSpellScript(spell_ignis_scorch_aura);
     RegisterSpellScript(spell_ignis_grab_initial);
     RegisterSpellScript(spell_ignis_slag_pot_aura);
+    RegisterSpellScript(spell_ignis_brittle_aura);
     new achievement_ignis_shattered();
 }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Fixes the Iron Construct **Brittle** shatter threshold for Ignis the Furnace Master.

The shatter mechanic was handled in the construct's `DamageTaken` override using `RAID_MODE(3000U, 5000U)`, which **swaps the per-raid thresholds relative to the spell tooltips**. On 10-man the construct shattered at only 3000 damage even though Brittle (62382) reads *"Shatters if dealt 5000 damage or more in a single attack"*; on 25-man it required 5000 even though Brittle (67114) reads *"more than 3000 damage"*.

This PR:
- Ports the shatter logic into an `AuraScript` (`spell_ignis_brittle_aura`) on the Brittle aura, mirroring cMaNGOS's `IgnisBrittle`. The aura already carries DBC proc flags and a `MOD_STUN` trigger effect, so AzerothCore's `SpellMgr::LoadSpellProcs()` auto-generates the proc entry — only a `spell_script_names` binding is needed (no `spell_proc` row).
- Reads the threshold per difficulty straight from the tooltips: **62382 (10m) = 5000**, **67114 (25m) = 3000**.
- Removes the now-redundant construct `DamageTaken` override.
- Converts the shatter notification from `SetData(1337, …)` to a typed `DoAction(ACTION_CONSTRUCT_SHATTERED)`, and names the achievement query `GetData(DATA_SHATTERED)`.

> Note: both TrinityCore (`damage >= 5000`) and cMaNGOS (`procData.damage < 5000`) hardcode a flat 5000 for both raid sizes; this PR instead follows the in-game tooltips, which differ per difficulty (25m = 3000).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (Opus 4.8) was used to investigate the issue and prepare the changes. The author understands and can justify the changes.

## Issues Addressed:
- Closes #25340

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

- Brittle spell tooltips (62382 = 10m / 5000, 67114 = 25m / 3000), confirmed via the aowow spell dump in the issue.
- Cross-referenced against TrinityCore and cMaNGOS `boss_ignis` shatter handling.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds and passes the C++/SQL codestyle linters. In-game verification of the shatter proc on both raid sizes is still recommended.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Pull a molten Iron Construct into the water during the Ignis encounter so it gains Brittle.
2. On 10-man, hit it for 5000+ in a single attack — it should shatter (and not at 3000).
3. On 25-man, hit it for 3000+ in a single attack — it should shatter.

## Known Issues and TODO List:

- [ ] None
