### PR TITLE
fix(Core/Battlegrounds): don't block BG entry on a stale charm reference

### DIFF
--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -2272,7 +2272,9 @@ namespace lfg
         {
             error = LFG_TELEPORTERROR_IN_VEHICLE;
         }
-        else if (player->GetCharmGUID() || player->IsInCombat())
+        // GetCharm() validates the charmed unit still exists and clears a stale reference,
+        // unlike GetCharmGUID(); a despawned vehicle must not permanently block the teleport.
+        else if (player->GetCharm() || player->IsInCombat())
         {
             error = LFG_TELEPORTERROR_COMBAT;
         }

--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -412,7 +412,9 @@ void WorldSession::HandleBattleFieldPortOpcode(WorldPacket& recvData)
         return;
     }
 
-    if (_player->GetCharmGUID() || _player->IsInCombat())
+    // GetCharm() validates the charmed unit still exists and clears a stale reference,
+    // unlike GetCharmGUID(); a despawned vehicle must not permanently block BG entry.
+    if (_player->GetCharm() || _player->IsInCombat())
     {
         ChatHandler(_player->GetSession()).SendNotification(LANG_YOU_IN_COMBAT);
         return;


### PR DESCRIPTION
## Changes Proposed:

Two "you're in combat" gates (battleground port-in and LFG teleport) rejected the action whenever `player->GetCharmGUID()` was set, sharing the message with the real `IsInCombat()` case.

`GetCharmGUID()` returns the raw `UNIT_FIELD_CHARM` without validating that the charmed unit still exists. When a player-controlled vehicle is torn down out-of-band (rather than by a clean dismount), that field can be left pointing at a unit that is already gone. The charm-cleanup chain (`remove CONTROL_VEHICLE aura -> HandleAuraControlVehicle -> _ExitVehicle -> Vehicle::RemovePassenger -> RemoveCharmedBy -> SetCharm(false)`) is not transactional and has several early-exits that clear `m_vehicle`/the seat while skipping the charm clear, so the stale reference is never removed. The player is then permanently unable to enter a battleground or use LFG (wrongly told they are in combat/`LFG_TELEPORTERROR_COMBAT`) until relog.

This matches the linked report: the player is provably not in combat (`.debug hostile` shows `InCombat: false | HasCombat: false` and an empty threat list). Per the reporter's follow-up the stale charm most likely originated from a **Wintergrasp** vehicle: `BattlefieldWG::EndBattle` mass-despawns every siege engine/demolisher/catapult/tower cannon at once (`DespawnOrUnsummon`) without ejecting the controlling players first, which is a prime setup for the non-transactional cleanup to leak. The battleground the player was *joining* happened to be Strand of the Ancients, but that is only the target of the port check and is unrelated to where the charm came from. Any player-controlled vehicle content can produce the same stale reference.

Fix: use `GetCharm()` in both gates. It resolves the GUID and, when the charmed unit no longer exists, clears the stale reference and returns null (this self-heal already exists in `Unit::GetCharm`). Legitimate charm (mind control) and active vehicle control still resolve to a live unit and block as before.

Changed handlers:
- `src/server/game/Handlers/BattleGroundHandler.cpp` — `CMSG_BATTLEFIELD_PORT` guard.
- `src/server/game/DungeonFinding/LFGMgr.cpp` — `LFGMgr::TeleportPlayer` guard (flagged on this PR by @PkllonG).

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Opus 4.8 (via Claude Code) was used to investigate the report and prepare this change. The author has reviewed and understands it.

## Issues Addressed:

- Related: https://github.com/chromiecraft/chromiecraft/issues/9398 (reported on ChromieCraft's tracker; cross-repo, so it will not auto-close).

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Code analysis only. The reporter's `.debug hostile` screenshot in the linked issue rules out combat, which leaves the `GetCharmGUID()` branch as the sole cause of the block.

## Tests Performed:

- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

C++ codestyle check passes. Not yet compiled/tested in-game; the underlying leak is a rare race (issue is labelled "Rare Bug / difficult to reproduce").

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing.

Because the leak is intermittent, the guards themselves can be verified directly:

1. Get into a state where `UNIT_FIELD_CHARM` points at a unit that no longer exists (e.g. control a Wintergrasp vehicle and be in it when the battle ends, or otherwise leave a stale charm GUID on the player).
2. Queue for any battleground and accept the invite (`Enter Battle`), and/or accept an LFG teleport.
3. Before this change: the action is refused with "You can't do that while in combat" / `LFG_TELEPORTERROR_COMBAT` even though the player is not in combat. After this change: the stale reference is cleared and the action proceeds. A player who is genuinely charmed or in a live vehicle is still blocked.

## Known Issues and TODO List:

- [ ] This is a defensive fix at the check points. The deeper cause (the charm-cleanup chain leaving `UNIT_FIELD_CHARM` set when a controlled vehicle is torn down out-of-band, e.g. WG `EndBattle` mass-despawn) is worth hardening separately in `Unit::_ExitVehicle` / `Vehicle::RemovePassenger`.
- [ ] A separate, related symptom in the same report (character saved at a BG position, loading screen persisting across relog) is not addressed here and likely needs its own investigation.
