### PR TITLE
fix(entities/gameobject): 修复钓鱼技能在loot窗口未关闭时重新施放失败的问题

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -165,6 +165,42 @@ void GameObject::AddToWorld()
         if (m_spawnId)
             GetMap()->GetGameObjectBySpawnIdStore().insert(std::make_pair(m_spawnId, this));
 
+        // 钓鱼节点：先判断前一个法术session是否释放，如果未释放则先释放
+        if (GetGoType() == GAMEOBJECT_TYPE_FISHINGNODE)
+        {
+            if (ObjectGuid ownerGUID = GetOwnerGUID())
+            {
+                if (Player* owner = ObjectAccessor::FindPlayer(ownerGUID))
+                {
+                    // 先释放可能打开的loot窗口
+                    if (ObjectGuid lguid = owner->GetLootGUID())
+                        if (lguid.IsGameObject())
+                            owner->GetSession()->DoLootRelease(lguid);
+
+                    // 检查并取消当前正在进行的channeled法术（前一个钓鱼法术session）
+                    if (owner->GetCurrentSpell(CURRENT_CHANNELED_SPELL))
+                        owner->InterruptSpell(CURRENT_CHANNELED_SPELL, true, true, true);
+
+                    // 查找并删除所有者所有旧的钓鱼节点（不包括当前正在添加的这个）
+                    std::vector<GameObject*> nodesToDelete;
+                    auto& allElements = GetMap()->GetObjectsStore().GetElements();
+                    auto& goContainer = allElements._TailElements._elements;
+                    for (auto& pair : goContainer._element)
+                    {
+                        GameObject* go = pair.second;
+                        if (go && go != this && go->GetGoType() == GAMEOBJECT_TYPE_FISHINGNODE && go->GetOwnerGUID() == ownerGUID)
+                            nodesToDelete.push_back(go);
+                    }
+                    for (GameObject* go : nodesToDelete)
+                    {
+                        go->SetOwnerGUID(ObjectGuid::Empty);
+                        go->SetRespawnTime(0);
+                        go->Delete();
+                    }
+                }
+            }
+        }
+
         if (m_model)
         {
             m_model->UpdatePosition();


### PR DESCRIPTION
问题描述：
玩家使用钓鱼技能，鱼漂有反应后点击鱼漂出现物品窗口，不拾取物品的情况下
再次使用钓鱼技能，技能执行失败（鱼竿与鱼漂无鱼线连接）。

根本原因：
当loot窗口打开时，前一个钓鱼法术的channel session虽然调用了FinishSpell， 但可能残留状态（m_currentSpells指针、channel object引用等）未完全清理， 导致新的钓鱼法术无法正确建立channel连接。

修复方案：
在GameObject::AddToWorld()中，当新的钓鱼节点（FISHINGNODE）被添加到世界时， 先执行三步清理操作：
1. 释放玩家可能打开的loot窗口（DoLootRelease）
2. 检查并中断当前正在进行的channeled法术（InterruptSpell）
3. 删除该玩家所有旧的钓鱼节点

修改文件：
- src/server/game/Entities/GameObject/GameObject.cpp

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- `https://www.azerothcore.org/wiki/commit-message-guidelines` -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude (Anthropic) was used for code analysis and generating the fix.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes N/A (internal bug fix)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other regression tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

**Reproduction Steps:**
1. Player casts the Fishing skill
2. Wait for the fishing bobber to splash (indicating a fish is available)
3. Click on the fishing bobber to open the loot window
4. **Without looting any items**, try to cast Fishing again
5. Verify that the fishing line correctly connects between the player and the new fishing bobber

**Expected Behavior:**
- Before fix: Fishing fails, no fishing line connection between player and bobber
- After fix: Fishing succeeds, fishing line correctly displays between player and new bobber

**Test Scenarios:**
1. Normal fishing (close loot window first, then fish again) - should still work
2. Fishing with loot window open (main fix) - should now work correctly
3. Multiple rapid fishing attempts - should handle gracefully
4. Fishing while previous bobber is still in water (before timeout) - should clean up old bobber

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] N/A

## Problem Analysis:

**Bug Description:**
When a player casts the Fishing skill and clicks on the fishing bobber to open the loot window, if the player attempts to cast Fishing again without closing the loot window, the spell fails. The fishing line between the player and the new bobber is not displayed.

**Root Cause:**
When the loot window is open, the previous fishing spell's channel session (CURRENT_CHANNELED_SPELL) has residual state that is not fully cleaned up, even after FinishSpell() is called. This prevents the new fishing spell from correctly establishing the UNIT_FIELD_CHANNEL_OBJECT, causing the fishing line to not display.

**Solution:**
In GameObject::AddToWorld(), when a new fishing node (FISHINGNODE) is added to the world, perform a three-step cleanup:
1. Release any open loot window (DoLootRelease)
2. Interrupt any ongoing channeled spell (InterruptSpell)
3. Delete all old fishing nodes belonging to the player

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

`http://www.azerothcore.org/wiki/How-to-test-a-PR`

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.