### PR TITLE
fix(Scripts/Freya): Iron Roots now hits 3 random players

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -580,7 +580,7 @@ struct boss_freya : public BossAI
                 break;
             case EVENT_FREYA_IRON_ROOT:
                 Talk(EMOTE_IRON_ROOTS);
-                me->CastCustomSpell(SPELL_IRON_ROOTS_FREYA, SPELLVALUE_MAX_TARGETS, 1, me, false);
+                me->CastCustomSpell(SPELL_IRON_ROOTS_FREYA, SPELLVALUE_MAX_TARGETS, 3, me, false);
                 events.Repeat(45s, 55s);
                 break;
             case EVENT_FREYA_UNSTABLE_SUN_BEAM:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -580,7 +580,7 @@ struct boss_freya : public BossAI
                 break;
             case EVENT_FREYA_IRON_ROOT:
                 Talk(EMOTE_IRON_ROOTS);
-                me->CastCustomSpell(SPELL_IRON_ROOTS_FREYA, SPELLVALUE_MAX_TARGETS, 3, me, false);
+                me->CastCustomSpell(SPELL_IRON_ROOTS_FREYA, SPELLVALUE_MAX_TARGETS, me->GetMap()->Is25ManRaid() ? 3 : 1, me, false);
                 events.Repeat(45s, 55s);
                 break;
             case EVENT_FREYA_UNSTABLE_SUN_BEAM:


### PR DESCRIPTION
Freya's Iron Roots (SPELL_IRON_ROOTS_FREYA, 62862) was cast with SPELLVALUE_MAX_TARGETS clamped to 1, so only a single random player was ever rooted. Blizzlike behaviour roots 3 random players per cast (same count in 10- and 25-man; only the damage differs between the 62862/62439 difficulty variants).

Bump the target cap from 1 to 3. The Elder Ironbranch add's own single-target Iron Roots is left unchanged.

Closes #26396

## Changes Proposed:
Freya's hard-mode Iron Roots ability (active while Elder Ironbranch is left alive) selects its victims through an uncapped area-enemy effect; the spell's own `MaxAffectedTargets` is `0`, so the number of rooted players is controlled entirely by the script via `SPELLVALUE_MAX_TARGETS`. It was hardcoded to `1`, so only one player was ever rooted. This bumps it to `3` to match blizzlike behaviour. Removing the override is not an option — with the DBC value of `0` it would root the entire raid.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (Opus 4.8), via Claude Code, was used partially — for investigation, verifying the spell data against `Spell.dbc`, and drafting. The change is a single-line value fix that the author understands and can explain/justify.

## Issues Addressed:
- Closes #26396

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

- Wowhead / Warcraft Wiki Freya encounter guides both state Iron Roots is cast on **3 random players** per cast, in both 10- and 25-man.
- Cross-checked against the client `Spell.dbc`: spells 62862 (10-man), 62439 (25-man) and 62275 (Elder Ironbranch) all use `TARGET_UNIT_SRC_AREA_ENEMY` with `MaxAffectedTargets = 0` (uncapped), confirming the target count must be enforced in script.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds cleanly (clang, `WITH_WARNINGS=ON`, no errors/warnings on the changed file). Not yet verified in-game — needs a live raid with 3+ players, so in-game confirmation by a tester is welcome.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Start the Freya encounter while leaving **Elder Ironbranch alive** — this is the hard-mode condition that grants Freya the Iron Roots ability (if all three elders are dead, Freya never casts it).
2. With 3+ players in the raid, wait for Freya's Iron Roots cast (~20s after engage, repeating every 45–55s).
3. Confirm **3** distinct random players are encased in Iron Roots, not just one. Check both 10- and 25-man.

## Known Issues and TODO List:
- [ ] None.
