### PR TITLE
fix(Scripts/BlackMorass): stop rift adds from spawning once Aeonus is up

### DIFF
--- a/src/server/scripts/Kalimdor/CavernsOfTime/TheBlackMorass/instance_the_black_morass.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/TheBlackMorass/instance_the_black_morass.cpp
@@ -32,6 +32,7 @@ const Position PortalLocation[4] =
 ObjectData const creatureData[] =
 {
     { NPC_MEDIVH, DATA_MEDIVH },
+    { NPC_AEONUS, DATA_AEONUS },
     { 0,          0           }
 };
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Aeonus is not supposed to have adds spawning during his fight, and the time rift script already accounts for that: `EVENT_SUMMON_AT_RIFT` only summons trash when `_instance->GetCreature(DATA_AEONUS)` is null.

That check never passes, though. `InstanceScript::GetCreature()` resolves through `_objectGuids`, which is only populated for entries registered via `LoadObjectData()`, and the Black Morass instance script only registered Medivh:

```cpp
ObjectData const creatureData[] =
{
    { NPC_MEDIVH, DATA_MEDIVH },
    { 0,          0           }
};
```

So `GetCreature(DATA_AEONUS)` always returned `nullptr` and every open rift kept cycling its 15s trash summon for the entire encounter, until Aeonus died and `SetBossState(DATA_AEONUS, DONE)` mass-despawned everything.

Registering `NPC_AEONUS` is enough to make the existing guard work. Temp summons go through `Creature::AddToWorld` -> `ZoneScript::OnCreatureCreate`, which the instance script already forwards to `InstanceScript::OnCreatureCreate`, so Aeonus is tracked from the moment he comes out of the portal and untracked on removal. That also means adds stop before he is engaged, while he is still walking towards Medivh, which is the behaviour shown in the sources.

Using `DATA_AEONUS` both as a boss index and an object data type is fine, boss state and `_objectGuids` are separate maps, and this is the usual pattern in other instance scripts.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 4.8)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26640

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TBC Classic footage of the encounter: https://youtu.be/3GksjINzs8E?t=1956

Wowhead comments from when TBC was current, stating no adds spawn: https://www.wowhead.com/tbc/npc=17881/aeonus#comments

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Create a character, `.character level 70`, `.tele blackmorass`.
2. Enter Black Morass on normal or heroic and progress through the waves until the eighteenth portal opens and Aeonus appears.
3. No further Infinite Dragonflight adds should come out of any rift for the rest of the encounter. Adds already summoned before Aeonus spawned remain and behave as usual.
4. Check for regressions on the earlier waves and on Chrono Lord Deja / Temporus, where rifts must keep summoning normally.

## Known Issues and TODO List:

- [ ] Rift 18 summons Aeonus 6 seconds after it opens, so a rift that was already open can still get one last summon off inside that window. Kept out of scope here since it does not change the reported behaviour.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
