### PR TITLE
fix(Core/Creature): the Gargoyle now obeys pet attack commands

### DIFF
--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -441,9 +441,9 @@ void Guardian::InitStats(uint32 duration)
     // auto-targets on its own (see npc_pet_dk_ebon_gargoyle in pet_dk.cpp) whenever no
     // explicit command has been issued, since AttackStart from a pet command simply takes
     // priority the same way it does for any other controllable guardian.
-    if (GetEntry() == NPC_EBON_GARGOYLE && !HasUnitTypeMask(UNIT_MASK_CONTROLLABLE_GUARDIAN))
+    if (GetEntry() == NPC_EBON_GARGOYLE && !IsControllableGuardian())
     {
-        m_unitTypeMask |= UNIT_MASK_CONTROLLABLE_GUARDIAN;
+        AddUnitTypeMask(UNIT_MASK_CONTROLLABLE_GUARDIAN);
         InitCharmInfo();
     }
 

--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -433,6 +433,20 @@ Guardian::Guardian(SummonPropertiesEntry const* properties, ObjectGuid owner) : 
 
 void Guardian::InitStats(uint32 duration)
 {
+    // Ebon Gargoyle's SummonPropertiesEntry isn't Category/Type == PET, so the constructor
+    // above never marks it controllable - force it here once the real entry is known, so
+    // /petattack and the rest of the pet command set work for it. Must run before
+    // Minion::InitStats() below, since that's what calls owner->SetMinion(), which only
+    // registers the summon as controllable if this flag is already set by then. It still
+    // auto-targets on its own (see npc_pet_dk_ebon_gargoyle in pet_dk.cpp) whenever no
+    // explicit command has been issued, since AttackStart from a pet command simply takes
+    // priority the same way it does for any other controllable guardian.
+    if (GetEntry() == NPC_EBON_GARGOYLE && !HasUnitTypeMask(UNIT_MASK_CONTROLLABLE_GUARDIAN))
+    {
+        m_unitTypeMask |= UNIT_MASK_CONTROLLABLE_GUARDIAN;
+        InitCharmInfo();
+    }
+
     Minion::InitStats(duration);
 
     if (Unit* m_owner = GetOwner())

--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -433,14 +433,9 @@ Guardian::Guardian(SummonPropertiesEntry const* properties, ObjectGuid owner) : 
 
 void Guardian::InitStats(uint32 duration)
 {
-    // Ebon Gargoyle's SummonPropertiesEntry isn't Category/Type == PET, so the constructor
-    // above never marks it controllable - force it here once the real entry is known, so
-    // /petattack and the rest of the pet command set work for it. Must run before
-    // Minion::InitStats() below, since that's what calls owner->SetMinion(), which only
-    // registers the summon as controllable if this flag is already set by then. It still
-    // auto-targets on its own (see npc_pet_dk_ebon_gargoyle in pet_dk.cpp) whenever no
-    // explicit command has been issued, since AttackStart from a pet command simply takes
-    // priority the same way it does for any other controllable guardian.
+    // The Gargoyle's SummonProperties are not PET, so the constructor never marks it
+    // controllable and /petattack does nothing. Must be set before Minion::InitStats below,
+    // which is what calls SetMinion. It still auto-targets when no command was issued.
     if (GetEntry() == NPC_EBON_GARGOYLE && !IsControllableGuardian())
     {
         AddUnitTypeMask(UNIT_MASK_CONTROLLABLE_GUARDIAN);


### PR DESCRIPTION
## Changes Proposed:

Summon Gargoyle is unresponsive to pet commands - `/petattack` (and the rest of the pet command set) silently does nothing.

**Root cause:** the Gargoyle's `SummonPropertiesEntry` (client DBC data) has `Category`/`Type` values that don't satisfy `Guardian::Guardian()`'s controllability check - confirmed live via debug logging (`Category=SUMMON_CATEGORY_ALLY`, not `SUMMON_CATEGORY_PET`). It only becomes a `Guardian`-class object at all through an unrelated `Flags & 512` carve-out in `Map::SummonCreature` (`src/server/game/Entities/Object/Object.cpp`, shared with Mirror Image). Since it never gets `UNIT_MASK_CONTROLLABLE_GUARDIAN`, `WorldSession::HandlePetAction` rejects every pet command for it, since it never becomes the player's `GetFirstControlled()`.

**Fix:** force `UNIT_MASK_CONTROLLABLE_GUARDIAN` for the Ebon Gargoyle specifically in `Guardian::InitStats()`, once its real creature entry is known - this has to run before `Minion::InitStats()` triggers `Unit::SetMinion()`, since the flag must already be set by then. The Gargoyle keeps its existing auto-target AI (`npc_pet_dk_ebon_gargoyle`) as the fallback whenever the player hasn't issued an explicit command.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Sonnet 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26611

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Tested locally on a Death Knight: cast Summon Gargoyle, confirmed `/petattack <target>` now makes it attack the specified target, confirmed its existing auto-target behavior (attacking whatever the owner is currently targeting) still works when no explicit command is given, and confirmed Mirror Image (which shares the `Flags & 512` classification path but is a different creature entry) is unaffected.

https://github.com/user-attachments/assets/9bcee1fa-893a-41f9-b5b1-39e6f5731c16

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. As a Death Knight, cast Summon Gargoyle.
2. Target an enemy and use `/petattack` (or the pet action bar's attack button once it's usable).
3. Confirm the Gargoyle attacks the specified target.

## Known Issues and TODO List:

- This PR only covers the Gargoyle's `/petattack` command responsiveness. The original issue also asked about it "responding to commands" more broadly (follow/stay, auto-cast) - out of scope here, as the Gargoyle's existing AI already provides equivalent passive behavior (auto-targeting the owner's current target) that covers the reported use case.

🤖 Generated with Claude Code (Sonnet 5)+AzerothMCP

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
