### PR TITLE
fix(Scripts/Ulduar): keep VX-001 arms deployed during Mimiron phase 4

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -952,6 +952,14 @@ struct npc_ulduar_leviathan_mkii : public ScriptedAI
         _events.Reset();
     }
 
+    void AttackStart(Unit* who) override
+    {
+        ScriptedAI::AttackStart(who);
+        // Unit::Attack clears the emote state on target switch, which would retract VX-001's arms
+        if (_phase == 4)
+            me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_CUSTOM_SPELL_01);
+    }
+
     void SetData(uint32 id, uint32 value) override
     {
         if (id == 1) // setting phase to start fighting
@@ -985,6 +993,8 @@ struct npc_ulduar_leviathan_mkii : public ScriptedAI
                     if (Unit* target = SelectTargetFromPlayerList(75.0f))
                         AttackStart(target);
                     DoZoneInCombat();
+                    // The assembled V0-L7R-ON animates through its vehicle base; this state keeps VX-001's arms deployed
+                    me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_CUSTOM_SPELL_01);
                     _events.Reset();
                     _events.ScheduleEvent(EVENT_SPELL_SHOCK_BLAST, 20s);
                     _events.ScheduleEvent(EVENT_PROXIMITY_MINES_1, 6s);
@@ -1380,7 +1390,8 @@ struct npc_ulduar_vx001 : public ScriptedAI
                     if (Unit* vb = me->GetVehicleBase())
                     {
                         vb->SendMeleeAttackStop();
-                        vb->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
+                        // Keep the arms-deployed state so the model returns to it after the one-shot pulse animation
+                        vb->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_CUSTOM_SPELL_01);
 
                         if (!_leftArm)
                         {


### PR DESCRIPTION
## Changes Proposed:

In phase 4 the assembled V0-L7R-ON is animated through its vehicle base (the Leviathan MK II), which is why the script plays all arm emotes on `GetVehicleBase()`. `EMOTE_STATE_CUSTOM_SPELL_01` on the base is the arms-deployed pose, and the script currently only sets it briefly during Spinning Up, so VX-001's arms are retracted for most of the phase and players cannot see where P3Wx2 Laser Barrage is aimed.

Two regressions caused this:
- #4876 removed the permanent arms-deployed state that used to be set on the MK II at assembly, and changed the Hand Pulse handler to reset the base to `EMOTE_ONESHOT_NONE`. Hand Pulse fires every 1.75s, so the base spends nearly the whole phase in the armless idle.
- #8170 moved a generic emote state clear into `Unit::Attack`, so every melee target switch of the MK II wipes the spin-up state mid-barrage. This is the inconsistent "arms disappear during spinning up" part of the report.

This PR restores the permanent arms-deployed state when phase 4 combat starts, keeps it through Hand Pulse (the one-shot pulse animations still play on top of it), and re-applies it after target switches via an `AttackStart` override on the MK II so the generic `Unit::Attack` behavior stays untouched for all other creatures. Phase 1 is unaffected: `Reset()` still clears the state and the override only acts in phase 4.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25199

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Both videos linked in the issue (Classic WotLK and a 2009 Tankspot kill) show the arms deployed for the entire phase 4, matching the pre-#4876 behavior.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.tele mimiron` and start the encounter, fight through to phase 4.
2. Check the arms stay deployed for the whole phase, including between Hand Pulse casts.
3. Have the MK II switch melee targets while Spinning Up / P3Wx2 Laser Barrage channels and check the arms no longer vanish mid-barrage.
4. Reset and re-check phase 1 (MK II alone) still has no emote state applied.

## Known Issues and TODO List:

- [ ] Whether the one-shot Hand Pulse emotes on the base are redundant with the spell visual kits of Hand Pulse L/R was not investigated; this PR keeps them as-is.

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
