### PR TITLE
fix(Core/Maps): don't block hard-reset and self-linked creatures from respawning

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2792,14 +2792,20 @@ void Map::ProcessCreatureRespawn(ObjectGuid::LowType spawnId)
     }
 
     // Check linked_respawn: don't spawn if the master creature is still dead.
-    // This mirrors the check in Creature::Respawn() for compat-mode creatures.
+    // This mirrors the check in Creature::Respawn() for compat-mode creatures:
+    // hard-reset creatures bypass it (they despawn on evade and must always
+    // come back), and a creature linked to itself never auto-respawns.
     ObjectGuid dbtableHighGuid = ObjectGuid::Create<HighGuid::Unit>(data->id, spawnId);
     time_t linkedRespawntime = GetLinkedRespawnTime(dbtableHighGuid);
-    if (linkedRespawntime)
+    CreatureTemplate const* cInfo = sObjectMgr->GetCreatureTemplate(data->id);
+    if (linkedRespawntime && !(cInfo && cInfo->HasFlagsExtra(CREATURE_FLAG_EXTRA_HARD_RESET)))
     {
-        // Master is still dead; re-queue at the master's respawn time + a small offset.
         time_t now = GameTime::GetGameTime().count();
-        time_t newRespawnTime = (now > linkedRespawntime ? now : linkedRespawntime) + urand(5, MINUTE);
+        time_t newRespawnTime;
+        if (sObjectMgr->GetLinkedRespawnGuid(dbtableHighGuid) == dbtableHighGuid)
+            newRespawnTime = now + DAY; // if linking self, never respawn (check delayed to next day)
+        else
+            newRespawnTime = (now > linkedRespawntime ? now : linkedRespawntime) + urand(5, MINUTE); // master is still dead; re-queue at the master's respawn time + a small offset
         SaveCreatureRespawnTime(spawnId, newRespawnTime);
         return;
     }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).

#26531 added a linked_respawn check to `Map::ProcessCreatureRespawn` (the non-compat respawn path) intending to mirror `Creature::Respawn()`, but it missed two of its cases (both from #14862):

- **`CREATURE_FLAG_EXTRA_HARD_RESET` creatures must bypass the check**  they despawn on evade and always need to come back.
- **A self-linked creature defers a day** ("never auto-respawn") instead of re-queueing every ≤60 seconds.

For self-linked spawns, `GetLinkedRespawnTime()` returns the spawn's *own* pending respawn time - always non-zero while its respawn is processed - so the spawn re-queued itself forever. All 12 self-links in `linked_respawn` are ICC bosses, six of them hard-reset (Deathwhisper, Festergut, Rotface, Putricide, Blood-Queen, Lich King): after any evade they despawned and never returned. Putricide evades after the Festergut/Rotface death lines even without a wipe, so every run lost him permanently.

### AI-assisted Pull Requests

- [x] AI tools were used entirely or partially to prepare this pull request.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26712

## Tests Performed:
- [x] Tested in-game by the author.

In ICC, reset Festergut/Rotface, they now respawn. Putricide is ready after Festergut/Rotface killed + the insect event. 
Also checked BWL, whelps respawn until Broodlord Lashlayer is killed. (#25799 ).

Also tested by the OP of the issue:
https://github.com/azerothcore/azerothcore-wotlk/issues/26712#issuecomment-5040604666

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Enter a fresh ICC instance and reset any boss that hard-resets. (Deathwhisper, Festergut, Rotface, Putricide, Blood-Queen, Lich King.) They should reset as normal and not despawn forever. 
2. Putricide will spawn as normal again.
3. (#25799): in BWL, whelps must keep respawning while Broodlord lives, and stay dead once he's killed. 