### PR TITLE
fix(CI): stop dashboard ccache from freezing after the first run

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -137,15 +137,21 @@ jobs:
 
       - name: Echo cache key
         shell: bash
-        run: echo "Cache key -> ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}"
+        run: echo "Cache key -> ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}"
 
+      # The primary key must be unique per run. A static key hits on itself from
+      # the second run onward and the save is then skipped, freezing the cache
+      # at its first-run contents. The first restore-key picks up the most
+      # recent cache on this ref; the rest are the existing cross-workflow
+      # fallbacks to the linux-build action's keys.
       - name: Restore ccache
         id: restore_ccache
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/var/ccache
-          key: ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}
+          key: ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}
           restore-keys: |
+            ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-
             ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:true:pch=false:
             ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:false:pch=false:
             ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:true:pch=true:
@@ -167,7 +173,7 @@ jobs:
           CCACHE_MAXSIZE=5G
           CCACHE_SLOPPINESS=pch_defines,time_macros,include_file_mtime
           CCACHE_COMPRESS=1
-          CCACHE_COMPRESSLEVEL=9
+          CCACHE_COMPRESSLEVEL=3
           CCACHE_COMPILERCHECK=content
           CCACHE_LOGFILE=${{ github.workspace }}/var/ccache/cache.debug
           CMAKE_C_COMPILER_LAUNCHER=ccache
@@ -273,13 +279,13 @@ jobs:
         timeout-minutes: 30
         continue-on-error: false
 
-      # save only if we didn't hit the cache
+      # The per-run key can never collide with an existing cache, so the old
+      # "only save on a cache miss" guard would always be true and is dropped.
       - name: Save ccache
-        if: steps.restore_ccache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/var/ccache
-          key: ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}
+          key: ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}
 
       - name: ccache stats (after)
         shell: bash

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -282,13 +282,15 @@ jobs:
         timeout-minutes: 30
         continue-on-error: false
 
-      # The per-run key can never collide with an existing cache, so the old
-      # "only save on a cache miss" guard would always be true and is dropped.
+      # The old "only save on a cache miss" guard is dropped: the per-run key
+      # only ever collides on a re-run, since github.run_id is stable across
+      # attempts, and there the save is a no-op anyway.
       # A failed build still compiled most of the tree and that work is worth
-      # keeping; a cancelled one is skipped so a superseded run cannot publish
-      # a half-populated cache as the newest for the ref.
+      # keeping. A cancelled one is skipped so a superseded run cannot publish
+      # a half-populated cache as the newest for the ref, and a run that died
+      # before the restore has no compiler id and no ccache dir to save.
       - name: Save ccache
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.restore_ccache.outcome == 'success' }}
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/var/ccache

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -138,21 +138,23 @@ jobs:
 
       - name: Echo cache key
         shell: bash
-        run: echo "Cache key -> ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}"
+        run: echo "Cache key -> ccache:${{ matrix.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}"
 
       # The primary key must be unique per run. A static key hits on itself from
       # the second run onward and the save is then skipped, freezing the cache
-      # at its first-run contents. The first restore-key picks up the most
-      # recent cache on this ref; the rest are the existing cross-workflow
-      # fallbacks to the linux-build action's keys.
+      # at its first-run contents. It is keyed on matrix.os rather than
+      # runner.os because both legs report Linux and share a run_id, so only the
+      # detected compiler would separate them. The first restore-key picks up
+      # the most recent cache for this leg on this ref; the rest keep runner.os
+      # because they are cross-workflow fallbacks to the linux-build action.
       - name: Restore ccache
         id: restore_ccache
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/var/ccache
-          key: ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}
+          key: ccache:${{ matrix.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}
           restore-keys: |
-            ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-
+            ccache:${{ matrix.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-
             ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:true:pch=false:
             ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:false:pch=false:
             ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:true:pch=true:
@@ -282,11 +284,15 @@ jobs:
 
       # The per-run key can never collide with an existing cache, so the old
       # "only save on a cache miss" guard would always be true and is dropped.
+      # A failed build still compiled most of the tree and that work is worth
+      # keeping; a cancelled one is skipped so a superseded run cannot publish
+      # a half-populated cache as the newest for the ref.
       - name: Save ccache
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/var/ccache
-          key: ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}
+          key: ccache:${{ matrix.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}
 
       - name: ccache stats (after)
         shell: bash

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -20,8 +20,9 @@ concurrency:
   #
   # - PRs use `refs/pull/<PR_NUMBER>/merge`, so new commits cancel older
   #   in-progress runs for the same PR.
-  # - When a PR is merged, a push to the target branch starts a new group,
-  #   canceling any still-running PR CI.
+  # - A merge does NOT cancel the PR's own runs: this group is keyed on
+  #   refs/pull/<N>/merge and the master push on refs/heads/master, so they
+  #   never share a group.
   # - Branch pushes are isolated by ref.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

CI only. @Yehonal, this one is yours via CODEOWNERS.

Split out of #26481, which carries the same fix for the Linux and macOS builds. It was removed there so the rest could merge without blocking on your review.

The primary ccache key is static per ref, so `actions/cache` finds an exact hit from the second run onward and skips the save. GitHub says so in the log of every run:

    Cache hit occurred on the primary key ccache:..., not saving cache.

The cache therefore freezes at whatever it held on the first run of a branch, and permanently on master. Measured on master today: master ccache entries sit at 44-58 MB while active PR entries are 99-372 MB for the same compilers, and the observed hit rate on a master build was 79/1175 = 6.7%.

Changes:

- Primary key gains `-${{ github.run_id }}`, so every run saves a fresh cache.
- The key is built from `matrix.os` rather than `runner.os`. Both matrix legs report `Linux` and share a `run_id`, so only the runtime-detected compiler separated them; if the two images ever ship the same clang major, they would collide on every run. The cross-workflow fallback restore-keys keep `runner.os` so they still match the `linux-build` action's keys.
- A `${{ github.ref_name }}-` restore-key is prepended to pick up the most recent cache for this leg on this ref. The existing fallbacks are untouched.
- The `if: steps.restore_ccache.outputs.cache-hit != 'true'` guard on the save step is replaced by `if: ${{ !cancelled() && steps.restore_ccache.outcome == 'success' }}`. A failed build has still compiled most of the tree and that work is worth keeping; a run cancelled by `cancel-in-progress` must not publish a half-populated cache as the newest for the ref; and a run that died before the compiler detection has no compiler id and no ccache dir to save.
- `CCACHE_COMPRESSLEVEL` 9 -> 3, matching `linux-build` after #26481.
- Corrects the stale concurrency comment, which claimed a merge cancels the PR's still-running CI. It does not: the groups are keyed on `github.ref`, which differs between `refs/pull/<N>/merge` and `refs/heads/master`. Same correction #26719 made in the other six workflows; folded in here because this file is under CODEOWNERS.

### Known limits

- `github.run_id` is stable across re-attempts, so re-running a failed job restores its own cache and the save is a no-op. The extra work from the second attempt is not kept. Same for `linux-build` and `macos_build` on master.
- The key namespace changes, so the first run on each leg after this merges is cold and the old `Linux`-keyed entries age out.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [X] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code, Opus 4.8
- [X] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes

None. Split out of #26481.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Not applicable, this is CI infrastructure. The figures above come from the repo's own cache listing and from the job logs of run 29817862977.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [X] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. On any PR run of Dashboard CI, check the "Post Save ccache" step. It should report a cache being saved rather than "not saving cache".
2. After a few pushes to master, the master ccache entry should grow past the ~50 MB it has been stuck at.
3. The "Previous cache stats" line on a later run should show a hit rate well above the current 6.7%.

## Known Issues and TODO List:

- [ ] Per-run keys mean more cache entries. #26717 deletes a PR's caches when it closes, which keeps the 10 GB pool from filling with dead entries.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
