### PR TITLE
fix(Core/Creature): stop mid-fight summons and proximity aggro from preferring totems/pets over players

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1925,6 +1925,11 @@ bool Creature::CanStartAttack(Unit const* who, bool force) const
         if (!_IsTargetAcceptable(who))
             return false;
 
+        // Totems never pull proximity aggro; they are only attacked in response
+        // to threat they generate themselves (e.g. Searing Totem)
+        if (who->IsTotem())
+            return false;
+
         if (IsNeutralToAll() || !IsWithinDistInMap(who, GetAggroRange(who) + m_CombatDistance, true, false, false))
             return false;
     }

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2337,8 +2337,9 @@ TempSummon* Map::SummonCreature(uint32 entry, Position const& pos, SummonPropert
 
     summon->InitSummon();
 
-    // call MoveInLineOfSight for nearby creatures
-    Acore::AIRelocationNotifier notifier(*summon);
+    // call MoveInLineOfSight for nearby players and creatures; players are visited
+    // first (grid typelist order) so aggressive summons prefer them over pets/totems
+    Acore::AIRelocationNotifier notifier(*summon, true);
     Cell::VisitObjects(summon, notifier, GetVisibilityRange());
 
     return summon;

--- a/src/server/game/Grids/Notifiers/GridNotifiers.cpp
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.cpp
@@ -186,6 +186,15 @@ void AIRelocationNotifier::Visit(CreatureMapType& m)
     }
 }
 
+void AIRelocationNotifier::Visit(PlayerMapType& m)
+{
+    if (!includePlayers || !isCreature || ((Creature*)(&i_unit))->IsMoveInLineOfSightStrictlyDisabled())
+        return;
+
+    for (PlayerMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
+        CreatureUnitRelocationWorker((Creature*)&i_unit, iter->GetSource());
+}
+
 // Uses visibility map
 void MessageDistDeliverer::Visit(VisiblePlayersMap const& m)
 {

--- a/src/server/game/Grids/Notifiers/GridNotifiers.cpp
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.cpp
@@ -188,11 +188,15 @@ void AIRelocationNotifier::Visit(CreatureMapType& m)
 
 void AIRelocationNotifier::Visit(PlayerMapType& m)
 {
-    if (!includePlayers || !isCreature || ((Creature*)(&i_unit))->IsMoveInLineOfSightStrictlyDisabled())
+    if (!includePlayers)
+        return;
+
+    Creature* creature = i_unit.ToCreature();
+    if (!creature || creature->IsMoveInLineOfSightStrictlyDisabled())
         return;
 
     for (PlayerMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
-        CreatureUnitRelocationWorker((Creature*)&i_unit, iter->GetSource());
+        CreatureUnitRelocationWorker(creature, iter->GetSource());
 }
 
 // Uses visibility map

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -91,9 +91,11 @@ namespace Acore
     {
         Unit& i_unit;
         bool isCreature;
-        explicit AIRelocationNotifier(Unit& unit) : i_unit(unit), isCreature(unit.IsCreature())  {}
+        bool includePlayers;
+        explicit AIRelocationNotifier(Unit& unit, bool includePlayers = false) : i_unit(unit), isCreature(unit.IsCreature()), includePlayers(includePlayers)  {}
         template<class T> void Visit(GridRefMgr<T>&) {}
         void Visit(CreatureMapType&);
+        void Visit(PlayerMapType&);
     };
 
     enum class TeamFilter


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Mid-fight summons (e.g. Sartharion's Lava Blaze elementals, Violet Hold portal adds) currently pick their first target from a creature-only grid pass. On spawn, `Map::SummonCreature` fires an `AIRelocationNotifier`, and that notifier only visited `CreatureMapType`, so the only aggro candidates offered to a fresh add are other creatures: shaman totems, warlock/hunter pets, guardians. Players standing right next to the add are not in the candidate set at all. Once the add engages, `MoveInLineOfSight` early-returns on `IsEngaged()`, so only real threat (damage/taunt) can pull it off afterwards. As a secondary symptom, after the add kills a buff totem its threat list is empty, so `SelectVictim` evades and the summon often despawns.

Two changes:

1. `AIRelocationNotifier` gains an opt-in `includePlayers` flag and a `Visit(PlayerMapType&)` overload. It is enabled only at summon time in `Map::SummonCreature`; the grid-load and periodic AI-notify call sites keep the old creature-only behaviour. Because the grid typelist stores `Player` before `Creature`, players in each cell are evaluated before any pet/totem, so an aggressive summon prefers a player when one is in aggro range.

2. `Creature::CanStartAttack` now rejects totems in the non-forced branch, so buff totems never pull proximity aggro. Totems are still attacked through the threat they generate themselves (e.g. Searing Totem deals damage → lands on the threat list → attacked normally; that path does not consult `CanStartAttack`), and pets assisting their owner still work via the `force = true` path.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Investigation and implementation assisted by Claude (Anthropic, Fable 5). The author understands and can justify the changes.

## Issues Addressed:
- Closes #26391

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Reference footage linked in the issue shows totems remaining placed for the whole encounter through repeated add spawns on retail/Classic WotLK, which is the behaviour this PR restores.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds locally; C++ codestyle passes. In-game verification of the specific encounters is still needed.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Level 80 shaman, learn class spells, drop 4 totems, `.tele Obsi`, `.cheat god`.
2. Engage Sartharion, wait for Lava Strike to spawn Fire Elementals.
3. Confirm the elementals go for players rather than beelining to the totems.
4. Regression check: cast a Searing Totem near a hostile mob and confirm the mob still attacks and destroys the totem (threat path unchanged).
5. Regression check: send a warlock/hunter pet into Violet Hold portal-guardian adds and confirm the adds no longer preferentially snipe the pet on spawn.

## Known Issues and TODO List:

- [ ] Priority ordering is per grid cell (players visited before creatures within a cell). A totem in an earlier-visited cell with no player nearby can still be picked; not a factor for the reported cases where totems sit next to their owner.
