### PR TITLE
fix(Core/Unit): require contested guard attacker for friendly-target attack bypass

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10835,7 +10835,7 @@ bool Unit::_IsValidAttackTarget(Unit const* target, SpellInfo const* bySpell, Wo
         if (Player const* player = target->GetCharmerOrOwnerPlayerOrPlayerItself())
             isContestedPvp = player->HasPlayerFlag(PLAYER_FLAGS_CONTESTED_PVP);
 
-        if (!isContestedGuard && !isContestedPvp)
+        if (!isContestedGuard || !isContestedPvp)
             return false;
     }
 


### PR DESCRIPTION
## Changes Proposed:

e6e6c6289 (#23935) added a bypass to the friendly-target rejection in `Unit::_IsValidAttackTarget` so contested guards (Booty Bay/Gadgetzan/Area 52/K3 bruisers) can attack players flagged with `PLAYER_FLAGS_CONTESTED_PVP` even though the reaction between them is friendly.

The bypass was granted when *either* the attacker is a contested guard *or* the target's owner carries the contested flag:

```cpp
if (!isContestedGuard && !isContestedPvp)
    return false;
```

The second grant makes any contested-flagged player attackable by everyone, teammates included. This is most visible in Wintergrasp:

- Wintergrasp has 40 spawns of Wintergrasp Detection Unit (entry 27869, faction template 2135, which carries `FACTION_TEMPLATE_FLAG_ATTACK_PVP_ACTIVE_PLAYERS`). They satisfy the contested-guard proximity check in `Unit::SetContestedPvP`, so nearly every battle participant is flagged after their first hit on an enemy player.
- The 30 s contested timer does not tick while in combat (`Player::UpdateContestedPvP`), and a WG battle is near continuous combat, so the flag sticks for the whole battle.
- Everyone is force PvP-flagged during the war, so after the bypass the final PvP block returns true via `target->IsPvP()`.
- Only server-side area target selection (`TARGET_CHECK_ENEMY`) is affected; the client still blocks direct hostile casts on allies. Hence enemy-only AoE: Shadowfury, Earthgrab Totem, hunter traps. Own pets are hit too, because the check reads the pet owner's flag.
- Battlegrounds are unaffected because `SetContestedPvP` early returns for players in a BG; Wintergrasp is a Battlefield.

This PR requires both conditions, so the bypass only applies to actual contested guards attacking flagged players. Player attackers never have a contested-guard faction template, which restores the pre-#23935 behavior for players. The scenario #23935 fixed still works: the guard grants both conditions, and its own reaction to the flagged player is already hostile via `GetFactionReactionTo`, while the flagged player's friendly reputation reaction to the guard no longer blocks the attack.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code (Claude Fable 5) was used to investigate the root cause and prepare the fix.

## Issues Addressed:
- Closes #24561

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Shadowfury and similar spells are enemy-only per Wowhead; AoE friendly fire never existed in WotLK outside FFA situations. Also reported on ChromieCraft: https://github.com/chromiecraft/chromiecraft/issues/9715 (analysis in the issue comments), where a two day test with crossfaction Wintergrasp disabled ruled out crossfaction modules.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds without errors. Root cause and fix verified by code analysis (see reproduction chain above); not yet runtime tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Friendly fire (needs 3 players, two on the same faction):
1. Start a Wintergrasp battle with same-faction players A and B and one enemy player.
2. Near a tower or fortress wall (within 45 yd of a Wintergrasp Detection Unit), have A hit the enemy once. A now has `PLAYER_FLAGS_CONTESTED_PVP` (0x100).
3. While A is still in combat, have B cast Shadowfury or drop an Earthgrab Totem on A's position.
4. Before this PR: A takes the damage/stun/root. After: A is unaffected.

Contested guard regression check (behavior from #23935 must be kept):
1. Flag two players of opposite factions for PvP and have them fight next to a Booty Bay bruiser (or Area 52 / K3 bruiser).
2. The bruiser must still attack the contested-flagged players.
3. Unflagged players of either faction must not be attacked by the bruiser.

## Known Issues and TODO List:

- [ ] Runtime testing per the steps above.
