### PR TITLE
fix(Core/Player): pets and critters now follow you through portals

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1475,8 +1475,50 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
         {
             //same map, only remove pet if out of range for new position
             if (pet && !pet->IsWithinDist3d(x, y, z, GetMap()->GetVisibilityRange()))
-                UnsummonPetTemporaryIfAny();
+            {
+                // Duration-limited real Pets have no way to persist their
+                // remaining duration across a full unsummon/resummon
+                // round-trip - character_pet has no duration column, so
+                // UnsummonPetTemporaryIfAny() would just lose them for
+                // good. Relocate the same object directly instead, same
+                // as the guardian/critter handling below.
+                if (pet->isTemporarySummoned())
+                    pet->NearTeleportTo(x, y, z, orientation);
+                else
+                    UnsummonPetTemporaryIfAny();
+            }
         }
+
+        // Guardian-type summons (e.g. a DK's basic Raise Dead ghoul without
+        // Master of Ghouls) aren't real Pets - GetPet() never returns them,
+        // and depending on their exact SummonProperties category, even
+        // GetGuardianPet()/GetPetGUID() might not either. Unit::SetMinion()
+        // unconditionally inserts every minion/guardian into m_Controlled
+        // regardless of category, so iterate that directly instead of
+        // guessing which accessor covers this particular summon type.
+        // Totems don't follow the player and are excluded; the real pet and
+        // critter are already handled separately above/below.
+        for (Unit* controlled : m_Controlled)
+        {
+            if (controlled->IsTotem())
+                continue;
+
+            Creature* summon = controlled->ToCreature();
+            if (!summon || summon == pet || summon->GetGUID() == GetCritterGUID())
+                continue;
+
+            if (!summon->IsWithinDist3d(x, y, z, GetMap()->GetVisibilityRange()))
+                summon->NearTeleportTo(x, y, z, orientation);
+        }
+
+        // vanity/companion critters can't warp back to the player like a
+        // real pet does and area-trigger portals are one-way (a following
+        // creature can't physically walk through them) - if this same-map
+        // teleport puts them out of range, bring them along directly
+        // instead of leaving them stuck on the other side permanently
+        if (Creature* critter = ObjectAccessor::GetCreature(*this, GetCritterGUID()))
+            if (!critter->IsWithinDist3d(x, y, z, GetMap()->GetVisibilityRange()))
+                critter->NearTeleportTo(x, y, z, orientation);
 
         if (!(options & TELE_TO_NOT_LEAVE_COMBAT))
             CombatStop();

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1476,12 +1476,8 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
             //same map, only remove pet if out of range for new position
             if (pet && !pet->IsWithinDist3d(x, y, z, GetMap()->GetVisibilityRange()))
             {
-                // Duration-limited real Pets have no way to persist their
-                // remaining duration across a full unsummon/resummon
-                // round-trip - character_pet has no duration column, so
-                // UnsummonPetTemporaryIfAny() would just lose them for
-                // good. Relocate the same object directly instead, same
-                // as the guardian/critter handling below.
+                // character_pet has no duration column, so a timed pet cannot survive
+                // an unsummon/resummon round trip. Relocate it directly instead.
                 if (pet->isTemporarySummoned())
                     pet->NearTeleportTo(x, y, z, orientation);
                 else
@@ -1489,15 +1485,9 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
             }
         }
 
-        // Guardian-type summons (e.g. a DK's basic Raise Dead ghoul without
-        // Master of Ghouls) aren't real Pets - GetPet() never returns them,
-        // and depending on their exact SummonProperties category, even
-        // GetGuardianPet()/GetPetGUID() might not either. Unit::SetMinion()
-        // unconditionally inserts every minion/guardian into m_Controlled
-        // regardless of category, so iterate that directly instead of
-        // guessing which accessor covers this particular summon type.
-        // Totems don't follow the player and are excluded; the real pet and
-        // critter are already handled separately above/below.
+        // Guardians are not real Pets and the accessors may miss them depending on
+        // category, but SetMinion always inserts them into m_Controlled.
+        // Totems do not follow the player; pet and critter are handled separately.
         for (Unit* controlled : m_Controlled)
         {
             if (controlled->IsTotem())
@@ -1511,11 +1501,8 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
                 summon->NearTeleportTo(x, y, z, orientation);
         }
 
-        // vanity/companion critters can't warp back to the player like a
-        // real pet does and area-trigger portals are one-way (a following
-        // creature can't physically walk through them) - if this same-map
-        // teleport puts them out of range, bring them along directly
-        // instead of leaving them stuck on the other side permanently
+        // critters cannot warp back like a real pet and area-trigger portals are
+        // one-way, so bring them along rather than stranding them
         if (Creature* critter = ObjectAccessor::GetCreature(*this, GetCritterGUID()))
             if (!critter->IsWithinDist3d(x, y, z, GetMap()->GetVisibilityRange()))
                 critter->NearTeleportTo(x, y, z, orientation);


### PR DESCRIPTION
## Changes Proposed:

Companion/vanity critters, duration-limited temporary pets, and non-Pet guardian summons (e.g. a Death Knight's basic Raise Dead ghoul without Master of Ghouls) get stranded when a player passes through a same-map area-trigger portal that puts them out of visibility range - most visibly the Stormwind Wizard's Sanctum's Dalaran-portal exit (area trigger 704). This is a same-map teleport (source and destination are both map 0), not a map change.

**Root cause:** `Player::TeleportTo`'s same-map branch only ever handled the real `Pet` object (`GetPet()`), via `UnsummonPetTemporaryIfAny()`. Three other summon types were never carried along: companion critters (tracked via a separate `GetCritterGUID()` field, no handling at all); duration-limited pets (`Pet::isTemporarySummoned()`), which lose their remaining time on the unsummon/resummon round trip since `character_pet` has no duration column; and guardian-type summons like a base ghoul (`spell_dk_raise_dead::GetGhoulSpellId()`), which aren't reliably tracked via `GetPet()`/`GetGuardianPet()` at all.

**Fix:** relocate all three directly via `NearTeleportTo()` instead of any unsummon/resummon round trip, sidestepping the "no persistence for temporary state" problem entirely since the object is never destroyed. Guardian-type summons are found by iterating `Unit::m_Controlled` directly (populated unconditionally for every minion/guardian), excluding totems and the already-handled pet/critter.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Sonnet 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26484

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Live-tested on a local build against the exact repro from the issue (Stormwind Wizard's Sanctum, area trigger 704, Dalaran-portal exit):
1. Companion critter (Giant Sewer Rat, spell 43698) - now crosses with the player instead of getting stuck.
2. DK Raise Dead ghoul without Master of Ghouls (a Guardian-type summon) - now crosses with the player instead of being lost.

Went through several iterations live-testing each summon type individually before landing on the `m_Controlled`-based approach for guardians - an earlier attempt using `GetGuardianPet()` didn't catch this specific ghoul.

https://github.com/user-attachments/assets/12f2ff1e-443b-4b96-b1d1-a583bfbd38ae

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Summon a companion/vanity critter (e.g. `.npc addvendor` or `/cast Giant Sewer Rat`, spell 43698), a duration-limited temporary pet, or (as a Death Knight without Master of Ghouls) a Raise Dead ghoul.
2. Walk from the Stormwind Wizard's Sanctum through the Dalaran portal exit (area trigger 704) - a same-map teleport, not a loading screen.
3. Confirm the summon relocates with you instead of being left behind or lost.

## Known Issues and TODO List:

- None

🤖 Generated with Claude Code (Sonnet 5)+AzerothMCP

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
