### PR TITLE
fix(Scripts/EoE): fix Malygos Phase 3 Surge of Power targeting (10-man)

### DIFF
--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -687,17 +687,18 @@ struct boss_malygos : public BossAI
             }
             else
             {
+                for (uint8 i = 0; i < NUM_MAX_SURGE_TARGETS; ++i)
+                    _surgeTargetGUID[i].Clear();
                 if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, false, true, SPELL_RIDE_RED_DRAGON_BUDDY))
                 {
                     if (Vehicle* vehicle = target->GetVehicleKit())
                         if (Unit* passenger = vehicle->GetPassenger(0))
                             if (Player* player = passenger->ToPlayer())
                                 Talk(EMOTE_SURGE_OF_POWER_WARNING_P3, player);
-                    ObjectGuid targetGuid = target->GetGUID();
-                    me->m_Events.AddEventAtOffset([this, targetGuid]
+                    SetGUID(target->GetGUID(), DATA_FIRST_SURGE_TARGET_GUID);
+                    me->m_Events.AddEventAtOffset([this]
                     {
-                        if (Unit* delayedTarget = ObjectAccessor::GetUnit(*me, targetGuid))
-                            me->CastSpell(delayedTarget, SPELL_PH3_SURGE_OF_POWER, true);
+                        me->CastSpell((Unit*)nullptr, SPELL_PH3_SURGE_OF_POWER, true);
                     }, 3s);
                 }
             }
@@ -1277,15 +1278,22 @@ class spell_eoe_ph3_surge_of_power : public SpellScript
 {
     PrepareSpellScript(spell_eoe_ph3_surge_of_power);
 
+    bool Load() override
+    {
+        return GetCaster()->IsCreature();
+    }
+
     void FilterTargets(std::list<WorldObject*>& targets)
     {
-        // Target selection and warning are handled in boss AI.
-        // Here we just restrict area targets to the explicit cast target.
-        if (Unit* explTarget = GetExplTargetUnit())
+        // The spell targets an area, but only the drake that received the fixate warning
+        // should be hit. The boss AI stores that drake's GUID; keep only that target.
+        Creature* caster = GetCaster()->ToCreature();
+        ObjectGuid targetGuid = caster->AI()->GetGUID(DATA_FIRST_SURGE_TARGET_GUID);
+
+        targets.remove_if([targetGuid](WorldObject* target)
         {
-            targets.clear();
-            targets.push_back(explTarget);
-        }
+            return target->GetGUID() != targetGuid;
+        });
     }
 
     void Register() override

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -679,26 +679,29 @@ struct boss_malygos : public BossAI
             {
                 for (uint8 i = 0; i < NUM_MAX_SURGE_TARGETS; ++i)
                     _surgeTargetGUID[i].Clear();
-                me->CastSpell((Unit*)nullptr, SPELL_SURGE_OF_POWER_WARN_SELECTOR_25, true);
+
+                DoCastAOE(SPELL_SURGE_OF_POWER_WARN_SELECTOR_25, true);
                 me->m_Events.AddEventAtOffset([this]
                 {
-                    me->CastSpell((Unit*)nullptr, SPELL_PH3_SURGE_OF_POWER_25, true);
+                    DoCastAOE(SPELL_PH3_SURGE_OF_POWER_25, true);
                 }, 3s);
             }
             else
             {
                 for (uint8 i = 0; i < NUM_MAX_SURGE_TARGETS; ++i)
                     _surgeTargetGUID[i].Clear();
+
                 if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, false, true, SPELL_RIDE_RED_DRAGON_BUDDY))
                 {
                     if (Vehicle* vehicle = target->GetVehicleKit())
                         if (Unit* passenger = vehicle->GetPassenger(0))
                             if (Player* player = passenger->ToPlayer())
                                 Talk(EMOTE_SURGE_OF_POWER_WARNING_P3, player);
+
                     SetGUID(target->GetGUID(), DATA_FIRST_SURGE_TARGET_GUID);
                     me->m_Events.AddEventAtOffset([this]
                     {
-                        me->CastSpell((Unit*)nullptr, SPELL_PH3_SURGE_OF_POWER, true);
+                        DoCastAOE(SPELL_PH3_SURGE_OF_POWER, true);
                     }, 3s);
                 }
             }


### PR DESCRIPTION
## Changes Proposed:
Fixes Malygos Phase 3 "Surge of Power" targeting in **10-man**. The beam could land on a random player instead of the one who received the `Malygos fixes his eyes on you!` fixate warning, so a warned player often took no beam while an unwarned player got hit. 25-man is unaffected.

Root cause: `57407` is corrected into an area spell (`TARGET_SRC_CASTER` -> `TARGET_UNIT_SRC_AREA_ENEMY`, `MaxAffectedTargets = 1`) to mirror the 25-man `60936`. The 10-man boss code, however, cast it at an explicit drake target and relied on `spell_eoe_ph3_surge_of_power::FilterTargets` calling `GetExplTargetUnit()` to narrow the area down to that drake. Because neither implicit target is a `TARGET_REFERENCE_TYPE_TARGET`, the spell's explicit-target mask carries no unit flag, so `Spell::InitExplicitTargets` strips the drake. `GetExplTargetUnit()` then returns null, the filter no-ops, and `MaxAffectedTargets = 1` picks one random enemy in the zone. This produces both symptoms and the intermittency.

Fix: mirror the proven 25-man path. The boss AI stores the warned drake's GUID (reusing the existing `_surgeTargetGUID` / `SetGUID` / `GetGUID` machinery) and casts with a null explicit target; the spell script keeps only the target whose GUID matches the stored one. No SQL/DBC change needed.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Fable 5 (via Claude Code) was used to investigate the root cause and prepare the fix.

## Issues Addressed:
- Closes #26507

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Triage video in the linked issue shows warned drakes taking no beam and unwarned players being hit. Spell data (57407/60936) cross-checked against Wowhead and the client DBCs.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Root cause confirmed by static analysis of the target-mask/explicit-target path and by frame-by-frame review of the triage video. Not yet verified in a live 10-man run.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Enter 10-man Eye of Eternity and take Malygos to Phase 3 (drake phase).
2. For several surge cycles, watch each `Malygos fixes his eyes on you!` whisper.
3. Confirm that ~3 seconds later the Surge of Power beam (six ticks of 12000 arcane, spell 57407) hits that same player's drake in the combat log, and that no unwarned player is hit. Also re-check 25-man still works (up to 3 warned drakes each take the beam).

## Known Issues and TODO List:

- [ ] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
