### PR TITLE
fix(Scripts/Commands): stop .mail return sending empty mails for online players

### DIFF
--- a/src/server/scripts/Commands/cs_mail.cpp
+++ b/src/server/scripts/Commands/cs_mail.cpp
@@ -288,87 +288,84 @@ public:
 
         if (player)
         {
-            // Online: same logic as WorldSession::HandleReturnToSender
-            // Get pointer before RemoveMail (which removes from deque but does not delete the object)
+            // Drop the mail from the session's loaded state if present. Attachments are
+            // collected from the DB below, so mails the session never loaded (expired at
+            // login, delivered mid-login, inserted externally) still return with their items.
+            // RemoveMail only erases from the deque, it does not delete the object.
             Mail* m = player->GetMail(mailId);
-
             player->RemoveMail(mailId);
-
-            if (m && m->HasItems())
-            {
-                for (auto const& itemInfo : m->items)
-                {
-                    if (Item* item = player->GetMItem(itemInfo.item_guid))
-                        draft.AddItem(item);
-
-                    player->RemoveMItem(itemInfo.item_guid);
-                }
-            }
-
             delete m;
         }
-        else
+
+        // mail_items is flushed to the DB on every item take, so it is authoritative even
+        // for online players. Same query shape as CHAR_SEL_MAILITEMS (LEFT JOIN to handle
+        // dangling mail_items) and same logic as Player::_LoadMailedItem
+        QueryResult itemResult = CharacterDatabase.Query(
+            "SELECT creatorGuid, giftCreatorGuid, count, duration, charges, flags, enchantments,"
+            " randomPropertyId, durability, playedTime, text, mi.item_guid, itemEntry, ii.owner_guid"
+            " FROM mail_items mi LEFT JOIN item_instance ii ON mi.item_guid = ii.guid"
+            " WHERE mi.mail_id = {}", mailId);
+
+        if (itemResult)
         {
-            // Offline: load Item* objects from DB using same query shape as CHAR_SEL_MAILITEMS
-            // (LEFT JOIN to handle dangling mail_items) and same logic as Player::_LoadMailedItem
-            QueryResult itemResult = CharacterDatabase.Query(
-                "SELECT creatorGuid, giftCreatorGuid, count, duration, charges, flags, enchantments,"
-                " randomPropertyId, durability, playedTime, text, mi.item_guid, itemEntry, ii.owner_guid"
-                " FROM mail_items mi LEFT JOIN item_instance ii ON mi.item_guid = ii.guid"
-                " WHERE mi.mail_id = {}", mailId);
-
-            if (itemResult)
+            do
             {
-                do
+                Field* itemFields = itemResult->Fetch();
+                uint32 itemGuid  = itemFields[11].Get<uint32>();
+                uint32 itemEntry = itemFields[12].Get<uint32>();
+
+                // Prefer the item object the session already has loaded over creating a duplicate
+                if (Item* item = player ? player->GetMItem(itemGuid) : nullptr)
                 {
-                    Field* itemFields = itemResult->Fetch();
-                    uint32 itemGuid  = itemFields[11].Get<uint32>();
-                    uint32 itemEntry = itemFields[12].Get<uint32>();
-
-                    // Handle dangling mail_items (missing item_instance)
-                    if (!itemEntry)
-                    {
-                        LOG_ERROR("misc", "cs_mail: Mail #{} has dangling mail_items row for item_guid {}. Cleaning up.", mailId, itemGuid);
-
-                        CharacterDatabasePreparedStatement* delStmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_INVALID_MAIL_ITEM);
-                        delStmt->SetData(0, itemGuid);
-                        trans->Append(delStmt);
-                        continue;
-                    }
-
-                    ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemEntry);
-                    if (!proto)
-                    {
-                        LOG_ERROR("misc", "cs_mail: Mail #{} has unknown item (entry: {}, guid: {}). Cleaning up.", mailId, itemEntry, itemGuid);
-
-                        CharacterDatabasePreparedStatement* delStmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_INVALID_MAIL_ITEM);
-                        delStmt->SetData(0, itemGuid);
-                        trans->Append(delStmt);
-                        continue;
-                    }
-
-                    Item* item = NewItemOrBag(proto);
-                    ObjectGuid ownerGuid = itemFields[13].Get<uint32>()
-                        ? ObjectGuid::Create<HighGuid::Player>(itemFields[13].Get<uint32>())
-                        : ObjectGuid::Empty;
-
-                    if (!item->LoadFromDB(itemGuid, ownerGuid, itemFields, itemEntry))
-                    {
-                        LOG_ERROR("misc", "cs_mail: Item (GUID: {}) in mail #{} failed to load. Cleaning up.", itemGuid, mailId);
-
-                        CharacterDatabasePreparedStatement* delStmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_INVALID_MAIL_ITEM);
-                        delStmt->SetData(0, itemGuid);
-                        trans->Append(delStmt);
-
-                        item->FSetState(ITEM_REMOVED);
-                        CharacterDatabaseTransaction nullTrans = CharacterDatabaseTransaction(nullptr);
-                        item->SaveToDB(nullTrans);
-                        return true;
-                    }
-
                     draft.AddItem(item);
-                } while (itemResult->NextRow());
-            }
+                    player->RemoveMItem(itemGuid);
+                    continue;
+                }
+
+                // Handle dangling mail_items (missing item_instance)
+                if (!itemEntry)
+                {
+                    LOG_ERROR("misc", "cs_mail: Mail #{} has dangling mail_items row for item_guid {}. Cleaning up.", mailId, itemGuid);
+
+                    CharacterDatabasePreparedStatement* delStmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_INVALID_MAIL_ITEM);
+                    delStmt->SetData(0, itemGuid);
+                    trans->Append(delStmt);
+                    continue;
+                }
+
+                ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemEntry);
+                if (!proto)
+                {
+                    LOG_ERROR("misc", "cs_mail: Mail #{} has unknown item (entry: {}, guid: {}). Cleaning up.", mailId, itemEntry, itemGuid);
+
+                    CharacterDatabasePreparedStatement* delStmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_INVALID_MAIL_ITEM);
+                    delStmt->SetData(0, itemGuid);
+                    trans->Append(delStmt);
+                    continue;
+                }
+
+                Item* item = NewItemOrBag(proto);
+                ObjectGuid ownerGuid = itemFields[13].Get<uint32>()
+                    ? ObjectGuid::Create<HighGuid::Player>(itemFields[13].Get<uint32>())
+                    : ObjectGuid::Empty;
+
+                if (!item->LoadFromDB(itemGuid, ownerGuid, itemFields, itemEntry))
+                {
+                    LOG_ERROR("misc", "cs_mail: Item (GUID: {}) in mail #{} failed to load. Cleaning up.", itemGuid, mailId);
+
+                    CharacterDatabasePreparedStatement* delStmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_INVALID_MAIL_ITEM);
+                    delStmt->SetData(0, itemGuid);
+                    trans->Append(delStmt);
+
+                    // Queue the row cleanup on the shared transaction instead of executing it
+                    // immediately; SaveToDB in ITEM_REMOVED state also frees the object
+                    item->FSetState(ITEM_REMOVED);
+                    item->SaveToDB(trans);
+                    continue;
+                }
+
+                draft.AddItem(item);
+            } while (itemResult->NextRow());
         }
 
         uint32 accountId = sCharacterCache->GetCharacterAccountIdByGuid(ObjectGuid(HighGuid::Player, receiver));

--- a/src/server/scripts/Commands/cs_mail.cpp
+++ b/src/server/scripts/Commands/cs_mail.cpp
@@ -243,63 +243,19 @@ public:
 
         Player* player = target.GetConnectedPlayer();
 
-        // Run the same script hook as the client return handler, failing early before any deletions
-        if (player)
-        {
-            Mail* m = player->GetMail(mailId);
-            if (m)
-            {
-                ObjectGuid senderGuid = ObjectGuid(HighGuid::Player, sender);
-
-                if (m->HasItems())
-                {
-                    for (auto const& itemInfo : m->items)
-                    {
-                        Item* item = player->GetMItem(itemInfo.item_guid);
-                        if (item && !sScriptMgr->OnPlayerCanSendMail(player, senderGuid, ObjectGuid::Empty, subject, body, money, 0, item))
-                        {
-                            handler->SendErrorMessage(LANG_MAIL_RETURN_HOOK_BLOCKED);
-                            return true;
-                        }
-                    }
-                }
-                else if (!sScriptMgr->OnPlayerCanSendMail(player, senderGuid, ObjectGuid::Empty, subject, body, money, 0, nullptr))
-                {
-                    handler->SendErrorMessage(LANG_MAIL_RETURN_HOOK_BLOCKED);
-                    return true;
-                }
-            }
-        }
-
-        // Same logic as WorldSession::HandleReturnToSender
         CharacterDatabaseTransaction trans = CharacterDatabase.BeginTransaction();
 
-        CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_MAIL_BY_ID);
-        stmt->SetData(0, mailId);
-        trans->Append(stmt);
-
-        stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_MAIL_ITEM_BY_ID);
-        stmt->SetData(0, mailId);
-        trans->Append(stmt);
-
-        MailDraft draft(subject, body);
-        if (mailTemplate)
-            draft = MailDraft(mailTemplate, false);
-
-        if (player)
-        {
-            // Drop the mail from the session's loaded state if present. Attachments are
-            // collected from the DB below, so mails the session never loaded (expired at
-            // login, delivered mid-login, inserted externally) still return with their items.
-            // RemoveMail only erases from the deque, it does not delete the object.
-            Mail* m = player->GetMail(mailId);
-            player->RemoveMail(mailId);
-            delete m;
-        }
-
+        // Collect attachments before the script-hook check and any deletion, so a hook
+        // veto can still abort the command with nothing changed.
         // mail_items is flushed to the DB on every item take, so it is authoritative even
-        // for online players. Same query shape as CHAR_SEL_MAILITEMS (LEFT JOIN to handle
-        // dangling mail_items) and same logic as Player::_LoadMailedItem
+        // for online players; mails the session never loaded (expired at login, delivered
+        // mid-login, inserted externally) are returned with their items too. Same query
+        // shape as CHAR_SEL_MAILITEMS (LEFT JOIN to handle dangling mail_items) and same
+        // logic as Player::_LoadMailedItem. Items the session already has loaded are
+        // reused and stay owned by the session; the bool marks objects loaded (and owned)
+        // here.
+        std::vector<std::pair<Item*, bool /*loadedFromDb*/>> attachments;
+
         QueryResult itemResult = CharacterDatabase.Query(
             "SELECT creatorGuid, giftCreatorGuid, count, duration, charges, flags, enchantments,"
             " randomPropertyId, durability, playedTime, text, mi.item_guid, itemEntry, ii.owner_guid"
@@ -317,8 +273,7 @@ public:
                 // Prefer the item object the session already has loaded over creating a duplicate
                 if (Item* item = player ? player->GetMItem(itemGuid) : nullptr)
                 {
-                    draft.AddItem(item);
-                    player->RemoveMItem(itemGuid);
+                    attachments.emplace_back(item, false);
                     continue;
                 }
 
@@ -341,6 +296,9 @@ public:
                     CharacterDatabasePreparedStatement* delStmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_INVALID_MAIL_ITEM);
                     delStmt->SetData(0, itemGuid);
                     trans->Append(delStmt);
+
+                    // The mail is going away, so drop the unloadable item_instance row too
+                    Item::DeleteFromDB(trans, itemGuid);
                     continue;
                 }
 
@@ -364,8 +322,67 @@ public:
                     continue;
                 }
 
-                draft.AddItem(item);
+                attachments.emplace_back(item, true);
             } while (itemResult->NextRow());
+        }
+
+        // Run the same script hook as the client return handler for online targets,
+        // covering DB-loaded attachments as well, before any deletion
+        if (player)
+        {
+            ObjectGuid senderGuid = ObjectGuid(HighGuid::Player, sender);
+            bool blocked = false;
+
+            if (attachments.empty())
+                blocked = !sScriptMgr->OnPlayerCanSendMail(player, senderGuid, ObjectGuid::Empty, subject, body, money, 0, nullptr);
+
+            for (auto const& [item, loadedFromDb] : attachments)
+            {
+                if (blocked)
+                    break;
+
+                blocked = !sScriptMgr->OnPlayerCanSendMail(player, senderGuid, ObjectGuid::Empty, subject, body, money, 0, item);
+            }
+
+            if (blocked)
+            {
+                for (auto const& [item, loadedFromDb] : attachments)
+                    if (loadedFromDb)
+                        delete item;
+
+                handler->SendErrorMessage(LANG_MAIL_RETURN_HOOK_BLOCKED);
+                return true;
+            }
+        }
+
+        // Same logic as WorldSession::HandleReturnToSender
+        CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_MAIL_BY_ID);
+        stmt->SetData(0, mailId);
+        trans->Append(stmt);
+
+        stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_MAIL_ITEM_BY_ID);
+        stmt->SetData(0, mailId);
+        trans->Append(stmt);
+
+        MailDraft draft(subject, body);
+        if (mailTemplate)
+            draft = MailDraft(mailTemplate, false);
+
+        if (player)
+        {
+            // Drop the mail from the session's loaded state if present.
+            // RemoveMail only erases from the deque, it does not delete the object.
+            Mail* m = player->GetMail(mailId);
+            player->RemoveMail(mailId);
+            delete m;
+        }
+
+        for (auto const& [item, loadedFromDb] : attachments)
+        {
+            if (!loadedFromDb)
+                player->RemoveMItem(item->GetGUID().GetCounter());
+
+            draft.AddItem(item);
         }
 
         uint32 accountId = sCharacterCache->GetCharacterAccountIdByGuid(ObjectGuid(HighGuid::Player, receiver));


### PR DESCRIPTION
## Changes Proposed:

`.mail return` could deliver an empty mail to the original sender and permanently orphan the attached items. The online branch of the command trusted the target player's in-memory mail list: if the mail existed in the DB but was never loaded into the session, `GetMail()` returned nullptr, so nothing was attached to the draft while the `mail`/`mail_items` rows were still deleted in the transaction. The items were left as orphaned `item_instance` rows and the sender received a mail with only subject, body and money.

Mails end up in the DB but not in a connected player's memory in several realistic cases:
- The mail expired before login. `Player::_LoadMail` skips expired mails but leaves the rows in the DB, and `ReturnOrDeleteOldMails` skips logged-in players.
- The mail was delivered during the login window, after the login query holder snapshotted the mail table.
- The mail was inserted directly into the DB by external tools while the player was online.

Fix: collect the attachments from `mail_items` in all cases. That table is authoritative even for online players because every item take flushes mail state to the DB immediately. When the session already has an item object loaded, it is reused (and removed from the session's mail item map) instead of instantiating a duplicate from the row. The previous online/offline split collapses into one code path; behavior for the two previously working cases (online with mail loaded, offline) is unchanged.

Also fixes the `LoadFromDB` failure path in the same function, which deleted the `item_instance` row immediately but then returned without committing the transaction, leaving a dangling `mail_items` row and silently aborting the return. The cleanup is now queued on the shared transaction and the command continues with the remaining items.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude Code (Claude Fable 5).**

## Issues Addressed:
- Based on live server reports of returned mails arriving without their attachments. No open issue on the tracker.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code analysis of the return path (`HandleMailReturnCommand` vs `WorldSession::HandleMailReturnToSender` and `Player::_LoadMail`).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Passes `codestyle-cpp.py`.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Reproducing the broken case (mail in DB but not in the session):

1. From character A (account 1), send character B (account 2) a mail with an item attached. The cross-account item mail gets a delivery delay.
2. Log character B in while the mail is still pending delivery and keep them online until the delivery time passes. The mail now exists in the DB as delivered but was never loaded into B's session.
3. As GM, run `.mail return <B> <mailId>` (the mail id can be taken from the `mail` table, `.mail list` while B is offline also shows it).
4. Log character A and open the mailbox. Without this PR the returned mail arrives without the item and the item is orphaned in `item_instance`; with this PR the item is attached.

Regression checks: return a normal mail of an online player (mail visible in their mailbox) and of an offline player; both should behave as before, items attached, and the target player's mailbox no longer shows the mail.

## Known Issues and TODO List:

- [ ] The root cause of the DB/memory divergence for pending mails is that `CHAR_SEL_MAIL` filters `deliver_time <= now` at login, so mails still in their delivery delay are invisible to the session until relog. A separate PR will address that.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
