### PR TITLE
fix(Scripts/Ulduar): keep Yogg-Saron engaged while players are inside portals

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -727,6 +727,23 @@ struct boss_yoggsaron_sara : public ScriptedAI
         damage = 0;
     }
 
+    // Players who descend into a portal are teleported ~100 yd below to the illusion
+    // realms, out of range of the main-chamber scan in SelectTargetFromPlayerList.
+    // The fight must keep going while any of them is alive, otherwise the boss resets
+    // and traps them underground.
+    bool HasAlivePlayerInIllusion() const
+    {
+        bool found = false;
+        me->GetMap()->DoForAllPlayers([&](Player* player)
+        {
+            if (found || !player->IsAlive() || player->IsGameMaster() || player->HasAura(SPELL_INSANE1))
+                return;
+            if (player->GetPositionZ() < 300.0f && me->IsWithinDist2d(player, 200.0f))
+                found = true;
+        });
+        return found;
+    }
+
     void UpdateAI(uint32 diff) override
     {
         if (_initFight)
@@ -745,7 +762,7 @@ struct boss_yoggsaron_sara : public ScriptedAI
             return;
         }
 
-        if (!SelectTargetFromPlayerList(90, SPELL_INSANE1))
+        if (!SelectTargetFromPlayerList(90, SPELL_INSANE1) && !HasAlivePlayerInIllusion())
         {
             _instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_INSANE1);
             EnterEvadeMode(EVADE_REASON_OTHER);


### PR DESCRIPTION
## Changes Proposed:
Yogg-Saron (Sara) no longer evades and resets the encounter while players are still alive inside the portals/illusion realms.

Sara's evade check used `SelectTargetFromPlayerList(90, SPELL_INSANE1)`, which only sees players within 90 yd of the central chamber. Players who click a portal are teleported roughly 100 yd down into an illusion realm, so they fall outside that scan. When the group above wiped, the boss reset and left those players stranded underground with no portal back.

The fix adds a check for alive, non-mind-controlled players in the illusion area (below the chamber, near the encounter) before evading. The boss now resets only when every player is dead or mind-controlled, matching the live behavior described in the issue. The existing `SPELL_INSANE1` exclusion is kept, so a fully mind-controlled raid still resets correctly.

Reference: both TrinityCore and CMaNGOS keep this encounter alive via combat membership rather than a proximity scan. A direct port of TrinityCore's `HasPvECombatWithPlayers()` gate is not safe on AzerothCore, because charm application here does not revalidate combat references, so a fully mind-controlled raid would never reset. This change keeps AzerothCore's existing reset semantics while fixing the actual defect.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude (Opus 4.8)** was used to investigate and prepare this change.

## Issues Addressed:
- Closes #18952

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.) Cross-referenced against TrinityCore and CMaNGOS encounter logic and the behavior described in the linked issue.
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Solo or with one character, engage Sara and progress to Phase 2 until portals spawn (requires Vezax and XT-002 already defeated in the instance).
2. Click a portal to descend into an illusion realm.
3. Let the character(s) above die (or have a single character descend with no one left above).
4. Confirm the encounter does NOT reset while the descended player is alive, and that the player can still escape via the flee portal or be mind-controlled.
5. Confirm the encounter still resets normally when all players are dead or mind-controlled.

## Known Issues and TODO List:

- [ ] In-game verification of the underground detection radius/Z threshold across all three illusion realms.
