### PR TITLE
fix(core/SAI): remove duplicate WAYPOINT_REACHED dispatch in MovementInform

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -1317,13 +1317,11 @@ void SmartAI::WaypointReached(uint32 nodeId, uint32 pathId)
     }
 }
 
-void SmartAI::WaypointPathEnded(uint32 nodeId, uint32 pathId)
+void SmartAI::WaypointPathEnded(uint32 /*nodeId*/, uint32 /*pathId*/)
 {
-    if (!HasEscortState(SMART_ESCORT_ESCORTING))
-    {
-        GetScript()->ProcessEventsFor(SMART_EVENT_WAYPOINT_ENDED, nullptr, nodeId, pathId);
-        return;
-    }
+    // WAYPOINT_ENDED is fired from SmartAI::PathEndReached (the waypoint generator calls both
+    // hooks at path end); firing it here too made the event trigger twice. PathEndReached also
+    // runs first, while me->GetWaypointPath() is still valid for the event's pathId filter.
 }
 
 void SmartAI::DistancingEnded()

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -687,8 +687,7 @@ void SmartAI::MovementInform(uint32 MovementType, uint32 Data)
     if (MovementType == POINT_MOTION_TYPE && Data == SMART_ESCORT_LAST_OOC_POINT)
         me->ClearUnitState(UNIT_STATE_EVADE);
 
-    // WAYPOINT_REACHED is fired from SmartAI::WaypointReached (the waypoint generator calls it
-    // alongside this and passes the pathId); firing it here too made the event trigger twice.
+    // WAYPOINT_REACHED is fired from WaypointReached() instead, to avoid a double trigger
     GetScript()->ProcessEventsFor(SMART_EVENT_MOVEMENTINFORM, nullptr, MovementType, Data);
     if (!HasEscortState(SMART_ESCORT_ESCORTING))
         return;
@@ -1319,9 +1318,7 @@ void SmartAI::WaypointReached(uint32 nodeId, uint32 pathId)
 
 void SmartAI::WaypointPathEnded(uint32 /*nodeId*/, uint32 /*pathId*/)
 {
-    // WAYPOINT_ENDED is fired from SmartAI::PathEndReached (the waypoint generator calls both
-    // hooks at path end); firing it here too made the event trigger twice. PathEndReached also
-    // runs first, while me->GetWaypointPath() is still valid for the event's pathId filter.
+    // // WAYPOINT_ENDED is fired from PathEndReached() instead, to avoid a double trigger
 }
 
 void SmartAI::DistancingEnded()

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -687,9 +687,8 @@ void SmartAI::MovementInform(uint32 MovementType, uint32 Data)
     if (MovementType == POINT_MOTION_TYPE && Data == SMART_ESCORT_LAST_OOC_POINT)
         me->ClearUnitState(UNIT_STATE_EVADE);
 
-    if (MovementType == WAYPOINT_MOTION_TYPE)
-        GetScript()->ProcessEventsFor(SMART_EVENT_WAYPOINT_REACHED, nullptr, Data); // data now corresponds to columns
-
+    // WAYPOINT_REACHED is fired from SmartAI::WaypointReached (the waypoint generator calls it
+    // alongside this and passes the pathId); firing it here too made the event trigger twice.
     GetScript()->ProcessEventsFor(SMART_EVENT_MOVEMENTINFORM, nullptr, MovementType, Data);
     if (!HasEscortState(SMART_ESCORT_ESCORTING))
         return;


### PR DESCRIPTION
#23251 reworked SAI WP/movement system and added dedicated Waypoint_Reached hook but did not remove the old dispatch inside of Movement_Inform. This removes the redundancy and NPCs who talk on waypoint_reached won't double fire their text lines.

## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


I was working on #26608 - can use it to test: .go c 125712