### PR TITLE
fix(Scripts/Ulduar): keep VX-001 arms deployed through MK II melee swings in Mimiron phase 4

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -964,7 +964,10 @@ struct npc_ulduar_leviathan_mkii : public ScriptedAI
         ScriptedAI::AttackStart(who);
         // Unit::Attack clears the emote state on target switch, which would retract VX-001's arms
         if (_phase == 4)
+        {
             me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_CUSTOM_SPELL_01);
+            me->HandleEmoteCommand(EMOTE_STATE_CUSTOM_SPELL_01);
+        }
     }
 
     void SetData(uint32 id, uint32 value) override
@@ -1065,7 +1068,15 @@ struct npc_ulduar_leviathan_mkii : public ScriptedAI
         _events.Update(diff);
 
         if (!me->HasUnitState(UNIT_STATE_CASTING))
+        {
+            bool wasAttackReady = me->isAttackReady();
             DoMeleeAttackIfReady();
+            // Each melee swing knocks the client out of the arms-deployed loop, retracting
+            // VX-001's arms. Field updates with an unchanged value are ignored by the client,
+            // so replay the state emote via SMSG_EMOTE, which is always applied.
+            if (_phase == 4 && wasAttackReady && !me->isAttackReady())
+                me->HandleEmoteCommand(EMOTE_STATE_CUSTOM_SPELL_01);
+        }
 
         Unit* cannon = GetS3();
         if (!cannon || cannon->HasUnitState(UNIT_STATE_CASTING) || me->HasUnitState(UNIT_STATE_CASTING) || me->HasSilenceAura())


### PR DESCRIPTION
## Changes Proposed:

Follow-up to #26623, which kept `EMOTE_STATE_CUSTOM_SPELL_01` (the arms-deployed pose of the assembled V0-L7R-ON) permanently set on the Leviathan MK II during phase 4. That fix works while the boss is not meleeing, but as reported in #26679 the arms still retract whenever the current victim is within melee range.

Root cause, confirmed with in-game instrumentation:

- The server-side emote state is never lost in phase 4 (the `AttackStart` override from #26623 covers the only core path that clears it), so the remaining problem is purely client-side.
- Every melee swing of the MK II plays the swing animation and leaves the composite model in the combat-ready pose, which has VX-001's arms retracted. At range there are no swings, which is why the arms stayed deployed there.
- The client ignores `UNIT_NPC_EMOTESTATE` update-field writes whose value did not change, so the server cannot restore the pose through the field alone. This was verified directly: re-sending the unchanged field with `ForceValuesUpdateAtIndex` after each swing had no visible effect.

The fix replays the state emote through `HandleEmoteCommand` (`SMSG_EMOTE`), which the client applies unconditionally:

- after every phase 4 melee swing of the MK II, and
- after target switches in the `AttackStart` override, where `Unit::Attack`'s clear and the script's restore collapse into a single unchanged-value field update that the client would likewise ignore.

The field writes are kept as they are what players entering visibility mid-phase receive. The script already uses this exact field-write plus `HandleEmoteCommand` pairing for the Spinning Up handler; this PR applies the same pattern to the two paths that were missing it.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26679

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The reference videos from #25199 and #26679 (Classic WotLK and a 2009 kill video) show the arms deployed for the entire phase 4, including while the boss melees the tank.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested in phase 4 with the victim in melee range: the arms now stay deployed between Hand Pulses, melee swings still land normally (verified in the combat log), and the Spinning Up / P3Wx2 Laser Barrage cycle is unaffected, with the MK II pacified only for the expected barrage windows across multiple consecutive cycles.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.tele mimiron`, start the encounter and fight through to phase 4.
2. Stand within melee range of the boss and check that VX-001's arms stay deployed between Hand Pulse casts while the MK II melees you (combat log shows the melee swings landing).
3. Move to long range and check the arms remain deployed there as well.
4. Wait for Spinning Up / P3Wx2 Laser Barrage and check the arms remain visible while the barrage rotates, then check melee resumes after it ends.
5. Reset and re-check phase 1 (MK II alone) still has no emote state applied.

## Known Issues and TODO List:

Nothing left to do after this PR.

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
