### PR TITLE
fix(Scripts/Ulduar): apply Yogg-Saron Sanity at full stacks

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784460171162193800.sql
+++ b/data/sql/updates/pending_db_world/rev_1784460171162193800.sql
@@ -1,0 +1,4 @@
+-- Attach Sanity (63050) stack-init script
+DELETE FROM `spell_script_names` WHERE `spell_id` = 63050 AND `ScriptName` = 'spell_yogg_saron_sanity';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(63050, 'spell_yogg_saron_sanity');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -611,13 +611,6 @@ struct boss_yoggsaron_sara : public ScriptedAI
         }
     }
 
-    void SpellHitTarget(Unit* target, SpellInfo const* spellInfo) override
-    {
-        if (spellInfo->Id == SPELL_SANITY)
-            if (Aura* aur = target->GetAura(SPELL_SANITY))
-                aur->SetStackAmount(100);
-    }
-
     uint32 GetData(uint32 param) const override
     {
         if (param == DATA_GET_KEEPERS_COUNT)
@@ -2504,6 +2497,22 @@ class spell_yogg_saron_insane_aura : public AuraScript
     }
 };
 
+// 63050 - Sanity
+class spell_yogg_saron_sanity : public SpellScript
+{
+    PrepareSpellScript(spell_yogg_saron_sanity);
+
+    void ModSanityStacks()
+    {
+        GetSpell()->SetSpellValue(SPELLVALUE_AURA_STACK, 100);
+    }
+
+    void Register() override
+    {
+        BeforeCast += SpellCastFn(spell_yogg_saron_sanity::ModSanityStacks);
+    }
+};
+
 // 64169 - Sanity Well
 class spell_yogg_saron_sanity_well_aura : public AuraScript
 {
@@ -2862,6 +2871,7 @@ void AddSC_boss_yoggsaron()
     RegisterSpellScript(spell_yogg_saron_empowered_aura);
     RegisterSpellScript(spell_yogg_saron_insane_periodic_trigger);
     RegisterSpellScript(spell_yogg_saron_insane_aura);
+    RegisterSpellScript(spell_yogg_saron_sanity);
     RegisterSpellScript(spell_yogg_saron_sanity_well_aura);
     RegisterSpellScript(spell_keeper_freya_summon_sanity_well);
     RegisterSpellScript(spell_yogg_saron_sanity_reduce);


### PR DESCRIPTION
## Changes Proposed:
Players engaged Yogg-Saron with 0 Sanity that only crept up a few stacks and never reached 100.

The logic that forced the Sanity aura (63050) to 100 stacks lived in Sara's `SpellHitTarget`, so it only ran while Sara was the caster. Once the Sanity base cast (63786) was moved to the Voice of Yogg-Saron in #26632 (Sara is friendly and can't apply it to players), that hook stopped firing, leaving players effectively at 0 Sanity.

This ports TrinityCore's caster-independent approach: the stack value is set on the Sanity spell itself via `BeforeCast`, so every fresh application starts at 100 regardless of which unit casts it. The dead `SpellHitTarget` on Sara is removed, and a `spell_script_names` row binds the new script to spell 63050.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 4.8)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26662

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Ported from TrinityCore's `spell_yogg_saron_sanity` (`ModSanityStacks`), originally authored by horn (`Scripts/Ulduar: Yogg-Saron`, commit `0a0698b1`). Commits carry the proper `--author` tag.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.tele yogg` and engage the encounter.
2. Confirm every player receives the Sanity debuff at 100 stacks on pull.
3. Confirm Sanity is reduced by the usual phase-1/phase-2 effects (Psychosis, Malady of the Mind, Brain Link, Lunatic Gaze) and restored by Sanity Wells, rather than sitting near 0.

## Known Issues and TODO List:

- [ ] Secondary timing nuance (out of scope here): AzerothCore summons the Voice of Yogg-Saron at `EVENT_SARA_P1_DOORS_CLOSE` (~15s in), so Sanity is applied slightly later than on retail, where it lands at engage.
