### PR TITLE
fix(Scripts/Ulduar): XT-002 Searing Light and Gravity Bomb target one non-tank player

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784463884644221000.sql
+++ b/data/sql/updates/pending_db_world/rev_1784463884644221000.sql
@@ -1,0 +1,8 @@
+--
+-- XT-002 Deconstructor: restore Searing Light / Gravity Bomb single random non-tank targeting
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_xt002_searing_light_gravity_bomb';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(63018, 'spell_xt002_searing_light_gravity_bomb'),
+(65121, 'spell_xt002_searing_light_gravity_bomb'),
+(63024, 'spell_xt002_searing_light_gravity_bomb'),
+(64234, 'spell_xt002_searing_light_gravity_bomb');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -709,6 +709,29 @@ private:
     TaskScheduler _scheduler;
 };
 
+// 63018, 65121 - Searing Light / 63024, 64234 - Gravity Bomb
+// Both hit a single random player, never the current tank
+class spell_xt002_searing_light_gravity_bomb : public SpellScript
+{
+    PrepareSpellScript(spell_xt002_searing_light_gravity_bomb);
+
+    void FilterTargets(std::list<WorldObject*>& targets)
+    {
+        if (Unit* victim = GetCaster()->GetVictim())
+        {
+            ObjectGuid victimGuid = victim->GetGUID();
+            targets.remove_if([victimGuid](WorldObject* target) { return target->GetGUID() == victimGuid; });
+        }
+
+        Acore::Containers::RandomResize(targets, 1);
+    }
+
+    void Register() override
+    {
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_xt002_searing_light_gravity_bomb::FilterTargets, EFFECT_ALL, TARGET_UNIT_DEST_AREA_ENEMY);
+    }
+};
+
 // 63018, 65121 - Searing Light
 class spell_xt002_searing_light_spawn_life_spark : public AuraScript
 {
@@ -1057,6 +1080,7 @@ void AddSC_boss_xt002()
     RegisterUlduarCreatureAI(npc_boombot);
     RegisterUlduarCreatureAI(npc_life_spark);
     RegisterUlduarCreatureAI(npc_xt_void_zone);
+    RegisterSpellScript(spell_xt002_searing_light_gravity_bomb);
     RegisterSpellScript(spell_xt002_searing_light_spawn_life_spark);
     RegisterSpellScript(spell_xt002_gravity_bomb_aura);
     RegisterSpellScript(spell_xt002_gravity_bomb_damage);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -18,6 +18,7 @@
 #include "AchievementCriteriaScript.h"
 #include "Containers.h"
 #include "CreatureScript.h"
+#include "GridNotifiers.h"
 #include "InstanceScript.h"
 #include "MotionMaster.h"
 #include "ObjectAccessor.h"
@@ -718,10 +719,7 @@ class spell_xt002_searing_light_gravity_bomb : public SpellScript
     void FilterTargets(std::list<WorldObject*>& targets)
     {
         if (Unit* victim = GetCaster()->GetVictim())
-        {
-            ObjectGuid victimGuid = victim->GetGUID();
-            targets.remove_if([victimGuid](WorldObject* target) { return target->GetGUID() == victimGuid; });
-        }
+            targets.remove_if(Acore::ObjectGUIDCheck(victim->GetGUID(), true));
 
         Acore::Containers::RandomResize(targets, 1);
     }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

XT-002's Searing Light (63018/65121) and Gravity Bomb (63024/64234) are area-enemy spells with no target cap in our spell data. Before the recent rework they were kept to a single random non-tank target by the boss casting them with `SPELLVALUE_MAX_TARGETS, 1` plus a `SpellScript` that removed the current victim from the target list.

The rework (c09afb0, #26345) ported the TrinityCore AI, which casts them with a bare `DoCastSelf` and relies on TC applying `MaxAffectedTargets = 1` to these spells in its `SpellMgr` corrections. AzerothCore has no equivalent correction, and the rework also removed the old `SpellScript`, so nothing constrained the target and both debuffs landed on every player in range.

This restores the intended behavior with a single `SpellScript` bound to all four spell IDs. In `OnObjectAreaTargetSelect` it removes the boss's current victim (the tank) and then resizes the list to one random target. If the tank is the only candidate the list ends up empty and the cast simply fizzles, which is the desired "never the tank" outcome.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 4.8)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26687

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Cross-checked against reference implementations: TrinityCore caps these spells to one target via `SpellMgr` (`MaxAffectedTargets = 1`), and CMaNGOS selects a single random attacker through its spell-list targeting. Both limit the abilities to one player per cast. This restores AzerothCore's own prior behavior, which additionally excludes the current tank.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Engage XT-002 (creature 33350) with a tank and at least two other players in range.
2. Observe periodic Searing Light and Gravity Bomb casts.
3. Each cast applies to a single random player other than the current tank, instead of all players in range.
