### PR TITLE
fix(Scripts/Naxxramas): Reset "And They Would All Go Down Together" timer on wipe

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/instance_naxxramas.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/instance_naxxramas.cpp
@@ -595,6 +595,7 @@ public:
                     case NOT_STARTED:
                     {
                         _horsemanAchievement = true;
+                        _events.CancelEvent(EVENT_AND_THEY_WOULD_ALL_GO_DOWN_TOGETHER);
 
                         if (!horsemanKilled)
                             break;


### PR DESCRIPTION
If the raid wiped while the 15 second achievement timer was still
ticking after a horseman's death, the next attempt could not earn
"And They Would All Go Down Together" even if all four bosses were
killed within 15 seconds, because the stale event from the previous
attempt would fire mid-fight and reset the achievement flag.

Added _events.CancelEvent for EVENT_AND_THEY_WOULD_ALL_GO_DOWN_TOGETHER
when the encounter resets to NOT_STARTED, so a wipe properly clears
the leftover timer.

Test video: https://youtu.be/yADjQhrGSiI

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Sonnet 4.6 - Max (Anthropic) was used to assist in preparing this pull request.

## Issues Addressed:
- Closes #26067

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
  Reproduced the exact scenario described in the issue (kill one horseman, wipe within 15s, restart, kill all four within 15s) and confirmed the achievement was not awarded before this fix, and is awarded correctly after it.
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Engage the Four Horsemen fight
2. Kill one of the horsemen
3. Wipe within 15 seconds of that horseman's death
4. Revive/release and re-engage the fight
5. Kill all 4 horsemen within 15 seconds of each other
6. Verify the achievement is awarded