### PR TITLE
fix(Core/Battlegrounds): fill existing BGs instead of starting duplicates

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -948,7 +948,7 @@ BGFreeSlotQueueContainer& BattlegroundMgr::GetBGFreeSlotQueueStore(BattlegroundT
 
 void BattlegroundMgr::AddToBGFreeSlotQueue(BattlegroundTypeId bgTypeId, Battleground* bg)
 {
-    bgDataStore[bgTypeId].BGFreeSlotQueue.push_front(bg);
+    bgDataStore[bgTypeId].BGFreeSlotQueue.push_back(bg);
 }
 
 void BattlegroundMgr::RemoveFromBGFreeSlotQueue(BattlegroundTypeId bgTypeId, uint32 instanceId)

--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -805,8 +805,7 @@ void BattlegroundQueue::BattlegroundQueueUpdate(uint32 diff, BattlegroundTypeId 
         }
     };
 
-    // battleground with free slot for player should be always in the beggining of the queue
-    // maybe it would be better to create bgfreeslotqueue for each bracket_id
+    // fill existing joinable battlegrounds, oldest first, before a new instance may form below
     BGFreeSlotQueueContainer& bgQueues = sBattlegroundMgr->GetBGFreeSlotQueueStore(bgTypeId);
     for (BGFreeSlotQueueContainer::iterator itr = bgQueues.begin(); itr != bgQueues.end();)
     {

--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -554,6 +554,8 @@ void WorldSession::HandleBattleFieldPortOpcode(WorldPacket& recvData)
             // leaks forever, permanently skewing team selection and blocking the
             // empty instance's cleanup.
             bg->DecreaseInvitedCount(teamId);
+            if (bg->HasFreeSlots())
+                bg->AddToBGFreeSlotQueue();
             _player->RemoveBattlegroundQueueId(bgQueueTypeId);
             _player->SetBattlegroundId(0, BATTLEGROUND_TYPE_NONE, PLAYER_MAX_BATTLEGROUND_QUEUES, false, false, TEAM_NEUTRAL);
 


### PR DESCRIPTION
## Changes Proposed:

This PR fixes two related issues that can make the server start a second battleground of the same type and bracket while an existing one still has free slots, and then starve the older instance once two of them coexist.

1. **A failed accept teleport leaves the freed slot invisible to the queue.** When a player accepts a BG invite but `SendToBattleground` fails (for example a DK still locked to Ebon Hold), the handler releases the invited reservation (added in #26556) but never puts the BG back into the free slot queue. If that invite had made the BG invited-full (so it was already removed from the free slot queue), the freed slot can no longer be seen by `BattlegroundQueueUpdate`, so with enough players waiting a new instance gets created while the first one has room. The BG is now re-added to the free slot queue when the reservation is released, mirroring what the invite decline/expiry path already does since #25001.

2. **The free slot queue fills the newest instance first.** `BattlegroundMgr::AddToBGFreeSlotQueue` used `push_front`, so whenever two instances of the same type and bracket coexist (for example after a full first game), new queuers always reinforce the newest instance and the older half-empty one starves. Changed to `push_back` so existing battlegrounds are filled oldest first, before a new instance can form.

Arenas and rated games are not affected: `Battleground::AddToBGFreeSlotQueue` only acts on battlegrounds, and the queue update loop never invites players to rated games.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any. **Claude Code was used to help investigate and prepare these changes.**

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The fixes come from code analysis of the queue/free slot logic, triggered by duplicate half-empty battlegrounds reported by players on a live realm.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds without errors (macOS arm64, clang). Reproducing this locally needs a realistic number of real players, so the changes will run on my production realm and I will report back.

## How to Test the Changes:

Both scenarios need enough players (or GM-controlled test accounts) to fill battlegrounds.

Oldest-first filling:
1. Get two instances of the same battleground and bracket running, both with free slots (fill a first BG so a second one starts, then have players leave both).
2. Queue a new player.
3. They should be invited to the older instance, not the newer one.

Freed slot after a failed accept teleport:
1. Queue enough players to make a BG invited-full (it gets removed from the free slot queue).
2. Have one invited player accept while their teleport must fail, e.g. a death knight that has not completed the starting chain and is still locked to Ebon Hold.
3. Queue one more player: they should be invited into the freed slot of the existing BG instead of a new instance forming.

## Known Issues and TODO List:

- [ ] `HandleMoveWorldportAck` has a sibling gap: when the accept teleport starts but the player lands on a non-BG map, the invite is released without re-adding the BG to the free slot queue. Rarer path, left for a follow-up.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.