### PR TITLE
chore(CI): bump actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/actions/linux-build/action.yml
+++ b/.github/actions/linux-build/action.yml
@@ -50,7 +50,7 @@ runs:
     # walk back from the most-recent cache on this branch to progressively
     # broader fallbacks (branch -> pch variant -> modules variant -> compiler).
     - name: Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ github.workspace }}/var/ccache
         key: ccache:${{ runner.os }}:${{ inputs.CC }}_${{ inputs.CXX }}:${{ inputs.modules }}:pch=${{ inputs.pch }}:${{ github.ref_name }}-${{ github.run_id }}

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -22,9 +22,9 @@ jobs:
     name: C++
     if: github.repository == 'azerothcore/azerothcore-wotlk' && !github.event.pull_request.draft
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
       - name: AzerothCore codestyle

--- a/.github/workflows/core-build-nopch.yml
+++ b/.github/workflows/core-build-nopch.yml
@@ -53,7 +53,7 @@ jobs:
     name: ${{ matrix.os }}-${{ matrix.compiler.CC }}-nopch
     if: github.repository == 'azerothcore/azerothcore-wotlk' && !github.event.pull_request.draft
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/linux-build
         with:
           CC: ${{ matrix.compiler.CC }}

--- a/.github/workflows/core-build-pch.yml
+++ b/.github/workflows/core-build-pch.yml
@@ -49,7 +49,7 @@ jobs:
     name: ${{ matrix.os }}-${{ matrix.compiler.CC }}-pch
     if: github.repository == 'azerothcore/azerothcore-wotlk' && !github.event.pull_request.draft
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/linux-build
         with:
           CC: ${{ matrix.compiler.CC }}

--- a/.github/workflows/core_modules_build.yml
+++ b/.github/workflows/core_modules_build.yml
@@ -49,7 +49,7 @@ jobs:
     name: ${{ matrix.os }}-${{ matrix.compiler.CC }}-nopch-modules
     if: github.repository == 'azerothcore/azerothcore-wotlk' && !github.event.pull_request.draft
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         # This script installs a general list of modules to compile with
         # azerothcore. This is useful for ensuring that module compilation
         # functionality works.

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -41,7 +41,7 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # The containers created in this workflow are used by
       # acore-docker, which has a dependency on mod-ale.
@@ -50,7 +50,7 @@ jobs:
       # build them locally (such as with `docker compose build`)
       - name: Download Eluna
         if: github.repository == 'azerothcore/azerothcore-wotlk' && github.ref_name == 'master'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: azerothcore/mod-ale
           path: modules/mod-ale

--- a/.github/workflows/import_pending.yml
+++ b/.github/workflows/import_pending.yml
@@ -12,7 +12,7 @@ jobs:
     permissions: write-all
     if: github.repository == 'azerothcore/azerothcore-wotlk' && !github.event.pull_request.draft
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # If we're fetching all the history in a later step it makes sense to

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -32,9 +32,9 @@ jobs:
       && !github.event.pull_request.draft
       && (github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'run-build') || github.event.label.name == 'run-build')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/Library/Caches/ccache
           # Unique per run so the cache is re-saved every run instead of

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -9,10 +9,10 @@ jobs:
     permissions: write-all
     if: github.repository == 'azerothcore/azerothcore-wotlk' && !github.event.pull_request.draft
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: true
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/sql-codestyle.yml
+++ b/.github/workflows/sql-codestyle.yml
@@ -22,9 +22,9 @@ jobs:
     name: SQL
     if: github.repository == 'azerothcore/azerothcore-wotlk' && !github.event.pull_request.draft
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
       - name: AzerothCore codestyle

--- a/.github/workflows/tools_build.yml
+++ b/.github/workflows/tools_build.yml
@@ -37,7 +37,7 @@ jobs:
       && !github.event.pull_request.draft
       && (github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'run-build') || github.event.label.name == 'run-build')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/linux-build
         with:
           CC: ${{ matrix.compiler.CC }}

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -35,14 +35,14 @@ jobs:
       && !github.event.pull_request.draft
       && (github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'run-build') || github.event.label.name == 'run-build')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.13
       # Cache the fetched Boost + MySQL client so we don't re-download ~350 MB
       # and re-run the Boost installer on every run. The Test-Path guards in
       # "Configure OS" short-circuit the install work when these are restored.
       - name: Cache Boost & MySQL
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             C:\local\boost_1_87_0


### PR DESCRIPTION
## Changes Proposed:

Bumps the pinned GitHub Actions that still target Node 20 to their current majors:

- `actions/checkout` v4 -> v7
- `actions/cache` v4 -> v6
- `actions/setup-python` v5 -> v7
- `actions/labeler` v5 -> v7

`dashboard-ci.yml` is deliberately left out since it has its own code owners.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

CI only, none of the above apply.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code, Opus 4.8
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

No issue. Every job currently logs:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4

The runners already force these onto Node 24, so today it is only noise, but the forced fallback goes away eventually.

## SOURCE:

- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Upstream release notes: [checkout v5](https://github.com/actions/checkout/releases/tag/v5.0.0), [cache v5](https://github.com/actions/cache/releases/tag/v5.0.0), [setup-python v6](https://github.com/actions/setup-python/releases/tag/v6.0.0), [labeler v6](https://github.com/actions/labeler/releases/tag/v6.0.0) are the majors that moved to Node 24. See also the [Node 20 deprecation announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

Breaking changes checked:

- `setup-python` v7 dropped the `pip-install` input; both codestyle workflows only pass `python-version`.
- `labeler` changed its config format in v5, which we already use, so `.github/labeler.yml` is unaffected.
- `checkout` v7 blocks checking out a fork PR head under `pull_request_target`. The only such workflow here is `pr_labeler.yml`, which checks out the base with no `ref:`.
- All of these require runner >= 2.327.1, which GitHub-hosted runners meet. Relevant only if self-hosted runners are ever added.

## Tests Performed:

- [x] This pull request requires further testing and may have edge cases to be tested.

CI on this PR is the test. With `run-build` set, the macOS, Windows and tools workflows run too, so every touched workflow gets exercised.

## How to Test the Changes:

1. Check that CI on this PR is green.
2. Check that the "Node.js 20 is deprecated" warning is gone from the job annotations.
3. Confirm the labeler still applies labels to this PR (it runs from master, so it needs a re-check after merge).

## Known Issues and TODO List:

- [ ] `hendrikmuhs/ccache-action@v1.2.13` in `windows_build.yml` is third-party and not covered here.
- [ ] `dashboard-ci.yml` still pins the Node 20 majors, left to its code owners.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
