### PR TITLE
fix(Scripts/Ulduar): keep Freya's loot chest from despawning early

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -293,14 +293,17 @@ struct boss_freya : public BossAI
                     ++_elderCount;
                 }
 
-                uint32 chestId = RAID_MODE(GO_FREYA_CHEST, GO_FREYA_CHEST_HERO);
-                chestId -= 2 * _elderCount; // offset
-
-                if (GameObject* go = me->SummonGameObject(chestId, 2345.61f, -71.20f, 425.104f, 3.0f, 0, 0, 0, 0, 0))
+                // Summon the chest via spell so it is a wild object not owned by Freya,
+                // otherwise it despawns with her when she teleports out. The spell is
+                // chosen by raid size and how many Elders empowered her.
+                static constexpr uint32 summonChestSpell[2][4] =
                 {
-                    go->ReplaceAllGameObjectFlags((GameObjectFlags)0);
-                    go->SetLootRecipient(me->GetMap());
-                }
+                    // 0 Elder, 1 Elder, 2 Elder, 3 Elder
+                    { 62950, 62952, 62953, 62954 }, // 10-man
+                    { 62955, 62956, 62957, 62958 }  // 25-man
+                };
+
+                me->CastSpell(me, summonChestSpell[me->GetMap()->Is25ManRaid() ? 1 : 0][_elderCount], true);
 
                 // Defeat credit
                 me->CastSpell(me, 65074, true); // credit

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -233,8 +233,6 @@ enum UlduarGameObjects
     GO_HODIR_CHEST_NORMAL_HERO              = 194308,
     GO_HODIR_CHEST_HARD                     = 194200,
     GO_HODIR_CHEST_HARD_HERO                = 194201,
-    GO_FREYA_CHEST                          = 194330, // Normal, -2 - elder offset
-    GO_FREYA_CHEST_HERO                     = 194331, // Hero, -2 - elder offset
     GO_MIMIRON_CHEST                        = 194789,
     GO_MIMIRON_CHEST_HARD                   = 194957,
     GO_MIMIRON_CHEST_HERO                   = 194956,


### PR DESCRIPTION
## Changes Proposed:
Freya summoned her loot chest with `SummonGameObject`, which makes the gameobject owned by her. A few seconds after death she turns into a friendly guardian and teleports to the Inner Sanctum, then despawns. `Unit::RemoveFromWorld` runs `RemoveAllGameObjects()` and deletes the chest along with her, so the raid only gets a very short window to loot it.

This ports TrinityCore's approach: the chest is now summoned through the retail `SUMMON_OBJECT_WILD` spells (62950-62958, selected by raid size and how many Elders empowered her). The wild gameobject has no owner, so it stays until looted or the instance resets. The old manual chest-id/elder-offset math and the now-unused `GO_FREYA_CHEST` enums were removed.

These spells summon at the caster (Freya is stationary on her platform) and do not use `spell_target_position`, so no DB changes are required.

-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used partially in preparing this pull request. Tool used: Claude Code (Claude Opus 4.8), for investigation, cross-referencing TrinityCore/cMaNGOS and drafting the change.

## Issues Addressed:
- Closes #26329

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Ported from TrinityCore (commits `7b0bff3f7b`, `28102c5683` by Machiavelli), committed with the `--author` tag. cMaNGOS uses the same spell-based summon. Spell effect confirmed via Wowhead (spell 62954 -> Freya's Gift).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds and passes the C++ codestyle check. Not yet verified with a live Freya kill.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Enter Ulduar and engage Freya (test with 0 up to 3 Elders active, in both 10 and 25-man).
2. Kill her and wait for her to teleport to the Inner Sanctum center and despawn.
3. Confirm the loot chest remains after she despawns and stays lootable by the raid.

## Known Issues and TODO List:

- [ ] None known.
