### PR TITLE
fix(DB): free Enslaved Druids of the Talon after Ursal the Mauler dies

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1781977612345678900.sql
+++ b/data/sql/updates/pending_db_world/rev_1781977612345678900.sql
@@ -1,0 +1,45 @@
+-- Quest 486 "Ursal the Mauler" (Teldrassil): the four Enslaved Druids of the Talon
+-- (entry 2852, guids 46212-46215) never reacted to Ursal's (2039) death. They should
+-- wake from their forced sleep, morph into Freed Druids of the Talon (2853), and flee
+-- along a short path before despawning; one of them announces the group is free.
+--
+-- Implemented via SmartAI: Ursal on death sets data 2/2 on the nearby druids. Following
+-- the cMaNGOS reference (the more polished of the two engines), all four wake together,
+-- then transform and peel off in a timed cascade rather than snapping away in unison:
+-- the speaker (guid 46215) says the line at 2s and morphs at 3s, two druids follow at 4s
+-- and the last at 5s. Flee path coordinates / morph target / broadcast line are identical
+-- across cMaNGOS and TrinityCore. AC remaps the waypoint action/event (232 / 108) and
+-- uses the `waypoints` table for the flee path.
+
+-- Flee path shared by all freed druids.
+DELETE FROM `waypoints` WHERE `entry` = 22817;
+INSERT INTO `waypoints` (`entry`, `pointid`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `point_comment`) VALUES
+(22817, 1, 9091.11, 1857.64, 1333.71, 0, 0, 'Freed Druid of the Talon - Flee'),
+(22817, 2, 9079.52, 1872.34, 1334.99, 0, 0, 'Freed Druid of the Talon - Flee'),
+(22817, 3, 9024.94, 1885.46, 1334.40, 0, 0, 'Freed Druid of the Talon - Flee');
+
+-- Enable SmartAI on the Enslaved Druid of the Talon.
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 2852;
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` IN (2039, -46212, -46213, -46214, -46215)) OR (`source_type` = 9 AND `entryorguid` IN (285200, 285201, 285202));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2039, 0, 0, 0, 0, 0, 80, 0, 2000, 2000, 4000, 4000, 0, 0, 11, 15793, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ursal the Mauler - In Combat - Cast \'Maul\''),
+(2039, 0, 1, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 45, 2, 2, 0, 0, 0, 0, 11, 2852, 100, 1, 0, 0, 0, 0, 0, 'Ursal the Mauler - On Just Died - Set Data 2 2 (Enslaved Druids of the Talon)'),
+(-46212, 0, 0, 0, 38, 0, 100, 0, 2, 2, 0, 0, 0, 0, 80, 285200, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - On Data Set 2 2 - Run Script (free + flee, 4s)'),
+(-46212, 0, 1, 0, 108, 0, 100, 0, 3, 22817, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - On Waypoint 3 Reached - Despawn Instant'),
+(-46213, 0, 0, 0, 38, 0, 100, 0, 2, 2, 0, 0, 0, 0, 80, 285200, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - On Data Set 2 2 - Run Script (free + flee, 4s)'),
+(-46213, 0, 1, 0, 108, 0, 100, 0, 3, 22817, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - On Waypoint 3 Reached - Despawn Instant'),
+(-46214, 0, 0, 0, 38, 0, 100, 0, 2, 2, 0, 0, 0, 0, 80, 285201, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - On Data Set 2 2 - Run Script (free + flee, 5s)'),
+(-46214, 0, 1, 0, 108, 0, 100, 0, 3, 22817, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - On Waypoint 3 Reached - Despawn Instant'),
+(-46215, 0, 0, 0, 38, 0, 100, 0, 2, 2, 0, 0, 0, 0, 80, 285202, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - On Data Set 2 2 - Run Script (speaker)'),
+(-46215, 0, 1, 0, 108, 0, 100, 0, 3, 22817, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - On Waypoint 3 Reached - Despawn Instant (speaker)'),
+(285200, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 91, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - Script - Wake (Remove Standstate Sleep)'),
+(285200, 9, 1, 0, 0, 0, 100, 0, 4000, 4000, 0, 0, 0, 0, 3, 2853, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - Script - Morph to Freed Druid of the Talon'),
+(285200, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 22817, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - Script - Start Waypoint 22817'),
+(285201, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 91, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - Script - Wake (Remove Standstate Sleep)'),
+(285201, 9, 1, 0, 0, 0, 100, 0, 5000, 5000, 0, 0, 0, 0, 3, 2853, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - Script - Morph to Freed Druid of the Talon'),
+(285201, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 22817, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - Script - Start Waypoint 22817'),
+(285202, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 91, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - Script - Wake (Remove Standstate Sleep)'),
+(285202, 9, 1, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - Script - Say Free Line'),
+(285202, 9, 2, 0, 0, 0, 100, 0, 1000, 1000, 0, 0, 0, 0, 3, 2853, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - Script - Morph to Freed Druid of the Talon'),
+(285202, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 22817, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Enslaved Druid of the Talon - Script - Start Waypoint 22817');


### PR DESCRIPTION
## Changes Proposed:
When **Ursal the Mauler** (NPC 2039) is defeated during the quest *Ursal the Mauler* (quest 486, Teldrassil), the four caged **Enslaved Druids of the Talon** (NPC 2852, GUIDs 46212-46215) previously did nothing.

With this change they now:
- wake from their forced sleep stand-state,
- morph into **Freed Druids of the Talon** (NPC 2853),
- flee along a short path and despawn,
- one of them shouts *"The nightmare of Ursal is over! We are free!"* (broadcast text 888, already present in `creature_text`).

The druids wake together, then transform and peel off in a timed cascade (one at ~3s with the line, two at ~4s, the last at ~5s) rather than all at once. Implemented with SmartAI: Ursal sets data 2/2 on the nearby druids on death; each druid runs a timed actionlist (wake → morph → start waypoint) and despawns on reaching the end of the flee path (`waypoints` path 22817).

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Tools used: **Claude (Opus 4.8)**, for cross-referencing the cMaNGOS/TrinityCore data and authoring the SmartAI port.

## Issues Addressed:
- Closes #6055

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Behaviour, timing, flee-path coordinates and the spoken line are based on the **cMaNGOS** end-script for quest 486 (`cmangos/wotlk-db` → `Updates/829_quest_486.sql`, *"[829] Added end script for quest 486"* by **MantisLord**). This is **not a literal cherry-pick** — cMaNGOS uses its `dbscripts_on_creature_death` engine, so the logic was re-implemented in AzerothCore SmartAI rather than committed with `--author`; crediting the original author here instead. The flee-path coordinates and morph target also match TrinityCore.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on a local WotLK 3.3.5a worldserver: after killing Ursal, all four druids wake, transform into Freed Druids of the Talon in the staggered cascade, the leader speaks, and they fly off to the northwest and despawn. The four druid spawns and Ursal respawn normally afterwards.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.quest add 486`
2. `.go creature 49853` (Ursal the Mauler)
3. Kill Ursal and observe the druids wake, morph into Freed Druids of the Talon, the leader announce the group is free, and all four flee and despawn.

## Known Issues and TODO List:

- [ ] None.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
