### PR TITLE
fix(DB/Creature): SOTA Battleground Demolisher can't dodge or block attacks

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784233414479962200.sql
+++ b/data/sql/updates/pending_db_world/rev_1784233414479962200.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `flags_extra` = 8388626 WHERE `entry` IN (28781, 32796);

--- a/data/sql/updates/pending_db_world/rev_1784233414479962200.sql
+++ b/data/sql/updates/pending_db_world/rev_1784233414479962200.sql
@@ -1,2 +1,2 @@
 --
-UPDATE `creature_template` SET `flags_extra` = 8388630 WHERE `entry` IN (28781, 32796);
+UPDATE `creature_template` SET `flags_extra` = `flags_extra`|4|16|8388608 WHERE `entry` IN (28781, 32796);

--- a/data/sql/updates/pending_db_world/rev_1784233414479962200.sql
+++ b/data/sql/updates/pending_db_world/rev_1784233414479962200.sql
@@ -1,2 +1,2 @@
 --
-UPDATE `creature_template` SET `flags_extra` = 8388626 WHERE `entry` IN (28781, 32796);
+UPDATE `creature_template` SET `flags_extra` = 8388630 WHERE `entry` IN (28781, 32796);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

The Strand of the Ancients Battleground Demolisher can dodge and block melee attacks, even though it's `CREATURE_TYPE_MECHANICAL` and should have no avoidance at all.

**Root cause:** avoidance isn't derived from creature type anywhere in this codebase - it's gated per-row by `creature_template.flags_extra` (`CREATURE_FLAG_EXTRA_NO_DODGE`/`NO_PARRY`/`NO_BLOCK`), checked in `Unit::RollMeleeOutcomeAgainst`. The Demolisher's two rows (`28781`, `32796`) only had `CREATURE_FLAG_EXTRA_CIVILIAN` set, so it rolled dodge/block like any ordinary NPC (flat 5% baseline for both, per `Unit::GetUnitDodgeChance`/`GetUnitBlockChance`). The "only happens off-hand" reports are likely a sampling artifact - dual-wielding roughly doubles swings per time window, making a flat 5% chance easier to observe - main-hand and off-hand share an identical roll path.

**Fix:** add `CREATURE_FLAG_EXTRA_NO_DODGE`/`NO_PARRY`/`NO_BLOCK` to `flags_extra` on both rows via bitwise OR, keeping the existing `CIVILIAN` bit.

This also covers feral druid abilities (Mangle, Shred, etc) against the Demolisher - they go through a separate path, `Unit::MeleeSpellHitResult`, but it checks the same `flags_extra` bits.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Sonnet 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26643

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Source cited in the original issue: https://www.wowhead.com/wotlk/npc=28781/battleground-demolisher (Mechanical, no avoidance).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested locally: attacked a Demolisher in Strand of the Ancients across a large sample of melee swings before and after the fix. Video attached separately in the PR comments.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.


https://github.com/user-attachments/assets/7cbd481c-dc82-4dae-b7a4-bc42f874f9e4


1. Enter Strand of the Ancients (or use `.debug bg` to force it).
2. Get on/near a Demolisher and attack it with a melee character, watching the combat log across several swings - try main-hand only, off-hand only, and dual-wield.
3. Confirm no "dodge" or "block" outcomes appear against it, in any of those cases.

## Known Issues and TODO List:

- [ ]
