### PR TITLE
fix(Scripts/ZulGurub): reset Thekal encounter after a wipe

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_thekal.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_thekal.cpp
@@ -209,11 +209,9 @@ struct boss_thekal : public BossAI
         if (me->IsEngaged())
         {
             if (!UpdateVictim())
-            {
                 return;
-            }
 
-            scheduler.Update(diff, std::bind(&BossAI::DoMeleeAttackIfReady, this));
+            scheduler.Update(diff, [this] { DoMeleeAttackIfReady(); });
         }
         else
         {
@@ -401,11 +399,9 @@ struct npc_zealot_lorkhan : public ScriptedAI
         if (me->IsEngaged())
         {
             if (!UpdateVictim())
-            {
                 return;
-            }
 
-            _scheduler.Update(diff, std::bind(&BossAI::DoMeleeAttackIfReady, this));
+            _scheduler.Update(diff, [this] { DoMeleeAttackIfReady(); });
         }
         else
         {
@@ -502,11 +498,9 @@ struct npc_zealot_zath : public ScriptedAI
         if (me->IsEngaged())
         {
             if (!UpdateVictim())
-            {
                 return;
-            }
 
-            _scheduler.Update(diff, std::bind(&BossAI::DoMeleeAttackIfReady, this));
+            _scheduler.Update(diff, [this] { DoMeleeAttackIfReady(); });
         }
         else
         {

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_thekal.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_thekal.cpp
@@ -204,14 +204,16 @@ struct boss_thekal : public BossAI
 
     void UpdateAI(uint32 diff) override
     {
-        if (me->IsInCombat() && !UpdateVictim())
+        // Gate on IsEngaged, not IsInCombat: on a wipe the boss leaves combat while still engaged,
+        // and UpdateVictim must keep running to evade and clear the IN_PROGRESS state.
+        if (me->IsEngaged())
         {
-            return;
-        }
-        else if (me->IsInCombat())
-        {
-            scheduler.Update(diff,
-            std::bind(&BossAI::DoMeleeAttackIfReady, this));
+            if (!UpdateVictim())
+            {
+                return;
+            }
+
+            scheduler.Update(diff, std::bind(&BossAI::DoMeleeAttackIfReady, this));
         }
         else
         {
@@ -396,14 +398,14 @@ struct npc_zealot_lorkhan : public ScriptedAI
 
     void UpdateAI(uint32 diff) override
     {
-        if (me->IsInCombat() && !UpdateVictim())
+        if (me->IsEngaged())
         {
-            return;
-        }
-        else if (me->IsInCombat())
-        {
-            _scheduler.Update(diff,
-            std::bind(&BossAI::DoMeleeAttackIfReady, this));
+            if (!UpdateVictim())
+            {
+                return;
+            }
+
+            _scheduler.Update(diff, std::bind(&BossAI::DoMeleeAttackIfReady, this));
         }
         else
         {
@@ -497,14 +499,14 @@ struct npc_zealot_zath : public ScriptedAI
 
     void UpdateAI(uint32 diff) override
     {
-        if (me->IsInCombat() && !UpdateVictim())
+        if (me->IsEngaged())
         {
-            return;
-        }
-        else if (me->IsInCombat())
-        {
-            _scheduler.Update(diff,
-            std::bind(&BossAI::DoMeleeAttackIfReady, this));
+            if (!UpdateVictim())
+            {
+                return;
+            }
+
+            _scheduler.Update(diff, std::bind(&BossAI::DoMeleeAttackIfReady, this));
         }
         else
         {


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

High Priest Thekal and his two zealots (Lor'Khan, Zath) can leave the encounter permanently stuck at `IN_PROGRESS` after a wipe or disconnect, so players get "encounter in progress" and cannot re-enter the instance.

Their `UpdateAI` gated `UpdateVictim()` behind `me->IsInCombat()`:

```cpp
if (me->IsInCombat() && !UpdateVictim())
    return;
else if (me->IsInCombat())
    scheduler.Update(diff, ...);
else
    scheduler.Update(diff);   // engaged but out of combat lands here
```

For a scripted boss the reset path runs through `UpdateVictim()` -> `SelectVictim()` -> `EnterEvadeMode()`; `CreatureAI::JustExitedCombat()` is intentionally a no-op, so leaving combat does not reset the boss by itself. When the last player dies or disconnects, the boss drops out of combat but stays `IsEngaged()`. With the gate above, `UpdateVictim()` is never called again, `EnterEvadeMode()` never fires, and `SetBossState(DATA_THEKAL, NOT_STARTED)` never runs.

Fix: gate on `me->IsEngaged()` instead of `me->IsInCombat()`, so the evade/reset check keeps running once combat ends while still driving the idle-emote scheduler when not engaged.

Fake death is unaffected. During it the boss is `REACT_PASSIVE`, and the passive branch of `UpdateVictim()` only evades when the creature is also out of combat. With a live player keeping the boss in combat it simply calls `AttackStop()` (the intended behavior) and never evades; it only resets when genuinely out of combat, which is the wipe/disconnect case being fixed.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 4.8)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/chromiecraft/chromiecraft/issues/9910

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

This is a code-logic fix derived from reading the AI and core evade flow; no external source.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Solo Zul'Gurub, engage High Priest Thekal, and die to him (or disconnect and let him finish you). Before this change the encounter stays "in progress" and you cannot zone back in; after it the boss evades, resets, and re-entry works.
2. Regression: fight Thekal normally through the phase-1 fake death and confirm he transitions to tiger form and the fight continues as expected.
3. Regression: kill Thekal cleanly and confirm the encounter is marked as done.

## Known Issues and TODO List:

- [ ]
