### PR TITLE
fix(Scripts/Ulduar): set Algalon encounter state through SetBossState

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -364,7 +364,7 @@ struct boss_algalon_the_observer : public ScriptedAI
         }
 
         if (_instance)
-            _instance->SetData(BOSS_ALGALON, FAIL);
+            _instance->SetBossState(BOSS_ALGALON, FAIL);
 
         ScriptedAI::EnterEvadeMode(why);
     }
@@ -391,7 +391,7 @@ struct boss_algalon_the_observer : public ScriptedAI
         }
 
         if (_instance)
-            _instance->SetData(BOSS_ALGALON, NOT_STARTED);
+            _instance->SetBossState(BOSS_ALGALON, NOT_STARTED);
     }
 
     void KilledUnit(Unit* victim) override
@@ -446,7 +446,7 @@ struct boss_algalon_the_observer : public ScriptedAI
                 me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
                 me->InterruptNonMeleeSpells(false);
                 if (_instance)
-                    _instance->SetData(BOSS_ALGALON, NOT_STARTED);
+                    _instance->SetBossState(BOSS_ALGALON, NOT_STARTED);
                 break;
             case ACTION_INIT_ALGALON:
                 _firstPull = false;
@@ -660,7 +660,7 @@ struct boss_algalon_the_observer : public ScriptedAI
                     brann->AI()->DoAction(ACTION_FINISH_INTRO);
                 break;
             case EVENT_START_COMBAT:
-                _instance->SetData(BOSS_ALGALON, IN_PROGRESS);
+                _instance->SetBossState(BOSS_ALGALON, IN_PROGRESS);
                 Talk(SAY_ALGALON_AGGRO);
                 break;
             case EVENT_REMOVE_UNNATTACKABLE:
@@ -737,7 +737,7 @@ struct boss_algalon_the_observer : public ScriptedAI
             case EVENT_OUTRO_START:
                 if (_instance)
                 {
-                    _instance->SetData(BOSS_ALGALON, DONE);
+                    _instance->SetBossState(BOSS_ALGALON, DONE);
                     _instance->SetData(DATA_ALGALON_DEFEATED, 1);
                 }
                 break;


### PR DESCRIPTION
## Changes Proposed:
The Algalon script set its encounter state with `_instance->SetData(BOSS_ALGALON, ...)`, but instance_ulduar's `SetData` override has no case for boss encounter ids, so all five calls (engage, evade fail, reset, despawn, kill) were silent no-ops and the Algalon encounter state stayed `NOT_STARTED` forever.

This PR converts them to `SetBossState(BOSS_ALGALON, ...)`, the same fix previously applied to Yogg-Saron. Effects:

- The Feeds on Tears achievement fail check in `OnUnitDeath` (`GetBossState(BOSS_ALGALON) == IN_PROGRESS`) can now actually trigger.
- `DONE` is now persisted to the instance save, so the `GetBossState(BOSS_ALGALON) != DONE` guard in `Load()` correctly stops the despawn-timer worldstate from re-enabling after a kill.
- The previously dead `GetBossState(BOSS_ALGALON) == FAIL` branch in `Reset()` (skips the long intro on repull) now works as designed.
- Algalon's DoorData entries become state-driven: the room doors (`GO_DOODAD_UL_SIGILDOOR_03`, `GO_DOODAD_UL_UNIVERSEFLOOR_01`) close during the fight and the spawn-hole GOs (`GO_DOODAD_UL_UNIVERSEFLOOR_02`, `GO_DOODAD_UL_UNIVERSEGLOBE01`, `GO_DOODAD_UL_ULDUAR_TRAPDOOR_03`) activate, matching TrinityCore's identical DoorData setup.

No double-handling is introduced: no script manipulates those five GOs manually (the boss script only touches sigil doors 01/02, which are not in DoorData), and all five have collision disabled in `OnGameObjectCreate`, so the state changes are visual only. The 1-hour despawn/summon persistence (`PERSISTENT_DATA_ALGALON_TIMER`) is driven by separate `SetData` cases and is unaffected. `FAIL`/`IN_PROGRESS` are sanitized to `NOT_STARTED` on save load by `ReadSaveDataBossStates`, so no stuck states can persist.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude Code (Claude Fable 5).**

## Issues Addressed:
- None linked.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.) **TrinityCore 3.3.5 uses `SetBossState` in the same five spots with identical DoorData for Algalon; this script is a port of it. Same approach as the earlier Yogg-Saron SetData/SetBossState fix in this repo.**
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Use the Celestial Planetarium console to summon Algalon and engage him. Once combat starts (after the intro on first pull), verify the sigil door behind the raid and the universe floor close, and the universe globe/floor visual activates. `.instance getbossstate 13` should report IN_PROGRESS.
2. Wipe (or let everyone leave the room) so Algalon evades. Verify the doors reopen, the visuals revert, and repulling skips the long first-pull intro.
3. Die to Algalon mid-fight, then kill him: the Feeds on Tears achievement should not be granted. Kill him with no player deaths in a separate lockout: it should be granted.
4. Kill Algalon, then restart the worldserver and re-enter: `.instance getbossstate 13` should report DONE and the 1-hour despawn timer worldstate must not reappear.
5. Let the 1-hour timer expire mid-combat: Algalon turns friendly, despawns, and the doors revert.

## Known Issues and TODO List:

- [ ] Not tested in-game yet.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
