### PR TITLE
fix(Core/Battlegrounds): fix invited-count accounting on BG entry

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -647,7 +647,7 @@ void BattlegroundMgr::BuildBattlegroundListPacket(WorldPacket* data, ObjectGuid 
     }
 }
 
-void BattlegroundMgr::SendToBattleground(Player* player, uint32 instanceId, BattlegroundTypeId bgTypeId)
+bool BattlegroundMgr::SendToBattleground(Player* player, uint32 instanceId, BattlegroundTypeId bgTypeId)
 {
     if (Battleground* bg = GetBattleground(instanceId, bgTypeId))
     {
@@ -655,12 +655,11 @@ void BattlegroundMgr::SendToBattleground(Player* player, uint32 instanceId, Batt
         Position const* pos = bg->GetTeamStartPosition(player->GetBgTeamId());
 
         LOG_DEBUG("bg.battleground", "BattlegroundMgr::SendToBattleground: Sending {} to map {}, {} (bgType {})", player->GetName(), mapid, pos->ToString(), bgTypeId);
-        player->TeleportTo(mapid, pos->GetPositionX(), pos->GetPositionY(), pos->GetPositionZ(), pos->GetOrientation());
+        return player->TeleportTo(mapid, pos->GetPositionX(), pos->GetPositionY(), pos->GetPositionZ(), pos->GetOrientation());
     }
-    else
-    {
-        LOG_ERROR("bg.battleground", "BattlegroundMgr::SendToBattleground: Instance {} (bgType {}) not found while trying to teleport player {}", instanceId, bgTypeId, player->GetName());
-    }
+
+    LOG_ERROR("bg.battleground", "BattlegroundMgr::SendToBattleground: Instance {} (bgType {}) not found while trying to teleport player {}", instanceId, bgTypeId, player->GetName());
+    return false;
 }
 
 void BattlegroundMgr::SendAreaSpiritHealerQueryOpcode(Player* player, Battleground* bg, ObjectGuid guid)

--- a/src/server/game/Battlegrounds/BattlegroundMgr.h
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.h
@@ -93,7 +93,10 @@ public:
     void LoadBattlegroundTemplates();
     void DeleteAllBattlegrounds();
 
-    void SendToBattleground(Player* player, uint32 InstanceID, BattlegroundTypeId bgTypeId);
+    // Returns false when the teleport could not start (instance gone, or a
+    // synchronous TeleportTo failure) so the accept path can release the
+    // otherwise-orphaned invited reservation.
+    bool SendToBattleground(Player* player, uint32 InstanceID, BattlegroundTypeId bgTypeId);
 
     /* Battleground queues */
     BattlegroundQueue& GetBattlegroundQueue(BattlegroundQueueTypeId bgQueueTypeId) { return m_BattlegroundQueues[bgQueueTypeId]; }

--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -1302,12 +1302,15 @@ int32 BattlegroundQueue::GetQueueAnnouncementTimer(uint32 bracketId) const
 
 void BattlegroundQueue::InviteGroupToBG(GroupQueueInfo* ginfo, Battleground* bg, TeamId teamId)
 {
+    // An already-invited group keeps the side it was invited under: writing
+    // teamId here would split a future re-invite's IncreaseInvitedCount from the
+    // original side's DecreaseInvitedCount at leave, desyncing the ledger.
+    if (ginfo->IsInvitedToBGInstanceGUID)
+        return;
+
     // set side if needed
     if (teamId != TEAM_NEUTRAL)
         ginfo->teamId = teamId;
-
-    if (ginfo->IsInvitedToBGInstanceGUID)
-        return;
 
     // set invitation
     ginfo->IsInvitedToBGInstanceGUID = bg->GetInstanceID();

--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -544,7 +544,31 @@ void WorldSession::HandleBattleFieldPortOpcode(WorldPacket& recvData)
         sLFGMgr->LeaveAllLfgQueues(_player->GetGUID(), false);
 
         _player->SetBattlegroundId(bg->GetInstanceID(), bg->GetBgTypeID(), queueSlot, true, bgTypeId == BATTLEGROUND_RB, teamId);
-        sBattlegroundMgr->SendToBattleground(_player, ginfo.IsInvitedToBGInstanceGUID, bgTypeId);
+
+        if (!sBattlegroundMgr->SendToBattleground(_player, ginfo.IsInvitedToBGInstanceGUID, bgTypeId))
+        {
+            // The teleport never started (instance gone, or a synchronous
+            // TeleportTo veto such as a DK still locked to Ebon Hold). The accept
+            // already pulled the player out of the queue and he can't decline
+            // now, so undo the accept here -- otherwise the invited reservation
+            // leaks forever, permanently skewing team selection and blocking the
+            // empty instance's cleanup.
+            bg->DecreaseInvitedCount(teamId);
+            _player->RemoveBattlegroundQueueId(bgQueueTypeId);
+            _player->SetBattlegroundId(0, BATTLEGROUND_TYPE_NONE, PLAYER_MAX_BATTLEGROUND_QUEUES, false, false, TEAM_NEUTRAL);
+
+            sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_NONE, 0, 0, 0, TEAM_NEUTRAL);
+            SendPacket(&data);
+
+            // Free slot -> let the queue refill it. BG only, like the sibling
+            // leave-queue path: an arena update needs its own type/rating.
+            if (!ginfo.ArenaType)
+                sBattlegroundMgr->ScheduleQueueUpdate(0, 0, bgQueueTypeId, bgTypeId, bracketEntry->GetBracketId());
+
+            LOG_ERROR("bg.battleground", "Battleground: player {} {} failed to teleport into bg {}, bgtype {}; released the invited reservation.",
+                _player->GetName(), _player->GetGUID().ToString(), bg->GetInstanceID(), bg->GetBgTypeID());
+            return;
+        }
 
         LOG_DEBUG("bg.battleground", "Battleground: player {} {} joined battle for bg {}, bgtype {}, queue type {}.", _player->GetName(), _player->GetGUID().ToString(), bg->GetInstanceID(), bg->GetBgTypeID(), bgQueueTypeId);
     }

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -499,8 +499,21 @@ public:
             // Remove from LFG queues
             sLFGMgr->LeaveAllLfgQueues(player->GetGUID(), false);
 
+            // Book the reservation like the queue path does, so it is symmetric
+            // with RemovePlayerAtLeave's decrement and the 0-players/0-invited
+            // state can't let Battleground::Update delete the arena while players
+            // are still on the loading screen.
+            bg->IncreaseInvitedCount(teamId);
             player->SetBattlegroundId(bg->GetInstanceID(), bgTypeId, queueSlot, true, false, teamId);
-            sBattlegroundMgr->SendToBattleground(player, bg->GetInstanceID(), bgTypeId);
+
+            // A synchronous teleport failure would strand that reservation (the
+            // player never enters and never reaches RemovePlayerAtLeave), leaving
+            // the arena undeletable; release it and reset his bg data.
+            if (!sBattlegroundMgr->SendToBattleground(player, bg->GetInstanceID(), bgTypeId))
+            {
+                bg->DecreaseInvitedCount(teamId);
+                player->SetBattlegroundId(0, BATTLEGROUND_TYPE_NONE, PLAYER_MAX_BATTLEGROUND_QUEUES, false, false, TEAM_NEUTRAL);
+            }
         }
 
         handler->PSendSysMessage("Success! Players are now being teleported to the arena.");


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Three small, independent robustness fixes to the battleground invite/entry path. They keep the invited-count ledger (`IncreaseInvitedCount` / `DecreaseInvitedCount`) balanced with the physical player counts, so a battleground can't end up holding a reservation that never gets released, or get torn down while players are still loading in.

- **Release the reservation when a synchronous port into the BG fails.** `BattlegroundMgr::SendToBattleground` now reports whether the teleport actually happened. On the accept path in `BattleGroundHandler`, if the port fails (e.g. the instance is already gone), we drop the invited count, clear the player's queue slot and reset his BG status, and re-run the queue update, instead of leaving a reservation stranded.
- **Don't overwrite `ginfo->teamId` after the group is already invited.** In `BattlegroundQueue::InviteGroupToBG` the team write now sits below the already-invited guard, so re-processing a group that's mid-invite can't flip its assigned team out from under the counts.
- **Book the invited count in `.skirmish`.** The GM skirmish command ported players in without ever calling `IncreaseInvitedCount`, so the arena's invited count was asymmetric with `RemovePlayerAtLeave`'s decrement. That could let `Battleground::Update` delete the arena while players were still on the loading screen. It now books the reservation like the queue path does, and releases it again if the teleport fails.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests iutors must clearly disclose when such tools have been usedand specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were usen preparing this pull request. Please specify which tools
were used, if any.

Claude Opus 4.8 (via Claude Code) was used to help write and review these changes.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- N/A (no linked issue)

## SOURCE:
<!-- If you can, include a source that can strengthen your
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source
- [ ] Video evidence, knowledge databases or other public ead, etc.)
- [ ] The changes promoted by this pull request come partither project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

These are internal accounting/consistency fixes to the BG om the surrounding code rather than from sniffs or liveresearch, so none of the boxes above apply.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [] This pull request requires further testing and may hd.

Not yet tested in-game. The two invite-path fixes only trihe target instance disappearing between invite and accept,
and a group being re-processed mid-invite), which are hard

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the repn the linked issue
- [] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players
please specify it as well.


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] None

<!-- If you intend to contribute repeatedly to our projectn our discord channel. We set ranks for our contributors
and give them access to special resources or knowledge: htyFvXpk7)
     Do not remove the instructions below about testing, tt your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback hereb. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **gode that handles more than one specific thing), the tester
should not only check that the PR does its job (e.g. fixinlly** check that the PR does not cause any regression (i.e.
introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.