### PR TITLE
fix(Scripts): dummy reset no longer evades

### DIFF
--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -1532,6 +1532,8 @@ public:
 
         void Reset() override
         {
+            // EnterEvadeMode override leaves UNIT_STATE_EVADE set; clear it so the dummy stays attackable
+            me->ClearUnitState(UNIT_STATE_EVADE);
             me->SetControlled(true, UNIT_STATE_STUNNED);
             isVulnerable = false;
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).

### Description

**Bug**
In the Argent Tournament (Icecrown), the jousting training dummies (entries 33272 / 33229 / 33243) become permanently "evading" after the first disengage. Every subsequent jousting ability — Shield Breaker (62575), Thrust (62544) and Charge (62960) — returns `SPELL_MISS_EVADE` (shown as "Avoidance"/dodge in the combat log) and never lands. The first engagement after a restart works, which is why it was easy to miss.

**Root cause**
`npc_tournament_training_dummyAI` overrides `EnterEvadeMode` and only calls `_EnterEvadeMode()` (which sets `UNIT_STATE_EVADE`) followed by `Reset()`:

```cpp
void EnterEvadeMode(EvadeReason why) override
{
    if (!_EnterEvadeMode(why))
        return;
    Reset();
}
```

Unlike the base `CreatureAI::EnterEvadeMode`, this override never calls `MoveTargetedHome()` — the path that normally clears `UNIT_STATE_EVADE` once the creature reaches home. On top of that the dummy is rooted (stunned via `SetControlled(true, UNIT_STATE_STUNNED)`), so it cannot walk home either. As a result `UNIT_STATE_EVADE` persists forever after the first evade, and `Unit::SpellHitResult` returns `SPELL_MISS_EVADE` for every jousting ability.

**Fix**
Clear `UNIT_STATE_EVADE` in `Reset()` (which runs both on spawn and on evade-reset) so the dummy is always attackable:

```cpp
void Reset() override
{
    me->ClearUnitState(UNIT_STATE_EVADE);
    me->SetControlled(true, UNIT_STATE_STUNNED);
    isVulnerable = false;
    ...
}
```

`ClearUnitState(UNIT_STATE_EVADE)` is the same API `CreatureAI::EnterEvadeMode` already uses to clear the evade state on pets/guardians.

### AI-assisted Pull Requests

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
- None (identified during local testing; no related GitHub issue found).

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.) — bug reproduced and fix verified on a running test server.
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes.

1. Go to the Argent Tournament grounds (Icecrown) and start a joust: mount a tournament horse and engage a training dummy (33272 charge target / 33229 melee target / 33243 ranged target).
2. Use Shield Breaker (62575) — it should hit (the first engagement after a restart always worked).
3. Disengage (move away / stop attacking) so the dummy resets, then wait for it to return to full health.
4. Re-engage and use Shield Breaker (62575) / Thrust (62544) / Charge (62960) again.
   - **Before the fix:** all of them return "evade/dodge" and never land.
   - **After the fix:** they hit normally and the dummy can be engaged repeatedly without restarting the server.
5. Repeat steps 3-4 several times to confirm the evade state no longer sticks.

## Known Issues and TODO List:
- [ ]
