### PR TITLE
fix(Core/Battlefield): repop ghosts when their Wintergrasp graveyard is captured

### DIFF
--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -593,8 +593,9 @@ void BattlefieldWG::RelocateDeadPlayers(uint8 graveyardId, TeamId newOwner)
 
     ForEachPlayerInZone([this, capturedLoc, newOwner](Player* player)
     {
-        // Only ghosts of the team that just lost this graveyard.
-        if (player->IsAlive() || !player->HasPlayerFlag(PLAYER_FLAGS_GHOST) || player->GetTeamId() == newOwner)
+        // Only players of the losing team waiting to resurrect; they would otherwise be
+        // revived in place on the now-inaccessible captured platform.
+        if (player->GetTeamId() == newOwner || !player->HasAura(SPELL_WAITING_FOR_RESURRECT))
             return;
 
         // Restrict to ghosts actually waiting at the captured graveyard, not elsewhere in the zone.

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -23,6 +23,7 @@
 #include "BattlefieldWG.h"
 #include "ScriptMgr.h"
 #include "Chat.h"
+#include "GameGraveyard.h"
 #include "GameTime.h"
 #include "MapMgr.h"
 #include "Opcodes.h"
@@ -578,6 +579,31 @@ uint32 BattlefieldWG::GetAreaByGraveyardId(uint8 gId) const
     }
 
     return 0;
+}
+
+void BattlefieldWG::RelocateDeadPlayers(uint8 graveyardId, TeamId newOwner)
+{
+    BfGraveyard const* graveyard = GetGraveyardById(graveyardId);
+    if (!graveyard)
+        return;
+
+    GraveyardStruct const* capturedLoc = sGraveyard->GetGraveyard(graveyard->GetGraveyardId());
+    if (!capturedLoc)
+        return;
+
+    ForEachPlayerInZone([this, capturedLoc, newOwner](Player* player)
+    {
+        // Only ghosts of the team that just lost this graveyard.
+        if (player->IsAlive() || !player->HasPlayerFlag(PLAYER_FLAGS_GHOST) || player->GetTeamId() == newOwner)
+            return;
+
+        // Restrict to ghosts actually waiting at the captured graveyard, not elsewhere in the zone.
+        if (player->GetDistance2d(capturedLoc->x, capturedLoc->y) > 50.0f)
+            return;
+
+        if (GraveyardStruct const* safeLoc = GetClosestGraveyard(player))
+            player->TeleportTo(safeLoc->Map, safeLoc->x, safeLoc->y, safeLoc->z, player->GetOrientation());
+    });
 }
 
 void BattlefieldWG::OnCreatureCreate(Creature* creature)

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -1474,7 +1474,8 @@ struct WGWorkshop
             bf->CapturePointTaken(bf->GetAreaByGraveyardId(workshopId));
 
             // Workshop graveyard share the workshop id; repop ghosts that lost it.
-            if (IsCapturable())
+            // Only on an actual capture, not while the workshop is merely contested (neutral).
+            if (IsCapturable() && teamControl != TEAM_NEUTRAL)
                 bf->RelocateDeadPlayers(workshopId, teamControl);
         }
     }

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -400,6 +400,9 @@ public:
     uint8 GetSpiritGraveyardId(uint32 areaId) const;
     uint32 GetAreaByGraveyardId(uint8 gId) const;
 
+    // Teleport ghosts waiting at a just-captured graveyard to their team's nearest controlled one.
+    void RelocateDeadPlayers(uint8 graveyardId, TeamId newOwner);
+
     uint32 GetData(uint32 data) const override;
 
     // True iff the most recent battle ended with the keep captured (attacker win).
@@ -1469,6 +1472,10 @@ struct WGWorkshop
         {
             bf->UpdateCounterVehicle(false);
             bf->CapturePointTaken(bf->GetAreaByGraveyardId(workshopId));
+
+            // Workshop graveyard share the workshop id; repop ghosts that lost it.
+            if (IsCapturable())
+                bf->RelocateDeadPlayers(workshopId, teamControl);
         }
     }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

In Wintergrasp, when the enemy captures a workshop, the friendly ghosts already waiting for resurrection at the linked graveyard were never moved. They stayed on the elevated graveyard platform, which is inaccessible as a ghost. If their corpse insignia had already been looted (so corpse resurrection was unavailable), the only way out was taking resurrection sickness and jumping off.

The graveyard control flip (`BfGraveyard::GiveControlTo`) only changed the owning team; it did nothing to players standing there. This adds the missing repop: on a genuine control change of a capturable workshop graveyard, ghosts of the team that lost it are teleported to the nearest graveyard their team still controls, reusing the existing `GetClosestGraveyard` lookup. It only affects released ghosts of the losing team within range of the captured graveyard, and the resurrection-wait aura survives the in-zone teleport, so the existing resurrect timer revives them at the new graveyard.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code (Claude Opus 4.8) was used to investigate the issue and draft the change.

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9818

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

On retail Wintergrasp, losing a graveyard repops the ghosts there to another friendly graveyard rather than stranding them.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds and passes the C++ codestyle check.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Die during a Wintergrasp battle and release at a workshop graveyard your team controls.
2. Click the spirit guide to wait for resurrection (and, to mirror the report, have the corpse insignia looted so corpse res is unavailable).
3. Have the enemy capture that workshop before the resurrect timer fires.
4. Confirm you are teleported to the nearest graveyard your team still controls instead of being stranded on the captured platform.

## Known Issues and TODO List:

- [ ] Ghosts are matched to the captured graveyard by proximity (50 yd) since the core does not track per-graveyard resurrect queues; WG graveyards are far enough apart that this is unambiguous.
