### PR TITLE
fix(Core/Movement): let melee pets attack targets whose chase point is unpathable

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -104,15 +104,38 @@ bool ChaseMovementGenerator<T>::DispatchSplineToPosition(T* owner, float x, floa
     if (owner->IsHovering())
         owner->UpdateAllowedPositionZ(x, y, z);
 
-    bool success = i_path->CalculatePath(x, y, z, forceDest);
-    uint32 pathType = i_path->GetPathType();
-    bool pathFailed = !success || (pathType & PATHFIND_NOPATH);
+    auto isPathUsable = [&]()
+    {
+        uint32 pathType = i_path->GetPathType();
+        if (pathType & PATHFIND_NOPATH)
+            return false;
 
-    // For pets, treat incomplete paths as failures to avoid clipping through geometry
-    // Players and Player-controlled units have more erratic movement, skip failure
-    if (cOwner && (cOwner->IsPet() || cOwner->IsControlledByPlayer()) && !GetTarget()->IsCharmedOwnedByPlayerOrPlayer())
-        if (pathType & PATHFIND_INCOMPLETE)
-            pathFailed = true;
+        // For pets, treat incomplete paths as failures to avoid clipping through geometry
+        // Players and Player-controlled units have more erratic movement, skip failure
+        if (cOwner && (cOwner->IsPet() || cOwner->IsControlledByPlayer()) && !GetTarget()->IsCharmedOwnedByPlayerOrPlayer())
+            if (pathType & PATHFIND_INCOMPLETE)
+                return false;
+
+        return true;
+    };
+
+    bool pathFailed = !i_path->CalculatePath(x, y, z, forceDest) || !isPathUsable();
+
+    // Targets with an oversized combat reach can stand entirely over unwalkable space
+    // (e.g. Kologarn) so pathing to their center or to an angled near point (pets chase
+    // to behind the target, which may hang over the void) fails even though the melee
+    // ring covers the navmesh. Retry against the nearest point on the ring, ignoring the
+    // chase angle, via GetNearPoint2D: GetNearPoint's LoS repositioning must be avoided
+    // here, it can rotate the point to the far side of the target.
+    if (pathFailed && (!_range || _range->MaxRange <= CONTACT_DISTANCE) && GetTarget()->GetCombatReach() > NOMINAL_MELEE_RANGE)
+    {
+        GetTarget()->GetNearPoint2D(owner, x, y, 0.0f, GetTarget()->GetAngle(owner));
+        z = GetTarget()->GetPositionZ();
+        owner->UpdateAllowedPositionZ(x, y, z);
+        pathFailed = !i_path->CalculatePath(x, y, z, forceDest) || !isPathUsable();
+        // the destination already lies on the melee ring, nothing to cut
+        cutPath = false;
+    }
 
     if (pathFailed)
     {

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -112,7 +112,8 @@ bool ChaseMovementGenerator<T>::DispatchSplineToPosition(T* owner, float x, floa
 
         // For pets, treat incomplete paths as failures to avoid clipping through geometry
         // Players and Player-controlled units have more erratic movement, skip failure
-        if (cOwner && (cOwner->IsPet() || cOwner->IsControlledByPlayer()) && !GetTarget()->IsCharmedOwnedByPlayerOrPlayer())
+        if (cOwner && (cOwner->IsPet() || cOwner->IsControlledByPlayer())
+            && !GetTarget()->IsCharmedOwnedByPlayerOrPlayer())
             if (pathType & PATHFIND_INCOMPLETE)
                 return false;
 
@@ -127,7 +128,8 @@ bool ChaseMovementGenerator<T>::DispatchSplineToPosition(T* owner, float x, floa
     // ring covers the navmesh. Retry against the nearest point on the ring, ignoring the
     // chase angle, via GetNearPoint2D: GetNearPoint's LoS repositioning must be avoided
     // here, it can rotate the point to the far side of the target.
-    if (pathFailed && (!_range || _range->MaxRange <= CONTACT_DISTANCE) && GetTarget()->GetCombatReach() > NOMINAL_MELEE_RANGE)
+    if (pathFailed && (!_range || _range->MaxRange <= CONTACT_DISTANCE)
+        && !GetTarget()->IsCharmedOwnedByPlayerOrPlayer() && GetTarget()->GetCombatReach() > NOMINAL_MELEE_RANGE)
     {
         GetTarget()->GetNearPoint2D(owner, x, y, 0.0f, GetTarget()->GetAngle(owner));
         z = GetTarget()->GetPositionZ();


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Melee pets refuse to attack Kologarn: they stand at the owner's side and the attack command silently cancels.

Root cause chain:
- `PetAI::DoAttack` makes melee pets chase to a point behind their target (`ChaseAngle(M_PI, M_PI_4)`).
- Kologarn's center hangs over the pit and only his 22yd melee ring touches the navmesh, so "behind him" resolves to a point on the pit floor (~49yd below). The path there comes back `PATHFIND_INCOMPLETE`.
- Since #24330, pets treat incomplete paths as hard failures and `AttackStop()`, so the pet cancels before ever moving. Ranged pets are unaffected because they never need to path to the melee ring.

Fix, in `ChaseMovementGenerator::DispatchSplineToPosition`: when a melee-intent chase path fails against a target whose combat reach exceeds `NOMINAL_MELEE_RANGE`, retry the path against the nearest melee ring point toward the chaser, with the same strict acceptance rules (pets still reject incomplete paths, so the anti-clipping behavior from #24330 is preserved). The ring point is computed with `GetNearPoint2D` plus a ground z-snap rather than `GetNearPoint`, because the latter's LoS repositioning rotates the point to the target's far side (and down into the pit) when the LoS ray grazes the ledge lip.

The retry only runs when the primary path already failed (cases that previously froze the chaser), never against player targets (1.5yd reach), and never for ranged chases.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26253

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Retail screenshot in the linked issue shows pets attacking Kologarn; the issue also links a video of the current broken behavior.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

Verified on Windows (MSVC, Release): felhunter and succubus run to the platform edge and melee Kologarn from the front, ranged pets unaffected, pet recall and re-attack work.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Level 80 warlock, `.learn all my class`, `.go xyz 1753.9615 -27.640793 448.80536 603`, spawn Kologarn if needed.
2. Summon a felhunter (or any melee pet) and send it to attack Kologarn: it should run east to the ledge and melee him.
3. Regression checks for the generic code path: send a melee pet at a mob behind a fence/closed gate (it must still refuse or path around, not clip through), at a mob around a dungeon corner (paths around normally), and at a normal big-hitbox boss such as Onyxia (pet still takes its usual behind-the-target position).

## Known Issues and TODO List:

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
