### PR TITLE
fix(DB/Creature): Prevent Vaelen the Flayed from attacking

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784856875186595900.sql
+++ b/data/sql/updates/pending_db_world/rev_1784856875186595900.sql
@@ -1,0 +1,6 @@
+-- --------------------------------------------------------------------------------------------
+-- Icecrown (Northrend, map 571)
+-- Vaelen the Flayed (Entry 30056, GUID 122535)
+-- Prevent NPC from attacking other NPCs while chained up
+-- -------------------------------------------
+UPDATE `creature_template` SET `unit_flags` = `unit_flags`|512 WHERE (`entry` = 30056);

--- a/data/sql/updates/pending_db_world/rev_1784856875186595900.sql
+++ b/data/sql/updates/pending_db_world/rev_1784856875186595900.sql
@@ -3,4 +3,8 @@
 -- Vaelen the Flayed (Entry 30056, GUID 122535)
 -- Prevent NPC from attacking other NPCs while chained up
 -- -------------------------------------------
-UPDATE `creature_template` SET `unit_flags` = `unit_flags`|512 WHERE (`entry` = 30056);
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 30056;
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 30056) AND (`source_type` = 0) AND (`id` IN (1));
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(30056, 0, 1, 0, 11, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Vaelen the Flayed - On Respawn - Set Reactstate Passive');


### PR DESCRIPTION
1. Set React State on Passive to prevent Vaelen from attacking.


## Changes Proposed:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #26442
- Closes https://github.com/chromiecraft/chromiecraft/issues/9506

## Tests Performed:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
1. .go c 122535
2. pull mobs to him
