### PR TITLE
fix(Scripts/Ulduar): Algalon replays arrival visual on wipe recovery, fixes room-effect activation, unifies pull timing (with video test)

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -119,7 +119,7 @@ enum Events
     EVENT_INTRO_2                   = 7,
     EVENT_INTRO_3                   = 8,
     EVENT_INTRO_FINISH              = 9,
-    EVENT_ACTIVATE_EFFECTS          = 10,
+    EVENT_START_COMBAT              = 10,
     EVENT_INTRO_TIMER_DONE          = 11,
     EVENT_QUANTUM_STRIKE            = 12,
     EVENT_PHASE_PUNCH               = 13,
@@ -270,19 +270,23 @@ private:
 class AlgalonArrivalVisualEndEvent : public BasicEvent
 {
 public:
-    AlgalonArrivalVisualEndEvent(Unit* algalon) : _algalon(algalon)
+    AlgalonArrivalVisualEndEvent(Unit* algalon) : _map(algalon->GetMap()), _algalonGuid(algalon->GetGUID())
     {
     }
 
     bool Execute(uint64 /*execTime*/, uint32 /*diff*/) override
     {
-        _algalon->SetDisableGravity(false);
-        _algalon->RemoveAurasDueToSpell(SPELL_RIDE_THE_LIGHTNING);
+        if (Creature* algalon = _map->GetCreature(_algalonGuid))
+        {
+            algalon->SetDisableGravity(false);
+            algalon->RemoveAurasDueToSpell(SPELL_RIDE_THE_LIGHTNING);
+        }
         return true;
     }
 
 private:
-    Unit* _algalon;
+    Map* _map;
+    ObjectGuid _algalonGuid;
 };
 
 struct boss_algalon_the_observer : public ScriptedAI
@@ -563,7 +567,7 @@ struct boss_algalon_the_observer : public ScriptedAI
         events.SetPhase(PHASE_ROLE_PLAY);
 
         events.ScheduleEvent(EVENT_SPEAK_AGGRO, introDelay);
-        events.ScheduleEvent(EVENT_ACTIVATE_EFFECTS, effectsDelay);
+        events.ScheduleEvent(EVENT_START_COMBAT, effectsDelay);
         events.ScheduleEvent(EVENT_REMOVE_UNNATTACKABLE, combatStartDelay - 500ms);
         events.ScheduleEvent(EVENT_INTRO_TIMER_DONE, combatStartDelay);
         events.ScheduleEvent(EVENT_QUANTUM_STRIKE, 3500ms + combatStartDelay);
@@ -721,7 +725,7 @@ struct boss_algalon_the_observer : public ScriptedAI
                 if (Creature* brann = _instance->GetCreature(DATA_BRANN_BRONZEBEARD_ALG))
                     brann->AI()->DoAction(ACTION_FINISH_INTRO);
                 break;
-            case EVENT_ACTIVATE_EFFECTS:
+            case EVENT_START_COMBAT:
                 _instance->SetBossState(BOSS_ALGALON, IN_PROGRESS);
                 break;
             case EVENT_SPEAK_AGGRO:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -76,8 +76,9 @@ enum Spells
 
 enum Actions
 {
-    //ACTION_INIT_ALGALON       = 1, defined in ulduar.h
-    //ACTION_DESPAWN_ALGALON    = 2, defined in ulduar.h
+    //ACTION_INIT_ALGALON             = 1, defined in ulduar.h
+    //ACTION_DESPAWN_ALGALON          = 2, defined in ulduar.h
+    //ACTION_REPLAY_ARRIVAL_VISUAL    = 9, defined in ulduar.h
     ACTION_START_INTRO      = 3,
     ACTION_FINISH_INTRO     = 4,
     ACTION_ACTIVATE_STAR    = 5,
@@ -118,7 +119,7 @@ enum Events
     EVENT_INTRO_2                   = 7,
     EVENT_INTRO_3                   = 8,
     EVENT_INTRO_FINISH              = 9,
-    EVENT_START_COMBAT              = 10,
+    EVENT_ACTIVATE_EFFECTS          = 10,
     EVENT_INTRO_TIMER_DONE          = 11,
     EVENT_QUANTUM_STRIKE            = 12,
     EVENT_PHASE_PUNCH               = 13,
@@ -152,6 +153,8 @@ enum Events
 
     // Living Constellation
     EVENT_ARCANE_BARRAGE            = 41,
+
+    EVENT_SPEAK_AGGRO               = 42,
 };
 
 enum EncounterPhases
@@ -260,25 +263,53 @@ private:
     Unit* _caster;
 };
 
+// He respawns already sitting on his landing spot (TempSummon respawn uses
+// GetHomePosition(), which was pinned to AlgalonLandPos on the original intro), so a
+// MovePoint there is zero-distance and MovementInform(POINT_ALGALON_LAND) never fires
+// to clear gravity/the lightning glow. Clear them on a plain timer instead.
+class AlgalonArrivalVisualEndEvent : public BasicEvent
+{
+public:
+    AlgalonArrivalVisualEndEvent(Unit* algalon) : _algalon(algalon)
+    {
+    }
+
+    bool Execute(uint64 /*execTime*/, uint32 /*diff*/) override
+    {
+        _algalon->SetDisableGravity(false);
+        _algalon->RemoveAurasDueToSpell(SPELL_RIDE_THE_LIGHTNING);
+        return true;
+    }
+
+private:
+    Unit* _algalon;
+};
+
 struct boss_algalon_the_observer : public ScriptedAI
 {
     boss_algalon_the_observer(Creature* creature) : ScriptedAI(creature), summons(me)
     {
         _fedOnTears = true;
-        _firstPull = true;
         _fightWon = false;
         _instance = me->GetInstanceScript();
+        _firstResetSinceCreation = true;
     }
 
     EventMap events;
     SummonList summons;
     InstanceScript* _instance;
 
-    bool _firstPull;
     bool _fightWon;
     bool _phaseTwo;
     bool _fedOnTears;
     bool _heraldOfTheTitans;
+
+    // CreatureAI::EnterEvadeMode() calls Reset() synchronously, then - because Algalon
+    // has CREATURE_FLAG_EXTRA_HARD_RESET - despawns him and schedules a real TempSummon
+    // respawn ~20s later, which constructs a brand new AI instance and calls Reset()
+    // again as its very first call. This flag is only ever true on that first call, so
+    // it tells apart "about to despawn" resets from "just actually respawned" ones.
+    bool _firstResetSinceCreation;
 
     bool IsValidHeraldItem(ItemTemplate const* item)
     {
@@ -357,14 +388,15 @@ struct boss_algalon_the_observer : public ScriptedAI
             me->SetInCombatWithZone();
             return;
         }
-        else if (events.GetPhaseMask() & PHASE_NORMAL)
+
+        if (_instance)
+            _instance->SetBossState(BOSS_ALGALON, FAIL);
+
+        if (events.GetPhaseMask() & PHASE_NORMAL)
         {
             DoAction(ACTION_ASCEND);
             return;
         }
-
-        if (_instance)
-            _instance->SetBossState(BOSS_ALGALON, FAIL);
 
         ScriptedAI::EnterEvadeMode(why);
     }
@@ -385,13 +417,19 @@ struct boss_algalon_the_observer : public ScriptedAI
         _phaseTwo = false;
         _heraldOfTheTitans = true;
 
-        if (_instance->GetBossState(BOSS_ALGALON) == FAIL)
-        {
-            _firstPull = false;
-        }
+        bool const isFreshRespawn = _firstResetSinceCreation;
+        _firstResetSinceCreation = false;
 
-        if (_instance)
+        // FAIL means we wiped last attempt. Only replay the arrival visual on the
+        // fresh-respawn Reset() call (see _firstResetSinceCreation) - otherwise it
+        // plays on the dying instance a few seconds before it actually despawns,
+        // instead of when Algalon is really back. DOOR_TYPE_ROOM doors already treat
+        // FAIL the same as NOT_STARTED, so leaving the state as FAIL in between is safe.
+        if (_instance && isFreshRespawn && _instance->GetBossState(BOSS_ALGALON) == FAIL)
+        {
+            DoAction(ACTION_REPLAY_ARRIVAL_VISUAL);
             _instance->SetBossState(BOSS_ALGALON, NOT_STARTED);
+        }
     }
 
     void KilledUnit(Unit* victim) override
@@ -427,6 +465,18 @@ struct boss_algalon_the_observer : public ScriptedAI
                     events.ScheduleEvent(EVENT_INTRO_FINISH, 36s, 0, PHASE_ROLE_PLAY);
                     break;
                 }
+            case ACTION_REPLAY_ARRIVAL_VISUAL:
+                // Arrival + planet-channel visual only - no immune/RP lock, so repulls
+                // aren't gated on it. SPELL_SUMMON_AZEROTH's JustSummoned handler casts
+                // SPELL_REORIGINATION on the planet, same as the original intro.
+                me->SetUnitFlag2(UNIT_FLAG2_DO_NOT_FADE_IN);
+                me->SetDisableGravity(true);
+                me->CastSpell(me, SPELL_ARRIVAL, true);
+                me->CastSpell(me, SPELL_RIDE_THE_LIGHTNING, true);
+                summons.DespawnEntry(NPC_AZEROTH);
+                me->CastSpell((Unit*)nullptr, SPELL_SUMMON_AZEROTH, true);
+                me->m_Events.AddEventAtOffset(new AlgalonArrivalVisualEndEvent(me), 5s);
+                break;
             case ACTION_DESPAWN_ALGALON:
                 _fightWon = true;
                 events.Reset();
@@ -449,7 +499,8 @@ struct boss_algalon_the_observer : public ScriptedAI
                     _instance->SetBossState(BOSS_ALGALON, NOT_STARTED);
                 break;
             case ACTION_INIT_ALGALON:
-                _firstPull = false;
+                if (_instance)
+                    _instance->StorePersistentData(PERSISTENT_DATA_ALGALON_FIRST_ATTEMPT, 1);
                 _fedOnTears = false;
                 me->SetImmuneToPC(false);
                 break;
@@ -479,7 +530,31 @@ struct boss_algalon_the_observer : public ScriptedAI
             return;
         }
 
-        Milliseconds  introDelay = 0ms;
+        // introDelay: engage -> text 2 (stock's original first-pull/repeat-pull
+        // split, kept as-is). effectsDelay: text 2 -> door/floor effect (estimated
+        // text 2 spoken duration, no exact measurement available). combatStartDelay:
+        // effect -> he's actually attackable.
+        Milliseconds introDelay = 0ms;
+
+        // Despawns the planet summoned by the intro/replay-arrival visual - on repulls
+        // that visual runs again on every respawn (see ACTION_REPLAY_ARRIVAL_VISUAL).
+        summons.DespawnEntry(NPC_AZEROTH);
+
+        if (_instance->GetPersistentData(PERSISTENT_DATA_ALGALON_FIRST_ATTEMPT))
+        {
+            introDelay = 8s;
+        }
+        else
+        {
+            _instance->StorePersistentData(PERSISTENT_DATA_ALGALON_FIRST_ATTEMPT, 1);
+            Talk(SAY_ALGALON_START_TIMER);
+            introDelay = 22s;
+            _instance->SetData(DATA_DESPAWN_ALGALON, 0);
+        }
+
+        Milliseconds const effectsDelay = introDelay + 8s;
+        Milliseconds const combatStartDelay = effectsDelay + 10s;
+
         me->setActive(true);
         me->SetInCombatWithZone();
         me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
@@ -487,30 +562,17 @@ struct boss_algalon_the_observer : public ScriptedAI
         events.Reset();
         events.SetPhase(PHASE_ROLE_PLAY);
 
-        if (!_firstPull)
-        {
-            events.ScheduleEvent(EVENT_START_COMBAT, 0ms);
-            introDelay = 8s;
-        }
-        else
-        {
-            summons.DespawnEntry(NPC_AZEROTH);
-            _firstPull = false;
-            Talk(SAY_ALGALON_START_TIMER);
-            introDelay = 22s;
-            events.ScheduleEvent(EVENT_START_COMBAT, 14s);
-            _instance->SetData(DATA_DESPAWN_ALGALON, 0);
-        }
-
-        events.ScheduleEvent(EVENT_REMOVE_UNNATTACKABLE, introDelay - 500ms);
-        events.ScheduleEvent(EVENT_INTRO_TIMER_DONE, introDelay);
-        events.ScheduleEvent(EVENT_QUANTUM_STRIKE, 3500ms + introDelay);
-        events.ScheduleEvent(EVENT_PHASE_PUNCH, 15500ms + introDelay);
-        events.ScheduleEvent(EVENT_SUMMON_COLLAPSING_STAR, 16500ms + introDelay);
-        events.ScheduleEvent(EVENT_COSMIC_SMASH, 25s + introDelay);
-        events.ScheduleEvent(EVENT_ACTIVATE_LIVING_CONSTELLATION, 50500ms + introDelay);
-        events.ScheduleEvent(EVENT_BIG_BANG, 90s + introDelay);
-        events.ScheduleEvent(EVENT_ASCEND_TO_THE_HEAVENS, 360s + introDelay);
+        events.ScheduleEvent(EVENT_SPEAK_AGGRO, introDelay);
+        events.ScheduleEvent(EVENT_ACTIVATE_EFFECTS, effectsDelay);
+        events.ScheduleEvent(EVENT_REMOVE_UNNATTACKABLE, combatStartDelay - 500ms);
+        events.ScheduleEvent(EVENT_INTRO_TIMER_DONE, combatStartDelay);
+        events.ScheduleEvent(EVENT_QUANTUM_STRIKE, 3500ms + combatStartDelay);
+        events.ScheduleEvent(EVENT_PHASE_PUNCH, 15500ms + combatStartDelay);
+        events.ScheduleEvent(EVENT_SUMMON_COLLAPSING_STAR, 16500ms + combatStartDelay);
+        events.ScheduleEvent(EVENT_COSMIC_SMASH, 25s + combatStartDelay);
+        events.ScheduleEvent(EVENT_ACTIVATE_LIVING_CONSTELLATION, 50500ms + combatStartDelay);
+        events.ScheduleEvent(EVENT_BIG_BANG, 90s + combatStartDelay);
+        events.ScheduleEvent(EVENT_ASCEND_TO_THE_HEAVENS, 360s + combatStartDelay);
 
         events.ScheduleEvent(EVENT_CHECK_HERALD_ITEMS, 5s);
         DoCheckHeraldOfTheTitans();
@@ -659,8 +721,10 @@ struct boss_algalon_the_observer : public ScriptedAI
                 if (Creature* brann = _instance->GetCreature(DATA_BRANN_BRONZEBEARD_ALG))
                     brann->AI()->DoAction(ACTION_FINISH_INTRO);
                 break;
-            case EVENT_START_COMBAT:
+            case EVENT_ACTIVATE_EFFECTS:
                 _instance->SetBossState(BOSS_ALGALON, IN_PROGRESS);
+                break;
+            case EVENT_SPEAK_AGGRO:
                 Talk(SAY_ALGALON_AGGRO);
                 break;
             case EVENT_REMOVE_UNNATTACKABLE:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -424,16 +424,25 @@ struct boss_algalon_the_observer : public ScriptedAI
         bool const isFreshRespawn = _firstResetSinceCreation;
         _firstResetSinceCreation = false;
 
+        bool const justFailed = _instance && _instance->GetBossState(BOSS_ALGALON) == FAIL;
+
         // FAIL means we wiped last attempt. Only replay the arrival visual on the
         // fresh-respawn Reset() call (see _firstResetSinceCreation) - otherwise it
         // plays on the dying instance a few seconds before it actually despawns,
-        // instead of when Algalon is really back. DOOR_TYPE_ROOM doors already treat
-        // FAIL the same as NOT_STARTED, so leaving the state as FAIL in between is safe.
-        if (_instance && isFreshRespawn && _instance->GetBossState(BOSS_ALGALON) == FAIL)
-        {
+        // instead of when Algalon is really back.
+        if (isFreshRespawn && justFailed)
             DoAction(ACTION_REPLAY_ARRIVAL_VISUAL);
+
+        // Resolve to NOT_STARTED every time, except on the evade-triggered
+        // pre-despawn call above (mid-life object, still FAIL) - that one must leave
+        // FAIL alone so the later fresh-respawn Reset() can still detect it and
+        // replay the visual. Also needed on the very first-ever Reset() (state starts
+        // TO_BE_DECIDED, not FAIL): InstanceScript::SetBossState() skips door updates
+        // on a TO_BE_DECIDED->x transition, so leaving it unresolved would make the
+        // *next* transition (IN_PROGRESS on first engage) silently skip opening the
+        // Universe Floor/Globe doors instead.
+        if (_instance && !(justFailed && !isFreshRespawn))
             _instance->SetBossState(BOSS_ALGALON, NOT_STARTED);
-        }
     }
 
     void KilledUnit(Unit* victim) override
@@ -534,25 +543,22 @@ struct boss_algalon_the_observer : public ScriptedAI
             return;
         }
 
-        // introDelay: engage -> text 2 (stock's original first-pull/repeat-pull
-        // split, kept as-is). effectsDelay: text 2 -> door/floor effect (estimated
-        // text 2 spoken duration, no exact measurement available). combatStartDelay:
-        // effect -> he's actually attackable.
-        Milliseconds introDelay = 0ms;
+        // introDelay: engage -> text 2. effectsDelay: text 2 -> door/floor effect
+        // (estimated text 2 spoken duration, no exact measurement available).
+        // combatStartDelay: effect -> he's actually attackable. Same on every pull,
+        // first or repeat - text 1 plays and the timing is identical either way.
+        Milliseconds const introDelay = 22s;
 
         // Despawns the planet summoned by the intro/replay-arrival visual - on repulls
         // that visual runs again on every respawn (see ACTION_REPLAY_ARRIVAL_VISUAL).
         summons.DespawnEntry(NPC_AZEROTH);
+        Talk(SAY_ALGALON_START_TIMER);
 
-        if (_instance->GetPersistentData(PERSISTENT_DATA_ALGALON_FIRST_ATTEMPT))
-        {
-            introDelay = 8s;
-        }
-        else
+        // One-time bookkeeping for a genuinely fresh attempt only - doesn't affect
+        // timing, which is identical on every pull.
+        if (!_instance->GetPersistentData(PERSISTENT_DATA_ALGALON_FIRST_ATTEMPT))
         {
             _instance->StorePersistentData(PERSISTENT_DATA_ALGALON_FIRST_ATTEMPT, 1);
-            Talk(SAY_ALGALON_START_TIMER);
-            introDelay = 22s;
             _instance->SetData(DATA_DESPAWN_ALGALON, 0);
         }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -317,6 +317,7 @@ enum UlduarPersistentData
     PERSISTENT_DATA_ALGALON_TIMER,
     PERSISTENT_DATA_C_OF_ULDUAR_MASK,
     PERSISTENT_DATA_MAGE_BARRIER,
+    PERSISTENT_DATA_ALGALON_FIRST_ATTEMPT,
     MAX_PERSISTENT_DATA
 };
 
@@ -342,6 +343,7 @@ enum UlduarMisc
     ACTION_FEEDS_ON_TEARS_FAILED            = 0,
     ACTION_INIT_ALGALON                     = 1,
     ACTION_DESPAWN_ALGALON                  = 2,
+    ACTION_REPLAY_ARRIVAL_VISUAL            = 9,
 
     TIMER_ALGALON_DEFEATED                  = 300,
     TIMER_ALGALON_TO_SUMMON                 = 200,


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Ulduar's Algalon the Observer never replayed his arrival visual after a wipe, and his door/floor room effects didn't reliably activate. All fixes are scoped to `boss_algalon_the_observer.cpp` and `ulduar.h`:

1. **Wipe-recovery visual.** After a wipe, once Algalon actually respawns (~20s later, `CREATURE_FLAG_EXTRA_HARD_RESET`), he now replays the same arrival visual as the very first pull: landing spell, lightning-glow aura, and summoning the little Azeroth planet in front of him with its channel effect. It doesn't gate combat - players can already attack while it plays.
2. **`EnterEvadeMode` now sets `BOSS_ALGALON` to `FAIL` before the `ACTION_ASCEND` branch too**, not just the plain-evade fallback, so a wipe is consistently flagged regardless of which path triggers it.
3. **`Reset()` tells apart the two calls a wipe produces**: `CreatureAI::EnterEvadeMode()` calls `Reset()` synchronously right before the hard-reset despawn, then a second, real `Reset()` fires ~20s later when the TempSummon actually respawns as a brand-new AI instance. A one-shot flag makes the arrival visual replay only on that second call - previously it played on the dying instance a few seconds before it actually vanished.
4. **Fixed a case where the Universe Floor/Globe doors never opened on a genuinely fresh first pull.** `Reset()` used to only resolve `BOSS_ALGALON` to `NOT_STARTED` when consuming a wipe's `FAIL` state, so on a brand-new instance the encounter's very first `SetBossState` transition ended up being the `IN_PROGRESS` one at combat start - `InstanceScript::SetBossState()` silently skips door updates on a `TO_BE_DECIDED` -> x transition. `Reset()` now resolves to `NOT_STARTED` on every call except the one deliberately held at `FAIL` to gate the wipe-recovery visual above.
5. **Unified first-pull and repull timing.** Repulls used to skip the first line of dialogue entirely and sit silent for 8s before the second line - text 1 now plays and the intro/effects/combat-start delays are identical on every pull.
6. **Split the old single combat-start event into two**: an aggro-yell event, and a separate door/floor-effects event 8s after the second line of dialogue, with a further 10s gap before he's actually attackable. Previously the room effects and attackability fired at the same instant as the dialogue itself.
7. **Fixed the arrival visual's gravity/lightning-glow cleanup.** He respawns already sitting on his landing spot, so a `MovePoint` there is zero-distance and `MovementInform` never fires to clear it - cleared with a plain timer instead.
8. **Fixed a raw `Unit*` held across that timer's 5s delay** (caught by CodeRabbit) - stores `Map*` + `ObjectGuid` and resolves the creature at execute time instead, per this project's own convention for not holding long-lived object pointers.
9. **The little Azeroth planet now despawns on every re-engage**, not just the first pull, since the arrival visual (and the planet summon with it) now also plays on repulls.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Sonnet 5)
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26600

The rest of the fixes in this PR (wipe-recovery visual, room-effect activation on first pull, CodeRabbit's `Unit*` finding) aren't tied to a filed issue - found and fixed through local live testing of the encounter's wipe/repull flow while working on #26600.

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Tested locally across several wipe/repull cycles on a private test server: first-pull and repull dialogue/effects/combat-start timing, the wipe-recovery visual firing at the correct moment without getting stuck floating/glowing, no leftover planet duplicates across repeated wipes, and the Universe Floor/Globe doors and Living Constellation ring activating correctly on a genuinely fresh first pull.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter a fresh (or reset) Ulduar 25-man instance and engage Algalon for the first time. Confirm text 1 plays, then text 2 after ~22s, then the Universe Floor/Globe doors open and the Living Constellation ring spawns ~8s after that, then he becomes attackable ~10s after that.
2. Wipe the encounter, wait for him to respawn (~20-25s after the wipe), and confirm he replays the arrival visual (falling with the lightning glow, the Azeroth planet appearing in front of him channeling) before you re-engage.
3. Attack him mid-visual and confirm the lightning glow/floating clears on its own a few seconds later, and the planet despawns once combat starts.
4. Repull (2nd/3rd attempt) and confirm the dialogue/effects/combat-start timing matches the first pull exactly, including text 1 playing again.

https://github.com/user-attachments/assets/a466b049-32e3-4744-9216-a24a90dd399f


## Known Issues and TODO List:

- [ ] The 8s (effects) and 10s (attackable) gaps are estimates based on manual live testing, not measured retail/sniff values - open to adjustment if someone has more precise numbers.
- [ ] Not yet tested by anyone other than the author.
