### PR TITLE
fix(DB): The Avalanche sub-Zone Improvements Part 2: Urgreth of the Thousand Tombs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784852139513895100.sql
+++ b/data/sql/updates/pending_db_world/rev_1784852139513895100.sql
@@ -1,0 +1,16 @@
+-- --------------------------------------------------------------------------------------------
+-- Sholazar Basin (Northrend, map 571)
+-- The Avalanche sub-Zone Improvements Part 2: Urgreth of the Thousand Tombs
+-- NPC Updates, waypoints, etc
+-- -------------------------------------------
+-- Urgreth of the Thousand Tombs (Entry 28103)
+-- Out of combat yell texts and emotes
+DELETE FROM `creature_text` WHERE `CreatureID`= 28103 AND `GroupID`= 1;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(28103, 1, 0, 'Onward, you maggots!  This land is the Lich King''s now!', 14, 0, 100, 53, 0, 0, 27537, 0, 'Urgreth of the Thousand Tombs'),
+(28103, 1, 1, 'Nothing can stop the Scourge!  Nothing!', 14, 0, 100, 53, 0, 0, 27538, 0, 'Urgreth of the Thousand Tombs'),
+(28103, 1, 2, 'Crush anything that stands in your path!  For the Lich King!', 14, 0, 100, 53, 0, 0, 27539, 0, 'Urgreth of the Thousand Tombs');
+
+DELETE FROM `smart_scripts` WHERE `entryorguid`= 28103 AND `source_type`= 0 AND `id`= 3;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(28103, 0, 3, 0, 1, 0, 100, 0, 90000, 175000, 90000, 175000, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Urgreth of the Thousand Tombs - Out of Combat - Say Line 1');

--- a/data/sql/updates/pending_db_world/rev_1784852139513895100.sql
+++ b/data/sql/updates/pending_db_world/rev_1784852139513895100.sql
@@ -3,7 +3,7 @@
 -- The Avalanche sub-Zone Improvements Part 2: Urgreth of the Thousand Tombs
 -- NPC Updates, waypoints, etc
 -- -------------------------------------------
--- Urgreth of the Thousand Tombs (Entry 28103)
+-- Urgreth of the Thousand Tombs (Entry 28103, GUID 114741)
 -- Out of combat yell texts and emotes
 DELETE FROM `creature_text` WHERE `CreatureID`= 28103 AND `GroupID`= 1;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES

--- a/data/sql/updates/pending_db_world/rev_1784852139513895100.sql
+++ b/data/sql/updates/pending_db_world/rev_1784852139513895100.sql
@@ -7,10 +7,12 @@
 -- Out of combat yell texts and emotes
 DELETE FROM `creature_text` WHERE `CreatureID`= 28103 AND `GroupID`= 1;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
-(28103, 1, 0, 'Onward, you maggots!  This land is the Lich King''s now!', 14, 0, 100, 53, 0, 0, 27537, 0, 'Urgreth of the Thousand Tombs'),
-(28103, 1, 1, 'Nothing can stop the Scourge!  Nothing!', 14, 0, 100, 53, 0, 0, 27538, 0, 'Urgreth of the Thousand Tombs'),
-(28103, 1, 2, 'Crush anything that stands in your path!  For the Lich King!', 14, 0, 100, 53, 0, 0, 27539, 0, 'Urgreth of the Thousand Tombs');
+    (28103, 1, 0, 'Onward, you maggots!  This land is the Lich King''s now!', 14, 0, 100, 53, 0, 0, 27537, 0, 'Urgreth of the Thousand Tombs'),
+    (28103, 1, 1, 'Nothing can stop the Scourge!  Nothing!', 14, 0, 100, 53, 0, 0, 27538, 0, 'Urgreth of the Thousand Tombs'),
+    (28103, 1, 2, 'Crush anything that stands in your path!  For the Lich King!', 14, 0, 100, 53, 0, 0, 27539, 0, 'Urgreth of the Thousand Tombs');
 
 DELETE FROM `smart_scripts` WHERE `entryorguid`= 28103 AND `source_type`= 0 AND `id`= 3;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (28103, 0, 3, 0, 1, 0, 100, 0, 90000, 175000, 90000, 175000, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Urgreth of the Thousand Tombs - Out of Combat - Say Line 1');
+-- Correct sheathe state
+UPDATE `creature_template_addon` SET `bytes2` = 1 WHERE (`entry` = 28103);


### PR DESCRIPTION
1. add out of combat yell lines and emotes for Urgreth of the Thousand Tombs (entry 28103, GUID 114741)
2. fix sheathe state

## Changes Proposed:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Opus 4.8 used to parse sniffs and consolidate/clean-up SQL file
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## SOURCE:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
.go c 114741
