### PR TITLE
Spell: mark Sunder/Rend/Hamstring as melee-dmg-class for procs (fix S…

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -1192,6 +1192,21 @@ void SpellMgr::LoadSpellInfoCorrections()
     {
         spellInfo->Effects[EFFECT_0].TriggerSpell = 11971;
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_SPELL_WITH_VALUE;
+        // Treat Sunder Armor as melee-dmg-class for proc system so talents
+        // like Sword Specialization / Sudden Death can trigger from it.
+        spellInfo->ProcFlags |= PROC_FLAG_DONE_SPELL_MELEE_DMG_CLASS;
+    });
+
+    // Rend (ensure treated as melee-dmg-class for procs)
+    ApplySpellFix({ 6547 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ProcFlags |= PROC_FLAG_DONE_SPELL_MELEE_DMG_CLASS;
+    });
+
+    // Hamstring (ensure treated as melee-dmg-class for procs)
+    ApplySpellFix({ 25212 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ProcFlags |= PROC_FLAG_DONE_SPELL_MELEE_DMG_CLASS;
     });
 
     // Improved Spell Reflection


### PR DESCRIPTION
Summary

Purpose: Fixes a proc bug where Sunder Armor, Rend, and Hamstring did not trigger extra-attack procs such as Sword Specialization / Sudden Death.
Changes Proposed

File: See SpellInfoCorrections.cpp
What: Marked the affected spells so the proc system treats them as melee-dmg-class (ProcFlags |= PROC_FLAG_DONE_SPELL_MELEE_DMG_CLASS), allowing eligible procs to trigger.
Step‑by‑Step — How I implemented it (human-friendly)

I inspected how the server decides which actions count as “melee” for procs (proc flags and ProcEventInfo).
I found Sunder Armor was already triggering a helper spell but lacked the proc flag that classifies it as a melee-damage spell for proc checks.
I added the same proc-flag treatment to the older Sunder ranks and added similar flags for Rend and Hamstring so they are considered melee-dmg-class by the proc filtering.
I committed the change on a branch fix/proc-sunder-rend-hamstring and pushed it to your remote.
How to test the change

Build the server and run a worldserver.
On a warrior (or other relevant class), reproduce the original steps: set dummy HP high, generate rage, cast Sunder Armor / Rend / Hamstring on a dummy.
Observe damage logs / meter to confirm Sword Specialization and/or Sudden Death procs appear from those spells.
Also sanity-check other melee procs to ensure no regressions.
Tests Performed Locally

Ran repository codestyle checks: codestyle-cpp.py and codestyle-sql.py (both passed).
No in-game testing performed by me — please test on a local server or test realm following the steps above.
Notes & Caveats

This is a focused, minimal change: it sets proc classification flags rather than broadly altering damage classes. In-game verification across ranks and weapon types is recommended.
If maintainers prefer altering DmgClass or a different approach, I can adapt the patch.
AI disclosure

I used AI assistance (GPT-5 mini) to draft and refine the explanation and implementation approach; the code changes and final commit were reviewed and applied by me.