### PR TITLE
fix(Scripts/CoS): despawn Arthas summons on death

### DIFF
--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
@@ -409,9 +409,6 @@ public:
 
         void JustDied(Unit*) override
         {
-            // Despawn event summons (Epoch etc.) here: the respawn system may
-            // destroy this creature and its AI instead of reusing them, so
-            // Reset() on the respawned Arthas can no longer reach these summons
             summons.DespawnAll();
             RemoveEscortState(STATE_ESCORT_ESCORTING);
             if (pInstance)

--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
@@ -409,6 +409,10 @@ public:
 
         void JustDied(Unit*) override
         {
+            // Despawn event summons (Epoch etc.) here: the respawn system may
+            // destroy this creature and its AI instead of reusing them, so
+            // Reset() on the respawned Arthas can no longer reach these summons
+            summons.DespawnAll();
             RemoveEscortState(STATE_ESCORT_ESCORTING);
             if (pInstance)
                 pInstance->SetData(DATA_ARTHAS_REPOSITION, 2);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Chrono-Lord Epoch has no DB spawn, he is a manual-despawn temp summon of Arthas, tracked only in `npc_arthasAI::summons`. Cleanup after Arthas dies relied on the instance script respawning him and his `Reset()` running `summons.DespawnAll()`.

Since the spawn system port (#25206) DB spawns default to the non-compatibility respawn path, so a dead Arthas is destroyed via `AddObjectToRemoveList()` and recreated by `ProcessRespawns()`. The old AI (and its summon list) is deleted without `Reset()` ever running, orphaning Epoch. The leftover boss evades to full health, regains his template immune flags through `Unit::ClearInCombat`, and restarting the town hall event summons a second Epoch, making the dungeon uncompletable.

Fix: despawn Arthas' event summons in `JustDied`, which restores the pre-port behavior (summons were despawned when the instance script reset the respawned Arthas) regardless of respawn mode. Also covers the other event summons Arthas owns when he dies (infinites, citymen, Mal'Ganis).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26131

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://www.youtube.com/watch?v=HK_fALFRrwg (2009, single Chrono-Lord Epoch as intended)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. On heroic, start the Culling of Stratholme event and progress to Chrono-Lord Epoch.
2. Die, let Arthas die to Epoch, then release and re-enter.
3. Talk to the respawned Arthas and run the town hall segment again: the old Epoch must be gone and only the newly summoned one present.

## Known Issues and TODO List:

Any other scripted DB-spawned NPC that dies while owning script summons can leak them the same way under the non-compatibility respawn path; this PR only fixes the CoS Arthas case.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
