### PR TITLE
fix(Core/Spells): General Vezax' Corrupted Rage and Wisdom

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -5208,6 +5208,24 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_CASTER);
     });
 
+    // 68415 Corrupted Rage
+    ApplySpellFix({ 68415 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].SpellClassMask = flag96(0, 0x20000, 0);
+    });
+
+    // 31930 Judgements of the Wise
+    ApplySpellFix({ 31930 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellFamilyFlags = flag96(0x200, 0, 0);
+    });
+
+    // 64646 Corrupted Wisdom
+    ApplySpellFix({ 64646 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].SpellClassMask = flag96(0x200, 0, 0);
+    });
+
     for (uint32 i = 0; i < GetSpellInfoStoreSize(); ++i)
     {
         SpellInfo* spellInfo = mSpellInfoMap[i];


### PR DESCRIPTION

## Changes Proposed:

Assign SpellFamilyFlags to ensure Vezax' SPELLMOD_EFFECT1 only affects the intended spells.

The aura `Corrupted Rage` (68415) and `Corrupted Wisdom` (64646) modify spell effect values via `SPELLMOD_EFFECT1` with a `SpellClassMask`. Without properly assigned `SpellFamilyFlags` on the target spells, the spell-mod mask could match unintended Paladin auras.

**Changes:**
- **31930** (*Judgements of the Wise* — mana-return spell): assign `SpellFamilyFlags(0x200, 0, 0)` so the Vezax spell-mod mask can target it correctly.
- **68415** (*Corrupted Rage*): set `Effects[EFFECT_1].SpellClassMask` to `flag96(0, 0x20000, 0)` to match the correct spell.
- **64646** (*Corrupted Wisdom*): set `Effects[EFFECT_1].SpellClassMask` to `flag96(0x200, 0, 0)` to match the correct spell.


This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).


### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: DeepSeek V4 Pro
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26523

## SOURCE:
The changes have been validated through:

## Tests Performed:
- [ ] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

`.aura` to apply corrupted vezax aura

Test with Lightning Bolt on Shaman
Test with Shield of the Righteous on Paladin

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

## Known Issues and TODO List:
