### PR TITLE
fix(Core/Scripts): Prevents Crystalline Frayer from staying in combat

### DIFF
--- a/src/server/scripts/Northrend/Nexus/Nexus/instance_nexus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Nexus/instance_nexus.cpp
@@ -256,6 +256,7 @@ struct npc_crystalline_frayer : public ScriptedAI
     void EnterSeedPod()
     {
         _inSeedPod = true;
+        me->SetIsCombatDisallowed(true);
         _scheduler.CancelGroup(GROUP_COMBAT);
 
         me->AttackStop();
@@ -283,6 +284,7 @@ struct npc_crystalline_frayer : public ScriptedAI
     void LeaveSeedPod()
     {
         _inSeedPod = false;
+        me->SetIsCombatDisallowed(false);
 
         Talk(SAY_EMOTE);
 

--- a/src/server/scripts/Northrend/Nexus/Nexus/instance_nexus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Nexus/instance_nexus.cpp
@@ -207,6 +207,7 @@ struct npc_crystalline_frayer : public ScriptedAI
     {
         _allowDeath = false;
         _inSeedPod = false;
+        me->SetIsCombatDisallowed(false);
         _scheduler.CancelAll();
 
         me->RemoveAllAuras();


### PR DESCRIPTION
The Crystalline Frayer were not dropping combat when entering the pods if killed by a spell.
This fix disallows combat on entering the pod and re-allows it on exit.

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
### Change Summary
Calls `me->SetIsCombatDisallowed(true)` on entry of the seed pod and `me->SetIsCombatDisallowed(false)` on exit.

### Issue Origin
I noticed through logging that the Frayer's `IsInCombat()` returned `false` at the end of `EnterSeedPod` but returned `true` in the `UpdateAI` call.
The cause of this issue was the `Spell::DoAllEffectOnTarget` function that would apply damage leading the Frayer to go into the pod when killed.
However, the function then calls `m_caster->AtTargetAttacked` which in turn calls `target->EngageWithTarget(this)`.
Finally, `Unit::EngageWithTarget` would call `SetInCombat(player)` putting both the Frayer and the player in combat.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes Issue #26505 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

This fix is based on the video provided by the issue.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
- [X] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Re-pasting the triage notes:
reproduce:
- Make a class that has AOE like warlock:
- `.levelup 79`
- `.learn all my class`
- Change dungeon diff to 5hc (fixes 5nm as well)
- `.go c i 26793`
- Pull many of them and kill them with aoe and observe
[[Test vid showing old behavior]](https://dl.dropboxusercontent.com/scl/fi/xjge7djby6dmsq3kd3jat/JPJ3CIDOUx.mp4?rlkey=s2iyvg1gn2tkfbz57u9u1vp0n&dl=0)

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->
- None currently

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
