### PR TITLE
fix(DB/Ulduar): make General Vezax immune to spell-haste debuffs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1783205268156315800.sql
+++ b/data/sql/updates/pending_db_world/rev_1783205268156315800.sql
@@ -1,0 +1,11 @@
+--
+-- General Vezax (33271) must resist spell-haste debuffs (Curse of Tongues, Mind-numbing Poison,
+-- Slow, core hound Lava Breath). They inflate his Shadow Crash / Searing Flames cast times and
+-- trivialize the encounter. He already uses shared CC set -287; a single creature can reference only
+-- one immunity set, so give him a dedicated superset that keeps -287's immunities and adds
+-- aura 216 (HASTE_SPELLS). Other -287 users are left untouched.
+DELETE FROM `creature_immunities` WHERE `ID`=-427;
+INSERT INTO `creature_immunities` (`ID`, `SchoolMask`, `DispelTypeMask`, `MechanicsMask`, `Effects`, `Auras`, `ImmuneAoE`, `ImmuneChain`, `Comment`) VALUES
+(-427, 0, 0, 1234599678, '98,114,124,144,145', '11,216', 0, 0, 'General Vezax: -287 (CC/knockback/taunt, auras=11(BIND)) + auras=216(HASTE_SPELLS) so cast-time slows do not trivialize the fight');
+
+UPDATE `creature_template` SET `CreatureImmunitiesId`=-427 WHERE `entry`=33271;

--- a/data/sql/updates/pending_db_world/rev_1783205268156315800.sql
+++ b/data/sql/updates/pending_db_world/rev_1783205268156315800.sql
@@ -6,6 +6,6 @@
 -- aura 216 (HASTE_SPELLS). Other -287 users are left untouched.
 DELETE FROM `creature_immunities` WHERE `ID`=-427;
 INSERT INTO `creature_immunities` (`ID`, `SchoolMask`, `DispelTypeMask`, `MechanicsMask`, `Effects`, `Auras`, `ImmuneAoE`, `ImmuneChain`, `Comment`) VALUES
-(-427, 0, 0, 1234599678, '98,114,124,144,145', '11,216', 0, 0, 'General Vezax: -287 (CC/knockback/taunt, auras=11(BIND)) + auras=216(HASTE_SPELLS) so cast-time slows do not trivialize the fight');
+(-427, 0, 0, 1234599678, '98,114,124,144,145', '11,216', 0, 0, 'General Vezax: -287 (CC/knockback/taunt, auras=11(MOD_TAUNT)) + auras=216(HASTE_SPELLS) so cast-time slows do not trivialize the fight');
 
 UPDATE `creature_template` SET `CreatureImmunitiesId`=-427 WHERE `entry`=33271;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

General Vezax (33271) is meant to be immune to effects that increase his cast time. Curse of Tongues, Mind-numbing Poison, Slow and the core hound's Lava Breath currently stretch the cast times of Shadow Crash (62660) and Searing Flames (62661), making the fight easier than intended.

Vezax already references the shared CC/knockback/taunt immunity set `-287`. Since `creature_template.CreatureImmunitiesId` allows only a single reference, this adds a dedicated superset (`-427`) that keeps everything from `-287` and adds aura `216` (`SPELL_AURA_HASTE_SPELLS`), then repoints only entry 33271 to it. The other creatures that share `-287` are left untouched.

This mirrors how Sindragosa and Twin Val'kyr already resist the same debuffs (they apply `IMMUNITY_STATE, SPELL_AURA_HASTE_SPELLS` in C++), but uses the data-driven `creature_immunities` table the project is migrating toward.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude Opus 4.8** was used to investigate the issue and prepare the SQL update.

## Issues Addressed:
- Closes #22379

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Common knowledge / issue report: cast-time-increase debuffs on Vezax trivialize the encounter. Consistent with existing AzerothCore handling of Sindragosa and Twin Val'kyr, which are immune to the same aura (216, `SPELL_AURA_HASTE_SPELLS`).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

Data-only change; SQL passes `apps/codestyle/codestyle-sql.py`.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.go c id 33271`
2. Pull Vezax and apply a cast-time increase (Curse of Tongues, Mind-numbing Poison, Slow, core hound Lava Breath).
3. The debuff should fail to apply / not affect his cast times, while his existing CC immunities remain intact.

## Known Issues and TODO List:

- [ ] None.
