### PR TITLE
fix(Core/Mail): load undelivered mails at login

### DIFF
--- a/src/server/database/Database/Implementation/CharacterDatabase.cpp
+++ b/src/server/database/Database/Implementation/CharacterDatabase.cpp
@@ -423,8 +423,6 @@ void CharacterDatabaseConnection::DoPrepareStatements()
     PrepareStatement(CHAR_SEL_CHAR_SOCIAL, "SELECT DISTINCT guid FROM character_social WHERE friend = ?", CONNECTION_SYNCH);
     PrepareStatement(CHAR_SEL_CHAR_OLD_CHARS, "SELECT guid, deleteInfos_Account FROM characters WHERE deleteDate IS NOT NULL AND deleteDate < ?", CONNECTION_SYNCH);
     PrepareStatement(CHAR_SEL_ARENA_TEAM_ID_BY_PLAYER_GUID, "SELECT arena_team_member.arenateamid FROM arena_team_member JOIN arena_team ON arena_team_member.arenateamid = arena_team.arenateamid WHERE guid = ? AND type = ? LIMIT 1", CONNECTION_SYNCH);
-    // No deliver_time filter: mails still in their delivery delay must be loaded so the
-    // session can announce and list them once the delay expires without requiring a relog
     PrepareStatement(CHAR_SEL_MAIL, "SELECT id, messageType, sender, receiver, subject, body, expire_time, deliver_time, money, cod, checked, stationery, mailTemplateId FROM mail WHERE receiver = ? ORDER BY id DESC", CONNECTION_ASYNC);
     PrepareStatement(CHAR_SEL_NEXT_MAIL_DELIVERYTIME, "SELECT MIN(deliver_time) FROM mail WHERE receiver = ? AND deliver_time > ? AND (checked & 1) = 0 LIMIT 1", CONNECTION_SYNCH);
     PrepareStatement(CHAR_DEL_CHAR_AURA_FROZEN, "DELETE FROM character_aura WHERE spell = 9454 AND guid = ?", CONNECTION_ASYNC);

--- a/src/server/database/Database/Implementation/CharacterDatabase.cpp
+++ b/src/server/database/Database/Implementation/CharacterDatabase.cpp
@@ -423,7 +423,9 @@ void CharacterDatabaseConnection::DoPrepareStatements()
     PrepareStatement(CHAR_SEL_CHAR_SOCIAL, "SELECT DISTINCT guid FROM character_social WHERE friend = ?", CONNECTION_SYNCH);
     PrepareStatement(CHAR_SEL_CHAR_OLD_CHARS, "SELECT guid, deleteInfos_Account FROM characters WHERE deleteDate IS NOT NULL AND deleteDate < ?", CONNECTION_SYNCH);
     PrepareStatement(CHAR_SEL_ARENA_TEAM_ID_BY_PLAYER_GUID, "SELECT arena_team_member.arenateamid FROM arena_team_member JOIN arena_team ON arena_team_member.arenateamid = arena_team.arenateamid WHERE guid = ? AND type = ? LIMIT 1", CONNECTION_SYNCH);
-    PrepareStatement(CHAR_SEL_MAIL, "SELECT id, messageType, sender, receiver, subject, body, expire_time, deliver_time, money, cod, checked, stationery, mailTemplateId FROM mail WHERE receiver = ? AND deliver_time <= ? ORDER BY id DESC", CONNECTION_ASYNC);
+    // No deliver_time filter: mails still in their delivery delay must be loaded so the
+    // session can announce and list them once the delay expires without requiring a relog
+    PrepareStatement(CHAR_SEL_MAIL, "SELECT id, messageType, sender, receiver, subject, body, expire_time, deliver_time, money, cod, checked, stationery, mailTemplateId FROM mail WHERE receiver = ? ORDER BY id DESC", CONNECTION_ASYNC);
     PrepareStatement(CHAR_SEL_NEXT_MAIL_DELIVERYTIME, "SELECT MIN(deliver_time) FROM mail WHERE receiver = ? AND deliver_time > ? AND (checked & 1) = 0 LIMIT 1", CONNECTION_SYNCH);
     PrepareStatement(CHAR_DEL_CHAR_AURA_FROZEN, "DELETE FROM character_aura WHERE spell = 9454 AND guid = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_SEL_CHAR_INVENTORY_COUNT_ITEM, "SELECT COUNT(itemEntry) FROM character_inventory ci INNER JOIN item_instance ii ON ii.guid = ci.item WHERE itemEntry = ?", CONNECTION_SYNCH);

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -129,7 +129,6 @@ bool LoginQueryHolder::Initialize()
 
     stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_MAIL);
     stmt->SetData(0, lowGuid);
-    stmt->SetData(1, uint32(GameTime::GetGameTime().count()));
     res &= SetPreparedQuery(PLAYER_LOGIN_QUERY_LOAD_MAILS, stmt);
 
     stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_MAILITEMS);


### PR DESCRIPTION
## Changes Proposed:

Player reports: "If you open the mailbox before the mail arrives, then you basically have to relog after it has really arrived to see it."

The login query `CHAR_SEL_MAIL` filtered `deliver_time <= now`, so mails still inside their delivery delay (cross-account mail with items or money, COD) were never loaded into the session of a player who logged in during the delay window. After the delivery time passed, nothing in that session could surface the mail: the arrival tick in `Player::Update` never fired (`m_nextMailDelivereTime` was never armed), `HandleGetMailList` only iterates in-memory mails, and `MSG_QUERY_NEXT_MAIL_TIME` reported nothing incoming. The only workaround was logging out and back in after the delivery time.

If the recipient was online when the mail was sent, everything worked, because `SendMailTo` puts the pending mail into memory directly. The bug only hit sessions that started inside the delay window, which is why it looked intermittent.

Fix: load all mails at login regardless of delivery time, as TrinityCore does, and drop the now-unused timestamp binding. Every consumer of the in-memory mail list already filters on `deliver_time` (`HandleGetMailList`, `HandleQueryNextMailTime`, `UpdateNextMailTimeAndUnreads`, and the take/read/return/delete handlers), so pending mails only become visible once due. `UpdateNextMailTimeAndUnreads` runs at the end of `_LoadMail` and arms the delivery notification for them.

This also removes an inconsistency where `CHAR_SEL_MAILITEMS` (which has no delivery filter) loaded the item objects of pending mails into the player's mail item map while the mails themselves were missing from the mail list. That divergence is one of the producers of the empty-return bug addressed in #26485.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude Code (Claude Fable 5).**

## Issues Addressed:
- Based on live server reports of delayed mails not appearing until relog. No open issue on the tracker.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Ported from TrinityCore, committed with `--author` crediting Shauren: TrinityCore/TrinityCore@57eaab80d9e1f6f25274f376da16e1f2f67ab4bc ("Core/Mail: Load mails at login instead of on demand when queried by packets").

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Passes `codestyle-cpp.py`.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. From character A (account 1), send character B (account 2) a mail with an item attached, so the mail gets a delivery delay (`MailDeliveryDelay`, default 1h; lower it in worldserver.conf to test faster).
2. Log character B in while the mail is still pending and stay online until the delivery time passes.
3. Without this PR: no new-mail notification appears, the mailbox stays empty, and the mail only shows after relogging. With this PR: the new-mail icon appears when the delay expires and the mailbox lists the mail.
4. Regression checks: the pending mail must not be visible or takeable before its delivery time (mailbox list, `.mail list`), and normal instant mails must behave as before.

## Known Issues and TODO List:

- [ ] `CHAR_SEL_NEXT_MAIL_DELIVERYTIME` is prepared but never executed anywhere; it looks like a leftover from an earlier approach to this problem and could be removed in a follow-up.
- [ ] `Player::_LoadMail` skips expired mails but leaves the rows in the DB (and leaks the `Mail` object), keeping a small DB/memory divergence window until the startup cleanup runs.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
