### PR TITLE
fix(Core/Spells): guard m_caster access during Spell destruction chain

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4475,7 +4475,9 @@ void Spell::finish(bool ok)
         return;
     m_spellState = SPELL_STATE_FINISHED;
 
-    if (Player* modOwner = m_caster->GetSpellModOwner())
+    // FindMap() check: pending spell events are destroyed after the caster has left the map,
+    // where resolving a unit-summoned caster's owner through ObjectAccessor would assert
+    if (Player* modOwner = (m_caster && m_caster->FindMap()) ? m_caster->GetSpellModOwner() : nullptr)
         modOwner->SetSpellModTakingSpell(this, false);
 
     if (m_spellInfo->IsChanneled())


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26778

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] Root-cause analysis of crash backtraces from production servers

## Context / relation to #26780

Issue #26778 reports two distinct crash paths during Spell destruction while the caster (Totem/Guardian/Minion) is being removed from the map:

1. Spell::~Spell() -> GetSpellModOwner() -> GetOwner() -> GetMap() ??**already fixed** by #26780 (e9abcd30) using a FindMap() guard.
2. SpellEvent::~SpellEvent() -> cancel() -> Spell::finish() -> GetSpellModOwner() -> GetOwner() -> GetMap() ??**NOT covered** by #26780. This is the Searing Totem III crash in the report.

This PR adds the equivalent FindMap() guard in Spell::finish(), closing the second path.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Have a Shaman place a Searing Totem (or any caster Minion/Totem with an active SpellEvent) and despawn it while its spell is still scheduled
2. Build and run the server with ASSERTs enabled
3. Without this fix: ASSERT(m_currMap) in Object.h during the destruction sequence (Searing Totem III crash in #26778)
4. With this fix: no crash occurs

## Known Issues and TODO List:

- [ ]
- [ ]