### PR TITLE
fix(Scripts/ICC): port Valithria Risen Archmage summon groups from TrinityCore

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784423027068230400.sql
+++ b/data/sql/updates/pending_db_world/rev_1784423027068230400.sql
@@ -1,0 +1,14 @@
+--
+-- Valithria Dreamwalker: turn the initial Risen Archmages (37868) from persistent
+-- creature spawns into summon groups on the Green Dragon Combat Trigger (38752).
+-- As permanent spawns they carried the world default 7-day respawn, so they failed to
+-- return on encounter reset. Ported from TrinityCore (Keader, PR #22754).
+DELETE FROM `creature` WHERE `id` = 37868;
+DELETE FROM `creature_summon_groups` WHERE `summonerId` = 38752 AND `entry` = 37868;
+INSERT INTO `creature_summon_groups` (`summonerId`, `summonerType`, `groupId`, `entry`, `position_x`, `position_y`, `position_z`, `orientation`, `summonType`, `summonTime`, `Comment`) VALUES
+(38752, 0, 1, 37868, 4222.86, 2504.58, 364.96, 3.90954, 8, 0, 'Risen Archmage'),
+(38752, 0, 1, 37868, 4223.4, 2465.11, 364.952, 2.3911, 8, 0, 'Risen Archmage'),
+(38752, 0, 2, 37868, 4230.44, 2478.56, 364.953, 2.93215, 8, 0, 'Risen Archmage'),
+(38752, 0, 2, 37868, 4230.53, 2490.22, 364.957, 3.36849, 8, 0, 'Risen Archmage'),
+(38752, 0, 3, 37868, 4185.29, 2464.01, 364.87, 0.798137, 8, 0, 'Risen Archmage'),
+(38752, 0, 3, 37868, 4183.7, 2503.93, 364.879, 5.50843, 8, 0, 'Risen Archmage');

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
@@ -139,23 +139,20 @@ enum Events
 
 enum Actions
 {
-    ACTION_ENTER_COMBAT = 1,
-    MISSED_PORTALS      = 2,
-    ACTION_DEATH        = 3,
+    ACTION_ENTER_COMBAT    = 1,
+    MISSED_PORTALS         = 2,
+    ACTION_DEATH           = 3,
+    ACTION_SETUP_ARCHMAGES = 4,
+};
+
+enum SummonGroups
+{
+    SUMMON_GROUP_ALL = 1,
+    SUMMON_GROUP_10  = 2,
+    SUMMON_GROUP_25  = 3,
 };
 
 Position const ValithriaSpawnPos = {4210.813f, 2484.443f, 364.9558f, 0.01745329f};
-
-class RisenArchmageCheck
-{
-public:
-    // look for all permanently spawned Risen Archmages that are not yet in combat
-    bool operator()(Creature* creature)
-    {
-        return creature->IsAlive() && creature->GetEntry() == NPC_RISEN_ARCHMAGE &&
-               creature->GetSpawnId() && !creature->IsInCombat();
-    }
-};
 
 struct ManaVoidSelector
 {
@@ -249,12 +246,8 @@ public:
                 creature->DespawnOrUnsummon();
                 return;
             case NPC_RISEN_ARCHMAGE:
-                if (!creature->GetSpawnId())
-                {
-                    creature->DespawnOrUnsummon();
-                    return;
-                }
-                break;
+                creature->DespawnOrUnsummon();
+                return;
             default:
                 return;
         }
@@ -498,6 +491,16 @@ public:
         {
             _Reset();
             me->SetReactState(REACT_PASSIVE);
+            summons.DespawnAll();
+
+            me->SummonCreatureGroup(SUMMON_GROUP_ALL);
+            if (Is25ManRaid())
+                me->SummonCreatureGroup(SUMMON_GROUP_25);
+            else
+                me->SummonCreatureGroup(SUMMON_GROUP_10);
+
+            EntryCheckPredicate pred(NPC_RISEN_ARCHMAGE);
+            summons.DoAction(ACTION_SETUP_ARCHMAGES, pred);
         }
 
         void JustEnteredCombat(Unit* target) override
@@ -522,12 +525,8 @@ public:
             if (Creature* lichKing = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_VALITHRIA_LICH_KING)))
                 lichKing->AI()->DoAction(ACTION_ENTER_COMBAT);
 
-            std::list<Creature*> archmages;
-            RisenArchmageCheck check;
-            Acore::CreatureListSearcher<RisenArchmageCheck> searcher(me, archmages, check);
-            Cell::VisitObjects(me, searcher, 100.0f);
-            for (std::list<Creature*>::iterator itr = archmages.begin(); itr != archmages.end(); ++itr)
-                (*itr)->AI()->DoAction(ACTION_ENTER_COMBAT);
+            EntryCheckPredicate pred(NPC_RISEN_ARCHMAGE);
+            summons.DoAction(ACTION_ENTER_COMBAT, pred);
         }
 
         void MoveInLineOfSight(Unit* /*who*/) override {}
@@ -675,7 +674,6 @@ public:
             _events.ScheduleEvent(EVENT_FROSTBOLT_VOLLEY, 5s, 15s);
             _events.ScheduleEvent(EVENT_MANA_VOID, 20s, 25s);
             _events.ScheduleEvent(EVENT_COLUMN_OF_FROST, 10s, 20s);
-            _isInitialArchmage = me->GetSpawnId() != 0;
         }
 
         void JustEnteredCombat(Unit* who) override
@@ -701,6 +699,8 @@ public:
         {
             if (action == ACTION_ENTER_COMBAT)
                 DoZoneInCombat();
+            else if (action == ACTION_SETUP_ARCHMAGES)
+                _isInitialArchmage = true;
         }
 
         void JustSummoned(Creature* summon) override


### PR DESCRIPTION
## Changes Proposed:

Ports TrinityCore's handling of the initial Risen Archmages (37868) in the Valithria Dreamwalker encounter.

They were persistent `creature` spawns, so they carried the world default 7-day respawn and did not return on encounter reset. This converts them to summon groups on the Green Dragon Combat Trigger (38752) and tags the initial ones through `ACTION_SETUP_ARCHMAGES` instead of `GetSpawnId()`. Despawning a summon on reset removes it outright and the trigger re-summons a fresh set from `Reset()`, so there is no DB respawn timer left to fight. TrinityCore has used this model since 2019; AzerothCore kept the older DB-spawn approach, which is the source of the divergence.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 4.8)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes #25768
- Closes https://github.com/azerothcore/azerothcore-wotlk/pull/25772

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Ported from TrinityCore ([TrinityCore/TrinityCore#22754](https://github.com/TrinityCore/TrinityCore/pull/22754)). Committed with `--author` for Keader, plus `Co-authored-by` for sirikfoll, ForesterDev and Treeston.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds cleanly in Release (MSVC, `-Werror`); worldserver links. Not yet tested in-game.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Enter Icecrown Citadel and start the Valithria Dreamwalker encounter.
2. Wipe or reset the encounter.
3. Confirm the initial Risen Archmages return for the next attempt (previously they stayed gone until the 7-day DB respawn).
4. Verify the initial archmages channel their idle visual out of combat and pull the encounter into combat as before, on both 10- and 25-man.

## Known Issues and TODO List:

- [ ] Scoped to the Risen Archmages; Valithria's own despawn/respawn path is left unchanged.
