### PR TITLE
fix(DB/Creature): Hodir Flash Freeze is no longer immune to Bleed

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1781744195259833100.sql
+++ b/data/sql/updates/pending_db_world/rev_1781744195259833100.sql
@@ -1,0 +1,4 @@
+--
+-- Hodir: Flash Freeze should not be Bleed-immune (let Warriors apply Rend).
+-- Move to preset -361 (identical to -369 but without the BLEED mechanic).
+UPDATE `creature_template` SET `CreatureImmunitiesId` = -361 WHERE `entry` IN (32926, 32938, 33352, 33353);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Hodir's Flash Freeze blocks (creature entries `32926`, `32938`, `33352`, `33353`) are currently immune to the **Bleed** mechanic, so Warriors cannot apply **Rend** (or any other bleed) to them.

These entries reference the shared immunity preset `-369` (mechanic mask `0x26CB7F7F`, which bundles `BLEED` together with the CC immunities). This PR repoints **only** the Flash Freeze entries to preset `-361`, which is identical to `-369` except the `BLEED` bit is cleared (mask `0x26CB3F7F`). The stored `MechanicsMask` differs by exactly the single BLEED bit; every other immunity (Charm, Fear, Root, Stun, knockback, etc.) is preserved.

Sindragosa's Ice Tomb creatures (`36980`/`38320`/`38321`/`38322`), which also use `-369`, are intentionally left untouched.

### AI-assisted Pull Requests

- [x] AI tools were used: **Claude Opus 4.8** (via Claude Code) assisted with locating the matching immunity preset and preparing the SQL. The change has been reviewed and is understood by the author.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9664

## SOURCE:
The changes have been validated through:
-  [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
-  [ ] Sniffs (remember to share them with the open source community!)
-  [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
-  [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

No hard sniff/source exists for this niche case (as noted in the linked issue). The rationale is design-based: there is no reason for Flash Freeze blocks to specifically resist Bleed, and the preset they used bundled `BLEED` in with the intended CC immunities. This PR removes only `BLEED` while leaving all crowd-control immunities intact.

## Tests Performed:
This PR has been:
-  [ ] Tested in-game by the author.
-  [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
-  [x] This pull request requires further testing and may have edge cases to be tested.

DB-only change; verified that preset `-361` is byte-for-byte identical to `-369` minus the BLEED mechanic, and that no other creatures share the Flash Freeze entries' new preset assignment. The Hodir script (`npc_ulduar_flash_freeze`) applies no additional mechanic immunity, so `creature_template` is the sole source.

## How to Test the Changes:

-  [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Enter Ulduar and pull/approach the Hodir encounter so Flash Freeze blocks spawn.
2. On a Warrior, target a Flash Freeze block and cast **Rend**.
3. Rend now applies its bleed and ticks damage on the block (previously it was rejected as "Immune").

## Known Issues and TODO List:

- [ ] None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
