### PR TITLE
fix(Scripts/SunwellPlateau): Brutallus fire barrier not removed after kill

### DIFF
--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_brutallus.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_brutallus.cpp
@@ -360,6 +360,7 @@ struct npc_madrigosa : public NullCreatureAI
             break;
         case EVENT_SPAWN_FELMYST:
             DoCastAOE(SPELL_SUMMON_FELBLAZE, true);
+            instance->SetBossState(DATA_FELMYST_DOORS, DONE);
             me->DespawnOrUnsummon(1ms);
             break;
         }


### PR DESCRIPTION
## Summary

The fire barrier (`GO_FIRE_BARRIER`) separating the Brutallus and Felmyst platforms is bound to `DATA_FELMYST_DOORS` in `doorData`, but `DATA_FELMYST_DOORS` was never set to `DONE` anywhere in the script.

The intended path via `spell_linked_spell` (`-46637 → 46638`) does not work because spell 46637 (`SPELL_MADRIGOSA_FROST_BREATH`) does not leave a persistent aura, so the linked despawn spell never fires.

As a result, the fire barrier remains after Brutallus is killed and players cannot access Felmyst.

### Fix

Set `DATA_FELMYST_DOORS` to `DONE` in `npc_madrigosa::UpdateAI` at `EVENT_SPAWN_FELMYST`, approximately 60 seconds after Brutallus dies when Madrigosa transforms into Felmyst and despawns. This correctly opens the fire barrier at the right story moment.

## How to test

1. Enter Sunwell Plateau and engage Brutallus
2. Kill Brutallus
3. Wait ~60 seconds for Madrigosa → Felmyst transformation
4. Verify the fire barrier despawns and the path to Felmyst is open

🤖 Generated with [Claude Code](https://claude.ai/claude-code)