### PR TITLE
fix(Core/DBC): award classic-tier XP in the starter isle ocean zones

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784762767399064200.sql
+++ b/data/sql/updates/pending_db_world/rev_1784762767399064200.sql
@@ -1,0 +1,14 @@
+--
+-- The ocean zones around the TBC starting isles live on map 530 (Outland) but have no
+-- WorldMapArea entry, so GetVirtualMapForMapAndZone() falls back to map 530 and
+-- GetContentLevelsForMapAndZone() classifies them as CONTENT_61_70 (base XP 235 instead
+-- of 45). Killing a mob swimming in The Veiled Sea off Azuremyst Isle rewards nearly
+-- 4x the XP of the same mob standing on shore.
+-- Add server-side WorldMapArea entries mapping these zones to their virtual continents,
+-- like the isles themselves (Azuremyst/Bloodmyst -> Kalimdor, Eversong/Ghostlands -> EK).
+-- Coordinate extents are the bounding box of the surrounded isles (only used by GM
+-- commands .gps / .go zonexy).
+DELETE FROM `worldmaparea_dbc` WHERE `ID` IN (1000, 1001);
+INSERT INTO `worldmaparea_dbc` (`ID`, `MapID`, `AreaID`, `AreaName`, `LocLeft`, `LocRight`, `LocTop`, `LocBottom`, `DisplayMapID`, `DefaultDungeonFloor`, `ParentWorldMapID`) VALUES
+(1000, 530, 3479, 'TheVeiledSea', -10075, -14570.833, -758.3333, -5508.333, 1, 0, 0),
+(1001, 530, 3455, 'TheNorthSea', -4487.5, -9412.5, 13568.75, 6066.6665, 0, 0, 0);

--- a/src/server/shared/DataStores/DBCDatabaseLoader.cpp
+++ b/src/server/shared/DataStores/DBCDatabaseLoader.cpp
@@ -31,6 +31,8 @@ DBCDatabaseLoader::DBCDatabaseLoader(char const* tableName, char const* dbcForma
     // Get sql index position
     int32 indexPos = -1;
     _recordSize = DBCFileLoader::GetFormatRecordSize(_dbcFormat, &indexPos);
+    if (indexPos >= 0)
+        _sqlIndexPos = indexPos;
 
     ASSERT(_recordSize);
 }


### PR DESCRIPTION
Mobs swimming in The Veiled Sea (3479) and The North Sea (3455) reward Outland-level XP because these ocean zones exist on map 530 but have no WorldMapArea entry, so `GetContentLevelsForMapAndZone()` falls back to map 530 and uses base XP 235 instead of 45. A level 7 crab off the Azuremyst coast rewards 293 XP to a level 4 player instead of 75, while the same crab on the beach rewards normal XP.

This PR adds server-side `worldmaparea_dbc` entries mapping both zones to their virtual continents (like the isles they surround), and fixes `DBCDatabaseLoader` discarding the computed index position: rows of any `*_dbc` table whose DBC format index is not in column 0 (`worldmaparea_dbc`, `currencytypes_dbc`, `scalingstatvalues_dbc`) were silently indexed by ID instead, making their overrides a no-op. Without the loader fix the new SQL rows have no effect.

## Changes Proposed:

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes #26672

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Root cause analysis of the XP formula and 3.3.5 client DBC/map data: both reported kill positions resolve to terrain area 3479, which has no WorldMapArea entry, and the reported XP values (293/72) match the formula output for CONTENT_61_70 vs CONTENT_1_60 exactly.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested in game:
<img width="381" height="168" alt="image" src="https://github.com/user-attachments/assets/9fd59b7c-6817-45af-ae42-9df44f5d371a" />
<img width="375" height="161" alt="image" src="https://github.com/user-attachments/assets/5a1f46ee-8ca9-4121-8d2e-ffba5267de05" />


## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Build with the core change and apply the SQL update to the world DB.
2. On a low level character, `.go xyz -4850 -12450 0 530`, then kill Skittering Crawlers swimming in the water and on the beach.
3. Without the fix, water kills reward roughly 4x XP; with the fix, water and shore kills reward the same classic-tier XP.



🤖 Generated with [Claude Code](https://claude.com/claude-code)