### PR TITLE
fix(DB/Creature): Make Thorim gauntlet Iron Ring Guards attackable

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1782398094522000000.sql
+++ b/data/sql/updates/pending_db_world/rev_1782398094522000000.sql
@@ -1,0 +1,1 @@
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` &~ 256 WHERE (`entry` = 32874);


### PR DESCRIPTION
## Summary
- Fixes Iron Ring Guards in Thorim's gauntlet being targetable but not attackable.
- Clears the player-combat immunity flag from creature template entry 32874.

## Changes
- Adds a pending world DB update removing `UNIT_FLAG_IMMUNE_TO_PC` (`256`) from Iron Ring Guard.

## Testing/Verification
- Ran `PYTHONIOENCODING=utf-8 python apps/codestyle/codestyle-sql.py data/sql/updates/pending_db_world/rev_1782398094522000000.sql`.
- Ran `git diff --check`.
- Verified `256` maps to `UNIT_FLAG_IMMUNE_TO_PC` in `UnitDefines.h`.

Closes #26351