### PR TITLE
fix(DB/Formations): Set Winter Revenant Winter Rumble formations.

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1782837164.sql
+++ b/data/sql/updates/pending_db_world/rev_1782837164.sql
@@ -1,0 +1,29 @@
+
+-- Set idle for three Winter Rumblers
+UPDATE `creature` SET `wander_distance` = 0, `MovementType` = 0 WHERE (`id` = 34135) AND (`guid` IN (136275, 136276, 136277));
+
+-- Two Winter Revenants must run
+UPDATE `waypoint_data` SET `move_type` = 1 WHERE (`id` IN (1362730, 1362820));
+
+-- Add new Winter Rumblers
+DELETE FROM `creature` WHERE (`id` = 34135) AND (`guid` IN (136283, 136284, 136285));
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `Comment`, `VerifiedBuild`) VALUES
+(136283, 34135, 603, 0, 0, 3, 1, 0, 1811.84, -354.296, 421.776, 0.19636, 604800, 0, 0, 195495, 81620, 0, 0, 0, 0, '', NULL, 0),
+(136284, 34135, 603, 0, 0, 3, 1, 0, 1812.91, -359.363, 412.904, 0.35580, 604800, 0, 0, 195495, 81620, 0, 0, 0, 0, '', NULL, 0),
+(136285, 34135, 603, 0, 0, 3, 1, 0, 1814.06, -364.178, 413.139, 0.20107, 604800, 0, 0, 195495, 81620, 0, 0, 0, 0, '', NULL, 0);
+
+-- Set Creature Formation
+DELETE FROM `creature_formations` WHERE (`LeaderGUID` IN (136272, 136273, 136282));
+INSERT INTO `creature_formations` (`leaderGUID`, `memberGUID`, `dist`, `angle`, `groupAI`, `point_1`, `point_2`) VALUES
+(136272, 136272, 0, 0, 515, 0, 0),
+(136272, 136279, 10, 180, 515, 0, 0),
+(136272, 136278, 10, 230, 515, 0, 0),
+(136272, 136280, 10, 130, 515, 0, 0),
+(136273, 136273, 0, 0, 515, 0, 0),
+(136273, 136275, 6, 180, 515, 0, 0),
+(136273, 136276, 12, 180, 515, 0, 0),
+(136273, 136277, 18, 180, 515, 0, 0),
+(136282, 136282, 0, 0, 515, 0, 0),
+(136282, 136283, 6, 180, 515, 0, 0),
+(136282, 136284, 12, 180, 515, 0, 0),
+(136282, 136285, 18, 180, 515, 0, 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/16085

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [X] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
