### PR TITLE
fix(Scripts/Ulduar): re-arm Kologarn arms so they can aggro after a wipe

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
@@ -161,8 +161,12 @@ struct boss_kologarn : public BossAI
 
         void AttachLeftArm()
         {
-            if (Unit* arm = ObjectAccessor::GetCreature(*me, _left))
+            if (Creature* arm = ObjectAccessor::GetCreature(*me, _left))
+            {
                 arm->SetHealth(arm->GetMaxHealth());
+                // Clear the arm's combat-start state so it can re-pull the boss on a subsequent attempt.
+                arm->AI()->Reset();
+            }
             else if (Creature* accessory = me->SummonCreature(NPC_LEFT_ARM, *me, TEMPSUMMON_MANUAL_DESPAWN))
             {
                 accessory->AddUnitTypeMask(UNIT_MASK_ACCESSORY);
@@ -179,8 +183,12 @@ struct boss_kologarn : public BossAI
 
         void AttachRightArm()
         {
-            if (Unit* arm = ObjectAccessor::GetCreature(*me, _right))
+            if (Creature* arm = ObjectAccessor::GetCreature(*me, _right))
+            {
                 arm->SetHealth(arm->GetMaxHealth());
+                // Clear the arm's combat-start state so it can re-pull the boss on a subsequent attempt.
+                arm->AI()->Reset();
+            }
             else if (Creature* accessory = me->SummonCreature(NPC_RIGHT_ARM, *me, TEMPSUMMON_MANUAL_DESPAWN))
             {
                 accessory->AddUnitTypeMask(UNIT_MASK_ACCESSORY);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

After a wipe, one of Kologarn's arms could no longer pull the boss when attacked, even though the body and the other arm still worked.

The arm accessories start the encounter from `boss_kologarn_arms::DamageTaken`, gated by a one-shot `_combatStarted` flag that is only cleared in the arm's `Reset()`. The arms never evade on their own (empty `EnterEvadeMode`). On a wipe only the boss evades and resets; in `AttachLeftArm()`/`AttachRightArm()` a surviving arm is only healed back to full, so its `_combatStarted` flag leaks into the next attempt and that arm can no longer call `AttackStart` on the boss.

It presents as "the right arm" because whichever arm died and respawned during the previous attempt comes back as a fresh creature (flag clear), while the surviving arm keeps the stale flag.

Fix: when re-attaching a surviving arm, also call `arm->AI()->Reset()` so `_combatStarted` is cleared on every wipe. This branch only runs from the boss's `Reset()`; the mid-combat callers always summon a fresh arm, so there is no in-combat side effect.

For reference, TrinityCore avoids this by force-pulling both passengers on engage instead of a per-arm flag, and CMaNGOS instakills both arms on evade so they are always re-summoned fresh. This change brings AzerothCore in line with that "arms are fresh after a wipe" behavior with a minimal, localized change.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude Code (Opus 4.8) was used to investigate the issue and draft the fix. The change is understood and can be justified.

## Issues Addressed:
- Closes #26264

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Cross-referenced against TrinityCore and CMaNGOS Kologarn implementations. The linked issue includes video evidence.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds and passes the C++ codestyle check.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Pull Kologarn and wipe to the boss.
2. Return to the encounter.
3. Cast single-target spells on each arm (Left Arm and Right Arm) in turn.
4. Each arm should start the encounter and close the arena doors, as on the first pull.

## Known Issues and TODO List:

- [ ] None known.
