### PR TITLE
fix(Scripts/Ulduar): Adjust Living Constellation's Arcane Barrage

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784454610015867838.sql
+++ b/data/sql/updates/pending_db_world/rev_1784454610015867838.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `CreatureImmunitiesId` = -280 WHERE (`entry` = 33052);

--- a/data/sql/updates/pending_db_world/rev_1784454610015867838.sql
+++ b/data/sql/updates/pending_db_world/rev_1784454610015867838.sql
@@ -1,2 +1,2 @@
 --
-UPDATE `creature_template` SET `CreatureImmunitiesId` = -280 WHERE (`entry` = 33052);
+UPDATE `creature_template` SET `CreatureImmunitiesId` = -280 WHERE (`entry` IN (33052, 33116));

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -949,7 +949,7 @@ struct npc_living_constellation : public ScriptedAI
     void Reset() override
     {
         events.Reset();
-        events.ScheduleEvent(EVENT_ARCANE_BARRAGE, 3s, 5s);
+        events.ScheduleEvent(EVENT_ARCANE_BARRAGE, 5s);
         _isActive = false;
     }
 
@@ -1008,7 +1008,7 @@ struct npc_living_constellation : public ScriptedAI
         {
             case EVENT_ARCANE_BARRAGE:
                 me->CastCustomSpell(SPELL_ARCANE_BARRAGE, SPELLVALUE_MAX_TARGETS, 1, (Unit*)nullptr, false);
-                events.Repeat(3s, 5s);
+                events.Repeat(5s);
                 break;
             case EVENT_RESUME_UPDATING:
                 events.SetPhase(0);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -949,7 +949,7 @@ struct npc_living_constellation : public ScriptedAI
     void Reset() override
     {
         events.Reset();
-        events.ScheduleEvent(EVENT_ARCANE_BARRAGE, 2500ms);
+        events.ScheduleEvent(EVENT_ARCANE_BARRAGE, 3s, 5s);
         _isActive = false;
     }
 
@@ -1007,8 +1007,8 @@ struct npc_living_constellation : public ScriptedAI
         switch (events.ExecuteEvent())
         {
             case EVENT_ARCANE_BARRAGE:
-                me->CastCustomSpell(SPELL_ARCANE_BARRAGE, SPELLVALUE_MAX_TARGETS, 1, (Unit*)nullptr, true);
-                events.Repeat(2500ms);
+                me->CastCustomSpell(SPELL_ARCANE_BARRAGE, SPELLVALUE_MAX_TARGETS, 1, (Unit*)nullptr, false);
+                events.Repeat(3s, 5s);
                 break;
             case EVENT_RESUME_UPDATING:
                 events.SetPhase(0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [ ] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used:
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

<img width="1121" height="63" alt="image" src="https://github.com/user-attachments/assets/72c25c38-2907-4e03-b05c-c782ce99459a" />

Source: https://wowpedia.fandom.com/wiki/Algalon_the_Observer_(tactics)

================================================

<img width="1110" height="92" alt="image" src="https://github.com/user-attachments/assets/84f2a3a8-92c4-4582-9498-87539abbd2fb" />

Source: https://www.wowhead.com/wotlk/guide/raids/ulduar/algalon-the-observer-strategy

================================================

<img width="285" height="215" alt="image" src="https://github.com/user-attachments/assets/e69ded31-e763-40ee-97a2-649a78e79b3b" />
<img width="354" height="36" alt="image" src="https://github.com/user-attachments/assets/c9a81d70-58b3-4659-b1b3-0bc0bc83486f" />

Source: https://www.youtube.com/live/mVXZQp79a6I?si=twlwxcYccjKiomEi&t=1825

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Engage Algalon in Ulduar
2. Wait for Living constellaitons to spawn
3. The spell is channeled and can be interrupted, no instant machine-gun behaviour now.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Remove Living Constellation's Interrupt Immunity.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
