### PR TITLE
fix(Core/Player): weapons can now be swapped while disarmed

### DIFF
--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2251,8 +2251,8 @@ public:
     void UpdateAllWeaponDependentCritAuras();
 
     void _ApplyItemMods(Item* item, uint8 slot, bool apply);
-    // Returns true and fills attackType if `slot` is currently disarmed, so callers can keep
-    // the weapon in it suppressed (issue #26426: Blizzlike lets you swap gear while disarmed).
+    /// @brief Returns true and fills attackType if `slot` is currently disarmed, so callers
+    /// can keep the weapon in it suppressed (issue #26426: Blizzlike lets you swap gear while disarmed).
     bool GetDisarmedAttackType(uint8 slot, WeaponAttackType& attackType) const;
     void _RemoveAllItemMods();
     void _ApplyAllItemMods();

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2251,6 +2251,9 @@ public:
     void UpdateAllWeaponDependentCritAuras();
 
     void _ApplyItemMods(Item* item, uint8 slot, bool apply);
+    // Returns true and fills attackType if `slot` is currently disarmed, so callers can keep
+    // the weapon in it suppressed (issue #26426: Blizzlike lets you swap gear while disarmed).
+    bool GetDisarmedAttackType(uint8 slot, WeaponAttackType& attackType) const;
     void _RemoveAllItemMods();
     void _ApplyAllItemMods();
     void _ApplyAllLevelScaleItemMods(bool apply);

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2251,9 +2251,6 @@ public:
     void UpdateAllWeaponDependentCritAuras();
 
     void _ApplyItemMods(Item* item, uint8 slot, bool apply);
-    /// @brief Returns true and fills attackType if `slot` is currently disarmed, so callers
-    /// can keep the weapon in it suppressed (issue #26426: Blizzlike lets you swap gear while disarmed).
-    bool GetDisarmedAttackType(uint8 slot, WeaponAttackType& attackType) const;
     void _RemoveAllItemMods();
     void _ApplyAllItemMods();
     void _ApplyAllLevelScaleItemMods(bool apply);

--- a/src/server/game/Entities/Player/PlayerStorage.cpp
+++ b/src/server/game/Entities/Player/PlayerStorage.cpp
@@ -1940,9 +1940,9 @@ InventoryResult Player::CanEquipItem(uint8 slot, uint16& dest, Item* pItem, bool
             if (eslot == NULL_SLOT)
                 return EQUIP_ERR_ITEM_CANT_BE_EQUIPPED;
 
-            // Xinef: dont allow to equip items on disarmed slot
-            if (!CanUseAttackType(GetAttackBySlot(eslot)))
-                return EQUIP_ERR_NOT_WHILE_DISARMED;
+            // Blizzlike allows swapping gear on a disarmed slot (issue #26426) - you just
+            // can't use the new weapon until Disarm ends. EquipItem()/RemoveItem() keep the
+            // weapon's damage/dependent auras suppressed while the slot stays disarmed.
 
             res = CanUseItem(pItem, not_loading);
             if (res != EQUIP_ERR_OK)
@@ -2096,9 +2096,7 @@ InventoryResult Player::CanUnequipItem(uint16 pos, bool swap) const
                 return EQUIP_ERR_NOT_DURING_ARENA_MATCH;
     }
 
-    // Xinef: dont allow to unequip items on disarmed slot
-    if (!CanUseAttackType(GetAttackBySlot(pItem->GetSlot())))
-        return EQUIP_ERR_NOT_WHILE_DISARMED;
+    // Blizzlike allows unequipping a disarmed weapon too (issue #26426) - see CanEquipItem().
 
     if (!swap && pItem->IsNotEmptyBag())
         return EQUIP_ERR_CAN_ONLY_DO_WITH_EMPTY_BAGS;
@@ -2804,6 +2802,24 @@ Item* Player::EquipNewItem(uint16 pos, uint32 item, bool update)
     return EquipItem(pos, _item, update);
 }
 
+bool Player::GetDisarmedAttackType(uint8 slot, WeaponAttackType& attackType) const
+{
+    switch (slot)
+    {
+        case EQUIPMENT_SLOT_MAINHAND:
+            attackType = BASE_ATTACK;
+            return HasUnitFlag(UNIT_FLAG_DISARMED);
+        case EQUIPMENT_SLOT_OFFHAND:
+            attackType = OFF_ATTACK;
+            return HasUnitFlag2(UNIT_FLAG2_DISARM_OFFHAND);
+        case EQUIPMENT_SLOT_RANGED:
+            attackType = RANGED_ATTACK;
+            return HasUnitFlag2(UNIT_FLAG2_DISARM_RANGED);
+        default:
+            return false;
+    }
+}
+
 Item* Player::EquipItem(uint16 pos, Item* pItem, bool update)
 {
     AddEnchantmentDurations(pItem);
@@ -2827,6 +2843,20 @@ Item* Player::EquipItem(uint16 pos, Item* pItem, bool update)
                 AddItemsSetItem(this, pItem);
 
             _ApplyItemMods(pItem, slot, true);
+
+            // Blizzlike lets you swap weapons while disarmed, you just can't use the new one
+            // until Disarm ends (issue #26426). _ApplyItemMods() above already turned this
+            // weapon's damage/dependent auras on, so suppress them the same way
+            // AuraEffect::HandleAuraModDisarm suppresses whatever was equipped when Disarm
+            // first landed - it undoes this symmetrically once the aura is removed, regardless
+            // of which weapon ends up in the slot by then.
+            WeaponAttackType disarmAttackType;
+            if (pProto && GetDisarmedAttackType(slot, disarmAttackType))
+            {
+                ApplyItemDependentAuras(pItem, false);
+                _ApplyWeaponDamage(slot, pProto, nullptr, false);
+                UpdateWeaponDependentAuras(disarmAttackType);
+            }
 
             if (pProto && IsInCombat() && (pProto->Class == ITEM_CLASS_WEAPON || pProto->InventoryType == INVTYPE_RELIC) && m_weaponChangeTimer == 0)
             {
@@ -3002,6 +3032,17 @@ void Player::RemoveItem(uint8 bag, uint8 slot, bool update)
 
                 if (pProto && pProto->ItemSet)
                     RemoveItemsSetItem(this, pProto);
+
+                // Mirror of the EquipItem() suppression (issue #26426): this weapon's
+                // damage/dependent auras are currently suppressed because the slot is disarmed,
+                // so restore them to normal first - otherwise _ApplyItemMods(false) below would
+                // subtract a second time on top of the suppression and corrupt the stat.
+                WeaponAttackType disarmAttackType;
+                if (pProto && GetDisarmedAttackType(slot, disarmAttackType))
+                {
+                    ApplyItemDependentAuras(pItem, true);
+                    _ApplyWeaponDamage(slot, pProto, nullptr, true);
+                }
 
                 _ApplyItemMods(pItem, slot, false);
             }

--- a/src/server/game/Entities/Player/PlayerStorage.cpp
+++ b/src/server/game/Entities/Player/PlayerStorage.cpp
@@ -2801,24 +2801,6 @@ Item* Player::EquipNewItem(uint16 pos, uint32 item, bool update)
     return EquipItem(pos, _item, update);
 }
 
-bool Player::GetDisarmedAttackType(uint8 slot, WeaponAttackType& attackType) const
-{
-    switch (slot)
-    {
-        case EQUIPMENT_SLOT_MAINHAND:
-            attackType = BASE_ATTACK;
-            return HasUnitFlag(UNIT_FLAG_DISARMED);
-        case EQUIPMENT_SLOT_OFFHAND:
-            attackType = OFF_ATTACK;
-            return HasUnitFlag2(UNIT_FLAG2_DISARM_OFFHAND);
-        case EQUIPMENT_SLOT_RANGED:
-            attackType = RANGED_ATTACK;
-            return HasUnitFlag2(UNIT_FLAG2_DISARM_RANGED);
-        default:
-            return false;
-    }
-}
-
 Item* Player::EquipItem(uint16 pos, Item* pItem, bool update)
 {
     AddEnchantmentDurations(pItem);
@@ -2845,12 +2827,12 @@ Item* Player::EquipItem(uint16 pos, Item* pItem, bool update)
 
             // _ApplyItemMods above turned this weapon's damage on, so suppress it the same way
             // HandleAuraModDisarm does - it undoes this symmetrically when the aura drops.
-            WeaponAttackType disarmAttackType;
-            if (pProto && GetDisarmedAttackType(slot, disarmAttackType))
+            WeaponAttackType const attackType = Player::GetAttackBySlot(slot);
+            if (pProto && !CanUseAttackType(attackType))
             {
                 ApplyItemDependentAuras(pItem, false);
                 _ApplyWeaponDamage(slot, pProto, nullptr, false);
-                UpdateWeaponDependentAuras(disarmAttackType);
+                UpdateWeaponDependentAuras(attackType);
             }
 
             if (pProto && IsInCombat() && (pProto->Class == ITEM_CLASS_WEAPON || pProto->InventoryType == INVTYPE_RELIC) && m_weaponChangeTimer == 0)
@@ -3030,8 +3012,7 @@ void Player::RemoveItem(uint8 bag, uint8 slot, bool update)
 
                 // Restore first: the slot is disarmed so this weapon's damage is suppressed, and
                 // _ApplyItemMods(false) below would subtract a second time on top of it.
-                WeaponAttackType disarmAttackType;
-                if (pProto && GetDisarmedAttackType(slot, disarmAttackType))
+                if (pProto && !CanUseAttackType(Player::GetAttackBySlot(slot)))
                 {
                     ApplyItemDependentAuras(pItem, true);
                     _ApplyWeaponDamage(slot, pProto, nullptr, true);

--- a/src/server/game/Entities/Player/PlayerStorage.cpp
+++ b/src/server/game/Entities/Player/PlayerStorage.cpp
@@ -1940,9 +1940,8 @@ InventoryResult Player::CanEquipItem(uint8 slot, uint16& dest, Item* pItem, bool
             if (eslot == NULL_SLOT)
                 return EQUIP_ERR_ITEM_CANT_BE_EQUIPPED;
 
-            // Blizzlike allows swapping gear on a disarmed slot (issue #26426) - you just
-            // can't use the new weapon until Disarm ends. EquipItem()/RemoveItem() keep the
-            // weapon's damage/dependent auras suppressed while the slot stays disarmed.
+            // Swapping gear on a disarmed slot is allowed (issue #26426); the new weapon's
+            // damage stays suppressed until Disarm ends.
 
             res = CanUseItem(pItem, not_loading);
             if (res != EQUIP_ERR_OK)
@@ -2844,12 +2843,8 @@ Item* Player::EquipItem(uint16 pos, Item* pItem, bool update)
 
             _ApplyItemMods(pItem, slot, true);
 
-            // Blizzlike lets you swap weapons while disarmed, you just can't use the new one
-            // until Disarm ends (issue #26426). _ApplyItemMods() above already turned this
-            // weapon's damage/dependent auras on, so suppress them the same way
-            // AuraEffect::HandleAuraModDisarm suppresses whatever was equipped when Disarm
-            // first landed - it undoes this symmetrically once the aura is removed, regardless
-            // of which weapon ends up in the slot by then.
+            // _ApplyItemMods above turned this weapon's damage on, so suppress it the same way
+            // HandleAuraModDisarm does - it undoes this symmetrically when the aura drops.
             WeaponAttackType disarmAttackType;
             if (pProto && GetDisarmedAttackType(slot, disarmAttackType))
             {
@@ -3033,10 +3028,8 @@ void Player::RemoveItem(uint8 bag, uint8 slot, bool update)
                 if (pProto && pProto->ItemSet)
                     RemoveItemsSetItem(this, pProto);
 
-                // Mirror of the EquipItem() suppression (issue #26426): this weapon's
-                // damage/dependent auras are currently suppressed because the slot is disarmed,
-                // so restore them to normal first - otherwise _ApplyItemMods(false) below would
-                // subtract a second time on top of the suppression and corrupt the stat.
+                // Restore first: the slot is disarmed so this weapon's damage is suppressed, and
+                // _ApplyItemMods(false) below would subtract a second time on top of it.
                 WeaponAttackType disarmAttackType;
                 if (pProto && GetDisarmedAttackType(slot, disarmAttackType))
                 {


### PR DESCRIPTION
## Changes Proposed:

Disarmed players couldn't swap gear at all in the disarmed weapon slot - trying to equip or unequip anything there (e.g. going from a two-hander to a one-hand + shield combo mid-Disarm) failed with "You can't do that while disarmed." Blizzlike behaviour, per the evidence in the issue, is that you *can* re-gear a disarmed slot - you just can't use the new weapon until Disarm wears off.

`Player::CanEquipItem`/`Player::CanUnequipItem` (`PlayerStorage.cpp`) had an explicit guard added a while back that blocked any equip/unequip on a disarmed slot outright:

```cpp
// Xinef: dont allow to equip items on disarmed slot
if (!CanUseAttackType(GetAttackBySlot(eslot)))
    return EQUIP_ERR_NOT_WHILE_DISARMED;
```

Removed both instances of that guard (equip side and unequip side). On its own that would let a disarmed weapon's damage go live again just by re-equipping it, which is presumably what the guard was there to prevent, so `Player::EquipItem()` now suppresses the newly-equipped weapon's damage and dependent auras for as long as the slot is still disarmed - the same treatment `AuraEffect::HandleAuraModDisarm` gives whatever's equipped at the moment Disarm lands. `Player::RemoveItem()` restores them symmetrically right before an item leaves a disarmed slot, so the bookkeeping stays correct no matter how many times gear gets swapped during a single Disarm window, and there's nothing left to double up when Disarm eventually ends and hands stat control back to `HandleAuraModDisarm` for whatever weapon is in the slot by then.

**What doesn't change**: `Unit::CanUseAttackType()` - the thing that actually stops a disarmed character from swinging - is untouched. It still reads `UNIT_FLAG_DISARMED`/`UNIT_FLAG2_DISARM_OFFHAND`/`UNIT_FLAG2_DISARM_RANGED` regardless of which weapon occupies the slot, so the new weapon just sits there unusable until the effect ends, exactly like the video evidence in the issue shows.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Sonnet 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26426

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Reproduced the issue's exact steps (2H warrior, disarmed, swap to a one-hander + shield): before this change the swap was rejected outright; after, the swap succeeds and the character can't attack with the new weapon until Disarm ends. Not independently tested: repeated swaps within a single Disarm window, offhand/ranged disarm variants, or interaction with weapon-swap-on-attack talents/procs. (The video evidence and forum references are the ones already gathered in the issue itself, not independently re-verified against a live client.)

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Make a Warrior, learn all class spells, and equip a two-handed weapon.
2. Get disarmed (e.g. Riposte/a Disarm ability from another player, or `.cast` it on yourself for testing).
3. While still disarmed, try swapping to a one-hand weapon + shield.
4. Confirm the swap now succeeds, and that the character still can't attack until Disarm ends.

## Known Issues and TODO List:

- None

🤖 Generated with Claude Code (Sonnet 5)+AzerothMCP

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
