### PR TITLE
fix(Scripts/UtgardeKeep): don't restart Ingvar's feign death sequence on residual damage

### DIFF
--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_ingvar_the_plunderer.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_ingvar_the_plunderer.cpp
@@ -120,6 +120,14 @@ struct boss_ingvar_the_plunderer : public ScriptedAI
 
     void DamageTaken(Unit*, uint32& damage, DamageEffectType, SpellSchoolMask) override
     {
+        // Residual damage (e.g. DoT ticks) during the feign death would restart
+        // the death sequence, repeating the yell and delaying Annhylde
+        if (me->HasUnitFlag2(UNIT_FLAG2_FEIGN_DEATH))
+        {
+            damage = 0;
+            return;
+        }
+
         if (me->GetDisplayId() == DISPLAYID_DEFAULT && damage >= me->GetHealth())
         {
             damage = 0;

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_ingvar_the_plunderer.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_ingvar_the_plunderer.cpp
@@ -124,13 +124,14 @@ struct boss_ingvar_the_plunderer : public ScriptedAI
         // the death sequence, repeating the yell and delaying Annhylde
         if (me->HasUnitFlag2(UNIT_FLAG2_FEIGN_DEATH))
         {
-            damage = 0;
+            if (damage >= me->GetHealth())
+                damage = me->GetHealth() - 1;
             return;
         }
 
         if (me->GetDisplayId() == DISPLAYID_DEFAULT && damage >= me->GetHealth())
         {
-            damage = 0;
+            damage = me->GetHealth() - 1;
             me->InterruptNonMeleeSpells(true);
             me->RemoveAllAuras();
             me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);


### PR DESCRIPTION
## Changes Proposed:

Ingvar the Plunderer repeated his phase 1 death yell ("My life for the... death god!") once per damage event that landed during the feign death, because `DamageTaken` re-entered the lethal-damage branch on every hit until the morph to undead changes his display id (~19 seconds later). With a DoT ticking on him the yell fired 7+ times in a row, and each re-entry also reset the resurrection event timers, delaying Annhylde's arrival.

This PR guards `DamageTaken` while `UNIT_FLAG2_FEIGN_DEATH` is set, so the death sequence triggers exactly once. Lethal damage during and at the start of the feign death is now clamped to `GetHealth() - 1` (parking him at 1 health) instead of being zeroed, matching the pattern used by other feign-death bosses (Thekal, Nightbane, Shade of Akama, etc.).

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26336

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - Official kill video where the yell plays once: https://www.youtube.com/watch?v=oUUKXEPoGh0

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. On a level 80 character, apply a DoT (e.g. Shadow Word: Pain) to Ingvar the Plunderer (`.go creature id 23954` or Utgarde Keep last boss) and deal lethal damage while the DoT is running.
2. Before the fix, the death yell text and audio repeat for every tick landing during the feign death and Annhylde's arrival is delayed; after the fix, the yell plays once and Ingvar stays at 1 health until the resurrection sequence heals him.
3. Let phase 2 play out and kill him to verify the second death yell, achievement credit and loot still work.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
