### PR TITLE
fix(Core/Player): remove deleted equip-probe items from the item update queue

### DIFF
--- a/src/server/game/Entities/Player/PlayerStorage.cpp
+++ b/src/server/game/Entities/Player/PlayerStorage.cpp
@@ -1863,6 +1863,10 @@ InventoryResult Player::CanEquipNewItem(uint8 slot, uint16& dest, uint32 item, b
     if (pItem)
     {
         InventoryResult result = CanEquipItem(slot, dest, pItem, swap);
+        // Random-property items queue themselves on creation (SetItemRandomProperties
+        // -> SetState(ITEM_CHANGED, owner)); the probe must leave the update queue
+        // before deletion or the queue keeps a pointer to freed memory.
+        pItem->RemoveFromUpdateQueueOf(const_cast<Player*>(this));
         delete pItem;
         return result;
     }


### PR DESCRIPTION
<!-- Title: fix(Core/Player): remove deleted equip-probe items from the item update queue -->

## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Fixes a use-after-free in the player item update queue that crashes the worldserver in `Player::_SaveInventory` (observed as ACCESS_VIOLATION).

`Player::CanEquipNewItem` creates a temporary probe item via `Item::CreateItem` to test equipability and raw-`delete`s it afterwards. For items with random properties or suffixes, `CreateItem` rolls the suffix via `SetItemRandomProperties`, and that call ends in `SetState(ITEM_CHANGED, GetOwner())`, which puts the probe into the owner's `m_itemUpdateQueue`. The `delete` then leaves a dangling pointer in the queue. On the next inventory save, `_SaveInventory` walks the queue, dereferences the freed probe, and crashes.

Both callers of `CanEquipNewItem` can reach this:
- `Player::_StoreOrEquipNewItem` with `bStore = false`: buying an item from a vendor directly into an equipment slot (`CMSG_BUY_ITEM_IN_SLOT`).
- `Player::StoreNewItemInBestSlots`: harmless at character creation, because the player isn't registered in `ObjectAccessor` yet and `GetOwner()` returns nullptr, but a crash when a module calls it for an online player. mod-playerbots does exactly that all day through bot gearing.

The fix pulls the probe out of the update queue before deleting it. `RemoveFromUpdateQueueOf` is a no-op for items that never got queued (no random properties), so nothing changes for ordinary items.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
>
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (via Claude Code) helped write and review this change.

## Issues Addressed:
- N/A. No existing issue tracks this crash. (#12567 mentions `_SaveInventory` but concerns a different path inside the save loop itself.)

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

None of the above. This is an internal memory-safety fix, derived from crash dumps (`ACCESS_VIOLATION` in `Player::_SaveInventory`) and from reading the code path between `CreateItem` and the item update queue.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds without errors (MSVC, Windows). Running on the author's server, where heavy mod-playerbots usage exercises `StoreNewItemInBestSlots` and `CanEquipNewItem` for online players all the time. The recurring `_SaveInventory` crashes stopped after applying this fix.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Find a vendor item with random properties: `SELECT nv.entry AS vendor, nv.item FROM npc_vendor nv JOIN item_template it ON it.entry = nv.item WHERE it.RandomProperty > 0 OR it.RandomSuffix > 0;`
2. On a character with the target equipment slot empty, buy that item from the vendor by right-clicking it (buy-to-slot, `CMSG_BUY_ITEM_IN_SLOT`), or trigger any code path that calls `CanEquipNewItem` for an online player.
3. Force a save (`.save`) or wait for the periodic save interval.
4. Without this fix the save dereferences the freed probe item: reliably caught by a debug/ASan build, intermittent ACCESS_VIOLATION in release. With the fix the save completes normally.
5. Regression check: buy and equip items *without* random properties the same way, plus normal inventory operations (store, swap, sell), and verify saving still works. `RemoveFromUpdateQueueOf` early-outs for never-queued items.

## Known Issues and TODO List:

- [ ] None

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
