### PR TITLE
fix(DB/Locale): quest 21 frFR objectives say 8 kobolds, requirement is 12

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1783885061161224.sql
+++ b/data/sql/updates/pending_db_world/rev_1783885061161224.sql
@@ -1,2 +1,4 @@
 -- Quest 21 (Skirmish at Echo Ridge): frFR objectives text says 8 Kobold Workers, the requirement is 12.
-UPDATE `quest_template_locale` SET `Objectives` = REPLACE(`Objectives`, 'Tuez 8 Travailleurs kobolds', 'Tuez 12 Travailleurs kobolds') WHERE `ID` = 21 AND `locale` = 'frFR';
+UPDATE `quest_template_locale` SET `Objectives` =
+    REPLACE(`Objectives`, 'Tuez 8 Travailleurs kobolds', 'Tuez 12 Travailleurs kobolds')
+WHERE `ID` = 21 AND `locale` = 'frFR';

--- a/data/sql/updates/pending_db_world/rev_1783885061161224.sql
+++ b/data/sql/updates/pending_db_world/rev_1783885061161224.sql
@@ -1,0 +1,2 @@
+-- Quest 21 (Skirmish at Echo Ridge): frFR objectives text says 8 Kobold Workers, the requirement is 12.
+UPDATE `quest_template_locale` SET `Objectives` = REPLACE(`Objectives`, 'Tuez 8 Travailleurs kobolds', 'Tuez 12 Travailleurs kobolds') WHERE `ID` = 21 AND `locale` = 'frFR';


### PR DESCRIPTION
## Changes Proposed:
The frFR `quest_template_locale.Objectives` for quest 21 (Skirmish at Echo Ridge) says « Tuez **8** Travailleurs kobolds » while `quest_template.RequiredNpcOrGoCount1` is **12** (and the enUS text says « Kill 12 Kobold Laborers »). French clients see a wrong required count in the quest log. This updates the number in the translated text to 12.

## Issues Addressed:
None open that I found.

## SOURCE:
`quest_template` ID 21: `RequiredNpcOrGo1=80`, `RequiredNpcOrGoCount1=12`; enUS `LogDescription` = "Kill 12 Kobold Laborers...". Wotlk 3.3.5 data agrees (12).

## Tests Performed:
Applied the update on my 3.3.5 server, confirmed the frFR objectives text now reads 12 and matches the server-side requirement.

## How to Test the Changes:
1. Apply the update, log a frFR client, take quest 21 in Northshire.
2. The objectives text in the quest log should say « Tuez 12 Travailleurs kobolds ».