### PR TITLE
fix(DB/SAI): Hyldsmeet Warbears now fight each other automatically

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1781798291298064049.sql
+++ b/data/sql/updates/pending_db_world/rev_1781798291298064049.sql
@@ -1,0 +1,3 @@
+-- Hyldsmeet Warbear
+UPDATE `smart_scripts` SET `action_param1` = 2, `comment` = "Hyldsmeet Warbear - On Reset - Set Reactstate Aggressive"
+WHERE (`entryorguid` = 30174 AND `id` = 3 AND `source_type` = 0);


### PR DESCRIPTION
Hyldsmeet Warbear (entry 30174) had its react state set to
Defensive on reset, so it never initiated combat on its own and
only reacted when attacked, leaving the NPCs passive in the pit.

Changed the react state to Aggressive so the Warbears actively
engage their enemies without requiring outside provocation first.

Note: smart_scripts id 3 for entry 30174 ("On Reset") is the row
this PR modifies. I could not find documentation for this specific
action/comment combination, and it shows as an unknown/undocumented
entry on https://aowow.trinitycore.info/8?npc=30174 as well. The fix
itself has been tested in-game and works correctly without affecting
player interaction with the NPCs. Also the current fixed behaviour is confirmed
by the reference issue's [video from 2016](https://www.youtube.com/watch?v=iUoIA6FlmKo).

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
 
Claude Sonnet 4.6 - Max (Anthropic) was used to assist in preparing this pull request.

## Issues Addressed:
- Closes #25944

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
  Reproduced the reported behavior (Warbears passive until provoked) before the fix, and confirmed they now engage each other automatically after the change, matching the reference videos linked in the issue.
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. `.go creature id 30174`
2. Observe the Hyldsmeet Warbears in Brunnhildar Village
3. Verify they now start fighting each other without being attacked first
4. Verify players are still treated as friendly and are not attacked