### PR TITLE
fix(Core/Movement): guard empty taxi flight paths

### DIFF
--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -650,7 +650,24 @@ bool FlightPathMovementGenerator::LoadPath(Player* player)
 
 void FlightPathMovementGenerator::DoInitialize(Player* player)
 {
+    if (i_path.empty())
+    {
+        LOG_ERROR("movement.flightpath", "FlightPathMovementGenerator::DoInitialize: empty taxi path for player {}", player->GetGUID().ToString());
+        player->m_taxi.ClearTaxiDestinations();
+        player->Dismount();
+        return;
+    }
+
     Reset(player);
+
+    if (i_path.empty())
+    {
+        LOG_ERROR("movement.flightpath", "FlightPathMovementGenerator::DoInitialize: empty taxi path after reset for player {}", player->GetGUID().ToString());
+        player->m_taxi.ClearTaxiDestinations();
+        player->Dismount();
+        return;
+    }
+
     InitEndGridInfo();
 }
 
@@ -682,8 +699,15 @@ void FlightPathMovementGenerator::DoFinalize(Player* player)
 
 void FlightPathMovementGenerator::DoReset(Player* player)
 {
-    uint32 end = GetPathAtMapEnd();
     uint32 currentNodeId = GetCurrentNode();
+
+    if (i_path.empty() || currentNodeId >= i_path.size())
+    {
+        LOG_ERROR("movement.flightpath", "FlightPathMovementGenerator::DoReset: invalid taxi path for player {}. Current node: {}, max nodes: {}", player->GetGUID().ToString(), currentNodeId, i_path.size());
+        return;
+    }
+
+    uint32 end = GetPathAtMapEnd();
 
     if (currentNodeId == end)
     {
@@ -713,6 +737,9 @@ void FlightPathMovementGenerator::DoReset(Player* player)
 
 bool FlightPathMovementGenerator::DoUpdate(Player* player, uint32 /*diff*/)
 {
+    if (i_path.empty() || i_currentNode >= i_path.size())
+        return false;
+
     // skipping the first spline path point because it's our starting point and not a taxi path point
     uint32 pointId = player->movespline->currentPathIdx() <= 0 ? 0 : player->movespline->currentPathIdx() - 1;
     if (pointId > i_currentNode && i_currentNode < i_path.size() - 1)
@@ -781,6 +808,9 @@ void FlightPathMovementGenerator::DoEventIfAny(Player* player, TaxiPathNodeEntry
 
 bool FlightPathMovementGenerator::GetResetPos(Player*, float& x, float& y, float& z)
 {
+    if (i_path.empty() || i_currentNode >= i_path.size())
+        return false;
+
     TaxiPathNodeEntry const* node = i_path[i_currentNode];
     x = node->x;
     y = node->y;
@@ -793,6 +823,9 @@ void FlightPathMovementGenerator::InitEndGridInfo()
     /*! Storage to preload flightmaster grid at end of flight. For multi-stop flights, this will
        be reinitialized for each flightmaster at the end of each spline (or stop) in the flight. */
     uint32 nodeCount = i_path.size();        //! Number of nodes in path.
+    if (!nodeCount)
+        return;
+
     _endMapId = i_path[nodeCount - 1]->mapid; //! MapId of last node
 
     // pussywizard:


### PR DESCRIPTION
## Changes
- Guard flight-path initialization/reset/update paths against empty or out-of-range taxi paths.
- Clear stale taxi destinations and dismount when initialization receives an empty path instead of continuing into end-grid preload logic.
- Return `false` from update/reset-position paths when the flight path is invalid, so the movement generator can expire cleanly.

## Why
A crash can happen when `FlightPathMovementGenerator::InitEndGridInfo()` indexes `i_path[nodeCount - 1]` while the flight path is empty. The existing `MoveTaxiFlight()` load guard handles the normal path, but the movement generator itself should still fail closed if initialized or ticked with invalid path state.

## Tests
- `git diff --check`
- `cmake --build var/build/obj --target worldserver -j2`
