### PR TITLE
fix(DB/spell_custom_attr): Watcher Gashra's Enrage should be a buff

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784087165100029500.sql
+++ b/data/sql/updates/pending_db_world/rev_1784087165100029500.sql
@@ -1,0 +1,6 @@
+-- Watcher Gashra's Enrage (52470) is a self-buff, but its -50% physical damage
+-- done effect (EFFECT_2) makes the core classify the whole aura as negative,
+-- so it shows as a debuff on the target frame.
+-- Mark all three effects positive (SPELL_ATTR0_CU_POSITIVE_EFF0 | EFF1 | EFF2).
+DELETE FROM `spell_custom_attr` WHERE `spell_id` = 52470;
+INSERT INTO `spell_custom_attr` (`spell_id`, `attributes`) VALUES (52470, 0x0E000000);


### PR DESCRIPTION
## Changes Proposed:
Watcher Gashra's Enrage (52470) is applied as a debuff instead of a buff. The spell has three self-auras: +melee haste (EFFECT_0), +scale (EFFECT_1) and -50% physical damage done (EFFECT_2). The negative basepoints of EFFECT_2 make `SpellInfo::_IsPositiveEffect` classify that effect as negative, and since one negative effect flags the whole self-cast aura application as `AFLAG_NEGATIVE`, the client shows Enrage in the debuff row of the target frame.

This adds a `spell_custom_attr` entry marking all three effects positive (`SPELL_ATTR0_CU_POSITIVE_EFF0 | EFF1 | EFF2` = 0x0E000000), so the aura is applied as a buff. The spell has no `spelldifficulty_dbc` entry, so the same spell id covers normal and heroic Azjol-Nerub.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26563

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Official footage shows Enrage on the buff row of the target frame: https://www.youtube.com/watch?v=OBegEdr8QGA (0:56, 1:21). Spell data: https://wowgaming.altervista.org/aowow/?spell=52470

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply the SQL update and restart the worldserver.
2. On a level 80 hunter: `.learn all my class`, then `.go c i 28730`.
3. Engage Watcher Gashra and wait for it to cast Enrage.
4. Enrage should now appear on the buff row of the target frame (larger icon row, no red border) instead of with the debuffs.
5. Cast Tranquilizing Shot on it: the Enrage should be removed.

## Known Issues and TODO List:

- [ ] Other creature enrages with a damage-done penalty effect may be misclassified the same way; this PR only fixes 52470.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
