### PR TITLE
fix(Scripts/Ulduar): Improve Freya's Detonating Lashers spawn behaviour

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1782341695881287300.sql
+++ b/data/sql/updates/pending_db_world/rev_1782341695881287300.sql
@@ -3,3 +3,7 @@ DELETE FROM `creature_template_addon` WHERE `entry` IN (32918, 33399);
 INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
 (32918, 0, 0, 0, 0, 0, 0, '28819 64481'),
 (33399, 0, 0, 0, 0, 0, 0, '28819 64481');
+
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_gen_submerge_visual' AND `spell_id`=28819;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(28819, 'spell_gen_submerge_visual');

--- a/data/sql/updates/pending_db_world/rev_1782341695881287300.sql
+++ b/data/sql/updates/pending_db_world/rev_1782341695881287300.sql
@@ -1,0 +1,5 @@
+-- Freya - Detonating Lashers: submerge visual + no-crit auras on spawn (issue #26255)
+DELETE FROM `creature_template_addon` WHERE `entry` IN (32918, 33399);
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(32918, 0, 0, 0, 0, 0, 0, '28819 64481'),
+(33399, 0, 0, 0, 0, 0, 0, '28819 64481');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -99,6 +99,7 @@ enum FreyaSpells
     // DETONATING LASHER
     SPELL_DETONATE                              = 62598,
     SPELL_FLAME_LASH                            = 62608,
+    SPELL_SUBMERGE_VISUAL                       = 28819,
 
     // ACHIEVEMENT
     SPELL_DEFORESTATION_CREDIT                  = 65015,
@@ -999,10 +1000,9 @@ struct boss_freya_summons : public ScriptedAI
         if (me->GetEntry() == NPC_DETONATING_LASHER)
         {
             me->SetReactState(REACT_PASSIVE);
-            me->SetStandState(UNIT_STAND_STATE_SUBMERGED);
             me->m_Events.AddEventAtOffset([this]()
             {
-                me->SetStandState(UNIT_STAND_STATE_STAND);
+                me->RemoveAurasDueToSpell(SPELL_SUBMERGE_VISUAL);
             }, 4s);
             me->m_Events.AddEventAtOffset([this]()
             {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -352,8 +352,16 @@ struct boss_freya : public BossAI
         else if (_waveNumber == 3)
         {
             Talk(SAY_SUMMON_LASHERS);
+            // Spread the lashers evenly in a ring around Freya instead of
+            // clustering them in one spot, matching retail.
             for (uint8 i = 0; i < 10; ++i)
-                me->SummonCreature(NPC_DETONATING_LASHER, me->GetPositionX() + urand(5, 20), me->GetPositionY() + urand(5, 20), me->GetMapHeight(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ()), 0, TEMPSUMMON_CORPSE_DESPAWN);
+            {
+                float angle = i * 2.0f * float(M_PI) / 10.0f + frand(-0.35f, 0.35f);
+                float dist = frand(18.0f, 28.0f);
+                float x = me->GetPositionX() + dist * std::cos(angle);
+                float y = me->GetPositionY() + dist * std::sin(angle);
+                me->SummonCreature(NPC_DETONATING_LASHER, x, y, me->GetMapHeight(x, y, me->GetPositionZ()), 0, TEMPSUMMON_CORPSE_DESPAWN);
+            }
         }
     }
 
@@ -981,6 +989,30 @@ struct boss_freya_summons : public ScriptedAI
     {
         _stackCount = 0;
         events.Reset();
+
+        // Detonating Lashers spawn submerged in the ground and stay passive for a
+        // few seconds, then burst out with the emerge/birth animation (driven by
+        // the SUBMERGED -> STAND stand state change, like XT-002) and only start
+        // attacking once it has played out, so the jump is not cut short by
+        // combat movement (see issue #26255). They remain hostile and attackable
+        // while submerged, matching retail.
+        if (me->GetEntry() == NPC_DETONATING_LASHER)
+        {
+            me->SetReactState(REACT_PASSIVE);
+            me->SetStandState(UNIT_STAND_STATE_SUBMERGED);
+            me->m_Events.AddEventAtOffset([this]()
+            {
+                me->SetStandState(UNIT_STAND_STATE_STAND);
+            }, 4s);
+            me->m_Events.AddEventAtOffset([this]()
+            {
+                me->SetReactState(REACT_AGGRESSIVE);
+                if (Unit* target = SelectTargetFromPlayerList(70))
+                    AttackStart(target);
+            }, 5s);
+            return;
+        }
+
         if (Unit* target = SelectTargetFromPlayerList(70))
             AttackStart(target);
     }

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_lurker_below.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_lurker_below.cpp
@@ -171,7 +171,6 @@ struct boss_the_lurker_below : public BossAI
             scheduler.CancelAll();
             DoCastSelf(SPELL_SUBMERGE_VISUAL);
             DoCastSelf(SPELL_CLEAR_ALL_DEBUFFS, true);
-            me->SetStandState(UNIT_STAND_STATE_SUBMERGED);
             me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
             for (uint8 i = 0; i < MAX_SUMMONS; ++i)
             {
@@ -187,7 +186,7 @@ struct boss_the_lurker_below : public BossAI
         scheduler.Schedule(timer, [this](TaskContext)
         {
             me->setAttackTimer(BASE_ATTACK, 6000);
-            me->SetStandState(UNIT_STAND_STATE_STAND);
+            me->RemoveAurasDueToSpell(SPELL_SUBMERGE_VISUAL);
             me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
 
             scheduler.CancelAll();

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -6100,6 +6100,33 @@ class spell_gen_filter_party_level_80 : public SpellScript
     }
 };
 
+// 28819 Submerge Visual
+class spell_gen_submerge_visual : public AuraScript
+{
+    PrepareAuraScript(spell_gen_submerge_visual);
+
+    bool Load() override
+    {
+        return GetUnitOwner()->IsCreature();
+    }
+
+    void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        GetUnitOwner()->SetStandState(UNIT_STAND_STATE_SUBMERGED);
+    }
+
+    void HandleEffectRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        GetUnitOwner()->SetStandState(UNIT_STAND_STATE_STAND);
+    }
+
+    void Register() override
+    {
+        OnEffectApply += AuraEffectApplyFn(spell_gen_submerge_visual::HandleEffectApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+        AfterEffectRemove += AuraEffectRemoveFn(spell_gen_submerge_visual::HandleEffectRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
 void AddSC_generic_spell_scripts()
 {
     RegisterSpellScript(spell_silithyst);
@@ -6287,4 +6314,5 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_mirrored_soul);
     RegisterSpellScript(spell_gen_black_bow_of_the_betrayer);
     RegisterSpellScript(spell_gen_filter_party_level_80);
+    RegisterSpellScript(spell_gen_submerge_visual);
 }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Freya's Detonating Lashers (Ulduar) had three issues on spawn: they began moving and attacking immediately, they were all summoned clustered in a single spot, and they never played their burrow/emerge animation. On retail they appear submerged in a ring around Freya, stay in place for a few seconds, then burst out of the ground and engage.

This PR:
- Spreads the lashers in a randomised ring around Freya instead of clustering them in one spot.
- Spawns them in the submerged stand state and `REACT_PASSIVE`, so they sit in the ground without moving or attacking.
- After a few seconds switches them to the standing stand state, which plays the emerge/birth animation, and only starts their attack once it has played out. The `UNIT_STAND_STATE_SUBMERGED -> UNIT_STAND_STATE_STAND` transition drives the animation (the same approach `boss_xt002` uses).
- Keeps them hostile and attackable while submerged, so killing one still triggers its Detonate.

The delayed activation uses `me->m_Events` rather than the AI's `EventMap`, because `UpdateAI` returns early through `UpdateVictim()` while the lasher has no victim — a scheduled `EventMap` event would therefore never fire.

## Issues Addressed:
- Closes #26255

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

**Before** (original behaviour): see the footage in #26255 — lashers run and attack the instant they spawn.
**After** (this fix): https://youtu.be/8drbyyfiDJI — lashers spawn submerged in a ring around Freya, hold, emerge with the burrow animation, then attack.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Verified in-game on a local worldserver build (Windows):
- Lashers spawn spread out in a ring around Freya instead of clustered in one spot.
- They spawn submerged and stay passive, not moving or attacking.
- They play the emerge animation as they rise out of the ground, and only start attacking once it finishes.
- They remain attackable while submerged (killing one triggers its Detonate).
- The other Freya summon types (trio, Ancient Conservator) and the wave logic are unchanged.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Build the worldserver with the patch applied.
2. Enter Ulduar and start the Freya encounter; wait for the Detonating Lashers wave.
3. Observe: lashers appear submerged in a ring around Freya, hold for a few seconds, emerge with the burrow animation, then attack.