### PR TITLE
feat(CI): delete Actions caches when a PR closes

### DIFF
--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -30,8 +30,10 @@ jobs:
           deleted=0
           # A single PR can hold more entries than one page: the ccache key is
           # unique per run, so a long-lived PR accumulates one entry per build
-          # leg per push.
-          for _ in $(seq 1 10); do
+          # leg per push. No iteration cap, or entries past the cap would be
+          # left behind silently; the no-progress check below is what
+          # terminates the loop.
+          while true; do
             ids="$(gh cache list --ref "$PR_REF" --limit 100 --json id --jq '.[].id')"
             # Not `[[ -z ]] && break`: under `set -e` a false test as the last
             # command of the loop body would abort the script.

--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -24,38 +24,6 @@ jobs:
           # unreachable from any other branch, so once the PR is closed they can
           # only occupy space. Deleting by this ref cannot touch master's caches.
           PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
-        run: |
-          set -euo pipefail
-
-          deleted=0
-          # A single PR can hold more entries than one page: the ccache key is
-          # unique per run, so a long-lived PR accumulates one entry per build
-          # leg per push. No iteration cap, or entries past the cap would be
-          # left behind silently; the no-progress check below is what
-          # terminates the loop.
-          while true; do
-            ids="$(gh cache list --ref "$PR_REF" --limit 100 --json id --jq '.[].id')"
-            # Not `[[ -z ]] && break`: under `set -e` a false test as the last
-            # command of the loop body would abort the script.
-            if [[ -z "$ids" ]]; then
-              break
-            fi
-
-            before=$deleted
-            while read -r id; do
-              if gh cache delete "$id"; then
-                deleted=$((deleted + 1))
-              else
-                echo "::warning::failed to delete cache $id"
-              fi
-            done <<< "$ids"
-
-            # Entries still listed but undeletable would otherwise be retried
-            # every round.
-            if [[ "$deleted" -eq "$before" ]]; then
-              echo "::warning::no progress, giving up with entries remaining"
-              break
-            fi
-          done
-
-          echo "Deleted $deleted cache entries for $PR_REF"
+        # --succeed-on-no-caches: without it gh exits 1 when the PR has no
+        # caches, which is the normal case for a PR that never ran CI.
+        run: gh cache delete --all --ref "$PR_REF" --succeed-on-no-caches

--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -1,0 +1,59 @@
+name: cleanup-pr-caches
+on:
+  # pull_request_target, not pull_request: for a PR from a fork the GITHUB_TOKEN
+  # of a pull_request run is read-only, so the delete would 403. This workflow
+  # never checks out or runs PR code, so the elevated token is not exposed to it.
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  actions: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: delete caches of the closed PR
+    if: github.repository == 'azerothcore/azerothcore-wotlk'
+    steps:
+      - name: Delete caches created by this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # Caches written during a PR run are scoped to the merge ref and are
+          # unreachable from any other branch, so once the PR is closed they can
+          # only occupy space. Deleting by this ref cannot touch master's caches.
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          set -euo pipefail
+
+          deleted=0
+          # A single PR can hold more entries than one page: the ccache key is
+          # unique per run, so a long-lived PR accumulates one entry per build
+          # leg per push.
+          for _ in $(seq 1 10); do
+            ids="$(gh cache list --ref "$PR_REF" --limit 100 --json id --jq '.[].id')"
+            # Not `[[ -z ]] && break`: under `set -e` a false test as the last
+            # command of the loop body would abort the script.
+            if [[ -z "$ids" ]]; then
+              break
+            fi
+
+            before=$deleted
+            while read -r id; do
+              if gh cache delete "$id"; then
+                deleted=$((deleted + 1))
+              else
+                echo "::warning::failed to delete cache $id"
+              fi
+            done <<< "$ids"
+
+            # Entries still listed but undeletable would otherwise be retried
+            # every round.
+            if [[ "$deleted" -eq "$before" ]]; then
+              echo "::warning::no progress, giving up with entries remaining"
+              break
+            fi
+          done
+
+          echo "Deleted $deleted cache entries for $PR_REF"


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

CI only: a new workflow that deletes the Actions caches scoped to `refs/pull/<N>/merge` when that PR closes.

### What this does and does not buy

GitHub already manages the pool on its own: it evicts LRU above the 10 GB limit and drops anything untouched for 7 days. Caches belonging to closed PRs are never read again, so they are already what LRU evicts first. This workflow does not rescue the pool from a state it could not reach by itself.

What it does buy is narrower:

- Space comes back on close instead of after up to 7 days of idling, so the pool spends less time pinned at the ceiling.
- Eviction gets less arbitrary. At the ceiling, LRU can drop a live PR's cache that happens to be a few hours cold in favour of a just-closed PR's cache touched ten minutes ago. Deleting on close targets dead entries directly instead of approximating them by age.

To be explicit about what it is *not*: master's ccache entries were never at risk. Every PR restores from them through the restore-key fallback chain, so their last-accessed timestamp is refreshed constantly and LRU does not reach them. An earlier draft of this description claimed this PR protects them. It does not.

### Known gaps

- No backfill. Only future closes are swept. PRs merged before this lands keep their caches until GitHub ages them out.
- Closing a PR does not cancel its in-flight builds, so a build still running at close can save a new cache after the cleanup has already run, and nothing deletes that one. Measured on #26716: merged at 11:47Z, its build jobs completed at 11:49, 11:52, 11:54 and 12:01. #24258 intended to cancel PR CI on merge, but the concurrency group is keyed on `github.ref`, which differs between `refs/pull/N/merge` and `refs/heads/master`, so no cancellation happens. Worth fixing separately.

### Notes on the implementation

- Uses `pull_request_target` rather than `pull_request` on purpose: for a PR from a fork, a `pull_request` run gets a read-only `GITHUB_TOKEN` and the delete would fail with 403. Nearly all AzerothCore PRs are from forks. The workflow never checks out or executes any PR code, so the elevated token is not exposed to it.
- Deleting by the merge ref cannot affect master's caches; GitHub's cache scoping makes PR caches unreachable from other branches.
- `gh cache delete --all --ref` handles the whole ref in one call. `--succeed-on-no-caches` keeps the step green for a PR that never ran CI.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [X] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code, Opus 4.8
- [X] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes

None. Follow-up to #26481.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Not applicable, this is CI infrastructure. The cache figures quoted above come from the repo's own `actions/cache/usage` and cache listing endpoints.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.

`gh cache delete --all --ref ... --succeed-on-no-caches` was verified against gh 2.93.0. The workflow cannot run for real until it is on master, since `pull_request_target` workflows execute from the base branch.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [X] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. After merge, close any PR that has run CI.
2. Check the `cleanup-pr-caches` run on that PR; the step logs what gh deleted.
3. `gh cache list --ref refs/pull/<N>/merge` should come back empty.
4. Total usage from `gh api repos/azerothcore/azerothcore-wotlk/actions/cache/usage` should drop by that PR's share.

## Known Issues and TODO List:

- [ ] Caches for PRs closed before this lands are not swept retroactively; GitHub expires them after 7 days of no access.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
