### PR TITLE
fix(Scripts/Ulduar): Flame Leviathan reset and visibility

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1782661989089356961.sql
+++ b/data/sql/updates/pending_db_world/rev_1782661989089356961.sql
@@ -1,0 +1,11 @@
+--
+-- 62375 Gathering Speed is not removed by Evade
+-- SPELL_ATTR0_CU_IGNORE_EVADE = 0x00000800
+DELETE FROM `spell_custom_attr` WHERE `spell_id` = 62375;
+INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (62375, 0x800);
+
+-- Flame Leviathan
+UPDATE `creature_template_addon` SET `visibilityDistanceType` = 4 WHERE (`entry` IN (33113, 33114, 33139, 34003, 34111, 33143));
+
+-- Ulduar Colossus
+UPDATE `creature_addon` SET `visibilityDistanceType`=4 WHERE `guid` IN (137476, 137477, 137478, 137479, 137480)

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -121,7 +121,6 @@ enum Events
     EVENT_MIMIRONS_INFERNO              = 8,
     EVENT_THORIMS_HAMMER                = 9,
     EVENT_SOUND_BEGINNING               = 10,
-    EVENT_POSITION_CHECK                = 11,
 };
 
 enum Texts
@@ -209,13 +208,13 @@ struct boss_flame_leviathan : public BossAI
     void ScheduleEvents();
     void SummonTowerHelpers(uint8 towerId);
 
-    // Original
     void JustReachedHome() override
     {
         _JustReachedHome();
         // For achievement
         instance->StorePersistentData(PERSISTENT_DATA_UNBROKEN, 0);
         me->setActive(false);
+        me->RemoveAurasDueToSpell(SPELL_GATHERING_SPEED);
     }
 
     void MoveInLineOfSight(Unit*) override {}
@@ -380,14 +379,6 @@ struct boss_flame_leviathan : public BossAI
 
         switch (events.ExecuteEvent())
         {
-            case EVENT_POSITION_CHECK:
-                if (me->GetPositionX() > 450 || me->GetPositionX() < 120)
-                {
-                    EnterEvadeMode();
-                    return;
-                }
-                events.Repeat(5s);
-                break;
             case EVENT_PURSUE:
                 Talk(FLAME_LEVIATHAN_SAY_PURSUE);
                 me->CastSpell(me, SPELL_PURSUED, false);
@@ -577,7 +568,6 @@ void boss_flame_leviathan::ScheduleEvents()
     events.RescheduleEvent(EVENT_VENT, 20s);
     events.RescheduleEvent(EVENT_SPEED, 15s);
     events.RescheduleEvent(EVENT_SOUND_BEGINNING, 10s);
-    events.RescheduleEvent(EVENT_POSITION_CHECK, 5s);
 
     events.RescheduleEvent(EVENT_PURSUE, 0ms);
 }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -164,6 +164,11 @@ ObjectData const gameobjectData[] =
     { 0,                                0                               }
 };
 
+BossBoundaryData const boundaries =
+{
+    { BOSS_LEVIATHAN, new RectangleBoundary(130.0f, 450.0f, -170.0f, 110.0f) },
+};
+
 class instance_ulduar : public InstanceMapScript
 {
 public:
@@ -183,6 +188,7 @@ public:
             SetPersistentDataCount(MAX_PERSISTENT_DATA);
             LoadDoorData(doorData);
             LoadObjectData(creatureData, gameobjectData);
+            LoadBossBoundaries(boundaries);
             Initialize();
         };
 


### PR DESCRIPTION

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).


Fix the following issues discovered by @Krateozshael 
- FL resets movement stacks upon reset. FL should keep stacks until reaching home.
- FL resets too far South (~145).
- FL and Colossus visibility is too short


### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
