### PR TITLE
chore(Core): drop unused Language.h include in NPCHandler

### DIFF
--- a/src/server/game/Handlers/NPCHandler.cpp
+++ b/src/server/game/Handlers/NPCHandler.cpp
@@ -21,7 +21,6 @@
 #include "Creature.h"
 #include "DatabaseEnv.h"
 #include "GameGraveyard.h"
-#include "Language.h"
 #include "NPCPackets.h"
 #include "ObjectMgr.h"
 #include "Opcodes.h"


### PR DESCRIPTION
## Changes Proposed:
Removes a dead `#include "Language.h"` from `NPCHandler.cpp`. The file references no `AcoreStrings`/`BroadcastTextIds` enum type and no `LANG_*`/`BROADCAST_TEXT_*` constant, so the include is unused. No behavior change.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 4.8)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None. Housekeeping only.

## SOURCE:
Static cleanup with no gameplay impact, so the live/sniff/video options do not apply. Verified by compiling.

## Tests Performed:
Built the `game` target in Release (MSVC, Visual Studio 2022) with no errors or warnings introduced. No runtime behavior change, so no in-game testing required.

## How to Test the Changes:
1. Build the core.
2. Confirm it compiles cleanly.

## Known Issues and TODO List:
- None.
