### PR TITLE
fix(Scripts/Spells): defer aura mutations out of proc-check handlers

### DIFF
--- a/src/server/game/Spells/SpellScript.h
+++ b/src/server/game/Spells/SpellScript.h
@@ -823,12 +823,14 @@ public:
 #define AuraEffectSplitFn(F, I) EffectSplitFunction(&F, I)
 
     // executed when aura checks if it can proc
+    // do not use this hook for triggering spellcasts/removing auras etc - runs mid proc-iteration and may be unsafe
     // example: DoCheckProc += AuraCheckProcFn(class::function);
     // where function is: bool function (ProcEventInfo& eventInfo);
     HookList<CheckProcHandler> DoCheckProc;
 #define AuraCheckProcFn(F) CheckProcHandlerFunction(&F)
 
     // executed when aura effect checks if it can proc the aura
+    // do not use this hook for triggering spellcasts/removing auras etc - runs mid proc-iteration and may be unsafe
     // example: DoCheckEffectProc += AuraCheckEffectProcFn(class::function, EffectIndexSpecifier, EffectAuraNameSpecifier);
     // where function is: bool function (AuraEffect const* aurEff, ProcEventInfo& eventInfo);
     HookList<CheckEffectProcHandler> DoCheckEffectProc;

--- a/src/server/scripts/Outland/TempestKeep/botanica/instance_the_botanica.cpp
+++ b/src/server/scripts/Outland/TempestKeep/botanica/instance_the_botanica.cpp
@@ -127,9 +127,19 @@ class spell_botanica_shift_form_aura : public AuraScript
             {
                 _swapTime = GameTime::GetGameTime().count() + 6;
                 _lastSchool = spellInfo->GetSchoolMask();
-                GetUnitOwner()->RemoveAurasDueToSpell(_lastForm);
+
+                // Runs from Aura::GetProcEffectMask while the proc engine iterates the owner's
+                // applied-aura map. Swapping forms mutates that map (RemoveAura + CastSpell),
+                // which invalidates the live iterator now that aura containers are flat_multimaps.
+                // Defer the swap to the owner's event queue so it runs outside the proc walk.
+                Unit* owner = GetUnitOwner();
+                uint32 const oldForm = _lastForm;
                 _lastForm = form;
-                GetUnitOwner()->CastSpell(GetUnitOwner(), _lastForm, true);
+                owner->m_Events.AddEventAtOffset([owner, oldForm, form]()
+                {
+                    owner->RemoveAurasDueToSpell(oldForm);
+                    owner->CastSpell(owner, form, true);
+                }, 1ms);
             }
         }
 

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -123,16 +123,21 @@ class spell_mage_burning_determination : public AuraScript
         if (!(eventInfo.GetSpellInfo()->GetAllEffectsMechanicMask() & ((1ULL << MECHANIC_INTERRUPT) | (1ULL << MECHANIC_SILENCE))))
             return false;
 
+        Unit* target = eventInfo.GetActionTarget();
+
+        // This hook runs while the proc engine iterates the target's aura map; removing an
+        // aura inline would invalidate the live iterator (aura containers are flat_multimaps).
+        // Defer removals to the target's event queue so they run outside the proc walk.
         // Xinef: immuned effect should just eat charge
         if (eventInfo.GetHitMask() & PROC_EX_IMMUNE)
         {
-            eventInfo.GetActionTarget()->RemoveAurasDueToSpell(54748);
+            target->m_Events.AddEventAtOffset([target]() { target->RemoveAurasDueToSpell(54748); }, 1ms);
             return false;
         }
-        if (Aura* aura = eventInfo.GetActionTarget()->GetAura(54748))
+        if (Aura* aura = target->GetAura(54748))
         {
             if (aura->GetDuration() < aura->GetMaxDuration())
-                eventInfo.GetActionTarget()->RemoveAurasDueToSpell(54748);
+                target->m_Events.AddEventAtOffset([target]() { target->RemoveAurasDueToSpell(54748); }, 1ms);
             return false;
         }
 
@@ -1045,7 +1050,14 @@ class spell_mage_combustion : public AuraScript
         // Do not take charges, add a stack of crit buff
         if (!(eventInfo.GetHitMask() & PROC_HIT_CRITICAL))
         {
-            eventInfo.GetActor()->CastSpell(static_cast<Unit*>(nullptr), SPELL_MAGE_COMBUSTION_PROC, true);
+            // Applying the stack mutates the actor's aura map while the proc engine iterates
+            // it (this hook runs from Aura::GetProcEffectMask); defer it so the insert can't
+            // invalidate the live iterator (aura containers are flat_multimaps).
+            Unit* actor = eventInfo.GetActor();
+            actor->m_Events.AddEventAtOffset([actor]()
+            {
+                actor->CastSpell(static_cast<Unit*>(nullptr), SPELL_MAGE_COMBUSTION_PROC, true);
+            }, 1ms);
             return false;
         }
 


### PR DESCRIPTION
## Changes Proposed:

Fixes a class of use-after-free crash where a proc **check** handler (`DoCheckProc`) mutates the owner's aura containers while the proc engine is iterating them.

`DoCheckProc` runs from `Aura::GetProcEffectMask`, which `Unit::GetProcAurasTriggeredOnEvent` calls while iterating the owner's applied-aura map with a live iterator. Removing or applying an aura on that unit from inside the check reenters and mutates the container mid-walk. This was survivable while aura maps were node-based `std::multimap`s, but #25885 switched them to `boost::container::flat_multimap` (vector-backed): insert can reallocate and erase shifts elements, invalidating the live iterator and every collected `AuraApplication*`. The next dereference reads freed/moved storage and crashes (`SIGSEGV` in `GetProcEffectMask`/`GetId`).

Three handlers mutate the walked unit's own auras. Each is fixed by deferring the mutation to the owner's event queue so it runs outside the proc walk (behavior preserved; the mutation lands one tick later):

- `spell_botanica_shift_form_aura` (Frayer, spell 34201) — the form swap (`RemoveAura` + `CastSpell`) runs on every proc, so the erase reliably corrupts the collection walk. **This is the observed crash** (always creature 18587 / Frayer, map 553 Botanica).
- `spell_mage_burning_determination` — `RemoveAurasDueToSpell(54748)` on the proc target (the aura owner) when the buff is already up.
- `spell_mage_combustion` — `CastSpell(stack)` on the actor (the aura owner).

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 4.8)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Related: #26634 (revert of #25647). That revert targets the wrong change; the crash root cause is the interaction described above with #25885, not #25647.

## SOURCE:

Diagnosed from GDB crash backtraces (15 dumps, all identical: `Unit::GetProcAurasTriggeredOnEvent` -> `Aura::GetProcEffectMask` -> `Aura::GetId`, always proc target 18587) combined with code analysis of the `#25885` container change. Not a game-behavior change, so the checkboxes below do not apply.

## Tests Performed:

- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

`apps/codestyle/codestyle-cpp.py` passes. **Not yet compiled or tested in-game** — needs a build + in-game verification before merge.

## How to Test the Changes:

1. Enter The Botanica (map 553) and get a Frayer (entry 18587) to proc its shift-form aura by exposing it to incoming spells of different schools in quick succession. On an affected build (post-#25885) this crashes the worldserver in the aura proc path; with this PR it should not.
2. Mage `Burning Determination`: with the buff (54748) active, take another interrupt/silence effect so the `CheckProc` removal path runs.
3. Mage `Combustion`: activate Combustion and land non-crit fire damage so the crit-stack is applied.

## Known Issues and TODO List:

- [ ] Defensive follow-up worth considering separately: have `Unit::GetProcAurasTriggeredOnEvent` iterate a snapshot instead of the live `flat_multimap`, so this whole class of script reentrancy is non-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
