### PR TITLE
fix(Scripts/NPC): Don't despawn Elder Clearwater

### DIFF
--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -118,12 +118,6 @@ public:
                         {
                             sCreatureTextMgr->SendChat(me, CLEARWATER_SAY_END, 0, CHAT_MSG_MONSTER_YELL, LANG_UNIVERSAL, TEXT_RANGE_MAP);
                             finishWarning = true;
-                            // no one won - despawn
-                            if (!finished)
-                            {
-                                me->DespawnOrUnsummon();
-                                break;
-                            }
                         }
 
                         events.Repeat(1s);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

When the Kalu'ak Fishing Derby fishing hour ends at 15:00, Elder Clearwater yells "The Kalu'ak Fishing Derby has ended! If you caught a shark, please bring it to me within the hour." But if nobody has won yet, `npc_elder_clearwaterAI` despawns him in that same moment, right after he announced the turn-in hour.

The despawn does not even stick. The spawn has `spawntimesecs` = 120 and `DespawnOrUnsummon()` schedules a normal respawn, so he is back about two minutes later with a fresh AI that offers the winner quest again. So the block does not actually close the derby, it just makes him vanish mid-announcement and pop back up shortly after.

It is also not needed for cleanup. His spawn (guid 209029) belongs to game event 63 (Kalu'ak Fishing Derby Turn-ins), which runs one hour longer than the fishing pools event (64). The game event system already removes him at 16:00, right when the announced grace period ends.

This PR removes the despawn block and lets the game event system handle his lifetime.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5, `claude-fable-5`). The code change and this description were prepared by the AI, directed and reviewed by the author.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The main evidence is his own retail end yell (`creature_text` 38294, group 3): "The Kalu'ak Fishing Derby has ended! If you caught a shark, please bring it to me within the hour." Public sources (Wowpedia) describe the same grace hour, with turn-ins accepted until 16:00.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

The current broken behavior was confirmed in game on a live server: with no winner he yells the end text at 15:00, despawns, then respawns about two minutes later through the 120 second spawn timer. The fix itself has not been run in game yet. `apps/codestyle/codestyle-cpp.py` passes.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Force the derby events with `.event start 63` and `.event start 64`, or wait for the weekly window (turn-ins 13:00 to 16:00, pools 14:00 to 15:00 server time).
2. Let the fishing hour end at 15:00 without anyone turning in quest 24803.
3. Without this PR, Elder Clearwater (38294) in Dalaran despawns right after the end yell, then reappears about two minutes later.
4. With this PR he stays put. A player holding a Blacktip Shark can still turn in the quest until 16:00, when game event 63 ends and removes him.

## Known Issues and TODO List:

- [ ]
- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
