### PR TITLE
chore(Agents): Update max line length from 80 to 120 characters

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -26,7 +26,7 @@ reviews:
     - path: "**/*.{cpp,h,hpp}"
       instructions: |
         AzerothCore C++ conventions (CI enforces these with -Werror; flag violations):
-        - C++20. 4-space indent, tabs forbidden. UTF-8, LF, max 80 columns, trailing newline.
+        - C++20. 4-space indent, tabs forbidden. UTF-8, LF, max 120 columns, trailing newline.
         - Allman braces. No braces around single-line statements. `if (x)`, never `if(x)` or `if ( x )`.
         - `auto const&` (not `const auto&`); `Type const*` (not `const Type*`).
         - Use fmt-style `{}` format specifiers, never printf-style `%u`/`%s`.

--- a/.github/agents/pr-reviewer.md
+++ b/.github/agents/pr-reviewer.md
@@ -24,7 +24,7 @@ Based on CLAUDE.md, always verify:
 - 4-space indentation for C++ (no tabs)
 - 2-space indentation for JSON, YAML, shell scripts
 - UTF-8 encoding, LF line endings
-- Max 80 character line length
+- Max 120 character line length
 - No braces around single-line statements
 - Format variables in output using {} placeholders instead of printf-style format specifiers like %u
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ python apps/codestyle/codestyle-sql.py     # SQL (compares to origin/master)
 
 Hard rules (also enforced by CI with `-Werror`):
 
-- 4-space indent for C++ (tabs forbidden); 2-space for JSON/YAML/sh/ts/js. UTF-8, LF, max 80 cols, trailing newline.
+- 4-space indent for C++ (tabs forbidden); 2-space for JSON/YAML/sh/ts/js. UTF-8, LF, max 120 cols, trailing newline.
 - Allman braces. No braces around single-line statements. `if (x)` — never `if(x)` or `if ( x )`.
 - `auto const&` (not `const auto&`); `Type const*` (not `const Type*`).
 - Use `{}` format specifiers (`fmt`-style), not `%u`/`%s`.


### PR DESCRIPTION
The pr-reviewer agent, Claude.md and CodeRabbit still documented "Max 80 character line length" as the official code style requirement after #26233 was merged. This created inconsistency where EditorConfig-aware tools enforced 120 characters while the agents continued to enforce 80, resulting in very different generated code/comments when coming from AI reviews. Updated the agents to reflect the new 120-character limit, keeping it consistent with what is already being used.

## References:
- #26233