### PR TITLE
fix(scripts/Zul'Farrak): Prevent repeated zombie summons from shallow…

### DIFF
--- a/src/server/scripts/Kalimdor/ZulFarrak/instance_zulfarrak.cpp
+++ b/src/server/scripts/Kalimdor/ZulFarrak/instance_zulfarrak.cpp
@@ -25,6 +25,8 @@
 #include "SpellScriptLoader.h"
 #include "TemporarySummon.h"
 #include "zulfarrak.h"
+#include <unordered_set>
+#include <cmath>
 
 enum Misc
 {
@@ -125,6 +127,27 @@ public:
         ObjectGuid MurtaGUID;
         ObjectGuid ShadowpriestGUID;
 
+        struct GraveLocation
+        {
+            int32 x;
+            int32 y;
+
+            bool operator==(GraveLocation const& other) const
+            {
+                return x == other.x && y == other.y;
+            }
+        };
+
+        struct GraveLocationHash
+        {
+            std::size_t operator()(GraveLocation const& g) const
+            {
+                return (std::hash<int32>()(g.x) << 1) ^ std::hash<int32>()(g.y);
+            }
+        };
+
+        std::unordered_set<GraveLocation, GraveLocationHash> UsedGraves;
+
         GuidList addsAtBase;
         GuidList movedadds;
 
@@ -134,6 +157,17 @@ public:
         uint32 minor_wave_Timer;
         uint32 addGroupSize;
         uint32 waypoint;
+
+        bool ConsumeGrave(float x, float y)
+        {
+            GraveLocation loc
+            {
+                static_cast<int32>(std::round(x * 100.0f)),
+                static_cast<int32>(std::round(y * 100.0f))
+            };
+
+            return UsedGraves.insert(loc).second;
+        }
 
         void Initialize() override
         {
@@ -465,18 +499,44 @@ class spell_zulfarrak_summon_zulfarrak_zombies : public SpellScript
 
     void HandleSummon(SpellEffIndex effIndex)
     {
+        Creature* trigger = GetCaster()->ToCreature();
+        if (!trigger)
+            return;
+
+        WorldLocation const* dest = GetExplTargetDest();
+        if (!dest)
+            return;
+
         if (effIndex == EFFECT_0)
         {
+            if (InstanceScript* instance = trigger->GetInstanceScript())
+            {
+                auto* zf = static_cast<instance_zulfarrak::instance_zulfarrak_InstanceMapScript*>(instance);
+
+                // Only allow this grave to summon zombies once per instance.
+                if (!zf->ConsumeGrave(dest->GetPositionX(), dest->GetPositionY()))
+                {
+                    PreventHitDefaultEffect(EFFECT_0);
+                    PreventHitDefaultEffect(EFFECT_1);
+                    return;
+                }
+            }
+
+            // Original AzerothCore summon chance.
             if (roll_chance_i(30))
             {
-                PreventHitDefaultEffect(effIndex);
+                PreventHitDefaultEffect(EFFECT_0);
                 return;
             }
         }
-        else if (roll_chance_i(40))
+        else
         {
-            PreventHitDefaultEffect(effIndex);
-            return;
+            // Original AzerothCore summon chance.
+            if (roll_chance_i(40))
+            {
+                PreventHitDefaultEffect(EFFECT_1);
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
## Changes Proposed:
-  [x] Scripts (bosses, spell scripts, creature scripts).
- This fix makes it so you can only spawn zombies from graves in ZF one time per grave preventing an infinite loot glitch.

### AI-assisted Pull Requests
- [x] ChatGPT was used to prepare this pull request

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 24692, 26534

## SOURCE:
This bug existed in retail but was patched out by blizzard after WOTLK. The combination of mod-autobalance makes this incredibly exploitable (more-so than it already was by mages on retail WoW).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [x] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Go to ZF
2. Disable Auto loot
3. Attempt to loot a grave without removing the contents
4. Zombies now only spawn once.

