### PR TITLE
fix(Scripts/Ulduar): cast Freya's Unstable Sun Beam on random players

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1782957767680699900.sql
+++ b/data/sql/updates/pending_db_world/rev_1782957767680699900.sql
@@ -1,0 +1,13 @@
+-- Register Freya Unstable Sun Beam spell script (targets up to 3 random players)
+DELETE FROM `spell_script_names` WHERE `spell_id` = 62450;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(62450, 'spell_freya_unstable_sun_beam');
+
+-- Unstable Sun Beam NPC (33170) applies its own visual + Unstable Energy via SmartAI, since it is now
+-- summoned on players by 62449 rather than by Freya (whose JustSummoned used to apply these).
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `ScriptName` = '' WHERE `entry` = 33170;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 33170;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(33170, 0, 0, 1, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Unstable Sun Beam - On Just Summoned - Set React Passive'),
+(33170, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 62216, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Unstable Sun Beam - On Link - Cast Unstable Sun Beam Visual'),
+(33170, 0, 2, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 62451, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Unstable Sun Beam - On Link - Cast Unstable Energy');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -21,6 +21,8 @@
 #include "Player.h"
 #include "ScriptedCreature.h"
 #include "SpellAuras.h"
+#include "SpellScript.h"
+#include "SpellScriptLoader.h"
 #include "ulduar.h"
 
 enum FreyaSpells
@@ -45,6 +47,7 @@ enum FreyaSpells
     SPELL_GROUND_TREMOR_FREYA                   = 62437,
     SPELL_IRON_ROOTS_FREYA                      = 62862,
     SPELL_IRON_ROOTS_FREYA_DAMAGE               = 62861,
+    SPELL_UNSTABLE_SUN_BEAM_FREYA               = 62450,
     SPELL_UNSTABLE_SUN_FREYA_DAMAGE             = 62451,
     SPELL_UNSTABLE_SUN_VISUAL                   = 62216,
 
@@ -319,16 +322,6 @@ struct boss_freya : public BossAI
         }
     }
 
-    void JustSummoned(Creature* cr) override
-    {
-        if (cr->GetEntry() == NPC_FREYA_UNSTABLE_SUN_BEAM)
-        {
-            cr->CastSpell(cr, SPELL_UNSTABLE_SUN_VISUAL, true);
-            cr->CastSpell(cr, SPELL_UNSTABLE_SUN_FREYA_DAMAGE, true);
-        }
-        BossAI::JustSummoned(cr);
-    }
-
     void SpawnWave()
     {
         _waveNumber = _waveNumber == 1 ? 3 : _waveNumber - 1;
@@ -584,12 +577,7 @@ struct boss_freya : public BossAI
                 events.Repeat(45s, 55s);
                 break;
             case EVENT_FREYA_UNSTABLE_SUN_BEAM:
-                me->SummonCreature(NPC_FREYA_UNSTABLE_SUN_BEAM, me->GetPositionX() + urand(7, 25), me->GetPositionY() + urand(7, 25), me->GetMapHeight(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ()), 0, TEMPSUMMON_TIMED_DESPAWN, 10000);
-                if (Is25ManRaid())
-                {
-                    me->SummonCreature(NPC_FREYA_UNSTABLE_SUN_BEAM, me->GetPositionX() + urand(7, 25), me->GetPositionY() + urand(7, 25), me->GetMapHeight(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ()), 0, TEMPSUMMON_TIMED_DESPAWN, 10000);
-                    me->SummonCreature(NPC_FREYA_UNSTABLE_SUN_BEAM, me->GetPositionX() + urand(7, 25), me->GetPositionY() + urand(7, 25), me->GetMapHeight(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ()), 0, TEMPSUMMON_TIMED_DESPAWN, 10000);
-                }
+                DoCastAOE(SPELL_UNSTABLE_SUN_BEAM_FREYA, true);
                 events.Repeat(38s, 48s);
                 break;
         }
@@ -1169,6 +1157,23 @@ private:
     uint32 const _elderCount;
 };
 
+// 62450 - Unstable Sun Beam
+class spell_freya_unstable_sun_beam : public SpellScript
+{
+    PrepareSpellScript(spell_freya_unstable_sun_beam);
+
+    void FilterTargets(std::list<WorldObject*>& targets)
+    {
+        targets.remove_if(Acore::ObjectTypeIdCheck(TYPEID_PLAYER, false));
+        Acore::Containers::RandomResize(targets, 3);
+    }
+
+    void Register() override
+    {
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_freya_unstable_sun_beam::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENEMY);
+    }
+};
+
 void AddSC_boss_freya()
 {
     RegisterUlduarCreatureAI(boss_freya);
@@ -1180,6 +1185,8 @@ void AddSC_boss_freya()
     RegisterUlduarCreatureAI(boss_freya_healthy_spore);
     RegisterUlduarCreatureAI(boss_freya_summons);
     RegisterUlduarCreatureAI(boss_freya_nature_bomb);
+
+    RegisterSpellScript(spell_freya_unstable_sun_beam);
 
     new achievement_freya_getting_back_to_nature();
     new achievement_freya_knock_on_wood("achievement_freya_knock_on_wood", 1);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -1165,7 +1165,7 @@ class spell_freya_unstable_sun_beam : public SpellScript
     void FilterTargets(std::list<WorldObject*>& targets)
     {
         targets.remove_if(Acore::ObjectTypeIdCheck(TYPEID_PLAYER, false));
-        Acore::Containers::RandomResize(targets, 3);
+        Acore::Containers::RandomResize(targets, GetCaster()->GetMap()->Is25ManRaid() ? 3 : 1);
     }
 
     void Register() override


### PR DESCRIPTION
## Changes Proposed:
Fixes Freya's hardmode Unstable Sun Beam (Elder Brightleaf alive). It summoned the beam NPCs at random points near Freya instead of on players. The spell (62450) is now cast as an area spell filtered to up to 3 random players; its force-cast effect summons a beam on each. The beam NPC (33170) applies its own visual (62216) and Unstable Energy (62451) via SmartAI, because it is now summoned by the player rather than by Freya.

This PR proposes changes to:
- [x] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used partially in preparing this pull request: Claude Opus 4.8 (via Claude Code).

## Issues Addressed:
- Closes #26317

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (official footage referenced in the issue; spell data in Spell.dbc showing effect 0 of 62450 is a FORCE_CAST that makes each target summon the beam on itself).

## Tests Performed:
- [x] Tested in-game by the author.

Builds without errors (RelWithDebInfo/Release, MSVC). Confirmed in-game that up to 3 random players are selected and each gets a beam with its visual and ticking Unstable Energy, and no beam spawns on Freya.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.cheat god`, `.tele Freya`.
2. Engage Freya while keeping the Elders (Brightleaf) alive to enable hardmode.
3. After ~1 minute, observe Unstable Sun Beams spawning on random raid members (up to 3), not at random locations.

## Known Issues and TODO List:

- [ ] None.
