### PR TITLE
fix(Core/Spells): allow Freya's Potent Pheromones to affect player pets

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -2016,7 +2016,6 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Potent Pheromones
     ApplySpellFix({ 64321 }, [](SpellInfo* spellInfo)
     {
-        spellInfo->AttributesEx3 |= SPELL_ATTR3_ONLY_ON_PLAYER;
         spellInfo->AttributesEx |= SPELL_ATTR1_IMMUNITY_PURGES_EFFECT;
     });
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Removes `SPELL_ATTR3_ONLY_ON_PLAYER` from the spell correction for Potent Pheromones (64321), the buff Healthy Spores pulse every 500ms in a 6 yd radius during Freya's Ancient Conservator phase. The buff grants silence-mechanic immunity and, through `SPELL_ATTR1_IMMUNITY_PURGES_EFFECT`, purges Conservator's Grip (62532) off targets near a spore.

With the player-only restriction, pets and guardians could never receive the pheromones. Since Conservator's Grip is an infinite-duration, unlimited-range area aura that constantly reapplies, pets stayed pacified for the entire phase and could not attack.

Retail combat logs (see SOURCE) show Potent Pheromones was gained by pets and guardians (hunter pets, Spirit Wolf, Water Elemental, Treants, Mirror Images, Bloodworms, Risen Ghoul) and by the Healthy Spores themselves. They also show pets did gain Conservator's Grip, so the correct behavior is not pet immunity to the grip but pets being freed by spores like players. Spores spawn around the conservator, so melee pets attacking it keep getting freed, matching the reference videos in the linked issue.

The attribute is also unnecessary for keeping the buff off NPCs: 64321 targets `TARGET_UNIT_SRC_AREA_ALLY` and the Healthy Spore's faction template (2110) is friendly to players and hostile to the monster group, so the Ancient Conservator is never a valid target. Retail logs confirm it never gained the buff. TrinityCore applies only `SPELL_ATTR1_IMMUNITY_PURGES_EFFECT` here; the player-only attribute was AC-only.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude Code (Claude Fable 5) was used for the investigation and preparation of this PR.**

## Issues Addressed:
- Closes #26310

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

2009 retail WWS combat log parses:
- Potent Pheromones (64321) gained by pets/guardians and spores: [parse 1](http://files.shefki.org/sws/sws-freya-1243308537/spell_64321.html), [parse 2](http://wws.piechart-guild.com/uld25/sws-freya-1248230876/spell_64321.html)
- Conservator's Grip (62532) applied to pets/guardians too: [parse 1](http://files.shefki.org/sws/sws-freya-1243308537/spell_62532.html), [parse 2](http://wws.piechart-guild.com/uld25/sws-freya-1248230876/spell_62532.html)

Retail-era videos from the linked issue showing pets attacking the Ancient Conservator: [WotLK Classic](https://youtu.be/gM-p7q469X8?si=OTfzQ5xNlDAc2VAP&t=301), [original WotLK](https://youtu.be/HJ1gxZZSRtI?si=9mpD21D2Xc01ucvV&t=92)

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Codestyle checks pass. Not yet tested in-game.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Create a warlock, `.levelup 79`, `.cheat god on`, `.learn all my class`, `.gm on`
2. `.add 6265`, `.go c i 32906`, summon a felhunter
3. Engage Freya and wait for the Ancient Conservator to spawn
4. Attack it and send the pet in: the pet should be pacified by Conservator's Grip while away from Healthy Spores, but should receive Potent Pheromones and resume attacking when near one (spores spawn around the conservator)
5. Verify players still lose Conservator's Grip when standing under a Healthy Spore, and that the Ancient Conservator itself never gains Potent Pheromones

## Known Issues and TODO List:

- [ ] In-game testing by a community member

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
