### PR TITLE
fix(Apps/SOAP): prevent shutdown deadlock on in-flight commands

### DIFF
--- a/src/server/apps/worldserver/ACSoap/ACSoap.cpp
+++ b/src/server/apps/worldserver/ACSoap/ACSoap.cpp
@@ -20,6 +20,7 @@
 #include "Log.h"
 #include "World.h"
 #include "soapStub.h"
+#include <chrono>
 
 void ACSoapThread(const std::string& host, uint16 port)
 {
@@ -117,8 +118,14 @@ int ns1__executeCommand(soap* soap, char* command, char** result)
         sWorld->QueueCliCommand(cmd);
     }
 
-    // Wait until the command has finished executing
-    connection.finishedPromise.get_future().wait();
+    // Wait for the command to finish, but bail on shutdown: ProcessCliCommands() (which fulfils
+    // the promise) stops once the world loop exits, so an unbounded wait here would deadlock.
+    std::future<void> finished = connection.finishedPromise.get_future();
+    while (finished.wait_for(std::chrono::seconds(1)) != std::future_status::ready)
+    {
+        if (World::IsStopped())
+            return soap_receiver_fault(soap, "Server is shutting down", "Command aborted: the server is shutting down");
+    }
 
     // The command has finished executing already
     char* printBuffer = soap_strdup(soap, connection.m_printBuffer.c_str());

--- a/src/server/apps/worldserver/ACSoap/ACSoap.cpp
+++ b/src/server/apps/worldserver/ACSoap/ACSoap.cpp
@@ -21,6 +21,7 @@
 #include "World.h"
 #include "soapStub.h"
 #include <chrono>
+#include <memory>
 
 void ACSoapThread(const std::string& host, uint16 port)
 {
@@ -109,18 +110,19 @@ int ns1__executeCommand(soap* soap, char* command, char** result)
         return soap_sender_fault(soap, "Command can not be empty", "The supplied command was an empty string");
 
     LOG_DEBUG("network.soap", "ACSoap: got command '{}'", command);
-    SOAPCommand connection;
+
+    // Shared so the object survives if we stop waiting below: the queued command keeps a raw
+    // pointer to it and the world thread may still run it after that. The extra reference is
+    // released by commandFinished() once the world side is done with it.
+    auto connection = std::make_shared<SOAPCommand>();
+    connection->m_self = connection;
 
     // commands are executed in the world thread. We have to wait for them to be completed
-    {
-        // CliCommandHolder will be deleted from world, accessing after queueing is NOT save
-        CliCommandHolder* cmd = new CliCommandHolder(&connection, command, &SOAPCommand::print, &SOAPCommand::commandFinished);
-        sWorld->QueueCliCommand(cmd);
-    }
+    sWorld->QueueCliCommand(new CliCommandHolder(connection.get(), command, &SOAPCommand::print, &SOAPCommand::commandFinished));
 
     // Wait for the command to finish, but bail on shutdown: ProcessCliCommands() (which fulfils
     // the promise) stops once the world loop exits, so an unbounded wait here would deadlock.
-    std::future<void> finished = connection.finishedPromise.get_future();
+    std::future<void> finished = connection->finishedPromise.get_future();
     while (finished.wait_for(std::chrono::seconds(1)) != std::future_status::ready)
     {
         if (World::IsStopped())
@@ -128,8 +130,8 @@ int ns1__executeCommand(soap* soap, char* command, char** result)
     }
 
     // The command has finished executing already
-    char* printBuffer = soap_strdup(soap, connection.m_printBuffer.c_str());
-    if (connection.hasCommandSucceeded())
+    char* printBuffer = soap_strdup(soap, connection->m_printBuffer.c_str());
+    if (connection->hasCommandSucceeded())
     {
         *result = printBuffer;
         return SOAP_OK;
@@ -142,6 +144,8 @@ void SOAPCommand::commandFinished(void* soapconnection, bool success)
 {
     SOAPCommand* con = (SOAPCommand*)soapconnection;
     con->setCommandSuccess(success);
+    // world side is done with us; drop the keep-alive (may free the object)
+    con->m_self.reset();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/server/apps/worldserver/ACSoap/ACSoap.h
+++ b/src/server/apps/worldserver/ACSoap/ACSoap.h
@@ -20,6 +20,7 @@
 
 #include "Define.h"
 #include <future>
+#include <memory>
 
 void process_message(struct soap* soap_message);
 void ACSoapThread(const std::string& host, uint16 port);
@@ -58,6 +59,8 @@ public:
     bool m_success;
     std::string m_printBuffer;
     std::promise<void> finishedPromise;
+    // keep-alive while a queued command still references this object; released in commandFinished()
+    std::shared_ptr<SOAPCommand> m_self;
 };
 
 #endif


### PR DESCRIPTION
## Changes Proposed:
This PR fixes a shutdown/restart deadlock in the SOAP serving thread.

`ns1__executeCommand` (`src/server/apps/worldserver/ACSoap/ACSoap.cpp`) queues the command to the world thread and then waits on `connection.finishedPromise` with **no timeout**. That promise is only ever fulfilled by `World::ProcessCliCommands()`, which runs solely from the world update loop.

When the world stops (restart/shutdown) while a SOAP command is still in flight, `ProcessCliCommands()` never runs again, so the SOAP thread blocks on the promise forever. The shutdown unwind then hangs in the `soapThread` deleter's `join()` (`Main.cpp:335`), deadlocking the whole process — **the server never exits** (it just sits there; the freeze detector is already torn down, so it can't self-recover).

The fix polls the future with a 1s timeout and aborts with a SOAP fault once `World::IsStopped()` is set, so the SOAP thread always returns and shutdown completes cleanly.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

**Claude Code with azerothMCP**

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Reproduced and verified locally (see below). The deadlock was confirmed live in lldb: the main thread parked in `std::thread::join()` at `Main.cpp:335` during the shutdown unwind, while the SOAP thread sat in an unbounded `future::wait()` at `ACSoap.cpp` — a promise the now-stopped world loop can never fulfill.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

A SOAP client hammered the port (~80 req/s of `server info`) while the server was restarted.

**Before the fix:** at the moment of shutdown the in-flight request hung for the full client timeout (8s, `curl_exit=28`) and the worldserver process never exited — it remained deadlocked in `join()`.

**After the fix:** the in-flight request returns a single `HTTP 500` "Server is shutting down" SOAP fault, the port closes immediately (connection refused), the process exits, and the restart comes back up — **zero timeouts**.

## How to Test the Changes:
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Enable SOAP in `worldserver.conf` (`SOAP.Enabled = 1`).
2. Start the worldserver and repeatedly send SOAP `executeCommand` requests (e.g. a loop of `server info`) so a command is always in flight.
3. Issue `.server restart 1` (or send `SIGTERM`) while the requests are flowing.
4. Confirm the process shuts down and restarts cleanly instead of hanging. In-flight requests should receive a "Server is shutting down" fault rather than timing out.

## Known Issues and TODO List:

- [ ] None.
