### PR TITLE
fix(Core/ObjectAccessor): guard PlayerNameMapHolder with a shared mutex

### DIFF
--- a/src/server/game/Globals/ObjectAccessor.cpp
+++ b/src/server/game/Globals/ObjectAccessor.cpp
@@ -84,19 +84,26 @@ namespace PlayerNameMapHolder
 {
     typedef std::unordered_map<std::string, Player*> MapType;
     static MapType PlayerNameMap;
+    static std::shared_mutex PlayerNameMapLock;
 
     void Insert(Player* p)
     {
+        std::unique_lock<std::shared_mutex> lock(PlayerNameMapLock);
+
         PlayerNameMap[p->GetName()] = p;
     }
 
     void Remove(Player* p)
     {
+        std::unique_lock<std::shared_mutex> lock(PlayerNameMapLock);
+
         PlayerNameMap.erase(p->GetName());
     }
 
     void RemoveByName(std::string const& name)
     {
+        std::unique_lock<std::shared_mutex> lock(PlayerNameMapLock);
+
         PlayerNameMap.erase(name);
     }
 
@@ -105,6 +112,8 @@ namespace PlayerNameMapHolder
         std::string charName(name);
         if (!normalizePlayerName(charName))
             return nullptr;
+
+        std::shared_lock<std::shared_mutex> lock(PlayerNameMapLock);
 
         auto itr = PlayerNameMap.find(charName);
         return (itr != PlayerNameMap.end()) ? itr->second : nullptr;


### PR DESCRIPTION
### Changes Proposed

`PlayerNameMapHolder` (in `ObjectAccessor.cpp`) accesses its global
`std::unordered_map` with no synchronization, while its sibling
`HashMapHolder` in the same file already guards its map with a
`std::shared_mutex`. This asymmetry is a data race.

With a multi-threaded map update (`MapUpdate.Threads`),
`Map::DeleteFromWorld<Player>` erases from a worker thread while the main
thread reads through `FindPlayerByName` (used by whispers, `.tele name`,
invites, name-based bans, guild/chat lookups). Two workers can also
insert/erase concurrently. Concurrent access to a mutating
`unordered_map` is undefined behavior (rehash, iterator/bucket
corruption) — a hard-to-reproduce crash under player load.

The fix mirrors `HashMapHolder`: a `shared_mutex`, `unique_lock` on the
writers (`Insert`/`Remove`/`RemoveByName`), `shared_lock` on the reader
(`Find`). No behavior or signature change; readers stay concurrent with
each other.

### Issues Addressed

Latent data race / UB in `PlayerNameMapHolder`; no linked issue (found
via code review).

### Tests Performed

- Builds clean; `codestyle-cpp.py` passes.
- Code-review verification of the threading model (MapUpdater worker pool
  vs. main-thread readers).
- Behavior unchanged: lookups by name and login/logout add/remove work as
  before.
- Reproducing the race deterministically is impractical
  (timing-dependent); the fix is a straightforward correctness guard
  matching the existing `HashMapHolder` pattern in the same file.

### How to Test the Changes

1. Run a server with `MapUpdate.Threads` >= 2.
2. Have several players repeatedly log in/out across different maps while
   others issue name-based lookups (whispers, `.tele <name>`, invites).
3. Before the patch this can intermittently crash/corrupt the name map
   under load; after it, name lookups and add/remove stay consistent with
   no data race.