### PR TITLE
fix(Scripts/Naxxramas): despawn summons on boss death

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/boss_gluth.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gluth.cpp
@@ -76,18 +76,13 @@ public:
 
     struct boss_gluthAI : public BossAI
     {
-        explicit boss_gluthAI(Creature* c) : BossAI(c, BOSS_GLUTH), summons(me)
+        explicit boss_gluthAI(Creature* c) : BossAI(c, BOSS_GLUTH)
         {}
-
-        EventMap events;
-        SummonList summons;
 
         void Reset() override
         {
             BossAI::Reset();
             me->ApplySpellImmune(SPELL_INFECTED_WOUND, IMMUNITY_ID, SPELL_INFECTED_WOUND, true);
-            events.Reset();
-            summons.DespawnAll();
             me->SetReactState(REACT_AGGRESSIVE);
         }
 
@@ -137,12 +132,6 @@ public:
 
             if (who->IsPlayer())
                 instance->StorePersistentData(PERSISTENT_DATA_IMMORTAL_FAIL, 1);
-        }
-
-        void JustDied(Unit*  killer) override
-        {
-            BossAI::JustDied(killer);
-            summons.DespawnAll();
         }
 
         bool SelectPlayerInRoom()

--- a/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
@@ -186,11 +186,9 @@ public:
 
     struct boss_gothikAI : public BossAI
     {
-        explicit boss_gothikAI(Creature* c) : BossAI(c, BOSS_GOTHIK), summons(me)
+        explicit boss_gothikAI(Creature* c) : BossAI(c, BOSS_GOTHIK)
         {}
 
-        EventMap events;
-        SummonList summons;
         bool secondPhase{};
         bool gateOpened{};
         bool lastTeleportDead{};
@@ -209,8 +207,6 @@ public:
         void Reset() override
         {
             BossAI::Reset();
-            events.Reset();
-            summons.DespawnAll();
             me->RemoveUnitFlag(UNIT_FLAG_DISABLE_MOVE);
             me->SetImmuneToPC(false);
             me->SetReactState(REACT_PASSIVE);
@@ -275,11 +271,6 @@ public:
             }
         }
 
-        void SummonedCreatureDespawn(Creature* cr) override
-        {
-            summons.Despawn(cr);
-        }
-
         void KilledUnit(Unit* who) override
         {
             if (!who->IsPlayer())
@@ -293,7 +284,6 @@ public:
         {
             BossAI::JustDied(killer);
             Talk(SAY_DEATH);
-            summons.DespawnAll();
         }
 
         void SummonHelpers(uint32 entry)

--- a/src/server/scripts/Northrend/Naxxramas/boss_grobbulus.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_grobbulus.cpp
@@ -67,18 +67,14 @@ public:
 
     struct boss_grobbulusAI : public BossAI
     {
-        explicit boss_grobbulusAI(Creature* c) : BossAI(c, BOSS_GROBBULUS), summons(me)
+        explicit boss_grobbulusAI(Creature* c) : BossAI(c, BOSS_GROBBULUS)
         {}
 
-        EventMap events;
-        SummonList summons;
         uint32 dropSludgeTimer{};
 
         void Reset() override
         {
             BossAI::Reset();
-            events.Reset();
-            summons.DespawnAll();
             dropSludgeTimer = 0;
         }
 
@@ -112,17 +108,6 @@ public:
                 cr->SetInCombatWithZone();
             }
             summons.Summon(cr);
-        }
-
-        void SummonedCreatureDespawn(Creature* summon) override
-        {
-            summons.Despawn(summon);
-        }
-
-        void JustDied(Unit*  killer) override
-        {
-            BossAI::JustDied(killer);
-            summons.DespawnAll();
         }
 
         void KilledUnit(Unit* who) override

--- a/src/server/scripts/Northrend/Naxxramas/boss_loatheb.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_loatheb.cpp
@@ -58,20 +58,16 @@ public:
 
     struct boss_loathebAI : public BossAI
     {
-        explicit boss_loathebAI(Creature* c) : BossAI(c, BOSS_LOATHEB), summons(me)
+        explicit boss_loathebAI(Creature* c) : BossAI(c, BOSS_LOATHEB)
         {
             me->SetHomePosition(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), me->GetOrientation());
         }
 
         uint8 doomCounter;
-        EventMap events;
-        SummonList summons;
 
         void Reset() override
         {
             BossAI::Reset();
-            events.Reset();
-            summons.DespawnAll();
             doomCounter = 0;
         }
 

--- a/src/server/scripts/Northrend/Naxxramas/boss_maexxna.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_maexxna.cpp
@@ -101,11 +101,8 @@ public:
 
     struct boss_maexxnaAI : public BossAI
     {
-        explicit boss_maexxnaAI(Creature* c) : BossAI(c, BOSS_MAEXXNA), summons(me)
+        explicit boss_maexxnaAI(Creature* c) : BossAI(c, BOSS_MAEXXNA)
         {}
-
-        EventMap events;
-        SummonList summons;
 
         GuidList wraps;
 
@@ -117,13 +114,6 @@ public:
                 return false;
             }
             return true;
-        }
-
-        void Reset() override
-        {
-            BossAI::Reset();
-            events.Reset();
-            summons.DespawnAll();
         }
 
         void JustEngagedWith(Unit* who) override
@@ -155,11 +145,6 @@ public:
         {
             if (who->IsPlayer())
                 instance->StorePersistentData(PERSISTENT_DATA_IMMORTAL_FAIL, 1);
-        }
-
-        void JustDied(Unit*  killer) override
-        {
-            BossAI::JustDied(killer);
         }
 
         void DoCastWebWrap()

--- a/src/server/scripts/Northrend/Naxxramas/boss_noth.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_noth.cpp
@@ -86,12 +86,10 @@ public:
 
     struct boss_nothAI : public BossAI
     {
-        explicit boss_nothAI(Creature* c) : BossAI(c, BOSS_NOTH), summons(me)
+        explicit boss_nothAI(Creature* c) : BossAI(c, BOSS_NOTH)
         {}
 
         uint8 timesInBalcony;
-        EventMap events;
-        SummonList summons;
 
         void StartGroundPhase()
         {
@@ -140,8 +138,6 @@ public:
         void Reset() override
         {
             BossAI::Reset();
-            events.Reset();
-            summons.DespawnAll();
             me->CastSpell(me, SPELL_TELEPORT_BACK, true);
             me->SetControlled(false, UNIT_STATE_ROOT);
             me->SetReactState(REACT_AGGRESSIVE);


### PR DESCRIPTION
## Changes Proposed:

Several Naxxramas boss AIs declared their own `EventMap events` and `SummonList summons` members, shadowing the ones `BossAI` already provides. Summons were registered in the shadowed list while `BossAI::_JustDied()` despawned the (empty) base list, so any summons alive at the moment of the boss kill survived it. Since these adds are put in combat with the zone, they kept the whole raid combat-flagged after the boss died until every one was hunted down.

- Maexxna and Noth were actually affected: their `JustDied` did not despawn the local list, so spiderlings/adds outlived the boss.
- Grobbulus, Gluth, Gothik and Loatheb duplicated the base cleanup manually, so they worked, but only by re-doing `BossAI`'s job. The shadowed members and the redundant overrides (`Reset`/`JustDied` forwarding, duplicated `SummonedCreatureDespawn`) are removed so everything runs on the base members.
- Kel'Thuzad and Razuvious are intentionally left untouched: their adds are meant to outlive the boss (guardians flee, understudies receive Hopeless), and today that behavior relies on the base list being empty.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code inspection: `BossAI::_JustDied()` operates on `BossAI::summons`, which the shadowed declarations left empty.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Engage Maexxna and wait for a spiderling wave (every 40s), then kill her while spiderlings are alive. They should despawn with her and the raid should leave combat.
2. Same for Noth: kill him while his summoned adds are up. They should despawn on his death.
3. Regression check on the refactored bosses: Grobbulus, Gluth, Gothik and Loatheb should still despawn their adds on death and on evade/reset, and fight normally otherwise.
4. Regression check that Kel'Thuzad's guardians still flee (not despawn) and Razuvious's understudies still receive Hopeless when the boss dies.

## Known Issues and TODO List:

- Kel'Thuzad and Razuvious still shadow the base members on purpose; cleaning them up would require restructuring how their surviving adds are tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
