### PR TITLE
fix(CI): cancel a PR's CI when the PR closes

### DIFF
--- a/.github/workflows/cancel-pr-runs-on-close.yml
+++ b/.github/workflows/cancel-pr-runs-on-close.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Cancel workflow runs for this PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
           PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/cancel-pr-runs-on-close.yml
+++ b/.github/workflows/cancel-pr-runs-on-close.yml
@@ -24,16 +24,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Runs are matched on head_sha. The `pull_requests` field of a run is
-          # empty for PRs from a fork, which is nearly all of them here, so it
-          # cannot be used. head_branch is the fork's branch name and can collide
-          # between forks. Restricting to event=pull_request keeps push runs for
-          # the same commit out of the selection.
+          # --commit filters server-side on head_sha. A run's `pull_requests`
+          # field is empty for PRs from a fork, which is nearly all of them here,
+          # and head_branch can collide between forks, so the sha is the only
+          # reliable key. --event keeps push runs for the same commit out.
           ids="$(
-            for status in queued in_progress; do
-              gh api "repos/${GH_REPO}/actions/runs?event=pull_request&status=${status}&per_page=100" \
-                | jq -r --arg sha "$PR_SHA" '.workflow_runs[] | select(.head_sha == $sha) | .id'
-            done | sort -u
+            gh run list --commit "$PR_SHA" --event pull_request --limit 100 \
+              --json databaseId,status \
+              --jq '.[] | select(.status == "queued" or .status == "in_progress") | .databaseId'
           )"
 
           if [[ -z "$ids" ]]; then

--- a/.github/workflows/cancel-pr-runs-on-close.yml
+++ b/.github/workflows/cancel-pr-runs-on-close.yml
@@ -1,0 +1,51 @@
+name: cancel-pr-runs-on-close
+on:
+  # pull_request_target, not pull_request: for a PR from a fork the GITHUB_TOKEN
+  # of a pull_request run is read-only, so the cancel would 403. This workflow
+  # never checks out or runs PR code, so the elevated token is not exposed to it.
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  actions: write
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    name: cancel CI still running for the closed PR
+    if: github.repository == 'azerothcore/azerothcore-wotlk'
+    steps:
+      - name: Cancel workflow runs for this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Runs are matched on head_sha. The `pull_requests` field of a run is
+          # empty for PRs from a fork, which is nearly all of them here, so it
+          # cannot be used. head_branch is the fork's branch name and can collide
+          # between forks. Restricting to event=pull_request keeps push runs for
+          # the same commit out of the selection.
+          ids="$(
+            for status in queued in_progress; do
+              gh api "repos/${GH_REPO}/actions/runs?event=pull_request&status=${status}&per_page=100" \
+                | jq -r --arg sha "$PR_SHA" '.workflow_runs[] | select(.head_sha == $sha) | .id'
+            done | sort -u
+          )"
+
+          if [[ -z "$ids" ]]; then
+            echo "Nothing still running for $PR_SHA"
+            exit 0
+          fi
+
+          while read -r id; do
+            # A run that finishes between the listing and the cancel returns 409.
+            if gh run cancel "$id"; then
+              echo "Cancelled run $id"
+            else
+              echo "::warning::could not cancel run $id, it likely already finished"
+            fi
+          done <<< "$ids"

--- a/.github/workflows/cancel-pr-runs-on-close.yml
+++ b/.github/workflows/cancel-pr-runs-on-close.yml
@@ -28,22 +28,11 @@ jobs:
           # field is empty for PRs from a fork, which is nearly all of them here,
           # and head_branch can collide between forks, so the sha is the only
           # reliable key. --event keeps push runs for the same commit out.
-          ids="$(
-            gh run list --commit "$PR_SHA" --event pull_request --limit 100 \
-              --json databaseId,status \
-              --jq '.[] | select(.status == "queued" or .status == "in_progress") | .databaseId'
-          )"
-
-          if [[ -z "$ids" ]]; then
-            echo "Nothing still running for $PR_SHA"
-            exit 0
-          fi
-
-          while read -r id; do
-            # A run that finishes between the listing and the cancel returns 409.
-            if gh run cancel "$id"; then
-              echo "Cancelled run $id"
-            else
-              echo "::warning::could not cancel run $id, it likely already finished"
-            fi
-          done <<< "$ids"
+          gh run list --commit "$PR_SHA" --event pull_request --limit 100 \
+            --json databaseId,status \
+            --jq '.[] | select(.status == "queued" or .status == "in_progress") | .databaseId' \
+          | while read -r id; do
+              # gh has no bulk cancel. A run that finishes between the listing
+              # and the cancel returns 409, which is not worth failing over.
+              gh run cancel "$id" || echo "::warning::run $id was already finished"
+            done

--- a/.github/workflows/cancel-pr-runs-on-close.yml
+++ b/.github/workflows/cancel-pr-runs-on-close.yml
@@ -21,18 +21,28 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           set -euo pipefail
 
-          # --commit filters server-side on head_sha. A run's `pull_requests`
-          # field is empty for PRs from a fork, which is nearly all of them here,
-          # and head_branch can collide between forks, so the sha is the only
-          # reliable key. --event keeps push runs for the same commit out.
-          gh run list --commit "$PR_SHA" --event pull_request --limit 100 \
-            --json databaseId,status \
-            --jq '.[] | select(.status == "queued" or .status == "in_progress") | .databaseId' \
+          # head_sha alone would let anyone cancel another PR's CI: push that
+          # PR's head commit to your own fork, open a PR and close it, and every
+          # run for the commit matches. So the run must also come from this PR's
+          # head repository. `gh run list` exposes neither head_repository nor
+          # the (fork-empty) pull_requests field, hence the raw API call.
+          gh api "repos/${GH_REPO}/actions/runs?event=pull_request&head_sha=${PR_SHA}&per_page=100" \
+            --jq '.workflow_runs[]
+                  | select(.head_repository.full_name == env.PR_REPO and .status != "completed")
+                  | .id' \
           | while read -r id; do
               # gh has no bulk cancel. A run that finishes between the listing
               # and the cancel returns 409, which is not worth failing over.
-              gh run cancel "$id" || echo "::warning::run $id was already finished"
+              if ! err=$(gh run cancel "$id" 2>&1); then
+                if echo "$err" | grep -Fq "HTTP 409"; then
+                  echo "::warning::run $id was already finished"
+                else
+                  echo "::error::Failed to cancel run $id: $err"
+                  exit 1
+                fi
+              fi
             done

--- a/.github/workflows/cancel-pr-runs-on-close.yml
+++ b/.github/workflows/cancel-pr-runs-on-close.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Cancel workflow runs for this PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
           PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/core-build-nopch.yml
+++ b/.github/workflows/core-build-nopch.yml
@@ -14,8 +14,9 @@ concurrency:
   #
   # - PRs use `refs/pull/<PR_NUMBER>/merge`, so new commits cancel older
   #   in-progress runs for the same PR.
-  # - When a PR is merged, a push to the target branch starts a new group,
-  #   canceling any still-running PR CI.
+  # - A merge does NOT cancel the PR's own runs: this group is keyed on
+  #   refs/pull/<N>/merge and the master push on refs/heads/master, so they
+  #   never share a group. See the cancel-pr-runs-on-close workflow.
   # - Branch pushes are isolated by ref.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/core-build-pch.yml
+++ b/.github/workflows/core-build-pch.yml
@@ -14,8 +14,9 @@ concurrency:
   #
   # - PRs use `refs/pull/<PR_NUMBER>/merge`, so new commits cancel older
   #   in-progress runs for the same PR.
-  # - When a PR is merged, a push to the target branch starts a new group,
-  #   canceling any still-running PR CI.
+  # - A merge does NOT cancel the PR's own runs: this group is keyed on
+  #   refs/pull/<N>/merge and the master push on refs/heads/master, so they
+  #   never share a group. See the cancel-pr-runs-on-close workflow.
   # - Branch pushes are isolated by ref.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/core_modules_build.yml
+++ b/.github/workflows/core_modules_build.yml
@@ -28,8 +28,9 @@ concurrency:
   #
   # - PRs use `refs/pull/<PR_NUMBER>/merge`, so new commits cancel older
   #   in-progress runs for the same PR.
-  # - When a PR is merged, a push to the target branch starts a new group,
-  #   canceling any still-running PR CI.
+  # - A merge does NOT cancel the PR's own runs: this group is keyed on
+  #   refs/pull/<N>/merge and the master push on refs/heads/master, so they
+  #   never share a group. See the cancel-pr-runs-on-close workflow.
   # - Branch pushes are isolated by ref.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -20,9 +20,8 @@ concurrency:
   #
   # - PRs use `refs/pull/<PR_NUMBER>/merge`, so new commits cancel older
   #   in-progress runs for the same PR.
-  # - A merge does NOT cancel the PR's own runs: this group is keyed on
-  #   refs/pull/<N>/merge and the master push on refs/heads/master, so they
-  #   never share a group. See the cancel-pr-runs-on-close workflow.
+  # - When a PR is merged, a push to the target branch starts a new group,
+  #   canceling any still-running PR CI.
   # - Branch pushes are isolated by ref.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -20,8 +20,9 @@ concurrency:
   #
   # - PRs use `refs/pull/<PR_NUMBER>/merge`, so new commits cancel older
   #   in-progress runs for the same PR.
-  # - When a PR is merged, a push to the target branch starts a new group,
-  #   canceling any still-running PR CI.
+  # - A merge does NOT cancel the PR's own runs: this group is keyed on
+  #   refs/pull/<N>/merge and the master push on refs/heads/master, so they
+  #   never share a group. See the cancel-pr-runs-on-close workflow.
   # - Branch pushes are isolated by ref.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -13,8 +13,9 @@ concurrency:
   #
   # - PRs use `refs/pull/<PR_NUMBER>/merge`, so new commits cancel older
   #   in-progress runs for the same PR.
-  # - When a PR is merged, a push to the target branch starts a new group,
-  #   canceling any still-running PR CI.
+  # - A merge does NOT cancel the PR's own runs: this group is keyed on
+  #   refs/pull/<N>/merge and the master push on refs/heads/master, so they
+  #   never share a group. See the cancel-pr-runs-on-close workflow.
   # - Branch pushes are isolated by ref.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tools_build.yml
+++ b/.github/workflows/tools_build.yml
@@ -13,8 +13,9 @@ concurrency:
   #
   # - PRs use `refs/pull/<PR_NUMBER>/merge`, so new commits cancel older
   #   in-progress runs for the same PR.
-  # - When a PR is merged, a push to the target branch starts a new group,
-  #   canceling any still-running PR CI.
+  # - A merge does NOT cancel the PR's own runs: this group is keyed on
+  #   refs/pull/<N>/merge and the master push on refs/heads/master, so they
+  #   never share a group. See the cancel-pr-runs-on-close workflow.
   # - Branch pushes are isolated by ref.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -13,8 +13,9 @@ concurrency:
   #
   # - PRs use `refs/pull/<PR_NUMBER>/merge`, so new commits cancel older
   #   in-progress runs for the same PR.
-  # - When a PR is merged, a push to the target branch starts a new group,
-  #   canceling any still-running PR CI.
+  # - A merge does NOT cancel the PR's own runs: this group is keyed on
+  #   refs/pull/<N>/merge and the master push on refs/heads/master, so they
+  #   never share a group. See the cancel-pr-runs-on-close workflow.
   # - Branch pushes are isolated by ref.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

CI only.

#24258 added the concurrency blocks these workflows carry, with this bullet:

    # - When a PR is merged, a push to the target branch starts a new group,
    #   canceling any still-running PR CI.

That does not happen. The group is `${{ github.workflow }}-${{ github.ref }}`, and a PR run's `github.ref` is `refs/pull/<N>/merge` while the post-merge push is `refs/heads/master`. The two never share a group, so the master push has nothing to cancel. `github.ref` cannot express a group shared between a PR and its base branch, so the intent was not reachable that way.

Measured on #26716: merged at 11:47:22Z, its build jobs completed at 11:49, 11:52, 11:54 and 12:01. Up to 14 minutes of runner time spent on a merged PR, per merge, across five build legs.

Changes:

- New `cancel-pr-runs-on-close` workflow. On PR close it cancels queued and in-progress `pull_request` runs for that PR.
- Corrects the misleading bullet in six of the seven workflows that carry it. `dashboard-ci.yml` is the seventh; it is under CODEOWNERS and gets the same correction in #26718, which already has to touch that file.

Notes:

- Runs are matched on `head_sha` **and** `head_repository`. head_sha alone is not unique to a PR: anyone could push another PR's head commit to their own fork, open and close a PR, and cancel that PR's CI. A run's `pull_requests` field is empty for PRs from a fork, which is nearly all of them here, and `gh run list` exposes neither field, so the selection uses the runs API. Restricting to `event=pull_request` keeps push runs for the same commit out.
- `pull_request_target` for the same reason as #26717: a `pull_request` run from a fork gets a read-only token and the cancel would 403. Nothing from the PR is checked out or executed.
- A run that finishes between the listing and the cancel returns 409; that is warned about, not failed. Any other cancel failure, and a failure of the listing itself, fails the step.
- `.status != "completed"` also catches runs held in `waiting` or `action_required`, not just `queued` and `in_progress`.

Relationship to #26717: both trigger on PR close. If both land, cancelling before deleting caches would also close the gap where a still-running build saves a cache after the cleanup has already run. Happy to fold them into one workflow in whichever lands second, if you prefer that.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [X] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code, Opus 4.8
- [X] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes

None. Fixes behaviour intended by #24258.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Not applicable, this is CI infrastructure. The timings above come from the run and job records of #26716.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.

The selection and cancel logic was exercised against a mocked `gh` covering a successful cancel, a 409 for an already-finished run, a 403 that must fail the step, no matching runs, and a listing failure. It cannot run for real until it is on master, since `pull_request_target` workflows execute from the base branch.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [X] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. After merge, merge or close any PR while its core builds are still running.
2. The `cancel-pr-runs-on-close` run should list the run ids it cancelled.
3. Those build runs should show as `cancelled` rather than continuing to completion.

## Known Issues and TODO List:

- [ ] Cancellation is best effort. A run that starts in the seconds after the listing is not caught.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
