### PR TITLE
fix(Scripts/Ulduar): Add Mimiron elevator knockback

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -47,6 +47,9 @@ enum SpellData
     SPELL_MINE_EXPLOSION                            = 66351,
     SPELL_SUMMON_PROXIMITY_MINE                     = 65347,
 
+    // PHASE 1 -> 2 TRANSITION:
+    SPELL_ELEVATOR_KNOCKBACK                        = 65096, // Self-cast by the world trigger; sweeps players off the elevator as it rises
+
     // PHASE 2:
     SPELL_HEAT_WAVE                                 = 64533,
 
@@ -98,6 +101,7 @@ enum NPCs
     NPC_ASSAULT_BOT                                 = 34057,
     NPC_JUNK_BOT                                    = 33855,
     NPC_MAGNETIC_CORE                               = 34068,
+    NPC_WORLD_TRIGGER                               = 21252,
 };
 
 enum GOs
@@ -488,6 +492,8 @@ struct boss_mimiron : public BossAI
                     elevator->SetLootState(GO_READY);
                     elevator->UseDoorOrButton(0, false);
                     elevator->EnableCollision(false);
+                    if (Creature* trigger = me->SummonCreature(NPC_WORLD_TRIGGER, elevator->GetPositionX(), elevator->GetPositionY(), elevator->GetPositionZ(), 0.0f, TEMPSUMMON_TIMED_DESPAWN, 5000))
+                        trigger->CastSpell(trigger, SPELL_ELEVATOR_KNOCKBACK);
                 }
                 events.ScheduleEvent(EVENT_ELEVATOR_INTERVAL_1, 6s);
                 break;


### PR DESCRIPTION
## Changes Proposed:
Adds the missing elevator knockback on Mimiron's Phase 1 (Leviathan MK II) to Phase 2 (VX-001) transition. Players who stayed on the elevator platform were not knocked off while the platform rises.

As the elevator starts to rise, a world trigger (creature 21252) is summoned at the platform center and self-casts spell 65096 (Elevator Knockback), sweeping players off. This mirrors retail behaviour and the TrinityCore implementation.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.8 was used to locate the relevant transition point and port the mechanic. The change was reviewed and is understood by the author.

## Issues Addressed:
- Closes #18951

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Spell `65096 - Elevator Knockback` is cast by a world trigger in retail. Reference implementation in TrinityCore: https://github.com/TrinityCore/TrinityCore/blob/master/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp

AzerothCore's Mimiron script is a fully independent implementation, so a literal `git cherry-pick` is not possible. The mechanic was ported and the commit is attributed to the original TrinityCore author (Unholychick) via the `--author` tag.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

The knockback is centered on the elevator gameobject position; the exact center/radius should be confirmed in-game.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.go c id 33350`
2. Defeat the first stage (Leviathan MK II).
3. Stay on the elevator platform during the transition.
4. Observe the knockback pushing players off the platform as it rises.

## Known Issues and TODO List:
- [ ] Confirm the knockback center/radius in-game.
