### PR TITLE
Respect MaxPlayerLevel in worldserver.conf and .character level command in-game

### DIFF
--- a/src/server/scripts/Commands/cs_character.cpp
+++ b/src/server/scripts/Commands/cs_character.cpp
@@ -449,8 +449,8 @@ public:
         if (newlevel < 1)
             return false;                                       // invalid level
 
-        if (newlevel > DEFAULT_MAX_LEVEL)                         // hardcoded maximum level
-            newlevel = DEFAULT_MAX_LEVEL;
+        if (newlevel > sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL))
+            newlevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
 
         HandleCharacterLevel(player->GetConnectedPlayer(), player->GetGUID(), oldlevel, newlevel, handler);
 


### PR DESCRIPTION
## Description

The `.character level` command clamps the requested level to `DEFAULT_MAX_LEVEL` (80), ignoring the configured `MaxPlayerLevel`.

As a result:

- `.levelup` correctly allows leveling above 80.
- `.character level` clamp levels back to whatever "MaxPlayerLevel " is set in worldserver.conf.

This change replaces the hardcoded `DEFAULT_MAX_LEVEL` check with `CONFIG_MAX_PLAYER_LEVEL`, making the command respect the server configuration file instead.

## Personal Note
_With the help of ChatGPT and a sudden bug in-game trying to use ".char level 255" where only ".levelup" worked past 80._
If you desire the other requirements such as player_xp_for_level, player_class_stats & pet_levelstats for worldserver to not print error messages saying it's missing the 81-255 Tables, let me know on discord Tyrvana. 

_I can also provide Tables allowing DK's lvl to be set to 1 using warrior's 1-54 stats, but a proper stat tuning would be suggested._