### PR TITLE
fix(Commands): quote go creature name query safely

### DIFF
--- a/src/server/scripts/Commands/cs_go.cpp
+++ b/src/server/scripts/Commands/cs_go.cpp
@@ -223,7 +223,7 @@ public:
         std::string str = name.data(); // Making subtractions to the last character does not with in string_view
         WorldDatabase.EscapeString(str);
 
-        QueryResult result = WorldDatabase.Query("SELECT entry FROM creature_template WHERE name = \"{}\" LIMIT 1", str);
+        QueryResult result = WorldDatabase.Query("SELECT entry FROM creature_template WHERE name = '{}' LIMIT 1", str);
         if (!result)
         {
             handler->SendErrorMessage(LANG_COMMAND_GOCREATNOTFOUND);


### PR DESCRIPTION
## Changes
- Use a single-quoted SQL string literal for `.go creature name` lookup after `EscapeString()`.

## Why
The command escapes the input string and then places it inside a double-quoted SQL literal. An embedded double quote in the command argument can still terminate the literal and produce invalid SQL, aborting the worldserver on query error. Single quotes match the escaping path and keep double quotes in creature names/input from breaking the query.

## Tests
- `git diff --check`
- `cmake --build var/build/obj --target worldserver -j2`
