### PR TITLE
fix(DB/Spells): Honor Among Thieves proc must not engage the rogue

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1783178553569042800.sql
+++ b/data/sql/updates/pending_db_world/rev_1783178553569042800.sql
@@ -1,0 +1,5 @@
+-- Honor Among Thieves triggered combo point (51699) is beneficial for the rogue:
+-- mark it positive so it never pulls the rogue into combat with the targeted enemy
+-- (SPELL_ATTR0_CU_POSITIVE_EFF0 | SPELL_ATTR0_CU_POSITIVE_EFF1)
+DELETE FROM `spell_custom_attr` WHERE `spell_id` = 51699;
+INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (51699, 0x6000000);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### Description

Since #24799, when a party member crits, the rogue casts the Honor Among Thieves combo point spell (51699) with no explicit target, which the core resolves to the rogue's current selection. Since #25167, casting a non-positive spell at a non-friendly target puts the caster in combat when the spell has initial aggro **or the target is already engaged**.

51699 carries `SPELL_ATTR1_NO_THREAT` ("generates no threat") and `SPELL_ATTR3_SUPPRESS_TARGET_PROCS` ("does not engage target") in the DBC, so `HasInitialAggro()` correctly returns false. But the `IsEngaged()` fallback in `Spell::DoAllEffectOnTarget` and `Spell::HandleLaunchPhase` ignores those attributes, and in the HAT scenario the rogue's target is almost always engaged, since a party member just crit it. On top of that, `SpellInfo::_IsPositiveEffect` classifies 51699 as non-positive purely because its effect targets `TARGET_UNIT_TARGET_ENEMY`.

Net result: an out-of-combat rogue with HAT gets pulled into combat just for having an engaged enemy targeted whenever anyone in the group crits.

The spell is beneficial for the rogue and does nothing to the target, so this marks it positive through `spell_custom_attr` (`SPELL_ATTR0_CU_POSITIVE_EFF0 | SPELL_ATTR0_CU_POSITIVE_EFF1`, matching its two effects: Add Combo Points + the self ICD marker aura). Both combat gates check `!IsPositive()` first, so the proc no longer engages anyone. This also stops the proc from stripping stealth from a targeted enemy player (`Spell::DoSpellHitOnUnit` removes `SPELL_AURA_MOD_STEALTH` from targets of hostile non-positive spells), which was broken the same way.

Note: gaining the combo points while out of combat is correct for 3.3.5; the "only works while in combat" restriction on HAT was a WoD-era hotfix (2015-01-07).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude Code (Claude Fable 5)**

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9529

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Spell attributes ("Generates no threat", "Does not engage target", "Cannot miss"): https://www.wowhead.com/wotlk/spell=51699
Video of the bug: linked ChromieCraft issue.
WoD hotfix that added the in-combat restriction (proving it did not exist in 3.3.5): https://warcraft.wiki.gg/wiki/Honor_Among_Thieves (changelog, 2015-01-07)

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Rogue with Honor Among Thieves talent, in a party with another damage dealer.
2. Have the party member fight a mob. Stay out of combat on the rogue and target that mob.
3. When the party member crits, the rogue gains a combo point on the target but must NOT enter combat (before this PR the rogue is pulled into combat).
4. Regression check: verify the rogue still gains combo points from party crits while in combat, and that the 1-second internal cooldown still applies.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
