### PR TITLE
fix(DB/Creature): hide The Lich King whisper trigger at Havenshire

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784731268413348600.sql
+++ b/data/sql/updates/pending_db_world/rev_1784731268413348600.sql
@@ -1,0 +1,2 @@
+-- Flag 'The Lich King' (28765) whisper controller in the Scarlet Enclave as a trigger creature so it is invisible to players
+UPDATE `creature_template` SET `flags_extra` = `flags_extra`|128 WHERE `entry` = 28765;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Creature 28765 "The Lich King" at Havenshire (Scarlet Enclave, map 609) is the invisible controller for the Lich King voice-over whispers players receive while fighting Citizens of Havenshire during the quest "If Chaos Drives, Let Suffering Hold The Reins" (12678): the citizens' SmartAI cross casts "Lich King VO Blocker" (58207) from this creature onto the player, which then whispers a random Lich King line (58208-58223).

Its template was missing `CREATURE_FLAG_EXTRA_TRIGGER` (`flags_extra` 128), so players saw its trigger model (display 169) rendered as an infernal standing under the grain silo. This PR sets the flag, so the core sends normal players the invisible model and only GM mode can see it.

The whisper mechanic is unaffected: the SmartAI cross cast resolves the caster by spawn id and `Whisper()` is a direct chat packet, neither requires client visibility. The creature already had `UNIT_FLAG_NOT_SELECTABLE` plus immune to PC/NPC, so visibility was the only missing piece. The faint ground mist that remains is the sniffed "Icebound Visage" (53274) aura from its addon data and is intended.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #24003

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The creature's own build-verified model data already follows the standard trigger creature pattern: trigger model 169 at index 0 (VerifiedBuild 12340) and a visible Lich King model 23767 at index 1 (VerifiedBuild 51831), which is exactly the setup the core's `CREATURE_FLAG_EXTRA_TRIGGER` handling expects (invisible model for players, visible model for GMs). Trigger units like this one are not visible to players on retail.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Verified in-game: the infernal under the silo is no longer visible or targetable for players, GM mode still shows the creature, and the Lich King whispers still fire when aggroing Citizens of Havenshire while on quest 12678.
Picture after fix 
<img width="397" height="606" alt="image" src="https://github.com/user-attachments/assets/113f60a1-2bd6-47b4-8628-92750ee0b2ab" />
The Mist is a bit odd, but it's there from data\sql\base\db_world\creature_template_addon.sql
"Icebound Visage" (53274) as mentioned earlier.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply the SQL update and restart the worldserver.
2. On a Death Knight in the starting zone (phase 1), go to the grain silo at Havenshire Farms (2051.46 -5782.35 106.652, map 609). Without GM mode there should be no visible infernal there anymore.
3. With `.gm on`, the creature is still visible and selectable for GMs.
4. While on the quest "If Chaos Drives, Let Suffering Hold The Reins" (12678), aggro Citizens of Havenshire and verify The Lich King still whispers to you (50% chance per aggro, rate-limited by the VO Blocker aura).

## Known Issues and TODO List:

None.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
