### PR TITLE
fix (Core/Spells) Persistent AOE spell animation

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3731,7 +3731,7 @@ void Spell::cancel(bool bySelf)
     Unit* dynObjOwner = (m_caster->GetEntry() == WORLD_TRIGGER && m_originalCaster) ? m_originalCaster : m_caster;
     if (!(bySelf && m_spellInfo->HasEffect(SPELL_EFFECT_ADD_FARSIGHT)))
         dynObjOwner->RemoveDynObject(m_spellInfo->Id);
-    
+
     //set state back so finish will be processed
     m_spellState = oldState;
 
@@ -4459,7 +4459,7 @@ void Spell::finish(bool ok)
         dynObjOwner->RemoveDynObject(m_spellInfo->Id);
         m_caster->RemoveGameObject(m_spellInfo->Id, true);
     }
-    
+
     if (m_spellInfo->IsChanneled())
         m_caster->UpdateInterruptMask();
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3732,9 +3732,6 @@ void Spell::cancel(bool bySelf)
     if (!(bySelf && m_spellInfo->HasEffect(SPELL_EFFECT_ADD_FARSIGHT)))
         dynObjOwner->RemoveDynObject(m_spellInfo->Id);
     
-    if (m_spellInfo->IsChanneled()) // if not channeled then the object for the current cast wasn't summoned yet
-        m_caster->RemoveGameObject(m_spellInfo->Id, true);
-
     //set state back so finish will be processed
     m_spellState = oldState;
 
@@ -4458,7 +4455,10 @@ void Spell::finish(bool ok)
 
     Unit* dynObjOwner = (m_caster->GetEntry() == WORLD_TRIGGER && m_originalCaster) ? m_originalCaster : m_caster;
     if (m_spellInfo->IsChanneled())
+    {
         dynObjOwner->RemoveDynObject(m_spellInfo->Id);
+        m_caster->RemoveGameObject(m_spellInfo->Id, true);
+    }
     
     if (m_spellInfo->IsChanneled())
         m_caster->UpdateInterruptMask();

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3728,11 +3728,10 @@ void Spell::cancel(bool bySelf)
         *m_selfContainer = nullptr;
 
     // Do not remove current far sight object (already done in Spell::EffectAddFarsight) to prevent from reset viewpoint to player
+    Unit* dynObjOwner = (m_caster->GetEntry() == WORLD_TRIGGER && m_originalCaster) ? m_originalCaster : m_caster;
     if (!(bySelf && m_spellInfo->HasEffect(SPELL_EFFECT_ADD_FARSIGHT)))
-    {
-        m_caster->RemoveDynObject(m_spellInfo->Id);
-    }
-
+        dynObjOwner->RemoveDynObject(m_spellInfo->Id);
+    
     if (m_spellInfo->IsChanneled()) // if not channeled then the object for the current cast wasn't summoned yet
         m_caster->RemoveGameObject(m_spellInfo->Id, true);
 
@@ -4457,6 +4456,10 @@ void Spell::finish(bool ok)
         return;
     m_spellState = SPELL_STATE_FINISHED;
 
+    Unit* dynObjOwner = (m_caster->GetEntry() == WORLD_TRIGGER && m_originalCaster) ? m_originalCaster : m_caster;
+    if (m_spellInfo->IsChanneled())
+        dynObjOwner->RemoveDynObject(m_spellInfo->Id);
+    
     if (m_spellInfo->IsChanneled())
         m_caster->UpdateInterruptMask();
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [X] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude was used to locate the problem.

Claude's fix:

## Concrete fix

Make dynobj cleanup independent of `m_caster` and of `finish()`-vs-`cancel()`.

**Primary — `Spell::cancel()` (`Spell.cpp:3731-3734`):** remove from the real owner:
```cpp
Unit* dynObjOwner = (m_caster->GetEntry() == WORLD_TRIGGER && m_originalCaster) ? m_originalCaster : m_caster;
if (!(bySelf && m_spellInfo->HasEffect(SPELL_EFFECT_ADD_FARSIGHT)))
    dynObjOwner->RemoveDynObject(m_spellInfo->Id);
```
Mirror the same owner resolution used in `EffectPersistentAA` (`SpellEffects.cpp:1860`).
Apply the same correction to `DelayedChannel`'s `GetDynObject` at `Spell.cpp:7889`.

**Defensive — guarantee removal on every channel end.** Move the channeled-spell
`RemoveDynObject`/`RemoveGameObject` block (currently only in `cancel()`,
`:3733-3737`) into `finish()` for the `IsChanneled()` case, so both `cancel()` and
the normal / lack-of-targets ends converge on the same teardown:
```cpp
if (m_spellInfo->IsChanneled())
    dynObjOwner->RemoveDynObject(m_spellInfo->Id);
```

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes:
- https://github.com/azerothcore/azerothcore-wotlk/issues/5910

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.
Because it's not a bug that happened that often, it requires a bit of time to know for sure the issue is solved.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [X] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

It's not that easy to test. People will most likely have encountered the issue, 
but to reproduce it on command was not that easy.
Best way IMO to test this is to do several dungeon runs, while using lots of aoe. If people know spots where this bug happened a lot, those areas would be good to revisit and test this at.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
nothing.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
