### PR TITLE
fix(CI): delete superseded ccache entries instead of leaving them to LRU

### DIFF
--- a/.github/actions/linux-build/action.yml
+++ b/.github/actions/linux-build/action.yml
@@ -263,7 +263,7 @@ runs:
     # restore-keys would otherwise reach. Skip both save and prune in that case.
     - name: Check for a ccache dir
       id: ccache_dir
-      if: ${{ always() }}
+      if: ${{ !cancelled() }}
       shell: bash
       run: |
         if [[ -d "${{ github.workspace }}/var/ccache" ]]
@@ -274,19 +274,18 @@ runs:
           echo "No ccache directory; skipping save and prune."
         fi
 
-    # always() is deliberately wider than the actions/cache post step this
-    # replaces, which was post-if: success(). A failed or cancelled run still
-    # compiled most of the tree, and for ccache a partial directory is a
-    # superset of the entry it was restored from.
+    # Wider than the actions/cache post step this replaces, which was
+    # post-if: success(): a failed build still compiled most of the tree and
+    # that work is worth keeping. A cancelled one is skipped, since its cache is
+    # barely ahead of what it restored and the upload rarely fits the
+    # cancellation grace period anyway.
     - name: Save ccache
-      if: ${{ always() && steps.ccache_dir.outputs.exists == 'true' }}
+      if: ${{ !cancelled() && steps.ccache_dir.outputs.exists == 'true' }}
       uses: actions/cache/save@v6
       with:
         path: ${{ github.workspace }}/var/ccache
         key: ${{ steps.cachekey.outputs.key }}
 
-    # Not always(): a cancelled run has a grace period the delete loop may not
-    # fit in, and skipping it only defers the prune to the next run.
     - name: Prune superseded ccaches
       if: ${{ !cancelled() && steps.ccache_dir.outputs.exists == 'true' }}
       uses: ./.github/actions/prune-ccache

--- a/.github/actions/linux-build/action.yml
+++ b/.github/actions/linux-build/action.yml
@@ -39,23 +39,64 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: echo cache key
+    # The key is built here rather than inline so the stream name appears once
+    # instead of in every restore-key, save and prune reference below.
+    #
+    # `tools` only enters the key when tools are actually built. tools-build and
+    # nopch-build are separate workflows that run concurrently with identical
+    # CC/CXX/modules/pch, so without it they share a stream and their prunes
+    # delete each other's entry. Adding the segment unconditionally would
+    # instead orphan every cache saved under the old key shape, which nothing
+    # would then prune.
+    - name: Build cache key
+      id: cachekey
       shell: bash
-      run: echo "Cache key -> ccache:${{ runner.os }}:${{ inputs.CC }}_${{ inputs.CXX }}:${{ inputs.modules }}:pch=${{ inputs.pch }}:${{ github.ref_name }}-${{ github.run_id }}"
+      run: |
+        stream="ccache:${{ runner.os }}:${{ inputs.CC }}_${{ inputs.CXX }}:${{ inputs.modules }}:pch=${{ inputs.pch }}"
+
+        if [[ "${{ inputs.tools }}" != "none" ]]
+        then
+          stream="$stream:tools=${{ inputs.tools }}"
+        fi
+
+        {
+          echo "stream=$stream"
+          echo "prefix=$stream:${{ github.ref_name }}-"
+          echo "key=$stream:${{ github.ref_name }}-${{ github.run_id }}"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "Cache key -> $stream:${{ github.ref_name }}-${{ github.run_id }}"
+
+        # actions/cache/save fails the step outright when its path is missing,
+        # and the save below runs on always(). On a total restore miss the
+        # directory would not exist until ccache first writes to it, so a build
+        # that dies before that (failed apt, failed cmake) would collect a
+        # second, misleading red step.
+        mkdir -p "${{ github.workspace }}/var/ccache"
 
     # The primary key is unique per run (`-${{ github.run_id }}`) so every run
     # saves a fresh cache. A static key would hit on itself on the second run
     # and `actions/cache` would then skip the upload, freezing the cache after
     # the first commit on a branch (and permanently on master). The restore-keys
     # walk back from the most-recent cache on this branch to progressively
-    # broader fallbacks (branch -> pch variant -> modules variant -> compiler).
-    - name: Cache
-      uses: actions/cache@v6
+    # broader fallbacks: this branch, then any branch, then across the tools
+    # variants, then the modules variants, then any cache for this compiler.
+    # On a leg that builds no tools the first two are the same string, since
+    # the stream carries no tools segment there; a repeated restore-key is just
+    # a repeated lookup, and spelling both out keeps the tools leg able to
+    # inherit a non-tools cache on its first run.
+    #
+    # Restore and save are split (rather than actions/cache, which saves in a
+    # post step) so the prune at the end of this action runs after the upload.
+    - name: Restore ccache
+      id: restore_ccache
+      uses: actions/cache/restore@v6
       with:
         path: ${{ github.workspace }}/var/ccache
-        key: ccache:${{ runner.os }}:${{ inputs.CC }}_${{ inputs.CXX }}:${{ inputs.modules }}:pch=${{ inputs.pch }}:${{ github.ref_name }}-${{ github.run_id }}
+        key: ${{ steps.cachekey.outputs.key }}
         restore-keys: |
-          ccache:${{ runner.os }}:${{ inputs.CC }}_${{ inputs.CXX }}:${{ inputs.modules }}:pch=${{ inputs.pch }}:${{ github.ref_name }}-
+          ${{ steps.cachekey.outputs.prefix }}
+          ${{ steps.cachekey.outputs.stream }}
           ccache:${{ runner.os }}:${{ inputs.CC }}_${{ inputs.CXX }}:${{ inputs.modules }}:pch=${{ inputs.pch }}
           ccache:${{ runner.os }}:${{ inputs.CC }}_${{ inputs.CXX }}:${{ inputs.modules }}
           ccache:${{ runner.os }}:${{ inputs.CC }}_${{ inputs.CXX }}
@@ -222,3 +263,23 @@ runs:
     - name: ccache stats
       shell: bash
       run: ccache -s || true
+
+    # always() is deliberately wider than the actions/cache post step this
+    # replaces, which was post-if: success(). A failed or cancelled run still
+    # compiled most of the tree, and for ccache a partial directory is a
+    # superset of the entry it was restored from.
+    - name: Save ccache
+      if: ${{ always() }}
+      uses: actions/cache/save@v6
+      with:
+        path: ${{ github.workspace }}/var/ccache
+        key: ${{ steps.cachekey.outputs.key }}
+
+    # Not always(): a cancelled run has a grace period the delete loop may not
+    # fit in, and skipping it only defers the prune to the next run.
+    - name: Prune superseded ccaches
+      if: ${{ !cancelled() }}
+      uses: ./.github/actions/prune-ccache
+      with:
+        key-prefix: ${{ steps.cachekey.outputs.prefix }}
+        keep-key: ${{ steps.cachekey.outputs.key }}

--- a/.github/actions/linux-build/action.yml
+++ b/.github/actions/linux-build/action.yml
@@ -67,13 +67,6 @@ runs:
 
         echo "Cache key -> $stream:${{ github.ref_name }}-${{ github.run_id }}"
 
-        # actions/cache/save fails the step outright when its path is missing,
-        # and the save below runs on always(). On a total restore miss the
-        # directory would not exist until ccache first writes to it, so a build
-        # that dies before that (failed apt, failed cmake) would collect a
-        # second, misleading red step.
-        mkdir -p "${{ github.workspace }}/var/ccache"
-
     # The primary key is unique per run (`-${{ github.run_id }}`) so every run
     # saves a fresh cache. A static key would hit on itself on the second run
     # and `actions/cache` would then skip the upload, freezing the cache after
@@ -81,15 +74,14 @@ runs:
     # walk back from the most-recent cache on this branch to progressively
     # broader fallbacks: this branch, then any branch, then across the tools
     # variants, then the modules variants, then any cache for this compiler.
-    # On a leg that builds no tools the first two are the same string, since
-    # the stream carries no tools segment there; a repeated restore-key is just
-    # a repeated lookup, and spelling both out keeps the tools leg able to
+    # The second and third are the same string on a leg that builds no tools,
+    # since the stream carries no tools segment there; a repeated restore-key is
+    # just a repeated lookup, and spelling both out keeps the tools leg able to
     # inherit a non-tools cache on its first run.
     #
     # Restore and save are split (rather than actions/cache, which saves in a
     # post step) so the prune at the end of this action runs after the upload.
     - name: Restore ccache
-      id: restore_ccache
       uses: actions/cache/restore@v6
       with:
         path: ${{ github.workspace }}/var/ccache
@@ -264,12 +256,30 @@ runs:
       shell: bash
       run: ccache -s || true
 
+    # The directory is absent only when the restore missed and the build died
+    # before ccache first wrote to it. Saving then would fail the step outright
+    # (actions/cache/save errors on a missing path) and, worse, publish an empty
+    # entry as the newest for this ref, shadowing the warm caches the
+    # restore-keys would otherwise reach. Skip both save and prune in that case.
+    - name: Check for a ccache dir
+      id: ccache_dir
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        if [[ -d "${{ github.workspace }}/var/ccache" ]]
+        then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+          echo "No ccache directory; skipping save and prune."
+        fi
+
     # always() is deliberately wider than the actions/cache post step this
     # replaces, which was post-if: success(). A failed or cancelled run still
     # compiled most of the tree, and for ccache a partial directory is a
     # superset of the entry it was restored from.
     - name: Save ccache
-      if: ${{ always() }}
+      if: ${{ always() && steps.ccache_dir.outputs.exists == 'true' }}
       uses: actions/cache/save@v6
       with:
         path: ${{ github.workspace }}/var/ccache
@@ -278,7 +288,7 @@ runs:
     # Not always(): a cancelled run has a grace period the delete loop may not
     # fit in, and skipping it only defers the prune to the next run.
     - name: Prune superseded ccaches
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && steps.ccache_dir.outputs.exists == 'true' }}
       uses: ./.github/actions/prune-ccache
       with:
         key-prefix: ${{ steps.cachekey.outputs.prefix }}

--- a/.github/actions/linux-build/action.yml
+++ b/.github/actions/linux-build/action.yml
@@ -73,7 +73,7 @@ runs:
     # the first commit on a branch (and permanently on master). The restore-keys
     # walk back from the most-recent cache on this branch to progressively
     # broader fallbacks: this branch, then any branch, then across the tools
-    # variants, then the modules variants, then any cache for this compiler.
+    # variants, then the pch variants, then any cache for this compiler.
     # The second and third are the same string on a leg that builds no tools,
     # since the stream carries no tools segment there; a repeated restore-key is
     # just a repeated lookup, and spelling both out keeps the tools leg able to
@@ -82,6 +82,7 @@ runs:
     # Restore and save are split (rather than actions/cache, which saves in a
     # post step) so the prune at the end of this action runs after the upload.
     - name: Restore ccache
+      id: restore_ccache
       uses: actions/cache/restore@v6
       with:
         path: ${{ github.workspace }}/var/ccache
@@ -256,38 +257,29 @@ runs:
       shell: bash
       run: ccache -s || true
 
-    # The directory is absent only when the restore missed and the build died
-    # before ccache first wrote to it. Saving then would fail the step outright
-    # (actions/cache/save errors on a missing path) and, worse, publish an empty
-    # entry as the newest for this ref, shadowing the warm caches the
-    # restore-keys would otherwise reach. Skip both save and prune in that case.
-    - name: Check for a ccache dir
-      id: ccache_dir
-      if: ${{ !cancelled() }}
-      shell: bash
-      run: |
-        if [[ -d "${{ github.workspace }}/var/ccache" ]]
-        then
-          echo "exists=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "exists=false" >> "$GITHUB_OUTPUT"
-          echo "No ccache directory; skipping save and prune."
-        fi
-
     # Wider than the actions/cache post step this replaces, which was
     # post-if: success(): a failed build still compiled most of the tree and
     # that work is worth keeping. A cancelled one is skipped, since its cache is
     # barely ahead of what it restored and the upload rarely fits the
     # cancellation grace period anyway.
+    #
+    # The cache-matched-key arm is what keeps a failed run from publishing a
+    # near-empty entry: with nothing restored and the build dead before it
+    # compiled anything, that entry would become the newest for this ref and
+    # shadow the warm caches the broader restore-keys reach, and the prune would
+    # then delete the rest of the stream. With a restore hit there is nothing to
+    # lose, since what gets saved is a superset of what came back.
     - name: Save ccache
-      if: ${{ !cancelled() && steps.ccache_dir.outputs.exists == 'true' }}
+      if: ${{ !cancelled() && (success() || steps.restore_ccache.outputs.cache-matched-key != '') }}
       uses: actions/cache/save@v6
       with:
         path: ${{ github.workspace }}/var/ccache
         key: ${{ steps.cachekey.outputs.key }}
 
+    # Same condition as the save: pruning without having saved would delete the
+    # stream's only usable entries.
     - name: Prune superseded ccaches
-      if: ${{ !cancelled() && steps.ccache_dir.outputs.exists == 'true' }}
+      if: ${{ !cancelled() && (success() || steps.restore_ccache.outputs.cache-matched-key != '') }}
       uses: ./.github/actions/prune-ccache
       with:
         key-prefix: ${{ steps.cachekey.outputs.prefix }}

--- a/.github/actions/prune-ccache/action.yml
+++ b/.github/actions/prune-ccache/action.yml
@@ -4,11 +4,9 @@ inputs:
   key-prefix:
     description: cache key prefix identifying the stream, i.e. the full key without the run id
     required: true
-    type: string
   keep-key:
     description: full key written by this run, which must survive the prune
     required: true
-    type: string
 runs:
   using: composite
   steps:

--- a/.github/actions/prune-ccache/action.yml
+++ b/.github/actions/prune-ccache/action.yml
@@ -1,0 +1,87 @@
+name: prune ccache
+description: delete the superseded ccache entries of one cache stream on this ref
+inputs:
+  key-prefix:
+    description: cache key prefix identifying the stream, i.e. the full key without the run id
+    required: true
+    type: string
+  keep-key:
+    description: full key written by this run, which must survive the prune
+    required: true
+    type: string
+runs:
+  using: composite
+  steps:
+    # Every build workflow keys its cache on `<stream>:<ref>-<run_id>` so that
+    # each run uploads a fresh entry (see the comment on the Restore step in
+    # .github/actions/linux-build). Nothing ever removed the previous entry, so
+    # a stream accumulated one full copy per run and only shed them once the
+    # repository hit the 10 GB quota and eviction kicked in. Only the newest
+    # entry of a stream is ever restored, so the older ones are dead weight.
+    - name: Prune superseded caches
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        KEY_PREFIX: ${{ inputs.key-prefix }}
+        KEEP_KEY: ${{ inputs.keep-key }}
+        # github.ref, not ref_name: `gh cache list --ref` wants the full ref.
+        CACHE_REF: ${{ github.ref }}
+      run: |
+        # `shell: bash` runs with errexit on. Turn it off: by the time this
+        # step runs the build has compiled, tested and uploaded, and a blip
+        # from the caches API must not turn that into a failed job.
+        set +e
+        set -uo pipefail
+
+        # gh's own --jq, so this does not depend on jq being on the image.
+        entries="$(gh cache list --ref "$CACHE_REF" --key "$KEY_PREFIX" --limit 100 \
+                     --json id,key --jq '.[] | [.id, .key] | @tsv')"
+        if [[ $? -ne 0 ]]
+        then
+          echo "Could not list caches for $KEY_PREFIX; nothing pruned."
+          exit 0
+        fi
+
+        if [[ -z "$entries" ]]
+        then
+          echo "No caches for $KEY_PREFIX on $CACHE_REF; nothing pruned."
+          exit 0
+        fi
+
+        # actions/cache/save reports a failed upload as a warning and still
+        # succeeds, so the entry this run meant to publish may not be there.
+        # Deleting the rest would leave the stream empty and the next build
+        # would compile cold, which is worse than keeping a stale entry. This
+        # also fails safe if KEEP_KEY ever arrives empty, where the inequality
+        # below would otherwise match every entry including this run's own.
+        # No pipeline here: with pipefail a `grep -q` that exits on the first
+        # match can SIGPIPE the writer and report 141, which would trip the
+        # guard even though KEEP_KEY was present.
+        if ! grep -qxF -- "$KEEP_KEY" <<< "$(cut -f2 <<< "$entries")"
+        then
+          echo "$KEEP_KEY is not in the cache list, so its upload did not land; nothing pruned."
+          exit 0
+        fi
+
+        # --key matches on prefix, so --ref is what keeps a prefix ending in
+        # "master-" from reaching a branch called "master-something": those
+        # caches live on refs/heads/master-something and are filtered out.
+        #
+        # A pull_request run from a fork gets a read-only GITHUB_TOKEN, so the
+        # delete 403s there. Those caches are reaped by cleanup-pr-caches when
+        # the PR closes, so a failure here must not fail the build either.
+        while IFS=$'\t' read -r id key
+        do
+          if [[ "$key" == "$KEEP_KEY" ]]
+          then
+            continue
+          fi
+
+          if gh cache delete "$id"
+          then
+            echo "Deleted superseded cache $id ($key)"
+          else
+            echo "Could not delete cache $id, leaving it to cleanup-pr-caches."
+          fi
+        done <<< "$entries"

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -291,25 +291,16 @@ jobs:
       # The old "only save on a cache miss" guard is dropped: the per-run key
       # only ever collides on a re-run, since github.run_id is stable across
       # attempts, and there the save is a no-op anyway.
-      # A failed or cancelled run still compiled most of the tree and that work
-      # is worth keeping: for ccache a partial directory is a superset of the
-      # entry it was restored from. A run that died before the restore has no
-      # compiler id and no ccache dir to save, hence the outcome guard.
+      # A failed build still compiled most of the tree and that work is worth
+      # keeping. A cancelled one is skipped so a superseded run cannot publish
+      # a half-populated cache as the newest for the ref, and a run that died
+      # before the restore has no compiler id and no ccache dir to save.
       - name: Save ccache
-        if: ${{ always() && steps.restore_ccache.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.restore_ccache.outcome == 'success' }}
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/var/ccache
           key: ccache:${{ matrix.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}
-
-      # Not always(): a cancelled run has a grace period the delete loop may not
-      # fit in, and skipping it only defers the prune to the next run.
-      - name: Prune superseded ccaches
-        if: ${{ !cancelled() && steps.restore_ccache.outcome == 'success' }}
-        uses: ./.github/actions/prune-ccache
-        with:
-          key-prefix: ccache:${{ matrix.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-
-          keep-key: ccache:${{ matrix.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}
 
       - name: ccache stats (after)
         shell: bash

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -291,16 +291,25 @@ jobs:
       # The old "only save on a cache miss" guard is dropped: the per-run key
       # only ever collides on a re-run, since github.run_id is stable across
       # attempts, and there the save is a no-op anyway.
-      # A failed build still compiled most of the tree and that work is worth
-      # keeping. A cancelled one is skipped so a superseded run cannot publish
-      # a half-populated cache as the newest for the ref, and a run that died
-      # before the restore has no compiler id and no ccache dir to save.
+      # A failed or cancelled run still compiled most of the tree and that work
+      # is worth keeping: for ccache a partial directory is a superset of the
+      # entry it was restored from. A run that died before the restore has no
+      # compiler id and no ccache dir to save, hence the outcome guard.
       - name: Save ccache
-        if: ${{ !cancelled() && steps.restore_ccache.outcome == 'success' }}
+        if: ${{ always() && steps.restore_ccache.outcome == 'success' }}
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/var/ccache
           key: ccache:${{ matrix.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}
+
+      # Not always(): a cancelled run has a grace period the delete loop may not
+      # fit in, and skipping it only defers the prune to the next run.
+      - name: Prune superseded ccaches
+        if: ${{ !cancelled() && steps.restore_ccache.outcome == 'success' }}
+        uses: ./.github/actions/prune-ccache
+        with:
+          key-prefix: ccache:${{ matrix.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-
+          keep-key: ccache:${{ matrix.os }}:${{ steps.detect.outputs.cc_id }}_${{ steps.detect.outputs.cxx_id }}:${{ github.ref_name }}-${{ github.run_id }}
 
       - name: ccache stats (after)
         shell: bash

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -36,6 +36,7 @@ jobs:
       # Split restore/save (rather than actions/cache, which saves in a post
       # step) so the prune below can run after the upload.
       - name: Restore ccache
+        id: restore_ccache
         uses: actions/cache/restore@v6
         with:
           path: ~/Library/Caches/ccache
@@ -58,38 +59,28 @@ jobs:
         shell: bash
         run: ccache -s || true
 
-      # The directory is absent only when the restore missed and the build died
-      # before ccache first wrote to it. Saving then would fail the step outright
-      # (actions/cache/save errors on a missing path) and, worse, publish an
-      # empty entry as the newest for this ref, shadowing the warm caches the
-      # restore-keys would otherwise reach. Skip both save and prune in that case.
-      - name: Check for a ccache dir
-        id: ccache_dir
-        if: ${{ !cancelled() }}
-        shell: bash
-        run: |
-          if [[ -d ~/Library/Caches/ccache ]]
-          then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "No ccache directory; skipping save and prune."
-          fi
-
       # Wider than the actions/cache post step this replaces, which was
       # post-if: success(): a failed build still compiled most of the tree and
       # that work is worth keeping. A cancelled one is skipped, since its cache
       # is barely ahead of what it restored and the upload rarely fits the
       # cancellation grace period anyway.
+      #
+      # The cache-matched-key arm is what keeps a failed run from publishing a
+      # near-empty entry: with nothing restored and the build dead before it
+      # compiled anything, that entry would become the newest for this ref and
+      # shadow the warm caches the broader restore-keys reach, and the prune
+      # would then delete the rest of the stream.
       - name: Save ccache
-        if: ${{ !cancelled() && steps.ccache_dir.outputs.exists == 'true' }}
+        if: ${{ !cancelled() && (success() || steps.restore_ccache.outputs.cache-matched-key != '') }}
         uses: actions/cache/save@v6
         with:
           path: ~/Library/Caches/ccache
           key: ccache:${{ matrix.os }}:${{ github.ref_name }}-${{ github.run_id }}
 
+      # Same condition as the save: pruning without having saved would delete
+      # the stream's only usable entries.
       - name: Prune superseded ccaches
-        if: ${{ !cancelled() && steps.ccache_dir.outputs.exists == 'true' }}
+        if: ${{ !cancelled() && (success() || steps.restore_ccache.outputs.cache-matched-key != '') }}
         uses: ./.github/actions/prune-ccache
         with:
           key-prefix: ccache:${{ matrix.os }}:${{ github.ref_name }}-

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -65,7 +65,7 @@ jobs:
       # restore-keys would otherwise reach. Skip both save and prune in that case.
       - name: Check for a ccache dir
         id: ccache_dir
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         shell: bash
         run: |
           if [[ -d ~/Library/Caches/ccache ]]
@@ -76,19 +76,18 @@ jobs:
             echo "No ccache directory; skipping save and prune."
           fi
 
-      # always() is deliberately wider than the actions/cache post step this
-      # replaces, which was post-if: success(). A failed or cancelled run still
-      # compiled most of the tree, and for ccache a partial directory is a
-      # superset of the entry it was restored from.
+      # Wider than the actions/cache post step this replaces, which was
+      # post-if: success(): a failed build still compiled most of the tree and
+      # that work is worth keeping. A cancelled one is skipped, since its cache
+      # is barely ahead of what it restored and the upload rarely fits the
+      # cancellation grace period anyway.
       - name: Save ccache
-        if: ${{ always() && steps.ccache_dir.outputs.exists == 'true' }}
+        if: ${{ !cancelled() && steps.ccache_dir.outputs.exists == 'true' }}
         uses: actions/cache/save@v6
         with:
           path: ~/Library/Caches/ccache
           key: ccache:${{ matrix.os }}:${{ github.ref_name }}-${{ github.run_id }}
 
-      # Not always(): a cancelled run has a grace period the delete loop may not
-      # fit in, and skipping it only defers the prune to the next run.
       - name: Prune superseded ccaches
         if: ${{ !cancelled() && steps.ccache_dir.outputs.exists == 'true' }}
         uses: ./.github/actions/prune-ccache

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -36,7 +36,6 @@ jobs:
       # Split restore/save (rather than actions/cache, which saves in a post
       # step) so the prune below can run after the upload.
       - name: Restore ccache
-        id: restore_ccache
         uses: actions/cache/restore@v6
         with:
           path: ~/Library/Caches/ccache
@@ -48,12 +47,7 @@ jobs:
             ccache:${{ matrix.os }}
       - name: reset ccache stats
         shell: bash
-        # The mkdir is what keeps the save below valid: actions/cache/save
-        # fails the step outright when its path is missing, and on a total
-        # restore miss ccache has not created the directory yet.
-        run: |
-          mkdir -p ~/Library/Caches/ccache
-          ccache -z || true
+        run: ccache -z || true
       - name: Install latest bash
         run: brew install bash
       - name: Configure OS
@@ -64,12 +58,30 @@ jobs:
         shell: bash
         run: ccache -s || true
 
+      # The directory is absent only when the restore missed and the build died
+      # before ccache first wrote to it. Saving then would fail the step outright
+      # (actions/cache/save errors on a missing path) and, worse, publish an
+      # empty entry as the newest for this ref, shadowing the warm caches the
+      # restore-keys would otherwise reach. Skip both save and prune in that case.
+      - name: Check for a ccache dir
+        id: ccache_dir
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [[ -d ~/Library/Caches/ccache ]]
+          then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No ccache directory; skipping save and prune."
+          fi
+
       # always() is deliberately wider than the actions/cache post step this
       # replaces, which was post-if: success(). A failed or cancelled run still
       # compiled most of the tree, and for ccache a partial directory is a
       # superset of the entry it was restored from.
       - name: Save ccache
-        if: ${{ always() }}
+        if: ${{ always() && steps.ccache_dir.outputs.exists == 'true' }}
         uses: actions/cache/save@v6
         with:
           path: ~/Library/Caches/ccache
@@ -78,7 +90,7 @@ jobs:
       # Not always(): a cancelled run has a grace period the delete loop may not
       # fit in, and skipping it only defers the prune to the next run.
       - name: Prune superseded ccaches
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.ccache_dir.outputs.exists == 'true' }}
         uses: ./.github/actions/prune-ccache
         with:
           key-prefix: ccache:${{ matrix.os }}:${{ github.ref_name }}-

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -33,8 +33,11 @@ jobs:
       && (github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'run-build') || github.event.label.name == 'run-build')
     steps:
       - uses: actions/checkout@v7
-      - name: Cache
-        uses: actions/cache@v6
+      # Split restore/save (rather than actions/cache, which saves in a post
+      # step) so the prune below can run after the upload.
+      - name: Restore ccache
+        id: restore_ccache
+        uses: actions/cache/restore@v6
         with:
           path: ~/Library/Caches/ccache
           # Unique per run so the cache is re-saved every run instead of
@@ -45,7 +48,12 @@ jobs:
             ccache:${{ matrix.os }}
       - name: reset ccache stats
         shell: bash
-        run: ccache -z || true
+        # The mkdir is what keeps the save below valid: actions/cache/save
+        # fails the step outright when its path is missing, and on a total
+        # restore miss ccache has not created the directory yet.
+        run: |
+          mkdir -p ~/Library/Caches/ccache
+          ccache -z || true
       - name: Install latest bash
         run: brew install bash
       - name: Configure OS
@@ -55,3 +63,23 @@ jobs:
       - name: ccache stats
         shell: bash
         run: ccache -s || true
+
+      # always() is deliberately wider than the actions/cache post step this
+      # replaces, which was post-if: success(). A failed or cancelled run still
+      # compiled most of the tree, and for ccache a partial directory is a
+      # superset of the entry it was restored from.
+      - name: Save ccache
+        if: ${{ always() }}
+        uses: actions/cache/save@v6
+        with:
+          path: ~/Library/Caches/ccache
+          key: ccache:${{ matrix.os }}:${{ github.ref_name }}-${{ github.run_id }}
+
+      # Not always(): a cancelled run has a grace period the delete loop may not
+      # fit in, and skipping it only defers the prune to the next run.
+      - name: Prune superseded ccaches
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/prune-ccache
+        with:
+          key-prefix: ccache:${{ matrix.os }}:${{ github.ref_name }}-
+          keep-key: ccache:${{ matrix.os }}:${{ github.ref_name }}-${{ github.run_id }}

--- a/.github/workflows/tools_build.yml
+++ b/.github/workflows/tools_build.yml
@@ -8,6 +8,10 @@ on:
       - labeled
       - synchronize
 
+permissions:
+  actions: write
+  contents: read
+
 concurrency:
   # One concurrency group per workflow + ref.
   #


### PR DESCRIPTION
## Changes Proposed:

Every build workflow keys its ccache on `<stream>:<ref>-<run_id>` (from #26481, so
the cache stops freezing after the first run on a branch), but nothing ever deleted
the previous entry. Each stream accumulates a full copy per run and only sheds them
once the 10 GB quota evicts. The repo is at 10.21 GB today, some streams have 5
copies, and the oldest entry is 11 hours old.

Adds a `prune-ccache` composite action that deletes the other entries of the same
stream on the same ref right after the save, wired into linux-build and
macos-build. Steady state is one entry per stream per ref, freeing roughly 5 GB.

- The prune only deletes if the key this run saved is in the listing.
  `actions/cache/save` reports a failed upload as a warning and still succeeds, and
  without the guard that would empty the stream.
- linux-build and macos-build move to `actions/cache/restore` + `save`, so the prune
  can run after the upload. Save runs when the build succeeded or the restore matched
  something, which is wider than the `post-if: success()` it replaces (a failed build
  still compiled most of the tree) while never publishing a near-empty entry that
  would shadow the warm caches the broader restore-keys reach. The prune runs under
  the same condition.
- The linux-build key gains a `tools=` segment, but only when tools are built, so
  tools-build and nopch-build stop sharing a stream while the existing backlog still
  gets reclaimed.
- `tools_build` gains `permissions: actions: write`.
- Fork PRs have a read-only token so the delete 403s. Logged and ignored, and
  cleanup-pr-caches still reaps those on close.

`windows_build` is not covered, it needs its own change.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

CI only, none of the above apply.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code, Opus 4.8
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

No issue.

## SOURCE:

- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Numbers from `gh cache list` on this repo. Quota and eviction behaviour: [caching reference](https://docs.github.com/en/actions/reference/dependency-caching-reference#usage-limits-and-eviction-policy).

## Tests Performed:

- [x] This pull request requires further testing and may have edge cases to be tested.

Not yet exercised on CI. The list/filter logic was verified against the live cache
data, including that it keeps the newest entry and bails when the run's own key is
missing.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

1. Run the build workflows twice on the same branch.
2. `gh cache list --key ccache: --limit 100` and confirm one entry per stream per
   ref instead of several, and that the newest survived.

## Known Issues and TODO List:

- [ ] `windows_build` ccache is unpruned and currently not wired into the build at all.
- [ ] `dashboard-ci.yml` is owned by @Yehonal per CODEOWNERS, so wiring the prune into it (its ccache streams are the two largest) is a separate PR.
