### PR TITLE
fix(DB/creature): reposition Arcanist Savan to Scryer's Tier

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784062930257635964.sql
+++ b/data/sql/updates/pending_db_world/rev_1784062930257635964.sql
@@ -1,0 +1,1 @@
+UPDATE `creature` SET `position_x` = -2139.0044, `position_y` = 5553.616, `position_z` = 50.296047, `orientation` = 0.23167777 WHERE `guid` = 2196 AND `id` = 23272;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Tool used: Claude (Sonnet 5), for cross-referencing spawn coordinates and drafting the SQL update.

## Issues Addressed:
- Closes #14917 (partial — only Arcanist Savan; Investigator Asric and Peacekeeper Jadaar are intentionally left unfixed, see Known Issues)

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Wowhead reference screenshot (Scryer's Tier, from 2007) used to identify the correct spot:

<img width="225" height="358" alt="image" src="https://github.com/user-attachments/assets/6ca86a9d-38cf-47f7-98ec-a8855d860bd5" />


## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

In-game screenshot at the new coordinates, matching the reference above:

<img width="829" height="889" alt="image" src="https://github.com/user-attachments/assets/727d94c1-2b46-4021-9b32-97d1d5836de3" />


## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.tele shattrath`
2. Go to Scryer's Tier.
3. Arcanist Savan should now be standing there instead of the World's End Tavern.

## Known Issues and TODO List:

- [ ] Investigator Asric and Peacekeeper Jadaar (also reported in #14917) are believed to belong at the Argent Tournament Grounds (Aspirants' Ring, Icecrown) per Wowpedia's patch history, but their exact spot couldn't be confidently verified against a reference image, so they're left out of this PR pending that.