### PR TITLE
fix(DB): grant Refuge Pointe Defender CREATURE_TYPE_FLAG_CAN_ASSIST

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784043027660896949.sql
+++ b/data/sql/updates/pending_db_world/rev_1784043027660896949.sql
@@ -1,0 +1,3 @@
+-- Refuge Pointe Defender (10696) does not assist players in combat against
+-- nearby hostile creatures because CREATURE_TYPE_FLAG_CAN_ASSIST is unset.
+UPDATE `creature_template` SET `type_flags` = `type_flags` | 0x1000 WHERE `entry` = 10696;


### PR DESCRIPTION
## Changes Proposed

* Sets `CREATURE_TYPE_FLAG_CAN_ASSIST` (`0x1000`) on Refuge Pointe Defender (entry 10696), which was previously `0`.

## Issue reference

Reported at chromiecraft/chromiecraft#9895 — Refuge Pointe Defender does not assist a player being attacked by a nearby hostile creature (e.g. a raptor), even when standing right next to the fight.

Repro steps from the report:
```
.go xyz -1377.2554 -2480.9768 60.010418 0
pull a nearby mob (raptor) and observe
```

## Root cause

`SmartAI::AssistPlayerInCombatAgainst` (`src/server/game/AI/SmartScripts/SmartAI.cpp`) requires `CREATURE_TYPE_FLAG_CAN_ASSIST` to be set on the assisting creature's `type_flags` before it will even attempt to intervene on a nearby player's behalf:

```cpp
if (!(me->GetCreatureTemplate()->type_flags & CREATURE_TYPE_FLAG_CAN_ASSIST))
    return false;
```

Entry 10696 had `type_flags = 0`, so this check always failed and the defender ignored players in combat nearby regardless of proximity or line of sight.

## Test done

* Rebuilt and ran a local server, applied the update via `dbimport`, confirmed `type_flags` changed from `0` to `4096` in `acore_world.creature_template`.
* Confirmed in-game that the Defender now moves to engage a hostile creature attacking a nearby player, where previously it took no action at all.

## Note for reviewers

During testing we found a second, deeper issue: even with this flag set, engagement can still stall in some cases because `Creature::CanCreatureAttack` (via `ThreatReference::ShouldBeOffline`) independently re-applies the same faction-hostility requirement that `AssistPlayerInCombatAgainst`'s `IsValidAttackTarget` check enforces, in a separate code path. That's a broader core-combat issue touching shared creature-vs-creature combat logic, so it's intentionally out of scope for this PR — happy to open a follow-up issue with the full trace if useful.