### PR TITLE
fix(Scripts/Ulduar): Yogg-Saron Constrictor Tentacles grab players

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1781961132247079100.sql
+++ b/data/sql/updates/pending_db_world/rev_1781961132247079100.sql
@@ -1,0 +1,3 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` = 64132;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (64132, 'spell_yogg_saron_constrictor_tentacle_aura');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -1571,11 +1571,9 @@ struct boss_yoggsaron_constrictor_tentacle : public ScriptedAI
     boss_yoggsaron_constrictor_tentacle(Creature* creature) : ScriptedAI(creature)
     {
         me->SetCombatMovement(false);
-        _checkTimer = 1;
         _playerGUID.Clear();
     }
 
-    uint32 _checkTimer;
     ObjectGuid _playerGUID;
 
     void GrabPlayer(Unit* target)
@@ -1583,7 +1581,6 @@ struct boss_yoggsaron_constrictor_tentacle : public ScriptedAI
         target->CastSpell(me, SPELL_LUNGE, true);
         target->CastSpell(target, SPELL_SQUEEZE, true);
         _playerGUID = target->GetGUID();
-        _checkTimer = 0;
     }
 
     void IsSummonedBy(WorldObject* summoner) override
@@ -1593,13 +1590,21 @@ struct boss_yoggsaron_constrictor_tentacle : public ScriptedAI
         me->HandleEmoteCommand(EMOTE_ONESHOT_EMERGE);
         me->SetInCombatWithZone();
 
-        // The summoner is the marked player (64133 is self-cast), so grab them at
-        // once instead of waiting for the periodic scan to pick a nearby player.
+        // The summoner is the marked player (64133 is self-cast); grab them
+        // directly, falling back to the nearest valid player only if that one
+        // can no longer be squeezed.
+        Unit* target = nullptr;
         if (Player* player = summoner ? summoner->ToPlayer() : nullptr)
             if (player->IsAlive() && !player->IsGameMaster()
                 && !player->HasAura(sSpellMgr->GetSpellIdForDifficulty(SPELL_SQUEEZE, me))
                 && !player->HasAura(SPELL_INSANE1))
-                GrabPlayer(player);
+                target = player;
+
+        if (!target)
+            target = SelectConstrictTarget();
+
+        if (target)
+            GrabPlayer(target);
 
         // Summoned from a player, so register with Sara to keep the encounter's
         // despawn handling working.
@@ -1628,24 +1633,6 @@ struct boss_yoggsaron_constrictor_tentacle : public ScriptedAI
         }
 
         return target;
-    }
-
-    void UpdateAI(uint32 diff) override
-    {
-        if (_checkTimer)
-        {
-            _checkTimer += diff;
-            if (_checkTimer >= 1000 && !me->HasUnitState(UNIT_STATE_STUNNED))
-            {
-                if (Unit* target = SelectConstrictTarget())
-                {
-                    GrabPlayer(target);
-                    return;
-                }
-
-                _checkTimer = 1;
-            }
-        }
     }
 
     void DoAction(int32 param) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -102,6 +102,8 @@ enum YoggSpells
     SPELL_FOCUSED_ANGER                 = 57688,
 
     // CONSTRICTOR TENTACLE
+    SPELL_CONSTRICTOR_TENTACLE          = 64132,
+    SPELL_CONSTRICTOR_TENTACLE_SUMMON   = 64133,
     SPELL_LUNGE                         = 64123,
     SPELL_SQUEEZE                       = 64125,
 
@@ -853,7 +855,7 @@ struct boss_yoggsaron_sara : public ScriptedAI
                 events.Repeat(Milliseconds(uint32((50000 + urand(0, 10000)) * _summonSpeed)));
                 break;
             case EVENT_SARA_P2_SUMMON_T2: // CONSTRICTOR
-                SpawnTentacle(NPC_CONSTRICTOR_TENTACLE);
+                me->CastCustomSpell(SPELL_CONSTRICTOR_TENTACLE, SPELLVALUE_MAX_TARGETS, 1, me, false);
                 events.Repeat(Milliseconds(uint32((15000 + urand(0, 5000))* _summonSpeed)));
                 break;
             case EVENT_SARA_P2_SUMMON_T3: // CORRUPTOR
@@ -886,7 +888,7 @@ struct boss_yoggsaron_sara : public ScriptedAI
                 me->SetPosition(me->GetPositionX(), me->GetPositionY(), 355, me->GetOrientation());
 
                 SpawnTentacle(NPC_CRUSHER_TENTACLE);
-                SpawnTentacle(NPC_CONSTRICTOR_TENTACLE);
+                me->CastCustomSpell(SPELL_CONSTRICTOR_TENTACLE, SPELLVALUE_MAX_TARGETS, 1, me, false);
                 SpawnTentacle(NPC_CORRUPTOR_TENTACLE);
                 SpawnTentacle(NPC_CORRUPTOR_TENTACLE);
 
@@ -1576,6 +1578,20 @@ struct boss_yoggsaron_constrictor_tentacle : public ScriptedAI
     uint32 _checkTimer;
     ObjectGuid _playerGUID;
 
+    void IsSummonedBy(WorldObject* /*summoner*/) override
+    {
+        me->CastSpell(me, SPELL_TENTACLE_ERUPT, true);
+        me->CastSpell(me, SPELL_VOID_ZONE_SMALL, true);
+        me->HandleEmoteCommand(EMOTE_ONESHOT_EMERGE);
+        me->SetInCombatWithZone();
+
+        // Summoned from a player (Constrictor Tentacle 64133), so register with
+        // Sara to keep the encounter's despawn handling working.
+        if (InstanceScript* instance = me->GetInstanceScript())
+            if (Creature* sara = instance->GetCreature(DATA_SARA))
+                sara->AI()->JustSummoned(me);
+    }
+
     Unit* SelectConstrictTarget()
     {
         Player* target = nullptr;
@@ -1629,6 +1645,8 @@ struct boss_yoggsaron_constrictor_tentacle : public ScriptedAI
     {
         if (Unit* player = ObjectAccessor::GetUnit(*me, _playerGUID))
             player->RemoveAura(sSpellMgr->GetSpellIdForDifficulty(SPELL_SQUEEZE, me));
+
+        me->DespawnOrUnsummon(5s);
     }
 };
 
@@ -2677,6 +2695,28 @@ class spell_yogg_saron_target_selectors : public SpellScript
     }
 };
 
+// 64132 - Constrictor Tentacle
+class spell_yogg_saron_constrictor_tentacle_aura : public AuraScript
+{
+    PrepareAuraScript(spell_yogg_saron_constrictor_tentacle_aura);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_CONSTRICTOR_TENTACLE_SUMMON });
+    }
+
+    void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        // Spawns the tentacle on the marked player so it grabs them on the spot.
+        GetTarget()->CastSpell(GetTarget(), SPELL_CONSTRICTOR_TENTACLE_SUMMON, true);
+    }
+
+    void Register() override
+    {
+        AfterEffectApply += AuraEffectApplyFn(spell_yogg_saron_constrictor_tentacle_aura::OnApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
 // 63305 - Grim Reprisal
 class spell_yogg_saron_grim_reprisal_aura : public AuraScript
 {
@@ -2807,6 +2847,7 @@ void AddSC_boss_yoggsaron()
     RegisterSpellScript(spell_yogg_saron_empowering_shadows);
     RegisterSpellScript(spell_yogg_saron_in_the_maws_of_the_old_god);
     RegisterSpellScript(spell_yogg_saron_target_selectors);
+    RegisterSpellScript(spell_yogg_saron_constrictor_tentacle_aura);
     RegisterSpellScript(spell_yogg_saron_grim_reprisal_aura);
 
     // ACHIEVEMENTS

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -1578,15 +1578,31 @@ struct boss_yoggsaron_constrictor_tentacle : public ScriptedAI
     uint32 _checkTimer;
     ObjectGuid _playerGUID;
 
-    void IsSummonedBy(WorldObject* /*summoner*/) override
+    void GrabPlayer(Unit* target)
+    {
+        target->CastSpell(me, SPELL_LUNGE, true);
+        target->CastSpell(target, SPELL_SQUEEZE, true);
+        _playerGUID = target->GetGUID();
+        _checkTimer = 0;
+    }
+
+    void IsSummonedBy(WorldObject* summoner) override
     {
         me->CastSpell(me, SPELL_TENTACLE_ERUPT, true);
         me->CastSpell(me, SPELL_VOID_ZONE_SMALL, true);
         me->HandleEmoteCommand(EMOTE_ONESHOT_EMERGE);
         me->SetInCombatWithZone();
 
-        // Summoned from a player (Constrictor Tentacle 64133), so register with
-        // Sara to keep the encounter's despawn handling working.
+        // The summoner is the marked player (64133 is self-cast), so grab them at
+        // once instead of waiting for the periodic scan to pick a nearby player.
+        if (Player* player = summoner ? summoner->ToPlayer() : nullptr)
+            if (player->IsAlive() && !player->IsGameMaster()
+                && !player->HasAura(sSpellMgr->GetSpellIdForDifficulty(SPELL_SQUEEZE, me))
+                && !player->HasAura(SPELL_INSANE1))
+                GrabPlayer(player);
+
+        // Summoned from a player, so register with Sara to keep the encounter's
+        // despawn handling working.
         if (InstanceScript* instance = me->GetInstanceScript())
             if (Creature* sara = instance->GetCreature(DATA_SARA))
                 sara->AI()->JustSummoned(me);
@@ -1623,10 +1639,7 @@ struct boss_yoggsaron_constrictor_tentacle : public ScriptedAI
             {
                 if (Unit* target = SelectConstrictTarget())
                 {
-                    target->CastSpell(me, SPELL_LUNGE, true);
-                    target->CastSpell(target, SPELL_SQUEEZE, true);
-                    _playerGUID = target->GetGUID();
-                    _checkTimer = 0;
+                    GrabPlayer(target);
                     return;
                 }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -1590,14 +1590,12 @@ struct boss_yoggsaron_constrictor_tentacle : public ScriptedAI
         me->HandleEmoteCommand(EMOTE_ONESHOT_EMERGE);
         me->SetInCombatWithZone();
 
-        // The summoner is the marked player (64133 is self-cast); grab them
-        // directly, falling back to the nearest valid player only if that one
-        // can no longer be squeezed.
+        // The summoner is the marked player (64133 is self-cast); 64132 already
+        // picked a valid enemy, so only re-check that they can still be squeezed.
+        // Fall back to the nearest valid player otherwise.
         Unit* target = nullptr;
         if (Player* player = summoner ? summoner->ToPlayer() : nullptr)
-            if (player->IsAlive() && !player->IsGameMaster()
-                && !player->HasAura(sSpellMgr->GetSpellIdForDifficulty(SPELL_SQUEEZE, me))
-                && !player->HasAura(SPELL_INSANE1))
+            if (player->IsAlive() && !player->HasAura(sSpellMgr->GetSpellIdForDifficulty(SPELL_SQUEEZE, me)))
                 target = player;
 
         if (!target)


### PR DESCRIPTION
## Changes Proposed:

During Phase 2, Constrictor Tentacles used to spawn at a random spot near the room edge and only grabbed a player who happened to wander within 10 yards, so most of them just sat idle. They now spawn directly on a random player (via Constrictor Tentacle `64132` -> `64133`) and immediately Lunge/Squeeze that player, matching the intended encounter mechanic.

This PR proposes changes to:
-  [x] Scripts (bosses, spell scripts, creature scripts).

### AI-assisted Pull Requests

- [x] AI tools were used. Claude (Opus 4.8) assisted with the investigation and porting. The author understands the change and can justify it.

## Issues Addressed:
- Closes #26283

## SOURCE:
The changes have been validated through:
- [x] The changes promoted by this pull request come from another project (cherry-pick). Ported from TrinityCore's Yogg-Saron implementation (the `64132` dummy aura that summons the tentacle on the marked player via `64133`). Committed with the proper `--author` tag crediting the original author (horn), with ariel- co-credited for the related Squeeze/Lunge fix the grab relies on.

AzerothCore already had the back half of the mechanic working (the Constrictor `33983` is a vehicle, `64123` performs the board and `64125`/`64126` the Squeeze) once a player was in range; only the spawn-on-player part was missing, which is what this adds.

## Tests Performed:
This PR has been:
- [x] This pull request requires further testing and may have edge cases to be tested.

Not yet tested in-game by the author (script-only change, builds clean against the surrounding code and passes the C++ codestyle check). Verification on a running server is welcome.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Progress the Yogg-Saron encounter to Phase 2.
2. Observe that Constrictor Tentacles now spawn directly on a random player and begin Squeezing immediately, instead of appearing at random spots and waiting to be approached.
3. Kill a Constrictor Tentacle and confirm it releases the player (Squeeze removed) and the corpse despawns; confirm leftover tentacles are cleaned up on wipe and on boss death.

## Known Issues and TODO List:

- [ ] In-game verification on a live/test server.
