### PR TITLE
fix(Core/Vehicles): protect Salvaged Siege Engine extra passengers from Flame Leviathan AoE

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -5345,6 +5345,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     vse = const_cast<VehicleSeatEntry*>(sVehicleSeatStore.LookupEntry(1520)); // Wyrmrest Vanquisher
     vse->m_flags |= VEHICLE_SEAT_FLAG_PASSENGER_NOT_SELECTABLE;
 
+    // Salvaged Siege Engine (Ulduar) extra passenger seats: the only salvaged vehicle seats
+    // without this flag, leaving those passengers targetable by Flame Leviathan's AoE
+    vse = const_cast<VehicleSeatEntry*>(sVehicleSeatStore.LookupEntry(4026));
+    vse->m_flags |= VEHICLE_SEAT_FLAG_PASSENGER_NOT_SELECTABLE;
+    vse = const_cast<VehicleSeatEntry*>(sVehicleSeatStore.LookupEntry(4027));
+    vse->m_flags |= VEHICLE_SEAT_FLAG_PASSENGER_NOT_SELECTABLE;
+
     // pussywizard: fix z offset for some vehicles:
     vse = const_cast<VehicleSeatEntry*>(sVehicleSeatStore.LookupEntry(6206)); // Marrowgar - Bone Spike
     vse->m_attachmentOffsetZ = 4.0f;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Players sitting in the two extra passenger seats of the Salvaged Siege Engine die to Flame Leviathan's ticking AoE. On retail they are protected: "This vehicle can also hold two additional passengers. They will be protected from the general AoE damage, but cannot do anything during the fight." (wowpedia).

Root cause: there is no generic "inside a vehicle = safe from AoE" rule. Vehicle passengers are only protected because their seat carries `VEHICLE_SEAT_FLAG_PASSENGER_NOT_SELECTABLE`, which sets `UNIT_FLAG_NOT_SELECTABLE` on the passenger and makes `_IsValidAttackTarget` reject them. Dumping VehicleSeat.dbc shows that across all four salvaged vehicles (Siege Engine 336, Turret 337, Chopper 335, Demolisher 338) every seat has that flag except exactly two: seats 4026 and 4027, the Siege Engine's extra passenger seats. Those passengers therefore remain valid targets for Flame Vents (62396 ticks 63847 every second, ~15k fire damage in a 500 yd radius), Missile Barrage (62400) and Battering Ram splash (62376), while driver and turret gunner are safe.

Fix: add `VEHICLE_SEAT_FLAG_PASSENGER_NOT_SELECTABLE` to seats 4026/4027 in `SpellInfoCorrections.cpp`, next to the existing seat flag corrections (same pattern as the Wyrmrest Vanquisher seat). These two seat entries are used only by vehicle 336, so the change cannot affect other content.

For reference, TrinityCore 3.3.5 and cmangos rely on the same seat flag mechanism and have no extra handling for these seats, so they share this bug; nothing to cherry-pick.

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Investigation and patch prepared with Claude Code (Claude Fable 5).

## Issues Addressed:
- Closes #26388

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Wrath Classic world 2nd POV showing no passenger deaths: https://youtu.be/bXP9TEAwhzU?t=272
Wowpedia on the Salvaged Siege Engine passenger seats: https://wowpedia.fandom.com/wiki/Salvaged_Siege_Engine

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Codestyle checks pass. Not yet built or tested in-game by the author.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Enter Ulduar (Flame Leviathan area) with 3 level 80 characters, no god mode on any of them.
2. Put all 3 into one Salvaged Siege Engine (driver, turret and one extra passenger seat).
3. Start the encounter.
4. Before the fix, the extra passenger takes constant Flame Vents ticks and dies; after the fix no passenger takes damage while the vehicle itself still does.
5. Leave the vehicle and verify the character is targetable/attackable again as usual.

## Known Issues and TODO List:

- [ ] While seated, the extra passengers are also unselectable for friendly spells from outside the vehicle. This matches the seat behavior of the driver/turret seats and the other salvaged vehicles.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
