### PR TITLE
feat(Core/ServerMail): Allow mail sender to be a creature

### DIFF
--- a/data/sql/updates/pending_db_characters/rev_1782050272664632800.sql
+++ b/data/sql/updates/pending_db_characters/rev_1782050272664632800.sql
@@ -1,0 +1,2 @@
+ ALTER TABLE `mail_server_template`
+    ADD COLUMN `senderEntry` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `id` COMMENT 'Entry from creature_template. 0 for default "Customer Support" sender.';

--- a/data/sql/updates/pending_db_characters/rev_1782050272664632800.sql
+++ b/data/sql/updates/pending_db_characters/rev_1782050272664632800.sql
@@ -1,2 +1,2 @@
- ALTER TABLE `mail_server_template`
+ALTER TABLE `mail_server_template`
     ADD COLUMN `senderEntry` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `id` COMMENT 'Entry from creature_template. 0 for default "Customer Support" sender.';

--- a/data/sql/updates/pending_db_characters/rev_1782050272664632800.sql
+++ b/data/sql/updates/pending_db_characters/rev_1782050272664632800.sql
@@ -1,2 +1,2 @@
 ALTER TABLE `mail_server_template`
-    ADD COLUMN `senderEntry` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `id` COMMENT 'Entry from creature_template. 0 for default "Customer Support" sender.';
+    ADD COLUMN `senderEntry` INT UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Entry from creature_template. 0 for default "Customer Support" sender.' AFTER `id`;

--- a/src/server/game/Mails/ServerMailMgr.cpp
+++ b/src/server/game/Mails/ServerMailMgr.cpp
@@ -41,8 +41,8 @@ void ServerMailMgr::LoadMailServerTemplates()
 
     _serverMailStore.clear(); // for reload case
 
-    //                                                    0     1         2         3          4       5
-    QueryResult result = CharacterDatabase.Query("SELECT `id`, `moneyA`, `moneyH`, `subject`, `body`, `active` FROM `mail_server_template`");
+    //                                                    0     1              2         3         4          5       6
+    QueryResult result = CharacterDatabase.Query("SELECT `id`, `senderEntry`, `moneyA`, `moneyH`, `subject`, `body`, `active` FROM `mail_server_template`");
     if (!result)
     {
         LOG_INFO("server.loading", ">> Loaded 0 server mail rewards. DB table `mail_server_template` is empty.");
@@ -60,11 +60,12 @@ void ServerMailMgr::LoadMailServerTemplates()
 
         ServerMail& servMail = _serverMailStore[id];
         servMail.id          = id;
-        servMail.moneyA      = fields[1].Get<uint32>();
-        servMail.moneyH      = fields[2].Get<uint32>();
-        servMail.subject     = fields[3].Get<std::string>();
-        servMail.body        = fields[4].Get<std::string>();
-        servMail.active      = fields[5].Get<uint8>();
+        servMail.senderEntry = fields[1].Get<uint32>();
+        servMail.moneyA      = fields[2].Get<uint32>();
+        servMail.moneyH      = fields[3].Get<uint32>();
+        servMail.subject     = fields[4].Get<std::string>();
+        servMail.body        = fields[5].Get<std::string>();
+        servMail.active      = fields[6].Get<uint8>();
 
         // Skip non-activated entries
         if (!servMail.active)
@@ -74,6 +75,12 @@ void ServerMailMgr::LoadMailServerTemplates()
         {
             LOG_ERROR("sql.sql", "Table `mail_server_template` has moneyA {} or moneyH {} larger than MAX_MONEY_AMOUNT {} for id {}, skipped.", servMail.moneyA, servMail.moneyH, MAX_MONEY_AMOUNT, servMail.id);
             continue;
+        }
+
+        if (servMail.senderEntry && !sObjectMgr->GetCreatureTemplate(servMail.senderEntry))
+        {
+            LOG_ERROR("sql.sql", "Table `mail_server_template` has invalid senderEntry {} (no matching creature_template) for id {}, falling back to default sender.", servMail.senderEntry, servMail.id);
+            servMail.senderEntry = 0;
         }
     } while (result->NextRow());
 
@@ -281,7 +288,7 @@ void ServerMailMgr::LoadMailServerTemplatesConditions()
     } while (result->NextRow());
 }
 
-void ServerMailMgr::SendServerMail(Player* player, uint32 id, uint32 money,
+void ServerMailMgr::SendServerMail(Player* player, uint32 id, uint32 senderEntry, uint32 money,
     std::vector<ServerMailItems> const& items,
     std::vector<ServerMailCondition> const& conditions,
     std::string const& subject, std::string const& body) const
@@ -292,7 +299,9 @@ void ServerMailMgr::SendServerMail(Player* player, uint32 id, uint32 money,
 
     CharacterDatabaseTransaction trans = CharacterDatabase.BeginTransaction();
 
-    MailSender sender(MAIL_NORMAL, player->GetGUID().GetCounter(), MAIL_STATIONERY_GM);
+    MailSender sender = senderEntry
+        ? MailSender(MAIL_CREATURE, senderEntry, MAIL_STATIONERY_DEFAULT)
+        : MailSender(MAIL_NORMAL, player->GetGUID().GetCounter(), MAIL_STATIONERY_GM);
     MailDraft draft(subject, body);
 
     draft.AddMoney(money);

--- a/src/server/game/Mails/ServerMailMgr.h
+++ b/src/server/game/Mails/ServerMailMgr.h
@@ -128,6 +128,7 @@ struct ServerMail
 {
     ServerMail() = default;
     uint32 id{ 0 };
+    uint32 senderEntry{ 0 }; ///< Entry from creature_template. 0 for default "Customer Support" sender.
     uint32 moneyA{ 0 };
     uint32 moneyH{ 0 };
     std::string subject;
@@ -205,6 +206,7 @@ public:
      *
      * @param player The recipient player.
      * @param id The template ID.
+     * @param senderEntry Entry from creature_template. 0 for default "Customer Support" sender.
      * @param money Money reward.
      * @param items List of items to include in the mail.
      * @param conditions List of the conditions for the mail.
@@ -212,7 +214,7 @@ public:
      * @param body Mail body.
      * @param active Whether the mail template is active.
      */
-    void SendServerMail(Player* player, uint32 id, uint32 money, std::vector<ServerMailItems> const& items, std::vector<ServerMailCondition> const& conditions, std::string const& subject, std::string const& body) const;
+    void SendServerMail(Player* player, uint32 id, uint32 senderEntry, uint32 money, std::vector<ServerMailItems> const& items, std::vector<ServerMailCondition> const& conditions, std::string const& subject, std::string const& body) const;
 
     /**
      * @brief Retrieves the entire server mail store.

--- a/src/server/scripts/World/server_mail.cpp
+++ b/src/server/scripts/World/server_mail.cpp
@@ -58,6 +58,7 @@ public:
                         sServerMailMgr->SendServerMail(
                             session->GetPlayer(),
                             servMail.id,
+                            servMail.senderEntry,
                             money,
                             items,
                             conditions,


### PR DESCRIPTION
Add a senderEntry column to mail_server_template (SQL migration) to allow specifying a creature_template entry as the mail sender (0 = default Customer Support). Update ServerMail struct and loading: select and store senderEntry, validate it against creature_template and fall back to 0 on invalid entries. Propagate senderEntry into SendServerMail (signature change) and construct MailSender as MAIL_CREATURE when set, otherwise keep existing behavior. Update script call sites accordingly.


*closes https://github.com/azerothcore/azerothcore-wotlk/issues/26274
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] Opus 4.7
## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x} Tested in-game by the author.

<img width="409" height="147" alt="image" src="https://github.com/user-attachments/assets/9ea3c99c-7333-4362-8df3-77baa07eb4bf" />


<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
