### PR TITLE
fix(Scripts/Ulduar): Assembly of Iron no longer revives dead council members on a partial evade

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
@@ -135,6 +135,22 @@ static uint8 CountAliveBosses(InstanceScript* instance)
     return count;
 }
 
+// True while any council member other than `me` is still alive and engaged.
+// IsEngaged() (not IsInCombat()) survives Brundir's ~16s CombatStop during
+// Lightning Tendrils, so a lone survivor's reset cannot revive dead members.
+static bool IsAnyAssemblyMemberEngaged(InstanceScript* pInstance, Creature* me)
+{
+    if (!pInstance || !me)
+        return false;
+
+    for (uint8 i = 0; i < 3; ++i)
+        if (Creature* boss = pInstance->GetCreature(DATA_STEELBREAKER + i))
+            if (boss != me && boss->IsAlive() && boss->IsEngaged())
+                return true;
+
+    return false;
+}
+
 bool IsEncounterComplete(InstanceScript* pInstance, Creature* me)
 {
     if (!pInstance || !me)
@@ -186,12 +202,16 @@ struct boss_steelbreaker : public ScriptedAI
     void Reset() override
     {
         me->SetLootMode(0);
-        RespawnAssemblyOfIron(pInstance, me);
 
         _phase = 0;
         events.Reset();
-        if (pInstance)
-            pInstance->SetBossState(BOSS_ASSEMBLY, NOT_STARTED);
+
+        if (!IsAnyAssemblyMemberEngaged(pInstance, me))
+        {
+            RespawnAssemblyOfIron(pInstance, me);
+            if (pInstance)
+                pInstance->SetBossState(BOSS_ASSEMBLY, NOT_STARTED);
+        }
     }
 
     void JustReachedHome() override
@@ -376,14 +396,17 @@ struct boss_runemaster_molgeim : public ScriptedAI
     void Reset() override
     {
         me->SetLootMode(0);
-        RespawnAssemblyOfIron(pInstance, me);
 
         _phase = 0;
         events.Reset();
         summons.DespawnAll();
 
-        if (pInstance)
-            pInstance->SetBossState(BOSS_ASSEMBLY, NOT_STARTED);
+        if (!IsAnyAssemblyMemberEngaged(pInstance, me))
+        {
+            RespawnAssemblyOfIron(pInstance, me);
+            if (pInstance)
+                pInstance->SetBossState(BOSS_ASSEMBLY, NOT_STARTED);
+        }
 
         me->m_Events.AddEventAtOffset(new CastRunesEvent(*me), 8s);
     }
@@ -568,7 +591,6 @@ struct boss_stormcaller_brundir : public ScriptedAI
     {
         SetInvincibility(false);
         me->SetLootMode(0);
-        RespawnAssemblyOfIron(pInstance, me);
 
         _channelTimer = 0;
         _phase = 0;
@@ -580,8 +602,13 @@ struct boss_stormcaller_brundir : public ScriptedAI
         me->SetDisableGravity(false);
         me->SetRegeneratingHealth(true);
         me->SetReactState(REACT_AGGRESSIVE);
-        if (pInstance)
-            pInstance->SetBossState(BOSS_ASSEMBLY, NOT_STARTED);
+
+        if (!IsAnyAssemblyMemberEngaged(pInstance, me))
+        {
+            RespawnAssemblyOfIron(pInstance, me);
+            if (pInstance)
+                pInstance->SetBossState(BOSS_ASSEMBLY, NOT_STARTED);
+        }
     }
 
     void JustReachedHome() override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Fixes a regression in the Ulduar **Assembly of Iron** (Steel Council) encounter where an already-killed council member could respawn mid-attempt.

Each council member's `Reset()` unconditionally called `RespawnAssemblyOfIron()` (which revives every dead member) and reset `BOSS_ASSEMBLY` to `NOT_STARTED`. Since `Reset()` runs on every per-creature `EnterEvadeMode()`, a single *surviving* boss losing all valid targets (a combat desync) revived bosses the raid had already killed.

The fix guards `RespawnAssemblyOfIron()` + `SetBossState(NOT_STARTED)` behind a new helper so they run only when no *other* council member is still alive and engaged. On a real wipe, members disengage one by one and only the last one performs the full reset; a partial/false evade by one survivor no longer revives the dead.

The guard keys on `Creature::IsEngaged()` (the AI engagement flag) rather than `IsInCombat()`, because Brundir intentionally calls `CombatStop()` for ~16s during Lightning Tendrils while the fight is still active — `IsInCombat()` would be `false` in that window and could let the revive slip through, whereas the engagement flag survives the brief combat gap (`ScriptedAI::JustExitedCombat` is a no-op).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Tool used: Claude Code (Claude Opus 4.8).** The author reviewed and understands the change.

## Issues Addressed:
- Closes #25559

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

This is a logic/regression fix. The intended behavior — that already-killed Steel Council members stay dead and only revive on a full encounter reset after a wipe — is standard WotLK encounter behavior (the council progresses through Supercharge after each kill). See the linked issue for the control-flow analysis and likely regression commit (`d3f1be6d2`).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds cleanly (script-only change, no core/SQL edits) and passes `apps/codestyle/codestyle-cpp.py`.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Start Assembly of Iron. Kill one council member, leaving at least one other alive.
2. Before the encounter ends, make one surviving member lose all acceptable targets and evade while another surviving member is still engaged.
3. Verify the already-dead member does **not** respawn, and the encounter continues.
4. Wipe the raid fully and confirm the council still respawns and the encounter resets to `NOT_STARTED` (doors reopen) as before.

## Known Issues and TODO List:

- [ ] None.
