### PR TITLE
fix(Core/Instances): day-align expired reset time

### DIFF
--- a/src/server/game/Instances/InstanceSaveMgr.cpp
+++ b/src/server/game/Instances/InstanceSaveMgr.cpp
@@ -354,7 +354,7 @@ void InstanceSaveMgr::LoadResetTimes()
         {
             // assume that expired instances have already been cleaned
             // calculate the next reset time
-            t = (t * DAY) / DAY;
+            t = (t / DAY) * DAY;
             t += ((today - t) / period + 1) * period + diff;
             CharacterDatabase.DirectExecute("UPDATE instance_reset SET resettime = '{}' WHERE mapid = '{}' AND difficulty = '{}'", (uint32)t, mapid, difficulty);
         }


### PR DESCRIPTION
## Changes Proposed:

In `InstanceSaveMgr::LoadResetTimes` the expression `t = (t * DAY) / DAY;` is a no-op. Looking at #1416, where this block was reworked, the intent was `t = (t / DAY) * DAY;`, rounding the expired reset time down to midnight before computing the next one.

Since the old hour of day survives, a global reset time that expires while the server is offline gets `Instance.ResetTimeHour` added on top of its old hour at startup, so the reset hour drifts later on every such recalculation. Resets that happen while the server is running go through `_ResetOrWarnAll`, which aligns correctly. On my server all heroic rows in `instance_reset` were at 04:00 while every raid row had drifted to 12:00 with the default `Instance.ResetTimeHour = 4`.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5). The code change, this description and the tests were produced by the AI agent, working with the author.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:

A/B tested on my server (Docker on a Windows host) with the steps below: same planted reset time (20:00 the previous day), buggy build recalculated it to 00:00, fixed build to 04:00 (`Instance.ResetTimeHour = 4`). Builds without errors.

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Stop the worldserver and pick a heroic row in the characters DB table `instance_reset`.
2. Set its `resettime` to yesterday at an hour different from `Instance.ResetTimeHour`, for example 20:00.
3. Start the worldserver and check the row. Broken: the new time keeps the wrong hour and adds `Instance.ResetTimeHour` on top (20:00 + 4h gives 00:00). Fixed: it lands on `Instance.ResetTimeHour` (04:00 by default).

Note: the wrong hour plus `Instance.ResetTimeHour` must still be ahead of the current time of day, otherwise the reset fires immediately at startup and `_ResetOrWarnAll` corrects the row before you can observe it.

## Known Issues and TODO List:

- [ ]
- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
