### PR TITLE
Core/Maps: Implement Multi-threaded Map Partitioning

### DIFF
--- a/src/common/Collision/DynamicTree.cpp
+++ b/src/common/Collision/DynamicTree.cpp
@@ -30,6 +30,7 @@
 #include <G3D/AABox.h>
 #include <G3D/Ray.h>
 #include <G3D/Vector3.h>
+#include <mutex>
 
 using VMAP::ModelInstance;
 

--- a/src/common/Collision/DynamicTree.cpp
+++ b/src/common/Collision/DynamicTree.cpp
@@ -116,31 +116,40 @@ DynamicMapTree::~DynamicMapTree()
 
 void DynamicMapTree::insert(const GameObjectModel& mdl)
 {
+    // Exclusive lock because Transports can move concurrently across map partitions
+    std::unique_lock<std::shared_mutex> lock(_lock);
     impl->insert(mdl);
 }
 
 void DynamicMapTree::remove(const GameObjectModel& mdl)
 {
+    // Exclusive lock because Transports can move concurrently across map partitions
+    std::unique_lock<std::shared_mutex> lock(_lock);
     impl->remove(mdl);
 }
 
 bool DynamicMapTree::contains(const GameObjectModel& mdl) const
 {
+    std::shared_lock<std::shared_mutex> lock(_lock);
     return impl->contains(mdl);
 }
 
 void DynamicMapTree::balance()
 {
+    // Exclusive lock to rebalance collision tree safely
+    std::unique_lock<std::shared_mutex> lock(_lock);
     impl->balance();
 }
 
 int DynamicMapTree::size() const
 {
+    std::shared_lock<std::shared_mutex> lock(_lock);
     return impl->size();
 }
 
 void DynamicMapTree::update(uint32 t_diff)
 {
+    std::unique_lock<std::shared_mutex> lock(_lock);
     impl->update(t_diff);
 }
 
@@ -198,6 +207,8 @@ private:
 
 bool DynamicMapTree::GetIntersectionTime(const uint32 phasemask, const G3D::Ray& ray, const G3D::Vector3& endPos, float& maxDist) const
 {
+    // Shared lock to allow concurrent reads across map partitions
+    std::shared_lock<std::shared_mutex> lock(_lock);
     float distance = maxDist;
     DynamicTreeIntersectionCallback callback(phasemask, VMAP::ModelIgnoreFlags::Nothing);
     impl->intersectRay(ray, callback, distance, endPos, false);
@@ -212,6 +223,8 @@ bool DynamicMapTree::GetObjectHitPos(const uint32 phasemask, const G3D::Vector3&
                                      const G3D::Vector3& endPos, G3D::Vector3& resultHit,
                                      float modifyDist) const
 {
+    // no Map Partition lock here as shared_mutex is not recursive
+    // this will call GetIntersectionTime internally which will get the lock for us
     bool result = false;
     float maxDist = (endPos - startPos).magnitude();
     // valid map coords should *never ever* produce float overflow, but this would produce NaNs too
@@ -256,6 +269,8 @@ bool DynamicMapTree::GetObjectHitPos(const uint32 phasemask, const G3D::Vector3&
 
 bool DynamicMapTree::isInLineOfSight(float x1, float y1, float z1, float x2, float y2, float z2, uint32 phasemask, VMAP::ModelIgnoreFlags ignoreFlags) const
 {
+    // Shared lock to allow concurrent reads across map partitions
+    std::shared_lock<std::shared_mutex> lock(_lock);
     G3D::Vector3 v1(x1, y1, z1), v2(x2, y2, z2);
 
     float maxDist = (v2 - v1).magnitude();
@@ -274,6 +289,8 @@ bool DynamicMapTree::isInLineOfSight(float x1, float y1, float z1, float x2, flo
 
 float DynamicMapTree::getHeight(float x, float y, float z, float maxSearchDist, uint32 phasemask) const
 {
+    // Shared lock to allow concurrent reads across map partitions
+    std::shared_lock<std::shared_mutex> lock(_lock);
     G3D::Vector3 v(x, y, z);
     G3D::Ray r(v, G3D::Vector3(0, 0, -1));
     DynamicTreeIntersectionCallback callback(phasemask, VMAP::ModelIgnoreFlags::Nothing);
@@ -291,6 +308,8 @@ float DynamicMapTree::getHeight(float x, float y, float z, float maxSearchDist, 
 
 bool DynamicMapTree::GetAreaAndLiquidData(float x, float y, float z, uint32 phasemask, Optional<uint8> reqLiquidType, VMAP::AreaAndLiquidData& data) const
 {
+    // Shared lock to allow concurrent reads across map partitions
+    std::shared_lock<std::shared_mutex> lock(_lock);
     G3D::Vector3 v(x, y, z + 0.5f);
     DynamicTreeLocationInfoCallback intersectionCallBack(phasemask);
     impl->intersectPoint(v, intersectionCallBack);

--- a/src/common/Collision/DynamicTree.h
+++ b/src/common/Collision/DynamicTree.h
@@ -20,6 +20,7 @@
 
 #include "Define.h"
 #include "Optional.h"
+#include <shared_mutex>
 
 namespace G3D
 {
@@ -39,6 +40,8 @@ struct DynTreeImpl;
 class DynamicMapTree
 {
     DynTreeImpl* impl;
+    // Using shared_mutex to allow infinite reads but locks for writing to prevent G3D::Table from getting corrupted
+    mutable std::shared_mutex _lock;
 
 public:
     DynamicMapTree();

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -94,6 +94,7 @@ class Unit;
 class Transport;
 class StaticTransport;
 class MotionTransport;
+class MapPartition;
 
 struct PositionFullTerrainStatus;
 
@@ -431,6 +432,7 @@ private:
 class UpdatableMapObject
 {
     friend class Map;
+    friend class MapPartition;
 
 public:
     enum UpdateState : uint8

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -521,7 +521,11 @@ void Unit::Update(uint32 p_time)
             {
                 m_delayed_unit_relocation_timer = 0;
                 //ExecuteDelayedUnitRelocationEvent();
-                FindMap()->i_objectsForDelayedVisibility.insert(this);
+                {
+                    // Locks the maps delayed visibility list to prevent concurrent unordered_set corruption
+                    std::lock_guard<std::mutex> lock(FindMap()->_delayedVisibilityLock);
+                    FindMap()->i_objectsForDelayedVisibility.insert(this);
+                }
             }
             else
                 m_delayed_unit_relocation_timer -= p_time;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -44,6 +44,7 @@
 #include "VMapMgr2.h"
 #include "Weather.h"
 #include "WeatherMgr.h"
+#include "MapPartition.h"
 
 #define MAP_INVALID_ZONE        0xFFFFFFFF
 
@@ -62,6 +63,12 @@ Map::~Map()
 
     if (!m_scriptSchedule.empty())
         sScriptMgr->DecreaseScheduledScriptCount(m_scriptSchedule.size());
+
+    for (MapPartition* partition : _partitions)
+    {
+        delete partition;
+    }
+    _partitions.clear();
 }
 
 Map::Map(uint32 id, uint32 InstanceId, uint8 SpawnMode, Map* _parent) :
@@ -80,6 +87,13 @@ Map::Map(uint32 id, uint32 InstanceId, uint8 SpawnMode, Map* _parent) :
 
     _weatherUpdateTimer.SetInterval(1 * IN_MILLISECONDS);
     _corpseUpdateTimer.SetInterval(20 * MINUTE * IN_MILLISECONDS);
+
+    // Splits the 64x64 map grid into 4 quadrants, this is good for 4 core cpu
+    // Can expand the num of partitions, but they should be equal to the num of cpu cores the server is run on
+    _partitions.push_back(new MapPartition(this, 0, 31, 0, 31)); //Northwest
+    _partitions.push_back(new MapPartition(this, 32, 63, 0, 31)); //Northeast
+    _partitions.push_back(new MapPartition(this, 0, 31, 32, 63)); //Southwest
+    _partitions.push_back(new MapPartition(this, 32, 63, 32, 63)); //Southeast
 }
 
 // Hook called after map is created AND after added to map list
@@ -3522,4 +3536,17 @@ std::string InstanceMap::GetDebugInfo() const
         << std::boolalpha
         << "ScriptId: " << GetScriptId() << " ScriptName: " << GetScriptName();
     return sstr.str();
+}
+
+// Finds which of the partitions the coordniates belongs to
+MapPartition* Map::GetPartition(uint16 gridX, uint16 gridY)
+{
+    for (MapPartition* partition : _partitions)
+    {
+        if (partition->Contains(gridX, gridY))
+        {
+            return partition;
+        }
+    }
+    return nullptr;
 }

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -546,27 +546,6 @@ void Map::Update(const uint32 t_diff, const uint32 s_diff, bool  /*thread*/)
 
 void Map::UpdateNonPlayerObjects(uint32 const diff)
 {
-    for (WorldObject* obj : _pendingAddUpdatableObjectList)
-    {
-        UpdatableMapObject* mapUpdatableObject = dynamic_cast<UpdatableMapObject*>(obj);
-        if (mapUpdatableObject)
-        {
-            mapUpdatableObject->SetUpdateState(UpdatableMapObject::UpdateState::Updating);
-
-            // Convert World Coordinates to Grid Coordinates
-            GridCoord coord = Acore::ComputeGridCoord(obj->GetPositionX(), obj->GetPositionY());
-
-            // Find the partition the coords reside in and push the object to the transfer list
-            MapPartition* p = GetPartition(coord.x_coord, coord.y_coord);
-            if (p)
-            {
-                p->QueueTransfer(obj);
-            }
-        }
-    }
-
-    _pendingAddUpdatableObjectList.clear();
-
     // Fork-Join Model Multithreading
     // Dispatches partitions simultaniously to C++ async thread pool
     std::vector<std::future<void>> futures;
@@ -584,7 +563,6 @@ void Map::UpdateNonPlayerObjects(uint32 const diff)
     {
         future.wait();
     }
-
 }
 
 void Map::AddObjectToPendingUpdateList(WorldObject* obj)
@@ -596,8 +574,13 @@ void Map::AddObjectToPendingUpdateList(WorldObject* obj)
     if (!mapUpdatableObject || mapUpdatableObject->GetUpdateState() != UpdatableMapObject::UpdateState::NotUpdating)
         return;
 
-    _pendingAddUpdatableObjectList.insert(obj);
-    mapUpdatableObject->SetUpdateState(UpdatableMapObject::UpdateState::PendingAdd);
+    GridCoord coord = Acore::ComputeGridCoord(obj->GetPositionX(), obj->GetPositionY());
+    MapPartition* p = GetPartition(coord.x_coord, coord.y_coord);
+    if (p)
+    {
+        mapUpdatableObject->SetUpdateState(UpdatableMapObject::UpdateState::Updating);
+        p->QueueTransfer(obj);
+    }
 }
 
 // Internal use only

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -45,6 +45,7 @@
 #include "Weather.h"
 #include "WeatherMgr.h"
 #include "MapPartition.h"
+#include <future>
 
 #define MAP_INVALID_ZONE        0xFFFFFFFF
 
@@ -546,44 +547,44 @@ void Map::Update(const uint32 t_diff, const uint32 s_diff, bool  /*thread*/)
 void Map::UpdateNonPlayerObjects(uint32 const diff)
 {
     for (WorldObject* obj : _pendingAddUpdatableObjectList)
-        _AddObjectToUpdateList(obj);
+    {
+        UpdatableMapObject* mapUpdatableObject = dynamic_cast<UpdatableMapObject*>(obj);
+        if (mapUpdatableObject)
+        {
+            mapUpdatableObject->SetUpdateState(UpdatableMapObject::UpdateState::Updating);
+        }
+
+        // Convert World Coordinates to Grid Coordinates
+        GridCoord coord = Acore::ComputeGridCoord(obj->GetPositionX(), obj->GetPositionY());
+
+        // Find the partition the coords reside in and push the object to the transfer list
+        MapPartition* p = GetPartition(coord.x_coord, coord.y_coord);
+        if (p)
+        {
+            p->QueueTransfer(obj);
+        }
+    }
+
     _pendingAddUpdatableObjectList.clear();
 
-    if (_updatableObjectListRecheckTimer.Passed())
+    // Fork-Join Model Multithreading
+    // Dispatches partitions simultaniously to C++ async thread pool
+    std::vector<std::future<void>> futures;
+    for (MapPartition* partition : _partitions)
     {
-        for (uint32 i = 0; i < _updatableObjectList.size();)
+        futures.push_back(std::async(std::launch::async, [partition, diff]()
         {
-            WorldObject* obj = _updatableObjectList[i];
-            if (!obj->IsInWorld())
-            {
-                ++i;
-                continue;
-            }
-
-            obj->Update(diff);
-
-            if (!obj->IsUpdateNeeded())
-            {
-                _RemoveObjectFromUpdateList(obj);
-                // Intentional no iteration here, obj is swapped with last element in
-                // _updatableObjectList so next loop will update that object at the same index
-            }
-            else
-                ++i;
-        }
-        _updatableObjectListRecheckTimer.Reset();
+            // Runs on seperate cpu thread
+            partition->Update(diff);
+        }));
     }
-    else
+
+    // stop master thread until cores finish calculations
+    for (auto& future : futures)
     {
-        for (uint32 i = 0; i < _updatableObjectList.size(); ++i)
-        {
-            WorldObject* obj = _updatableObjectList[i];
-            if (!obj->IsInWorld())
-                continue;
-
-            obj->Update(diff);
-        }
+        future.wait();
     }
+
 }
 
 void Map::AddObjectToPendingUpdateList(WorldObject* obj)

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -194,11 +194,15 @@ void Map::DeleteFromWorld(Player* player)
 
 void Map::EnsureGridCreated(GridCoord const& gridCoord)
 {
+    // prevent concurrent MapGridManager memory corruption
+    std::lock_guard<std::recursive_mutex> lock(_gridLock);
     _mapGridManager.CreateGrid(gridCoord.x_coord, gridCoord.y_coord);
 }
 
 bool Map::EnsureGridLoaded(Cell const& cell)
 {
+    // prevent concurrent NavMesh corruption from addTile()
+    std::lock_guard<std::recursive_mutex> lock(_gridLock);
     EnsureGridCreated(GridCoord(cell.GridX(), cell.GridY()));
 
     if (_mapGridManager.LoadGrid(cell.GridX(), cell.GridY()))
@@ -696,11 +700,17 @@ ZoneWideVisibleWorldObjectsSet const* Map::GetZoneWideVisibleWorldObjectsForZone
 
 void Map::HandleDelayedVisibility()
 {
-    if (i_objectsForDelayedVisibility.empty())
-        return;
-    for (std::unordered_set<Unit*>::iterator itr = i_objectsForDelayedVisibility.begin(); itr != i_objectsForDelayedVisibility.end(); ++itr)
+    std::unordered_set<Unit*> localCopy;
+    {
+        // Lock set and safely move the contents to a local copy to prevent deadlocks
+        std::lock_guard<std::mutex> lock(_delayedVisibilityLock);
+        if (i_objectsForDelayedVisibility.empty())
+            return;
+        localCopy = std::move(i_objectsForDelayedVisibility);
+    }
+    
+    for (std::unordered_set<Unit*>::iterator itr = localCopy.begin(); itr != localCopy.end(); ++itr)
         (*itr)->ExecuteDelayedUnitRelocationEvent();
-    i_objectsForDelayedVisibility.clear();
 }
 
 struct ResetNotifier
@@ -827,9 +837,7 @@ void Map::CreatureRelocation(Creature* creature, float x, float y, float z, floa
 
     if (old_cell.DiffGrid(new_cell) || old_cell.DiffCell(new_cell))
     {
-        if (old_cell.DiffGrid(new_cell))
-            EnsureGridLoaded(new_cell);
-
+        //Removed EnsureGridLoaded(new_cell), runs syncronously in MoveAllCreatures later and will corrupt pathfinding if ran here
         AddCreatureToMoveList(creature);
     }
     else
@@ -849,9 +857,7 @@ void Map::GameObjectRelocation(GameObject* go, float x, float y, float z, float 
 
     if (old_cell.DiffGrid(new_cell) || old_cell.DiffCell(new_cell))
     {
-        if (old_cell.DiffGrid(new_cell))
-            EnsureGridLoaded(new_cell);
-
+        //Removed EnsureGridLoaded(new_cell), runs syncronously in MoveAllCreatures later and will corrupt pathfinding if ran here
         AddGameObjectToMoveList(go);
     }
     else
@@ -885,6 +891,7 @@ void Map::DynamicObjectRelocation(DynamicObject* dynObj, float x, float y, float
 
 void Map::AddCreatureToMoveList(Creature* c)
 {
+    std::lock_guard<std::mutex> lock(_moveListLock);
     if (c->_moveState == MAP_OBJECT_CELL_MOVE_NONE)
         _creaturesToMove.push_back(c);
     c->_moveState = MAP_OBJECT_CELL_MOVE_ACTIVE;
@@ -898,6 +905,7 @@ void Map::RemoveCreatureFromMoveList(Creature* c)
 
 void Map::AddGameObjectToMoveList(GameObject* go)
 {
+    std::lock_guard<std::mutex> lock(_moveListLock);
     if (go->_moveState == MAP_OBJECT_CELL_MOVE_NONE)
         _gameObjectsToMove.push_back(go);
     go->_moveState = MAP_OBJECT_CELL_MOVE_ACTIVE;
@@ -911,6 +919,7 @@ void Map::RemoveGameObjectFromMoveList(GameObject* go)
 
 void Map::AddDynamicObjectToMoveList(DynamicObject* dynObj)
 {
+    std::lock_guard<std::mutex> lock(_moveListLock);
     if (dynObj->_moveState == MAP_OBJECT_CELL_MOVE_NONE)
         _dynamicObjectsToMove.push_back(dynObj);
     dynObj->_moveState = MAP_OBJECT_CELL_MOVE_ACTIVE;
@@ -1022,6 +1031,8 @@ void Map::MoveAllDynamicObjectsInMoveList()
 
 bool Map::UnloadGrid(MapGridType& grid)
 {
+    // prevent concurrent NavMesh corruption from removeTile()
+    std::lock_guard<std::recursive_mutex> lock(_gridLock);
     _mapGridManager.UnloadGrid(grid.GetX(), grid.GetY());
 
     ASSERT(i_objectsToRemove.empty());

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -626,9 +626,7 @@ void Map::RemoveObjectFromMapUpdateList(WorldObject* obj)
         _pendingAddUpdatableObjectList.erase(obj);
     else if (mapUpdatableObject->GetUpdateState() == UpdatableMapObject::UpdateState::Updating)
     {
-        GridCoord coord = Acore::ComputeGridCoord(obj->GetPositionX(), obj->GetPositionY());
-        MapPartition* p = GetPartition(coord.x_coord, coord.y_coord);
-        if (p)
+        for (MapPartition* p : _partitions)
         {
             p->RemoveObject(obj);
         }

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -552,16 +552,16 @@ void Map::UpdateNonPlayerObjects(uint32 const diff)
         if (mapUpdatableObject)
         {
             mapUpdatableObject->SetUpdateState(UpdatableMapObject::UpdateState::Updating);
-        }
 
-        // Convert World Coordinates to Grid Coordinates
-        GridCoord coord = Acore::ComputeGridCoord(obj->GetPositionX(), obj->GetPositionY());
+            // Convert World Coordinates to Grid Coordinates
+            GridCoord coord = Acore::ComputeGridCoord(obj->GetPositionX(), obj->GetPositionY());
 
-        // Find the partition the coords reside in and push the object to the transfer list
-        MapPartition* p = GetPartition(coord.x_coord, coord.y_coord);
-        if (p)
-        {
-            p->QueueTransfer(obj);
+            // Find the partition the coords reside in and push the object to the transfer list
+            MapPartition* p = GetPartition(coord.x_coord, coord.y_coord);
+            if (p)
+            {
+                p->QueueTransfer(obj);
+            }
         }
     }
 
@@ -633,10 +633,19 @@ void Map::RemoveObjectFromMapUpdateList(WorldObject* obj)
         return;
 
     UpdatableMapObject* mapUpdatableObject = dynamic_cast<UpdatableMapObject*>(obj);
+    if (!mapUpdatableObject)
+        return;
     if (mapUpdatableObject->GetUpdateState() == UpdatableMapObject::UpdateState::PendingAdd)
         _pendingAddUpdatableObjectList.erase(obj);
     else if (mapUpdatableObject->GetUpdateState() == UpdatableMapObject::UpdateState::Updating)
-        _RemoveObjectFromUpdateList(obj);
+    {
+        GridCoord coord = Acore::ComputeGridCoord(obj->GetPositionX(), obj->GetPositionY());
+        MapPartition* p = GetPartition(coord.x_coord, coord.y_coord);
+        if (p)
+        {
+            p->RemoveObject(obj);
+        }
+    }
 }
 
 // Used in VisibilityDistanceType::Large and VisibilityDistanceType::Gigantic

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -565,7 +565,7 @@ void Map::UpdateNonPlayerObjects(uint32 const diff)
     // stop master thread until cores finish calculations
     for (auto& future : futures)
     {
-        future.wait();
+        future.get();
     }
 }
 
@@ -706,7 +706,7 @@ void Map::HandleDelayedVisibility()
             return;
         localCopy = std::move(i_objectsForDelayedVisibility);
     }
-    
+
     for (std::unordered_set<Unit*>::iterator itr = localCopy.begin(); itr != localCopy.end(); ++itr)
         (*itr)->ExecuteDelayedUnitRelocationEvent();
 }

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -64,12 +64,6 @@ Map::~Map()
 
     if (!m_scriptSchedule.empty())
         sScriptMgr->DecreaseScheduledScriptCount(m_scriptSchedule.size());
-
-    for (MapPartition* partition : _partitions)
-    {
-        delete partition;
-    }
-    _partitions.clear();
 }
 
 Map::Map(uint32 id, uint32 InstanceId, uint8 SpawnMode, Map* _parent) :
@@ -91,10 +85,10 @@ Map::Map(uint32 id, uint32 InstanceId, uint8 SpawnMode, Map* _parent) :
 
     // Splits the 64x64 map grid into 4 quadrants, this is good for 4 core cpu
     // Can expand the num of partitions, but they should be equal to the num of cpu cores the server is run on
-    _partitions.push_back(new MapPartition(this, 0, 31, 0, 31)); //Northwest
-    _partitions.push_back(new MapPartition(this, 32, 63, 0, 31)); //Northeast
-    _partitions.push_back(new MapPartition(this, 0, 31, 32, 63)); //Southwest
-    _partitions.push_back(new MapPartition(this, 32, 63, 32, 63)); //Southeast
+    _partitions.push_back(std::make_unique<MapPartition>(this, 0, 31, 0, 31)); //Northwest
+    _partitions.push_back(std::make_unique<MapPartition>(this, 32, 63, 0, 31)); //Northeast
+    _partitions.push_back(std::make_unique<MapPartition>(this, 0, 31, 32, 63)); //Southwest
+    _partitions.push_back(std::make_unique<MapPartition>(this, 32, 63, 32, 63)); //Southeast
 }
 
 // Hook called after map is created AND after added to map list
@@ -551,14 +545,15 @@ void Map::Update(const uint32 t_diff, const uint32 s_diff, bool  /*thread*/)
 void Map::UpdateNonPlayerObjects(uint32 const diff)
 {
     // Fork-Join Model Multithreading
-    // Dispatches partitions simultaniously to C++ async thread pool
+    // Dispatches partitions simultaneously to C++ async thread pool
     std::vector<std::future<void>> futures;
-    for (MapPartition* partition : _partitions)
+    for (auto& partition : _partitions)
     {
-        futures.push_back(std::async(std::launch::async, [partition, diff]()
+        MapPartition* rawPartition = partition.get();
+        futures.push_back(std::async(std::launch::async, [rawPartition, diff]()
         {
-            // Runs on seperate cpu thread
-            partition->Update(diff);
+            // Runs on separate cpu thread
+            rawPartition->Update(diff);
         }));
     }
 
@@ -587,33 +582,6 @@ void Map::AddObjectToPendingUpdateList(WorldObject* obj)
     }
 }
 
-// Internal use only
-void Map::_AddObjectToUpdateList(WorldObject* obj)
-{
-    UpdatableMapObject* mapUpdatableObject = dynamic_cast<UpdatableMapObject*>(obj);
-    ASSERT(mapUpdatableObject && mapUpdatableObject->GetUpdateState() == UpdatableMapObject::UpdateState::PendingAdd);
-
-    mapUpdatableObject->SetUpdateState(UpdatableMapObject::UpdateState::Updating);
-    mapUpdatableObject->SetMapUpdateListOffset(_updatableObjectList.size());
-    _updatableObjectList.push_back(obj);
-}
-
-// Internal use only
-void Map::_RemoveObjectFromUpdateList(WorldObject* obj)
-{
-    UpdatableMapObject* mapUpdatableObject = dynamic_cast<UpdatableMapObject*>(obj);
-    ASSERT(mapUpdatableObject && mapUpdatableObject->GetUpdateState() == UpdatableMapObject::UpdateState::Updating);
-
-    if (obj != _updatableObjectList.back())
-    {
-        dynamic_cast<UpdatableMapObject*>(_updatableObjectList.back())->SetMapUpdateListOffset(mapUpdatableObject->GetMapUpdateListOffset());
-        std::swap(_updatableObjectList[mapUpdatableObject->GetMapUpdateListOffset()], _updatableObjectList.back());
-    }
-
-    _updatableObjectList.pop_back();
-    mapUpdatableObject->SetUpdateState(UpdatableMapObject::UpdateState::NotUpdating);
-}
-
 void Map::RemoveObjectFromMapUpdateList(WorldObject* obj)
 {
     if (!obj->CanBeAddedToMapUpdateList())
@@ -622,11 +590,9 @@ void Map::RemoveObjectFromMapUpdateList(WorldObject* obj)
     UpdatableMapObject* mapUpdatableObject = dynamic_cast<UpdatableMapObject*>(obj);
     if (!mapUpdatableObject)
         return;
-    if (mapUpdatableObject->GetUpdateState() == UpdatableMapObject::UpdateState::PendingAdd)
-        _pendingAddUpdatableObjectList.erase(obj);
-    else if (mapUpdatableObject->GetUpdateState() == UpdatableMapObject::UpdateState::Updating)
+    if (mapUpdatableObject->GetUpdateState() == UpdatableMapObject::UpdateState::Updating)
     {
-        for (MapPartition* p : _partitions)
+        for (auto& p : _partitions)
         {
             p->RemoveObject(obj);
         }
@@ -835,7 +801,7 @@ void Map::CreatureRelocation(Creature* creature, float x, float y, float z, floa
 
     if (old_cell.DiffGrid(new_cell) || old_cell.DiffCell(new_cell))
     {
-        //Removed EnsureGridLoaded(new_cell), runs syncronously in MoveAllCreatures later and will corrupt pathfinding if ran here
+        EnsureGridLoaded(new_cell);
         AddCreatureToMoveList(creature);
     }
     else
@@ -855,7 +821,7 @@ void Map::GameObjectRelocation(GameObject* go, float x, float y, float z, float 
 
     if (old_cell.DiffGrid(new_cell) || old_cell.DiffCell(new_cell))
     {
-        //Removed EnsureGridLoaded(new_cell), runs syncronously in MoveAllCreatures later and will corrupt pathfinding if ran here
+        EnsureGridLoaded(new_cell);
         AddGameObjectToMoveList(go);
     }
     else
@@ -3540,15 +3506,23 @@ std::string InstanceMap::GetDebugInfo() const
     return sstr.str();
 }
 
-// Finds which of the partitions the coordniates belongs to
+// Finds which of the partitions the coordinates belongs to
 MapPartition* Map::GetPartition(uint16 gridX, uint16 gridY)
 {
-    for (MapPartition* partition : _partitions)
+    for (auto& partition : _partitions)
     {
         if (partition->Contains(gridX, gridY))
         {
-            return partition;
+            return partition.get();
         }
     }
     return nullptr;
+}
+
+size_t Map::GetUpdatableObjectsCount() const
+{
+    size_t count = 0;
+    for (auto const& p : _partitions)
+        count += p->GetUpdatableObjectsCount();
+    return count;
 }

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -67,6 +67,7 @@ class StaticTransport;
 class MotionTransport;
 class PathGenerator;
 class WorldSession;
+class MapPartition;
 
 enum WeatherState : uint32;
 
@@ -564,6 +565,9 @@ public:
     MapCollisionData& GetMapCollisionData() { return _mapCollisionData; }
     MapCollisionData const& GetMapCollisionData()  const { return _mapCollisionData; }
 
+    MapPartition* GetPartition(uint16 gridX, uint16 gridY);
+    std::vector<MapPartition*> const& GetPartitions() const { return _partitions; }
+
 private:
 
     template<class T> void InitializeObject(T* obj);
@@ -577,6 +581,7 @@ private:
     std::vector<Creature*> _creaturesToMove;
     std::vector<GameObject*> _gameObjectsToMove;
     std::vector<DynamicObject*> _dynamicObjectsToMove;
+    std::vector<MapPartition*> _partitions;
 
     bool EnsureGridLoaded(Cell const& cell);
     MapGridType* GetMapGrid(uint16 const x, uint16 const y);

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -704,7 +704,7 @@ private:
     std::mutex _updateObjectsLock;
     // protects _creaturesToMove, _gameObjectsToMove, _dynamicObjectsToMove when mutliple partitions trigger object relocations concurrently
     std::mutex _moveListLock;
-    
+
     std::unordered_set<Object*> _updateObjects;
 
     UpdatableObjectList _updatableObjectList;

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -536,7 +536,7 @@ public:
         _updateObjects.erase(obj);
     }
 
-    size_t GetUpdatableObjectsCount() const { return _updatableObjectList.size(); }
+    size_t GetUpdatableObjectsCount() const;
 
     virtual std::string GetDebugInfo() const;
 
@@ -569,7 +569,7 @@ public:
     MapCollisionData const& GetMapCollisionData()  const { return _mapCollisionData; }
 
     MapPartition* GetPartition(uint16 gridX, uint16 gridY);
-    std::vector<MapPartition*> const& GetPartitions() const { return _partitions; }
+    std::vector<std::unique_ptr<MapPartition>> const& GetPartitions() const { return _partitions; }
 
     // protects i_objectsForDelayedVisibility when multiple partitions Uint::Update call insert() concurrently
     std::mutex _delayedVisibilityLock;
@@ -589,7 +589,7 @@ private:
     std::vector<Creature*> _creaturesToMove;
     std::vector<GameObject*> _gameObjectsToMove;
     std::vector<DynamicObject*> _dynamicObjectsToMove;
-    std::vector<MapPartition*> _partitions;
+    std::vector<std::unique_ptr<MapPartition>> _partitions;
 
     bool EnsureGridLoaded(Cell const& cell);
     MapGridType* GetMapGrid(uint16 const x, uint16 const y);
@@ -647,9 +647,6 @@ private:
 
     void UpdateNonPlayerObjects(uint32 const diff);
 
-    void _AddObjectToUpdateList(WorldObject* obj);
-    void _RemoveObjectFromUpdateList(WorldObject* obj);
-
     std::unordered_map<ObjectGuid::LowType /*dbGUID*/, time_t> _creatureRespawnTimes;
     std::unordered_map<ObjectGuid::LowType /*dbGUID*/, time_t> _goRespawnTimes;
 
@@ -702,13 +699,11 @@ private:
 
     // mutex prevents unordered_set corruption during the multithreaded MapPartition updates
     std::mutex _updateObjectsLock;
-    // protects _creaturesToMove, _gameObjectsToMove, _dynamicObjectsToMove when mutliple partitions trigger object relocations concurrently
+    // protects _creaturesToMove, _gameObjectsToMove, _dynamicObjectsToMove when multiple partitions trigger object relocations concurrently
     std::mutex _moveListLock;
 
     std::unordered_set<Object*> _updateObjects;
 
-    UpdatableObjectList _updatableObjectList;
-    PendingAddUpdatableObjectList _pendingAddUpdatableObjectList;
     IntervalTimer _updatableObjectListRecheckTimer;
     ZoneWideVisibleWorldObjectsMap _zoneWideVisibleWorldObjectsMap;
 };

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -43,6 +43,7 @@
 #include <memory>
 #include <set>
 #include <shared_mutex>
+#include <mutex>
 
 class Unit;
 class WorldPacket;
@@ -525,11 +526,13 @@ public:
 
     void AddUpdateObject(Object* obj)
     {
+        std::lock_guard<std::mutex> lock(_updateObjectsLock);
         _updateObjects.insert(obj);
     }
 
     void RemoveUpdateObject(Object* obj)
     {
+        std::lock_guard<std::mutex> lock(_updateObjectsLock);
         _updateObjects.erase(obj);
     }
 
@@ -567,6 +570,11 @@ public:
 
     MapPartition* GetPartition(uint16 gridX, uint16 gridY);
     std::vector<MapPartition*> const& GetPartitions() const { return _partitions; }
+
+    // protects i_objectsForDelayedVisibility when multiple partitions Uint::Update call insert() concurrently
+    std::mutex _delayedVisibilityLock;
+    // protects MapGridManager and NavMesh from concurrent memory corruption and infinite loops
+    std::recursive_mutex _gridLock;
 
 private:
 
@@ -692,6 +700,11 @@ private:
     std::unordered_map<ObjectGuid, Corpse*> _corpsesByPlayer;
     std::unordered_set<Corpse*> _corpseBones;
 
+    // mutex prevents unordered_set corruption during the multithreaded MapPartition updates
+    std::mutex _updateObjectsLock;
+    // protects _creaturesToMove, _gameObjectsToMove, _dynamicObjectsToMove when mutliple partitions trigger object relocations concurrently
+    std::mutex _moveListLock;
+    
     std::unordered_set<Object*> _updateObjects;
 
     UpdatableObjectList _updatableObjectList;

--- a/src/server/game/Maps/MapPartition.cpp
+++ b/src/server/game/Maps/MapPartition.cpp
@@ -19,6 +19,11 @@
 #include "Map.h"
 #include "Object.h"
 #include <algorithm>
+#include "ObjectAccessor.h"
+#include "Player.h"
+#include "Pet.h"
+#include "DynamicObject.h"
+#include "Corpse.h"
 
 // Constructor: Initializes a MapPartition object with its parent map and grid boudnaries
 MapPartition::MapPartition(Map* parent, uint16 minGridX, uint16 maxGridX, uint16 minGridY, uint16 maxGridY)
@@ -45,7 +50,7 @@ void MapPartition::RemoveObject(WorldObject* obj)
     auto it = std::find(_updatableObjects.begin(), _updatableObjects.end(), obj);
     if (it != _updatableObjects.end())
     {
-        //overwrites the deleted object with the last object in the list and shrinks the list size by 1 
+        //overwrites the deleted object with the last object in the list and shrinks the list size by 1
         *it = _updatableObjects.back();
         _updatableObjects.pop_back();
 
@@ -60,16 +65,34 @@ void MapPartition::RemoveObject(WorldObject* obj)
 //Pushes a world object into the transfer queue
 void MapPartition::QueueTransfer(WorldObject* obj)
 {
-    _transferQueue.add(obj);
+    if(obj)
+    {
+        _transferQueue.add(obj->GetGUID());
+    }
 }
 
 // The core physics and AI update loop
 void MapPartition::Update(uint32 const diff)
 {
     //Add objects from transfer queue before starting updates
-    WorldObject* incomingObj = nullptr;
-    while (_transferQueue.next(incomingObj))
+    ObjectGuid incomingGuid;
+    while (_transferQueue.next(incomingGuid))
     {
+        WorldObject* incomingObj = nullptr;
+
+        switch (incomingGuid.GetHigh())
+        {
+        case HighGuid::Player: incomingObj = ObjectAccessor::FindPlayer(incomingGuid); break;
+        case HighGuid::Transport:
+        case HighGuid::Mo_Transport:
+        case HighGuid::GameObject: incomingObj = _parentMap->GetGameObject(incomingGuid); break;
+        case HighGuid::Vehicle:
+        case HighGuid::Unit: incomingObj = _parentMap->GetCreature(incomingGuid); break;
+        case HighGuid::Pet: incomingObj = _parentMap->GetPet(incomingGuid); break;
+        case HighGuid::DynamicObject: incomingObj = _parentMap->GetDynamicObject(incomingGuid); break;
+        case HighGuid::Corpse: incomingObj = _parentMap->GetCorpse(incomingGuid); break;
+        default: break;
+        }
         if (incomingObj && incomingObj->IsInWorld())
         {
             AddObject(incomingObj);
@@ -121,7 +144,8 @@ void MapPartition::Update(uint32 const diff)
 
             // intentionally skip ++i because RemoveObject swaps array elements
         }
-        else {
+        else
+        {
             // object gets updated and is still active, moves onto the next object
             ++i;
         }

--- a/src/server/game/Maps/MapPartition.cpp
+++ b/src/server/game/Maps/MapPartition.cpp
@@ -1,0 +1,86 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "MapPartition.h"
+#include "Map.h"
+#include "Object.h"
+#include <algorithm>
+
+// Constructor: Initializes a MapPartition object with its parent map and grid boudnaries
+MapPartition::MapPartition(Map* parent, uint16 minGridX, uint16 maxGridX, uint16 minGridY, uint16 maxGridY)
+    : _parentMap(parent), _minX(minGridX), _maxX(maxGridX), _minY(minGridY), _maxY(maxGridY)
+{
+}
+
+// Checks if a given coordinate is inside the partition
+bool MapPartition::Contains(uint16 gridX, uint16 gridY) const
+{
+    return (gridX >= _minX && gridX <= _maxX && gridY >= _minY && gridY <= _maxY);
+}
+
+// Adds a world object to be updated by this partition
+void MapPartition::AddObject(WorldObject* obj)
+{
+    _updatableObjects.push_back(obj);
+}
+
+// Removes a world object from being updated by this partition
+void MapPartition::RemoveObject(WorldObject* obj)
+{
+    // Finds the objects exact index in the vector
+    auto it = std::find(_updatableObjects.begin(), _updatableObjects.end(), obj);
+    if (it != _updatableObjects.end())
+    {
+        //overwrites the deleted object with the last object in the list and shrinks the list size by 1 
+        *it = _updatableObjects.back();
+        _updatableObjects.pop_back();
+    }
+}
+
+// The core physics and AI update loop
+void MapPartition::Update(uint32 const diff)
+{
+    // Conditionally increment i inside the loop to avoid skipping swaped elements
+    for (uint32 i = 0; i < _updatableObjects.size();)
+    {
+        WorldObject* obj = _updatableObjects[i];
+
+        // skips the loop if the object was deleted from memory or is not in the world
+        if (!obj || !obj->IsInWorld())
+        {
+            ++i;
+            continue;
+        }
+
+        // triggers combat, spellcasting, movement, and pathfinding calc here
+        obj->Update(diff);
+
+        // removes the entity from the active list if it does not need updating
+        if (!obj->IsUpdateNeeded())
+        {
+            RemoveObject(obj);
+
+            // intentionally not executing ++i here
+            // RemoveObject() swaps the deleted object with the last element of the array
+            // keeping i the same correctly processes the swapped elements
+        }
+        else {
+            // object gets updated and is still active, moves onto the next object
+            ++i;
+        }
+    }
+}

--- a/src/server/game/Maps/MapPartition.cpp
+++ b/src/server/game/Maps/MapPartition.cpp
@@ -51,9 +51,25 @@ void MapPartition::RemoveObject(WorldObject* obj)
     }
 }
 
+//Pushes a world object into the transfer queue
+void MapPartition::QueueTransfer(WorldObject* obj)
+{
+    _transferQueue.add(obj);
+}
+
 // The core physics and AI update loop
 void MapPartition::Update(uint32 const diff)
 {
+    //Add objects from transfer queue before starting updates
+    WorldObject* incomingObj = nullptr;
+    while (_transferQueue.next(incomingObj))
+    {
+        if (incomingObj && incomingObj->IsInWorld())
+        {
+            AddObject(incomingObj);
+        }
+    }
+
     // Conditionally increment i inside the loop to avoid skipping swaped elements
     for (uint32 i = 0; i < _updatableObjects.size();)
     {

--- a/src/server/game/Maps/MapPartition.cpp
+++ b/src/server/game/Maps/MapPartition.cpp
@@ -84,7 +84,7 @@ void MapPartition::Update(uint32 const diff)
         // skips the loop if the object was deleted from memory or is not in the world
         if (!obj || !obj->IsInWorld())
         {
-            ++i;
+            RemoveObject(obj);
             continue;
         }
 

--- a/src/server/game/Maps/MapPartition.cpp
+++ b/src/server/game/Maps/MapPartition.cpp
@@ -85,14 +85,30 @@ void MapPartition::Update(uint32 const diff)
         // triggers combat, spellcasting, movement, and pathfinding calc here
         obj->Update(diff);
 
+        // Check if the object is no longer within the partition
+        GridCoord currentGrid = Acore::ComputeGridCoord(obj->GetPositionX(), obj->GetPositionY());
+        if (!Contains(currentGrid.x_coord, currentGrid.y_coord))
+        {
+            // Remove object from partition if it is no longer inside the partition
+            RemoveObject(obj);
+
+            // Ask parent map what partition the object is in, then push the object to that partitions queue
+            MapPartition* newPartition = GetParent()->GetPartition(currentGrid.x_coord, currentGrid.y_coord);
+            if (newPartition)
+            {
+                newPartition->QueueTransfer(obj);
+            }
+
+            // intentionally skip ++i because RemoveObject swaps array elements
+            continue;
+        }
+
         // removes the entity from the active list if it does not need updating
         if (!obj->IsUpdateNeeded())
         {
             RemoveObject(obj);
 
-            // intentionally not executing ++i here
-            // RemoveObject() swaps the deleted object with the last element of the array
-            // keeping i the same correctly processes the swapped elements
+            // intentionally skip ++i because RemoveObject swaps array elements
         }
         else {
             // object gets updated and is still active, moves onto the next object

--- a/src/server/game/Maps/MapPartition.cpp
+++ b/src/server/game/Maps/MapPartition.cpp
@@ -25,7 +25,7 @@
 #include "DynamicObject.h"
 #include "Corpse.h"
 
-// Constructor: Initializes a MapPartition object with its parent map and grid boudnaries
+// Constructor: Initializes a MapPartition object with its parent map and grid boundaries
 MapPartition::MapPartition(Map* parent, uint16 minGridX, uint16 maxGridX, uint16 minGridY, uint16 maxGridY)
     : _parentMap(parent), _minX(minGridX), _maxX(maxGridX), _minY(minGridY), _maxY(maxGridY)
 {
@@ -44,7 +44,7 @@ void MapPartition::AddObject(WorldObject* obj)
 }
 
 // Removes a world object from being updated by this partition
-void MapPartition::RemoveObject(WorldObject* obj)
+bool MapPartition::RemoveObject(WorldObject* obj)
 {
     // Finds the objects exact index in the vector
     auto it = std::find(_updatableObjects.begin(), _updatableObjects.end(), obj);
@@ -54,12 +54,17 @@ void MapPartition::RemoveObject(WorldObject* obj)
         *it = _updatableObjects.back();
         _updatableObjects.pop_back();
 
-        UpdatableMapObject* mapUpdatableObject = dynamic_cast<UpdatableMapObject*>(obj);
-        if (mapUpdatableObject)
+        if (obj)
         {
-            mapUpdatableObject->SetUpdateState(UpdatableMapObject::UpdateState::NotUpdating);
+            UpdatableMapObject* mapUpdatableObject = dynamic_cast<UpdatableMapObject*>(obj);
+            if (mapUpdatableObject)
+            {
+                mapUpdatableObject->SetUpdateState(UpdatableMapObject::UpdateState::NotUpdating);
+            }
         }
+        return true;
     }
+    return false;
 }
 
 //Pushes a world object into the transfer queue
@@ -99,7 +104,7 @@ void MapPartition::Update(uint32 const diff)
         }
     }
 
-    // Conditionally increment i inside the loop to avoid skipping swaped elements
+    // Conditionally increment i inside the loop to avoid skipping swapped elements
     for (uint32 i = 0; i < _updatableObjects.size();)
     {
         WorldObject* obj = _updatableObjects[i];
@@ -107,7 +112,10 @@ void MapPartition::Update(uint32 const diff)
         // skips the loop if the object was deleted from memory or is not in the world
         if (!obj || !obj->IsInWorld())
         {
-            RemoveObject(obj);
+            if (!RemoveObject(obj))
+            {
+                ++i; // Forces increment to prevent infinite spin if obj isnt found
+            }
             continue;
         }
 

--- a/src/server/game/Maps/MapPartition.cpp
+++ b/src/server/game/Maps/MapPartition.cpp
@@ -65,7 +65,7 @@ void MapPartition::RemoveObject(WorldObject* obj)
 //Pushes a world object into the transfer queue
 void MapPartition::QueueTransfer(WorldObject* obj)
 {
-    if(obj)
+    if (obj)
     {
         _transferQueue.add(obj->GetGUID());
     }

--- a/src/server/game/Maps/MapPartition.cpp
+++ b/src/server/game/Maps/MapPartition.cpp
@@ -91,6 +91,11 @@ void MapPartition::Update(uint32 const diff)
         // triggers combat, spellcasting, movement, and pathfinding calc here
         obj->Update(diff);
 
+        if (i >= _updatableObjects.size() || _updatableObjects[i] != obj)
+        {
+            continue;
+        }
+
         // Check if the object is no longer within the partition
         GridCoord currentGrid = Acore::ComputeGridCoord(obj->GetPositionX(), obj->GetPositionY());
         if (!Contains(currentGrid.x_coord, currentGrid.y_coord))

--- a/src/server/game/Maps/MapPartition.cpp
+++ b/src/server/game/Maps/MapPartition.cpp
@@ -48,6 +48,12 @@ void MapPartition::RemoveObject(WorldObject* obj)
         //overwrites the deleted object with the last object in the list and shrinks the list size by 1 
         *it = _updatableObjects.back();
         _updatableObjects.pop_back();
+
+        UpdatableMapObject* mapUpdatableObject = dynamic_cast<UpdatableMapObject*>(obj);
+        if (mapUpdatableObject)
+        {
+            mapUpdatableObject->SetUpdateState(UpdatableMapObject::UpdateState::NotUpdating);
+        }
     }
 }
 

--- a/src/server/game/Maps/MapPartition.h
+++ b/src/server/game/Maps/MapPartition.h
@@ -26,7 +26,7 @@ class Map;
 class WorldObject;
 
 /**
- * @class MapPartition 
+ * @class MapPartition
  * @brief Represents a subdivision of a map
  *
  * Subdivides maps into paritions to avoid bottlenecking with high volumes of world objects
@@ -46,7 +46,7 @@ public:
      */
     MapPartition(Map* parent, uint16 minGridX, uint16 maxGridX, uint16 minGridY, uint16 maxGridY);
 
-    ~MapPartition() = default;  
+    ~MapPartition() = default;
 
     /**
      * @brief The core AI and physics loop for the partition
@@ -96,7 +96,7 @@ private:
 
     std::vector<WorldObject*> _updatableObjects;
 
-    LockedQueue<WorldObject*> _transferQueue;
+    LockedQueue<ObjectGuid> _transferQueue;
 };
 
 #endif //MAPPARTITION_H

--- a/src/server/game/Maps/MapPartition.h
+++ b/src/server/game/Maps/MapPartition.h
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MAPPARTITION_H
+#define MAPPARTITION_H
+
+#include "Common.h"
+#include <vector>
+
+class Map;
+class WorldObject;
+
+/**
+ * @class MapPartition 
+ * @brief Represents a thread safe subdivision of a map
+ *
+ * To prevent bottlenecking on populated maps, the maps will be subdivided into map partitions.
+ * Each partition will manage its own subset of entities and will run its update loop in parallel across multiple threads.
+ */
+class MapPartition
+{
+public:
+    /**
+     * @brief Constructs a new MapPartition object with specific bounding coordinates
+     * @param parent The parent map of the partition
+     * @param minGridX The west most grid boundary
+     * @param maxGridX The east most grid boundary
+     * @param minGridY The north most grid boundary
+     * @param maxGridY The south most grid boundary
+     */
+    MapPartition(Map* parent, uint16 minGridX, uint16 maxGridX, uint16 minGridY, uint16 maxGridY);
+
+    ~MapPartition() = default;  
+
+    /**
+     * @brief The core AI and physics loop for the partition
+     * @param diff Time since last server tick (ms)
+     */
+    void Update(uint32 const diff);
+
+    /**
+     * @brief Adds an entity to the partitions update loop
+     * @param obj The entity entering the partition
+     */
+    void AddObject(WorldObject* obj);
+
+    /**
+     * @brief Removes an entity from the partitions update loop
+     * @param obj The entity leaving the partition
+     */
+    void RemoveObject(WorldObject* obj);
+
+    /**
+     * @brief Checks if a grid coordinate is within the partition
+     * @param gridX The X of the coordinate to check
+     * @param gridY The Y of the coordinate to check
+     * @return True if the coordinate falls within the partition, False otherwise.
+     */
+    [[nodiscard]] bool Contains(uint16 gridX, uint16 gridY) const;
+
+    /**
+     * @brief Gets the parent map of the partition
+     * @return A Pointer to the parent map
+     */
+    [[nodiscard]] Map* GetParent() const { return _parentMap; }
+
+private:
+    Map* _parentMap;
+
+    uint16 _minX;
+    uint16 _maxX;
+    uint16 _minY;
+    uint16 _maxY;
+
+    std::vector<WorldObject*> _updatableObjects;
+};
+
+#endif //MAPPARTITION_H

--- a/src/server/game/Maps/MapPartition.h
+++ b/src/server/game/Maps/MapPartition.h
@@ -19,6 +19,7 @@
 #define MAPPARTITION_H
 
 #include "Common.h"
+#include "LockedQueue.h"
 #include <vector>
 
 class Map;
@@ -26,10 +27,11 @@ class WorldObject;
 
 /**
  * @class MapPartition 
- * @brief Represents a thread safe subdivision of a map
+ * @brief Represents a subdivision of a map
  *
- * To prevent bottlenecking on populated maps, the maps will be subdivided into map partitions.
- * Each partition will manage its own subset of entities and will run its update loop in parallel across multiple threads.
+ * Subdivides maps into paritions to avoid bottlenecking with high volumes of world objects
+ * Paritions manages it own subset of world objects
+ * Update loops run parallel across multiple threads
  */
 class MapPartition
 {
@@ -65,6 +67,12 @@ public:
     void RemoveObject(WorldObject* obj);
 
     /**
+     * @brief Safely queues an entity to be added to this partition
+     * @param obj the entity to queue
+     */
+    void QueueTransfer(WorldObject* obj);
+
+    /**
      * @brief Checks if a grid coordinate is within the partition
      * @param gridX The X of the coordinate to check
      * @param gridY The Y of the coordinate to check
@@ -87,6 +95,8 @@ private:
     uint16 _maxY;
 
     std::vector<WorldObject*> _updatableObjects;
+
+    LockedQueue<WorldObject*> _transferQueue;
 };
 
 #endif //MAPPARTITION_H

--- a/src/server/game/Maps/MapPartition.h
+++ b/src/server/game/Maps/MapPartition.h
@@ -65,13 +65,15 @@ public:
      * @brief Removes an entity from the partitions update loop
      * @param obj The entity leaving the partition
      */
-    void RemoveObject(WorldObject* obj);
+    bool RemoveObject(WorldObject* obj);
 
     /**
      * @brief Safely queues an entity to be added to this partition
      * @param obj the entity to queue
      */
     void QueueTransfer(WorldObject* obj);
+
+    size_t GetUpdatableObjectsCount() const { return _updatableObjects.size(); }
 
     /**
      * @brief Checks if a grid coordinate is within the partition

--- a/src/server/game/Maps/MapPartition.h
+++ b/src/server/game/Maps/MapPartition.h
@@ -21,6 +21,7 @@
 #include "Common.h"
 #include "LockedQueue.h"
 #include <vector>
+#include "ObjectGuid.h"
 
 class Map;
 class WorldObject;

--- a/src/server/game/Movement/MovementGenerators/PathGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/PathGenerator.cpp
@@ -37,24 +37,6 @@ PathGenerator::PathGenerator(WorldObject const* owner) :
 {
     memset(_pathPolyRefs, 0, sizeof(_pathPolyRefs));
 
-    //if (sDisableMgr->IsPathfindingEnabled(_sourceUnit->FindMap()))
-    {
-        _navMesh = _source->GetMap()->GetMapCollisionData().GetMMapData().GetNavMesh();
-
-        // fetch/creates a thread local NavMeshQuery for this specific thread and map
-        uint32 mapId = _source->GetMapId();
-        auto& cacheEntry = t_navMeshQueries[mapId];
-
-        // creates a new query if it doesnt exist yet or the map was reloaded
-        if (cacheEntry.first != _navMesh || !cacheEntry.second)
-        {
-            cacheEntry.first = _navMesh;
-            cacheEntry.second = MMAP::MMapMgr::CreateNavMeshQuery(const_cast<dtNavMesh*>(_navMesh));
-        }
-
-        _navMeshQuery = cacheEntry.second.get();
-    }
-
     CreateFilter();
 }
 
@@ -74,6 +56,21 @@ bool PathGenerator::CalculatePath(float x, float y, float z, float destX, float 
 {
     // prevent NavMesh reading while a different thread is altering NavMesh
     std::lock_guard<std::recursive_mutex> lock(_source->GetMap()->_gridLock);
+
+    _navMesh = _source->GetMap()->GetMapCollisionData().GetMMapData().GetNavMesh();
+
+    // fetch/creates a thread local NavMeshQuery for this specific thread and map
+    uint32 mapId = _source->GetMapId();
+    auto& cacheEntry = t_navMeshQueries[mapId];
+
+    // creates a new query if it doesnt exist yet or the map was reloaded
+    if (cacheEntry.first != _navMesh || !cacheEntry.second)
+    {
+        cacheEntry.first = _navMesh;
+        cacheEntry.second = MMAP::MMapMgr::CreateNavMeshQuery(const_cast<dtNavMesh*>(_navMesh));
+    }
+
+    _navMeshQuery = cacheEntry.second.get();
 
     if (!Acore::IsValidMapCoord(destX, destY, destZ) || !Acore::IsValidMapCoord(x, y, z))
         return false;

--- a/src/server/game/Movement/MovementGenerators/PathGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/PathGenerator.cpp
@@ -23,6 +23,10 @@
 #include "MMapMgr.h"
 #include "Map.h"
 #include "Metric.h"
+#include <unordered_map>
+
+// Thread local cache for thread safe pathfinding across map partitions
+thread_local std::unordered_map<uint32, std::pair<dtNavMesh const*, MMAP::ManagedNavMeshQuery>> t_navMeshQueries;
 
  ////////////////// PathGenerator //////////////////
 PathGenerator::PathGenerator(WorldObject const* owner) :
@@ -36,7 +40,19 @@ PathGenerator::PathGenerator(WorldObject const* owner) :
     //if (sDisableMgr->IsPathfindingEnabled(_sourceUnit->FindMap()))
     {
         _navMesh = _source->GetMap()->GetMapCollisionData().GetMMapData().GetNavMesh();
-        _navMeshQuery = _source->GetMap()->GetMapCollisionData().GetMMapData().GetNavMeshQuery();
+
+        // fetch/creates a thread local NavMeshQuery for this specific thread and map
+        uint32 mapId = _source->GetMapId();
+        auto& cacheEntry = t_navMeshQueries[mapId];
+
+        // creates a new query if it doesnt exist yet or the map was reloaded
+        if (cacheEntry.first != _navMesh || !cacheEntry.second)
+        {
+            cacheEntry.first = _navMesh;
+            cacheEntry.second = MMAP::MMapMgr::CreateNavMeshQuery(const_cast<dtNavMesh*>(_navMesh));
+        }
+
+        _navMeshQuery = cacheEntry.second.get();
     }
 
     CreateFilter();
@@ -56,6 +72,9 @@ bool PathGenerator::CalculatePath(float destX, float destY, float destZ, bool fo
 
 bool PathGenerator::CalculatePath(float x, float y, float z, float destX, float destY, float destZ, bool forceDest)
 {
+    // prevent NavMesh reading while a different thread is altering NavMesh
+    std::lock_guard<std::recursive_mutex> lock(_source->GetMap()->_gridLock);
+
     if (!Acore::IsValidMapCoord(destX, destY, destZ) || !Acore::IsValidMapCoord(x, y, z))
         return false;
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
This PR proposes changes to:
-  [ X ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

The PR introduces a multithreaded map architecture that divides larger maps into logical partitions (currently 4 partitions per map) which can be processed in parallel using a Fork-Join model. This will reduce single-thread CPU bottlenecks in highly populated areas.
- Implemented LockedQueue<WorldObject*> for transferring entities across partition boundaries.
- Made DynamicTreeMap thread safe with std::shared_mutex for concurrent checks while protecting transport updates
- Refactored map object update lists to safely transition between partitions
- Resolves BountyHub Bounty:  https://www.bountyhub.dev/en/bounty/view/ae3d1ab6-8f15-4d72-b39c-a7153339fa44/feature-map-partitioning-support-for-azerothcore

### AI-assisted Pull Requests

> [!IMPORTANT]

- [ X ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

>Google Antigravity CLI was used in identifying race conditions and debugging call stacks
>All code was written by a human

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #22571

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [X ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). 
> The architectural approach was inspired by Project-Epoch TrinityCore PR #120, and adapted to fit AzerothCore's map update sequence and collision trees.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ X ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

> Tested cross partition movement with a boundary at X=0, Y=0 with both Player and non player map objects, cross partition spell casting, teleporting across maps and partitions, and instance map generations. Benchmarks showed a large reduction in main thread diff time under heavy spawn loads since worker threads now take over partition processing.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ X ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Map Partitions divide the map into 4 quadrants intersecting at X=0 and Y=0. Testing the partition hand offs can be done as following:
1. Teleport slightly inside of a partition near a boundary (e.g. x=5, y=5, .gm fly may need to be on to avoid dying from fall damage)
2. Spawn or find an aggressive monster and have it aggro to you (I used the naturally spawning Moss Creepers on Map 0)
3. Run across the partition boundary (X=0 or Y=0)
4. Confirm that the monster seamlessly continues pathfinding as it transfers partitions without any server stutter and continues to pathfind/attack.
5. Additionally spawn a monster on one side of a partition boundary (e.g. x=5, y=5) and then stand across the partition boundary in another partition (e.g. x=5 y=-5).
6. Target the monster with a spell and attack it to confirm cross-partition spell casting and targeting
7. Additionally spawn hundreds of NPCs in a partition (such as Booty Bay in map 0), and then teleport to another partition and check the server info to confirm that the update time diff remains low, since multiple CPU cores now process the grids in parallel.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability for map updates, object movement, and collision queries under heavy concurrent load.
  * Reduced the chance of crashes or corrupted world state during grid loading, unloading, and relocation.
  * Improved pathfinding reliability by making navigation data access more resilient during updates.
  * Updated delayed visibility handling to avoid timing-related issues during object updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->