### PR TITLE
feat(CI): skip pch/nopch core builds on DB-only pull requests

### DIFF
--- a/.github/workflows/core-build-nopch.yml
+++ b/.github/workflows/core-build-nopch.yml
@@ -8,6 +8,12 @@ on:
       - opened
       - reopened
       - synchronize
+    # A PR that only touches data/ (SQL) leaves the C++ untouched, so there is
+    # nothing to compile. Dashboard CI runs on every PR unfiltered and already
+    # imports the SQL and starts a real worldserver, so coverage is unaffected.
+    # Pushes to master are not filtered and always build.
+    paths-ignore:
+      - 'data/**'
 
 concurrency:
   # One concurrency group per workflow + ref.

--- a/.github/workflows/core-build-pch.yml
+++ b/.github/workflows/core-build-pch.yml
@@ -8,6 +8,12 @@ on:
       - opened
       - reopened
       - synchronize
+    # A PR that only touches data/ (SQL) leaves the C++ untouched, so there is
+    # nothing to compile. Dashboard CI runs on every PR unfiltered and already
+    # imports the SQL and starts a real worldserver, so coverage is unaffected.
+    # Pushes to master are not filtered and always build.
+    paths-ignore:
+      - 'data/**'
 
 concurrency:
   # One concurrency group per workflow + ref.


### PR DESCRIPTION
## Changes Proposed:

Add `paths-ignore: data/**` to the `pull_request` trigger of `pch-build` and `nopch-build`.

A PR that only touches `data/` leaves the C++ untouched, so the five core build legs (3 nopch + 2 pch) compile an unchanged tree. `data/` contains only `sql/`, so the filter is exactly "DB-only PR".

SQL validation is not lost. Dashboard CI has no paths filter, so it runs on every PR under the same repo/draft gate, and `./acore.sh init` does the full SQL import followed by a `worldserver --dry-run` and a real worldserver start. That is more coverage than a core build leg gives, and it is the faster job: on master today Dashboard CI takes ~26 min against ~60 min for the core legs.

`push` to master is not filtered and still builds everything. `core_modules_build` already uses a paths filter for the same reason.

### Worth checking before merge

If any of the `ubuntu-*-<compiler>-pch/nopch` check names are marked required in branch protection, a DB-only PR would sit waiting on a check that never reports. The existing `core_modules_build` paths filter suggests they are not, but someone with admin should confirm.

### AI-assisted Pull Requests

- [X] Opus 4.8

## Tests Performed:

Not yet run against CI.

## How to Test the Changes:

Open a PR touching only files under `data/sql/`, confirm pch/nopch do not start and Dashboard CI still runs and imports the SQL. Then push a PR touching `src/`, confirm all five core legs run as before.
