### PR TITLE
fix(DB/Creature): Algalon the Observer melee damage too low

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784397705121168200.sql
+++ b/data/sql/updates/pending_db_world/rev_1784397705121168200.sql
@@ -1,0 +1,4 @@
+-- Algalon the Observer: melee damage retuned to match Wrath Classic log data
+-- and original-era on-plate values (~27k MH / ~15k OH per second on 25-man)
+UPDATE `creature_template` SET `DamageModifier` = 190 WHERE `entry` = 32871;
+UPDATE `creature_template` SET `DamageModifier` = 285 WHERE `entry` = 33070;


### PR DESCRIPTION
## Changes Proposed:

Algalon the Observer's auto attacks deal roughly a quarter of the damage they should. On a naked level 80 (about 1% armor mitigation), the 25-man version deals ~30k unmitigated DPS (18-22k main hand, 9-11k off hand), while Wrath Classic combat logs show unmitigated swings of 76-83k main hand and 37-42k off hand at the same ~1s cadence.

The current `DamageModifier` values (35 on entry 32871, 70 on difficulty entry 33070) are unchanged legacy data from the original TDB import, and the same undertuned value exists in cmangos wotlk-db (`DamageMultiplier=70`), so this is shared-heritage data rather than a regression.

This PR raises `creature_template.DamageModifier`:

| Entry | Difficulty | Old | New | Resulting MH swing |
|---|---|---|---|---|
| 32871 | 10-man | 35 | 190 | 44.6k-61.4k (avg ~53k) |
| 33070 | 25-man | 70 | 285 | 66.9k-92.1k (avg ~79.5k) |

With AC's damage formula (`(basedamage 177.074 + 805 AP / 14) * DamageModifier` at 1.0s swings), 285 lands the 25-man average exactly on the logged unmitigated values. The 10-man value follows the 2:3 ratio documented in the original-era tactics wiki (~18k vs ~27k main hand on plate). Only auto attacks are affected; his spells do not use `DamageModifier`.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9903

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Evidence:
- [Wrath Classic Warcraft Logs 25-man kill, raw events](https://classic.warcraftlogs.com/reports/VzGqwTDmbPBQvxtM?fight=20&type=damage-taken&source=7&ability=1&view=events): unmitigated MH 76.4k-82.2k, OH 38.0k-41.4k, both hands swinging ~1.2s apart (1.0s base under the standard 20% attack speed slow). Log is from after the March 2023 Classic 10% melee nerf.
- [Original-era tactics wiki](https://warcraft.wiki.gg/wiki/Algalon_the_Observer_(tactics)): 25-man "~27,000 main hand and ~15,000 offhand swings coming every second or less", 10-man ~18,000/~10,000. At a typical Ulduar tank's ~64% armor mitigation, 79.5k unmitigated is ~28k on plate, matching the 2009 numbers. This convergence also shows Wrath Classic post-nerf values reproduce original Wrath values, so no Classic-specific correction is needed.
- [Blizzard post on the Classic dodge bugfix and Algalon tuning](https://us.forums.blizzard.com/en/wow/t/dodge-bugfix-and-algalon-tuning/1558852) for hotfix context.
- Full analysis in the linked ChromieCraft issue.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Values verified against the damage formula in `Creature::SelectLevel` / `Unit::CalculateMinMaxDamage`; SQL codestyle check passes.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Be level 80 without any gear, `.additem 45798`, `.tele kologarn`, `.modify hp 10000000`.
2. `.gm fly on`, fly to the Planetarium, open the door and engage Algalon.
3. On 25-man expect main hand hits of roughly 66.9k-92.1k and off hand hits of 33.4k-46.0k before armor; on 10-man roughly 44.6k-61.4k / 22.3k-30.7k.

## Known Issues and TODO List:

- [ ] The 10-man value is derived from the era wiki ratio (no accessible Wrath Classic 10-man unmitigated log was found); a 10-man log check could refine it.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
