### PR TITLE
fix(scripts/Dragonblight): Eligor Dawnbringer Naxxramas Lecture

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1782160443614327200.sql
+++ b/data/sql/updates/pending_db_world/rev_1782160443614327200.sql
@@ -1,0 +1,20 @@
+-- Commander Eligor Dawnbringer (27784): Pinnacle of Naxxramas Mr. Bigglesworth gag lines.
+DELETE FROM `creature_text` WHERE `CreatureID`=27784 AND `GroupID` IN (27,28,29);
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(27784, 27, 0, 'Mr. Bigglesworth. The last living creature in Naxxramas, this cat is said to be the last thread connecting Kel\'Thuzad to his mortal life. It is said that any who dare to harm a hair on his head doom themselves to... wait a second, what is he doing on there?', 12, 7, 100, 0, 0, 0, 0, 0, 'Commander Eligor Dawnbringer - Bigglesworth'),
+(27784, 28, 0, '%s pounds on the display.', 16, 0, 100, 0, 0, 0, 0, 0, 'Commander Eligor Dawnbringer - pounds on the display'),
+(27784, 29, 0, 'Well, nevermind. I\'m sure no one would be foolish enough to lay a hand on Kel\'Thuzad\'s precious pet.', 12, 7, 100, 0, 0, 0, 0, 0, 'Commander Eligor Dawnbringer - nevermind');
+
+-- Commander Eligor Dawnbringer (27784): on-click gossip greeting (menu 9600 -> npc_text 12958/12961).
+UPDATE `npc_text` SET `text0_0`='Yes, $c, what can I do for you?$B$BIf you\'re here for a lesson on Naxxramas, there\'s plenty of room.', `BroadcastTextID0`=0 WHERE `ID` IN (12958, 12961);
+
+-- Commander Eligor Dawnbringer (27784): don't pause his scripted narration walk when a player interacts.
+-- InteractionPauseTimer 0 disables the gossip-hello movement pause (default is the 3s Creature.MovingStopTimeForPlayer).
+DELETE FROM `creature_template_movement` WHERE `CreatureId`=27784;
+INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES
+(27784, 1, 1, 0, 0, 0, 0, 0);
+
+-- Casing alignment: "Kel'Thuzad" always uppercase T across Eligor's narration (creature_text fallback + the
+-- broadcast_text that actually displays). REPLACE is idempotent (no match once already uppercase).
+UPDATE `creature_text` SET `Text`=REPLACE(`Text`, 'Kel\'thuzad', 'Kel\'Thuzad') WHERE `CreatureID`=27784;
+UPDATE `broadcast_text` SET `MaleText`=REPLACE(`MaleText`, 'Kel\'thuzad', 'Kel\'Thuzad'), `FemaleText`=REPLACE(`FemaleText`, 'Kel\'thuzad', 'Kel\'Thuzad') WHERE `ID` IN (27079, 27081, 27082);

--- a/data/sql/updates/pending_db_world/rev_1782160443614327200.sql
+++ b/data/sql/updates/pending_db_world/rev_1782160443614327200.sql
@@ -18,3 +18,4 @@ INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Fligh
 -- broadcast_text that actually displays). REPLACE is idempotent (no match once already uppercase).
 UPDATE `creature_text` SET `Text`=REPLACE(`Text`, 'Kel\'thuzad', 'Kel\'Thuzad') WHERE `CreatureID`=27784;
 UPDATE `broadcast_text` SET `MaleText`=REPLACE(`MaleText`, 'Kel\'thuzad', 'Kel\'Thuzad'), `FemaleText`=REPLACE(`FemaleText`, 'Kel\'thuzad', 'Kel\'Thuzad') WHERE `ID` IN (27079, 27081, 27082);
+

--- a/data/sql/updates/pending_db_world/rev_1782160443614327200.sql
+++ b/data/sql/updates/pending_db_world/rev_1782160443614327200.sql
@@ -1,21 +1,18 @@
 -- Commander Eligor Dawnbringer (27784): Pinnacle of Naxxramas Mr. Bigglesworth gag lines.
 DELETE FROM `creature_text` WHERE `CreatureID`=27784 AND `GroupID` IN (27,28,29);
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
-(27784, 27, 0, 'Mr. Bigglesworth. The last living creature in Naxxramas, this cat is said to be the last thread connecting Kel\'Thuzad to his mortal life. It is said that any who dare to harm a hair on his head doom themselves to... wait a second, what is he doing on there?', 12, 7, 100, 0, 0, 0, 0, 0, 'Commander Eligor Dawnbringer - Bigglesworth'),
-(27784, 28, 0, '%s pounds on the display.', 16, 0, 100, 0, 0, 0, 0, 0, 'Commander Eligor Dawnbringer - pounds on the display'),
-(27784, 29, 0, 'Well, nevermind. I\'m sure no one would be foolish enough to lay a hand on Kel\'Thuzad\'s precious pet.', 12, 7, 100, 0, 0, 0, 0, 0, 'Commander Eligor Dawnbringer - nevermind');
+(27784, 27, 0, 'Mr. Bigglesworth. The last living creature in Naxxramas, this cat is said to be the last thread connecting Kel\'Thuzad to his mortal life. It is said that any who dare to harm a hair on his head doom themselves to... wait a second, what is he doing on there?', 12, 7, 100, 0, 0, 0, 0, 0, 'Commander Eligor Dawnbringer - Bigglesworth gag'),
+(27784, 28, 0, '%s pounds on the display.', 16, 0, 100, 0, 0, 0, 0, 0, 'Commander Eligor Dawnbringer - Bigglesworth gag'),
+(27784, 29, 0, 'Well, nevermind. I\'m sure no one would be foolish enough to lay a hand on Kel\'Thuzad\'s precious pet.', 12, 7, 100, 0, 0, 0, 0, 0, 'Commander Eligor Dawnbringer - Bigglesworth gag');
 
 -- Commander Eligor Dawnbringer (27784): on-click gossip greeting (menu 9600 -> npc_text 12958/12961).
-UPDATE `npc_text` SET `text0_0`='Yes, $c, what can I do for you?$B$BIf you\'re here for a lesson on Naxxramas, there\'s plenty of room.', `BroadcastTextID0`=0 WHERE `ID` IN (12958, 12961);
+DELETE FROM `npc_text` WHERE `ID` IN (12958, 12961);
+INSERT INTO `npc_text` VALUES
+(12958,'Yes, $c, what can I do for you?$B$BIf you\'re here for a lesson on Naxxramas, there\'s plenty of room.','',0,0,1,1000,1,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,11685),
+(12961,'Yes, $c, what can I do for you?$B$BIf you\'re here for a lesson on Naxxramas, there\'s plenty of room.','',0,0,1,0,1,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,11723);
 
 -- Commander Eligor Dawnbringer (27784): don't pause his scripted narration walk when a player interacts.
 -- InteractionPauseTimer 0 disables the gossip-hello movement pause (default is the 3s Creature.MovingStopTimeForPlayer).
 DELETE FROM `creature_template_movement` WHERE `CreatureId`=27784;
 INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES
 (27784, 1, 1, 0, 0, 0, 0, 0);
-
--- Casing alignment: "Kel'Thuzad" always uppercase T across Eligor's narration (creature_text fallback + the
--- broadcast_text that actually displays). REPLACE is idempotent (no match once already uppercase).
-UPDATE `creature_text` SET `Text`=REPLACE(`Text`, 'Kel\'thuzad', 'Kel\'Thuzad') WHERE `CreatureID`=27784;
-UPDATE `broadcast_text` SET `MaleText`=REPLACE(`MaleText`, 'Kel\'thuzad', 'Kel\'Thuzad'), `FemaleText`=REPLACE(`FemaleText`, 'Kel\'thuzad', 'Kel\'Thuzad') WHERE `ID` IN (27079, 27081, 27082);
-

--- a/data/sql/updates/pending_db_world/rev_1782160443614327200.sql
+++ b/data/sql/updates/pending_db_world/rev_1782160443614327200.sql
@@ -9,7 +9,7 @@ INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Lan
 DELETE FROM `npc_text` WHERE `ID` IN (12958, 12961);
 INSERT INTO `npc_text` VALUES
 (12958,'Yes, $c, what can I do for you?$B$BIf you\'re here for a lesson on Naxxramas, there\'s plenty of room.','',0,0,1,1000,1,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,11685),
-(12961,'Yes, $c, what can I do for you?$B$BIf you\'re here for a lesson on Naxxramas, there\'s plenty of room.','',0,0,1,0,1,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,11723);
+(12961,'Yes, $c, what can I do for you?$B$BIf you\'re here for a lesson on Naxxramas, there\'s plenty of room.','',0,0,1,0,1,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,'','',0,0,0,0,0,0,0,0,0,11723);
 
 -- Commander Eligor Dawnbringer (27784): don't pause his scripted narration walk when a player interacts.
 -- InteractionPauseTimer 0 disables the gossip-hello movement pause (default is the 3s Creature.MovingStopTimeForPlayer).

--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -1690,6 +1690,7 @@ enum CommanderEligorDawnbringer
     MODEL_IMAGE_OF_NOTH                = 24797, // Image of Noth
     MODEL_IMAGE_OF_HEIGAN              = 24793, // Image of Heigan
     MODEL_IMAGE_OF_LOATHEB             = 24795, // Image of Loatheb
+    MODEL_IMAGE_OF_MR_BIGGLESWORTH     = 26055, // Image of Mr. Bigglesworth
 
     NPC_IMAGE_OF_KELTHUZAD             = 27766, // Image of Kel'Thuzad
     NPC_IMAGE_OF_SAPPHIRON             = 27767, // Image of Sapphiron
@@ -1708,9 +1709,10 @@ enum CommanderEligorDawnbringer
     NPC_IMAGE_OF_NOTH                  = 27779, // Image of Noth
     NPC_IMAGE_OF_HEIGAN                = 27780, // Image of Heigan
     NPC_IMAGE_OF_LOATHEB               = 27781, // Image of Loatheb
+    NPC_IMAGE_OF_MR_BIGGLESWORTH       = 29223, // Image of Mr. Bigglesworth
 
     NPC_INFANTRYMAN                    = 27160, // Add in case I randomize the spawning
-    NPC_SENTINAL                       = 27162,
+    NPC_SENTINEL                       = 27162,
     NPC_BATTLE_MAGE                    = 27164,
 
     // Five platforms to choose from
@@ -1747,6 +1749,10 @@ enum CommanderEligorDawnbringer
     SAY_HEIGAN_1                       = 24,
     SAY_HEIGAN_2                       = 25,
     SAY_LOATHEB                        = 26,
+    // Pinnacle Mr. Bigglesworth gag
+    SAY_BIGGLESWORTH                   = 27,
+    EMOTE_BIGGLESWORTH_POUND           = 28,
+    SAY_NEVERMIND                      = 29,
 
     SPELL_HEROIC_IMAGE_CHANNEL         = 49519,
 
@@ -1759,10 +1765,17 @@ enum CommanderEligorDawnbringer
     EVENT_DEATH_KNIGHTS_2              = 7,
     EVENT_DEATH_KNIGHTS_3              = 8,
     EVENT_DEATH_KNIGHTS_4              = 9,
-    EVENT_HEIGAN_2                     = 10
+    EVENT_HEIGAN_2                     = 10,
+    EVENT_BIGGLESWORTH_POUND           = 11,
+    EVENT_BIGGLESWORTH_NEVERMIND       = 12,
+    EVENT_MOVE_WATCHDOG                = 13
 };
 
-uint32 const AudienceMobs[3] = { NPC_INFANTRYMAN, NPC_SENTINAL, NPC_BATTLE_MAGE };
+uint32 const AudienceMobs[3] = { NPC_INFANTRYMAN, NPC_SENTINEL, NPC_BATTLE_MAGE };
+
+// The middle/Pinnacle display (Kel'Thuzad, Sapphiron, Bigglesworth) faces the area entrance,
+// 180 degrees opposite Eligor's home position.
+float const FACING_PINNACLE_ENTRANCE = 5.91667f;
 
 Position const PosTalkLocations[6] =
 {
@@ -1806,6 +1819,7 @@ public:
             {
                 if (id == 1)
                 {
+                    _events.CancelEvent(EVENT_MOVE_WATCHDOG); // arrived, the move succeeded
                     me->SetFacingTo(PosTalkLocations[talkWing].GetOrientation());
                     TurnAudience();
 
@@ -1813,7 +1827,7 @@ public:
                     {
                         case 0: // Pinnacle of Naxxramas
                             {
-                                switch (urand (0, 1))
+                                switch (urand (0, 2))
                                 {
                                     case 0:
                                         ChangeImage(NPC_IMAGE_OF_KELTHUZAD, MODEL_IMAGE_OF_KELTHUZAD, SAY_KELTHUZAD_1);
@@ -1821,6 +1835,10 @@ public:
                                         break;
                                     case 1:
                                         ChangeImage(NPC_IMAGE_OF_SAPPHIRON, MODEL_IMAGE_OF_SAPPHIRON, SAY_SAPPHIRON);
+                                        break;
+                                    case 2: // Mr. Bigglesworth gag
+                                        ChangeImage(NPC_IMAGE_OF_MR_BIGGLESWORTH, MODEL_IMAGE_OF_MR_BIGGLESWORTH, SAY_BIGGLESWORTH);
+                                        _events.ScheduleEvent(EVENT_BIGGLESWORTH_POUND, 6s);
                                         break;
                                 }
                             }
@@ -1930,6 +1948,23 @@ public:
                 imageList[3] = creature->GetGUID();
             if (Creature* creature = me->FindNearestCreature(NPC_IMAGE_OF_NOTH, 20.0f, true))
                 imageList[4] = creature->GetGUID();
+
+            FaceImagesToRest();
+        }
+
+        // Snap every image back to its resting orientation: the four corner platforms face the
+        // central display, the middle/Pinnacle platform faces the area entrance.
+        void FaceImagesToRest()
+        {
+            Creature* center = ObjectAccessor::GetCreature(*me, imageList[0]);
+
+            for (uint8 i = 1; i < 5; ++i)
+                if (Creature* image = ObjectAccessor::GetCreature(*me, imageList[i]))
+                    if (center)
+                        image->SetFacingToObject(center);
+
+            if (center)
+                center->SetFacingTo(FACING_PINNACLE_ENTRANCE);
         }
 
         void ChangeImage(uint32 entry, uint32 model, uint8 text)
@@ -1953,6 +1988,16 @@ public:
             }
         }
 
+        // Walk to the current platform (or home). Arms a watchdog so the cycle recovers if the
+        // move is ever interrupted and MovementInform never reports arrival.
+        void MoveToTalkPoint()
+        {
+            me->SetWalk(true);
+            me->GetMotionMaster()->Clear();
+            me->GetMotionMaster()->MovePoint(1, PosTalkLocations[talkWing].m_positionX, PosTalkLocations[talkWing].m_positionY, PosTalkLocations[talkWing].m_positionZ);
+            _events.RescheduleEvent(EVENT_MOVE_WATCHDOG, 15s);
+        }
+
         void UpdateAI(uint32 diff) override
         {
             _events.Update(diff);
@@ -1967,13 +2012,26 @@ public:
                         _events.ScheduleEvent(EVENT_MOVE_TO_POINT, 8s);
                         break;
                     case EVENT_MOVE_TO_POINT:
-                        me->SetWalk(true);
-                        me->GetMotionMaster()->Clear();
-                        me->GetMotionMaster()->MovePoint(1, PosTalkLocations[talkWing].m_positionX, PosTalkLocations[talkWing].m_positionY, PosTalkLocations[talkWing].m_positionZ);
+                        MoveToTalkPoint();
+                        break;
+                    case EVENT_MOVE_WATCHDOG:
+                        // Arrival was never reported (the walk got interrupted) - re-issue it so the
+                        // narration cycle can't get stuck, e.g. from an on-click interaction.
+                        MoveToTalkPoint();
                         break;
                     case EVENT_TALK_COMPLETE:
+                        // The image's spin/narration is done: snap it back to its resting facing.
+                        if (Creature* image = ObjectAccessor::GetCreature(*me, imageList[talkWing]))
+                        {
+                            if (talkWing == 0)
+                                image->SetFacingTo(FACING_PINNACLE_ENTRANCE);
+                            else if (Creature* center = ObjectAccessor::GetCreature(*me, imageList[0]))
+                                image->SetFacingToObject(center);
+                        }
+                        // Eligor only sometimes adds his closing remark before heading home.
+                        if (roll_chance_i(50))
+                            Talk(SAY_TALK_COMPLETE);
                         talkWing = 5;
-                        Talk(talkWing);
                         _events.ScheduleEvent(EVENT_MOVE_TO_POINT, 5s);
                         break;
                     case EVENT_GET_TARGETS:
@@ -2009,6 +2067,13 @@ public:
                         break;
                     case EVENT_HEIGAN_2:
                         Talk(SAY_HEIGAN_2);
+                        break;
+                    case EVENT_BIGGLESWORTH_POUND:
+                        Talk(EMOTE_BIGGLESWORTH_POUND);
+                        _events.ScheduleEvent(EVENT_BIGGLESWORTH_NEVERMIND, 4s);
+                        break;
+                    case EVENT_BIGGLESWORTH_NEVERMIND:
+                        Talk(SAY_NEVERMIND);
                         break;
                     default:
                         break;


### PR DESCRIPTION
This PR does the following:

1. Add correct on-click gossip for Eligor Dawnbringer
2. Add 'Image of Mr. Bigglesworth' gag to the rotation
3. Correct the facing of the 'Image of..' NPCs (4 platforms face center, middle platform faces exit)
4. Randomize the line **"I shall leave this image on display for your perusal. Study your opponents' strengths, for a creature's strength can also be its weakness."**
5. Adds safety nets to ensure the event continues uninterrupted by player on-click

All of the above were observed by me by watching the behavior on retail (current day Midnight) and Mists of Pandaria classic

## Changes Proposed:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
Claude Opus

## SOURCE:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
.go c 133420
observe for 15-20 minutes

