### PR TITLE
fix(Core/Loot): keep group loot rolls when the roller leaves the loot's map

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -750,7 +750,7 @@ void Creature::Update(uint32 diff)
                 {
                     Group* group = sGroupMgr->GetGroupByGUID(lootingGroupLowGUID);
                     if (group)
-                        group->EndRoll(&loot, GetMap());
+                        group->EndRoll(&loot);
                     m_groupLootTimer = 0;
                     lootingGroupLowGUID = 0;
                 }

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -766,7 +766,7 @@ void GameObject::Update(uint32 diff)
                             {
                                 Group* group = sGroupMgr->GetGroupByGUID(lootingGroupLowGUID);
                                 if (group)
-                                    group->EndRoll(&loot, GetMap());
+                                    group->EndRoll(&loot);
                                 m_groupLootTimer = 0;
                                 lootingGroupLowGUID = 0;
                             }

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1407,20 +1407,20 @@ bool Group::CountRollVote(ObjectGuid playerGUID, ObjectGuid Guid, uint8 Choice)
 
     if (roll->totalPass + roll->totalNeed + roll->totalGreed >= roll->totalPlayersRolling)
     {
-        CountTheRoll(rollI, nullptr);
+        CountTheRoll(rollI);
         return true;
     }
     return false;
 }
 
 //called when roll timer expires
-void Group::EndRoll(Loot* pLoot, Map* allowedMap)
+void Group::EndRoll(Loot* pLoot)
 {
     for (Rolls::iterator itr = RollId.begin(); itr != RollId.end();)
     {
         if ((*itr)->getLoot() == pLoot)
         {
-            CountTheRoll(itr, allowedMap);           //i don't have to edit player votes, who didn't vote ... he will pass
+            CountTheRoll(itr);           //i don't have to edit player votes, who didn't vote ... he will pass
             itr = RollId.begin();
         }
         else
@@ -1459,7 +1459,7 @@ void Group::RemovePlayerFromRolls(ObjectGuid guid)
     }
 }
 
-void Group::CountTheRoll(Rolls::iterator rollI, Map* allowedMap)
+void Group::CountTheRoll(Rolls::iterator rollI)
 {
     Roll* roll = *rollI;
     if (!roll->isValid())                                   // is loot already deleted ?
@@ -1484,7 +1484,7 @@ void Group::CountTheRoll(Rolls::iterator rollI, Map* allowedMap)
                     continue;
 
                 player = ObjectAccessor::FindPlayer(itr->first);
-                if (!player || (allowedMap != nullptr && player->FindMap() != allowedMap))
+                if (!player)
                 {
                     --roll->totalNeed;
                     continue;
@@ -1548,7 +1548,7 @@ void Group::CountTheRoll(Rolls::iterator rollI, Map* allowedMap)
                 roll->totalNeed = 0;
         }
     }
-    if (roll->totalNeed == 0 && roll->totalGreed > 0) // pussywizard: if (roll->totalNeed == 0 && ...), not else if, because numbers can be modified above if player is on a different map
+    if (roll->totalNeed == 0 && roll->totalGreed > 0) // if (roll->totalNeed == 0 && ...), not else if, because totalNeed can be decremented above when a needing player is offline
     {
         if (!roll->playerVote.empty())
         {
@@ -1564,7 +1564,7 @@ void Group::CountTheRoll(Rolls::iterator rollI, Map* allowedMap)
                     continue;
 
                 player = ObjectAccessor::FindPlayer(itr->first);
-                if (!player || (allowedMap != nullptr && player->FindMap() != allowedMap))
+                if (!player)
                 {
                     --roll->totalGreed;
                     continue;
@@ -1662,7 +1662,7 @@ void Group::CountTheRoll(Rolls::iterator rollI, Map* allowedMap)
                 roll->totalGreed = 0;
         }
     }
-    if (roll->totalNeed == 0 && roll->totalGreed == 0) // pussywizard: if, not else, because numbers can be modified above if player is on a different map
+    if (roll->totalNeed == 0 && roll->totalGreed == 0) // if, not else, because the totals can be decremented above when a rolling player is offline
     {
         SendLootAllPassed(*roll);
 

--- a/src/server/game/Groups/Group.h
+++ b/src/server/game/Groups/Group.h
@@ -303,9 +303,9 @@ public:
     void NeedBeforeGreed(Loot* loot, WorldObject* pLootedObject);
     void MasterLoot(Loot* loot, WorldObject* pLootedObject);
     Rolls::iterator GetRoll(ObjectGuid Guid);
-    void CountTheRoll(Rolls::iterator roll, Map* allowedMap);
+    void CountTheRoll(Rolls::iterator roll);
     bool CountRollVote(ObjectGuid playerGUID, ObjectGuid Guid, uint8 Choise);
-    void EndRoll(Loot* loot, Map* allowedMap);
+    void EndRoll(Loot* loot);
     void RemovePlayerFromRolls(ObjectGuid guid);
 
     // related to disenchant rolls


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

When a group-loot roll timer expires, `Group::CountTheRoll` discarded any Need/Greed vote whose caster was no longer on the loot source's map (the `player->FindMap() != allowedMap` check in both the Need and Greed winner-selection loops). If every roller of a contested item had left the instance, both `totalNeed` and `totalGreed` were decremented to 0, so the roll fell through to the "all passed" branch: the item was unblocked and became free-for-all on the corpse. This is the behavior reported in the issue, and it can also be abused to deny loot to players who stayed inside.

The map membership of the winner is irrelevant to awarding the item: it is delivered straight to the bag (or mailed when bags are full) via the existing `CanStoreNewItem` / `StoreNewItem` / `SendRollWonItemViaMail` paths, regardless of where the player physically is. The fix drops the map term and keeps only the offline guard (`!player`), so a valid roll is counted no matter which map the roller is on. The now-unused `allowedMap` parameter is removed from `EndRoll` and `CountTheRoll`.

This also removes an inconsistency: when all eligible players voted before the timer, the roll was finalized with no map filter at all, so the same leaver kept their roll if voting happened to finish in time but lost it if the timer ran out.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code (Opus 4.8) was used to investigate the issue and draft the change.

## Issues Addressed:
- Closes #26221

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Reasoned from the loot-roll code path. For reference, TrinityCore 3.3.5 carries the identical `allowedMap` filtering, so there is no upstream fix to cherry-pick; this is an original change that knowingly diverges from TC here.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds with the existing signatures updated at both call sites (`Creature.cpp`, `GameObject.cpp`). C++ codestyle check passes.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Form a party of 3 and enter an instance together.
2. Kill a boss with an over-threshold drop and open the loot.
3. Two members roll Greed (or Need) and immediately leave the instance (Hearthstone).
4. The third member does not roll and lets the timer expire.
5. Before: the two rolls are discarded, the item shows "everyone passed" and is freely lootable by whoever remains. After: the rolls count, a winner is picked among the rollers, and the item is awarded to them.

## Known Issues and TODO List:

- [ ] The issue also describes a separate symptom where the roll window does not close / the roll "never finishes" for some clients. That appears to be an independent problem (the result packet not reaching every client / the loot timer not finalizing) and is not addressed here. This PR only fixes the lost-roll and free-for-all behavior.
