### PR TITLE
fix(Core/Events): correct looping holiday event start time (BG Call to Arms)

### DIFF
--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1960,6 +1960,17 @@ void GameEventMgr::SetHolidayEventTime(GameEventData& event)
 
     time_t curTime = GameTime::GetGameTime().count();
 
+    if (holiday->Looping)
+    {
+        // Looping events (Battleground Call to Arms) carry a single past anchor in the DBC and
+        // recur via event.Occurence. Anchor to that DBC date so the window keeps the correct phase
+        // instead of inheriting the wrong time of day from a stale game_event.start_time.
+        if (time_t start = HolidayDateCalculator::FindLoopingStartTime(holiday->Date[0], stageOffset, event.Occurence, curTime))
+            event.Start = start;
+
+        return;
+    }
+
     if (!singleDate)
     {
         time_t start = HolidayDateCalculator::FindStartTimeForStage(

--- a/src/server/game/Events/HolidayDateCalculator.cpp
+++ b/src/server/game/Events/HolidayDateCalculator.cpp
@@ -671,3 +671,28 @@ time_t HolidayDateCalculator::FindStartTimeForStage(const uint32_t* packedDates,
 
     return 0;
 }
+
+time_t HolidayDateCalculator::FindLoopingStartTime(uint32_t packedAnchor, time_t stageOffset,
+    uint32_t occurenceMinutes, time_t curTime)
+{
+    if (!packedAnchor)
+        return 0;
+
+    std::tm timeInfo = {};
+    timeInfo.tm_year = static_cast<int>((packedAnchor >> 24) & 0x1F) + 100; // years since 1900 (2000-2031)
+    timeInfo.tm_mon  = static_cast<int>((packedAnchor >> 20) & 0xF);
+    timeInfo.tm_mday = static_cast<int>((packedAnchor >> 14) & 0x3F) + 1;
+    timeInfo.tm_hour = static_cast<int>((packedAnchor >> 6) & 0x1F);
+    timeInfo.tm_min  = static_cast<int>(packedAnchor & 0x3F);
+    timeInfo.tm_sec  = 0;
+    timeInfo.tm_isdst = -1;
+
+    time_t anchor = mktime(&timeInfo) + stageOffset;
+
+    // Roll forward by whole periods to the most recent occurrence, preserving phase.
+    time_t const period = static_cast<time_t>(occurenceMinutes) * 60;
+    if (period > 0 && anchor < curTime)
+        anchor += ((curTime - anchor) / period) * period;
+
+    return anchor;
+}

--- a/src/server/game/Events/HolidayDateCalculator.h
+++ b/src/server/game/Events/HolidayDateCalculator.h
@@ -107,6 +107,11 @@ public:
     static time_t FindStartTimeForStage(const uint32_t* packedDates, uint8_t numDates,
         time_t stageOffset, uint32_t stageLengthMinutes, time_t curTime);
 
+    // Start time for a looping holiday event (Battleground Call to Arms): rolls the packed anchor
+    // forward by whole occurenceMinutes periods to the most recent occurrence. Returns 0 if anchor is 0.
+    static time_t FindLoopingStartTime(uint32_t packedAnchor, time_t stageOffset,
+        uint32_t occurenceMinutes, time_t curTime);
+
 private:
     // Julian Date conversions for lunar calculations
     static double DateToJulianDay(int year, int month, double day);

--- a/src/test/server/game/Events/HolidayDateCalculatorTest.cpp
+++ b/src/test/server/game/Events/HolidayDateCalculatorTest.cpp
@@ -1389,3 +1389,86 @@ TEST_F(FindStartTimeForStageTest, AllDatesPast_ReturnsZero)
     time_t result = HolidayDateCalculator::FindStartTimeForStage(dates, 26, stageOffset, stageLengthMin, curTime);
     EXPECT_EQ(result, 0);
 }
+
+// ============================================================================
+// FindLoopingStartTime tests (Battleground Call to Arms)
+// ============================================================================
+
+class FindLoopingStartTimeTest : public ::testing::Test
+{
+protected:
+    static time_t MakeTime(int year, int month, int day, int hour = 0)
+    {
+        std::tm t = {};
+        t.tm_year = year - 1900;
+        t.tm_mon = month - 1;
+        t.tm_mday = day;
+        t.tm_hour = hour;
+        t.tm_isdst = -1;
+        return mktime(&t);
+    }
+
+    static uint32_t PackAnchor(int year, int month, int day, int hour, int minute)
+    {
+        uint32_t packed = 0;
+        packed |= (static_cast<uint32_t>(year - 2000) & 0x1F) << 24;
+        packed |= (static_cast<uint32_t>(month - 1) & 0xF) << 20;
+        packed |= (static_cast<uint32_t>(day - 1) & 0x3F) << 14;
+        packed |= (static_cast<uint32_t>(hour) & 0x1F) << 6;
+        packed |= (static_cast<uint32_t>(minute) & 0x3F);
+        return packed;
+    }
+
+    static constexpr uint32_t OCCURENCE_MIN = 60480; // 42 day cycle (AV Call to Arms)
+};
+
+TEST_F(FindLoopingStartTimeTest, ZeroAnchor_ReturnsZero)
+{
+    time_t curTime = MakeTime(2026, 6, 1);
+    EXPECT_EQ(HolidayDateCalculator::FindLoopingStartTime(0, 0, OCCURENCE_MIN, curTime), 0);
+}
+
+TEST_F(FindLoopingStartTimeTest, FutureAnchor_NotRolled)
+{
+    uint32_t anchor = PackAnchor(2026, 10, 30, 0, 0);
+    time_t curTime = MakeTime(2026, 6, 1);
+    EXPECT_EQ(HolidayDateCalculator::FindLoopingStartTime(anchor, 0, OCCURENCE_MIN, curTime),
+        MakeTime(2026, 10, 30));
+}
+
+// The bug: an ancient midnight anchor must roll forward preserving phase, not fall back to a stale start_time.
+TEST_F(FindLoopingStartTimeTest, AncientAnchor_RollsToMostRecentOccurrence)
+{
+    uint32_t anchor = PackAnchor(2007, 10, 26, 0, 0);
+    time_t curTime = MakeTime(2026, 2, 6, 12);
+
+    time_t result = HolidayDateCalculator::FindLoopingStartTime(anchor, 0, OCCURENCE_MIN, curTime);
+
+    time_t const period = static_cast<time_t>(OCCURENCE_MIN) * 60;
+    time_t const base = MakeTime(2007, 10, 26);
+
+    EXPECT_LE(result, curTime);
+    EXPECT_GT(result + period, curTime);
+    EXPECT_EQ((result - base) % period, 0);
+}
+
+TEST_F(FindLoopingStartTimeTest, StageOffsetApplied)
+{
+    uint32_t anchor = PackAnchor(2007, 10, 26, 0, 0);
+    time_t stageOffset = 96 * 3600;
+    time_t curTime = MakeTime(2026, 2, 6, 12);
+
+    time_t result = HolidayDateCalculator::FindLoopingStartTime(anchor, stageOffset, OCCURENCE_MIN, curTime);
+
+    time_t const period = static_cast<time_t>(OCCURENCE_MIN) * 60;
+    time_t const base = MakeTime(2007, 10, 26) + stageOffset;
+    EXPECT_EQ((result - base) % period, 0);
+}
+
+TEST_F(FindLoopingStartTimeTest, ZeroOccurence_ReturnsAnchor)
+{
+    uint32_t anchor = PackAnchor(2007, 10, 26, 0, 0);
+    time_t curTime = MakeTime(2026, 2, 6, 12);
+    EXPECT_EQ(HolidayDateCalculator::FindLoopingStartTime(anchor, 0, 0, curTime),
+        MakeTime(2007, 10, 26));
+}


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Looping holiday events (BG Call to Arms) anchor `event.Start` to the DBC date and roll forward by whole occurrence periods, instead of falling back to the stale `game_event.start_time` that made them start/end ~12 hours late.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. — **Claude Code with AzerothMCP**

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #22027

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds clean and is covered by unit tests (`FindLoopingStartTimeTest`).

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
