### PR TITLE
fix(Scripts/Ulduar): apply Yogg-Saron keeper buffs on pull again

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784596450250937900.sql
+++ b/data/sql/updates/pending_db_world/rev_1784596450250937900.sql
@@ -1,0 +1,4 @@
+-- Spawn Voice of Yogg-Saron in Ulduar (spawn data from TrinityCore)
+DELETE FROM `creature` WHERE `id` = 33280 AND `map` = 603;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `MovementType`, `ScriptName`, `Comment`, `VerifiedBuild`) VALUES
+(62015, 33280, 603, 0, 0, 3, 1, 0, 1980.14, -25.7438, 326.467, 0, 604800, 0, 0, '', 'Voice of Yogg-Saron', 0);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -384,7 +384,7 @@ struct boss_yoggsaron_sara : public ScriptedAI
     uint32 _initFight;
     uint8 _summonedGuardiansCount;
     uint32 _p2TalkTimer;
-    bool _secondPhase;
+    bool _secondPhase = false;
     float _summonSpeed;
     uint8 _currentIllusion;
     bool _isIllusionReversed;
@@ -439,9 +439,10 @@ struct boss_yoggsaron_sara : public ScriptedAI
 
     void Reset() override
     {
-        if (!_secondPhase) // Phase 1 wipe
+        // Whisper only on a real phase 1 wipe, not on the initial reset
+        if (!_secondPhase && _instance && _instance->GetBossState(BOSS_YOGGSARON) == IN_PROGRESS)
         {
-            if (Creature* voice = _instance ? _instance->GetCreature(DATA_VOICE_OF_YOGG_SARON) : nullptr)
+            if (Creature* voice = _instance->GetCreature(DATA_VOICE_OF_YOGG_SARON))
             {
                 me->GetMap()->DoForAllPlayers([&](Player* player)
                 {
@@ -696,9 +697,8 @@ struct boss_yoggsaron_sara : public ScriptedAI
             summons.DespawnEntry(NPC_FREYA_KEEPER);
             summons.DespawnEntry(NPC_THORIM_KEEPER);
             summons.DespawnEntry(NPC_SANITY_WELL);
-            if (_instance)
-                if (Creature* voice = _instance->GetCreature(DATA_VOICE_OF_YOGG_SARON))
-                    voice->AI()->DoAction(ACTION_VOICE_STOP);
+            if (Creature* voice = _instance ? _instance->GetCreature(DATA_VOICE_OF_YOGG_SARON) : nullptr)
+                voice->AI()->DoAction(ACTION_VOICE_STOP);
             me->KillSelf();
             return;
         }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -183,7 +183,6 @@ enum NPCsGOs
     NPC_GUARDIAN_OF_YS                  = 33136,
     NPC_SANITY_WELL                     = 33991,
     NPC_YOGG_SARON                      = 33288,
-    NPC_VOICE_OF_YOGG_SARON             = 33280,
     NPC_YOGG_SARON_VISION               = 33552,
 
     NPC_CRUSHER_TENTACLE                = 33966, // 50 secs ?
@@ -230,6 +229,9 @@ enum NPCsGOs
 
 enum Misc
 {
+    ACTION_ACTIVATE_KEEPER              = -19,
+    ACTION_VOICE_STOP                   = -18,
+    ACTION_VOICE_START                  = -17,
     ACTION_UNSUMMON_CLOUDS              = -16,
     ACTION_DESPAWN_ADDS                 = -15,
     ACTION_START_SUMMONING              = -14,
@@ -439,13 +441,13 @@ struct boss_yoggsaron_sara : public ScriptedAI
     {
         if (!_secondPhase) // Phase 1 wipe
         {
-            me->GetMap()->DoForAllPlayers([&](Player* player)
+            if (Creature* voice = _instance ? _instance->GetCreature(DATA_VOICE_OF_YOGG_SARON) : nullptr)
             {
-                if (Creature* voice = me->FindNearestCreature(NPC_VOICE_OF_YOGG_SARON, 10.0f))
+                me->GetMap()->DoForAllPlayers([&](Player* player)
                 {
                     voice->AI()->Talk(WHISPER_VOICE_PHASE_1_WIPE, player);
-                }
-            });
+                });
+            }
         }
 
         summons.DoAction(ACTION_DESPAWN_ADDS);
@@ -474,6 +476,8 @@ struct boss_yoggsaron_sara : public ScriptedAI
         {
             _instance->DoStopTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, CRITERIA_NOT_GETTING_OLDER);
             _instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_SANITY);
+            if (Creature* voice = _instance->GetCreature(DATA_VOICE_OF_YOGG_SARON))
+                voice->AI()->DoAction(ACTION_VOICE_STOP);
             _instance->SetBossState(BOSS_YOGGSARON, NOT_STARTED);
             if (GameObject* go = _instance->GetGameObject(DATA_YOGG_SARON_DOORS))
                 go->SetGoState(GO_STATE_ACTIVE);
@@ -494,8 +498,13 @@ struct boss_yoggsaron_sara : public ScriptedAI
         AttackStart(target);
 
         DespawnGossipKeepers();
-        // Engage Keepers
         summons.DoZoneInCombat();
+
+        if (Creature* voice = _instance->GetCreature(DATA_VOICE_OF_YOGG_SARON))
+            voice->AI()->DoAction(ACTION_VOICE_START);
+
+        // Keepers are friendly to players and never enter combat, activate them directly
+        ActivateKeepers();
 
         events.ScheduleEvent(EVENT_SARA_P1_DOORS_CLOSE, 15s, 0, EVENT_PHASE_ONE);
         events.ScheduleEvent(EVENT_SARA_P1_BERSERK, 15min, 0, 0);
@@ -532,6 +541,20 @@ struct boss_yoggsaron_sara : public ScriptedAI
                 if (!summons.HasEntry(TABLE_KEEPER_ENTRY[i]))
                     me->SummonCreature(TABLE_KEEPER_ENTRY[i], KeepersPos[i]);
             }
+        }
+    }
+
+    void ActivateKeepers()
+    {
+        for (SummonList::const_iterator itr = summons.begin(); itr != summons.end(); ++itr)
+        {
+            Creature* summon = ObjectAccessor::GetCreature(*me, *itr);
+            if (!summon)
+                continue;
+
+            for (uint8 i = KEEPER_FREYA; i <= KEEPER_THORIM; i++)
+                if (summon->GetEntry() == TABLE_KEEPER_ENTRY[i])
+                    summon->AI()->DoAction(ACTION_ACTIVATE_KEEPER);
         }
     }
 
@@ -634,6 +657,7 @@ struct boss_yoggsaron_sara : public ScriptedAI
         if (param == ACTION_SARA_UPDATE_SUMMON_KEEPERS)
         {
             UpdateKeeperSpawns();
+            return;
         }
         else if (param == ACTION_BRAIN_DAMAGED)
         {
@@ -662,7 +686,6 @@ struct boss_yoggsaron_sara : public ScriptedAI
             summons.DespawnEntry(NPC_CRUSHER_TENTACLE);
             summons.DespawnEntry(NPC_CONSTRICTOR_TENTACLE);
             summons.DespawnEntry(NPC_CORRUPTOR_TENTACLE);
-            summons.DespawnEntry(NPC_VOICE_OF_YOGG_SARON);
             summons.DespawnEntry(NPC_BRAIN_OF_YOGG_SARON);
             summons.DespawnEntry(NPC_MIMIRON_GOSSIP);
             summons.DespawnEntry(NPC_HODIR_GOSSIP);
@@ -673,6 +696,9 @@ struct boss_yoggsaron_sara : public ScriptedAI
             summons.DespawnEntry(NPC_FREYA_KEEPER);
             summons.DespawnEntry(NPC_THORIM_KEEPER);
             summons.DespawnEntry(NPC_SANITY_WELL);
+            if (_instance)
+                if (Creature* voice = _instance->GetCreature(DATA_VOICE_OF_YOGG_SARON))
+                    voice->AI()->DoAction(ACTION_VOICE_STOP);
             me->KillSelf();
             return;
         }
@@ -804,9 +830,6 @@ struct boss_yoggsaron_sara : public ScriptedAI
         switch (events.ExecuteEvent())
         {
             case EVENT_SARA_P1_DOORS_CLOSE:
-                // Whispers of YS
-                me->SummonCreature(NPC_VOICE_OF_YOGG_SARON, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ());
-
                 if (_instance)
                     if (GameObject* go = _instance->GetGameObject(DATA_YOGG_SARON_DOORS))
                         go->SetGoState(GO_STATE_READY);
@@ -1673,6 +1696,8 @@ struct boss_yoggsaron_keeper : public NullCreatureAI
             me->CastSpell(me, SPELL_TITANIC_STORM_PASSIVE, false);
         else if (param == ACTION_DESPAWN_ADDS)
             _summons.DespawnAll();
+        else if (param == ACTION_ACTIVATE_KEEPER)
+            Activate();
     }
 
     void JustSummoned(Creature* summon) override
@@ -1680,7 +1705,7 @@ struct boss_yoggsaron_keeper : public NullCreatureAI
         _summons.Summon(summon);
     }
 
-    void JustEngagedWith(Unit* /*who*/) override
+    void Activate()
     {
         switch (me->GetEntry())
         {
@@ -2092,8 +2117,21 @@ struct boss_yoggsaron_voice : public NullCreatureAI
 
     void Reset() override
     {
-        DoCastSelf(SPELL_INSANE_PERIODIC, true);
-        DoCastSelf(SPELL_SANITY_BASE, true);
+        events.Reset();
+        _targets.clear();
+        _current = 0;
+        me->RemoveAllAuras();
+    }
+
+    void DoAction(int32 param) override
+    {
+        if (param == ACTION_VOICE_START)
+        {
+            DoCastSelf(SPELL_INSANE_PERIODIC, true);
+            DoCastSelf(SPELL_SANITY_BASE, true);
+        }
+        else if (param == ACTION_VOICE_STOP)
+            Reset();
     }
 
     void SpellHitTarget(Unit* target, SpellInfo const* spellInfo) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -114,6 +114,7 @@ ObjectData const creatureData[] =
     // Yogg-Saron helpers
     { NPC_SARA,                     DATA_SARA                   },
     { NPC_BRAIN_OF_YOGG_SARON,      DATA_BRAIN_OF_YOGG_SARON    },
+    { NPC_VOICE_OF_YOGG_SARON,      DATA_VOICE_OF_YOGG_SARON    },
     // Observation Ring Keepers
     { NPC_FREYA_GOSSIP,             DATA_FREYA_GOSSIP           },
     { NPC_HODIR_GOSSIP,             DATA_HODIR_GOSSIP           },

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -127,6 +127,7 @@ enum UlduarData
     DATA_SARA                               = 760,
     DATA_BRAIN_OF_YOGG_SARON               = 761,
     DATA_YOGG_SARON_DOORS                   = 762,
+    DATA_VOICE_OF_YOGG_SARON                = 763,
 
     // Middle section
     DATA_ASSEMBLY_DOORS                     = 770,
@@ -192,6 +193,7 @@ enum UlduarNPCs
     NPC_ELDER_IRONBRANCH                    = 32913,
 
     // Yogg-Saron
+    NPC_VOICE_OF_YOGG_SARON                 = 33280,
     NPC_FREYA_GOSSIP                        = 33241,
     NPC_HODIR_GOSSIP                        = 33213,
     NPC_THORIM_GOSSIP                       = 33242,


### PR DESCRIPTION
## Changes Proposed:

Since the threat system port (#24715), the Yogg-Saron keepers could no longer be engaged through `DoZoneInCombat`: they are friendly to players, so `CanBeginCombat` rejects the pairing, their `JustEngagedWith` never fired and none of their effects were applied (raid buffs, Freya's Sanity Wells, Hodir's Protective Gaze, Mimiron's Destabilization Matrix).

- Keepers are now activated directly by Sara when the fight starts, without relying on combat state.
- The Voice of Yogg-Saron (33280) is now a permanent spawn, as it is on TrinityCore and cMaNGOS (spawn data taken from TrinityCore). It starts its Sanity and Insane periodics at encounter start and stops them on wipe or kill. As a side effect Sanity is now applied at the pull, like on retail, instead of 15 seconds into the fight.
- Fixed Sara casting Shattered Illusion on herself whenever a keeper was teleported at the Observation Ring: the `ACTION_SARA_UPDATE_SUMMON_KEEPERS` branch in her `DoAction` was missing a `return`, so the positive action id (4) fell through into the illusion shatter block, which treats any positive param as a stun duration.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26247

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Behavior cross-checked against TrinityCore (`boss_yogg_saron.cpp`) and cMaNGOS (`boss_yogg_saron.cpp`, `603_ulduar.sql`). Both projects keep the Voice of Yogg-Saron permanently spawned and apply the keeper buffs when the encounter starts. The creature spawn row is taken from TrinityCore's data.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Defeat Freya, Thorim, Mimiron and Hodir, then talk to their versions at the Observation Ring so they teleport to Yogg-Saron's room (check that Sara does not get the Shattered Illusion aura when they do).
2. Start the Yogg-Saron encounter.
3. Each teleported keeper should apply its raid buff (Resilience of Nature, Fury of the Storm, Speed of Invention, Fortitude of Frost), Freya should conjure Sanity Wells, and the Sanity bar should appear right at the pull.
4. Wipe and re-pull to verify everything resets and reapplies correctly.

## Known Issues and TODO List:

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
