### PR TITLE
fix(DB/Loot): split Kel'Thuzad reference loot to pools

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1783316518108834675.sql
+++ b/data/sql/updates/pending_db_world/rev_1783316518108834675.sql
@@ -1,0 +1,25 @@
+-- Kel'Thuzad 25-player loot pool structure fix.
+
+UPDATE `creature_loot_template` SET `MinCount`=1, `MaxCount`=1
+  WHERE `Entry`=30061 AND `Item`=1 AND `Reference`=34136;
+
+-- Pool A (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34136 AND `Item`=40384; -- Betrayer of Humanity
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34136 AND `Item`=40387; -- Boundless Ambition
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34136 AND `Item`=40383; -- Calamity's Grasp
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34136 AND `Item`=40386; -- Sinister Revenge
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34136 AND `Item`=40385; -- Envoy of Mortality
+
+-- Pool B (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34136 AND `Item`=40405; -- Cape of the Unworthy Wizard
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34136 AND `Item`=40403; -- Drape of the Deadly Foe
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34136 AND `Item`=40402; -- Last Laugh
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34136 AND `Item`=40401; -- Voice of Reason
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34136 AND `Item`=40400; -- Wall of Terror
+
+-- Pool C (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34136 AND `Item`=40388; -- Journey's End
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34136 AND `Item`=40399; -- Signet of Manifested Pain
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34136 AND `Item`=40395; -- Torch of Holy Fire
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34136 AND `Item`=40398; -- Leggings of Mortal Arrogance
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34136 AND `Item`=40396; -- The Turning Tide


### PR DESCRIPTION
Resolves https://github.com/azerothcore/azerothcore-wotlk/issues/26267

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Split Kel'Thuzad loot into 3 pools with 5 items each.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Codex with GPT-5.5 Medium

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26267

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Validation present in the referenced issue.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested using the `.debug loot` command to test for distribution.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Steps to test (kill Kel'Thuzad) are present in the issue. Alternatively the `.debug loot` command can be used.

I ran 50 simulations before and after the change locally.

1. Run `.debug loot creature 30061 50`
2. Compare the loot distribution


Attached are screenshots with the simulation output for before and after. The tokens for the helm continue to drop 2x each kill.



Prior to the change you would receive less or more than a 50 count in each pool.



| Pool | Combined Drops |
| --- | --- |
| A | 42 |
| B | 47 |
| C | 61|
<img width="692" height="494" alt="kt_loot_50_sim" src="https://github.com/user-attachments/assets/43d48d34-aa29-417e-94ff-67ff3e4a1ff0" />

After the change you should see 50 total drops from each pool. 

| Pool | Combined Drops |
| --- | --- |
| A | 50 |
| B | 50 |
| C | 50|
<img width="769" height="533" alt="kt_loot_50_sim_fixed" src="https://github.com/user-attachments/assets/b8073877-3821-47bc-9ae4-2bbdc5938738" />

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
