### PR TITLE
fix(Tests): make HolidayDateCalculator test mktime-free for pre-1970 dates

### DIFF
--- a/src/test/server/game/Events/HolidayDateCalculatorTest.cpp
+++ b/src/test/server/game/Events/HolidayDateCalculatorTest.cpp
@@ -52,6 +52,45 @@ protected:
     {
         return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
     }
+
+    // Portable replacement for mktime() when only the date fields need rolling over.
+    // std::mktime rejects pre-1970 dates on MSVC, so tests covering years before 1970
+    // cannot rely on it to normalize month/day overflow (see HolidayDateCalculator.cpp).
+    void NormalizeTm(std::tm& date)
+    {
+        static int const table[] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+        auto daysInMonth = [&](int y, int m)
+        {
+            return (m == 2 && IsLeapYear(y)) ? 29 : table[m - 1];
+        };
+
+        int year = date.tm_year + 1900;
+        int month = date.tm_mon + 1;
+        int day = date.tm_mday;
+
+        while (day > daysInMonth(year, month))
+        {
+            day -= daysInMonth(year, month);
+            if (++month > 12)
+            {
+                month = 1;
+                ++year;
+            }
+        }
+        while (day < 1)
+        {
+            if (--month < 1)
+            {
+                month = 12;
+                --year;
+            }
+            day += daysInMonth(year, month);
+        }
+
+        date.tm_year = year - 1900;
+        date.tm_mon = month - 1;
+        date.tm_mday = day;
+    }
 };
 
 // ============================================================
@@ -311,7 +350,7 @@ TEST_F(HolidayDateCalculatorTest, Noblegarden_DayAfterEaster_1900_2200)
         // Calculate expected Noblegarden date (Easter + 1)
         std::tm expectedNoblegarden = easter;
         expectedNoblegarden.tm_mday += 1;
-        mktime(&expectedNoblegarden); // Normalize (handles month rollover)
+        NormalizeTm(expectedNoblegarden); // Normalize (handles month rollover)
 
         // Get calculated Noblegarden from holiday rule
         HolidayRule noblegarden = { 181, HolidayCalculationType::EASTER_OFFSET, 0, 0, 0, 1 };
@@ -343,7 +382,7 @@ TEST_F(HolidayDateCalculatorTest, PilgrimsBounty_SundayBeforeThanksgiving_1900_2
         // Pilgrim's Bounty starts on Sunday before (4 days earlier)
         std::tm expectedPilgrims = thanksgiving;
         expectedPilgrims.tm_mday -= 4;
-        mktime(&expectedPilgrims);
+        NormalizeTm(expectedPilgrims);
 
         // Get calculated date using rule with -4 offset
         HolidayRule pilgrimsBounty = { 404, HolidayCalculationType::NTH_WEEKDAY, 11, 4, static_cast<int>(Weekday::THURSDAY), -4 };


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

This is a unit-test-only change; no Core/Scripts/Database behaviour is affected.

`HolidayDateCalculatorTest` built the *expected* date with `std::mktime()`, which rejects pre-1970 dates on MSVC and returns `-1` without normalizing. The only years where Easter + 1 day crosses a month boundary are those where Easter falls on March 31 (e.g. 1907/1918/1929), so the expected value stayed an invalid "March 32" while the production code (which already avoids `mktime`) correctly yields April 1 — failing `Noblegarden_DayAfterEaster_1900_2200`. This adds a portable `NormalizeTm()` helper to the test and uses it for the Noblegarden and Pilgrim's Bounty expected values. Production code is unchanged.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. — Claude Code with azerothMCP

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #25619

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Unit-test-only change. Cross-checked the new `NormalizeTm()` helper against the production normalization for every year 1900–2200: 0 mismatches, and confirmed the 13 March-31 rollover years that triggered the MSVC failure.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Configure with `-DBUILD_TESTING=ON` and build on Windows/MSVC.
2. Run `unit_tests` (e.g. `.\bin\Release\unit_tests.exe`).
3. Confirm `HolidayDateCalculatorTest.Noblegarden_DayAfterEaster_1900_2200` passes.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
