### PR TITLE
fix(DB/Conditions): restrict Mimiron Rocket Strike to the rocket visuals

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784479606995022900.sql
+++ b/data/sql/updates/pending_db_world/rev_1784479606995022900.sql
@@ -1,0 +1,6 @@
+-- Rocket Strike must only hit VX-001's mounted rocket visuals, otherwise the
+-- area-entry target degrades to any nearby unit and VX-001 fires itself
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 13) AND (`SourceGroup` = 1) AND (`SourceEntry` IN (64402, 65034)) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 34050) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 1, 64402, 0, 0, 31, 0, 3, 34050, 0, 0, 0, 0, '', 'Rocket Strike EFFECT_0 can only hit NPC_ROCKET_MIMIRON_VISUAL'),
+(13, 1, 65034, 0, 0, 31, 0, 3, 34050, 0, 0, 0, 0, '', 'Rocket Strike EFFECT_0 can only hit NPC_ROCKET_MIMIRON_VISUAL');

--- a/data/sql/updates/pending_db_world/rev_1784479606995022900.sql
+++ b/data/sql/updates/pending_db_world/rev_1784479606995022900.sql
@@ -2,5 +2,5 @@
 -- area-entry target degrades to any nearby unit and VX-001 fires itself
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 13) AND (`SourceGroup` = 1) AND (`SourceEntry` IN (64402, 65034)) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 34050) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(13, 1, 64402, 0, 0, 31, 0, 3, 34050, 0, 0, 0, 0, '', 'Rocket Strike EFFECT_0 can only hit NPC_ROCKET_MIMIRON_VISUAL'),
-(13, 1, 65034, 0, 0, 31, 0, 3, 34050, 0, 0, 0, 0, '', 'Rocket Strike EFFECT_0 can only hit NPC_ROCKET_MIMIRON_VISUAL');
+(13, 1, 64402, 0, 0, 31, 0, 3, 34050, 0, 0, 0, 0, '', 'Rocket Strike EFFECT_0 can only hit NPC_ROCKET_VISUAL'),
+(13, 1, 65034, 0, 0, 31, 0, 3, 34050, 0, 0, 0, 0, '', 'Rocket Strike EFFECT_0 can only hit NPC_ROCKET_VISUAL');


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Fixes a regression from #26685: during Mimiron's VX-001 phase, the torso launches *itself* instead of one of its mounted rockets.

Rocket Strike (64402, 65034) picks its target with `TARGET_UNIT_SRC_AREA_ENTRY`. That implicit target is narrowed to a specific creature entry purely by `conditions` rows — there is nothing in the spell data itself that restricts it. #26685 ported the scripts and added the `spell_script_names` entries, but not the accompanying conditions, so the target selection degrades to "any unit in range" and VX-001 matches itself.

The knock-on effect is visible because `spell_mimiron_rocket_strike_target_select::HandleScript` calls `SetDisplayId(11686)` to hide the spent rocket. With VX-001 as the hit unit, that hides the torso and sends it flying as the projectile.

This adds the two `CONDITION_OBJECT_ENTRY_GUID` rows limiting EFFECT_0 to `NPC_ROCKET_VISUAL` (34050).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 4.8)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

Not a filed issue — this is a regression introduced by #26685.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

These two rows mirror the equivalent `conditions` entries in TrinityCore, matching the scripts that #26685 ported from there. It is data equivalence rather than a git cherry-pick of a single upstream commit, so there was no commit to carry an `--author` tag from. Happy to re-attribute if a maintainer can point at the originating TC commit.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.tele Mimiron`, then engage the encounter and bring it to the VX-001 (torso) phase.
2. Wait for Rocket Strike. Before this change the torso model itself is launched and disappears; after it, one of the two rockets mounted on VX-001 fires and the torso is unaffected.
3. Continue to the assembled V0-L-7R-ON phase and confirm Rocket Strike still fires both mounted rockets (65034) rather than the torso.

## Known Issues and TODO List:

- [ ] The separate P4 arm-retraction visual bug (#26679) is **not** addressed here and remains open.
