### PR TITLE
fix(Scripts/Ulduar): track Yogg-Saron encounter state and gate phase 2 on engagement

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -469,7 +469,7 @@ struct boss_yoggsaron_sara : public ScriptedAI
         {
             _instance->DoStopTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, CRITERIA_NOT_GETTING_OLDER);
             _instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_SANITY);
-            _instance->SetData(BOSS_YOGGSARON, NOT_STARTED);
+            _instance->SetBossState(BOSS_YOGGSARON, NOT_STARTED);
             if (GameObject* go = _instance->GetGameObject(DATA_YOGG_SARON_DOORS))
                 go->SetGoState(GO_STATE_ACTIVE);
         }
@@ -480,12 +480,11 @@ struct boss_yoggsaron_sara : public ScriptedAI
         if (!_instance)
             return;
 
-        // some simple hack checks
-        if (_instance->GetBossState(BOSS_VEZAX) != DONE || _instance->GetBossState(BOSS_XT002) != DONE)
+        if (_instance->GetBossState(BOSS_VEZAX) != DONE)
             return;
 
         _instance->DoStartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, CRITERIA_NOT_GETTING_OLDER);
-        _instance->SetData(BOSS_YOGGSARON, IN_PROGRESS);
+        _instance->SetBossState(BOSS_YOGGSARON, IN_PROGRESS);
         me->SetInCombatWithZone();
         AttackStart(target);
 
@@ -702,6 +701,14 @@ struct boss_yoggsaron_sara : public ScriptedAI
 
     void DamageTaken(Unit* who, uint32& damage, DamageEffectType, SpellSchoolMask) override
     {
+        // Guardians can be spawned by walking into Ominous Clouds even when InitFight
+        // never ran (e.g. Vezax not defeated); their novas must not start phase 2 then.
+        if (!_instance || _instance->GetBossState(BOSS_YOGGSARON) != IN_PROGRESS)
+        {
+            damage = 0;
+            return;
+        }
+
         if (who && who->GetEntry() == NPC_GUARDIAN_OF_YS && !_secondPhase)
         {
             damage = 25000;
@@ -1104,7 +1111,7 @@ struct boss_yoggsaron : public ScriptedAI
 
         if (_instance)
         {
-            _instance->SetData(BOSS_YOGGSARON, DONE);
+            _instance->SetBossState(BOSS_YOGGSARON, DONE);
             if (Creature* sara = _instance->GetCreature(DATA_SARA))
                 sara->AI()->DoAction(ACTION_YOGG_SARON_DEATH);
             if (GameObject* go = _instance->GetGameObject(DATA_YOGG_SARON_DOORS))

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -47,7 +47,8 @@ DoorData const doorData[] =
     { GO_KEEPERS_GATE,                 BOSS_THORIM,    DOOR_TYPE_PASSAGE    },
     { GO_KEEPERS_GATE,                 BOSS_FREYA,     DOOR_TYPE_PASSAGE    },
     { GO_VEZAX_DOOR,                   BOSS_VEZAX,     DOOR_TYPE_PASSAGE    },
-    { GO_YOGG_SARON_DOORS,             BOSS_YOGGSARON, DOOR_TYPE_ROOM       },
+    // GO_YOGG_SARON_DOORS is handled by boss_yoggsaron_sara: it closes 15 seconds
+    // after the pull, not immediately when the encounter enters IN_PROGRESS.
     { GO_DOODAD_UL_SIGILDOOR_03,       BOSS_ALGALON,   DOOR_TYPE_ROOM       },
     { GO_DOODAD_UL_UNIVERSEFLOOR_01,   BOSS_ALGALON,   DOOR_TYPE_ROOM       },
     { GO_DOODAD_UL_UNIVERSEFLOOR_02,   BOSS_ALGALON,   DOOR_TYPE_SPAWN_HOLE },


### PR DESCRIPTION
## Changes Proposed:

The Yogg-Saron encounter state was never actually tracked: `boss_yoggsaron.cpp` set it through `InstanceScript::SetData(BOSS_YOGGSARON, ...)`, but `instance_ulduar` has no `SetData` case for encounter ids, so all three calls (pull, wipe, kill) were silent no-ops. Every other Ulduar boss calls `SetBossState` directly; Yogg-Saron was left behind when the instance was refactored to boss states.

On top of that, the encounter could be pushed into phase 2 without ever being initialized. `InitFight()` silently bails when Vezax/XT-002 are not flagged DONE, but Ominous Clouds spawn Guardians on player contact regardless, and `DamageTaken` accepted their Shadow Nova pushes unconditionally. The result is the half-working fight reported in the linked issues: phase 2 reachable, but no Sanity aura (63786/63050 is cast in `InitFight`), no Voice of Yogg-Saron (so reaching 0 Sanity does nothing and Induce Madness only teleports you out), and Sara out of combat and regenerating HP in phase 1.

Changes:
- Use `SetBossState` for the Yogg-Saron encounter state (also makes the kill persist in the instance save like every other boss).
- Ignore damage to Sara while the encounter is not `IN_PROGRESS`, so lured Guardians can no longer start phase 2 on an uninitialized encounter.
- Drop the XT-002 check from `InitFight`; Vezax remains the gatekeeper (its door already gates access to the chamber).
- Remove `GO_YOGG_SARON_DOORS` from `DoorData`: now that `IN_PROGRESS` is real, DoorData would close the doors instantly at the pull, while the script intentionally closes them 15 seconds later (same grace period TC uses). The script already handles all door transitions itself.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude Code (Claude Fable 5)**

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26280
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26279

Both issues are symptoms of the same uninitialized-encounter state: no Sanity because `InitFight` (which casts Sanity Base 63786) never ran, and Sara regenerating because `SetInCombatWithZone` (also `InitFight`) never ran. Note the triage repro in both issues (`.tele yogg` into a fresh instance) lands in this state by construction, since Vezax is not DONE there; after this PR the boss is simply inert in that scenario until `.instance setbossstate 11 3` is used.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The Sanity application chain (63786 Sanity self-aura ticking 63050 every 3s, applied at pull) matches the client DBC data and TrinityCore's implementation (`npc_voice_of_yogg_saron::JustEngagedWith` casts 63786 with a 15s door-lock event, no DoorData room entry for the Yogg doors).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds pending CI; codestyle checks pass.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.instance setbossstate 11 3` (Vezax DONE) inside Ulduar, `.cheat god on`, `.gm off` (GMs are excluded from the pull scan), then approach Sara: the fight starts (aggro yell) and within ~15 seconds every player in the room gets Sanity x100. Doors close 15 seconds after the pull.
2. Kill lured Guardians of Yogg-Saron on top of Sara: her HP drops by 25000 per Shadow Nova and does not regenerate; 8 novas start phase 2. Verify Sanity drains from Psychosis/Brain Link/Lunatic Gaze/Malady, restores in Sanity Wells (if Freya was freed), and reaching 0 Sanity mind-controls the player.
3. Without step 1 (fresh instance, Vezax not DONE): Sara does not engage and Guardian novas deal no damage to her, instead of starting a broken phase 2.
4. Regression check: full legit kill still opens the doors and Sara/Yogg die properly; after a wipe the fight resets and can be re-pulled.

## Known Issues and TODO List:

- [ ] `boss_algalon_the_observer.cpp` has the same dead `SetData(BOSS_ALGALON, ...)` calls; not touched here because Algalon's doors are DoorData-managed and need a separate audit.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
