### PR TITLE
fix(Scripts/Ulduar): Freya no longer stuck in combat with Hodir's helpers

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1783886287444094700.sql
+++ b/data/sql/updates/pending_db_world/rev_1783886287444094700.sql
@@ -1,0 +1,4 @@
+-- Hodir helpers (#26330): swap PACIFIED (131072) for IMMUNE_TO_NPC (512) per sniffs, so Freya's
+-- instance-wide Ground Tremor can't tag them and block her reset. SWIMMING kept where set;
+-- immunity is cleared on Hodir engage (boss_hodir.cpp).
+UPDATE `creature_template` SET `unit_flags` = (`unit_flags` & ~131072) | 512 WHERE `entry` IN (32893, 32897, 32900, 32901, 32941, 32946, 32948, 32950, 33325, 33326, 33327, 33328, 33330, 33331, 33332, 33333);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -255,6 +255,12 @@ struct boss_hodir : public BossAI
         events.ScheduleEvent(EVENT_HARD_MODE_MISSED, 3min);
         Talk(TEXT_AGGRO);
 
+        // Helpers spawn IMMUNE_TO_NPC so idle bosses (e.g. Freya's Ground Tremor, #26330) can't tag
+        // them; drop it on engage. TODO: confirm timing - sniffs may clear it per-helper on unfreeze.
+        for (uint8 i = 0; i < 8; ++i)
+            if (Creature* helper = GetHelper(i))
+                helper->RemoveUnitFlag(UNIT_FLAG_IMMUNE_TO_NPC);
+
         if (instance->GetBossState(BOSS_HODIR) != DONE)
             instance->SetBossState(BOSS_HODIR, IN_PROGRESS);
     }


### PR DESCRIPTION
## Changes Proposed:
Freya (Ulduar) does not reset after a wipe: she stops moving and her adds never despawn.

Root cause: Freya's hard-mode Ground Tremor (spell 62437, 25-man variant 62859) is an NPC-sourced AoE that reaches across the instance and tags Hodir's helper NPCs. Those helpers never evade (their `EnterEvadeMode` is a no-op), so the threat references they hold on Freya keep her `GetThreatenedByMeList()` non-empty, which blocks her own evade in `Creature::SelectVictim`. She never resets.

Retail sniffs show the helpers carry `UNIT_FLAG_IMMUNE_TO_NPC` (and not `UNIT_FLAG_PACIFIED`), which makes them invalid targets for any NPC-sourced ability via `_IsValidAttackTarget`. This PR applies that flag in `creature_template` and removes it again when Hodir is engaged, so the helpers still behave normally during his own encounter.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code (Opus 4.8) was used to investigate the combat/threat interaction and draft the fix. The author reviewed and validated the changes.

## Issues Addressed:
- Closes #26330

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (unit_flags for the helper NPCs, e.g. entry 32941 = 295424 = STUNNED | SWIMMING | IMMUNE_TO_NPC).
- [x] Video evidence, knowledge databases or other public sources (reproduction video in the linked issue).
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Debug logging confirmed the exact chain: each helper received a `spell 62859 HIT` from Freya ~370 yd away, immediately followed by a threat link onto Freya. With the fix, the helpers are no longer valid NPC targets and Freya resets cleanly.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Engage Freya in hard mode (at least one Elder alive, so Ground Tremor is used).
2. Let Ground Tremor go out a few times, then wipe.
3. Freya should despawn her adds and return to her home position instead of standing idle in combat.
4. Separately, engage Hodir and confirm his helper NPCs still fight and can be interacted with normally.

## Known Issues and TODO List:

- [ ] Confirm the exact point at which `IMMUNE_TO_NPC` should be cleared. It is currently removed on Hodir engage; retail sniffs suggest it may be cleared per-helper only when it breaks out of Flash Freeze (noted with a TODO in `boss_hodir.cpp`).
