### PR TITLE
fix(CI): let dashboard PR runs inherit master's ccache again

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -145,8 +145,11 @@ jobs:
       # at its first-run contents. It is keyed on matrix.os rather than
       # runner.os because both legs report Linux and share a run_id, so only the
       # detected compiler would separate them. The first restore-key picks up
-      # the most recent cache for this leg on this ref; the rest keep runner.os
-      # because they are cross-workflow fallbacks to the linux-build action.
+      # the most recent cache for this leg on this ref, the second any cache for
+      # this leg on any ref, which is how a PR's first run inherits master's.
+      # Both must use matrix.os to stay in the same namespace as the key. The
+      # rest keep runner.os: they are cross-workflow fallbacks to the
+      # linux-build action, whose keys are built from runner.os.
       - name: Restore ccache
         id: restore_ccache
         uses: actions/cache/restore@v4
@@ -155,6 +158,7 @@ jobs:
           key: ccache:${{ matrix.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}
           restore-keys: |
             ccache:${{ matrix.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-
+            ccache:${{ matrix.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:
             ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:true:pch=false:
             ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:false:pch=false:
             ccache:${{ runner.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:true:pch=true:

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -145,11 +145,13 @@ jobs:
       # at its first-run contents. It is keyed on matrix.os rather than
       # runner.os because both legs report Linux and share a run_id, so only the
       # detected compiler would separate them. The first restore-key picks up
-      # the most recent cache for this leg on this ref, the second any cache for
-      # this leg on any ref, which is how a PR's first run inherits master's.
-      # Both must use matrix.os to stay in the same namespace as the key. The
-      # rest keep runner.os: they are cross-workflow fallbacks to the
-      # linux-build action, whose keys are built from runner.os.
+      # the most recent cache for this leg on this ref; the second the most
+      # recent on any ref the run can reach, which is its own and the base
+      # branch, and is how a first run inherits master's. Both must use
+      # matrix.os to stay in the key's namespace.
+      # The runner.os entries below reach the linux-build action's caches, but
+      # only on the 24.04 leg: on 26.04 this workflow detects clang-21 while
+      # linux-build is passed clang-20, so nothing there lines up.
       - name: Restore ccache
         id: restore_ccache
         uses: actions/cache/restore@v4


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

CI only. @Yehonal, this file is yours via CODEOWNERS. Follow-up to #26718.

#26718 moved the primary ccache key and the ref-specific restore-key onto `matrix.os`, because both matrix legs report `runner.os == Linux` and share a `run_id`. That part is correct. What it missed is that every *ref-independent* fallback stayed on `runner.os`, so nothing in the ladder can reach the new namespace.

Concretely, a PR's first dashboard run today:

    ccache:ubuntu-24.04:clang-18_clang++-18:26715/merge-   <- miss, no cache for this ref yet
    ccache:Linux:clang-18_clang++-18:true:pch=false:       <- cannot prefix-match ubuntu-24.04:*
    ...six more Linux-prefixed entries...

while master's cache now sits at:

    383MB  ccache:ubuntu-24.04:clang-18_clang++-18:master-29848724737

So the PR falls through to the legacy pre-#26718 `ccache:Linux:clang-18_clang++-18:master` entry, or to linux-build's core-build caches, which are built with different compile flags, instead of the 383 MB dashboard cache master wrote an hour ago.

Note this only lines up on the `ubuntu-24.04` leg. On `ubuntu-26.04` the dashboard detects clang-21 while linux-build is passed clang-20, so that leg has no live cross-workflow fallback at all and today starts cold on every new ref.

This adds the one missing prefix in the right namespace:

    ccache:${{ matrix.os }}:<cc>_<cxx>:

The `runner.os` entries stay below it as cross-workflow fallbacks to the `linux-build` action, whose keys really are built from `runner.os`, with the 26.04 caveat above.

Master-to-master was never affected, since its first restore-key (`...:master-`) already matched. Only PR runs were losing the inheritance.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [X] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code, Opus 4.8
- [X] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes

None. Follow-up to #26718.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Not applicable, this is CI infrastructure. The key names quoted above come from the repo's own cache listing.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.

The prefix match was checked against the live cache listing: `ccache:ubuntu-24.04:clang-18_clang++-18:` is a prefix of the existing `ccache:ubuntu-24.04:clang-18_clang++-18:master-29848724737`. The restore path itself cannot be exercised until the workflow is on master.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [X] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. After merge, open or push to any PR and look at the Dashboard CI "Restore ccache" step.
2. It should log `Cache restored from key: ccache:<os>:<compiler>:master-<run id>` rather than a `ccache:Linux:...` entry.
3. The `ccache -s` block at the end of that job should show a hit rate in the high nineties instead of near zero.

## Known Issues and TODO List:

- [ ] The stale `ccache:Linux:...:master` entries are now unreachable from the dashboard workflow and will age out on their own after 7 days without access.
- [ ] No measurable change to cache footprint. A PR leg compiles the whole tree and saves a full cache whether or not it inherited one: this PR's own entries are 383-388 MB against master's 383/387 MB. The repo pool is at its 10 GB cap and evicting LRU regardless, with the dead entries above as the first victims and #26717 reaping a PR's caches on close.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
