### PR TITLE
fix(Scripts/BattleForMountHyjal): Fix boss state progression race condition

### DIFF
--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_anetheron.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_anetheron.cpp
@@ -129,6 +129,8 @@ public:
     void JustDied(Unit * killer) override
     {
         Talk(SAY_ONDEATH);
+        if (instance)
+            instance->SetBossState(DATA_ANETHERON, DONE);
         BossAI::JustDied(killer);
     }
 

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_azgalor.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_azgalor.cpp
@@ -108,6 +108,8 @@ public:
             archi->AI()->DoAction(ACTION_BECOME_ACTIVE_AND_CHANNEL);
             archi->AI()->Talk(SAY_ARCHIMONDE_INTRO, 25s);
         }
+        if (instance)
+            instance->SetBossState(DATA_AZGALOR, DONE);
         BossAI::JustDied(killer);
     }
 

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_kazrogal.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_kazrogal.cpp
@@ -121,6 +121,8 @@ public:
     void JustDied(Unit * killer) override
     {
         me->PlayDirectSound(SOUND_ONDEATH);
+        if (instance)
+            instance->SetBossState(DATA_KAZROGAL, DONE);
         BossAI::JustDied(killer);
     }
 

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_rage_winterchill.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_rage_winterchill.cpp
@@ -132,6 +132,8 @@ public:
     void JustDied(Unit* killer) override
     {
         Talk(SAY_ONDEATH);
+        if (instance)
+            instance->SetBossState(DATA_WINTERCHILL, DONE);
         BossAI::JustDied(killer);
     }
 


### PR DESCRIPTION
## Summary

In `instance_hyjal.cpp`, `OnUnitDeath` is called from `Unit::Kill()` **before** `ai->JustDied(killer)`. This means `ResetWaves()` is triggered while the boss's state is still `IN_PROGRESS`, causing the instance to reset to the wrong wave instead of advancing to the next one.

Talking with Jaina after killing Rage Winterchill would restart Winterchill waves instead of progressing to Anetheron.

### Fix

Explicitly call `SetBossState(DATA_X, DONE)` **before** `BossAI::JustDied()` in all four Hyjal boss `JustDied` handlers:
- `boss_rage_winterchill.cpp`
- `boss_anetheron.cpp`
- `boss_kazrogal.cpp`
- `boss_azgalor.cpp`

This ensures the boss state is committed before any wave logic reads it via `OnUnitDeath`.

## How to test

1. Enter Battle for Mount Hyjal
2. Kill Rage Winterchill
3. Talk to Jaina — she should trigger Anetheron waves, not Winterchill again
4. Repeat for remaining bosses in sequence

🤖 Generated with [Claude Code](https://claude.ai/claude-code)