### PR TITLE
fix(Scripts/Ulduar): keep Thorim loot chest alive through his outro

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -550,10 +550,12 @@ struct boss_thorim : public BossAI
                 if (_hardMode)
                     chestId += 1; // hard mode offset
 
-                if ((go = me->SummonGameObject(chestId, 2134.73f, -286.32f, 419.51f, 4.65f, 0, 0, 0, 0, 0)))
+                // Summoned by the map, not Thorim, so the chest survives his despawn during the outro.
+                if ((go = me->GetMap()->SummonGameObject(chestId, 2134.73f, -286.32f, 419.51f, 4.65f, 0, 0, 0, 0, 0)))
                 {
                     go->ReplaceAllGameObjectFlags((GameObjectFlags)0);
                     go->SetLootRecipient(me->GetMap());
+                    go->SetRespawnTime(7 * DAY);
                 }
 
                 // Defeat credit


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Scripts (bosses, spell scripts, creature scripts).

Thorim's Cache of Storms was summoned with `Creature::SummonGameObject`, which binds the gameobject to Thorim's lifetime. At the end of the defeat RP he casts `SPELL_TELEPORT` and despawns himself, and the chest was removed with him before players could loot it.

The fix summons the chest from the map instead, so it is not owned by Thorim, and gives it a real respawn time. This mirrors the existing Mimiron chest handling (#26498). TrinityCore and cMaNGOS both avoid the problem by spawning/toggling the chest independently of the boss creature.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. **Model used: Claude Opus 4.8.**

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9738

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.) — behavior confirmed in the linked issue; cross-referenced against TrinityCore and cMaNGOS, which keep the chest independent of the boss creature.

## Tests Performed:
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Kill Thorim in Ulduar (normal or hard mode, 10 or 25).
2. Let his post-encounter RP play out until he teleports away.
3. Confirm the Cache of Storms remains and is lootable after he despawns.

## Known Issues and TODO List:

- [ ] Needs in-game verification across all difficulties (normal/hard, 10/25).
