### PR TITLE
refactor(Scripts/Ulduar): seat Kologarn arms as vehicle accessories

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784760633944475600.sql
+++ b/data/sql/updates/pending_db_world/rev_1784760633944475600.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `vehicle_template_accessory` WHERE `entry` = 32930;
+INSERT INTO `vehicle_template_accessory` (`entry`, `accessory_entry`, `seat_id`, `minion`, `description`, `summontype`, `summontimer`) VALUES
+(32930, 32933, 0, 1, 'Kologarn', 8, 0),
+(32930, 32934, 1, 1, 'Kologarn', 8, 0);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
@@ -156,6 +156,10 @@ struct boss_kologarn : public BossAI
                 instance->SaveToDB();
             }
             Reset();
+            // Arms are vehicle accessories; the initial pair is seated by Map::AddToMap,
+            // so only wipe recovery needs to heal survivors or reinstall missing arms.
+            AttachLeftArm();
+            AttachRightArm();
             me->setActive(false);
         }
 
@@ -167,18 +171,8 @@ struct boss_kologarn : public BossAI
                 // Clear the arm's combat-start state so it can re-pull the boss on a subsequent attempt.
                 arm->AI()->Reset();
             }
-            else if (Creature* accessory = me->SummonCreature(NPC_LEFT_ARM, *me, TEMPSUMMON_MANUAL_DESPAWN))
-            {
-                accessory->AddUnitTypeMask(UNIT_MASK_ACCESSORY);
-                if (!me->HandleSpellClick(accessory, 0))
-                    accessory->DespawnOrUnsummon();
-                else
-                {
-                    _left = accessory->GetGUID();
-                    accessory->SetOrientation(M_PI);
-                    accessory->CastSpell(accessory, SPELL_ARM_RESPAWN_VISUAL, true);
-                }
-            }
+            else
+                vehicle->InstallAccessory(NPC_LEFT_ARM, 0, true, TEMPSUMMON_MANUAL_DESPAWN, 0);
         }
 
         void AttachRightArm()
@@ -189,18 +183,8 @@ struct boss_kologarn : public BossAI
                 // Clear the arm's combat-start state so it can re-pull the boss on a subsequent attempt.
                 arm->AI()->Reset();
             }
-            else if (Creature* accessory = me->SummonCreature(NPC_RIGHT_ARM, *me, TEMPSUMMON_MANUAL_DESPAWN))
-            {
-                accessory->AddUnitTypeMask(UNIT_MASK_ACCESSORY);
-                if (!me->HandleSpellClick(accessory, 1))
-                    accessory->DespawnOrUnsummon();
-                else
-                {
-                    _right = accessory->GetGUID();
-                    accessory->SetOrientation(M_PI);
-                    accessory->CastSpell(accessory, SPELL_ARM_RESPAWN_VISUAL, true);
-                }
-            }
+            else
+                vehicle->InstallAccessory(NPC_RIGHT_ARM, 1, true, TEMPSUMMON_MANUAL_DESPAWN, 0);
         }
 
         void Reset() override
@@ -220,9 +204,6 @@ struct boss_kologarn : public BossAI
                 if (GameObject* door = instance->GetGameObject(DATA_KOLOGARN_DOORS))
                     door->SetGoState(GO_STATE_ACTIVE);
             }
-
-            AttachLeftArm();
-            AttachRightArm();
 
             // Reset breath on pull
             breathReady = false;
@@ -326,35 +307,46 @@ struct boss_kologarn : public BossAI
 
         void PassengerBoarded(Unit* who, int8  /*seatId*/, bool apply) override
         {
+            if (apply)
+            {
+                if (who->GetEntry() == NPC_LEFT_ARM)
+                    _left = who->GetGUID();
+                else if (who->GetEntry() == NPC_RIGHT_ARM)
+                    _right = who->GetGUID();
+                else
+                    return;
+
+                who->SetOrientation(M_PI);
+                who->CastSpell(who, SPELL_ARM_RESPAWN_VISUAL, true);
+                return;
+            }
+
             if (!me->IsAlive() || instance->GetBossState(BOSS_KOLOGARN) != IN_PROGRESS)
                 return;
 
-            if (!apply)
+            // left arm
+            if (who->GetGUID() == _left)
             {
-                // left arm
-                if (who->GetGUID() == _left)
+                _left.Clear();
+                if (me->IsInCombat())
                 {
-                    _left.Clear();
-                    if (me->IsInCombat())
-                    {
-                        Talk(SAY_LEFT_ARM_GONE);
-                        events.ScheduleEvent(EVENT_RESTORE_ARM_LEFT, 50s);
-                    }
+                    Talk(SAY_LEFT_ARM_GONE);
+                    events.ScheduleEvent(EVENT_RESTORE_ARM_LEFT, 50s);
                 }
-                else
-                {
-                    _right.Clear();
-                    if (me->IsInCombat())
-                    {
-                        Talk(SAY_RIGHT_ARM_GONE);
-                        events.ScheduleEvent(EVENT_RESTORE_ARM_RIGHT, 50s);
-                    }
-                }
-
-                me->CastSpell(me, SPELL_ARM_DEAD, true);
-                if (!_right && !_left)
-                    events.ScheduleEvent(EVENT_STONE_SHOUT, 5s);
             }
+            else
+            {
+                _right.Clear();
+                if (me->IsInCombat())
+                {
+                    Talk(SAY_RIGHT_ARM_GONE);
+                    events.ScheduleEvent(EVENT_RESTORE_ARM_RIGHT, 50s);
+                }
+            }
+
+            me->CastSpell(me, SPELL_ARM_DEAD, true);
+            if (!_right && !_left)
+                events.ScheduleEvent(EVENT_STONE_SHOUT, 5s);
         }
 
         void DamageTaken(Unit* who, uint32& damage, DamageEffectType, SpellSchoolMask) override


### PR DESCRIPTION
## Changes Proposed:
Kologarn's arms are currently hand-summoned by the boss script (`SummonCreature` + `AddUnitTypeMask(UNIT_MASK_ACCESSORY)` + `HandleSpellClick`). This PR moves them to the vehicle accessory system, matching how TrinityCore and our own Flame Leviathan handle boss vehicle passengers:

- Adds the two `vehicle_template_accessory` rows for Kologarn (32930): left arm 32933 seat 0, right arm 32934 seat 1, minion, manual despawn. Values mirror TrinityCore.
- The initial pair is seated by the core when the vehicle is added to the map, so `Reset()` no longer summons arms (keeping it would double-install, since the first `InstallAllAccessories` ejects existing passengers).
- `AttachLeftArm`/`AttachRightArm` keep the wipe-recovery behavior from #26569 (heal a surviving arm and reset its AI so it can re-pull) and otherwise call `Vehicle::InstallAccessory`, the same call TrinityCore uses for its in-combat arm respawn events.
- Arm guid tracking, orientation, and the arm respawn visual move into `PassengerBoarded(apply)`, so every seating path (map add, in-combat restore, wipe re-arm) is handled uniformly.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Related to #25991 (does not close it). The floating "zombie" arms there are re-summoned when the defeated torso is recreated by the respawn system; that root cause needs a separate respawn-guard fix. This PR aligns the arm mechanics with TrinityCore so the arms' lifecycle is owned by the vehicle system rather than the script.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The `vehicle_template_accessory` rows are taken from TrinityCore's 3.3.5 database, and the script approach follows TrinityCore's `boss_kologarn`. Not a commit cherry-pick; the script changes are adapted to our version of the encounter.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds without errors on Windows (VS 2022, Release).

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Ulduar and approach Kologarn: both arms must be seated on the boss (grid load path).
2. Engage him, kill one arm: rubble spawns, and the arm is restored after 50 seconds.
3. Kill both arms: Stone Shout starts; the boss keeps fighting.
4. Wipe with one arm dead: after reset, the missing arm is reinstalled, the surviving one is back at full health, and hitting an arm pulls the boss again (#26569 behavior).
5. Kill him: both arms despawn a few seconds after death, and nothing respawns afterwards within the lockout.

## Known Issues and TODO List:

- [ ] #25991 itself (defeated bosses being recreated alive by the dynamic respawn path mid-lockout) is a core/DB issue and will be addressed separately.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
