### PR TITLE
fix(Core/Spells): don't resolve spellmod owner for casters no longer on a map

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -695,7 +695,9 @@ Spell::Spell(Unit* caster, SpellInfo const* info, TriggerCastFlags triggerFlags,
 
 Spell::~Spell()
 {
-    if (Player* modOwner = m_caster ? m_caster->GetSpellModOwner() : nullptr)
+    // FindMap() check: pending spell events are destroyed after the caster has left the map,
+    // where resolving a unit-summoned caster's owner through ObjectAccessor would assert
+    if (Player* modOwner = (m_caster && m_caster->FindMap()) ? m_caster->GetSpellModOwner() : nullptr)
         if (modOwner->m_spellModTakingSpell == this)
             modOwner->SetSpellModTakingSpell(this, false);
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

#26535 added a `GetSpellModOwner()` call to `Spell::~Spell`. When the caster is a unit-summoned totem/creature, resolving its owner goes through `ObjectAccessor::GetCreature`, which calls `GetMap()` on the caster. If the spell is destroyed while the caster itself is being deleted (`Map::RemoveAllObjectsInRemoveList` -> `RemoveFromMap` -> `DeleteFromWorld`), the caster has already left the map and `ASSERT(m_currMap)` fires, crashing the server:

```
#1  WorldObject::GetMap () at Object.h:630 (ASSERT m_currMap, "Scorching Totem", Entry 9637, Map 530)
#2  ObjectAccessor::GetCreature
#3  Unit::GetOwner
#4  Unit::GetSpellModOwner
#5  Spell::~Spell () at Spell.cpp:698
#6  SpellEvent::~SpellEvent
#8  EventProcessor::KillAllEvents
#10 WorldObject::~WorldObject
#12 Totem::~Totem
#14 Map::RemoveFromMap<Creature>
#15 Map::RemoveAllObjectsInRemoveList
```

The fix guards the lookup with `FindMap()`, which returns `m_currMap` without asserting. In this teardown scenario there is no spellmod owner to clean up anyway (player casters are unaffected by the guard: `GetSpellModOwner` returns the player itself without any map lookup).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Fixes a crash regression introduced by #26535 (no separate issue filed)

## SOURCE:
The changes have been validated through:
- [x] Live research (crash captured on a production server, backtrace above)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

1. Spawn a creature that summons a totem which casts spells (e.g. Scorching Elemental / Scorching Totem, entry 9637 in Blade's Edge Mountains), or any unit-summoned totem with a cast in flight.
2. Kill or despawn the totem so it is deleted while it still has a pending spell event. Without this patch the worldserver can crash on `ASSERT(m_currMap)`; with it, deletion proceeds normally.
3. Regression-check #26535 still works: on a mage, use Presence of Mind and let the instant cast get interrupted/cancelled edge cases; spellmods must not remain stuck on the player.

## Known Issues and TODO List:

- [ ] None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
