### PR TITLE
fix(Core/Instances): snapshot minions before state updates

### DIFF
--- a/src/server/game/Instances/InstanceScript.cpp
+++ b/src/server/game/Instances/InstanceScript.cpp
@@ -398,6 +398,8 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
     if (id < bosses.size())
     {
         BossInfo* bossInfo = &bosses[id];
+        MinionSet minions = bossInfo->minion;
+
         sScriptMgr->OnBeforeSetBossState(id, state, bossInfo->state, instance);
         if (bossInfo->state == TO_BE_DECIDED) // loading
         {
@@ -410,8 +412,8 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
                 return false;
 
             if (state == DONE)
-                for (MinionSet::iterator i = bossInfo->minion.begin(); i != bossInfo->minion.end(); ++i)
-                    if ((*i)->isWorldBoss() && (*i)->IsAlive())
+                for (Creature* minion : minions)
+                    if (minion && minion->isWorldBoss() && minion->IsAlive())
                         return false;
 
             bossInfo->state = state;
@@ -422,8 +424,9 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
             for (DoorSet::iterator i = bossInfo->door[type].begin(); i != bossInfo->door[type].end(); ++i)
                 UpdateDoorState(*i);
 
-        for (MinionSet::iterator i = bossInfo->minion.begin(); i != bossInfo->minion.end(); ++i)
-            UpdateMinionState(*i, state);
+        for (Creature* minion : minions)
+            if (minion)
+                UpdateMinionState(minion, state);
 
         return true;
     }


### PR DESCRIPTION
## Changes
- Snapshot the boss minion set before `SetBossState()` updates minion states.
- Use the snapshot for the world-boss completion guard and for `UpdateMinionState()`.
- Ignore null minion pointers defensively while preserving existing behavior for valid minions.

## Why
`UpdateMinionState()` can indirectly mutate a boss' minion set while `SetBossState()` is iterating it. That can invalidate the iterator and crash during encounter reset/evade paths, for example when Karathress minions trigger a boss reset in Serpentshrine Cavern.

## Tests
- `git diff --check`
- `cmake --build var/build/obj --target worldserver -j2`
