### PR TITLE
fix(Scripts/SlavePens): spawn Ahune loot chest when killed during submerge

### DIFF
--- a/src/server/scripts/Outland/CoilfangReservoir/SlavePens/boss_ahune.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SlavePens/boss_ahune.cpp
@@ -304,11 +304,11 @@ struct npc_frozen_core : public ScriptedAI
 
     void JustDied(Unit* /*killer*/) override
     {
-        if (Creature* ahune = _instance->GetCreature(DATA_AHUNE))
-            Unit::Kill(me, ahune);
-
         DoCastSelf(SPELL_SUMMON_LOOT_MISSILE, true);
         DoCastSelf(SPELL_MINION_DESPAWNER, true);
+
+        if (Creature* ahune = _instance->GetCreature(DATA_AHUNE))
+            Unit::Kill(me, ahune);
     }
 
     void DoAction(int32 action) override


### PR DESCRIPTION
## Changes Proposed:
Killing Ahune while he is in his submerge phase did not spawn his loot chest.

The Frozen Core summons the loot missile in its `JustDied` only after killing Ahune. Ahune's death runs `BossAI::_JustDied()`, which calls `summons.DespawnAll()` and removes its summons (the Frozen Core) from the world. The Frozen Core then tried to cast the loot missile with no valid (in-world) caster, so the chest never spawned.

This only happened when the killing blow landed on the Frozen Core, which is the case during the submerge phase. In the emerged phase the order is reversed (Ahune dies first and kills the Frozen Core, which then casts the loot while still in-world), so the chest spawned correctly there.

Fix: cast the loot missile before killing Ahune, so the chest spawns regardless of which phase the killing blow lands in.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.8 was used to investigate the issue and prepare the fix.

## Issues Addressed:
- Closes #26297

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Retail WotLK reference from the issue: https://youtu.be/I9YUWIac8Ks?t=284

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Built on Windows (Win64, RelWithDebInfo/Release). Verified in-game that the loot chest now spawns when Ahune is killed during the submerge phase, and confirmed no regression when killed during the emerged phase.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Queue/start The Frost Lord Ahune (during the Midsummer Fire Festival).
2. Wait for Ahune to enter the submerge phase.
3. Kill him during that phase.
4. The loot chest now spawns. Repeat with a kill during the emerged phase to confirm no regression.

## Known Issues and TODO List:

- [ ] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
