### PR TITLE
fix(Core/Spells): Decahedral Dwarven Dice

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3932,17 +3932,6 @@ void Spell::EffectScriptEffect(SpellEffIndex effIndex)
                         }
                         break;
                     }*/
-                    // Roll Dice - Decahedral Dwarven Dice
-                    case 47770:
-                        {
-                            char buf[128];
-                            char const* gender = "his";
-                            if (m_caster->getGender() > 0)
-                                gender = "her";
-                            snprintf(buf, sizeof(buf), "%s rubs %s [Decahedral Dwarven Dice] between %s hands and rolls. One %u and one %u.", m_caster->GetName().c_str(), gender, gender, urand(1, 10), urand(1, 10));
-                            m_caster->TextEmote(buf);
-                            break;
-                        }
                     case 52173: // Coyote Spirit Despawn
                     case 60243: // Blood Parrot Despawn
                         if (unitTarget->IsCreature() && unitTarget->ToCreature()->IsSummon())


### PR DESCRIPTION
1. remove legacy hardcode that fired Decahedral Dwarven Dice behavior incorrectly

## Changes Proposed:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Opus 4.8 was used to find the root cause of the issue
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26510
- Closes https://github.com/chromiecraft/chromiecraft/issues/9852

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

male character:
<img width="438" height="32" alt="image" src="https://github.com/user-attachments/assets/d8bc2daa-cac3-4cce-9d6d-c34c80809f57" />

female character:
<img width="426" height="33" alt="image" src="https://github.com/user-attachments/assets/eb906d8c-0066-47d0-9c03-1a48de91be5c" />


## How to Test the Changes:
1. make a rogue
2. .add 36863
3. click on it and observe
