### PR TITLE
fix(Core/Movement): don't teleport unreleased corpses out of instances when falling under the map

### DIFF
--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -22,7 +22,6 @@
 #include "CellImpl.h"
 #include "Chat.h"
 #include "Corpse.h"
-#include "GameGraveyard.h"
 #include "GameTime.h"
 #include "InstanceSaveMgr.h"
 #include "Log.h"
@@ -520,15 +519,10 @@ void WorldSession::HandleMoverRelocation(MovementInfo& movementInfo, Unit* mover
                     if (plrMover->IsAlive())
                         plrMover->KillPlayer();
                 }
-                else if (!plrMover->HasPlayerFlag(PLAYER_FLAGS_IS_OUT_OF_BOUNDS))
-                {
-                    GraveyardStruct const* grave = sGraveyard->GetClosestGraveyard(plrMover, plrMover->GetTeamId());
-                    if (grave)
-                    {
-                        plrMover->TeleportTo(grave->Map, grave->x, grave->y, grave->z, plrMover->GetOrientation());
-                        plrMover->Relocate(grave->x, grave->y, grave->z, plrMover->GetOrientation());
-                    }
-                }
+                // Rescue only released ghosts: teleporting an unreleased body would move the corpse
+                // out of instances (e.g. Eye of Eternity platform destruction, issue #25757).
+                else if (plrMover->HasPlayerFlag(PLAYER_FLAGS_GHOST) && !plrMover->HasPlayerFlag(PLAYER_FLAGS_IS_OUT_OF_BOUNDS))
+                    plrMover->RepopAtGraveyard();
             }
         }
     }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

When a dead player who has not released spirit falls below the map's minimum height, the under-map handler in `WorldSession::HandleMoverRelocation` teleported them to the closest graveyard. For instances whose linked graveyard is on another map this moves the unreleased body (and therefore the corpse) out of the instance.

This is exactly what happens in Eye of Eternity: at the P2/P3 transition Malygos destroys the platform and its collision is disabled, so bodies of players who died during P1/P2 fall into the void. The only graveyard linked to zone 4500 is the Coldarra graveyard on map 571, so their corpses were teleported out of the raid, breaking resurrection and loot eligibility and producing the broken ghost states described in the linked issue.

Changes:
- The dead-player branch now only rescues released ghosts (`PLAYER_FLAGS_GHOST`). An unreleased body stays where it fell, so the corpse remains inside the instance. When the player releases, `Player::RepopAtGraveyard` already auto-revives players resting below the map's minimum height, so they come out alive at the graveyard and can't get stuck.
- The ghost rescue now goes through `RepopAtGraveyard()` instead of a raw `TeleportTo` + `Relocate`. This correctly handles battleground/battlefield graveyards, resets the death timer, clears `PLAYER_FLAGS_IS_OUT_OF_BOUNDS`, and avoids calling `Relocate` right after an asynchronous cross-map teleport.

For reference, TrinityCore's under-map handler has no graveyard teleport for dead players at all, and cMaNGOS routes the dead case through `RepopAtGraveyard()` (which auto-revives below the void threshold). Neither project moves an unreleased corpse to a cross-map graveyard.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25757

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Compared against the TrinityCore 3.3.5 and cMaNGOS (mangos-wotlk) implementations of the under-map handling.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Enter Eye of Eternity with 2 characters in a raid group and start the Malygos encounter.
2. Damage Malygos into P2, kill the Scions/Nexus Lords, and let the second character die before the P2/P3 transition.
3. On the transition, the dead character's body falls into the void but must stay inside the instance (previously it was teleported to Coldarra, map 571).
4. Release spirit with the dead character: they should be auto-revived at the Coldarra graveyard and be able to re-enter the instance normally.
5. Regression check: die somewhere in the open world, release, and walk the ghost off a cliff below the map's minimum height (or into a void hole). The released ghost should still be rescued to the graveyard.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
