### PR TITLE
fix(Core/Spells): Varedis is now immune to damage while transformed

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -5422,15 +5422,9 @@ void SpellMgr::LoadSpellInfoCorrections()
     LockEntry* key = const_cast<LockEntry*>(sLockStore.LookupEntry(36)); // 3366 Opening, allows to open without proper key
     key->Type[2] = LOCK_KEY_NONE;
 
-    // Metamorphosis (Varedis, Shadowmoon Valley, issue #26641) - transforms him into a demon
-    // and buffs his damage (Effect 1), but grants no invulnerability, so players could always
-    // just melee him down at 50% HP regardless of the Book of Fel Names mechanic that's
-    // supposed to be required. Effect 2 is unused in the DBC; using it for a full
-    // SCHOOL_IMMUNITY aura matches contemporaneous player accounts of him being immune to all
-    // damage once transformed (see issue for sources). Already-existing
-    // spell_q10651_q10692_book_of_fel_names (spell_quest.cpp) strips this whole aura -
-    // transform, buff, and this immunity together - when the quest item is used on him; no
-    // changes needed there, it was only ever missing the immunity effect itself.
+    // Metamorphosis (issue #26641) buffs Varedis but grants no invulnerability, so he could be
+    // meleed down at 50% HP without the Book of Fel Names. Effect 2 is unused in the DBC, so it
+    // carries the immunity; the existing quest script already strips the whole aura.
     ApplySpellFix({ 36298 }, [](SpellInfo* spellInfo)
     {
         spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -5422,6 +5422,23 @@ void SpellMgr::LoadSpellInfoCorrections()
     LockEntry* key = const_cast<LockEntry*>(sLockStore.LookupEntry(36)); // 3366 Opening, allows to open without proper key
     key->Type[2] = LOCK_KEY_NONE;
 
+    // Metamorphosis (Varedis, Shadowmoon Valley, issue #26641) - transforms him into a demon
+    // and buffs his damage (Effect 1), but grants no invulnerability, so players could always
+    // just melee him down at 50% HP regardless of the Book of Fel Names mechanic that's
+    // supposed to be required. Effect 2 is unused in the DBC; using it for a full
+    // SCHOOL_IMMUNITY aura matches contemporaneous player accounts of him being immune to all
+    // damage once transformed (see issue for sources). Already-existing
+    // spell_q10651_q10692_book_of_fel_names (spell_quest.cpp) strips this whole aura -
+    // transform, buff, and this immunity together - when the quest item is used on him; no
+    // changes needed there, it was only ever missing the immunity effect itself.
+    ApplySpellFix({ 36298 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
+        spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_SCHOOL_IMMUNITY;
+        spellInfo->Effects[EFFECT_2].MiscValue = 127; // all schools
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+    });
+
     LOG_INFO("server.loading", ">> Loading spell dbc data corrections  in {} ms", GetMSTimeDiffToNow(oldMSTime));
     LOG_INFO("server.loading", " ");
 }


### PR DESCRIPTION
## Changes Proposed:

Varedis (Shadowmoon Valley) is meant to transform into a demon at 50% HP and become immune to all damage until the Book of Fel Names (his quest item) is used on him - but he was never actually immune, so players could just melee him down at 50% regardless of the item mechanic.

- [x] Varedis is genuinely immune to all damage while transformed, not just passive/harder to kill.
- [x] Using the Book of Fel Names on him still correctly reverts the transformation and removes the immunity, exactly as before.

**Root cause:** Metamorphosis (36298), the spell he casts on himself at 50% HP, only had two effects in the DBC - transforming his model into a demon and buffing his damage - with no invulnerability effect at all. The item side of the mechanic already worked correctly: `spell_q10651_q10692_book_of_fel_names` (`spell_quest.cpp`) already strips the whole Metamorphosis aura when the Book of Fel Names is used on him, it just never had an immunity effect to remove.

Fixed by using the spell's previously-unused third effect slot to add a full `SCHOOL_IMMUNITY` aura (all damage schools), applied to himself alongside the transform and damage buff. Since it's part of the same aura, it gets stripped together with the rest when the book is used, requiring no changes anywhere else.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Sonnet 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26641

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Multiple contemporaneous Wowhead comments (from when this was current content) confirm he becomes immune to all damage once transformed, only removable with the Book of Fel Names - see the linked issue for the exact quotes and source.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Followed the issue's own reproduction steps: leveled a character to 70, teleported to Ruins of Karabor, brought Varedis to 50% HP to trigger the transformation, confirmed he's now immune to damage, then used the Book of Fel Names on him and confirmed he reverts to his blood elf form and becomes vulnerable again.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.character level 70`, `.additem 30854` (Book of Fel Names), `.tele ruinsofkarabor`.
2. Reach Varedis and bring him to 50% HP (e.g. `.damage 50 pct`) to trigger his demon transformation.
3. Confirm he's now immune to all damage.
4. Use the Book of Fel Names on him and confirm he reverts to his blood elf form and becomes vulnerable again.

## Known Issues and TODO List:

- None

🤖 Generated with Claude Code (Sonnet 5)+AzerothMCP

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
