### PR TITLE
fix(scripts/Icecrown): Banshee's Revenge 

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1782172804531209100.sql
+++ b/data/sql/updates/pending_db_world/rev_1782172804531209100.sql
@@ -6,7 +6,8 @@ UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_ov
     `unit_flags`= 33088, `CreatureImmunitiesId`= 31016, `ManaModifier`= 2 WHERE `entry`= 31016;
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_safirdrang',
     `unit_flags`= 256, `ManaModifier`= 2 WHERE `entry`= 31050;
-UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_elite' WHERE `entry`= 31030;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_elite',
+    `unit_flags`= 256 WHERE `entry`= 31030;
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_vardmadra',
     `unit_flags`= 33536 WHERE `entry`= 31029;
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_nightswood' WHERE `entry`= 31087;

--- a/data/sql/updates/pending_db_world/rev_1782172804531209100.sql
+++ b/data/sql/updates/pending_db_world/rev_1782172804531209100.sql
@@ -3,20 +3,20 @@
 -- Safirdrang (NPC 31050) and hidden Chill target stalkers (NPC 31077)
 
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_overthane',
-    `unit_flags`=33088, `CreatureImmunitiesId`=31016 WHERE `entry`=31016;
+    `unit_flags`= 33088, `CreatureImmunitiesId`= 31016, `ManaModifier`= 2 WHERE `entry`= 31016;
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_safirdrang',
-    `unit_flags`=256 WHERE `entry`=31050;
-UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_elite' WHERE `entry`=31030;
+    `unit_flags`= 256, `ManaModifier`= 2 WHERE `entry`= 31050;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_elite' WHERE `entry`= 31030;
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_vardmadra',
-    `unit_flags`=33536 WHERE `entry`=31029;
-UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_nightswood' WHERE `entry`=31087;
+    `unit_flags`= 33536 WHERE `entry`= 31029;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_nightswood' WHERE `entry`= 31087;
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_lich_king',
-    `unit_flags`=768 WHERE `entry`=31083;
+    `unit_flags`= 768 WHERE `entry`= 31083;
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_chill_target',
-    `unit_flags`=33555200 WHERE `entry`=31077;
+    `unit_flags`= 33555200 WHERE `entry`= 31077;
 
 -- Overthane Balargarde (NPC 31016) CC immunity
-DELETE FROM `creature_immunities` WHERE `ID`=31016;
+DELETE FROM `creature_immunities` WHERE `ID`= 31016;
 INSERT INTO `creature_immunities` (`ID`, `SchoolMask`, `DispelTypeMask`, `MechanicsMask`, `Effects`, `Auras`, `ImmuneAoE`, `ImmuneChain`, `Comment`) VALUES
 (31016, 0, 0, 1301708534, '', '', 0, 0, 'Overthane Balargarde - Banshees Revenge boss crowd-control immunity');
 

--- a/data/sql/updates/pending_db_world/rev_1782172804531209100.sql
+++ b/data/sql/updates/pending_db_world/rev_1782172804531209100.sql
@@ -6,13 +6,18 @@
 -- NOTE: AzerothCore has no `creature_template`.`InhabitType` column (TC-only); flight is stored in
 -- `creature_template_movement`. 31050/31030/31029/31087 are already `Flight`=1 in the base data, so no
 -- movement rows are needed here.
-UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_overthane', `unit_flags`=33088 WHERE `entry`=31016;
-UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_safirdrang', `unit_flags`=256 WHERE `entry`=31050;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_overthane',
+    `unit_flags`=33088 WHERE `entry`=31016;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_safirdrang',
+    `unit_flags`=256 WHERE `entry`=31050;
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_elite' WHERE `entry`=31030;
-UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_vardmadra', `unit_flags`=33536 WHERE `entry`=31029;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_vardmadra',
+    `unit_flags`=33536 WHERE `entry`=31029;
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_nightswood' WHERE `entry`=31087;
-UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_lich_king', `unit_flags`=768 WHERE `entry`=31083;
-UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_chill_target', `unit_flags`=33555200 WHERE `entry`=31077;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_lich_king',
+    `unit_flags`=768 WHERE `entry`=31083;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_chill_target',
+    `unit_flags`=33555200 WHERE `entry`=31077;
 
 -- The Balargarde Elites use a cosmetic proto-drake mount (creature_addon mount 26882) and fly their own
 -- patrols, so the custom proto-drake vehicle NPC (310300) is removed (clean up any earlier import of it).
@@ -21,8 +26,10 @@ DELETE FROM `creature_template_model` WHERE `CreatureID`=310300;
 DELETE FROM `creature_template_movement` WHERE `CreatureId`=310300;
 DELETE FROM `creature_template_addon` WHERE `entry`=310300;
 
--- Remove the legacy SmartAI rows for the encounter creatures.
+-- Remove the legacy SmartAI rows for the encounter creatures (source_type 0) and Overthane's
+-- timed action list (source_type 9, entryorguid 31016).
 DELETE FROM `smart_scripts` WHERE `source_type`=0 AND `entryorguid` IN (31016, 31029, 31030, 31050, 31077, 31083, 31087);
+DELETE FROM `smart_scripts` WHERE `source_type`=9 AND `entryorguid`=31016;
 
 -- Cosmetic spawn auras / hover anim states. The elite (31030) gets the cosmetic proto-drake mount (26882).
 DELETE FROM `creature_template_addon` WHERE `entry` IN (31016, 31029, 31030, 31050, 31083);
@@ -39,7 +46,7 @@ INSERT INTO `event_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, 
 (20108, 0, 10, 31029, 1800000, 0, 7116.824, 4308.362, 883.3842, 2.46227);
 
 -- Safirdrang's Chill (4020) only affects the chill target stalkers.
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry`=4020;
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceGroup`=1 AND `SourceEntry`=4020 AND `SourceId`=0 AND `ElseGroup`=0;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (13, 1, 4020, 0, 0, 31, 0, 3, 31077, 0, 0, 0, 0, '', 'Safirdrangs Chill targets Safirdrangs Chill Target');
 

--- a/data/sql/updates/pending_db_world/rev_1782172804531209100.sql
+++ b/data/sql/updates/pending_db_world/rev_1782172804531209100.sql
@@ -1,11 +1,5 @@
 -- Quest 13142 "Banshee's Revenge" - Overthane Balargarde encounter.
--- The SmartAI implementation is replaced by C++ (zone_icecrown.cpp); this update
--- wires the creatures to the new scripts and provides the supporting data.
 
--- Attach the C++ AIs and clear the legacy SmartAI / apply the encounter unit flags.
--- NOTE: AzerothCore has no `creature_template`.`InhabitType` column (TC-only); flight is stored in
--- `creature_template_movement`. 31050/31030/31029/31087 are already `Flight`=1 in the base data, so no
--- movement rows are needed here.
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_overthane',
     `unit_flags`=33088 WHERE `entry`=31016;
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_safirdrang',
@@ -18,13 +12,6 @@ UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_li
     `unit_flags`=768 WHERE `entry`=31083;
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_chill_target',
     `unit_flags`=33555200 WHERE `entry`=31077;
-
--- The Balargarde Elites use a cosmetic proto-drake mount (creature_addon mount 26882) and fly their own
--- patrols, so the custom proto-drake vehicle NPC (310300) is removed (clean up any earlier import of it).
-DELETE FROM `creature_template` WHERE `entry`=310300;
-DELETE FROM `creature_template_model` WHERE `CreatureID`=310300;
-DELETE FROM `creature_template_movement` WHERE `CreatureId`=310300;
-DELETE FROM `creature_template_addon` WHERE `entry`=310300;
 
 -- Remove the legacy SmartAI rows for the encounter creatures (source_type 0) and Overthane's
 -- timed action list (source_type 9, entryorguid 31016).

--- a/data/sql/updates/pending_db_world/rev_1782172804531209100.sql
+++ b/data/sql/updates/pending_db_world/rev_1782172804531209100.sql
@@ -1,7 +1,9 @@
--- Quest 13142 "Banshee's Revenge" - Overthane Balargarde encounter.
+-- Quest 13142 "Banshee's Revenge" - Overthane Balargarde (NPC 31016) encounter, featuring Balargarde Elite (NPC 31030),
+-- The Lich King (31083), Possessed Vardmadra (NPC 31029), Lady Nightswood (NPC 31087),
+-- Safirdrang (NPC 31050) and hidden Chill target stalkers (NPC 31077)
 
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_overthane',
-    `unit_flags`=33088 WHERE `entry`=31016;
+    `unit_flags`=33088, `CreatureImmunitiesId`=31016 WHERE `entry`=31016;
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_safirdrang',
     `unit_flags`=256 WHERE `entry`=31050;
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_elite' WHERE `entry`=31030;
@@ -13,12 +15,16 @@ UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_li
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_chill_target',
     `unit_flags`=33555200 WHERE `entry`=31077;
 
--- Remove the legacy SmartAI rows for the encounter creatures (source_type 0) and Overthane's
--- timed action list (source_type 9, entryorguid 31016).
+-- Overthane Balargarde (NPC 31016) CC immunity
+DELETE FROM `creature_immunities` WHERE `ID`=31016;
+INSERT INTO `creature_immunities` (`ID`, `SchoolMask`, `DispelTypeMask`, `MechanicsMask`, `Effects`, `Auras`, `ImmuneAoE`, `ImmuneChain`, `Comment`) VALUES
+(31016, 0, 0, 1301708534, '', '', 0, 0, 'Overthane Balargarde - Banshees Revenge boss crowd-control immunity');
+
+-- Remove legacy SAI
 DELETE FROM `smart_scripts` WHERE `source_type`=0 AND `entryorguid` IN (31016, 31029, 31030, 31050, 31077, 31083, 31087);
 DELETE FROM `smart_scripts` WHERE `source_type`=9 AND `entryorguid`=31016;
 
--- Cosmetic spawn auras / hover anim states. The elite (31030) gets the cosmetic proto-drake mount (26882).
+-- Spawn auras and hover states
 DELETE FROM `creature_template_addon` WHERE `entry` IN (31016, 31029, 31030, 31050, 31083);
 INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
 (31016, 0, 0, 0, 1, 0, 0, '61081'),
@@ -27,68 +33,69 @@ INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `b
 (31050, 0, 0, 50331648, 1, 0, 0, ''),
 (31083, 0, 0, 0, 1, 0, 0, '34427');
 
--- War Horn of Jotunheim (event 20108) now summons Possessed Vardmadra to start the event.
-DELETE FROM `event_scripts` WHERE `id`=20108;
+-- War Horn of Jotunheim (GO 193028) summons Possessed Vardmadra (NPC 31029)
+DELETE FROM `event_scripts` WHERE `id` = 20108;
 INSERT INTO `event_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `dataint`, `x`, `y`, `z`, `o`) VALUES
 (20108, 0, 10, 31029, 1800000, 0, 7116.824, 4308.362, 883.3842, 2.46227);
 
--- Safirdrang's Chill (4020) only affects the chill target stalkers.
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceGroup`=1 AND `SourceEntry`=4020 AND `SourceId`=0 AND `ElseGroup`=0;
+-- Safirdrang's Chill (4020) only cast on hidden Chill target stalkers (NPC 31077)
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceGroup`= 1 AND `SourceEntry`= 4020 AND `SourceId`= 0 AND `ElseGroup`= 0;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(13, 1, 4020, 0, 0, 31, 0, 3, 31077, 0, 0, 0, 0, '', 'Safirdrangs Chill targets Safirdrangs Chill Target');
+(13, 1, 4020, 0, 0, 31, 0, 3, 31077, 0, 0, 0, 0, '', 'Safirdrang`s Chill targets Safirdrang`s Chill Target');
 
--- Encounter dialogue.
-DELETE FROM `creature_text` WHERE `CreatureID` IN (31016, 31029, 31083);
+-- Encounter dialogue
+DELETE FROM `creature_text` WHERE `CreatureID` IN (31016, 31029, 31083, 31087);
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextID`, `TextRange`, `comment`) VALUES
-(31016, 1, 0, 'You dare to challenge me? You haven''t earned the right!', 14, 0, 100, 25, 0, 15633, 31597, 0, 'Overthane Balargarde to Safirdrang'),
-(31016, 2, 0, 'Vardmadra?! Did the Lich King send you personally?', 14, 0, 100, 66, 0, 15634, 31599, 0, 'Overthane Balargarde to Possessed Vardmadra'),
-(31016, 3, 0, 'Very well. I will dispatch these creatures. It is only an inconvenience. Prepare to die!', 14, 0, 100, 0, 0, 15635, 31600, 0, 'Overthane Balargarde to Possessed Vardmadra'),
-(31016, 4, 0, 'Safirdrang, let them feel the chill of Icecrown!', 14, 0, 100, 0, 0, 15636, 31601, 0, 'Overthane Balargarde'),
-(31016, 5, 0, 'STOP! Kneel you fools, it''s the Lich King!', 14, 0, 100, 0, 0, 15637, 31627, 0, 'Overthane Balargarde to The Lich King'),
-(31016, 6, 0, 'But, my lord...?', 14, 0, 100, 0, 0, 15638, 31635, 0, 'Overthane Balargarde to The Lich King'),
-(31016, 7, 0, 'DIE DOGS!', 14, 0, 100, 0, 0, 15639, 31637, 0, 'Overthane Balargarde to The Lich King'),
-(31029, 0, 0, 'He''s on his way!', 14, 0, 100, 457, 0, 15643, 31595, 0, 'Possessed Vardmadra to Player'),
-(31029, 1, 0, 'Wrong, Balargarde. You WILL accept this challenge!', 14, 0, 100, 457, 0, 15644, 31598, 0, 'Possessed Vardmadra to Overthane Balargarde'),
-(31029, 2, 0, 'My lord.', 14, 0, 100, 457, 0, 15645, 31631, 0, 'Possessed Vardmadra to The Lich King'),
-(31029, 3, 0, 'But...!', 14, 0, 100, 0, 0, 15646, 31633, 0, 'Possessed Vardmadra to The Lich King'),
-(31083, 0, 0, 'Honor guard stay where you are.', 14, 0, 100, 1, 0, 15600, 31628, 0, 'The Lich King'),
-(31083, 1, 0, 'Vardmadra. I''d wondered where you disappeared to. How is Iskalder?', 14, 0, 100, 6, 0, 15601, 31629, 0, 'The Lich King'),
-(31083, 2, 0, 'I see through your disguise, Lady Nightswood. YOU THINK THAT YOU CAN FOOL ME?!', 14, 0, 100, 5, 0, 15602, 31632, 0, 'The Lich King'),
-(31083, 3, 0, 'You may continue your combat, overthane.', 14, 0, 100, 25, 0, 15603, 31634, 0, 'The Lich King'),
-(31083, 4, 0, 'But nothing! Finish them! DO NOT FAIL ME, BALARGARDE!', 14, 0, 100, 5, 0, 15604, 31636, 0, 'The Lich King to Overthane Balargarde'),
-(31083, 5, 0, 'You have bested one of my finest, but your efforts are for naught.', 14, 0, 100, 1, 0, 15605, 31693, 0, 'The Lich King'),
-(31083, 6, 0, 'The frozen heart of Icecrown awaits....', 14, 0, 100, 1, 0, 15606, 31695, 0, 'The Lich King');
+(31016, 1, 0, 'You dare to challenge me? You haven''t earned the right!', 14, 0, 100, 25, 0, 15633, 31597, 0, 'Banshee''s Revenge - Overthane Balargarde to Safirdrang'),
+(31016, 2, 0, 'Vardmadra?! Did the Lich King send you personally?', 14, 0, 100, 66, 0, 15634, 31599, 0, 'Banshee''s Revenge - Overthane Balargarde to Possessed Vardmadra'),
+(31016, 3, 0, 'Very well. I will dispatch these creatures. It is only an inconvenience. Prepare to die!', 14, 0, 100, 0, 0, 15635, 31600, 0, 'Banshee''s Revenge - Overthane Balargarde to Possessed Vardmadra'),
+(31016, 4, 0, 'Safirdrang, let them feel the chill of Icecrown!', 14, 0, 100, 0, 0, 15636, 31601, 0, 'Banshee''s Revenge - Overthane Balargarde'),
+(31016, 5, 0, 'STOP! Kneel you fools, it''s the Lich King!', 14, 0, 100, 0, 0, 15637, 31627, 0, 'Banshee''s Revenge - Overthane Balargarde to The Lich King'),
+(31016, 6, 0, 'But, my lord...?', 14, 0, 100, 0, 0, 15638, 31635, 0, 'Banshee''s Revenge - Overthane Balargarde to The Lich King'),
+(31016, 7, 0, 'DIE DOGS!', 14, 0, 100, 0, 0, 15639, 31637, 0, 'Banshee''s Revenge - Overthane Balargarde to The Lich King'),
+(31029, 0, 0, 'He''s on his way!', 14, 0, 100, 457, 0, 15643, 31595, 0, 'Banshee''s Revenge - Possessed Vardmadra to Player'),
+(31029, 1, 0, 'Wrong, Balargarde. You WILL accept this challenge!', 14, 0, 100, 457, 0, 15644, 31598, 0, 'Banshee''s Revenge - Possessed Vardmadra to Overthane Balargarde'),
+(31029, 2, 0, 'My lord.', 14, 0, 100, 0, 0, 15645, 31631, 0, 'Banshee''s Revenge - Possessed Vardmadra to The Lich King'),
+(31029, 3, 0, 'But...!', 14, 0, 100, 0, 0, 15646, 31633, 0, 'Banshee''s Revenge - Possessed Vardmadra to The Lich King'),
+(31083, 0, 0, 'Honor guard stay where you are.', 14, 0, 100, 1, 0, 15600, 31628, 0, 'Banshee''s Revenge - The Lich King'),
+(31083, 1, 0, 'Vardmadra. I''d wondered where you disappeared to. How is Iskalder?', 14, 0, 100, 6, 0, 15601, 31629, 0, 'Banshee''s Revenge - The Lich King'),
+(31083, 2, 0, 'I see through your disguise, Lady Nightswood. YOU THINK THAT YOU CAN FOOL ME?!', 14, 0, 100, 5, 0, 15602, 31632, 0, 'Banshee''s Revenge - The Lich King'),
+(31083, 3, 0, 'You may continue your combat, overthane.', 14, 0, 100, 25, 0, 15603, 31634, 0, 'Banshee''s Revenge - The Lich King'),
+(31083, 4, 0, 'But nothing! Finish them! DO NOT FAIL ME, BALARGARDE!', 14, 0, 100, 5, 0, 15604, 31636, 0, 'Banshee''s Revenge - The Lich King to Overthane Balargarde'),
+(31083, 5, 0, 'You have bested one of my finest, but your efforts are for naught.', 14, 0, 100, 1, 0, 15605, 31693, 0, 'Banshee''s Revenge - The Lich King'),
+(31083, 6, 0, 'The frozen heart of Icecrown awaits....', 14, 0, 100, 1, 0, 15606, 31695, 0, 'Banshee''s Revenge - The Lich King'),
+(31087, 0, 0, '%s smiles and flies off to return to possessing The Bone Witch.', 16, 0, 100, 0, 0, 0, 0, 1, 'Banshee''s Revenge - Lady Nightswood emote');
 
--- Flight paths used by the C++ encounter (MovePath / PathSource::WAYPOINT_MGR).
+-- Flight paths
 DELETE FROM `waypoint_data` WHERE `id` IN (31029, 31050, 3105000, 31087, 31083, 3103001, 3103002, 3103003, 3103004, 3103005, 3103006);
 INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`) VALUES
--- Possessed Vardmadra intro
+-- Possessed Vardmadra (NPC 31029)
 (31029, 1, 7119.714, 4305.82, 883.7371),
 (31029, 2, 7119.045, 4306.563, 883.7371),
 (31029, 3, 7094.592, 4326.246, 879.7935),
 (31029, 4, 7094.592, 4326.246, 879.7935),
--- Safirdrang intro (carries Overthane in)
+-- Safirdrang (NPC 31050) enter
 (31050, 1, 7097.518, 4417.555, 831.8486),
 (31050, 2, 7097.292, 4416.581, 831.8486),
 (31050, 3, 7097.876, 4416.293, 832.2352),
 (31050, 4, 7096.67, 4412.85, 892.0963),
 (31050, 5, 7083.72, 4365.534, 886.1511),
 (31050, 6, 7083.72, 4365.534, 886.1511),
--- Safirdrang depart (after Overthane dies)
+-- Safirdrang (NPC 31050) depart
 (3105000, 1, 7053.937, 4377.317, 901.5513),
 (3105000, 2, 7020.913, 4415.733, 938.7733),
 (3105000, 3, 7014.491, 4475.228, 933.1346),
 (3105000, 4, 7053.163, 4507.731, 899.1902),
--- Lady Nightswood escape
+-- Lady Nightswood (NPC 31087)
 (31087, 1, 7079.599, 4301.017, 874.3533),
 (31087, 2, 7082.374, 4283.685, 878.2528),
 (31087, 3, 7093.269, 4251.247, 855.1418),
--- The Lich King walk
+-- The Lich King (31083)
 (31083, 1, 7092.936, 4343.906, 871.9753),
 (31083, 2, 7094.104, 4331.222, 871.5023),
 (31083, 3, 7092.936, 4343.906, 871.9331),
 (31083, 4, 7088.768, 4385.59, 872.3639),
--- Balargarde Elite patrols
+-- Balargarde Elite (NPC 31030)
 (3103001, 1, 7108.212, 4429.457, 837.8948),
 (3103001, 2, 7108.282, 4428.459, 837.8948),
 (3103001, 3, 7106.677, 4418.644, 890.2556),

--- a/data/sql/updates/pending_db_world/rev_1782172804531209100.sql
+++ b/data/sql/updates/pending_db_world/rev_1782172804531209100.sql
@@ -1,0 +1,131 @@
+-- Quest 13142 "Banshee's Revenge" - Overthane Balargarde encounter.
+-- The SmartAI implementation is replaced by C++ (zone_icecrown.cpp); this update
+-- wires the creatures to the new scripts and provides the supporting data.
+
+-- Attach the C++ AIs and clear the legacy SmartAI / apply the encounter unit flags.
+-- NOTE: AzerothCore has no `creature_template`.`InhabitType` column (TC-only); flight is stored in
+-- `creature_template_movement`. 31050/31030/31029/31087 are already `Flight`=1 in the base data, so no
+-- movement rows are needed here.
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_overthane', `unit_flags`=33088 WHERE `entry`=31016;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_safirdrang', `unit_flags`=256 WHERE `entry`=31050;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_elite' WHERE `entry`=31030;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_vardmadra', `unit_flags`=33536 WHERE `entry`=31029;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_nightswood' WHERE `entry`=31087;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_lich_king', `unit_flags`=768 WHERE `entry`=31083;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_bansheesrevenge_chill_target', `unit_flags`=33555200 WHERE `entry`=31077;
+
+-- The Balargarde Elites use a cosmetic proto-drake mount (creature_addon mount 26882) and fly their own
+-- patrols, so the custom proto-drake vehicle NPC (310300) is removed (clean up any earlier import of it).
+DELETE FROM `creature_template` WHERE `entry`=310300;
+DELETE FROM `creature_template_model` WHERE `CreatureID`=310300;
+DELETE FROM `creature_template_movement` WHERE `CreatureId`=310300;
+DELETE FROM `creature_template_addon` WHERE `entry`=310300;
+
+-- Remove the legacy SmartAI rows for the encounter creatures.
+DELETE FROM `smart_scripts` WHERE `source_type`=0 AND `entryorguid` IN (31016, 31029, 31030, 31050, 31077, 31083, 31087);
+
+-- Cosmetic spawn auras / hover anim states. The elite (31030) gets the cosmetic proto-drake mount (26882).
+DELETE FROM `creature_template_addon` WHERE `entry` IN (31016, 31029, 31030, 31050, 31083);
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(31016, 0, 0, 0, 1, 0, 0, '61081'),
+(31029, 0, 0, 50331648, 1, 0, 0, '58102'),
+(31030, 0, 26882, 0, 1, 0, 3, ''),
+(31050, 0, 0, 50331648, 1, 0, 0, ''),
+(31083, 0, 0, 0, 1, 0, 0, '34427');
+
+-- War Horn of Jotunheim (event 20108) now summons Possessed Vardmadra to start the event.
+DELETE FROM `event_scripts` WHERE `id`=20108;
+INSERT INTO `event_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `dataint`, `x`, `y`, `z`, `o`) VALUES
+(20108, 0, 10, 31029, 1800000, 0, 7116.824, 4308.362, 883.3842, 2.46227);
+
+-- Safirdrang's Chill (4020) only affects the chill target stalkers.
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry`=4020;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 1, 4020, 0, 0, 31, 0, 3, 31077, 0, 0, 0, 0, '', 'Safirdrangs Chill targets Safirdrangs Chill Target');
+
+-- Encounter dialogue.
+DELETE FROM `creature_text` WHERE `CreatureID` IN (31016, 31029, 31083);
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextID`, `TextRange`, `comment`) VALUES
+(31016, 1, 0, 'You dare to challenge me? You haven''t earned the right!', 14, 0, 100, 25, 0, 15633, 31597, 0, 'Overthane Balargarde to Safirdrang'),
+(31016, 2, 0, 'Vardmadra?! Did the Lich King send you personally?', 14, 0, 100, 66, 0, 15634, 31599, 0, 'Overthane Balargarde to Possessed Vardmadra'),
+(31016, 3, 0, 'Very well. I will dispatch these creatures. It is only an inconvenience. Prepare to die!', 14, 0, 100, 0, 0, 15635, 31600, 0, 'Overthane Balargarde to Possessed Vardmadra'),
+(31016, 4, 0, 'Safirdrang, let them feel the chill of Icecrown!', 14, 0, 100, 0, 0, 15636, 31601, 0, 'Overthane Balargarde'),
+(31016, 5, 0, 'STOP! Kneel you fools, it''s the Lich King!', 14, 0, 100, 0, 0, 15637, 31627, 0, 'Overthane Balargarde to The Lich King'),
+(31016, 6, 0, 'But, my lord...?', 14, 0, 100, 0, 0, 15638, 31635, 0, 'Overthane Balargarde to The Lich King'),
+(31016, 7, 0, 'DIE DOGS!', 14, 0, 100, 0, 0, 15639, 31637, 0, 'Overthane Balargarde to The Lich King'),
+(31029, 0, 0, 'He''s on his way!', 14, 0, 100, 457, 0, 15643, 31595, 0, 'Possessed Vardmadra to Player'),
+(31029, 1, 0, 'Wrong, Balargarde. You WILL accept this challenge!', 14, 0, 100, 457, 0, 15644, 31598, 0, 'Possessed Vardmadra to Overthane Balargarde'),
+(31029, 2, 0, 'My lord.', 14, 0, 100, 457, 0, 15645, 31631, 0, 'Possessed Vardmadra to The Lich King'),
+(31029, 3, 0, 'But...!', 14, 0, 100, 0, 0, 15646, 31633, 0, 'Possessed Vardmadra to The Lich King'),
+(31083, 0, 0, 'Honor guard stay where you are.', 14, 0, 100, 1, 0, 15600, 31628, 0, 'The Lich King'),
+(31083, 1, 0, 'Vardmadra. I''d wondered where you disappeared to. How is Iskalder?', 14, 0, 100, 6, 0, 15601, 31629, 0, 'The Lich King'),
+(31083, 2, 0, 'I see through your disguise, Lady Nightswood. YOU THINK THAT YOU CAN FOOL ME?!', 14, 0, 100, 5, 0, 15602, 31632, 0, 'The Lich King'),
+(31083, 3, 0, 'You may continue your combat, overthane.', 14, 0, 100, 25, 0, 15603, 31634, 0, 'The Lich King'),
+(31083, 4, 0, 'But nothing! Finish them! DO NOT FAIL ME, BALARGARDE!', 14, 0, 100, 5, 0, 15604, 31636, 0, 'The Lich King to Overthane Balargarde'),
+(31083, 5, 0, 'You have bested one of my finest, but your efforts are for naught.', 14, 0, 100, 1, 0, 15605, 31693, 0, 'The Lich King'),
+(31083, 6, 0, 'The frozen heart of Icecrown awaits....', 14, 0, 100, 1, 0, 15606, 31695, 0, 'The Lich King');
+
+-- Flight paths used by the C++ encounter (MovePath / PathSource::WAYPOINT_MGR).
+DELETE FROM `waypoint_data` WHERE `id` IN (31029, 31050, 3105000, 31087, 31083, 3103001, 3103002, 3103003, 3103004, 3103005, 3103006);
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`) VALUES
+-- Possessed Vardmadra intro
+(31029, 1, 7119.714, 4305.82, 883.7371),
+(31029, 2, 7119.045, 4306.563, 883.7371),
+(31029, 3, 7094.592, 4326.246, 879.7935),
+(31029, 4, 7094.592, 4326.246, 879.7935),
+-- Safirdrang intro (carries Overthane in)
+(31050, 1, 7097.518, 4417.555, 831.8486),
+(31050, 2, 7097.292, 4416.581, 831.8486),
+(31050, 3, 7097.876, 4416.293, 832.2352),
+(31050, 4, 7096.67, 4412.85, 892.0963),
+(31050, 5, 7083.72, 4365.534, 886.1511),
+(31050, 6, 7083.72, 4365.534, 886.1511),
+-- Safirdrang depart (after Overthane dies)
+(3105000, 1, 7053.937, 4377.317, 901.5513),
+(3105000, 2, 7020.913, 4415.733, 938.7733),
+(3105000, 3, 7014.491, 4475.228, 933.1346),
+(3105000, 4, 7053.163, 4507.731, 899.1902),
+-- Lady Nightswood escape
+(31087, 1, 7079.599, 4301.017, 874.3533),
+(31087, 2, 7082.374, 4283.685, 878.2528),
+(31087, 3, 7093.269, 4251.247, 855.1418),
+-- The Lich King walk
+(31083, 1, 7092.936, 4343.906, 871.9753),
+(31083, 2, 7094.104, 4331.222, 871.5023),
+(31083, 3, 7092.936, 4343.906, 871.9331),
+(31083, 4, 7088.768, 4385.59, 872.3639),
+-- Balargarde Elite patrols
+(3103001, 1, 7108.212, 4429.457, 837.8948),
+(3103001, 2, 7108.282, 4428.459, 837.8948),
+(3103001, 3, 7106.677, 4418.644, 890.2556),
+(3103001, 4, 7105.132, 4316.933, 890.2556),
+(3103001, 5, 7105.132, 4316.933, 890.2556),
+(3103002, 1, 7092.335, 4432.937, 836.562),
+(3103002, 2, 7092.213, 4431.944, 836.562),
+(3103002, 3, 7088.707, 4422.627, 890.4507),
+(3103002, 4, 7042.402, 4334.195, 890.4507),
+(3103002, 5, 7042.402, 4334.195, 890.4507),
+(3103003, 1, 7118.292, 4433.163, 837.6826),
+(3103003, 2, 7118.448, 4432.175, 837.6826),
+(3103003, 3, 7118.339, 4415.652, 891.2397),
+(3103003, 4, 7116.423, 4360.689, 891.2397),
+(3103003, 5, 7116.423, 4360.689, 891.2397),
+(3103004, 1, 7084.022, 4439.456, 834.9834),
+(3103004, 2, 7083.883, 4438.466, 834.9834),
+(3103004, 3, 7084.125, 4439.286, 835.0841),
+(3103004, 4, 7078.116, 4422.103, 891.0005),
+(3103004, 5, 7052.648, 4376.112, 891.0005),
+(3103004, 6, 7052.648, 4376.112, 891.0005),
+(3103005, 1, 7111.17, 4446.118, 838.3093),
+(3103005, 2, 7111.292, 4445.125, 838.3093),
+(3103005, 3, 7097.193, 4415.753, 886.4199),
+(3103005, 4, 7091.205, 4393.473, 886.4199),
+(3103005, 5, 7091.205, 4393.473, 886.4199),
+(3103006, 1, 7095.478, 4449.356, 836.9002),
+(3103006, 2, 7095.443, 4448.357, 836.9002),
+(3103006, 3, 7052.521, 4434.108, 838.8722),
+(3103006, 4, 7003.175, 4398.929, 844.0392),
+(3103006, 5, 6988.518, 4335.11, 856.9001),
+(3103006, 6, 7018.119, 4279.629, 875.7885),
+(3103006, 7, 7067.475, 4300.513, 892.5076),
+(3103006, 8, 7067.475, 4300.513, 892.5076);

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -101,7 +101,8 @@ void SpellMgr::LoadSpellInfoCorrections()
     ApplySpellFix({
         53096,  // Quetz'lun's Judgment
         70743,  // AoD Special
-        70614   // AoD Special - Vegard
+        70614,  // AoD Special - Vegard
+        4020    // Safirdrang's Chill
         }, [](SpellInfo* spellInfo)
     {
         spellInfo->MaxAffectedTargets = 1;

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -2184,6 +2184,7 @@ enum BansheesRevenge
     POINT_LK_RETURN                 = 2,
     POINT_LK_BODY                   = 3,
     POINT_NIGHTSWOOD_HORN           = 4,
+    POINT_BALARGARDE_LEAP           = 5,
 
     EVENT_HEROIC_LEAP               = 1,
     EVENT_WHIRLWIND                 = 2,
@@ -2206,6 +2207,9 @@ enum BansheesPaths
 Position const SafirdrangSpawnPos   = { 7097.292f, 4416.581f, 831.8486f, 4.485496f };
 Position const LichKingSpawnPos      = { 7088.768f, 4385.59f,  872.4484f, 4.468043f };
 Position const LichKingConfrontPos   = { 7094.104f, 4331.222f, 871.5023f, 0.0f };
+Position const BalargardeLandPos      = { 7095.094f, 4363.894f, 872.05566f, 0.0f };
+float const BalargardeLeapSpeedXY    = 20.0f;
+float const BalargardeLeapSpeedZ     = 6.0f;
 float const LichKingWalkSpeed        = 5.5f;
 float const SafirdrangEntryFlightSpeed = 2.25f;
 float const EliteRearFlightSpeed     = 5.0f;
@@ -2266,12 +2270,7 @@ public:
             {
                 case ACTION_BALARGARDE_JUMP:
                     me->ExitVehicle();
-                    me->GetMotionMaster()->MoveFall();
-                    scheduler.Schedule(2s, [this](TaskContext /*context*/)
-                    {
-                        if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 200.0f))
-                            me->SetFacingToObject(vardmadra);
-                    });
+                    me->GetMotionMaster()->MoveJump(BalargardeLandPos, BalargardeLeapSpeedXY, BalargardeLeapSpeedZ, POINT_BALARGARDE_LEAP);
                     break;
                 case ACTION_BALARGARDE_ENGAGE:
                     me->SetHomePosition(me->GetPosition());
@@ -2301,6 +2300,18 @@ public:
                 default:
                     break;
             }
+        }
+
+        void MovementInform(uint32 type, uint32 id) override
+        {
+            if (type != EFFECT_MOTION_TYPE || id != POINT_BALARGARDE_LEAP)
+                return;
+
+            scheduler.Schedule(1s, [this](TaskContext /*context*/)
+            {
+                if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 200.0f))
+                    me->SetFacingToObject(vardmadra);
+            });
         }
 
         void JustEngagedWith(Unit* /*who*/) override
@@ -2565,7 +2576,7 @@ public:
             {
                 if (Creature* balargarde = me->FindNearestCreature(NPC_BALARGARDE, 200.0f))
                     balargarde->AI()->Talk(SAY_BALARGARDE_TO_VARDMADRA_2);
-            }).Schedule(23s, [this](TaskContext /*context*/)
+            }).Schedule(26s, [this](TaskContext /*context*/)
             {
                 if (Creature* balargarde = me->FindNearestCreature(NPC_BALARGARDE, 200.0f))
                     balargarde->AI()->DoAction(ACTION_BALARGARDE_ENGAGE);

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -2112,6 +2112,870 @@ class spell_crashing_wave : public SpellScript
     }
 };
 
+/*######
+## Quest 13142 "Banshee's Revenge" - Overthane Balargarde outdoor encounter.
+## War Horn of Jotunheim (GO 193028) summons Vardmadra, who brings in Safirdrang
+## (carrying Overthane) and the elite riders. Overthane fights to 50%, the Lich King
+## interlude plays, then the fight resumes until death.
+######*/
+enum BansheesRevenge
+{
+    // Creatures
+    NPC_OVERTHANE_BALARGARDE        = 31016,
+    NPC_POSSESSED_VARDMADRA         = 31029,
+    NPC_BALARGARDE_ELITE            = 31030,
+    NPC_SAFIRDRANG                  = 31050,
+    NPC_SAFIRDRANGS_CHILL_TARGET    = 31077,
+    NPC_BANSHEE_LICH_KING           = 31083,
+    NPC_LADY_NIGHTSWOOD             = 31087,
+
+    GO_WAR_HORN_OF_JOTUNHEIM        = 193028,
+
+    // Overthane combat
+    SPELL_BR_HEROIC_LEAP            = 60108,
+    SPELL_BR_WHIRLWIND              = 61076,
+    SPELL_BR_FROSTBOLT              = 15043,
+    SPELL_BR_BLIZZARD               = 61085,
+
+    // Encounter spells
+    SPELL_SAFIRDRANGS_CHILL         = 4020,
+    SPELL_SAFIRDRANGS_CHILL_RELAY   = 4307,
+    SPELL_ETHEREAL_TELEPORT         = 34427,
+    SPELL_ICEBOUND_VISAGE           = 53274,
+    SPELL_SUMMON_LADY_NIGHTSWOOD    = 58359,
+    SPELL_BR_SUICIDE                = 51744,
+    SPELL_LK_SPECIAL_2H             = 42904,
+
+    SOUND_LICH_KING_LAUGH           = 15714,
+
+    // creature_text groups - Overthane Balargarde (31016)
+    SAY_BALARGARDE_TO_SAFIRDRANG    = 1,
+    SAY_BALARGARDE_TO_VARDMADRA_1   = 2,
+    SAY_BALARGARDE_TO_VARDMADRA_2   = 3,
+    SAY_BALARGARDE_80PCT            = 4,
+    SAY_BALARGARDE_KNEEL            = 5,
+    SAY_BALARGARDE_MY_LORD          = 6,
+    SAY_BALARGARDE_DIE_DOGS         = 7,
+    // creature_text groups - Possessed Vardmadra (31029)
+    SAY_VARDMADRA_ARRIVE            = 0,
+    SAY_VARDMADRA_CHALLENGE         = 1,
+    SAY_VARDMADRA_MY_LORD           = 2,
+    SAY_VARDMADRA_BUT               = 3,
+    // creature_text groups - The Lich King (31083)
+    SAY_LK_HONOR_GUARD              = 0,
+    SAY_LK_VARDMADRA                = 1,
+    SAY_LK_DISGUISE                 = 2,
+    SAY_LK_CONTINUE                 = 3,
+    SAY_LK_FINISH_THEM              = 4,
+    SAY_LK_BESTED                   = 5,
+    SAY_LK_FROZEN_HEART             = 6,
+
+    // Phases: opening combat -> Lich King interlude -> resumed combat -> Lich King outro
+    BR_PHASE_ONE                    = 1,
+    BR_PHASE_INTERLUDE              = 2,
+    BR_PHASE_RESUME                 = 3,
+    BR_PHASE_OUTRO                  = 4,
+
+    // Actions
+    ACTION_ELITE_START_PATROL       = 1,
+    ACTION_ELITE_DESPAWN            = 2,
+    ACTION_SAFIRDRANG_CHILL         = 3,
+    ACTION_SAFIRDRANG_DEPART        = 4,
+    ACTION_BALARGARDE_ENGAGE        = 5,
+    ACTION_BALARGARDE_RESUME        = 6,
+    ACTION_LK_FINALE                = 7,
+    ACTION_VARDMADRA_REVEAL         = 8,
+    ACTION_VARDMADRA_KNEEL          = 9,
+
+    // MovePoint ids (Lich King interlude walk)
+    POINT_LK_CONFRONT               = 1,
+    POINT_LK_RETURN                 = 2,
+
+    // EventMap (Overthane combat)
+    EVENT_BR_HEROIC_LEAP            = 1,
+    EVENT_BR_WHIRLWIND              = 2,
+    EVENT_BR_FROSTBOLT              = 3,
+    EVENT_BR_BLIZZARD               = 4,
+    EVENT_BR_CHILL_RUN              = 5
+};
+
+enum BansheesPaths
+{
+    PATH_VARDMADRA_INTRO            = 31029,
+    PATH_VARDMADRA_GROUND           = 3102900,
+    PATH_SAFIRDRANG_INTRO           = 31050,
+    PATH_SAFIRDRANG_DEPART          = 3105000,
+    PATH_LADY_NIGHTSWOOD            = 31087,
+    PATH_LICH_KING                  = 31083,
+    PATH_ELITE_BASE                 = 3103000 // elite i (0..5) uses PATH_ELITE_BASE + 1 + i
+};
+
+// Spawn positions taken verbatim from the TrinityCore script.
+Position const SafirdrangSpawnPos   = { 7097.292f, 4416.581f, 831.8486f, 4.485496f };
+Position const LichKingSpawnPos      = { 7088.768f, 4385.59f,  872.4484f, 4.468043f };
+// The Lich King walks up to confront Vardmadra during the interlude, then walks back to his guard spot.
+Position const LichKingConfrontPos   = { 7094.104f, 4331.222f, 871.5023f, 0.0f };
+float const LK_INTERLUDE_WALK_SPEED  = 4.5f; // brisk walk pace (walk animation, faster than the default ~2.5)
+Position const BalargardeElitePos[6] =
+{
+    { 7108.229f, 4428.539f, 837.9857f, 4.782202f },
+    { 7092.146f, 4431.810f, 836.6280f, 4.590216f },
+    { 7118.420f, 4432.598f, 837.9554f, 4.869469f },
+    { 7083.883f, 4438.466f, 834.9834f, 4.572762f },
+    { 7111.272f, 4445.171f, 838.5065f, 4.834562f },
+    { 7090.730f, 4446.960f, 837.0818f, 3.402185f }
+};
+
+// Helper: enable flight movement on a cosmetic flyer summon.
+static void BansheesMakeFlyer(Creature* creature)
+{
+    creature->SetCanFly(true);
+    creature->SetDisableGravity(true);
+    creature->SetAnimTier(AnimTier::Fly); // play the flying pose, not the ground walk/run, while airborne
+    creature->SetReactState(REACT_PASSIVE);
+}
+
+/*######
+## Banshee's Revenge: npc_bansheesrevenge_overthane (31016) - the boss
+######*/
+class npc_bansheesrevenge_overthane : public CreatureScript
+{
+public:
+    npc_bansheesrevenge_overthane() : CreatureScript("npc_bansheesrevenge_overthane") { }
+
+    struct npc_bansheesrevenge_overthaneAI : public ScriptedAI
+    {
+        npc_bansheesrevenge_overthaneAI(Creature* creature) : ScriptedAI(creature)
+        {
+            _phase = BR_PHASE_ONE;
+            _interludeStarted = false;
+            _chillActive = false;
+        }
+
+        void InitializeAI() override
+        {
+            // Spawns seated on Safirdrang; stays passive until ejected and engaged.
+            me->SetReactState(REACT_PASSIVE);
+            me->SetImmuneToPC(true);
+        }
+
+        void Reset() override
+        {
+            _events.Reset();
+            scheduler.CancelAll();
+            _phase = BR_PHASE_ONE;
+            _interludeStarted = false;
+            _chillActive = false;
+        }
+
+        void DoAction(int32 action) override
+        {
+            switch (action)
+            {
+                case ACTION_BALARGARDE_ENGAGE:
+                    // Ejected from Safirdrang well above the arena: drop to the ground
+                    // before anchoring the home position and engaging.
+                    me->ExitVehicle();
+                    me->GetMotionMaster()->MoveFall();
+                    me->SetImmuneToPC(false);
+                    me->SetReactState(REACT_AGGRESSIVE);
+                    scheduler.Schedule(2s, [this](TaskContext /*context*/)
+                    {
+                        me->SetHomePosition(me->GetPosition());
+                        if (Player* player = me->SelectNearestPlayer(100.0f))
+                            AttackStart(player);
+
+                        // Overthane is now in position: the two elites centred on his axis fly in together.
+                        // #4 (behind) has a short patrol and lands just behind him; #5 (front) loops the long
+                        // way, so its AI flies it faster to arrive out front at about the same time.
+                        SummonPatrolElite(4);
+                        SummonPatrolElite(5);
+                    });
+                    break;
+                case ACTION_BALARGARDE_RESUME:
+                    me->SetStandState(UNIT_STAND_STATE_STAND);
+                    me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+                    me->SetImmuneToPC(false);
+                    me->SetReactState(REACT_AGGRESSIVE);
+                    _phase = BR_PHASE_RESUME; // b633a62: resume into the combat phase, not the opening
+                    if (Player* player = me->SelectNearestPlayer(100.0f))
+                        AttackStart(player);
+                    ScheduleCombatEvents();
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        void JustEngagedWith(Unit* /*who*/) override
+        {
+            ScheduleCombatEvents();
+        }
+
+        void ScheduleCombatEvents()
+        {
+            _events.Reset();
+            _events.ScheduleEvent(EVENT_BR_HEROIC_LEAP, 20s, 30s);
+            _events.ScheduleEvent(EVENT_BR_WHIRLWIND, 60s, 90s);
+            _events.ScheduleEvent(EVENT_BR_FROSTBOLT, 20s, 25s);
+            _events.ScheduleEvent(EVENT_BR_BLIZZARD, 15s, 25s);
+            if (_chillActive)
+                _events.ScheduleEvent(EVENT_BR_CHILL_RUN, 3s, 5s);
+        }
+
+        // Summon one of the two axis-centred elites (#4 behind / #5 in front) at its spawn point and
+        // start its patrol; used after Overthane is in position so they stagger in behind the side four.
+        void SummonPatrolElite(uint8 index)
+        {
+            if (Creature* elite = me->SummonCreature(NPC_BALARGARDE_ELITE,
+                BalargardeElitePos[index], TEMPSUMMON_MANUAL_DESPAWN))
+                elite->AI()->DoAction(ACTION_ELITE_START_PATROL + 1000 + index);
+        }
+
+        void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType, SpellSchoolMask) override
+        {
+            // Invulnerable while the interlude plays out: still targettable/attackable, just takes no damage.
+            if (_phase == BR_PHASE_INTERLUDE)
+            {
+                damage = 0;
+                return;
+            }
+
+            // Cannot die before the Lich King interlude has played out.
+            if (!_interludeStarted)
+            {
+                uint32 const minHealth = me->CountPctFromMaxHealth(50);
+                if (me->GetHealth() > minHealth && damage >= me->GetHealth() - minHealth)
+                {
+                    damage = me->GetHealth() - minHealth;
+                    StartInterlude();
+                    return;
+                }
+            }
+
+            if (!_chillActive && me->HealthBelowPctDamaged(80, damage))
+            {
+                _chillActive = true;
+                Talk(SAY_BALARGARDE_80PCT);
+                _events.ScheduleEvent(EVENT_BR_CHILL_RUN, 3s, 5s);
+            }
+        }
+
+        void StartInterlude()
+        {
+            _interludeStarted = true;
+            _phase = BR_PHASE_INTERLUDE;
+            _events.Reset();
+
+            me->AttackStop();
+            me->GetMotionMaster()->Clear();
+            me->GetMotionMaster()->MoveIdle();
+            // Kneel and stop fighting, but stay targettable AND in the players' combat. Do NOT set
+            // ImmuneToPC/NOT_SELECTABLE here: ImmuneToPC drops player combat, which makes the core evade
+            // (no hostiles) and CleanupEncounter resets everything. Invulnerability is handled in DamageTaken.
+            me->SetReactState(REACT_PASSIVE);
+            Talk(SAY_BALARGARDE_KNEEL);
+
+            Creature* lichKing = me->SummonCreature(NPC_BANSHEE_LICH_KING, LichKingSpawnPos, TEMPSUMMON_MANUAL_DESPAWN);
+            if (!lichKing)
+                return;
+
+            me->SetFacingToObject(lichKing);
+
+            // Vardmadra drops out of the air and kneels alongside Overthane.
+            if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 200.0f))
+                vardmadra->AI()->DoAction(ACTION_VARDMADRA_KNEEL);
+
+            scheduler.Schedule(1s, [this](TaskContext /*context*/)
+            {
+                me->SetStandState(UNIT_STAND_STATE_KNEEL);
+            });
+        }
+
+        void JustDied(Unit* /*killer*/) override
+        {
+            _phase = BR_PHASE_OUTRO; // the Lich King now runs the outro sequence
+            if (Creature* lichKing = me->FindNearestCreature(NPC_BANSHEE_LICH_KING, 200.0f))
+                lichKing->AI()->DoAction(ACTION_LK_FINALE);
+
+            // Allow the War Horn to be used again.
+            if (GameObject* horn = me->FindNearestGameObject(GO_WAR_HORN_OF_JOTUNHEIM, 200.0f))
+                horn->ResetDoorOrButton();
+        }
+
+        void EnterEvadeMode(EvadeReason why) override
+        {
+            // The scripted interlude deliberately stops combat; never let an evade reset it mid-cutscene.
+            if (_phase == BR_PHASE_INTERLUDE)
+                return;
+
+            ScriptedAI::EnterEvadeMode(why);
+            CleanupEncounter();
+        }
+
+        void CleanupEncounter()
+        {
+            std::list<Creature*> summons;
+            uint32 const entries[] =
+            {
+                NPC_SAFIRDRANG, NPC_BALARGARDE_ELITE,
+                NPC_POSSESSED_VARDMADRA, NPC_LADY_NIGHTSWOOD, NPC_BANSHEE_LICH_KING
+            };
+            for (uint32 entry : entries)
+            {
+                summons.clear();
+                me->GetCreatureListWithEntryInGrid(summons, entry, 250.0f);
+                for (Creature* creature : summons)
+                    creature->DespawnOrUnsummon();
+            }
+
+            if (GameObject* horn = me->FindNearestGameObject(GO_WAR_HORN_OF_JOTUNHEIM, 200.0f))
+                horn->ResetDoorOrButton();
+
+            me->DespawnOrUnsummon();
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            scheduler.Update(diff);
+
+            if (_phase == BR_PHASE_INTERLUDE)
+                return;
+
+            if (!UpdateVictim())
+                return;
+
+            _events.Update(diff);
+
+            if (me->HasUnitState(UNIT_STATE_CASTING))
+                return;
+
+            while (uint32 eventId = _events.ExecuteEvent())
+            {
+                switch (eventId)
+                {
+                    case EVENT_BR_HEROIC_LEAP:
+                        if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 40.0f, true))
+                            DoCast(target, SPELL_BR_HEROIC_LEAP);
+                        _events.Repeat(25s, 32s);
+                        break;
+                    case EVENT_BR_WHIRLWIND:
+                        DoCastSelf(SPELL_BR_WHIRLWIND);
+                        _events.Repeat(60s, 90s);
+                        break;
+                    case EVENT_BR_FROSTBOLT:
+                        DoCastVictim(SPELL_BR_FROSTBOLT);
+                        _events.Repeat(25s, 30s);
+                        break;
+                    case EVENT_BR_BLIZZARD:
+                        if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
+                            DoCast(target, SPELL_BR_BLIZZARD);
+                        _events.Repeat(25s, 35s);
+                        break;
+                    case EVENT_BR_CHILL_RUN:
+                        if (Creature* safirdrang = me->FindNearestCreature(NPC_SAFIRDRANG, 200.0f))
+                            safirdrang->AI()->DoAction(ACTION_SAFIRDRANG_CHILL);
+                        _events.Repeat(13s, 14s);
+                        break;
+                    default:
+                        break;
+                }
+
+                if (me->HasUnitState(UNIT_STATE_CASTING))
+                    break;
+            }
+
+            DoMeleeAttackIfReady();
+        }
+
+    private:
+        EventMap _events;
+        uint8 _phase;
+        bool _interludeStarted;
+        bool _chillActive;
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_bansheesrevenge_overthaneAI(creature);
+    }
+};
+
+/*######
+## Banshee's Revenge: npc_bansheesrevenge_safirdrang (31050) - proto-drake that carries Overthane
+######*/
+class npc_bansheesrevenge_safirdrang : public CreatureScript
+{
+public:
+    npc_bansheesrevenge_safirdrang() : CreatureScript("npc_bansheesrevenge_safirdrang") { }
+
+    struct npc_bansheesrevenge_safirdrangAI : public ScriptedAI
+    {
+        npc_bansheesrevenge_safirdrangAI(Creature* creature) : ScriptedAI(creature) { }
+
+        void InitializeAI() override
+        {
+            BansheesMakeFlyer(me);
+
+            // The vehicle kit is installed AFTER AIM_Initialize()/InitializeAI() in Creature::AddToWorld,
+            // so seating a passenger here silently fails. Defer the summon/board and the flight by one tick.
+            scheduler.Schedule(1s, [this](TaskContext /*context*/)
+            {
+                // Carry Overthane in seat 0 and fly the intro path.
+                if (Creature* overthane = me->SummonCreature(NPC_OVERTHANE_BALARGARDE, *me, TEMPSUMMON_MANUAL_DESPAWN))
+                    overthane->EnterVehicleUnattackable(me, 0);
+
+                me->GetMotionMaster()->MovePath(PATH_SAFIRDRANG_INTRO, FORCED_MOVEMENT_NONE, PathSource::WAYPOINT_MGR);
+            });
+        }
+
+        void MovementInform(uint32 type, uint32 /*id*/) override
+        {
+            // MovePath drives an EscortMovementGenerator (ESCORT_MOTION_TYPE), firing per spline
+            // segment; act only at the path's end and use the state flags to tell the paths apart.
+            if (type != ESCORT_MOTION_TYPE || !me->movespline->Finalized())
+                return;
+
+            if (!_introDone) // reached the end of the intro path
+            {
+                _introDone = true;
+                RunIntroDialogue();
+            }
+            else if (_departing) // reached the end of the depart path
+                me->DespawnOrUnsummon();
+        }
+
+        void RunIntroDialogue()
+        {
+            scheduler.Schedule(0s, [this](TaskContext /*context*/)
+            {
+                if (Creature* overthane = GetSeatedOverthane())
+                    overthane->AI()->Talk(SAY_BALARGARDE_TO_SAFIRDRANG);
+            }).Schedule(6s, [this](TaskContext /*context*/)
+            {
+                if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 200.0f))
+                    vardmadra->AI()->Talk(SAY_VARDMADRA_CHALLENGE);
+            }).Schedule(12s, [this](TaskContext /*context*/)
+            {
+                if (Creature* overthane = GetSeatedOverthane())
+                    overthane->AI()->Talk(SAY_BALARGARDE_TO_VARDMADRA_1);
+            }).Schedule(18s, [this](TaskContext /*context*/)
+            {
+                if (Creature* overthane = GetSeatedOverthane())
+                    overthane->AI()->Talk(SAY_BALARGARDE_TO_VARDMADRA_2);
+            }).Schedule(23s, [this](TaskContext /*context*/)
+            {
+                if (Creature* overthane = GetSeatedOverthane())
+                    overthane->AI()->DoAction(ACTION_BALARGARDE_ENGAGE);
+                me->SetHomePosition(me->GetPosition());
+            });
+        }
+
+        Creature* GetSeatedOverthane()
+        {
+            if (Vehicle* kit = me->GetVehicleKit())
+                if (Unit* passenger = kit->GetPassenger(0))
+                    return passenger->ToCreature();
+            return nullptr;
+        }
+
+        void DoAction(int32 action) override
+        {
+            switch (action)
+            {
+                case ACTION_SAFIRDRANG_CHILL:
+                    if (Player* player = me->SelectNearestPlayer(60.0f))
+                    {
+                        me->SetFacingToObject(player);
+                        DoCast(player, SPELL_SAFIRDRANGS_CHILL);
+                    }
+                    break;
+                case ACTION_SAFIRDRANG_DEPART:
+                    _departing = true;
+                    me->GetMotionMaster()->MovePath(PATH_SAFIRDRANG_DEPART,
+                        FORCED_MOVEMENT_NONE, PathSource::WAYPOINT_MGR);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            scheduler.Update(diff);
+        }
+
+    private:
+        bool _introDone = false;
+        bool _departing = false;
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_bansheesrevenge_safirdrangAI(creature);
+    }
+};
+
+/*######
+## Banshee's Revenge: npc_bansheesrevenge_elite (31030) - vrykul elite; cosmetic-mounted flyer that patrols
+######*/
+class npc_bansheesrevenge_elite : public CreatureScript
+{
+public:
+    npc_bansheesrevenge_elite() : CreatureScript("npc_bansheesrevenge_elite") { }
+
+    struct npc_bansheesrevenge_eliteAI : public ScriptedAI
+    {
+        npc_bansheesrevenge_eliteAI(Creature* creature) : ScriptedAI(creature) { }
+
+        void InitializeAI() override
+        {
+            // Rides a cosmetic proto-drake mount (creature_addon mount 26882) and flies its own patrol.
+            BansheesMakeFlyer(me);
+            me->SetImmuneToPC(true);
+        }
+
+        void DoAction(int32 action) override
+        {
+            if (action >= ACTION_ELITE_START_PATROL + 1000) // patrol path encoded as action + 1000 + index
+            {
+                uint32 const index = action - (ACTION_ELITE_START_PATROL + 1000);
+                // #5 (front) loops the long way around, so fly it faster to reach its spot at about the same
+                // time the short rear patrol (#4) lands. Tuning knob: raise if #5 still trails, lower if it
+                // beats #4 there. The factor ~matches its patrol length relative to #4's.
+                if (index == 5)
+                    me->SetSpeedRate(MOVE_FLIGHT, 4.0f);
+                me->GetMotionMaster()->MovePath(PATH_ELITE_BASE + 1 + index,
+                    FORCED_MOVEMENT_NONE, PathSource::WAYPOINT_MGR);
+                // Keep facing Possessed Vardmadra until the Lich King's arrival despawns the riders.
+                scheduler.Schedule(1s, [this](TaskContext context)
+                {
+                    if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 250.0f))
+                        me->SetFacingToObject(vardmadra);
+                    context.Repeat(1s);
+                });
+            }
+            else if (action == ACTION_ELITE_DESPAWN)
+                me->DespawnOrUnsummon();
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            scheduler.Update(diff);
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_bansheesrevenge_eliteAI(creature);
+    }
+};
+
+/*######
+## Banshee's Revenge: npc_bansheesrevenge_vardmadra (31029) - summoned by the War Horn; triggers the intro
+######*/
+class npc_bansheesrevenge_vardmadra : public CreatureScript
+{
+public:
+    npc_bansheesrevenge_vardmadra() : CreatureScript("npc_bansheesrevenge_vardmadra") { }
+
+    struct npc_bansheesrevenge_vardmadraAI : public ScriptedAI
+    {
+        npc_bansheesrevenge_vardmadraAI(Creature* creature) : ScriptedAI(creature) { }
+
+        void InitializeAI() override
+        {
+            BansheesMakeFlyer(me);
+            me->GetMotionMaster()->MovePath(PATH_VARDMADRA_INTRO, FORCED_MOVEMENT_NONE, PathSource::WAYPOINT_MGR);
+        }
+
+        void MovementInform(uint32 type, uint32 /*id*/) override
+        {
+            // MovePath drives an EscortMovementGenerator, which reports ESCORT_MOTION_TYPE (not
+            // WAYPOINT_MOTION_TYPE) and fires per spline segment; act only at the path's end.
+            if (type != ESCORT_MOTION_TYPE || !me->movespline->Finalized())
+                return;
+
+            if (!_introDone) // reached the end of the intro path
+            {
+                _introDone = true;
+                Talk(SAY_VARDMADRA_ARRIVE);
+                me->SummonCreature(NPC_SAFIRDRANG, SafirdrangSpawnPos, TEMPSUMMON_MANUAL_DESPAWN);
+
+                // Only the four side elites (#0-#3: two left, two right) fly in with the intro. The two
+                // centred on Overthane's axis (#4 behind, #5 in front) are summoned by Overthane once he is
+                // in position, so they don't pop in before he has landed.
+                for (uint8 i = 0; i < 4; ++i)
+                    if (Creature* elite = me->SummonCreature(NPC_BALARGARDE_ELITE,
+                        BalargardeElitePos[i], TEMPSUMMON_MANUAL_DESPAWN))
+                        elite->AI()->DoAction(ACTION_ELITE_START_PATROL + 1000 + i);
+            }
+        }
+
+        void DoAction(int32 action) override
+        {
+            switch (action)
+            {
+                case ACTION_VARDMADRA_KNEEL:
+                    // Land out of the air and kneel before the Lich King, alongside Overthane.
+                    me->SetCanFly(false);
+                    me->SetDisableGravity(false);
+                    me->SetAnimTier(AnimTier::Ground);
+                    me->GetMotionMaster()->MoveFall();
+                    scheduler.Schedule(1500ms, [this](TaskContext /*context*/)
+                    {
+                        me->SetStandState(UNIT_STAND_STATE_KNEEL);
+                        if (Creature* lichKing = me->FindNearestCreature(NPC_BANSHEE_LICH_KING, 200.0f))
+                            me->SetFacingToObject(lichKing);
+                    });
+                    break;
+                case ACTION_VARDMADRA_REVEAL:
+                    // The "possessed" body is a disguise; the real banshee escapes and the body dies.
+                    me->SetStandState(UNIT_STAND_STATE_STAND);
+                    DoCastSelf(SPELL_SUMMON_LADY_NIGHTSWOOD, true);
+                    scheduler.Schedule(600ms, [this](TaskContext /*context*/)
+                    {
+                        Talk(SAY_VARDMADRA_BUT);
+                    }).Schedule(1s, [this](TaskContext /*context*/)
+                    {
+                        DoCastSelf(SPELL_BR_SUICIDE, true);
+                        me->DespawnOrUnsummon(15s);
+                    });
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            scheduler.Update(diff);
+        }
+
+    private:
+        bool _introDone = false;
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_bansheesrevenge_vardmadraAI(creature);
+    }
+};
+
+/*######
+## Banshee's Revenge: npc_bansheesrevenge_nightswood (31087) - revealed banshee, flees the arena
+######*/
+class npc_bansheesrevenge_nightswood : public CreatureScript
+{
+public:
+    npc_bansheesrevenge_nightswood() : CreatureScript("npc_bansheesrevenge_nightswood") { }
+
+    struct npc_bansheesrevenge_nightswoodAI : public ScriptedAI
+    {
+        npc_bansheesrevenge_nightswoodAI(Creature* creature) : ScriptedAI(creature) { }
+
+        void InitializeAI() override
+        {
+            BansheesMakeFlyer(me);
+            if (Creature* lichKing = me->FindNearestCreature(NPC_BANSHEE_LICH_KING, 200.0f))
+                me->SetFacingToObject(lichKing);
+
+            scheduler.Schedule(20s, [this](TaskContext /*context*/)
+            {
+                me->GetMotionMaster()->MovePath(PATH_LADY_NIGHTSWOOD, FORCED_MOVEMENT_NONE, PathSource::WAYPOINT_MGR);
+            });
+        }
+
+        void MovementInform(uint32 type, uint32 /*id*/) override
+        {
+            // MovePath -> ESCORT_MOTION_TYPE; despawn once the escape path is fully traversed.
+            if (type == ESCORT_MOTION_TYPE && me->movespline->Finalized())
+                me->DespawnOrUnsummon();
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            scheduler.Update(diff);
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_bansheesrevenge_nightswoodAI(creature);
+    }
+};
+
+/*######
+## Banshee's Revenge: npc_bansheesrevenge_lich_king (31083) - drives the interlude and the death sequence
+######*/
+class npc_bansheesrevenge_lich_king : public CreatureScript
+{
+public:
+    npc_bansheesrevenge_lich_king() : CreatureScript("npc_bansheesrevenge_lich_king") { }
+
+    struct npc_bansheesrevenge_lich_kingAI : public ScriptedAI
+    {
+        npc_bansheesrevenge_lich_kingAI(Creature* creature) : ScriptedAI(creature) { }
+
+        void InitializeAI() override
+        {
+            me->SetReactState(REACT_PASSIVE);
+            me->SetImmuneToPC(true);
+            RunInterlude();
+        }
+
+        void RunInterlude()
+        {
+            scheduler.Schedule(1s, [this](TaskContext /*context*/)
+            {
+                DoCastSelf(SPELL_ETHEREAL_TELEPORT, true);
+            }).Schedule(4s, [this](TaskContext /*context*/)
+            {
+                DespawnElites();
+                DoCastSelf(SPELL_ICEBOUND_VISAGE, true);
+                FaceCreature(NPC_POSSESSED_VARDMADRA);
+            }).Schedule(8s, [this](TaskContext /*context*/)
+            {
+                Talk(SAY_LK_HONOR_GUARD);
+            }).Schedule(14s, [this](TaskContext /*context*/)
+            {
+                Talk(SAY_LK_VARDMADRA);
+                // Brisk WALK up to Vardmadra and stop in front of her (no run, no out-and-back). He stays
+                // here through the dialogue and the reveal, then walks back to his guard spot afterwards.
+                me->GetMotionMaster()->MovePoint(POINT_LK_CONFRONT, LichKingConfrontPos,
+                    FORCED_MOVEMENT_WALK, LK_INTERLUDE_WALK_SPEED);
+            }).Schedule(23s, [this](TaskContext /*context*/)
+            {
+                if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 200.0f))
+                    vardmadra->AI()->Talk(SAY_VARDMADRA_MY_LORD);
+            }).Schedule(27s, [this](TaskContext /*context*/)
+            {
+                FaceCreature(NPC_POSSESSED_VARDMADRA);
+                Talk(SAY_LK_DISGUISE);
+            }).Schedule(36s, [this](TaskContext /*context*/)
+            {
+                if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 200.0f))
+                {
+                    DoCast(vardmadra, SPELL_LK_SPECIAL_2H, true);
+                    vardmadra->AI()->DoAction(ACTION_VARDMADRA_REVEAL);
+                }
+            }).Schedule(40s, [this](TaskContext /*context*/)
+            {
+                me->PlayDirectSound(SOUND_LICH_KING_LAUGH);
+            }).Schedule(43s, [this](TaskContext /*context*/)
+            {
+                Talk(SAY_LK_CONTINUE);
+                FaceCreature(NPC_OVERTHANE_BALARGARDE);
+            }).Schedule(46s, [this](TaskContext /*context*/)
+            {
+                // Reveal done: walk back to his honor-guard position to observe the resumed fight.
+                me->GetMotionMaster()->MovePoint(POINT_LK_RETURN, LichKingSpawnPos,
+                    FORCED_MOVEMENT_WALK, LK_INTERLUDE_WALK_SPEED);
+            }).Schedule(48s, [this](TaskContext /*context*/)
+            {
+                if (Creature* overthane = me->FindNearestCreature(NPC_OVERTHANE_BALARGARDE, 200.0f))
+                    overthane->AI()->Talk(SAY_BALARGARDE_MY_LORD);
+            }).Schedule(52s, [this](TaskContext /*context*/)
+            {
+                Talk(SAY_LK_FINISH_THEM);
+            }).Schedule(59s, [this](TaskContext /*context*/)
+            {
+                if (Creature* overthane = me->FindNearestCreature(NPC_OVERTHANE_BALARGARDE, 200.0f))
+                    overthane->AI()->Talk(SAY_BALARGARDE_DIE_DOGS);
+            }).Schedule(60s, [this](TaskContext /*context*/)
+            {
+                if (Creature* overthane = me->FindNearestCreature(NPC_OVERTHANE_BALARGARDE, 200.0f))
+                    overthane->AI()->DoAction(ACTION_BALARGARDE_RESUME);
+            });
+        }
+
+        void DoAction(int32 action) override
+        {
+            if (action != ACTION_LK_FINALE)
+                return;
+
+            scheduler.CancelAll();
+
+            if (Creature* safirdrang = me->FindNearestCreature(NPC_SAFIRDRANG, 200.0f))
+                safirdrang->AI()->DoAction(ACTION_SAFIRDRANG_DEPART);
+
+            if (Player* player = me->SelectNearestPlayer(60.0f))
+                me->SetFacingToObject(player);
+
+            scheduler.Schedule(3s, [this](TaskContext /*context*/)
+            {
+                Talk(SAY_LK_BESTED);
+            }).Schedule(11s, [this](TaskContext /*context*/)
+            {
+                Talk(SAY_LK_FROZEN_HEART);
+            }).Schedule(19s, [this](TaskContext /*context*/)
+            {
+                DoCastSelf(SPELL_ETHEREAL_TELEPORT, true);
+                DespawnElites();
+                if (Creature* nightswood = me->FindNearestCreature(NPC_LADY_NIGHTSWOOD, 250.0f))
+                    nightswood->DespawnOrUnsummon();
+            }).Schedule(20s, [this](TaskContext /*context*/)
+            {
+                me->DespawnOrUnsummon();
+            });
+        }
+
+        void FaceCreature(uint32 entry)
+        {
+            if (Creature* target = me->FindNearestCreature(entry, 250.0f))
+                me->SetFacingToObject(target);
+        }
+
+        void DespawnElites()
+        {
+            std::list<Creature*> elites;
+            me->GetCreatureListWithEntryInGrid(elites, NPC_BALARGARDE_ELITE, 250.0f);
+            for (Creature* elite : elites)
+                elite->AI()->DoAction(ACTION_ELITE_DESPAWN);
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            scheduler.Update(diff);
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_bansheesrevenge_lich_kingAI(creature);
+    }
+};
+
+/*######
+## Banshee's Revenge: npc_bansheesrevenge_chill_target (31077) - relays Safirdrang's Chill
+######*/
+class npc_bansheesrevenge_chill_target : public CreatureScript
+{
+public:
+    npc_bansheesrevenge_chill_target() : CreatureScript("npc_bansheesrevenge_chill_target") { }
+
+    struct npc_bansheesrevenge_chill_targetAI : public ScriptedAI
+    {
+        npc_bansheesrevenge_chill_targetAI(Creature* creature) : ScriptedAI(creature) { }
+
+        void InitializeAI() override
+        {
+            me->SetReactState(REACT_PASSIVE);
+        }
+
+        void SpellHit(Unit* /*caster*/, SpellInfo const* spell) override
+        {
+            if (spell->Id == SPELL_SAFIRDRANGS_CHILL)
+                DoCastSelf(SPELL_SAFIRDRANGS_CHILL_RELAY, true);
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_bansheesrevenge_chill_targetAI(creature);
+    }
+};
+
 void AddSC_icecrown()
 {
     new npc_black_knight_graveyard();
@@ -2132,4 +2996,12 @@ void AddSC_icecrown()
     new npc_blessed_banner();
     new npc_frostbrood_skytalon();
     RegisterSpellScript(spell_crashing_wave);
+    // Quest 13142: Banshee's Revenge
+    new npc_bansheesrevenge_overthane();
+    new npc_bansheesrevenge_safirdrang();
+    new npc_bansheesrevenge_elite();
+    new npc_bansheesrevenge_vardmadra();
+    new npc_bansheesrevenge_nightswood();
+    new npc_bansheesrevenge_lich_king();
+    new npc_bansheesrevenge_chill_target();
 }

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -2215,6 +2215,9 @@ float const LichKingWalkSpeed        = 5.5f;
 float const SafirdrangEntryFlightSpeed = 2.25f;
 float const EliteRearFlightSpeed     = 5.0f;
 float const EliteFrontFlightSpeed    = 18.0f;
+uint8 const EliteCount               = 6;
+uint8 const EliteRearIndex           = 4;
+uint8 const EliteFrontIndex          = 5;
 Position const BalargardeElitePos[6] =
 {
     { 7108.229f, 4428.539f, 837.9857f, 4.782202f },
@@ -2251,7 +2254,6 @@ public:
         {
             me->SetReactState(REACT_PASSIVE);
             me->SetImmuneToPC(true);
-            me->ApplySpellImmune(0, IMMUNITY_ID, SPELL_SAFIRDRANGS_CHILL, true);
             me->ApplySpellImmune(0, IMMUNITY_ID, SPELL_SAFIRDRANGS_CHILL_RELAY, true);
         }
 
@@ -2550,7 +2552,7 @@ public:
                 _introDone = true;
                 me->SetSpeedRate(MOVE_FLIGHT, 1.0f);
 
-                for (uint8 i = 4; i < 6; ++i)
+                for (uint8 i = EliteRearIndex; i < EliteCount; ++i)
                     if (Creature* elite = me->SummonCreature(NPC_BALARGARDE_ELITE,
                         BalargardeElitePos[i], TEMPSUMMON_MANUAL_DESPAWN))
                         elite->AI()->DoAction(ACTION_ELITE_START_PATROL + i);
@@ -2655,7 +2657,6 @@ public:
         void InitializeAI() override
         {
             BansheesMakeFlyer(me);
-            me->SetImmuneToPC(true);
         }
 
         void DoAction(int32 action) override
@@ -2663,9 +2664,9 @@ public:
             if (action >= ACTION_ELITE_START_PATROL)
             {
                 uint32 const index = action - ACTION_ELITE_START_PATROL;
-                if (index == 4)
+                if (index == EliteRearIndex)
                     me->SetSpeedRate(MOVE_FLIGHT, EliteRearFlightSpeed);
-                else if (index == 5)
+                else if (index == EliteFrontIndex)
                     me->SetSpeedRate(MOVE_FLIGHT, EliteFrontFlightSpeed);
                 me->GetMotionMaster()->MovePath(PATH_ELITE_BASE + 1 + index,
                     FORCED_MOVEMENT_NONE, PathSource::WAYPOINT_MGR);
@@ -2734,7 +2735,7 @@ public:
                 Talk(SAY_VARDMADRA_ARRIVE);
                 me->SummonCreature(NPC_SAFIRDRANG, SafirdrangSpawnPos, TEMPSUMMON_MANUAL_DESPAWN);
 
-                for (uint8 i = 0; i < 4; ++i)
+                for (uint8 i = 0; i < EliteRearIndex; ++i)
                     if (Creature* elite = me->SummonCreature(NPC_BALARGARDE_ELITE,
                         BalargardeElitePos[i], TEMPSUMMON_MANUAL_DESPAWN))
                         elite->AI()->DoAction(ACTION_ELITE_START_PATROL + i);
@@ -2759,10 +2760,8 @@ public:
                     break;
                 case ACTION_VARDMADRA_REVEAL:
                     me->SetStandState(UNIT_STAND_STATE_STAND);
-                    scheduler.Schedule(600ms, [this](TaskContext /*context*/)
-                    {
-                        Talk(SAY_VARDMADRA_BUT);
-                    }).Schedule(1s, [this](TaskContext /*context*/)
+                    Talk(SAY_VARDMADRA_BUT, 600ms);
+                    scheduler.Schedule(1s, [this](TaskContext /*context*/)
                     {
                         DoCastSelf(SPELL_SUICIDE, true);
                     });
@@ -2802,7 +2801,6 @@ public:
         void InitializeAI() override
         {
             BansheesMakeFlyer(me);
-            me->ApplySpellImmune(0, IMMUNITY_ID, SPELL_SAFIRDRANGS_CHILL, true);
             me->ApplySpellImmune(0, IMMUNITY_ID, SPELL_SAFIRDRANGS_CHILL_RELAY, true);
             me->GetMotionMaster()->MovePoint(POINT_NIGHTSWOOD_HORN, NightswoodHornPos);
         }

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -2113,14 +2113,10 @@ class spell_crashing_wave : public SpellScript
 };
 
 /*######
-## Quest 13142 "Banshee's Revenge" - Overthane Balargarde outdoor encounter.
-## War Horn of Jotunheim (GO 193028) summons Vardmadra, who brings in Safirdrang
-## (carrying Overthane) and the elite riders. Overthane fights to 50%, the Lich King
-## interlude plays, then the fight resumes until death.
+## Banshee's Revenge (Quest 13142) - Overthane Balargarde outdoor encounter.
 ######*/
 enum BansheesRevenge
 {
-    // Creatures
     NPC_BALARGARDE                  = 31016,
     NPC_POSSESSED_VARDMADRA         = 31029,
     NPC_BALARGARDE_ELITE            = 31030,
@@ -2131,13 +2127,11 @@ enum BansheesRevenge
 
     GO_WAR_HORN_OF_JOTUNHEIM        = 193028,
 
-    // Overthane combat
     SPELL_HEROIC_LEAP               = 60108,
     SPELL_WHIRLWIND                 = 61076,
     SPELL_FROSTBOLT                 = 15043,
     SPELL_BLIZZARD                  = 61085,
 
-    // Encounter spells
     SPELL_SAFIRDRANGS_CHILL         = 4020,
     SPELL_SAFIRDRANGS_CHILL_RELAY   = 4307,
     SPELL_ETHEREAL_TELEPORT         = 34427,
@@ -2148,7 +2142,6 @@ enum BansheesRevenge
 
     SOUND_LICH_KING_LAUGH           = 15714,
 
-    // creature_text groups - Overthane Balargarde (31016)
     SAY_BALARGARDE_TO_SAFIRDRANG    = 1,
     SAY_BALARGARDE_TO_VARDMADRA_1   = 2,
     SAY_BALARGARDE_TO_VARDMADRA_2   = 3,
@@ -2156,12 +2149,10 @@ enum BansheesRevenge
     SAY_BALARGARDE_KNEEL            = 5,
     SAY_BALARGARDE_MY_LORD          = 6,
     SAY_BALARGARDE_DIE_DOGS         = 7,
-    // creature_text groups - Possessed Vardmadra (31029)
     SAY_VARDMADRA_ARRIVE            = 0,
     SAY_VARDMADRA_CHALLENGE         = 1,
     SAY_VARDMADRA_MY_LORD           = 2,
     SAY_VARDMADRA_BUT               = 3,
-    // creature_text groups - The Lich King (31083)
     SAY_LK_HONOR_GUARD              = 0,
     SAY_LK_VARDMADRA                = 1,
     SAY_LK_DISGUISE                 = 2,
@@ -2169,14 +2160,13 @@ enum BansheesRevenge
     SAY_LK_FINISH_THEM              = 4,
     SAY_LK_BESTED                   = 5,
     SAY_LK_FROZEN_HEART             = 6,
+    SAY_NIGHTSWOOD_EMOTE            = 0,
 
-    // Phases: opening combat -> Lich King interlude -> resumed combat -> Lich King outro
     PHASE_ONE                       = 1,
     PHASE_INTERLUDE                 = 2,
     PHASE_RESUME                    = 3,
     PHASE_OUTRO                     = 4,
 
-    // Actions
     ACTION_ELITE_DESPAWN            = 1,
     ACTION_SAFIRDRANG_CHILL         = 2,
     ACTION_SAFIRDRANG_DEPART        = 3,
@@ -2185,15 +2175,16 @@ enum BansheesRevenge
     ACTION_LK_FINALE                = 6,
     ACTION_VARDMADRA_REVEAL         = 7,
     ACTION_VARDMADRA_KNEEL          = 8,
-    // Elite patrol: DoAction(ACTION_ELITE_START_PATROL + index), index 0..5 selects that elite's patrol
-    // path; offset high so the per-index values cannot collide with the actions above.
+    ACTION_NIGHTSWOOD_EXIT          = 9,
+    ACTION_BALARGARDE_JUMP          = 10,
+    ACTION_BALARGARDE_SALUTE        = 11,
     ACTION_ELITE_START_PATROL       = 1000,
 
-    // MovePoint ids (Lich King interlude walk)
     POINT_LK_CONFRONT               = 1,
     POINT_LK_RETURN                 = 2,
+    POINT_LK_BODY                   = 3,
+    POINT_NIGHTSWOOD_HORN           = 4,
 
-    // EventMap (Overthane combat)
     EVENT_HEROIC_LEAP               = 1,
     EVENT_WHIRLWIND                 = 2,
     EVENT_FROSTBOLT                 = 3,
@@ -2209,15 +2200,16 @@ enum BansheesPaths
     PATH_SAFIRDRANG_DEPART          = 3105000,
     PATH_LADY_NIGHTSWOOD            = 31087,
     PATH_LICH_KING                  = 31083,
-    PATH_ELITE_BASE                 = 3103000 // elite i (0..5) uses PATH_ELITE_BASE + 1 + i
+    PATH_ELITE_BASE                 = 3103000
 };
 
-// Spawn positions taken verbatim from the TrinityCore script.
 Position const SafirdrangSpawnPos   = { 7097.292f, 4416.581f, 831.8486f, 4.485496f };
 Position const LichKingSpawnPos      = { 7088.768f, 4385.59f,  872.4484f, 4.468043f };
-// The Lich King walks up to confront Vardmadra during the interlude, then walks back to his guard spot.
 Position const LichKingConfrontPos   = { 7094.104f, 4331.222f, 871.5023f, 0.0f };
-float const LichKingWalkSpeed  = 4.5f; // brisk walk pace (walk animation, faster than the default ~2.5)
+float const LichKingWalkSpeed        = 5.5f;
+float const SafirdrangEntryFlightSpeed = 2.25f;
+float const EliteRearFlightSpeed     = 5.0f;
+float const EliteFrontFlightSpeed    = 18.0f;
 Position const BalargardeElitePos[6] =
 {
     { 7108.229f, 4428.539f, 837.9857f, 4.782202f },
@@ -2227,18 +2219,19 @@ Position const BalargardeElitePos[6] =
     { 7111.272f, 4445.171f, 838.5065f, 4.834562f },
     { 7090.730f, 4446.960f, 837.0818f, 3.402185f }
 };
+Position const NightswoodSpawnPos    = { 7094.104f,  4331.222f,  874.0f,     0.0f };
+Position const NightswoodHornPos     = { 7078.8545f, 4295.6245f, 875.26514f, 1.461f };
 
-// Helper: enable flight movement on a cosmetic flyer summon.
 static void BansheesMakeFlyer(Creature* creature)
 {
     creature->SetCanFly(true);
     creature->SetDisableGravity(true);
-    creature->SetAnimTier(AnimTier::Fly); // play the flying pose, not the ground walk/run, while airborne
+    creature->SetAnimTier(AnimTier::Fly);
     creature->SetReactState(REACT_PASSIVE);
 }
 
 /*######
-## Banshee's Revenge: npc_bansheesrevenge_overthane (31016) - the boss
+## Banshee's Revenge: npc_bansheesrevenge_overthane (31016)
 ######*/
 class npc_bansheesrevenge_overthane : public CreatureScript
 {
@@ -2251,9 +2244,10 @@ public:
 
         void InitializeAI() override
         {
-            // Spawns seated on Safirdrang; stays passive until ejected and engaged.
             me->SetReactState(REACT_PASSIVE);
             me->SetImmuneToPC(true);
+            me->ApplySpellImmune(0, IMMUNITY_ID, SPELL_SAFIRDRANGS_CHILL, true);
+            me->ApplySpellImmune(0, IMMUNITY_ID, SPELL_SAFIRDRANGS_CHILL_RELAY, true);
         }
 
         void Reset() override
@@ -2263,37 +2257,44 @@ public:
             _phase = PHASE_ONE;
             _interludeStarted = false;
             _chillActive = false;
+            _kneeling = false;
         }
 
         void DoAction(int32 action) override
         {
             switch (action)
             {
-                case ACTION_BALARGARDE_ENGAGE:
-                    // Ejected from Safirdrang well above the arena: drop to the ground
-                    // before anchoring the home position and engaging.
+                case ACTION_BALARGARDE_JUMP:
                     me->ExitVehicle();
                     me->GetMotionMaster()->MoveFall();
-                    me->SetImmuneToPC(false);
-                    me->SetReactState(REACT_AGGRESSIVE);
                     scheduler.Schedule(2s, [this](TaskContext /*context*/)
                     {
-                        me->SetHomePosition(me->GetPosition());
-                        if (Player* player = me->SelectNearestPlayer(100.0f))
-                            AttackStart(player);
-
-                        // Overthane is now in position: the two elites centred on his axis fly in together.
-                        // #4 (behind) has a short patrol and lands just behind him; #5 (front) loops the long
-                        // way, so its AI flies it faster to arrive out front at about the same time.
-                        SummonPatrolElite(4);
-                        SummonPatrolElite(5);
+                        if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 200.0f))
+                            me->SetFacingToObject(vardmadra);
+                    });
+                    break;
+                case ACTION_BALARGARDE_ENGAGE:
+                    me->SetHomePosition(me->GetPosition());
+                    me->SetImmuneToPC(false);
+                    me->SetReactState(REACT_AGGRESSIVE);
+                    if (Player* player = me->SelectNearestPlayer(100.0f))
+                        AttackStart(player);
+                    break;
+                case ACTION_BALARGARDE_SALUTE:
+                    _kneeling = false;
+                    me->SetStandState(UNIT_STAND_STATE_STAND);
+                    scheduler.Schedule(1s, [this](TaskContext /*context*/)
+                    {
+                        me->HandleEmoteCommand(EMOTE_ONESHOT_SALUTE);
                     });
                     break;
                 case ACTION_BALARGARDE_RESUME:
                     me->SetStandState(UNIT_STAND_STATE_STAND);
                     me->SetReactState(REACT_AGGRESSIVE);
-                    _phase = PHASE_RESUME; // b633a62: resume into the combat phase, not the opening
-                    if (Player* player = me->SelectNearestPlayer(100.0f))
+                    me->ApplySpellImmune(0, IMMUNITY_SCHOOL, SPELL_SCHOOL_MASK_ALL, false);
+                    _phase = PHASE_RESUME;
+                    RepullNearbyPlayers();
+                    if (Player* player = me->SelectNearestPlayer(200.0f))
                         AttackStart(player);
                     ScheduleCombatEvents();
                     break;
@@ -2318,25 +2319,23 @@ public:
                 _events.ScheduleEvent(EVENT_CHILL_RUN, 3s, 5s);
         }
 
-        // Summon one of the two axis-centred elites (#4 behind / #5 in front) at its spawn point and
-        // start its patrol; used after Overthane is in position so they stagger in behind the side four.
-        void SummonPatrolElite(uint8 index)
+        bool RepullNearbyPlayers()
         {
-            if (Creature* elite = me->SummonCreature(NPC_BALARGARDE_ELITE,
-                BalargardeElitePos[index], TEMPSUMMON_MANUAL_DESPAWN))
-                elite->AI()->DoAction(ACTION_ELITE_START_PATROL + index);
+            bool found = false;
+            me->SetHomePosition(me->GetPosition());
+            Map::PlayerList const& players = me->GetMap()->GetPlayers();
+            for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
+                if (Player* player = itr->GetSource())
+                    if (player->IsAlive() && me->IsValidAttackTarget(player) && me->IsWithinDistInMap(player, 200.0f))
+                    {
+                        DoAddThreat(player, 5.0f);
+                        found = true;
+                    }
+            return found;
         }
 
         void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
-            // Invulnerable while the interlude plays out: still targettable/attackable, just takes no damage.
-            if (_phase == PHASE_INTERLUDE)
-            {
-                damage = 0;
-                return;
-            }
-
-            // Cannot die before the Lich King interlude has played out.
             if (!_interludeStarted)
             {
                 uint32 const minHealth = me->CountPctFromMaxHealth(50);
@@ -2365,10 +2364,8 @@ public:
             me->AttackStop();
             me->GetMotionMaster()->Clear();
             me->GetMotionMaster()->MoveIdle();
-            // Kneel and stop fighting, but stay targettable AND in the players' combat. Do NOT set
-            // ImmuneToPC/NOT_SELECTABLE here: ImmuneToPC drops player combat, which makes the core evade
-            // (no hostiles) and CleanupEncounter resets everything. Invulnerability is handled in DamageTaken.
             me->SetReactState(REACT_PASSIVE);
+            me->ApplySpellImmune(0, IMMUNITY_SCHOOL, SPELL_SCHOOL_MASK_ALL, true);
             Talk(SAY_BALARGARDE_KNEEL);
 
             Creature* lichKing = me->SummonCreature(NPC_LICH_KING, LichKingSpawnPos, TEMPSUMMON_MANUAL_DESPAWN);
@@ -2377,30 +2374,29 @@ public:
 
             me->SetFacingToObject(lichKing);
 
-            // Vardmadra drops out of the air and kneels alongside Overthane.
             if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 200.0f))
                 vardmadra->AI()->DoAction(ACTION_VARDMADRA_KNEEL);
 
             scheduler.Schedule(1s, [this](TaskContext /*context*/)
             {
                 me->SetStandState(UNIT_STAND_STATE_KNEEL);
+                _kneeling = true;
             });
         }
 
         void JustDied(Unit* /*killer*/) override
         {
-            _phase = PHASE_OUTRO; // the Lich King now runs the outro sequence
+            _phase = PHASE_OUTRO;
             if (Creature* lichKing = me->FindNearestCreature(NPC_LICH_KING, 200.0f))
                 lichKing->AI()->DoAction(ACTION_LK_FINALE);
-
-            // The War Horn is re-armed at the end of the Lich King's outro (see ACTION_LK_FINALE), not here,
-            // so a fresh group cannot ring it until the event is completely over and the platform is clear.
         }
 
         void EnterEvadeMode(EvadeReason why) override
         {
-            // The scripted interlude deliberately stops combat; never let an evade reset it mid-cutscene.
             if (_phase == PHASE_INTERLUDE)
+                return;
+
+            if (_phase == PHASE_RESUME && RepullNearbyPlayers())
                 return;
 
             ScriptedAI::EnterEvadeMode(why);
@@ -2434,7 +2430,11 @@ public:
             scheduler.Update(diff);
 
             if (_phase == PHASE_INTERLUDE)
+            {
+                if (_kneeling && me->getStandState() != UNIT_STAND_STATE_KNEEL)
+                    me->SetStandState(UNIT_STAND_STATE_KNEEL);
                 return;
+            }
 
             if (!UpdateVictim())
                 return;
@@ -2487,6 +2487,7 @@ public:
         uint8 _phase = PHASE_ONE;
         bool _interludeStarted = false;
         bool _chillActive = false;
+        bool _kneeling = false;
     };
 
     CreatureAI* GetAI(Creature* creature) const override
@@ -2511,31 +2512,34 @@ public:
         {
             BansheesMakeFlyer(me);
 
-            // The vehicle kit is installed AFTER AIM_Initialize()/InitializeAI() in Creature::AddToWorld,
-            // so seating a passenger here silently fails. Defer the summon/board and the flight by one tick.
             scheduler.Schedule(1s, [this](TaskContext /*context*/)
             {
-                // Carry Overthane in seat 0 and fly the intro path.
                 if (Creature* balargarde = me->SummonCreature(NPC_BALARGARDE, *me, TEMPSUMMON_MANUAL_DESPAWN))
                     balargarde->EnterVehicleUnattackable(me, 0);
 
+                me->SetSpeedRate(MOVE_FLIGHT, SafirdrangEntryFlightSpeed);
                 me->GetMotionMaster()->MovePath(PATH_SAFIRDRANG_INTRO, FORCED_MOVEMENT_NONE, PathSource::WAYPOINT_MGR);
             });
         }
 
         void MovementInform(uint32 type, uint32 /*id*/) override
         {
-            // MovePath drives an EscortMovementGenerator (ESCORT_MOTION_TYPE), firing per spline
-            // segment; act only at the path's end and use the state flags to tell the paths apart.
             if (type != ESCORT_MOTION_TYPE || !me->movespline->Finalized())
                 return;
 
-            if (!_introDone) // reached the end of the intro path
+            if (!_introDone)
             {
                 _introDone = true;
+                me->SetSpeedRate(MOVE_FLIGHT, 1.0f);
+
+                for (uint8 i = 4; i < 6; ++i)
+                    if (Creature* elite = me->SummonCreature(NPC_BALARGARDE_ELITE,
+                        BalargardeElitePos[i], TEMPSUMMON_MANUAL_DESPAWN))
+                        elite->AI()->DoAction(ACTION_ELITE_START_PATROL + i);
+
                 RunIntroDialogue();
             }
-            else if (_departing) // reached the end of the depart path
+            else if (_departing)
                 me->DespawnOrUnsummon();
         }
 
@@ -2553,13 +2557,17 @@ public:
             {
                 if (Creature* balargarde = GetSeatedBalargarde())
                     balargarde->AI()->Talk(SAY_BALARGARDE_TO_VARDMADRA_1);
-            }).Schedule(18s, [this](TaskContext /*context*/)
+            }).Schedule(15s, [this](TaskContext /*context*/)
             {
                 if (Creature* balargarde = GetSeatedBalargarde())
+                    balargarde->AI()->DoAction(ACTION_BALARGARDE_JUMP);
+            }).Schedule(18s, [this](TaskContext /*context*/)
+            {
+                if (Creature* balargarde = me->FindNearestCreature(NPC_BALARGARDE, 200.0f))
                     balargarde->AI()->Talk(SAY_BALARGARDE_TO_VARDMADRA_2);
             }).Schedule(23s, [this](TaskContext /*context*/)
             {
-                if (Creature* balargarde = GetSeatedBalargarde())
+                if (Creature* balargarde = me->FindNearestCreature(NPC_BALARGARDE, 200.0f))
                     balargarde->AI()->DoAction(ACTION_BALARGARDE_ENGAGE);
                 me->SetHomePosition(me->GetPosition());
             });
@@ -2624,39 +2632,49 @@ public:
 
         void InitializeAI() override
         {
-            // Rides a cosmetic proto-drake mount (creature_addon mount 26882) and flies its own patrol.
             BansheesMakeFlyer(me);
             me->SetImmuneToPC(true);
         }
 
         void DoAction(int32 action) override
         {
-            if (action >= ACTION_ELITE_START_PATROL) // patrol path encoded as action + index
+            if (action >= ACTION_ELITE_START_PATROL)
             {
                 uint32 const index = action - ACTION_ELITE_START_PATROL;
-                // #5 (front) loops the long way around, so fly it faster to reach its spot at about the same
-                // time the short rear patrol (#4) lands. Tuning knob: raise if #5 still trails, lower if it
-                // beats #4 there. The factor ~matches its patrol length relative to #4's.
-                if (index == 5)
-                    me->SetSpeedRate(MOVE_FLIGHT, 4.0f);
+                if (index == 4)
+                    me->SetSpeedRate(MOVE_FLIGHT, EliteRearFlightSpeed);
+                else if (index == 5)
+                    me->SetSpeedRate(MOVE_FLIGHT, EliteFrontFlightSpeed);
                 me->GetMotionMaster()->MovePath(PATH_ELITE_BASE + 1 + index,
                     FORCED_MOVEMENT_NONE, PathSource::WAYPOINT_MGR);
-                // Keep facing Possessed Vardmadra until the Lich King's arrival despawns the riders.
-                scheduler.Schedule(1s, [this](TaskContext context)
-                {
-                    if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 250.0f))
-                        me->SetFacingToObject(vardmadra);
-                    context.Repeat(1s);
-                });
             }
             else if (action == ACTION_ELITE_DESPAWN)
                 me->DespawnOrUnsummon();
+        }
+
+        void MovementInform(uint32 type, uint32 /*id*/) override
+        {
+            if (type != ESCORT_MOTION_TYPE || !me->movespline->Finalized() || _holdingPosition)
+                return;
+
+            _holdingPosition = true;
+            scheduler.Schedule(1s, [this](TaskContext context)
+            {
+                if (Creature* lichKing = me->FindNearestCreature(NPC_LICH_KING, 250.0f))
+                    me->SetFacingToObject(lichKing);
+                else if (Creature* safirdrang = me->FindNearestCreature(NPC_SAFIRDRANG, 250.0f))
+                    me->SetFacingToObject(safirdrang);
+                context.Repeat(1s);
+            });
         }
 
         void UpdateAI(uint32 diff) override
         {
             scheduler.Update(diff);
         }
+
+    private:
+        bool _holdingPosition = false;
     };
 
     CreatureAI* GetAI(Creature* creature) const override
@@ -2685,20 +2703,15 @@ public:
 
         void MovementInform(uint32 type, uint32 /*id*/) override
         {
-            // MovePath drives an EscortMovementGenerator, which reports ESCORT_MOTION_TYPE (not
-            // WAYPOINT_MOTION_TYPE) and fires per spline segment; act only at the path's end.
             if (type != ESCORT_MOTION_TYPE || !me->movespline->Finalized())
                 return;
 
-            if (!_introDone) // reached the end of the intro path
+            if (!_introDone)
             {
                 _introDone = true;
                 Talk(SAY_VARDMADRA_ARRIVE);
                 me->SummonCreature(NPC_SAFIRDRANG, SafirdrangSpawnPos, TEMPSUMMON_MANUAL_DESPAWN);
 
-                // Only the four side elites (#0-#3: two left, two right) fly in with the intro. The two
-                // centred on Overthane's axis (#4 behind, #5 in front) are summoned by Overthane once he is
-                // in position, so they don't pop in before he has landed.
                 for (uint8 i = 0; i < 4; ++i)
                     if (Creature* elite = me->SummonCreature(NPC_BALARGARDE_ELITE,
                         BalargardeElitePos[i], TEMPSUMMON_MANUAL_DESPAWN))
@@ -2711,7 +2724,6 @@ public:
             switch (action)
             {
                 case ACTION_VARDMADRA_KNEEL:
-                    // Land out of the air and kneel before the Lich King, alongside Overthane.
                     me->SetCanFly(false);
                     me->SetDisableGravity(false);
                     me->SetAnimTier(AnimTier::Ground);
@@ -2724,16 +2736,13 @@ public:
                     });
                     break;
                 case ACTION_VARDMADRA_REVEAL:
-                    // The "possessed" body is a disguise; the real banshee escapes and the body dies.
                     me->SetStandState(UNIT_STAND_STATE_STAND);
-                    DoCastSelf(SPELL_SUMMON_LADY_NIGHTSWOOD, true);
                     scheduler.Schedule(600ms, [this](TaskContext /*context*/)
                     {
                         Talk(SAY_VARDMADRA_BUT);
                     }).Schedule(1s, [this](TaskContext /*context*/)
                     {
                         DoCastSelf(SPELL_SUICIDE, true);
-                        me->DespawnOrUnsummon(15s);
                     });
                     break;
                 default:
@@ -2771,20 +2780,38 @@ public:
         void InitializeAI() override
         {
             BansheesMakeFlyer(me);
-            if (Creature* lichKing = me->FindNearestCreature(NPC_LICH_KING, 200.0f))
-                me->SetFacingToObject(lichKing);
+            me->ApplySpellImmune(0, IMMUNITY_ID, SPELL_SAFIRDRANGS_CHILL, true);
+            me->ApplySpellImmune(0, IMMUNITY_ID, SPELL_SAFIRDRANGS_CHILL_RELAY, true);
+            me->GetMotionMaster()->MovePoint(POINT_NIGHTSWOOD_HORN, NightswoodHornPos);
+        }
 
-            scheduler.Schedule(20s, [this](TaskContext /*context*/)
+        void MovementInform(uint32 type, uint32 id) override
+        {
+            if (type == POINT_MOTION_TYPE && id == POINT_NIGHTSWOOD_HORN)
+            {
+                if (Creature* lichKing = me->FindNearestCreature(NPC_LICH_KING, 300.0f))
+                    me->SetFacingToObject(lichKing);
+
+                scheduler.Schedule(3s, [this](TaskContext /*context*/)
+                {
+                    if (Creature* balargarde = me->FindNearestCreature(NPC_BALARGARDE, 300.0f))
+                        me->SetFacingToObject(balargarde);
+                });
+            }
+            else if (type == ESCORT_MOTION_TYPE && me->movespline->Finalized())
+                me->DespawnOrUnsummon();
+        }
+
+        void DoAction(int32 action) override
+        {
+            if (action != ACTION_NIGHTSWOOD_EXIT)
+                return;
+
+            Talk(SAY_NIGHTSWOOD_EMOTE);
+            scheduler.Schedule(3s, [this](TaskContext /*context*/)
             {
                 me->GetMotionMaster()->MovePath(PATH_LADY_NIGHTSWOOD, FORCED_MOVEMENT_NONE, PathSource::WAYPOINT_MGR);
             });
-        }
-
-        void MovementInform(uint32 type, uint32 /*id*/) override
-        {
-            // MovePath -> ESCORT_MOTION_TYPE; despawn once the escape path is fully traversed.
-            if (type == ESCORT_MOTION_TYPE && me->movespline->Finalized())
-                me->DespawnOrUnsummon();
         }
 
         void UpdateAI(uint32 diff) override
@@ -2825,61 +2852,86 @@ public:
                 DoCastSelf(SPELL_ETHEREAL_TELEPORT, true);
             }).Schedule(4s, [this](TaskContext /*context*/)
             {
-                DespawnElites();
                 DoCastSelf(SPELL_ICEBOUND_VISAGE, true);
                 FaceCreature(NPC_POSSESSED_VARDMADRA);
-            }).Schedule(8s, [this](TaskContext /*context*/)
+            }).Schedule(6s, [this](TaskContext /*context*/)
             {
                 Talk(SAY_LK_HONOR_GUARD);
-            }).Schedule(14s, [this](TaskContext /*context*/)
+            }).Schedule(13s, [this](TaskContext /*context*/)
             {
                 Talk(SAY_LK_VARDMADRA);
-                // Brisk WALK up to Vardmadra and stop in front of her (no run, no out-and-back). He stays
-                // here through the dialogue and the reveal, then walks back to his guard spot afterwards.
                 me->GetMotionMaster()->MovePoint(POINT_LK_CONFRONT, LichKingConfrontPos,
                     FORCED_MOVEMENT_WALK, LichKingWalkSpeed);
-            }).Schedule(23s, [this](TaskContext /*context*/)
+            });
+        }
+
+        void MovementInform(uint32 type, uint32 id) override
+        {
+            if (type != POINT_MOTION_TYPE)
+                return;
+
+            if (id == POINT_LK_CONFRONT && !_confronted)
+            {
+                _confronted = true;
+                ConfrontVardmadra();
+            }
+            else if (id == POINT_LK_BODY)
+                RunOutro();
+        }
+
+        void ConfrontVardmadra()
+        {
+            FaceCreature(NPC_POSSESSED_VARDMADRA);
+
+            scheduler.Schedule(0s, [this](TaskContext /*context*/)
             {
                 if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 200.0f))
+                {
                     vardmadra->AI()->Talk(SAY_VARDMADRA_MY_LORD);
-            }).Schedule(27s, [this](TaskContext /*context*/)
+                    vardmadra->SetStandState(UNIT_STAND_STATE_KNEEL);
+                    vardmadra->SetFacingToObject(me);
+                }
+            }).Schedule(4s, [this](TaskContext /*context*/)
             {
                 FaceCreature(NPC_POSSESSED_VARDMADRA);
                 Talk(SAY_LK_DISGUISE);
-            }).Schedule(36s, [this](TaskContext /*context*/)
+            }).Schedule(11s, [this](TaskContext /*context*/)
             {
                 if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 200.0f))
                 {
                     DoCast(vardmadra, SPELL_LK_SPECIAL_2H, true);
                     vardmadra->AI()->DoAction(ACTION_VARDMADRA_REVEAL);
                 }
-            }).Schedule(40s, [this](TaskContext /*context*/)
+            }).Schedule(17s, [this](TaskContext /*context*/)
             {
                 me->PlayDirectSound(SOUND_LICH_KING_LAUGH);
-            }).Schedule(43s, [this](TaskContext /*context*/)
+            }).Schedule(20s, [this](TaskContext /*context*/)
             {
                 Talk(SAY_LK_CONTINUE);
                 FaceCreature(NPC_BALARGARDE);
-            }).Schedule(46s, [this](TaskContext /*context*/)
-            {
-                // Reveal done: walk back to his honor-guard position to observe the resumed fight.
-                me->GetMotionMaster()->MovePoint(POINT_LK_RETURN, LichKingSpawnPos,
-                    FORCED_MOVEMENT_WALK, LichKingWalkSpeed);
-            }).Schedule(48s, [this](TaskContext /*context*/)
+            }).Schedule(25s, [this](TaskContext /*context*/)
             {
                 if (Creature* balargarde = me->FindNearestCreature(NPC_BALARGARDE, 200.0f))
                     balargarde->AI()->Talk(SAY_BALARGARDE_MY_LORD);
-            }).Schedule(52s, [this](TaskContext /*context*/)
+            }).Schedule(29s, [this](TaskContext /*context*/)
             {
                 Talk(SAY_LK_FINISH_THEM);
-            }).Schedule(59s, [this](TaskContext /*context*/)
+            }).Schedule(33s, [this](TaskContext /*context*/)
+            {
+                me->GetMotionMaster()->MovePoint(POINT_LK_RETURN, LichKingSpawnPos,
+                    FORCED_MOVEMENT_WALK, LichKingWalkSpeed);
+            }).Schedule(34s, [this](TaskContext /*context*/)
             {
                 if (Creature* balargarde = me->FindNearestCreature(NPC_BALARGARDE, 200.0f))
+                    balargarde->AI()->DoAction(ACTION_BALARGARDE_SALUTE);
+                me->SummonCreature(NPC_LADY_NIGHTSWOOD, NightswoodSpawnPos, TEMPSUMMON_MANUAL_DESPAWN);
+            }).Schedule(38s, [this](TaskContext /*context*/)
+            {
+                if (Creature* balargarde = me->FindNearestCreature(NPC_BALARGARDE, 200.0f))
+                {
                     balargarde->AI()->Talk(SAY_BALARGARDE_DIE_DOGS);
-            }).Schedule(60s, [this](TaskContext /*context*/)
-            {
-                if (Creature* balargarde = me->FindNearestCreature(NPC_BALARGARDE, 200.0f))
                     balargarde->AI()->DoAction(ACTION_BALARGARDE_RESUME);
+                }
             });
         }
 
@@ -2893,6 +2945,26 @@ public:
             if (Creature* safirdrang = me->FindNearestCreature(NPC_SAFIRDRANG, 200.0f))
                 safirdrang->AI()->DoAction(ACTION_SAFIRDRANG_DEPART);
 
+            if (Creature* nightswood = me->FindNearestCreature(NPC_LADY_NIGHTSWOOD, 300.0f))
+                nightswood->AI()->DoAction(ACTION_NIGHTSWOOD_EXIT);
+
+            if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 300.0f, false))
+                vardmadra->DespawnOrUnsummon();
+
+            if (Creature* corpse = me->FindNearestCreature(NPC_BALARGARDE, 300.0f, false))
+            {
+                float const angle = corpse->GetAbsoluteAngle(me);
+                float const x = corpse->GetPositionX() + 8.0f * std::cos(angle);
+                float const y = corpse->GetPositionY() + 8.0f * std::sin(angle);
+                me->GetMotionMaster()->MovePoint(POINT_LK_BODY, x, y, corpse->GetPositionZ(),
+                    FORCED_MOVEMENT_WALK, LichKingWalkSpeed);
+            }
+            else
+                RunOutro();
+        }
+
+        void RunOutro()
+        {
             if (Player* player = me->SelectNearestPlayer(60.0f))
                 me->SetFacingToObject(player);
 
@@ -2906,12 +2978,8 @@ public:
             {
                 DoCastSelf(SPELL_ETHEREAL_TELEPORT, true);
                 DespawnElites();
-                if (Creature* nightswood = me->FindNearestCreature(NPC_LADY_NIGHTSWOOD, 250.0f))
-                    nightswood->DespawnOrUnsummon();
             }).Schedule(20s, [this](TaskContext /*context*/)
             {
-                // Event fully over: Overthane is dead and the Lich King has left the platform. Re-arm the
-                // War Horn of Jotunheim so a new group can ring it and start the event again.
                 if (GameObject* horn = me->FindNearestGameObject(GO_WAR_HORN_OF_JOTUNHEIM, 200.0f))
                     horn->ResetDoorOrButton();
                 me->DespawnOrUnsummon();
@@ -2936,6 +3004,9 @@ public:
         {
             scheduler.Update(diff);
         }
+
+    private:
+        bool _confronted = false;
     };
 
     CreatureAI* GetAI(Creature* creature) const override

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -2121,21 +2121,21 @@ class spell_crashing_wave : public SpellScript
 enum BansheesRevenge
 {
     // Creatures
-    NPC_OVERTHANE_BALARGARDE        = 31016,
+    NPC_BALARGARDE                  = 31016,
     NPC_POSSESSED_VARDMADRA         = 31029,
     NPC_BALARGARDE_ELITE            = 31030,
     NPC_SAFIRDRANG                  = 31050,
     NPC_SAFIRDRANGS_CHILL_TARGET    = 31077,
-    NPC_BANSHEE_LICH_KING           = 31083,
+    NPC_LICH_KING                   = 31083,
     NPC_LADY_NIGHTSWOOD             = 31087,
 
     GO_WAR_HORN_OF_JOTUNHEIM        = 193028,
 
     // Overthane combat
-    SPELL_BR_HEROIC_LEAP            = 60108,
-    SPELL_BR_WHIRLWIND              = 61076,
-    SPELL_BR_FROSTBOLT              = 15043,
-    SPELL_BR_BLIZZARD               = 61085,
+    SPELL_HEROIC_LEAP               = 60108,
+    SPELL_WHIRLWIND                 = 61076,
+    SPELL_FROSTBOLT                 = 15043,
+    SPELL_BLIZZARD                  = 61085,
 
     // Encounter spells
     SPELL_SAFIRDRANGS_CHILL         = 4020,
@@ -2143,7 +2143,7 @@ enum BansheesRevenge
     SPELL_ETHEREAL_TELEPORT         = 34427,
     SPELL_ICEBOUND_VISAGE           = 53274,
     SPELL_SUMMON_LADY_NIGHTSWOOD    = 58359,
-    SPELL_BR_SUICIDE                = 51744,
+    SPELL_SUICIDE                   = 51744,
     SPELL_LK_SPECIAL_2H             = 42904,
 
     SOUND_LICH_KING_LAUGH           = 15714,
@@ -2171,32 +2171,34 @@ enum BansheesRevenge
     SAY_LK_FROZEN_HEART             = 6,
 
     // Phases: opening combat -> Lich King interlude -> resumed combat -> Lich King outro
-    BR_PHASE_ONE                    = 1,
-    BR_PHASE_INTERLUDE              = 2,
-    BR_PHASE_RESUME                 = 3,
-    BR_PHASE_OUTRO                  = 4,
+    PHASE_ONE                       = 1,
+    PHASE_INTERLUDE                 = 2,
+    PHASE_RESUME                    = 3,
+    PHASE_OUTRO                     = 4,
 
     // Actions
-    ACTION_ELITE_START_PATROL       = 1,
-    ACTION_ELITE_DESPAWN            = 2,
-    ACTION_SAFIRDRANG_CHILL         = 3,
-    ACTION_SAFIRDRANG_DEPART        = 4,
-    ACTION_BALARGARDE_ENGAGE        = 5,
-    ACTION_BALARGARDE_RESUME        = 6,
-    ACTION_LK_FINALE                = 7,
-    ACTION_VARDMADRA_REVEAL         = 8,
-    ACTION_VARDMADRA_KNEEL          = 9,
+    ACTION_ELITE_DESPAWN            = 1,
+    ACTION_SAFIRDRANG_CHILL         = 2,
+    ACTION_SAFIRDRANG_DEPART        = 3,
+    ACTION_BALARGARDE_ENGAGE        = 4,
+    ACTION_BALARGARDE_RESUME        = 5,
+    ACTION_LK_FINALE                = 6,
+    ACTION_VARDMADRA_REVEAL         = 7,
+    ACTION_VARDMADRA_KNEEL          = 8,
+    // Elite patrol: DoAction(ACTION_ELITE_START_PATROL + index), index 0..5 selects that elite's patrol
+    // path; offset high so the per-index values cannot collide with the actions above.
+    ACTION_ELITE_START_PATROL       = 1000,
 
     // MovePoint ids (Lich King interlude walk)
     POINT_LK_CONFRONT               = 1,
     POINT_LK_RETURN                 = 2,
 
     // EventMap (Overthane combat)
-    EVENT_BR_HEROIC_LEAP            = 1,
-    EVENT_BR_WHIRLWIND              = 2,
-    EVENT_BR_FROSTBOLT              = 3,
-    EVENT_BR_BLIZZARD               = 4,
-    EVENT_BR_CHILL_RUN              = 5
+    EVENT_HEROIC_LEAP               = 1,
+    EVENT_WHIRLWIND                 = 2,
+    EVENT_FROSTBOLT                 = 3,
+    EVENT_BLIZZARD                  = 4,
+    EVENT_CHILL_RUN                 = 5
 };
 
 enum BansheesPaths
@@ -2215,7 +2217,7 @@ Position const SafirdrangSpawnPos   = { 7097.292f, 4416.581f, 831.8486f, 4.48549
 Position const LichKingSpawnPos      = { 7088.768f, 4385.59f,  872.4484f, 4.468043f };
 // The Lich King walks up to confront Vardmadra during the interlude, then walks back to his guard spot.
 Position const LichKingConfrontPos   = { 7094.104f, 4331.222f, 871.5023f, 0.0f };
-float const LK_INTERLUDE_WALK_SPEED  = 4.5f; // brisk walk pace (walk animation, faster than the default ~2.5)
+float const LichKingWalkSpeed  = 4.5f; // brisk walk pace (walk animation, faster than the default ~2.5)
 Position const BalargardeElitePos[6] =
 {
     { 7108.229f, 4428.539f, 837.9857f, 4.782202f },
@@ -2245,12 +2247,7 @@ public:
 
     struct npc_bansheesrevenge_overthaneAI : public ScriptedAI
     {
-        npc_bansheesrevenge_overthaneAI(Creature* creature) : ScriptedAI(creature)
-        {
-            _phase = BR_PHASE_ONE;
-            _interludeStarted = false;
-            _chillActive = false;
-        }
+        npc_bansheesrevenge_overthaneAI(Creature* creature) : ScriptedAI(creature) { }
 
         void InitializeAI() override
         {
@@ -2263,7 +2260,7 @@ public:
         {
             _events.Reset();
             scheduler.CancelAll();
-            _phase = BR_PHASE_ONE;
+            _phase = PHASE_ONE;
             _interludeStarted = false;
             _chillActive = false;
         }
@@ -2294,10 +2291,8 @@ public:
                     break;
                 case ACTION_BALARGARDE_RESUME:
                     me->SetStandState(UNIT_STAND_STATE_STAND);
-                    me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
-                    me->SetImmuneToPC(false);
                     me->SetReactState(REACT_AGGRESSIVE);
-                    _phase = BR_PHASE_RESUME; // b633a62: resume into the combat phase, not the opening
+                    _phase = PHASE_RESUME; // b633a62: resume into the combat phase, not the opening
                     if (Player* player = me->SelectNearestPlayer(100.0f))
                         AttackStart(player);
                     ScheduleCombatEvents();
@@ -2315,12 +2310,12 @@ public:
         void ScheduleCombatEvents()
         {
             _events.Reset();
-            _events.ScheduleEvent(EVENT_BR_HEROIC_LEAP, 20s, 30s);
-            _events.ScheduleEvent(EVENT_BR_WHIRLWIND, 60s, 90s);
-            _events.ScheduleEvent(EVENT_BR_FROSTBOLT, 20s, 25s);
-            _events.ScheduleEvent(EVENT_BR_BLIZZARD, 15s, 25s);
+            _events.ScheduleEvent(EVENT_HEROIC_LEAP, 20s, 30s);
+            _events.ScheduleEvent(EVENT_WHIRLWIND, 60s, 90s);
+            _events.ScheduleEvent(EVENT_FROSTBOLT, 20s, 25s);
+            _events.ScheduleEvent(EVENT_BLIZZARD, 15s, 25s);
             if (_chillActive)
-                _events.ScheduleEvent(EVENT_BR_CHILL_RUN, 3s, 5s);
+                _events.ScheduleEvent(EVENT_CHILL_RUN, 3s, 5s);
         }
 
         // Summon one of the two axis-centred elites (#4 behind / #5 in front) at its spawn point and
@@ -2329,13 +2324,13 @@ public:
         {
             if (Creature* elite = me->SummonCreature(NPC_BALARGARDE_ELITE,
                 BalargardeElitePos[index], TEMPSUMMON_MANUAL_DESPAWN))
-                elite->AI()->DoAction(ACTION_ELITE_START_PATROL + 1000 + index);
+                elite->AI()->DoAction(ACTION_ELITE_START_PATROL + index);
         }
 
         void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
             // Invulnerable while the interlude plays out: still targettable/attackable, just takes no damage.
-            if (_phase == BR_PHASE_INTERLUDE)
+            if (_phase == PHASE_INTERLUDE)
             {
                 damage = 0;
                 return;
@@ -2357,14 +2352,14 @@ public:
             {
                 _chillActive = true;
                 Talk(SAY_BALARGARDE_80PCT);
-                _events.ScheduleEvent(EVENT_BR_CHILL_RUN, 3s, 5s);
+                _events.ScheduleEvent(EVENT_CHILL_RUN, 3s, 5s);
             }
         }
 
         void StartInterlude()
         {
             _interludeStarted = true;
-            _phase = BR_PHASE_INTERLUDE;
+            _phase = PHASE_INTERLUDE;
             _events.Reset();
 
             me->AttackStop();
@@ -2376,7 +2371,7 @@ public:
             me->SetReactState(REACT_PASSIVE);
             Talk(SAY_BALARGARDE_KNEEL);
 
-            Creature* lichKing = me->SummonCreature(NPC_BANSHEE_LICH_KING, LichKingSpawnPos, TEMPSUMMON_MANUAL_DESPAWN);
+            Creature* lichKing = me->SummonCreature(NPC_LICH_KING, LichKingSpawnPos, TEMPSUMMON_MANUAL_DESPAWN);
             if (!lichKing)
                 return;
 
@@ -2394,19 +2389,18 @@ public:
 
         void JustDied(Unit* /*killer*/) override
         {
-            _phase = BR_PHASE_OUTRO; // the Lich King now runs the outro sequence
-            if (Creature* lichKing = me->FindNearestCreature(NPC_BANSHEE_LICH_KING, 200.0f))
+            _phase = PHASE_OUTRO; // the Lich King now runs the outro sequence
+            if (Creature* lichKing = me->FindNearestCreature(NPC_LICH_KING, 200.0f))
                 lichKing->AI()->DoAction(ACTION_LK_FINALE);
 
-            // Allow the War Horn to be used again.
-            if (GameObject* horn = me->FindNearestGameObject(GO_WAR_HORN_OF_JOTUNHEIM, 200.0f))
-                horn->ResetDoorOrButton();
+            // The War Horn is re-armed at the end of the Lich King's outro (see ACTION_LK_FINALE), not here,
+            // so a fresh group cannot ring it until the event is completely over and the platform is clear.
         }
 
         void EnterEvadeMode(EvadeReason why) override
         {
             // The scripted interlude deliberately stops combat; never let an evade reset it mid-cutscene.
-            if (_phase == BR_PHASE_INTERLUDE)
+            if (_phase == PHASE_INTERLUDE)
                 return;
 
             ScriptedAI::EnterEvadeMode(why);
@@ -2419,7 +2413,7 @@ public:
             uint32 const entries[] =
             {
                 NPC_SAFIRDRANG, NPC_BALARGARDE_ELITE,
-                NPC_POSSESSED_VARDMADRA, NPC_LADY_NIGHTSWOOD, NPC_BANSHEE_LICH_KING
+                NPC_POSSESSED_VARDMADRA, NPC_LADY_NIGHTSWOOD, NPC_LICH_KING
             };
             for (uint32 entry : entries)
             {
@@ -2439,7 +2433,7 @@ public:
         {
             scheduler.Update(diff);
 
-            if (_phase == BR_PHASE_INTERLUDE)
+            if (_phase == PHASE_INTERLUDE)
                 return;
 
             if (!UpdateVictim())
@@ -2454,25 +2448,25 @@ public:
             {
                 switch (eventId)
                 {
-                    case EVENT_BR_HEROIC_LEAP:
+                    case EVENT_HEROIC_LEAP:
                         if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 40.0f, true))
-                            DoCast(target, SPELL_BR_HEROIC_LEAP);
+                            DoCast(target, SPELL_HEROIC_LEAP);
                         _events.Repeat(25s, 32s);
                         break;
-                    case EVENT_BR_WHIRLWIND:
-                        DoCastSelf(SPELL_BR_WHIRLWIND);
+                    case EVENT_WHIRLWIND:
+                        DoCastSelf(SPELL_WHIRLWIND);
                         _events.Repeat(60s, 90s);
                         break;
-                    case EVENT_BR_FROSTBOLT:
-                        DoCastVictim(SPELL_BR_FROSTBOLT);
+                    case EVENT_FROSTBOLT:
+                        DoCastVictim(SPELL_FROSTBOLT);
                         _events.Repeat(25s, 30s);
                         break;
-                    case EVENT_BR_BLIZZARD:
+                    case EVENT_BLIZZARD:
                         if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
-                            DoCast(target, SPELL_BR_BLIZZARD);
+                            DoCast(target, SPELL_BLIZZARD);
                         _events.Repeat(25s, 35s);
                         break;
-                    case EVENT_BR_CHILL_RUN:
+                    case EVENT_CHILL_RUN:
                         if (Creature* safirdrang = me->FindNearestCreature(NPC_SAFIRDRANG, 200.0f))
                             safirdrang->AI()->DoAction(ACTION_SAFIRDRANG_CHILL);
                         _events.Repeat(13s, 14s);
@@ -2490,9 +2484,9 @@ public:
 
     private:
         EventMap _events;
-        uint8 _phase;
-        bool _interludeStarted;
-        bool _chillActive;
+        uint8 _phase = PHASE_ONE;
+        bool _interludeStarted = false;
+        bool _chillActive = false;
     };
 
     CreatureAI* GetAI(Creature* creature) const override
@@ -2522,8 +2516,8 @@ public:
             scheduler.Schedule(1s, [this](TaskContext /*context*/)
             {
                 // Carry Overthane in seat 0 and fly the intro path.
-                if (Creature* overthane = me->SummonCreature(NPC_OVERTHANE_BALARGARDE, *me, TEMPSUMMON_MANUAL_DESPAWN))
-                    overthane->EnterVehicleUnattackable(me, 0);
+                if (Creature* balargarde = me->SummonCreature(NPC_BALARGARDE, *me, TEMPSUMMON_MANUAL_DESPAWN))
+                    balargarde->EnterVehicleUnattackable(me, 0);
 
                 me->GetMotionMaster()->MovePath(PATH_SAFIRDRANG_INTRO, FORCED_MOVEMENT_NONE, PathSource::WAYPOINT_MGR);
             });
@@ -2549,29 +2543,29 @@ public:
         {
             scheduler.Schedule(0s, [this](TaskContext /*context*/)
             {
-                if (Creature* overthane = GetSeatedOverthane())
-                    overthane->AI()->Talk(SAY_BALARGARDE_TO_SAFIRDRANG);
+                if (Creature* balargarde = GetSeatedBalargarde())
+                    balargarde->AI()->Talk(SAY_BALARGARDE_TO_SAFIRDRANG);
             }).Schedule(6s, [this](TaskContext /*context*/)
             {
                 if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 200.0f))
                     vardmadra->AI()->Talk(SAY_VARDMADRA_CHALLENGE);
             }).Schedule(12s, [this](TaskContext /*context*/)
             {
-                if (Creature* overthane = GetSeatedOverthane())
-                    overthane->AI()->Talk(SAY_BALARGARDE_TO_VARDMADRA_1);
+                if (Creature* balargarde = GetSeatedBalargarde())
+                    balargarde->AI()->Talk(SAY_BALARGARDE_TO_VARDMADRA_1);
             }).Schedule(18s, [this](TaskContext /*context*/)
             {
-                if (Creature* overthane = GetSeatedOverthane())
-                    overthane->AI()->Talk(SAY_BALARGARDE_TO_VARDMADRA_2);
+                if (Creature* balargarde = GetSeatedBalargarde())
+                    balargarde->AI()->Talk(SAY_BALARGARDE_TO_VARDMADRA_2);
             }).Schedule(23s, [this](TaskContext /*context*/)
             {
-                if (Creature* overthane = GetSeatedOverthane())
-                    overthane->AI()->DoAction(ACTION_BALARGARDE_ENGAGE);
+                if (Creature* balargarde = GetSeatedBalargarde())
+                    balargarde->AI()->DoAction(ACTION_BALARGARDE_ENGAGE);
                 me->SetHomePosition(me->GetPosition());
             });
         }
 
-        Creature* GetSeatedOverthane()
+        Creature* GetSeatedBalargarde()
         {
             if (Vehicle* kit = me->GetVehicleKit())
                 if (Unit* passenger = kit->GetPassenger(0))
@@ -2637,9 +2631,9 @@ public:
 
         void DoAction(int32 action) override
         {
-            if (action >= ACTION_ELITE_START_PATROL + 1000) // patrol path encoded as action + 1000 + index
+            if (action >= ACTION_ELITE_START_PATROL) // patrol path encoded as action + index
             {
-                uint32 const index = action - (ACTION_ELITE_START_PATROL + 1000);
+                uint32 const index = action - ACTION_ELITE_START_PATROL;
                 // #5 (front) loops the long way around, so fly it faster to reach its spot at about the same
                 // time the short rear patrol (#4) lands. Tuning knob: raise if #5 still trails, lower if it
                 // beats #4 there. The factor ~matches its patrol length relative to #4's.
@@ -2708,7 +2702,7 @@ public:
                 for (uint8 i = 0; i < 4; ++i)
                     if (Creature* elite = me->SummonCreature(NPC_BALARGARDE_ELITE,
                         BalargardeElitePos[i], TEMPSUMMON_MANUAL_DESPAWN))
-                        elite->AI()->DoAction(ACTION_ELITE_START_PATROL + 1000 + i);
+                        elite->AI()->DoAction(ACTION_ELITE_START_PATROL + i);
             }
         }
 
@@ -2725,7 +2719,7 @@ public:
                     scheduler.Schedule(1500ms, [this](TaskContext /*context*/)
                     {
                         me->SetStandState(UNIT_STAND_STATE_KNEEL);
-                        if (Creature* lichKing = me->FindNearestCreature(NPC_BANSHEE_LICH_KING, 200.0f))
+                        if (Creature* lichKing = me->FindNearestCreature(NPC_LICH_KING, 200.0f))
                             me->SetFacingToObject(lichKing);
                     });
                     break;
@@ -2738,7 +2732,7 @@ public:
                         Talk(SAY_VARDMADRA_BUT);
                     }).Schedule(1s, [this](TaskContext /*context*/)
                     {
-                        DoCastSelf(SPELL_BR_SUICIDE, true);
+                        DoCastSelf(SPELL_SUICIDE, true);
                         me->DespawnOrUnsummon(15s);
                     });
                     break;
@@ -2777,7 +2771,7 @@ public:
         void InitializeAI() override
         {
             BansheesMakeFlyer(me);
-            if (Creature* lichKing = me->FindNearestCreature(NPC_BANSHEE_LICH_KING, 200.0f))
+            if (Creature* lichKing = me->FindNearestCreature(NPC_LICH_KING, 200.0f))
                 me->SetFacingToObject(lichKing);
 
             scheduler.Schedule(20s, [this](TaskContext /*context*/)
@@ -2843,7 +2837,7 @@ public:
                 // Brisk WALK up to Vardmadra and stop in front of her (no run, no out-and-back). He stays
                 // here through the dialogue and the reveal, then walks back to his guard spot afterwards.
                 me->GetMotionMaster()->MovePoint(POINT_LK_CONFRONT, LichKingConfrontPos,
-                    FORCED_MOVEMENT_WALK, LK_INTERLUDE_WALK_SPEED);
+                    FORCED_MOVEMENT_WALK, LichKingWalkSpeed);
             }).Schedule(23s, [this](TaskContext /*context*/)
             {
                 if (Creature* vardmadra = me->FindNearestCreature(NPC_POSSESSED_VARDMADRA, 200.0f))
@@ -2865,27 +2859,27 @@ public:
             }).Schedule(43s, [this](TaskContext /*context*/)
             {
                 Talk(SAY_LK_CONTINUE);
-                FaceCreature(NPC_OVERTHANE_BALARGARDE);
+                FaceCreature(NPC_BALARGARDE);
             }).Schedule(46s, [this](TaskContext /*context*/)
             {
                 // Reveal done: walk back to his honor-guard position to observe the resumed fight.
                 me->GetMotionMaster()->MovePoint(POINT_LK_RETURN, LichKingSpawnPos,
-                    FORCED_MOVEMENT_WALK, LK_INTERLUDE_WALK_SPEED);
+                    FORCED_MOVEMENT_WALK, LichKingWalkSpeed);
             }).Schedule(48s, [this](TaskContext /*context*/)
             {
-                if (Creature* overthane = me->FindNearestCreature(NPC_OVERTHANE_BALARGARDE, 200.0f))
-                    overthane->AI()->Talk(SAY_BALARGARDE_MY_LORD);
+                if (Creature* balargarde = me->FindNearestCreature(NPC_BALARGARDE, 200.0f))
+                    balargarde->AI()->Talk(SAY_BALARGARDE_MY_LORD);
             }).Schedule(52s, [this](TaskContext /*context*/)
             {
                 Talk(SAY_LK_FINISH_THEM);
             }).Schedule(59s, [this](TaskContext /*context*/)
             {
-                if (Creature* overthane = me->FindNearestCreature(NPC_OVERTHANE_BALARGARDE, 200.0f))
-                    overthane->AI()->Talk(SAY_BALARGARDE_DIE_DOGS);
+                if (Creature* balargarde = me->FindNearestCreature(NPC_BALARGARDE, 200.0f))
+                    balargarde->AI()->Talk(SAY_BALARGARDE_DIE_DOGS);
             }).Schedule(60s, [this](TaskContext /*context*/)
             {
-                if (Creature* overthane = me->FindNearestCreature(NPC_OVERTHANE_BALARGARDE, 200.0f))
-                    overthane->AI()->DoAction(ACTION_BALARGARDE_RESUME);
+                if (Creature* balargarde = me->FindNearestCreature(NPC_BALARGARDE, 200.0f))
+                    balargarde->AI()->DoAction(ACTION_BALARGARDE_RESUME);
             });
         }
 
@@ -2916,6 +2910,10 @@ public:
                     nightswood->DespawnOrUnsummon();
             }).Schedule(20s, [this](TaskContext /*context*/)
             {
+                // Event fully over: Overthane is dead and the Lich King has left the platform. Re-arm the
+                // War Horn of Jotunheim so a new group can ring it and start the event again.
+                if (GameObject* horn = me->FindNearestGameObject(GO_WAR_HORN_OF_JOTUNHEIM, 200.0f))
+                    horn->ResetDoorOrButton();
                 me->DespawnOrUnsummon();
             });
         }

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -2185,6 +2185,7 @@ enum BansheesRevenge
     POINT_LK_BODY                   = 3,
     POINT_NIGHTSWOOD_HORN           = 4,
     POINT_BALARGARDE_LEAP           = 5,
+    POINT_SAFIRDRANG_ASCEND         = 6,
 
     EVENT_HEROIC_LEAP               = 1,
     EVENT_WHIRLWIND                 = 2,
@@ -2578,6 +2579,10 @@ public:
             {
                 if (Creature* balargarde = GetSeatedBalargarde())
                     balargarde->AI()->DoAction(ACTION_BALARGARDE_JUMP);
+            }).Schedule(17s, [this](TaskContext /*context*/)
+            {
+                me->GetMotionMaster()->MovePoint(POINT_SAFIRDRANG_ASCEND,
+                    me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 10.0f);
             }).Schedule(18s, [this](TaskContext /*context*/)
             {
                 if (Creature* balargarde = me->FindNearestCreature(NPC_BALARGARDE, 200.0f))

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -2322,10 +2322,10 @@ public:
         void ScheduleCombatEvents()
         {
             _events.Reset();
-            _events.ScheduleEvent(EVENT_HEROIC_LEAP, 20s, 30s);
-            _events.ScheduleEvent(EVENT_WHIRLWIND, 60s, 90s);
-            _events.ScheduleEvent(EVENT_FROSTBOLT, 20s, 25s);
-            _events.ScheduleEvent(EVENT_BLIZZARD, 15s, 25s);
+            _events.ScheduleEvent(EVENT_HEROIC_LEAP, 10s);
+            _events.ScheduleEvent(EVENT_WHIRLWIND, 15s);
+            _events.ScheduleEvent(EVENT_FROSTBOLT, 2s);
+            _events.ScheduleEvent(EVENT_BLIZZARD, 7s, 8s);
             if (_chillActive)
                 _events.ScheduleEvent(EVENT_CHILL_RUN, 3s, 5s);
         }
@@ -2373,6 +2373,8 @@ public:
             _events.Reset();
 
             me->AttackStop();
+            me->InterruptNonMeleeSpells(true);
+            me->RemoveAurasDueToSpell(SPELL_WHIRLWIND);
             me->GetMotionMaster()->Clear();
             me->GetMotionMaster()->MoveIdle();
             me->SetReactState(REACT_PASSIVE);
@@ -2407,7 +2409,7 @@ public:
             if (_phase == PHASE_INTERLUDE)
                 return;
 
-            if (_phase == PHASE_RESUME && RepullNearbyPlayers())
+            if ((_phase == PHASE_ONE || _phase == PHASE_RESUME) && RepullNearbyPlayers())
                 return;
 
             ScriptedAI::EnterEvadeMode(why);
@@ -2460,22 +2462,26 @@ public:
                 switch (eventId)
                 {
                     case EVENT_HEROIC_LEAP:
-                        if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 40.0f, true))
-                            DoCast(target, SPELL_HEROIC_LEAP);
-                        _events.Repeat(25s, 32s);
+                        if (Unit* victim = me->GetVictim())
+                        {
+                            float const dist = me->GetDistance(victim);
+                            if (dist >= 8.0f && dist <= 25.0f)
+                                me->CastSpell(victim, SPELL_HEROIC_LEAP, TRIGGERED_IGNORE_POWER_AND_REAGENT_COST);
+                        }
+                        _events.Repeat(10s);
                         break;
                     case EVENT_WHIRLWIND:
-                        DoCastSelf(SPELL_WHIRLWIND);
-                        _events.Repeat(60s, 90s);
+                        me->CastSpell(me, SPELL_WHIRLWIND, TRIGGERED_IGNORE_POWER_AND_REAGENT_COST);
+                        _events.Repeat(30s);
                         break;
                     case EVENT_FROSTBOLT:
                         DoCastVictim(SPELL_FROSTBOLT);
-                        _events.Repeat(25s, 30s);
+                        _events.Repeat(8s);
                         break;
                     case EVENT_BLIZZARD:
                         if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
-                            DoCast(target, SPELL_BLIZZARD);
-                        _events.Repeat(25s, 35s);
+                            me->CastSpell(target, SPELL_BLIZZARD, TRIGGERED_IGNORE_POWER_AND_REAGENT_COST);
+                        _events.Repeat(15s);
                         break;
                     case EVENT_CHILL_RUN:
                         if (Creature* safirdrang = me->FindNearestCreature(NPC_SAFIRDRANG, 200.0f))


### PR DESCRIPTION
## Changes Proposed:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Implement event for quest Banshee's Revenge (Quest ID 13142)

### AI-assisted Pull Requests
- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.
Claude Opus

## Issues Addressed:
- Closes #21761
- Closes #11796
- Closes https://github.com/chromiecraft/chromiecraft/issues/7972

## SOURCE:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Partial cherry pick, namely sniff data, from https://github.com/TrinityCore/TrinityCore/issues/4841

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Rev 9 Test: https://www.youtube.com/watch?v=kvLygNYj6CY


## How to Test the Changes:
.go xyz 7071 4317 871 571
.quest add 13142
.cheat god on
click horn
play the event

(optional) .aura 39089 to reasonable amount of stacks (to give yourself more damage and simulate more players)

## Known Issues and TODO List:
- [x] Some minor emotes and flair during the roleplay can be added later
