### PR TITLE
fix(Scripts/DK): Raise Ally no longer blocks the ally's next resurrection

### DIFF
--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -69,7 +69,7 @@ void WorldSession::HandleRepopRequestOpcode(WorldPacket& recv_data)
         return; // silently return, client should display the error by itself
 
     if (GetPlayer()->GetCharm())
-        return; // e.g. still possessing a Death Knight Raise Ally ghoul - repopping now would strand it
+        return;
 
     // the world update order is sessions, players, creatures
     // the netcode runs in parallel with all of these

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -68,6 +68,9 @@ void WorldSession::HandleRepopRequestOpcode(WorldPacket& recv_data)
     if (GetPlayer()->HasPreventResurectionAura())
         return; // silently return, client should display the error by itself
 
+    if (GetPlayer()->GetCharm())
+        return; // e.g. still possessing a Death Knight Raise Ally ghoul - repopping now would strand it
+
     // the world update order is sessions, players, creatures
     // the netcode runs in parallel with all of these
     // creatures can kill players

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -265,6 +265,9 @@ void Spell::EffectResurrectNew(SpellEffIndex effIndex)
     if (target->isResurrectRequested())       // already have one active request
         return;
 
+    if (target->GetCharm())                   // e.g. still possessing a Death Knight Raise Ally ghoul
+        return;
+
     uint32 health = damage;
     uint32 mana = m_spellInfo->Effects[effIndex].MiscValue;
     ExecuteLogEffectResurrect(effIndex, target);
@@ -4670,6 +4673,9 @@ void Spell::EffectResurrect(SpellEffIndex effIndex)
         return;
 
     if (target->isResurrectRequested())       // already have one active request
+        return;
+
+    if (target->GetCharm())                   // e.g. still possessing a Death Knight Raise Ally ghoul
         return;
 
     uint32 health = target->CountPctFromMaxHealth(damage);

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -265,7 +265,7 @@ void Spell::EffectResurrectNew(SpellEffIndex effIndex)
     if (target->isResurrectRequested())       // already have one active request
         return;
 
-    if (target->GetCharm())                   // e.g. still possessing a Death Knight Raise Ally ghoul
+    if (target->GetCharm())
         return;
 
     uint32 health = damage;
@@ -4675,7 +4675,7 @@ void Spell::EffectResurrect(SpellEffIndex effIndex)
     if (target->isResurrectRequested())       // already have one active request
         return;
 
-    if (target->GetCharm())                   // e.g. still possessing a Death Knight Raise Ally ghoul
+    if (target->GetCharm())
         return;
 
     uint32 health = target->CountPctFromMaxHealth(damage);

--- a/src/server/scripts/Pet/pet_dk.cpp
+++ b/src/server/scripts/Pet/pet_dk.cpp
@@ -329,8 +329,12 @@ struct npc_pet_dk_risen_ally : public PossessedAI
 
                     if (!player->GetCorpse())
                         player->BuildPlayerRepop();
-                    else if (!player->HasAura(8326))
-                        player->CastSpell(player, 8326, true);
+                    else if (!player->HasPlayerFlag(PLAYER_FLAGS_GHOST))
+                    {
+                        player->SetPlayerFlag(PLAYER_FLAGS_GHOST);
+                        player->m_serverSideVisibilityDetect.SetValue(
+                            SERVERSIDE_VISIBILITY_GHOST, GHOST_VISIBILITY_GHOST);
+                    }
                 }
     }
 };

--- a/src/server/scripts/Pet/pet_dk.cpp
+++ b/src/server/scripts/Pet/pet_dk.cpp
@@ -329,6 +329,8 @@ struct npc_pet_dk_risen_ally : public PossessedAI
 
                     if (!player->GetCorpse())
                         player->BuildPlayerRepop();
+                    else if (!player->HasAura(8326))
+                        player->CastSpell(player, 8326, true);
                 }
     }
 };

--- a/src/server/scripts/Pet/pet_dk.cpp
+++ b/src/server/scripts/Pet/pet_dk.cpp
@@ -326,7 +326,9 @@ struct npc_pet_dk_risen_ally : public PossessedAI
                 {
                     player->RemoveAurasDueToSpell(SPELL_DK_RAISE_ALLY); // Remove Raise Ally aura
                     player->RemoveAurasDueToSpell(SPELL_GHOUL_FRENZY); // Remove Frenzy aura
-                    //player->ClearResurrectRequestData();
+
+                    if (!player->GetCorpse())
+                        player->BuildPlayerRepop();
                 }
     }
 };

--- a/src/server/scripts/Pet/pet_dk.cpp
+++ b/src/server/scripts/Pet/pet_dk.cpp
@@ -332,6 +332,8 @@ struct npc_pet_dk_risen_ally : public PossessedAI
                     else if (!player->HasPlayerFlag(PLAYER_FLAGS_GHOST))
                     {
                         player->SetPlayerFlag(PLAYER_FLAGS_GHOST);
+                        player->m_serverSideVisibility.SetValue(
+                            SERVERSIDE_VISIBILITY_GHOST, GHOST_VISIBILITY_GHOST);
                         player->m_serverSideVisibilityDetect.SetValue(
                             SERVERSIDE_VISIBILITY_GHOST, GHOST_VISIBILITY_GHOST);
                     }

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -192,7 +192,7 @@ class spell_dk_raise_ally : public SpellScript
             return SPELL_FAILED_TARGET_NOT_DEAD;
 
         Player* player = unitTarget->ToPlayer();
-        if (player && (player->GetCharm() || player->GetCorpse())) // already possessing a ghoul, or already released as a plain ghost
+        if (player && (player->GetCharm() || player->GetCorpse()))
             return SPELL_FAILED_TARGET_AURASTATE;
 
         return SPELL_CAST_OK;

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -205,7 +205,8 @@ class spell_dk_raise_ally : public SpellScript
             if (!unitTarget->GetCorpse())
                 unitTarget->BuildPlayerRepop();
 
-            unitTarget->RemoveAurasDueToSpell(8326);
+            unitTarget->RemovePlayerFlag(PLAYER_FLAGS_GHOST);
+            unitTarget->m_serverSideVisibilityDetect.SetValue(SERVERSIDE_VISIBILITY_GHOST, GHOST_VISIBILITY_ALIVE);
 
             unitTarget->CastSpell(unitTarget, GetEffectValue(), true);
             if (Unit* ghoul = unitTarget->GetCharm())

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -191,6 +191,10 @@ class spell_dk_raise_ally : public SpellScript
         if (unitTarget->IsAlive()) // not discovered attributeEx5?
             return SPELL_FAILED_TARGET_NOT_DEAD;
 
+        Player* player = unitTarget->ToPlayer();
+        if (player && (player->GetCharm() || player->GetCorpse())) // already possessing a ghoul, or already released as a plain ghost
+            return SPELL_FAILED_TARGET_AURASTATE;
+
         return SPELL_CAST_OK;
     }
 

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -206,6 +206,7 @@ class spell_dk_raise_ally : public SpellScript
                 unitTarget->BuildPlayerRepop();
 
             unitTarget->RemovePlayerFlag(PLAYER_FLAGS_GHOST);
+            unitTarget->m_serverSideVisibility.SetValue(SERVERSIDE_VISIBILITY_GHOST, GHOST_VISIBILITY_ALIVE);
             unitTarget->m_serverSideVisibilityDetect.SetValue(SERVERSIDE_VISIBILITY_GHOST, GHOST_VISIBILITY_ALIVE);
 
             unitTarget->CastSpell(unitTarget, GetEffectValue(), true);

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -202,6 +202,11 @@ class spell_dk_raise_ally : public SpellScript
     {
         if (Player* unitTarget = GetHitPlayer())
         {
+            if (!unitTarget->GetCorpse())
+                unitTarget->BuildPlayerRepop();
+
+            unitTarget->RemoveAurasDueToSpell(8326);
+
             unitTarget->CastSpell(unitTarget, GetEffectValue(), true);
             if (Unit* ghoul = unitTarget->GetCharm())
             {


### PR DESCRIPTION
## Changes Proposed:

Death Knight's Raise Ally lets a dead ally control a Ghoul for a while. The problem: once that ended (cancelled or the Ghoul died), nobody could resurrect the ally anymore - a healer's resurrect spell just did nothing, no prompt, nothing.

This PR fixes that, plus a few related things found while testing it:
- The ally now properly becomes a normal ghost the moment the Ghoul possession ends, so resurrecting them afterward works exactly like resurrecting anyone else.
- While still controlling the Ghoul, a resurrect spell cast on the ally no longer shows a broken-looking prompt - it just doesn't do anything until they're done piloting the Ghoul, which is expected.
- Raise Ally can't be cast again on someone who's already controlling a Ghoul, or who's already a released ghost.
- Clicking "Release Spirit" while still controlling the Ghoul used to be able to strand it and cause visual glitches - now it just does nothing, same as the resurrect prompt.
- The "time until release spirit" window and the ghost screen filter no longer show while piloting the Ghoul - the ally's spirit releases the moment Raise Ally lands, so both are already done with by the time the Ghoul shows up.
- The ally's own body still looks like a proper ghost to everyone else the whole time (it just doesn't affect the pilot's own screen or block the Ghoul from seeing normal NPCs anymore).

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Sonnet 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26536

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Set up a DK, a healer, and a third character to kill and raise ally. Confirmed the healer can resurrect the ally normally right after the Ghoul possession ends (both by cancelling it manually and by letting the Ghoul die in combat). Confirmed re-casting Raise Ally on an already-possessing or already-released target fails cleanly. Confirmed clicking Release Spirit while still possessing the Ghoul no longer breaks anything. Confirmed the ghost screen filter and the release-spirit window don't show while piloting the Ghoul, and that the ally becomes a normal ghost right when the Ghoul form ends.

https://github.com/user-attachments/assets/4900d272-a034-4923-af59-29f99f48d307

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Kill an ally character, have a DK cast Raise Ally (61999) on them. Confirm they see a normal view while piloting the Ghoul (no ghost screen filter, no "release spirit" window).
2. Cancel the Ghoul form (right-click the buff) or let the Ghoul die in combat. The ally should immediately look and act like a normal released ghost.
3. Have a healer cast a resurrection spell on the ally - it should prompt and work normally now.
4. Separately, while the ally is still controlling the Ghoul, try resurrecting them and try clicking their own "Release Spirit" button - neither should do anything or cause issues.

## Known Issues and TODO List:

- None

🤖 Generated with Claude Code (Sonnet 5)+AzerothMCP

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
