### PR TITLE
fix(Core/Petitions): re-key petition_sign on petition_id and fix type-filtered signature deletes

### DIFF
--- a/data/sql/updates/pending_db_characters/rev_1784315136456725704.sql
+++ b/data/sql/updates/pending_db_characters/rev_1784315136456725704.sql
@@ -1,0 +1,10 @@
+-- petition_sign kept its (petitionguid, playerguid) primary key when the
+-- petition_id schema stopped writing petitionguid: every row inserts with
+-- petitionguid = 0, so the key collapses to (0, playerguid) and a character
+-- can never hold more than one signature row overall (later signs fail
+-- silently with a duplicate key on the async insert).
+-- Re-key on (petition_id, playerguid) and drop the signature rows orphaned
+-- by the type-filtered deletes that no longer match (`type` is not written
+-- by the insert either).
+DELETE `ps` FROM `petition_sign` `ps` LEFT JOIN `petition` `p` ON `p`.`petition_id` = `ps`.`petition_id` WHERE `p`.`petition_id` IS NULL;
+ALTER TABLE `petition_sign` DROP PRIMARY KEY, ADD PRIMARY KEY (`petition_id`, `playerguid`), DROP INDEX `idx_petition_id_player`;

--- a/src/server/database/Database/Implementation/CharacterDatabase.cpp
+++ b/src/server/database/Database/Implementation/CharacterDatabase.cpp
@@ -272,7 +272,8 @@ void CharacterDatabaseConnection::DoPrepareStatements()
 
     // Petitions
     PrepareStatement(CHAR_DEL_ALL_PETITION_SIGNATURES, "DELETE FROM petition_sign WHERE playerguid = ?", CONNECTION_ASYNC);
-    PrepareStatement(CHAR_DEL_PETITION_SIGNATURE, "DELETE FROM petition_sign WHERE playerguid = ? AND type = ?", CONNECTION_ASYNC);
+    // petition_sign.type is not written by the sign insert (petition_id schema), join petition for the type filter
+    PrepareStatement(CHAR_DEL_PETITION_SIGNATURE, "DELETE ps FROM petition_sign ps INNER JOIN petition p ON p.petition_id = ps.petition_id WHERE ps.playerguid = ? AND p.type = ?", CONNECTION_ASYNC);
 
     // Arena teams
     PrepareStatement(CHAR_INS_ARENA_TEAM, "INSERT INTO arena_team (arenaTeamId, name, captainGuid, type, rating, backgroundColor, emblemStyle, emblemColor, borderStyle, borderColor) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", CONNECTION_ASYNC);
@@ -534,7 +535,7 @@ void CharacterDatabaseConnection::DoPrepareStatements()
     PrepareStatement(CHAR_DEL_PETITION_BY_OWNER, "DELETE FROM petition WHERE ownerguid = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_DEL_PETITION_SIGNATURE_BY_OWNER, "DELETE FROM petition_sign WHERE ownerguid = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_DEL_PETITION_BY_OWNER_AND_TYPE, "DELETE FROM petition WHERE ownerguid = ? AND type = ?", CONNECTION_ASYNC);
-    PrepareStatement(CHAR_DEL_PETITION_SIGNATURE_BY_OWNER_AND_TYPE, "DELETE FROM petition_sign WHERE ownerguid = ? AND type = ?", CONNECTION_ASYNC);
+    PrepareStatement(CHAR_DEL_PETITION_SIGNATURE_BY_OWNER_AND_TYPE, "DELETE ps FROM petition_sign ps INNER JOIN petition p ON p.petition_id = ps.petition_id WHERE ps.ownerguid = ? AND p.type = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_INS_CHAR_GLYPHS, "INSERT INTO character_glyphs VALUES(?, ?, ?, ?, ?, ?, ?, ?)", CONNECTION_ASYNC);
     PrepareStatement(CHAR_DEL_CHAR_TALENT_BY_SPELL, "DELETE FROM character_talent WHERE guid = ? AND spell = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_INS_CHAR_TALENT, "INSERT INTO character_talent (guid, spell, specMask) VALUES (?, ?, ?)", CONNECTION_ASYNC);


### PR DESCRIPTION
## Changes Proposed:

The petition_id schema (#22774) stopped writing `petitionguid` and `type` into `petition_sign`, which broke two things:

- the `(petitionguid, playerguid)` primary key collapses to `(0, playerguid)`: a character can never hold more than one signature row overall — later signs fail silently on the async insert and the in-memory signature map diverges from the database;
- the type-filtered deletes in `Player::RemovePetitionsAndSigns` never match a row anymore (`type` is always 0), so signature rows leak when a character joins a guild or an arena team.

This re-keys `petition_sign` on `(petition_id, playerguid)` (with a cleanup of the already-orphaned rows first) and joins `petition` for the two type-filtered deletes.

## Issues Addressed:

- None open that I could find (searched for petition_sign).

## SOURCE:

- Reproduced and verified on my 3.3.5 server: before the fix a second charter sign silently failed with a 1062 duplicate key on `(0, playerguid)`; after it, sign → turn-in → re-sign cycles leave no orphan rows.
- The insert only writes `(ownerguid, petition_id, playerguid, player_account)`: [CharacterDatabase.cpp#L358](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/database/Database/Implementation/CharacterDatabase.cpp#L358)

## Tests Performed:

- `apps/codestyle/codestyle-sql.py` passes.
- Migration applied on a live characters DB with pre-existing orphaned rows: orphans removed, re-key succeeds, subsequent petition cycles leave the table clean.

## How to Test the Changes:

1. Create a guild charter, sign it with a character, turn it in.
2. Buy a second charter with the same owner and try to sign it with the same character: without the fix the sign silently fails (duplicate key on the async insert, worldserver error log); with it the sign succeeds.
3. Check `petition_sign` after the guild is created: without the fix the signature rows of the first charter are still there; with it they are gone.