### PR TITLE
fix(Scripts/Ulduar): spawn Mimiron chest via map and stop friendly reset

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -758,10 +758,12 @@ struct boss_mimiron : public BossAI
                 // spawn chest
                 if (uint32 chestId = (_hardmode ? RAID_MODE(GO_MIMIRON_CHEST_HARD, GO_MIMIRON_CHEST_HERO_HARD) : RAID_MODE(GO_MIMIRON_CHEST, GO_MIMIRON_CHEST_HERO)))
                 {
-                    if (GameObject* go = me->SummonGameObject(chestId, 2744.65f, 2569.46f, 364.397f, 0, 0, 0, 0, 0, 0))
+                    // Summoned by the map, not Mimiron, so the chest survives his despawn during the outro.
+                    if (GameObject* go = me->GetMap()->SummonGameObject(chestId, 2744.65f, 2569.46f, 364.397f, 0, 0, 0, 0, 0, 0))
                     {
                         go->ReplaceAllGameObjectFlags((GameObjectFlags)0);
                         go->SetLootRecipient(me->GetMap());
+                        go->SetRespawnTime(7 * DAY);
                     }
                 }
                 events.ScheduleEvent(EVENT_DISAPPEAR, 9s);
@@ -786,6 +788,9 @@ struct boss_mimiron : public BossAI
 
     void EnterEvadeMode(EvadeReason why) override
     {
+        // Once Mimiron turns friendly for the defeat RP, don't reset the encounter.
+        if (me->GetFaction() == FACTION_FRIENDLY)
+            return;
         if (_isEvading)
             return;
         _isEvading = true;


### PR DESCRIPTION
## Changes Proposed:
Two fixes to the Mimiron encounter in Ulduar:

- The loot cache is now summoned by the map (`me->GetMap()->SummonGameObject`) instead of by Mimiron himself. Objects owned by a creature are removed when that creature is destroyed, so the previous creature-owned chest disappeared when Mimiron despawns at the end of the defeat RP. It is now given a 7-day respawn.
- `EnterEvadeMode` returns early while Mimiron is `FACTION_FRIENDLY`. During the defeat RP he turns friendly, after which `SelectTargetFromPlayerList` finds no hostile players and the out-of-combat check would fire an evade, resetting the encounter mid-outro.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used partially in preparing this pull request (Claude Opus 4.8).

## Issues Addressed:
- Closes #26107

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

1. Enter Ulduar and engage Mimiron (any difficulty / hard mode).
2. Defeat him and let the outro RP play out fully. He should not turn hostile or reset.
3. Confirm the loot cache spawns and stays in the world after Mimiron despawns.
4. Loot the chest and confirm the correct cache spawned for the difficulty/hard mode.

## Known Issues and TODO List:

- [ ]
