### PR TITLE
fix(Scripts/Ulduar): Storm Beacons spawn Steelforged Defenders against vehicles

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -1096,7 +1096,7 @@ struct npc_storm_beacon_spawn : public NullCreatureAI
             if (_checkTimer >= 4000)
             {
                 _checkTimer = 0;
-                if (Unit* target = me->SelectNearbyTarget(nullptr, 80.0f))
+                if (Unit* target = me->SelectNearestTarget(80.0f))
                 {
                     ++_amount;
                     if (Creature* cr = me->SummonCreature(NPC_DEFENDER_GENERATED, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 4, me->GetOrientation(), TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 900000))


### PR DESCRIPTION
## Changes Proposed:
Fixes the Ulduar Flame Leviathan trash gauntlet so Storm Beacons spawn additional Steelforged Defenders while the raid is mounted in siege vehicles.

The Ulduar Gauntlet Generators (`npc_storm_beacon_spawn`, creature 33571) used `SelectNearbyTarget`, which requires line of sight to the candidate. The generators are positioned behind the Storm Beacons, off the vehicle road, so LoS to the raid is blocked and the selection always returned nothing while players stayed in vehicles. On foot you walk close enough for LoS to clear, which is why it appeared to work only on foot.

Swapped to `Creature::SelectNearestTarget`, which performs the same hostile grid search but does not call `IsWithinLOSInMap`. Its `IsValidAttackTarget` filter also resolves to the siege vehicle (attackable) rather than the seated player (not attackable while in a vehicle seat).

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used. **Claude Opus 4.8 (Claude Code)** was used to diagnose the root cause and prepare the fix.

## Issues Addressed:
- Closes #26284

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources - official-behaviour videos linked in #26284.

## Tests Performed:
The root cause was confirmed in-game by instrumenting the generator and logging, for each nearby player/vehicle, the three predicates the selection relies on. With the raid mounted the candidate vehicle logged `friendly=false validAttack=true los=false`, and `SelectNearbyTarget` returned `NONE`; the failing predicate was line of sight, with the seated player additionally `validAttack=false`. The fix targets exactly that: a hostile search without the LoS requirement that resolves to the attackable vehicle.

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Be level 80 and enter Ulduar; talk to Brann Bronzebeard and start the assault.
2. Enter one of the spawned siege vehicles and drive into the gauntlet leading to Flame Leviathan.
3. Damage a Storm Beacon and stay mounted: additional Steelforged Defenders should now spawn and engage the vehicles. Confirm it still works on foot.

## Known Issues and TODO List:

- [ ]
