### PR TITLE
fix(Apps/SOAP): avoid bind crash on quick restart

### DIFF
--- a/src/server/apps/worldserver/ACSoap/ACSoap.cpp
+++ b/src/server/apps/worldserver/ACSoap/ACSoap.cpp
@@ -33,10 +33,15 @@ void ACSoapThread(const std::string& host, uint16 port)
     soap.recv_timeout = 5;
     soap.send_timeout = 5;
 
+    // allow rebinding while the previous socket is still in TIME_WAIT (e.g. on a quick restart)
+    soap.bind_flags = SO_REUSEADDR;
+
     if (!soap_valid_socket(soap_bind(&soap, host.c_str(), port, 100)))
     {
         LOG_ERROR("network.soap", "ACSoap: couldn't bind to {}:{}", host, port);
-        exit(-1);
+        // graceful shutdown: exit() here would destroy SocketMgr before StopNetwork() and assert
+        World::StopNow(ERROR_EXIT_CODE);
+        return;
     }
 
     LOG_INFO("network.soap", "ACSoap: bound to http://{}:{}", host, port);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

When the SOAP listener fails to bind (e.g. the previous socket is still in `TIME_WAIT` after a quick restart) it called `exit()` from the SOAP worker thread, destroying the `SocketMgr` singleton before `StopNetwork()` and tripping its assertion. This sets `SO_REUSEADDR` so it can rebind, and signals a graceful shutdown instead of `exit()` on failure.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. — Claude Code with azerothMCP

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Built and tested on Linux: ran a SOAP command, then performed a quick restart; the server rebound the SOAP port cleanly instead of crashing on the `SocketMgr` assertion.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enable SOAP (`SOAP.Enabled = 1`) and start the worldserver.
2. Issue any SOAP command, then immediately restart the worldserver.
3. Confirm SOAP rebinds (`ACSoap: bound to ...`) instead of crashing on the `SocketMgr` assertion.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
