### PR TITLE
fix(Scripts/Ulduar): Brundir no longer despawns during Lightning Tendrils

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
@@ -783,11 +783,13 @@ struct boss_stormcaller_brundir : public ScriptedAI
                     me->SetDisableGravity(true);
                     me->SetHover(true);
 
-                    me->CombatStop();
+                    // AttackStop (not CombatStop) so he stays in combat while REACT_PASSIVE;
+                    // otherwise UpdateVictim() sees engaged+passive+out-of-combat and evades
+                    // him mid-flight, resetting the whole encounter.
+                    me->AttackStop();
                     me->StopMoving();
                     me->SetReactState(REACT_PASSIVE);
                     me->SetGuidValue(UNIT_FIELD_TARGET, ObjectGuid::Empty);
-                    me->SetUnitFlag(UNIT_FLAG_STUNNED);
 
                     me->CastSpell(me, SPELL_LIGHTNING_TENDRILS, true);
                     me->CastSpell(me, SPELL_LIGHTNING_TENDRILS_2, true);
@@ -807,16 +809,17 @@ struct boss_stormcaller_brundir : public ScriptedAI
                 me->SetHover(false);
                 me->SetReactState(REACT_AGGRESSIVE);
                 me->SetDisableGravity(false);
-                if (Unit* flyTarget = ObjectAccessor::GetUnit(*me, _flyTargetGUID))
-                {
-                    me->Attack(flyTarget, false);
-                }
-
                 me->SetRegeneratingHealth(true);
-                _flyTargetGUID.Clear();
                 me->RemoveAura(sSpellMgr->GetSpellIdForDifficulty(SPELL_LIGHTNING_TENDRILS, me));
                 me->RemoveAura(SPELL_LIGHTNING_TENDRILS_2);
                 DoResetThreatList();
+
+                // AttackStart (not Attack) so MoveChase is re-issued; Attack() alone only
+                // sets the victim, leaving him landed but standing still.
+                if (Unit* flyTarget = ObjectAccessor::GetUnit(*me, _flyTargetGUID))
+                    AttackStart(flyTarget);
+
+                _flyTargetGUID.Clear();
                 events.CancelEvent(EVENT_LIGHTNING_FLIGHT);
                 break;
             case EVENT_ENRAGE:


### PR DESCRIPTION
## Changes Proposed:
Fixes Stormcaller Brundir (Assembly of Iron, Ulduar) despawning and resetting the encounter when he is left last and enters his Lightning Tendrils flight phase.

Root cause: the flight setup called `CombatStop()` and set `REACT_PASSIVE`. `CombatStop()` clears `IsInCombat()` but not `IsEngaged()` (which is AI-tracked), so on the next tick `CreatureAI::UpdateVictim()` takes the `engaged + passive + out-of-combat` branch and calls `EnterEvadeMode(EVADE_REASON_NO_HOSTILES)`. As the last boss alive, his `Reset()` then respawns the whole council. Lightning Tendrils is a phase-3 ability, and phase 3 is only reached once he is the sole survivor, so this happened every time.

Changes:
- Use `AttackStop()` instead of `CombatStop()` so he stays in combat while `REACT_PASSIVE`, avoiding the evade.
- On landing, use `AttackStart()` (re-issues `MoveChase`) instead of `Attack()`, which only set the victim and left him standing still instead of resuming pursuit.
- Drop the manual `UNIT_FLAG_STUNNED` on liftoff. It has no equivalent in TrinityCore or cmangos and was never cleared on landing.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude (Opus 4.8) was used to investigate and prepare the fix.

## Issues Addressed:
- Closes #26223

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Cross-checked the flight/landing handling against TrinityCore and cmangos: neither applies a manual stun flag, both keep the boss in combat during flight, and both re-issue chase movement on landing (`DoStartMovement`/`MoveChase` on the current victim).

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds and passes the C++ codestyle check. In-game testing of the full flight/land cycle is still recommended.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.gm on`, `.go c i 32857`, `.gm off`.
2. Engage the Assembly of Iron, kill two of the three bosses, and leave Stormcaller Brundir last.
3. Wait for his Lightning Tendrils flight phase: he should fly, chase players, then land and resume attacking his target, without despawning or resetting the encounter.

## Known Issues and TODO List:
- [ ] None
