### PR TITLE
fix(Scripts/Naxxramas): Stalagg and Feugen feign death instead of dying

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
@@ -251,6 +251,8 @@ public:
                             summon->ToCreature()->AI()->Talk(EMOTE_TESLA_OVERLOAD);
                             summon->ToCreature()->CastSpell(me, SPELL_SHOCK_VISUAL, true);
                         }
+                        else // Stalagg and Feugen only feign death; the overload finishes them off
+                            summon->ToCreature()->KillSelf();
                     });
 
                     reviveTimer = 0;
@@ -369,6 +371,7 @@ public:
         uint32 pullTimer{};
         uint32 visualTimer{};
         bool overload;
+        bool isFeignDeath{};
         ObjectGuid myCoil;
 
         void Reset() override
@@ -376,6 +379,7 @@ public:
             pullTimer = 0;
             visualTimer = 1;
             overload = false;
+            isFeignDeath = false;
             events.Reset();
             me->SetControlled(false, UNIT_STATE_STUNNED);
             if (Creature* cr = me->FindNearestCreature(NPC_TESLA_COIL, 150.0f))
@@ -437,11 +441,16 @@ public:
             }
             else if (param == ACTION_RESTORE)
             {
-                if (!me->IsAlive())
+                if (isFeignDeath)
                 {
-                    me->Respawn();
-                    me->SetInCombatWithZone();
+                    isFeignDeath = false;
+                    me->SetFullHealth();
+                    me->SetStandState(UNIT_STAND_STATE_STAND);
+                    me->SetReactState(REACT_AGGRESSIVE);
+                    me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+                    me->SetControlled(false, UNIT_STATE_ROOT);
                     Talk(me->GetEntry() == NPC_STALAGG ? EMOTE_STAL_REVIVE : EMOTE_FEUG_REVIVE);
+                    me->SetInCombatWithZone();
                 }
                 else
                 {
@@ -451,13 +460,37 @@ public:
             }
         }
 
-        void JustDied(Unit* /*killer*/) override
+        // Fatal damage puts the minion in feign death instead of killing it, so a later
+        // ACTION_RESTORE can revive it without respawning (which would wipe AI state).
+        void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*damagetype*/, SpellSchoolMask /*damageSchoolMask*/) override
         {
+            if (damage < me->GetHealth())
+                return;
+
+            if (isFeignDeath) // don't take damage while feigning death
+            {
+                damage = 0;
+                return;
+            }
+
+            isFeignDeath = true;
+            damage = me->GetHealth() - 1;
+
             Talk(me->GetEntry() == NPC_STALAGG ? SAY_STAL_DEATH : SAY_FEUG_DEATH);
             Talk(me->GetEntry() == NPC_STALAGG ? EMOTE_STAL_DEATH : EMOTE_FEUG_DEATH);
 
-            if (Creature* cr = me->GetInstanceScript()->GetCreature(DATA_THADDIUS_BOSS))
-                cr->AI()->DoAction(ACTION_SUMMON_DIED);
+            if (Creature* thaddius = instance->GetCreature(DATA_THADDIUS_BOSS))
+                thaddius->AI()->DoAction(ACTION_SUMMON_DIED);
+
+            me->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+            me->RemoveAllAuras();
+            me->SetReactState(REACT_PASSIVE);
+            me->AttackStop();
+            overload = false;
+            pullTimer = 0;
+            me->SetControlled(false, UNIT_STATE_STUNNED);
+            me->SetControlled(true, UNIT_STATE_ROOT);
+            me->SetStandState(UNIT_STAND_STATE_DEAD);
         }
 
         void KilledUnit(Unit* who) override
@@ -473,6 +506,9 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
+            if (isFeignDeath)
+                return;
+
             if (visualTimer)
             {
                 visualTimer += diff;

--- a/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
@@ -462,7 +462,7 @@ public:
 
         // Fatal damage puts the minion in feign death instead of killing it, so a later
         // ACTION_RESTORE can revive it without respawning (which would wipe AI state).
-        void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*damagetype*/, SpellSchoolMask /*damageSchoolMask*/) override
+        void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType, SpellSchoolMask) override
         {
             if (damage < me->GetHealth())
                 return;
@@ -491,6 +491,15 @@ public:
             me->SetControlled(false, UNIT_STATE_STUNNED);
             me->SetControlled(true, UNIT_STATE_ROOT);
             me->SetStandState(UNIT_STAND_STATE_DEAD);
+        }
+
+        void JustDied(Unit* /*killer*/) override
+        {
+            // covers deaths that bypass DamageTaken (e.g. .die command via Unit::Kill);
+            // the overload KillSelf() arrives with isFeignDeath still set, so it can't double-fire
+            if (!isFeignDeath)
+                if (Creature* thaddius = instance->GetCreature(DATA_THADDIUS_BOSS))
+                    thaddius->AI()->DoAction(ACTION_SUMMON_DIED);
         }
 
         void KilledUnit(Unit* who) override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Stalagg and Feugen no longer die and get respawned during phase 1. Fatal damage now puts them in feign death at 1 HP (death pose, unselectable), the 5 second revive restores them in place, and both minions are truly killed when the tesla coils overload during the transition to Thaddius. This is the feign death behaviour ported from TrinityCore (commit TrinityCore/TrinityCore@29feae5901, by treeston), adapted to our script's orchestration.

Root cause of the linked issue: since the TrinityCore threat port (#24715), death no longer clears the AI engagement flag, so after `Respawn()` the revived minion never fired `JustEngagedWith` again, while the AI `Reset()` done by `Respawn()` had already wiped the EventMap. Stalagg then never rescheduled `EVENT_MINION_MAGNETIC_PULL` (which drives Magnetic Pull for both tanks), so the mechanic was lost for the rest of the fight. A revived Feugen similarly lost Static Field. With feign death the AI object never dies, so its events simply pause while it is down and resume on revive.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26525

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Feign death mechanism ported from TrinityCore (TrinityCore/TrinityCore@29feae5901), committed with `--author` crediting treeston. Reproduction videos of the bug are linked in the issue.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds without errors, codestyle checks pass.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. With two level 80 characters, `.tele Thaddius` and engage, one character on each platform.
2. Observe Magnetic Pull swapping the tanks every 20 seconds.
3. `.damage 10000000` on one minion. It should collapse (feign death) and revive after 5 seconds with the emote.
4. Observe that Magnetic Pull (and Static Field/Power Surge) continue after the revive. This is where it broke before this PR.
5. Kill both minions within 5 seconds of each other and verify the transition still works: coils overload, both minions die for real, Thaddius activates and engages.
6. Wipe during phase 1 and re-pull to verify the encounter resets cleanly.

## Known Issues and TODO List:

- [ ] None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
