### PR TITLE
fix(Core/Player): dismount flying mounts entering strict no-fly zones

### DIFF
--- a/src/server/game/Entities/Player/PlayerUpdates.cpp
+++ b/src/server/game/Entities/Player/PlayerUpdates.cpp
@@ -1880,6 +1880,29 @@ void Player::UpdateAreaDependentAuras(uint32 newArea)
             ++iter;
     }
 
+    // The lenient check above (strict=false) deliberately skips
+    // AREA_FLAG_NO_FLY_ZONE so unrelated area-limited auras aren't dropped
+    // over a technicality; flying mounts need that flag enforced though, or
+    // one cast/restored before entering a no-fly zone (e.g. Dalaran) never
+    // gets re-validated and the player is left flying with no valid mount.
+    Unit::AuraEffectList const& mountAuras = GetAuraEffectsByType(SPELL_AURA_MOUNTED);
+    if (!mountAuras.empty())
+    {
+        SpellInfo const* mountSpellInfo = mountAuras.front()->GetSpellInfo();
+        if (mountSpellInfo->CheckLocation(GetMapId(), m_zoneUpdateId, newArea, this) != SPELL_CAST_OK)
+        {
+            bool wasFlying = CanFly();
+            RemoveAurasDueToSpell(mountSpellInfo->Id);
+            if (wasFlying)
+            {
+                SetCanFly(false);
+                // same safe-descent used when a flying vehicle passenger is
+                // force-ejected mid-air (Vehicle::RemovePassenger)
+                CastSpell(this, VEHICLE_SPELL_PARACHUTE, true);
+            }
+        }
+    }
+
     // Xinef: check controlled auras
     if (!m_Controlled.empty())
         for (ControlSet::iterator itr = m_Controlled.begin();


### PR DESCRIPTION
## Root cause

Closes #26346

`Player::UpdateAreaDependentAuras()` checks area-limited auras via `SpellInfo::CheckLocation(..., strict=false)`. `strict=false` deliberately skips the `AREA_FLAG_NO_FLY_ZONE` check, so other area-limited auras aren't dropped over a technicality — but it also means a flying mount already active (cast before entering a no-fly zone, or still active on reconnect/relogin) is never re-validated against that flag. `IsFlyable()` alone doesn't catch it either, since Dalaran is flyable terrain that's additionally flagged as a no-fly zone.

Symptom reported in #26346: a player flying a mount over Dalaran who closes the client and reconnects (especially a fast reconnect, which reuses the live in-memory `Player` object and skips a full DB reload) ends up stuck flying with no mount, since nothing ever re-validates the mount against the zone.

## Fix

Added a dedicated strict re-check for `SPELL_AURA_MOUNTED` right after the existing lenient loop in `UpdateAreaDependentAuras()`:
- Remove the mount aura and clear `CanFly()` if strict `CheckLocation` fails.
- Cast the same `VEHICLE_SPELL_PARACHUTE` safe-descent spell AzerothCore already uses when a flying vehicle passenger is force-ejected mid-air (`Vehicle::RemovePassenger`), so the forced dismount doesn't cause fall damage.

Since `UpdateAreaDependentAuras()` runs on every area change (not just login), this fixes the bug at its actual source instead of patching individual login code paths: a flying mount now gets stripped the instant it's active in a strict no-fly zone's airspace, regardless of how the player got there (normal flight, GM `.cast`, or any login/reconnect path). The invalid "flying mounted in a no-fly zone" state can no longer persist even momentarily, so there's nothing left to break on a subsequent disconnect/reconnect.

## How Has This Been Tested?

Local RelWithDebInfo build, live server testing:
1. `.cast 32239` (Ebon Gryphon) while standing in Dalaran (Krasus' Landing) — mount is immediately removed, `CanFly` cleared, safe parachute descent (no fall damage).
2. Full original repro: mount + fly over Dalaran, close client mid-flight, reconnect (both fast reconnect and normal reload) — player no longer ends up stuck flying without a mount.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (N/A - no doc change needed)