### PR TITLE
feat(Commands): add .reset cooldown all command

### DIFF
--- a/src/server/scripts/Commands/cs_reset.cpp
+++ b/src/server/scripts/Commands/cs_reset.cpp
@@ -46,9 +46,14 @@ public:
             { "all",            HandleResetItemsAllCommand,                 rbac::RBAC_PERM_COMMAND_RESET, Console::Yes },
             { "allbags",        HandleResetItemsAllAndDeleteBagsCommand,    rbac::RBAC_PERM_COMMAND_RESET, Console::Yes },
         };
+        static ChatCommandTable resetCooldownCommandTable =
+        {
+            { "all", HandleResetCooldownAllCommand, rbac::RBAC_PERM_COMMAND_RESET, Console::Yes },
+        };
         static ChatCommandTable resetCommandTable =
         {
             { "achievements",   HandleResetAchievementsCommand, rbac::RBAC_PERM_COMMAND_RESET_ACHIEVEMENTS, Console::Yes },
+            { "cooldown",       resetCooldownCommandTable },
             { "honor",          HandleResetHonorCommand,        rbac::RBAC_PERM_COMMAND_RESET_HONOR,        Console::Yes },
             { "level",          HandleResetLevelCommand,        rbac::RBAC_PERM_COMMAND_RESET_LEVEL,        Console::Yes },
             { "spells",         HandleResetSpellsCommand,       rbac::RBAC_PERM_COMMAND_RESET_SPELLS,       Console::Yes },
@@ -77,6 +82,34 @@ public:
             playerTarget->ResetAchievements();
         else
             AchievementMgr::DeleteFromDB(target->GetGUID().GetCounter());
+
+        return true;
+    }
+
+    static bool HandleResetCooldownAllCommand(ChatHandler* handler, Optional<PlayerIdentifier> target)
+    {
+        if (!target)
+        {
+            target = PlayerIdentifier::FromTargetOrSelf(handler);
+        }
+
+        if (!target)
+        {
+            return false;
+        }
+
+        Player* playerTarget = target->GetConnectedPlayer();
+        if (!playerTarget)
+        {
+            handler->SendSysMessage(LANG_PLAYER_NOT_EXIST_OR_OFFLINE);
+            return false;
+        }
+
+        playerTarget->RemoveAllSpellCooldown();
+
+        ChatHandler(playerTarget->GetSession()).PSendSysMessage("Your spell cooldowns have been reset.");
+        if (!handler->GetSession() || handler->GetSession()->GetPlayer() != playerTarget)
+            handler->PSendSysMessage("Reset all spell cooldowns for {}.", handler->GetNameLink(playerTarget));
 
         return true;
     }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

Adds a new GM command, `.reset cooldown all`, that clears every spell cooldown on the target player (or yourself if nobody's selected). Useful for testing spells without waiting cooldowns out or relogging.

Follows the same pattern as the existing `.reset spells` / `.reset talents` commands - targets the selected player or falls back to yourself, and lets both the caster and the target know it happened.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Sonnet 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- N/A

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Cast a few spells to put them on cooldown, ran `.reset cooldown all`, confirmed all cooldowns cleared immediately client-side. Also tested targeting another connected player.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Cast a few spells so they go on cooldown.
2. Run `.reset cooldown all` (no target needed to reset your own).
3. Confirm every cooldown clears right away.
4. Optionally, select another online player first and confirm it resets theirs instead, with both of you getting a message.

## Known Issues and TODO List:

- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
