### PR TITLE
fix(Scripts/Ulduar): make Mimiron's Aerial Command Unit chase players

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784088692116509100.sql
+++ b/data/sql/updates/pending_db_world/rev_1784088692116509100.sql
@@ -1,3 +1,7 @@
 -- Aerial Command Unit: hover height and flags to match TDB (hover-based chase)
 -- 256 = UNIT_FLAG_IMMUNE_TO_PC (cleared by script at phase start), 512 = CREATURE_FLAG_EXTRA_NO_MOVE_FLAGS_UPDATE
 UPDATE `creature_template` SET `HoverHeight` = 15, `unit_flags` = `unit_flags`|256, `flags_extra` = `flags_extra`|512 WHERE `entry` IN (33670, 34109);
+
+-- Values ported from TrinityCore (TrinityCore/TrinityCore@7c13b383); zeroed combat reach
+-- made the hovering ACU unreachable for Magnetic Core's 15y check
+UPDATE `creature_model_info` SET `BoundingRadius` = 0.31, `CombatReach` = 5 WHERE `DisplayID` = 28979;

--- a/data/sql/updates/pending_db_world/rev_1784088692116509100.sql
+++ b/data/sql/updates/pending_db_world/rev_1784088692116509100.sql
@@ -1,0 +1,3 @@
+-- Aerial Command Unit: hover height and flags to match TDB (hover-based chase)
+-- 256 = UNIT_FLAG_IMMUNE_TO_PC (cleared by script at phase start), 512 = CREATURE_FLAG_EXTRA_NO_MOVE_FLAGS_UPDATE
+UPDATE `creature_template` SET `HoverHeight` = 15, `unit_flags` = `unit_flags`|256, `flags_extra` = `flags_extra`|512 WHERE `entry` IN (33670, 34109);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -264,7 +264,8 @@ enum Texts
 #define GetVX001() instance->GetCreature(DATA_MIMIRON_VX001)
 #define GetACU() instance->GetCreature(DATA_MIMIRON_ACU)
 
-Position const ACUSummonPos = { 2742.6265f, 2568.0571f, 377.22076f, 0.0f }; /// @todo: replace with sniffed position
+// Z is above hover height (15y) so that activating hover does not relocate the ACU upwards
+Position const ACUSummonPos = { 2744.650f, 2569.460f, 380.0f, 3.141593f };
 
 struct boss_mimiron : public BossAI
 {
@@ -1502,7 +1503,8 @@ struct npc_ulduar_aerial_command_unit : public ScriptedAI
         _isDefeated = false;
         _events.Reset();
         _summons.DespawnAll();
-        me->SetCombatMovement(false); /// @todo: research ACU behaviour
+        me->SetHover(false);
+        me->SetDisableGravity(true);
     }
 
     void SetData(uint32 id, uint32 value) override
@@ -1517,7 +1519,12 @@ struct npc_ulduar_aerial_command_unit : public ScriptedAI
                     break;
                 case 3:
                     _phase = 3;
+                    // Hover instead of disabled gravity: chase then keeps the ACU at
+                    // HoverHeight above ground instead of dragging it to ground level.
+                    me->SetDisableGravity(false);
+                    me->SetHover(true);
                     me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+                    me->SetImmuneToPC(false);
                     DoZoneInCombat();
                     _events.Reset();
                     _events.ScheduleEvent(EVENT_SUMMON_BOMB_BOT, 15s);
@@ -1549,16 +1556,11 @@ struct npc_ulduar_aerial_command_unit : public ScriptedAI
                 me->CastStop();
                 me->AttackStop();
                 me->SetReactState(REACT_PASSIVE);
-                me->SetDisableGravity(false);
                 me->GetMotionMaster()->MoveFall();
                 _events.DelayEvents(25s);
                 break;
             case DO_ENABLE_AERIAL:
-                me->SetDisableGravity(true);
-                me->GetMotionMaster()->MovePoint(0, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 10.0f);
-                me->m_Events.AddEventAtOffset([&] {
-                    me->SetReactState(REACT_AGGRESSIVE);
-                }, 2s);
+                me->SetReactState(REACT_AGGRESSIVE);
                 break;
             case 1337:
                 _summons.DespawnAll();
@@ -1588,6 +1590,8 @@ struct npc_ulduar_aerial_command_unit : public ScriptedAI
                     me->InterruptNonMeleeSpells(false);
                     me->RemoveAllAurasExceptType(SPELL_AURA_CONTROL_VEHICLE);
 
+                    me->SetHover(false);
+                    me->SetDisableGravity(true);
                     me->GetMotionMaster()->MovePoint(0, 2744.65f, 2569.46f, 381.34f);
 
                     if (Creature* c = GetMimiron())

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -1556,11 +1556,26 @@ struct npc_ulduar_aerial_command_unit : public ScriptedAI
                 me->CastStop();
                 me->AttackStop();
                 me->SetReactState(REACT_PASSIVE);
+                // Raw flag removal first: MoveFall lands at ground + hover height, which would
+                // keep the ACU airborne, and SetHover(false) would relocate it without a spline.
+                // SetHover(false) afterwards is relocation-free and tells the client to stop
+                // hovering, else it keeps floating the grounded unit back up
+                me->RemoveUnitMovementFlag(MOVEMENTFLAG_HOVER);
                 me->GetMotionMaster()->MoveFall();
+                me->SetHover(false);
                 _events.DelayEvents(25s);
                 break;
             case DO_ENABLE_AERIAL:
-                me->SetReactState(REACT_AGGRESSIVE);
+                if (_isDefeated)
+                    break;
+                me->SetDisableGravity(true);
+                // 16y: above hover height (15y) so SetHover does not relocate it further up
+                me->GetMotionMaster()->MovePoint(0, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 16.0f);
+                me->m_Events.AddEventAtOffset([&] {
+                    me->SetDisableGravity(false);
+                    me->SetHover(true);
+                    me->SetReactState(REACT_AGGRESSIVE);
+                }, 2s);
                 break;
             case 1337:
                 _summons.DespawnAll();
@@ -1590,7 +1605,6 @@ struct npc_ulduar_aerial_command_unit : public ScriptedAI
                     me->InterruptNonMeleeSpells(false);
                     me->RemoveAllAurasExceptType(SPELL_AURA_CONTROL_VEHICLE);
 
-                    me->SetHover(false);
                     me->SetDisableGravity(true);
                     me->GetMotionMaster()->MovePoint(0, 2744.65f, 2569.46f, 381.34f);
 


### PR DESCRIPTION
## Changes Proposed:

Ports TrinityCore's hover-based movement for Mimiron's Aerial Command Unit. Since https://github.com/azerothcore/azerothcore-wotlk/pull/24998 the ACU has combat movement disabled, so it never follows players that leave Plasma Ball range and just idles in place. Simply enabling combat movement makes it chase at ground level instead, because its movement template allows flight and chase paths straight to the target.

This PR matches the TC setup instead:

- DB: `HoverHeight = 15`, `UNIT_FLAG_IMMUNE_TO_PC` (cleared by the script when the aerial phase starts) and `CREATURE_FLAG_EXTRA_NO_MOVE_FLAGS_UPDATE` for 33670/34109, matching TDB values.
- Script: the ACU swaps disabled gravity for hover when phase 3 starts and uses regular chase movement, so it follows players while staying at hover height. The magnetic core actions no longer need to toggle gravity (`MoveFall` already lands at ground + hover height), and the phase 3 defeat path switches back to disable-gravity mode for the scripted flight to the assembly point.
- The ACU summon position is TC's (z = 380, above hover height), so activating hover does not relocate it upwards; this keeps it within the magnetic core's 15y range.
- `creature_model_info` for the ACU display (28979) gets TC's values (`BoundingRadius` 0.31, `CombatReach` 5, from the same TC update); AC had 0/0, which made the 15y magnetic core check fail against the hovering unit since area checks add the target's combat reach.
- While a magnetic core holds it, the ACU is now fully grounded (hover cleared server- and client-side before `MoveFall`, else it lands at ground + hover height and stays airborne) and flies back up when released.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25250

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Ported from TrinityCore: TrinityCore/TrinityCore@7c13b383 (Unholychick, used as commit author), TrinityCore/TrinityCore@510bc0b7 (Chaouki Dhib) and TrinityCore/TrinityCore@a8033420 (sirikfoll), both credited as co-authors.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Tested in-game: ACU enters combat, follows players at flight height, casts Plasma Ball, and the full Magnetic Core cycle works (pull to the ground, grounded phase, fly back up). Heroic difficulty (34109) and a full clear through V0L7RON could use additional community testing.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.tele mimiron` and start the encounter, fight until phase 3 (Aerial Command Unit).
2. Have the player with the highest threat run away: the ACU should follow at flight height (never at ground level) and resume casting Plasma Ball when back in range.
3. Kill an Assault Bot, loot and use the Magnetic Core beneath the ACU: it must fall to the ground for ~20s, then resume the fight at flight height.
4. Defeat the ACU and finish phase 4 (V0L7RON) to verify the assembly flight and the head behaving normally.

## Known Issues and TODO List:

- [ ] While repositioning after a target runs away the ACU can glide below hover height toward the target's level (same behaviour as TrinityCore; chase Z is computed at the target's position for flight-capable creatures).

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
